### PR TITLE
Implemented changes to the "Restore the Plama Pleven Refinery" focus

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -23,6 +23,7 @@ v1.12.4
   - Added MIO Benefits for North Korea
   - Added a Starting Nuclear Reactor for North korea without any entrenchment facility
   - Added Entrenchment facility in the Focuses for North Korea to Balance out some stuff and help players Have Easier Start
+  - Updated Restore Pleven Focus to give bonuses for Bulgarian fuel
 
  Bugfix:
   - Fixed Linux runtime crashes caused by parsing errors (Issue #176)

--- a/common/ideas/bulgarian.txt
+++ b/common/ideas/bulgarian.txt
@@ -1062,6 +1062,15 @@ ideas = {
 				energy_gain_multiplier = 0.03
 			}
 		}
+		#Plama Pleven Refinery
+		BUL_plama_pleven_refinery = {
+			allowed = { always = yes }
+			picture = oil_production2
+			modifier = {
+				corporate_tax_income_multiplier_modifier = 0.02
+				fuel_gain_factor = 0.02
+			}
+		}
 		#Vivacom
 		BUL_vivacom_idea = {
 			allowed = { always = yes }

--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -473,7 +473,10 @@ focus_tree = {
 		}
 
 		completion_reward = {
+			log = "[GetDateText]: [This.GetName]: BUL_restore_pleven"
 			one_random_synthetic_refinery = yes
+			add_resource = { type = oil amount = 2 state = 153 }
+			add_ideas = BUL_plama_pleven_refinery
 		}
 
 		ai_will_do = {

--- a/localisation/english/MD_focus_BUL_l_english.yml
+++ b/localisation/english/MD_focus_BUL_l_english.yml
@@ -426,7 +426,7 @@
  BUL_appeal_to_farmers: "Agro-Reformation"
  BUL_appeal_to_farmers_desc: "Our agriculture must be reformed to become more beneficial."
  BUL_cult_of_past: "Cult of Past"
- BUL_cult_of_past_desc: "In an unexpected turn of events, the newly elected nationalist government of Bulgaria has thrown its support behind a controversial patriotic cult known as "Past". The group, which claims to be descended from the ancient Thracians, has long been shunned by mainstream society for its extremist beliefs and violent tactics. But now, with the backing of the government, Past has been emboldened, and its members have become increasingly aggressive in their actions."
+ BUL_cult_of_past_desc: "In an unexpected turn of events, the newly elected nationalist government of Bulgaria has thrown its support behind a controversial patriotic cult known as 'Past'. The group, which claims to be descended from the ancient Thracians, has long been shunned by mainstream society for its extremist beliefs and violent tactics. But now, with the backing of the government, Past has been emboldened, and its members have become increasingly aggressive in their actions."
 
  bulg.7.t: "Bulgarian Politics"
  bulg.7.d: "In the year 2000, Bulgaria was undergoing significant changes in its political landscape. The country was still recovering from the economic and political turmoil of the 1990s, and there was a growing sense of frustration among the people towards the government. The ruling party, the Bulgarian Socialist Party (BSP), had been in power since 1995 and was facing increasing criticism for its handling of the economy and corruption allegations. In this context, the presidential elections of 2000 were a crucial moment for the country. The incumbent president, Petar Stoyanov, ran for re-election as an independent candidate, promising to continue his pro-European and pro-market reforms. He faced a tough challenge from the BSP's candidate, Georgi Parvanov, who promised a return to socialist policies and closer ties with Russia. In the end, Stoyanov won a narrow victory, securing a second term in office. However, Parvanov's strong showing signaled a shift in the political climate"
@@ -920,6 +920,7 @@
  BUL_overgas_idea: "Overgas Inc. AD"
  BUL_vivacom_idea: "Vivacom"
  BUL_energyholding_idea: "Bulgarian Energy Holding"
+ BUL_plama_pleven_refinery: "Plama Pleven Refinery"
  BUL_tourism: "Tourism in Bulgaria"
  BUL_agrix_idea: "Agrix"
  BUL_agria_idea: "Agria Group Holding JSC"


### PR DESCRIPTION
 1. Created New Idea 
  Added a new national spirit BUL_plama_pleven_refinery that provides:
  - +2% corporate tax revenue (corporate_tax_income_multiplier_modifier = 0.02)
  - +2% fuel gain (fuel_gain_factor = 0.02) - representing the refinery's lubricant and fuel production

  2. Modified Focus 

  Updated the BUL_restore_pleven focus to:
  - Add 2 oil resources to state 153 (Western Bulgaria, where Pleven is located)
  - Grant the new national spirit for corporate tax revenue and fuel production bonuses
  - Added logging for proper tracking
  - Kept the existing synthetic refinery building reward

  3. Added Localization 
  - Added the name "Plama Pleven Refinery" for the new idea
  - Also fixed a pre-existing YAML syntax error (changed double quotes to single quotes in the "Past" cult description)


AND edits from closed PR #195 