### PR TITLE
Fixed the Strv 121 tank model showing invisible due to missing entity definition (Issue #139)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -17,6 +17,7 @@ v1.12.4
 
  Bugfix:
   - Fixed NATO faction being disbanded when USA (or any faction leader) leaves NATO - leadership now transfers to another member (Issue #94)
+  - Fixed the Strv 121 tank model showing invisible due to missing entity definition (Issue #139)
   - Fixed the Chechen event "Chechnya Offers Us a Cooperation Agreement" only having position opinion options
   - Fixed the Libyan decision "Dig for Iron Ore in Wadi Ash-Shati"
   - Patched the Afghanistan Almond wall-hack money-treasury-extravaganza

--- a/docs/misc/authors.md
+++ b/docs/misc/authors.md
@@ -164,7 +164,7 @@ The following page is a non-exhaustive list of contributors from over the years 
 | RTmanfre | @RTmanfre | - | - | - |
 | JhonyGEM | @JhonyGEM | @JhonyGEM | - | - |
 | denzzerr | @denzzerr | - | - | - |
-| 4RH1T3CT0R | - | @4RH1T3CT0R7 | - | - |
+| 4RH1T3CT0R | @4rh1t3ct0r | @4RH1T3CT0R7 | - | - |
 
 # Fellow Modders/Teams
 

--- a/gfx/entities/GER_tanks.asset
+++ b/gfx/entities/GER_tanks.asset
@@ -105,6 +105,11 @@ entity = {
 	name = "western_european_gfx_armor_Bat_1_entity_desert"
 	pdxmesh = "GER_medium_tank_Leopard_2A4desert_mesh"
 }
+entity = {
+	clone = "GER_MD4_medium_armor_entity"
+	name = "GEN_Leopard2A4green_entity"
+	pdxmesh = "GER_medium_tank_Leopard_2A4_mesh"
+}
 #Leopard 2A5
 entity = {
 	name = "GER_MD4_medium_armor_3_entity"


### PR DESCRIPTION
The Strv 121 tank had a reference to a non-existent 3D model entity called GEN_Leopard2A4green_entity, which caused the tank to appear invisible and be unassignable in-game

 I've created the missing entity in /Users/artem/PycharmProjects/Millennium-Dawn/gfx/entities/GER_tanks.asset:108-112:
    - Added GEN_Leopard2A4green_entity as a clone of the base GER_MD4_medium_armor_entity
    - Uses the standard GER_medium_tank_Leopard_2A4_mesh

#139 