### PR TITLE
Fixed Issue #157: Pakistani Taliban Setup

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -48,6 +48,8 @@ v1.12.4
   - Fixed Tajikistan changing their flag under the Rahmon regime to an alternate flag
   - Fixed Panavia MIO selection for medium aircraft so it can actually be used with the Tornado
   - Fixed the missing Air Force Academy spirit icons
+  - Pakistani Taliban is now correctly setup when they are spawned
+
  Content:
   - The Generic focus "Military Education Reform" now gives a +1 skill level to all generals while also increasing your education law for unit leaders
   - The Generic tree will now actually give doctrinal benefits and are now updated to the newest system for doctrines

--- a/events/Taliban.txt
+++ b/events/Taliban.txt
@@ -28,7 +28,46 @@ country_event = {
 				add_state_core = 573
 				add_state_core = 594
 				add_state_core = 993
-				load_oob = ttp_2017
+
+				# Setup country flag for leader system
+				set_country_flag = set_Caliphate
+				set_variable = { Caliphate_leader = 0 }
+				set_leader_TTP = yes
+
+				# Create militia division template
+				division_template = {
+					name = "Taliban Militia"
+					regiments = {
+						Militia_Bat = { x = 0 y = 0 }
+						Militia_Bat = { x = 0 y = 1 }
+						Militia_Bat = { x = 0 y = 2 }
+						Militia_Bat = { x = 0 y = 3 }
+					}
+				}
+
+				# Spawn militia units in capital state
+				594 = {
+					create_unit = {
+						division = "name = \"1st Taliban Militia\" division_template = \"Taliban Militia\" start_experience_factor = 0.3 start_equipment_factor = 0.5"
+						owner = TTP
+					}
+					create_unit = {
+						division = "name = \"2nd Taliban Militia\" division_template = \"Taliban Militia\" start_experience_factor = 0.3 start_equipment_factor = 0.5"
+						owner = TTP
+					}
+					create_unit = {
+						division = "name = \"3rd Taliban Militia\" division_template = \"Taliban Militia\" start_experience_factor = 0.3 start_equipment_factor = 0.5"
+						owner = TTP
+					}
+					create_unit = {
+						division = "name = \"4th Taliban Militia\" division_template = \"Taliban Militia\" start_experience_factor = 0.3 start_equipment_factor = 0.5"
+						owner = TTP
+					}
+					create_unit = {
+						division = "name = \"5th Taliban Militia\" division_template = \"Taliban Militia\" start_experience_factor = 0.3 start_equipment_factor = 0.5"
+						owner = TTP
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
  1. Removed broken OOB reference - Deleted load_oob = ttp_2017 which no longer exists

  2. Added leader setup - Added proper initialization:
    - Set country flag for Caliphate ideology system
    - Initialized leader variable
    - Called set_leader_TTP effect to assign proper leader (Nek Muhammad Wazir)
  3. Created militia division template - Added "Taliban Militia" template with 4 Militia battalions
  4. Spawned 5 militia units - Created units in their capital state (594):
    - 1st through 5th Taliban Militia divisions
    - Start experience: 0.3 (low experience, as expected for insurgents)
    - Start equipment: 0.5 (limited equipment)

#157 

Review required