### PR TITLE
Use `relative_position_id` in UK focuses

### DIFF
--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -1,4 +1,4 @@
-﻿# Author(s): Jumaron & Angriest Bird
+# Author(s): Jumaron & Angriest Bird
 # Last Modified: Feb. 03 2022 by Angriest Bird
 focus_tree = {
 	id = united_kingdom_focus
@@ -90,8 +90,9 @@ focus_tree = {
 	focus = {
 		id = ENG_economic_stimulus
 		icon = pound_sterling
-		x = 2
+		x = -4
 		y = 1
+		relative_position_id = ENG_vitalize_westminster
 		cost = 5
 
 		prerequisite = { focus = ENG_vitalize_westminster }
@@ -437,8 +438,9 @@ focus_tree = {
 	focus = {
 		id = ENG_imperial_dockyards
 		icon = naval_dockyard
-		x = 5
-		y = 3
+		x = 1
+		y = 1
+		relative_position_id = ENG_imperial_industry
 		cost = 10
 
 		prerequisite = {
@@ -485,8 +487,9 @@ focus_tree = {
 	focus = {
 		id = ENG_dockyards_2
 		icon = naval_dockyard
-		x = 1
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_dockyards_1
 		cost = 10
 
 		prerequisite = {
@@ -554,8 +557,9 @@ focus_tree = {
 	focus = {
 		id = ENG_fortify_the_empire
 		icon = coastal_fort
-		x = 5
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_imperial_dockyards
 		cost = 10
 
 		prerequisite = { focus = ENG_imperial_dockyards }
@@ -618,7 +622,8 @@ focus_tree = {
 		id = ENG_english_factories
 		icon = factory_complex
 		x = 0
-		y = 5
+		y = 3
+		relative_position_id = ENG_english_industry
 		cost = 10
 
 		prerequisite = {
@@ -679,8 +684,9 @@ focus_tree = {
 	focus = {
 		id = ENG_scottish_factories
 		icon = industry_military
-		x = 2
-		y = 5
+		x = 0
+		y = 3
+		relative_position_id = ENG_scottish_industry
 		cost = 10
 
 		prerequisite = {
@@ -766,12 +772,12 @@ focus_tree = {
 		}
 	}
 
-
 	focus = {
 		id = ENG_political_reform
 		icon = big_ben_gay
-		x = 10
+		x = 4
 		y = 1
+		relative_position_id = ENG_vitalize_westminster
 		cost = 10
 
 		prerequisite = {
@@ -793,8 +799,9 @@ focus_tree = {
 	focus = {
 		id = ENG_democratic_tradition
 		icon = Election_graphics
-		x = 22
+		x = -5
 		y = 1
+		relative_position_id = ENG_the_future_of_britain
 		cost = 10
 
 		prerequisite = {
@@ -826,8 +833,9 @@ focus_tree = {
 	focus = {
 		id = ENG_a_new_path
 		icon = anti_democracy
-		x = 32
+		x = 5
 		y = 1
+		relative_position_id = ENG_the_future_of_britain
 		cost = 10
 
 		prerequisite = {
@@ -864,8 +872,9 @@ focus_tree = {
 	focus = {
 		id = ENG_focus_on_the_army
 		icon = infantry_commonwealth
-		x = 44
+		x = -2
 		y = 1
+		relative_position_id = ENG_british_armed_forces
 		cost = 10
 
 		prerequisite = {
@@ -885,8 +894,9 @@ focus_tree = {
 	focus = {
 		id = ENG_focus_on_the_navy
 		icon = ship_bleur_point
-		x = 48
+		x = 2
 		y = 1
+		relative_position_id = ENG_british_armed_forces
 		cost = 10
 
 		prerequisite = {
@@ -906,8 +916,9 @@ focus_tree = {
 	focus = {
 		id = ENG_expand_the_home_ministry
 		icon = housing_secured
-		x = 8
-		y = 2
+		x = -2
+		y = 1
+		relative_position_id = ENG_political_reform
 		cost = 10
 
 		prerequisite = {
@@ -929,8 +940,9 @@ focus_tree = {
 	focus = {
 		id = ENG_expand_the_foreign_ministry
 		icon = Generic_Big_Ben02
-		x = 13
-		y = 2
+		x = 3
+		y = 1
+		relative_position_id = ENG_political_reform
 		cost = 10
 
 		prerequisite = {
@@ -952,8 +964,9 @@ focus_tree = {
 	focus = {
 		id = ENG_the_future_of_the_NHS
 		icon = generic_healthcare
-		x = 15
-		y = 2
+		x = 5
+		y = 1
+		relative_position_id = ENG_political_reform
 		cost = 10
 
 		prerequisite = {
@@ -975,8 +988,9 @@ focus_tree = {
 	focus = {
 		id = ENG_europe_is_the_future
 		icon = EU_constitution
-		x = 18
-		y = 2
+		x = -4
+		y = 1
+		relative_position_id = ENG_democratic_tradition
 		cost = 10
 
 		prerequisite = {
@@ -1027,8 +1041,9 @@ focus_tree = {
 	focus = {
 		id = ENG_careful_cooperation
 		icon = britain_eu
-		x = 22
-		y = 2
+		x = 0
+		y = 1
+		relative_position_id = ENG_democratic_tradition
 		cost = 10
 
 		prerequisite = {
@@ -1067,8 +1082,9 @@ focus_tree = {
 	focus = {
 		id = ENG_distance_from_europe
 		icon = PB_ENG_Haig_Initial
-		x = 26
-		y = 2
+		x = 4
+		y = 1
+		relative_position_id = ENG_democratic_tradition
 		cost = 10
 
 		prerequisite = {
@@ -1110,8 +1126,9 @@ focus_tree = {
 	focus = {
 		id = ENG_towards_the_left
 		icon = generic_communism_focus
-		x = 29
-		y = 2
+		x = -3
+		y = 1
+		relative_position_id = ENG_a_new_path
 		cost = 10
 
 		prerequisite = {
@@ -1146,8 +1163,9 @@ focus_tree = {
 	focus = {
 		id = ENG_towards_the_right
 		icon = fascism
-		x = 35
-		y = 2
+		x = 3
+		y = 1
+		relative_position_id = ENG_a_new_path
 		cost = 10
 
 		prerequisite = {
@@ -1187,8 +1205,9 @@ focus_tree = {
 	focus = {
 		id = ENG_industry_in_manchester
 		icon = industry_military
-		x = 40
-		y = 2
+		x = -4
+		y = 1
+		relative_position_id = ENG_focus_on_the_army
 		cost = 10
 
 		prerequisite = {
@@ -1229,8 +1248,9 @@ focus_tree = {
 	focus = {
 		id = ENG_army_training
 		icon = PB_ENG_Haig_Son
-		x = 42
-		y = 2
+		x = -2
+		y = 1
+		relative_position_id = ENG_focus_on_the_army
 		cost = 10
 
 		prerequisite = {
@@ -1250,8 +1270,9 @@ focus_tree = {
 	focus = {
 		id = ENG_expand_the_air_force
 		icon = air_force
-		x = 46
-		y = 2
+		x = 2
+		y = 1
+		relative_position_id = ENG_focus_on_the_army
 		cost = 10
 
 		prerequisite = {
@@ -1272,8 +1293,9 @@ focus_tree = {
 	focus = {
 		id = ENG_naval_prototypes
 		icon = navy
-		x = 50
-		y = 2
+		x = 2
+		y = 1
+		relative_position_id = ENG_focus_on_the_navy
 		cost = 10
 
 		prerequisite = {
@@ -1293,8 +1315,9 @@ focus_tree = {
 	focus = {
 		id = ENG_industry_in_liverpool
 		icon = naval_dockyard
-		x = 52
-		y = 2
+		x = 4
+		y = 1
+		relative_position_id = ENG_focus_on_the_navy
 		cost = 10
 
 		prerequisite = {
@@ -1335,8 +1358,9 @@ focus_tree = {
 	focus = {
 		id = ENG_freedom_first
 		icon = split_britian_map
-		x = 7
-		y = 3
+		x = -1
+		y = 1
+		relative_position_id = ENG_expand_the_home_ministry
 		cost = 10
 
 		prerequisite = {
@@ -1371,8 +1395,9 @@ focus_tree = {
 	focus = {
 		id = ENG_security_first
 		icon = neutrality
-		x = 9
-		y = 3
+		x = 1
+		y = 1
+		relative_position_id = ENG_expand_the_home_ministry
 		cost = 10
 
 		prerequisite = {
@@ -1403,8 +1428,9 @@ focus_tree = {
 	focus = {
 		id = ENG_go_with_europe
 		icon = align_to_europe
-		x = 11
-		y = 3
+		x = -2
+		y = 1
+		relative_position_id = ENG_expand_the_foreign_ministry
 		cost = 10
 
 		prerequisite = {
@@ -1455,8 +1481,9 @@ focus_tree = {
 	focus = {
 		id = ENG_go_with_the_commonwealth
 		icon = Rule_Britannia
-		x = 13
-		y = 3
+		x = 0
+		y = 1
+		relative_position_id = ENG_expand_the_foreign_ministry
 		cost = 10
 
 		prerequisite = {
@@ -1497,8 +1524,9 @@ focus_tree = {
 	focus = {
 		id = ENG_britain_first
 		icon = align_to_britain
-		x = 15
-		y = 3
+		x = 2
+		y = 1
+		relative_position_id = ENG_expand_the_foreign_ministry
 		cost = 10
 
 		prerequisite = {
@@ -1546,8 +1574,9 @@ focus_tree = {
 	focus = {
 		id = ENG_european_cooperation_1
 		icon = green_england
-		x = 18
-		y = 3
+		x = 0
+		y = 1
+		relative_position_id = ENG_europe_is_the_future
 		cost = 10
 
 		prerequisite = {
@@ -1797,8 +1826,9 @@ focus_tree = {
 	focus = {
 		id = ENG_abolish_the_monarchy
 		icon = anti_monarchism4
-		x = 29
-		y = 3
+		x = 0
+		y = 1
+		relative_position_id = ENG_towards_the_left
 		cost = 10
 
 		prerequisite = {
@@ -1818,8 +1848,9 @@ focus_tree = {
 	focus = {
 		id = ENG_empower_the_throne
 		icon = british_monarchy
-		x = 33
-		y = 3
+		x = -2
+		y = 1
+		relative_position_id = ENG_towards_the_right
 		cost = 10
 
 		prerequisite = {
@@ -1860,8 +1891,9 @@ focus_tree = {
 	focus = {
 		id = ENG_empower_the_government
 		icon = british_cabinet
-		x = 37
-		y = 3
+		x = 2
+		y = 1
+		relative_position_id = ENG_towards_the_right
 		cost = 10
 
 		prerequisite = {
@@ -1897,8 +1929,9 @@ focus_tree = {
 	focus = {
 		id = ENG_artillery_for_britain
 		icon = artillery2
-		x = 41
-		y = 3
+		x = -1
+		y = 1
+		relative_position_id = ENG_army_training
 		cost = 10
 
 		prerequisite = {
@@ -1925,8 +1958,9 @@ focus_tree = {
 	focus = {
 		id = ENG_tanks_for_britain
 		icon = tanks4
-		x = 43
-		y = 3
+		x = 1
+		y = 1
+		relative_position_id = ENG_army_training
 		cost = 10
 
 		prerequisite = {
@@ -1953,8 +1987,9 @@ focus_tree = {
 	focus = {
 		id = ENG_develop_our_fighters
 		icon = modern_fighter
-		x = 45
-		y = 3
+		x = -1
+		y = 1
+		relative_position_id = ENG_expand_the_air_force
 		cost = 10
 
 		prerequisite = {
@@ -1981,8 +2016,9 @@ focus_tree = {
 	focus = {
 		id = ENG_develop_heavy_planes
 		icon = modern_bomber
-		x = 47
-		y = 3
+		x = 1
+		y = 1
+		relative_position_id = ENG_expand_the_air_force
 		cost = 10
 
 		prerequisite = {
@@ -2009,8 +2045,9 @@ focus_tree = {
 	focus = {
 		id = ENG_develop_submarines
 		icon = ENG_Fleet_in_Being2
-		x = 49
-		y = 3
+		x = -1
+		y = 1
+		relative_position_id = ENG_naval_prototypes
 		cost = 10
 
 		prerequisite = {
@@ -2037,8 +2074,9 @@ focus_tree = {
 	focus = {
 		id = ENG_develop_carriers
 		icon = ENG_Embrace_Carriers
-		x = 51
-		y = 3
+		x = 1
+		y = 1
+		relative_position_id = ENG_naval_prototypes
 		cost = 10
 
 		prerequisite = {
@@ -2062,13 +2100,12 @@ focus_tree = {
 		}
 	}
 
-
-
 	focus = {
 		id = ENG_assure_individual_freedoms
 		icon = torchbearers_of_tomorrow
-		x = 7
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_freedom_first
 		cost = 10
 
 		prerequisite = {
@@ -2090,8 +2127,9 @@ focus_tree = {
 	focus = {
 		id = ENG_public_CCTV_systems
 		icon = cctv2
-		x = 9
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_security_first
 		cost = 10
 
 		prerequisite = {
@@ -2115,8 +2153,9 @@ focus_tree = {
 	focus = {
 		id = ENG_european_logistics
 		icon = euro
-		x = 18
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_european_cooperation_1
 		cost = 15
 
 		prerequisite = {
@@ -2142,7 +2181,6 @@ focus_tree = {
 		}
 	}
 
-	### Kill Backstop - Empower Boris
 	focus = {
 		id = ENG_defy_remain ### old name, not changed
 		icon = boris_johnson
@@ -2512,8 +2550,9 @@ focus_tree = {
 	focus = {
 		id = ENG_fight_capitalism
 		icon = Fabianist
-		x = 29
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_abolish_the_monarchy
 		cost = 10
 
 		available = {
@@ -2573,8 +2612,9 @@ focus_tree = {
 	focus = {
 		id = ENG_benevolent_monarchy
 		icon = god_save_the_king
-		x = 32
-		y = 4
+		x = -1
+		y = 1
+		relative_position_id = ENG_empower_the_throne
 		cost = 10
 
 		prerequisite = {
@@ -2614,8 +2654,9 @@ focus_tree = {
 	focus = {
 		id = ENG_imperialism
 		icon = the_new_commonealth
-		x = 35
-		y = 4
+		x = 2
+		y = 1
+		relative_position_id = ENG_empower_the_throne
 		cost = 10
 
 		prerequisite = {
@@ -2639,8 +2680,9 @@ focus_tree = {
 	focus = {
 		id = ENG_nationalism
 		icon = Focus_ENG_Mosleys_New_Deal
-		x = 38
-		y = 4
+		x = 1
+		y = 1
+		relative_position_id = ENG_empower_the_government
 		cost = 10
 
 		prerequisite = {
@@ -2682,8 +2724,9 @@ focus_tree = {
 	focus = {
 		id = ENG_army_doctrine_1
 		icon = Generic_British_Soldier_Flag
-		x = 42
-		y = 4
+		x = 1
+		y = 1
+		relative_position_id = ENG_artillery_for_britain
 		cost = 10
 
 		prerequisite = {
@@ -2711,8 +2754,9 @@ focus_tree = {
 	focus = {
 		id = ENG_air_force_doctrine_1
 		icon = air_doctrine
-		x = 46
-		y = 4
+		x = 1
+		y = 1
+		relative_position_id = ENG_develop_our_fighters
 		cost = 10
 
 		prerequisite = {
@@ -2740,8 +2784,9 @@ focus_tree = {
 	focus = {
 		id = ENG_naval_doctrine_1
 		icon = navy3
-		x = 50
-		y = 4
+		x = 1
+		y = 1
+		relative_position_id = ENG_develop_submarines
 		cost = 10
 
 		prerequisite = {
@@ -2770,8 +2815,9 @@ focus_tree = {
 	focus = {
 		id = ENG_liberal_economics
 		icon = consumer_goods
-		x = 7
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_assure_individual_freedoms
 		cost = 10
 
 		prerequisite = {
@@ -2801,8 +2847,9 @@ focus_tree = {
 	focus = {
 		id = ENG_internet_surveillance
 		icon = internet_censorship
-		x = 9
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_public_CCTV_systems
 		cost = 10
 
 		prerequisite = {
@@ -2828,8 +2875,9 @@ focus_tree = {
 	focus = {
 		id = ENG_EU_border_compromise
 		icon = generic_euroscepticism
-		x = 11
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_go_with_europe
 		cost = 10
 
 		prerequisite = {
@@ -2856,8 +2904,9 @@ focus_tree = {
 	focus = {
 		id = ENG_propose_the_CANZUK_alliance
 		icon = Focus_ENG_Hoare_at_the_Helm
-		x = 13
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_go_with_the_commonwealth
 		cost = 10
 
 		prerequisite = {
@@ -2891,8 +2940,9 @@ focus_tree = {
 	focus = {
 		id = ENG_the_british_alliance
 		icon = focus_generic_league_of_nations
-		x = 15
-		y = 4
+		x = 0
+		y = 1
+		relative_position_id = ENG_britain_first
 		cost = 10
 
 		prerequisite = {
@@ -2923,8 +2973,9 @@ focus_tree = {
 	focus = {
 		id = ENG_european_cooperation_2
 		icon = EU_policies
-		x = 17
-		y = 5
+		x = -1
+		y = 1
+		relative_position_id = ENG_european_logistics
 		cost = 10
 
 		prerequisite = {
@@ -3151,8 +3202,9 @@ focus_tree = {
 	focus = {
 		id = ENG_break_the_banks
 		icon = communist_slums
-		x = 28
-		y = 5
+		x = -1
+		y = 1
+		relative_position_id = ENG_fight_capitalism
 		cost = 10
 
 		prerequisite = {
@@ -3181,8 +3233,9 @@ focus_tree = {
 	focus = {
 		id = ENG_persecute_lobbyists
 		icon = british_decolonization
-		x = 30
-		y = 5
+		x = 1
+		y = 1
+		relative_position_id = ENG_fight_capitalism
 		cost = 10
 
 		prerequisite = {
@@ -3211,8 +3264,9 @@ focus_tree = {
 	focus = {
 		id = ENG_royal_office_of_employment
 		icon = Focus_generic_monarchist_workers
-		x = 32
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_benevolent_monarchy
 		cost = 10
 
 		prerequisite = {
@@ -3237,8 +3291,9 @@ focus_tree = {
 	focus = {
 		id = ENG_restore_the_british_empire
 		icon = united_anglosphere
-		x = 34
-		y = 5
+		x = -1
+		y = 1
+		relative_position_id = ENG_imperialism
 		cost = 10
 
 		prerequisite = {
@@ -3281,8 +3336,9 @@ focus_tree = {
 	focus = {
 		id = ENG_realm_of_britain
 		icon = british_global_defense
-		x = 36
-		y = 5
+		x = 1
+		y = 1
+		relative_position_id = ENG_imperialism
 		cost = 10
 
 		prerequisite = {
@@ -3325,8 +3381,9 @@ focus_tree = {
 	focus = {
 		id = ENG_national_militarism
 		icon = focus_generic_fascist_militarism
-		x = 38
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_nationalism
 		cost = 10
 
 		prerequisite = {
@@ -3348,8 +3405,9 @@ focus_tree = {
 	focus = {
 		id = ENG_school_for_strategic_warfare
 		icon = chiefs_of_staff_committee
-		x = 41
-		y = 5
+		x = -1
+		y = 1
+		relative_position_id = ENG_army_doctrine_1
 		cost = 10
 
 		prerequisite = {
@@ -3369,8 +3427,9 @@ focus_tree = {
 	focus = {
 		id = ENG_ground_support_planes
 		icon = bombs
-		x = 44
-		y = 5
+		x = 2
+		y = 1
+		relative_position_id = ENG_army_doctrine_1
 		cost = 10
 
 		prerequisite = {
@@ -3393,8 +3452,9 @@ focus_tree = {
 	focus = {
 		id = ENG_air_force_doctrine_2
 		icon = air_doctrine
-		x = 46
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_air_force_doctrine_1
 		cost = 10
 
 		prerequisite = {
@@ -3421,8 +3481,9 @@ focus_tree = {
 	focus = {
 		id = ENG_naval_support_planes
 		icon = naval_bombers
-		x = 48
-		y = 5
+		x = 2
+		y = 1
+		relative_position_id = ENG_air_force_doctrine_1
 		cost = 10
 
 		prerequisite = {
@@ -3442,12 +3503,12 @@ focus_tree = {
 		}
 	}
 
-
 	focus = {
 		id = ENG_air_travel_agreements_with_europe
 		icon = air_defense
-		x = 11
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_EU_border_compromise
 		cost = 10
 
 		prerequisite = {
@@ -3474,8 +3535,9 @@ focus_tree = {
 	focus = {
 		id = ENG_invite_the_united_states
 		icon = unite_the_anglosphere
-		x = 13
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_propose_the_CANZUK_alliance
 		cost = 10
 
 		prerequisite = {
@@ -3495,8 +3557,9 @@ focus_tree = {
 	focus = {
 		id = ENG_diplomatic_sovereignity
 		icon = political_pressure
-		x = 15
-		y = 5
+		x = 0
+		y = 1
+		relative_position_id = ENG_the_british_alliance
 		cost = 10
 
 		prerequisite = {
@@ -3590,8 +3653,9 @@ focus_tree = {
 	focus = {
 		id = ENG_industrial_development_program
 		icon = industry_civilian
-		x = 27
-		y = 6
+		x = 0
+		y = 2
+		relative_position_id = ENG_national_development_2
 		cost = 10
 
 		prerequisite = {
@@ -3613,8 +3677,9 @@ focus_tree = {
 	focus = {
 		id = ENG_universal_employment
 		icon = worker_paradise
-		x = 29
-		y = 6
+		x = 1
+		y = 1
+		relative_position_id = ENG_break_the_banks
 		cost = 10
 
 		prerequisite = {
@@ -3640,8 +3705,9 @@ focus_tree = {
 	focus = {
 		id = ENG_royal_industries
 		icon = autarky_ambitions
-		x = 32
-		y = 6
+		x = 0
+		y = 1
+		relative_position_id = ENG_royal_office_of_employment
 		cost = 10
 
 		prerequisite = {
@@ -3663,8 +3729,9 @@ focus_tree = {
 	focus = {
 		id = ENG_colonial_outposts_in_africa
 		icon = british_africa
-		x = 34
-		y = 6
+		x = 0
+		y = 1
+		relative_position_id = ENG_restore_the_british_empire
 		cost = 10
 
 		prerequisite = {
@@ -3724,8 +3791,9 @@ focus_tree = {
 	focus = {
 		id = ENG_subjugate_ireland
 		icon = attack_ireland
-		x = 36
-		y = 6
+		x = 0
+		y = 1
+		relative_position_id = ENG_realm_of_britain
 		cost = 10
 
 		prerequisite = {
@@ -3756,8 +3824,9 @@ focus_tree = {
 	focus = {
 		id = ENG_reorganize_the_education_system
 		icon = focus_ARG_fascist_researchers
-		x = 38
-		y = 6
+		x = 0
+		y = 1
+		relative_position_id = ENG_national_militarism
 		cost = 10
 
 		prerequisite = {
@@ -3779,8 +3848,9 @@ focus_tree = {
 	focus = {
 		id = ENG_army_doctrine_2
 		icon = Generic_British_Soldiers03
-		x = 42
-		y = 6
+		x = 0
+		y = 2
+		relative_position_id = ENG_army_doctrine_1
 		cost = 10
 
 		prerequisite = {
@@ -3807,8 +3877,9 @@ focus_tree = {
 	focus = {
 		id = ENG_ground_crew_training
 		icon = special_air_service
-		x = 46
-		y = 6
+		x = 0
+		y = 1
+		relative_position_id = ENG_air_force_doctrine_2
 		cost = 10
 
 		prerequisite = {
@@ -3836,8 +3907,9 @@ focus_tree = {
 	focus = {
 		id = ENG_naval_doctrine_2
 		icon = naval_doctrine
-		x = 50
-		y = 6
+		x = 0
+		y = 2
+		relative_position_id = ENG_naval_doctrine_1
 		cost = 10
 
 		prerequisite = {
@@ -4012,8 +4084,9 @@ focus_tree = {
 	focus = {
 		id = ENG_invest_in_resources
 		icon = PB_ENG_Target_Monopolies
-		x = 28
-		y = 7
+		x = -1
+		y = 1
+		relative_position_id = ENG_universal_employment
 		cost = 10
 
 		prerequisite = {
@@ -4070,8 +4143,9 @@ focus_tree = {
 	focus = {
 		id = ENG_establish_a_revolutionary_committee
 		icon = Focus_Socialist_Propaganda
-		x = 30
-		y = 7
+		x = 1
+		y = 1
+		relative_position_id = ENG_universal_employment
 		cost = 10
 
 		prerequisite = {
@@ -4104,8 +4178,9 @@ focus_tree = {
 	focus = {
 		id = ENG_royal_factories
 		icon = construction3
-		x = 32
-		y = 7
+		x = 0
+		y = 1
+		relative_position_id = ENG_royal_industries
 		cost = 10
 
 		prerequisite = {
@@ -4129,8 +4204,9 @@ focus_tree = {
 	focus = {
 		id = ENG_restore_the_cape_colony
 		icon = attack_south_africa
-		x = 35
-		y = 7
+		x = 1
+		y = 1
+		relative_position_id = ENG_colonial_outposts_in_africa
 		cost = 10
 
 		prerequisite = {
@@ -4172,8 +4248,9 @@ focus_tree = {
 	focus = {
 		id = ENG_maintain_a_multiethnic_army
 		icon = british_imperialism
-		x = 37
-		y = 7
+		x = -1
+		y = 1
+		relative_position_id = ENG_reorganize_the_education_system
 		cost = 10
 
 		prerequisite = {
@@ -4204,8 +4281,9 @@ focus_tree = {
 	focus = {
 		id = ENG_national_office_for_the_colored_workforce
 		icon = colonial_immigration
-		x = 39
-		y = 7
+		x = 1
+		y = 1
+		relative_position_id = ENG_reorganize_the_education_system
 		cost = 10
 
 		prerequisite = {
@@ -4236,8 +4314,9 @@ focus_tree = {
 	focus = {
 		id = ENG_army_of_quality
 		icon = cavalry
-		x = 41
-		y = 7
+		x = -1
+		y = 1
+		relative_position_id = ENG_army_doctrine_2
 		cost = 10
 
 		prerequisite = {
@@ -4263,8 +4342,9 @@ focus_tree = {
 	focus = {
 		id = ENG_army_of_quantity
 		icon = artillery
-		x = 43
-		y = 7
+		x = 1
+		y = 1
+		relative_position_id = ENG_army_doctrine_2
 		cost = 10
 
 		prerequisite = {
@@ -4292,8 +4372,9 @@ focus_tree = {
 	focus = {
 		id = ENG_improve_our_small_ships
 		icon = longboat
-		x = 49
-		y = 7
+		x = -1
+		y = 1
+		relative_position_id = ENG_naval_doctrine_2
 		cost = 20
 
 		prerequisite = {
@@ -4316,8 +4397,9 @@ focus_tree = {
 	focus = {
 		id = ENG_improve_our_large_ships
 		icon = battleships
-		x = 51
-		y = 7
+		x = 1
+		y = 1
+		relative_position_id = ENG_naval_doctrine_2
 		cost = 20
 
 		prerequisite = {
@@ -4382,8 +4464,9 @@ focus_tree = {
 	focus = {
 		id = ENG_socialist_secret_police
 		icon = communist_spies
-		x = 29
-		y = 8
+		x = -1
+		y = 1
+		relative_position_id = ENG_establish_a_revolutionary_committee
 		cost = 10
 
 		prerequisite = {
@@ -4405,8 +4488,9 @@ focus_tree = {
 	focus = {
 		id = ENG_the_throne_of_all_britons
 		icon = british_nationalism
-		x = 32
-		y = 8
+		x = 0
+		y = 1
+		relative_position_id = ENG_royal_factories
 		cost = 10
 
 		prerequisite = {
@@ -4437,8 +4521,9 @@ focus_tree = {
 	focus = {
 		id = ENG_restore_the_raj
 		icon = british_investors_in_india
-		x = 34
-		y = 8
+		x = 0
+		y = 2
+		relative_position_id = ENG_colonial_outposts_in_africa
 		cost = 10
 
 		prerequisite = {
@@ -4470,8 +4555,9 @@ focus_tree = {
 	focus = {
 		id = ENG_revolt_in_quebec
 		icon = quebec_conflict
-		x = 36
-		y = 8
+		x = 0
+		y = 2
+		relative_position_id = ENG_subjugate_ireland
 		cost = 10
 
 		prerequisite = {
@@ -4497,8 +4583,9 @@ focus_tree = {
 	focus = {
 		id = ENG_jingoism
 		icon = Ultranationalism_2
-		x = 38
-		y = 8
+		x = 1
+		y = 1
+		relative_position_id = ENG_maintain_a_multiethnic_army
 		cost = 10
 
 		prerequisite = {
@@ -4521,8 +4608,9 @@ focus_tree = {
 	focus = {
 		id = ENG_army_doctrine_3
 		icon = Generic_ENG_SAS
-		x = 42
-		y = 8
+		x = 1
+		y = 1
+		relative_position_id = ENG_army_of_quality
 		cost = 10
 
 		prerequisite = {
@@ -4551,8 +4639,9 @@ focus_tree = {
 	focus = {
 		id = ENG_naval_doctrine_3
 		icon = wolfpacks
-		x = 50
-		y = 8
+		x = -1
+		y = 1
+		relative_position_id = ENG_improve_our_large_ships
 		cost = 10
 
 		prerequisite = {
@@ -4628,8 +4717,9 @@ focus_tree = {
 	focus = {
 		id = ENG_royal_army
 		icon = british_nationalism
-		x = 42
-		y = 9
+		x = 0
+		y = 1
+		relative_position_id = ENG_army_doctrine_3
 		cost = 25
 
 		prerequisite = {
@@ -4651,8 +4741,9 @@ focus_tree = {
 	focus = {
 		id = ENG_britannia_rules_the_waves
 		icon = amphibious_assault
-		x = 50
-		y = 9
+		x = 0
+		y = 1
+		relative_position_id = ENG_naval_doctrine_3
 		cost = 25
 
 		prerequisite = {


### PR DESCRIPTION
Updates the UK focus tree to use relative_position_id instead of absolute positions for most focuses.
Example:
```
	focus = {
		id = ENG_restore_the_british_empire
		icon = united_anglosphere
		x = 34
		y = 5
		cost = 10

		prerequisite = {
			focus = ENG_imperialism
		}
```
becomes
```
	focus = {
		id = ENG_restore_the_british_empire
		icon = united_anglosphere
		x = -1
		y = 1
		relative_position_id = ENG_imperialism
		cost = 10

		prerequisite = {
			focus = ENG_imperialism
		}
```
The purpose is to make editing the focus tree easier in the future.