### PR TITLE
Fix issue #140 and discovered it was affecting multiple landmarks

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -18,6 +18,7 @@ v1.12.4
  Bugfix:
   - Fixed NATO faction being disbanded when USA (or any faction leader) leaves NATO - leadership now transfers to another member (Issue #94)
   - Fixed the Strv 121 tank model showing invisible due to missing entity definition (Issue #139)
+  - Fixed Big Ben and other landmark buildings not displaying due to missing GFX sprite definitions (Issue #140)
   - Fixed the Chechen event "Chechnya Offers Us a Cooperation Agreement" only having position opinion options
   - Fixed the Libyan decision "Dig for Iron Ore in Wadi Ash-Shati"
   - Patched the Afghanistan Almond wall-hack money-treasury-extravaganza

--- a/interface/buildings/MD_landmarks.gfx
+++ b/interface/buildings/MD_landmarks.gfx
@@ -1,5 +1,15 @@
 spriteTypes = {
 	spriteType = {
+		name = "GFX_big_ben_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/big_ben_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_big_ben_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/big_ben_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
 		name = "GFX_kaaba_icon"
 		texturefile = "gfx/interface/buildings/historical_buildings/large/kaaba_icon.dds"
 		noOfFrames = 2
@@ -107,6 +117,86 @@ spriteTypes = {
 	spriteType = {
 		name = "GFX_binnenhof_icon_small"
 		texturefile = "gfx/interface/buildings/historical_buildings/small/binnenhof_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_colosseum_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/colosseum_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_colosseum_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/colosseum_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_cristo_redentor_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/cristo_redentor_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_cristo_redentor_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/cristo_redentor_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_eiffel_tower_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/eiffel_tower_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_eiffel_tower_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/eiffel_tower_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_statue_of_liberty_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/statue_of_liberty_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_statue_of_liberty_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/statue_of_liberty_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_kremlin_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/kremlin_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_kremlin_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/kremlin_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_hofburg_palace_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/hofburg_palace_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_hofburg_palace_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/hofburg_palace_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_berlin_reichstag_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/berlin_reichstag_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_berlin_reichstag_icon_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/berlin_reichstag_icon_small.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_volkshalle_icon"
+		texturefile = "gfx/interface/buildings/historical_buildings/large/volkshalle_icon.dds"
+		noOfFrames = 2
+	}
+	spriteType = {
+		name = "GFX_volkshalle_small"
+		texturefile = "gfx/interface/buildings/historical_buildings/small/volkshalle_small.dds"
 		noOfFrames = 2
 	}
 }


### PR DESCRIPTION
Added GFX sprite definitions for 9 missing landmarks (they were affected too):

Götterdämmerung DLC landmarks:
  1. Big Ben (London, England) - Issue #140
  2. Colosseum (Rome, Italy)
  3. Cristo Redentor (Rio de Janeiro, Brazil)
  4. Eiffel Tower (Paris, France)
  5. Hofburg Palace (Vienna, Austria)
  6. Berlin Reichstag (Berlin, Germany)
  7. Volkshalle (Berlin, Germany)

  Non-DLC landmarks:
  8. Statue of Liberty (New York, USA)
  9. Kremlin (Moscow, Russia)