### PR TITLE
fix: `FOCUS_FILTER_EQUIPMENT` typo in default focus tree

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -117,6 +117,7 @@ v1.12.3
   - Renamed the religious idea "Christian" to "Western Christian" to more accurately portray it
   - Changes made to Swedish MIO names. Aligning them more closely to what they were in 2000.
   - Fixed some missing localization in the doctrines for some of the unit categories like Light Fighters and All Aircraft
+  - Fixed default focus tree search filter typo (`FOCUS_FILTER_MILITARY_EQUIPMENT` -> `FOCUS_FILTER_EQUIPMENT`).
 
  Performance:
   - Reduced duplicate code across on actions which should hopefully optimize various actions throughout the game

--- a/common/national_focus/generic.txt
+++ b/common/national_focus/generic.txt
@@ -4109,7 +4109,7 @@
 
 		cost = 10
 
-		search_filters = { FOCUS_FILTER_EXPENDITURE FOCUS_FILTER_MILITARY_EQUIPMENT }
+		search_filters = { FOCUS_FILTER_EXPENDITURE FOCUS_FILTER_EQUIPMENT }
 		prerequisite = {
 			focus = GENERIC_military_emergency
 			focus = GENERIC_army_reform


### PR DESCRIPTION
`FOCUS_FILTER_MILITARY_EQUIPMENT` doesn't exist, this typo creates an issue on the default focus tree:

<img width="512" height="171" alt="image" src="https://github.com/user-attachments/assets/66d6ec79-495f-499b-86a3-8337c79fa72f" />
