### PR TITLE
Fix NATO faction disbanding when leader leaves (Issue #94)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -17,6 +17,7 @@ v1.12.3b
   - AI will be more likely to send satellites in the event they are an influencer in your nation
 
  Bugfix:
+ - Fixed NATO faction being disbanded when USA (or any faction leader) leaves NATO - leadership now transfers to another member (Issue #94)
  - Fixed the Zombies not building units due to the productivity system
  - Fixed the decision for Rwanda taking the historical flag in 2001 (gotta love five year old bugs)
  - Fixed the Wehrbereichkommando name list not working as expected when recruiting additional units

--- a/common/scripted_effects/01_NATO_effects.txt
+++ b/common/scripted_effects/01_NATO_effects.txt
@@ -74,6 +74,24 @@ NATO_leave = {
 		remove_from_array = { global.nato_members = THIS }
 		remove_ideas = NATO_member
 		remove_from_tech_sharing_group = NATO_Tech_Share
+
+		# If we are the faction leader, transfer leadership before leaving
+		if = {
+			limit = { is_faction_leader = yes }
+			# Find another NATO member to transfer leadership to
+			random_country = {
+				limit = {
+					has_idea = NATO_member
+					NOT = { tag = ROOT }
+					is_in_faction_with = ROOT
+				}
+				# Transfer faction leadership
+				ROOT = {
+					set_faction_leader = PREV
+				}
+			}
+		}
+
 		leave_faction = yes
 
 		for_each_scope_loop = {

--- a/docs/misc/authors.md
+++ b/docs/misc/authors.md
@@ -164,6 +164,7 @@ The following page is a non-exhaustive list of contributors from over the years 
 | RTmanfre | @RTmanfre | - | - | - |
 | JhonyGEM | @JhonyGEM | @JhonyGEM | - | - |
 | denzzerr | @denzzerr | - | - | - |
+| 4RH1T3CT0R | - | @4RH1T3CT0R7 | - | - |
 
 # Fellow Modders/Teams
 


### PR DESCRIPTION
- Modified NATO_leave scripted effect to transfer faction leadership before leaving
- Updated Changelog.txt with bug fix entry
- Added contributor to authors.md

Resolves GitHub Issue #94 