### PR TITLE
Fix `MD_focus_PER_l_english.yml` utf-8-bom encoding

### DIFF
--- a/localisation/english/MD_focus_PER_l_english.yml
+++ b/localisation/english/MD_focus_PER_l_english.yml
@@ -1,4 +1,4 @@
- l_english:
+﻿ l_english:
  iran_focus: "Iranian Focus tree"
  # FOCUS TREE
 


### PR DESCRIPTION
In making a change the encoding was set to `utf8` instead of `utf8 with bom` which causes an error.

> [03:10:04][no_game_date][localize.cpp:1628]: Localization file 'localisation/english/MD_focus_PER_l_english.yml' should be in in utf-8-bom encoding
> [03:10:04][no_game_date][pdx_localize.cpp:1015]: Missing UTF8 BOM in localisation/english/MD_focus_PER_l_english.yml

Definitely one of the errors of all time.