### PR TITLE
🐛 Fixing SPR decision SPR_install_the_carlists_decision visibility when country flag SPR_carlist_rising is set

### DIFF
--- a/common/decisions/Spain.txt
+++ b/common/decisions/Spain.txt
@@ -1123,6 +1123,7 @@ SPR_monarchist_spain = {
 		visible = {
 			has_completed_focus = SPR_question_of_thrones
 			has_country_flag = SPR_carlists_chosen
+			NOT = { has_country_flag = SPR_carlist_rising }
 		}
 
 		available = {


### PR DESCRIPTION
[Original Bug Report](https://discord.com/channels/210890013334831104/1435149097677099028/1435149097677099028)
So I was investigating into this bug report, and I found out that the OP's claim is not exactly true since the decision does what it is supposed to do, but there's definitely something to improve.

So, the decision actually does the following: 
It sets a country flag for `SPR_carlist_uprising`, and then it sets the corresponding leaders to carlists. What's missing here that essentially led to this bug report is that the decision does not have a check to hide the decision for when the `SPR_carlist_uprising` contry flag already exists.

Maybe something even better we can do is that we add an event to be triggered for the `remove_effect` to hint the player on what to do next.