### PR TITLE
 Fixed the missing Air Force Academy spirit icons 

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -47,7 +47,7 @@ v1.12.4
   - Added another failsafe for the weird edge cases where the Zombies just stopped attacking (damn mechanics)
   - Fixed Tajikistan changing their flag under the Rahmon regime to an alternate flag
   - Fixed Panavia MIO selection for medium aircraft so it can actually be used with the Tornado
-
+  - Fixed the missing Air Force Academy spirit icons
  Content:
   - The Generic focus "Military Education Reform" now gives a +1 skill level to all generals while also increasing your education law for unit leaders
   - The Generic tree will now actually give doctrinal benefits and are now updated to the newest system for doctrines

--- a/interface/officer_corp_spirits.gfx
+++ b/interface/officer_corp_spirits.gfx
@@ -48,11 +48,11 @@ spriteTypes = {
 	spriteType = {
 		name = "GFX_idea_inventive_leadership_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_inventive_leadership.dds"
-	} 
+	}
 	spriteType = {
 		name = "GFX_idea_combined_arms_schools_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_combined_arms_schools.dds"
-	}  	
+	}
 	spriteType = {
 		name = "GFX_idea_deep_defence_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_deep_defence.dds"
@@ -64,16 +64,16 @@ spriteTypes = {
 	spriteType = {
 		name = "GFX_idea_infantry_combat_schools_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_infantry_combat_schools.dds"
-	} 
+	}
 	spriteType = {
 		name = "GFX_idea_self_taught_academy_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_self_taught_academy.dds"
-	} 
+	}
 	spriteType = {
 		name = "GFX_idea_art_of_war_army_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_art_of_war_army.dds"
-	} 
-	
+	}
+
     ### Army Spirits ###
 
     ## Good Spirits ##
@@ -129,7 +129,7 @@ spriteTypes = {
 		name = "GFX_idea_guerrilla_warfare_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_guerrilla_warfare.dds"
 	}
-	
+
    ### ARMY Division Command Spirits ###
 
     ## Good Spirits ##
@@ -177,7 +177,7 @@ spriteTypes = {
 		name = "GFX_idea_counter_insurgency_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_counter_insurgency.dds"
 	}
-	
+
     ### NAVY Academy Spirits ###
 
     ## Good Spirits ##
@@ -229,7 +229,7 @@ spriteTypes = {
 		name = "GFX_idea_rule_the_waves_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_rule_the_waves.dds"
 	}
-	
+
     ### NAVY Spirits ###
 
     ## Good Spirits ##
@@ -317,7 +317,7 @@ spriteTypes = {
 		name = "GFX_idea_bureau_of_ordnance_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_bureau_of_ordnance.dds"
 	}
-	
+
 ### AIR Spirits ###
 
     ## Good Spirits ##
@@ -358,6 +358,34 @@ spriteTypes = {
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_air_crew_surveys.dds"
 	}
 
+ ### AIR Academy Spirits ###
+
+    ## Good Spirits ##
+	spriteType = {
+		name = "GFX_idea_air_combat_training_courses"
+		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_effective_training_programs.dds"
+	}
+	spriteType = {
+		name = "GFX_idea_logistics_training_focus"
+		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_logistical_focus.dds"
+	}
+	spriteType = {
+		name = "GFX_idea_aerospace_defence_focus"
+		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_home_defence.dds"
+	}
+	spriteType = {
+		name = "GFX_idea_legends_of_the_academy"
+		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_veteran_air_instructors.dds"
+	}
+	spriteType = {
+		name = "GFX_idea_air_dominance_theory"
+		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_centralized_control.dds"
+	}
+	spriteType = {
+		name = "GFX_idea_the_bomber_must_get_through"
+		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_industrial_destruction.dds"
+	}
+
  ### AIR Division Command Spirits ###
 
     ## Good Spirits ##
@@ -396,13 +424,13 @@ spriteTypes = {
 	spriteType = {
 		name = "GFX_idea_continuous_strike_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_continuous_strike.dds"
-	} 
+	}
 	spriteType = {
 		name = "GFX_idea_total_devastation_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_total_devastation.dds"
 	}
-	
-	
+
+
 	spriteType = {
 		name = "GFX_idea_elite_fighter_pilots_spirit"
 		texturefile = "gfx/interface/officer_corp/spirits/spirit_idea_elite_fighter_pilots.dds"


### PR DESCRIPTION
Added a new "AIR Academy Spirits" section to the graphics file with icon definitions for all (I hope) 6 missing air force academy spirits:

  1. air_combat_training_courses → Uses spirit_idea_effective_training_programs.dds
  2. logistics_training_focus → Uses spirit_idea_logistical_focus.dds
  3. aerospace_defence_focus → Uses spirit_idea_home_defence.dds
  4. legends_of_the_academy → Uses spirit_idea_veteran_air_instructors.dds
  5. air_dominance_theory → Uses spirit_idea_centralized_control.dds
  6. the_bomber_must_get_through → Uses spirit_idea_industrial_destruction.dds

#170 