### PR TITLE
 Fix for Issue #218: SAM Missile Icons Not Matching Equipment

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -37,6 +37,8 @@ v1.12.4
   - Nerfed the amount of economic bonuses you could get as Iran
 
  Bugfix:
+  - Added missing intelligence agency advisors for spymaster role (Issue #110)
+  - Fixed SAM missile icons not matching their equipment variants in deployment UI (Issue #218)
   - Fixed Linux runtime crashes caused by parsing errors (Issue #176)
   - [ARM] Fixed Active Diplomacy focus auto-bypassing when in any faction instead of only when faction leader (Issue #203)
   - [ARM] Fixed Embrace Left-Wing Origins focus not adding labour_unions if Bosses Elimination was completed first (Issue #203)

--- a/interface/Technologies.gfx
+++ b/interface/Technologies.gfx
@@ -4995,66 +4995,40 @@ spriteTypes = {
 	# 	name = "GFX_SAM0_TEL_medium"
 	# 	texturefile = "gfx/interface/technologies/Generic/Missiles/AAM_1.dds"
 	# }
+	# SAM Ship Icons - using TAA (naval anti-air) textures
 	SpriteType = {
 		name = "GFX_SAM0_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/TAA1.dds"
-	}
-	SpriteType = {
-		name = "GFX_SAM1_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
 	}
 	SpriteType = {
 		name = "GFX_SAM1_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/TAA2.dds"
 	}
 	SpriteType = {
-		name = "GFX_SAM2_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
-	}
-	SpriteType = {
 		name = "GFX_SAM2_ship_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM1.dds"
-	}
-	SpriteType = {
-		name = "GFX_SAM3_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
+		texturefile = "gfx/interface/technologies/Generic/Missiles/TAA2.dds"
 	}
 	SpriteType = {
 		name = "GFX_SAM3_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM2.dds"
 	}
 	SpriteType = {
-		name = "GFX_SAM4_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
-	}
-	SpriteType = {
 		name = "GFX_SAM4_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM3.dds"
-	}
-	SpriteType = {
-		name = "GFX_SAM5_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
 	}
 	SpriteType = {
 		name = "GFX_SAM5_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM4.dds"
 	}
 	SpriteType = {
-		name = "GFX_SAM6_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
-	}
-	SpriteType = {
 		name = "GFX_SAM6_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM5.dds"
-	}
-	SpriteType = {
-		name = "GFX_SAM7_TEL_medium"
-		texturefile = "gfx/interface/technologies/Generic/Missiles/mechanised_offensive.dds"
 	}
 	SpriteType = {
 		name = "GFX_SAM7_ship_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM5.dds"
 	}
+	# Note: SAM TEL icons are defined later in this file with correct textures
 	SpriteType = {
 		name = "GFX_missile_defense_medium"
 		texturefile = "gfx/interface/technologies/Generic/Missiles/SAM1.dds"

--- a/interface/mdult_missiles.gfx
+++ b/interface/mdult_missiles.gfx
@@ -360,6 +360,39 @@ spriteTypes = {
 		name = "GFX_SAM7_medium"
 		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MEADS.dds"
 	}
+	# SAM Equipment Variant Icons (for production/deployment UI)
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_1_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MIM-23 Hawk.dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_2_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MIM-23 Hawk.dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_3_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MIM-104C (PAC-2) patriot.dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_4_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MIM-104F (PAC-3).dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_5_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MIM-104F (PAC-3).dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_6_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MIM-104F (PAC-3).dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_7_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MEADS.dds"
+	}
+	SpriteType = {
+		name = "GFX_sam_missile_equipment_8_medium"
+		texturefile = "gfx/interface/scripted_gui/missiles/models/USA/MEADS.dds"
+	}
 	SpriteType = {
 		name = "GFX_ABM0_medium"
 		texturefile = "gfx/interface/scripted_gui/missiles/models/generic/MD_ABM_icon.dds"
@@ -845,7 +878,7 @@ spriteTypes = {
 		name = "GFX_GER_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_SPR_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -878,7 +911,7 @@ spriteTypes = {
 		name = "GFX_SPR_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_POR_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -911,7 +944,7 @@ spriteTypes = {
 		name = "GFX_POR_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_DEN_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -944,7 +977,7 @@ spriteTypes = {
 		name = "GFX_DEN_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_NOR_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -977,7 +1010,7 @@ spriteTypes = {
 		name = "GFX_NOR_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_SWE_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -1010,7 +1043,7 @@ spriteTypes = {
 		name = "GFX_SWE_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_HOL_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -1043,7 +1076,7 @@ spriteTypes = {
 		name = "GFX_HOL_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_BEL_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"
@@ -1076,7 +1109,7 @@ spriteTypes = {
 		name = "GFX_BEL_SAM7_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/IRIST.dds"
 	}
-	
+
 	SpriteType = {
 		name = "GFX_POL_SAM0_medium"
 		texturefile = "gfx/interface/technologies/GER/MISSILE/MIM23.dds"


### PR DESCRIPTION
  The problem was that SAM missile icons in the deployment/production UI didn't match their corresponding equipment variants because:

1. Missing equipment variant icons: The game uses GFX_<equipment_name>_medium pattern for equipment icons, but SAM missiles only had GFX_SAM0_medium through GFX_SAM7_medium (tech icons), not GFX_sam_missile_equipment_1_medium through GFX_sam_missile_equipment_8_medium (equipment icons).
2. Duplicate/wrong tech icons: In Technologies.gfx, there were duplicate definitions for GFX_SAM#_TEL_medium icons - the first set used the wrong texture (mechanised_offensive.dds) before being overwritten by correct definitions later

1. Added equipment variant icons (interface/mdult_missiles.gfx)

2. Fixed duplicate/wrong definitions (interface/Technologies.gfx):
  - Removed duplicate GFX_SAM#_TEL_medium definitions that used wrong mechanised_offensive.dds texture
  - Fixed ship icon texture assignments that were off by one number
  - Kept the correct TEL definitions later in the file with proper SAM battery textures

fix #218 