### PR TITLE
Armenian Loc Fixes

### DIFF
--- a/localisation/english/MD_focus_ARM_l_english.yml
+++ b/localisation/english/MD_focus_ARM_l_english.yml
@@ -69,7 +69,7 @@
  arme.2.d: "The assassination attempt on Arkady Ghukasyan showed that not everyone accepts his policy. At about one in the morning, the president's car was fired upon from an ambush, which was set up just 200 meters from the residence. The terrorists opened crossfire from both sides simultaneously. Ghukasyan was wounded in the legs, and two of his guards were seriously wounded."
  arme.2.a: "Terrible!"
  arme.2.b: "Caucasian showdown."
- arme.2.c: "We Need to End Banditry."
+ arme.2.c: "We need to end banditry."
  arme.2.o1: "It's a pity that they didn't kill him!"
  arme.3.t: "Communists of Transcaucasia have united into the \"Red Bridge\""
  arme.3.d: "On Saturday, the communists of Azerbaijan, Armenia and Georgia united again. During the meeting of the top leadership of the Communist Parties of Transcaucasia, which took place at the Red Bridge (the place where the borders of all three republics meet), a protocol was signed on the establishment of the Armenian-Azerbaijani-Georgian public communist organization \"Red Bridge - Brotherhood and Friendship. countries, there are no contradictions, and therefore, the communists are the only force capable of settling all conflicts in the region, \"- said Comrade Georgadze."


### PR DESCRIPTION
Just finished a play-through as Armenia, and a new round of small typos I caught (I only did full-left ARF, so I probably didn't catch all of them). Its only a few typos, inconsistent use of punctuation, and some minor editing where there was random capitalization. Much like Egypt, it was pretty fun!

I also noticed a few bugs:

-Active Diplomacy auto-bypassed for me, so I was unable to create my own faction and declare war on Turkey without some shenanigans. Perhaps if the player is in a faction, but not the faction leader, it should block the focus?

-It likely isn't a bug, but just in case; there are a number of states you get claims on, such as Djavakheti, as seemingly any political party, but only some can actually integrate.

-Puppet Lebanon will not remain under ARF influence due to influence from any ARF aligned Armenia slowly drifting towards nationalist or emerging support. Fairly minor, but since the entire premise of the event was that the ARF were taking power, it is a little odd (I imagine even moreso if you are playing as a nationalist ARF).

-Labour Unions never appeared for me as an internal faction and thus the focus 'Embrace Left-Wing Origins' never did anything with internal factions. It is possible its because I had done the focus to get rid of Oligarchs within Kocharyan's tree beforehand.

-The leader put into power by the 'Embrace Left-wing Origins' focus vanished as soon as I unified Armenia, I'm unsure if that is intended or not.


After peeking at Libya, I should also probably mention that Egypt (I was playing as the Autocratic pan-Arabic party) can form the African Union after forming the UAR - which Libya seems to be barred from doing? Egypt->UAR->Africa was pretty fun though! I think I'll be waiting for the tech extension integration before doing another game quite that long though.