### PR TITLE
Fix of issue #203: Armenian Issues

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -28,6 +28,8 @@ v1.12.4
 
  Bugfix:
   - Fixed Linux runtime crashes caused by parsing errors (Issue #176)
+  - [ARM] Fixed Active Diplomacy focus auto-bypassing when in any faction instead of only when faction leader (Issue #203)
+  - [ARM] Fixed Embrace Left-Wing Origins focus not adding labour_unions if Bosses Elimination was completed first (Issue #203)
   - Renamed "special forces" subdoctrine directory to "special_forces" to fix Linux path parsing
   - Fixed NATO faction being disbanded when USA (or any faction leader) leaves NATO - leadership now transfers to another member (Issue #94)
   - Fixed investment system allowing AI to offer investments for buildings when pending projects would already max out capacity (Issue #99)

--- a/common/national_focus/armenia.txt
+++ b/common/national_focus/armenia.txt
@@ -4256,9 +4256,23 @@ focus_tree = {
 					inexperienced
 				}
 			}
-			swap_ideas = {
-				remove_idea = oligarchs
-				add_idea = labour_unions
+			if = {
+				limit = {
+					has_idea = oligarchs
+				}
+				swap_ideas = {
+					remove_idea = oligarchs
+					add_idea = labour_unions
+				}
+			}
+			if = {
+				limit = {
+					has_idea = small_medium_business_owners
+				}
+				swap_ideas = {
+					remove_idea = small_medium_business_owners
+					add_idea = labour_unions
+				}
 			}
 		}
 		ai_will_do = {
@@ -18232,7 +18246,7 @@ focus_tree = {
 			}
 
 			bypass = {
-				is_in_faction = yes
+				is_faction_leader = yes
 			}
 
 			completion_reward = {


### PR DESCRIPTION
1. Problem: Focus was bypassing when Armenia joined ANY faction, preventing players from creating their own faction.

Fix: Changed bypass condition from is_in_faction = yes to is_faction_leader = yes

Now the focus only bypasses if you already lead a faction, not when you're just a member.

2. Problem: The "Embrace Left-Wing Origins" focus failed to add the labour_unions internal faction if players completed "Bosses Elimination" first (which swaps oligarchs → small_medium_business_owners). The focus tried to remove oligarchs which no longer existed, causing the swap to fail silently.

Fix: Added conditional logic to handle both scenarios:
Now labour_unions will be added regardless of which path you took

3. The Lebanon puppet script gives a one-time influence boost (+10%) and changes their government to pro-ARF, but there's no ongoing maintenance mechanism

Why it happens: The mod's influence system naturally drifts based on government alignment, economic ties, and competing foreign influence. There's no generic mechanic to lock puppet influence

4. I couldn't find any code that removes the "Dashnak Committee" leader during unification. No Armenia-specific on_actions, events, or focus effects retire this leader

#203 
