### PR TITLE
🐛  Fixed Incorrect state transfer and tech inherit for Catalunya independent event

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -40,6 +40,7 @@ v1.12.2
   - Added visibility condition check to Spanish `Install the Carlist Monarchy` decision
   - Removed global stability penalty for news event `United States Not So United?`
   - Fixed unexpected combatants increments to both sides when using the Serbian `Attack Montenegrin Militants` decisions.
+  - Fixed Incorrect state transfer and tech inherit for Catalunya independent event.
 
  Balance:
   - Reduced the stability penalty for the "Nuclear Power (Offensive)" idea from -0.15 to -0.10

--- a/events/Spain.txt
+++ b/events/Spain.txt
@@ -6082,7 +6082,7 @@ country_event = {
 	picture = GFX_2017_catalan_refer
 	trigger = {
 		original_tag = SPR
-		owns_state = 96
+		owns_state = 86
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
@@ -6095,8 +6095,8 @@ country_event = {
 		custom_effect_tooltip = SPR_catalonia_is_free_tt
 
 		CAT = {
-			transfer_state = 96
-			inherit_technology = FROM
+			transfer_state = 86
+			inherit_technology = SPR
 		}
 		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }


### PR DESCRIPTION
<img width="1312" height="989" alt="image" src="https://github.com/user-attachments/assets/129ff072-59f0-42d2-ae07-c8a7a5f5df3f" />
Fixing the incorrect event effects for Catalunya independent event