### PR TITLE
Fix for issue #231. Here's a summary of the changes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -6,6 +6,10 @@ v1.12.4
   - Fixed a broken AI strategy for Egypt which was incorrectly referencing LBA instead of EGY
   - The Serbian AI should no longer suicide itself into other post-Yugoslavia nations
   - Improved AI decision-making for Libyan tribal mechanics to prevent civil wars (Issue #153)
+  - [LBA] Improved AI handling of Gaddafi family stability mechanics (Issue #231)
+    - AI now proactively uses TV speech and lawsuit decisions based on family instability level
+    - Reduced family instability decay rate from -0.25 to -0.20 per family member
+    - This prevents the Gaddafi civil war from triggering earlier than expected
   - AI oil development decisions now use balanced thresholds (45%/25% vs previous 70%/40%)
   - AI tribal placate decisions now use escalating urgency weights with cross-referencing
   - AI now avoids placating one tribe if it would endanger others (prevents creating new crises)

--- a/common/decisions/libya.txt
+++ b/common/decisions/libya.txt
@@ -2052,10 +2052,15 @@ libya_gaddafi_family = {
 		}
 
 		ai_will_do = {
-			factor = 5
+			factor = 50
+			#Fire only once decision - AI should take it early to reduce instability
 			modifier = {
-				factor = 0
-				has_stability > 0.20
+				factor = 2
+				check_variable = { gaddafi_family_instability > 30 }
+			}
+			modifier = {
+				factor = 2
+				check_variable = { gaddafi_family_instability > 60 }
 			}
 		}
 
@@ -4172,10 +4177,23 @@ libya_gaddafi_family = {
 		}
 
 		ai_will_do = {
-			factor = 5
+			factor = 10
+			#AI should proactively manage family instability before stability crashes
 			modifier = {
-				factor = 0
-				has_stability > 0.20
+				factor = 3
+				check_variable = { gaddafi_family_instability > 50 }
+			}
+			modifier = {
+				factor = 3
+				check_variable = { gaddafi_family_instability > 100 }
+			}
+			modifier = {
+				factor = 2
+				check_variable = { gaddafi_family_instability > 150 }
+			}
+			modifier = {
+				factor = 2
+				has_stability < 0.30
 			}
 		}
 

--- a/common/scripted_effects/99_LBA_scripted_effects.txt
+++ b/common/scripted_effects/99_LBA_scripted_effects.txt
@@ -157,7 +157,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = muhammad_muammar_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Muhammad Muammar Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = muhammad_muammar_gaddafi_head_of_GPTC }
 				add_ideas = LBA_head_of_gptc_idea_version
@@ -177,7 +177,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = saif_al_islam_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Saif al-Islam Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = saif_al_islam_gaddafi_master_maneuverer }
 				add_ideas = LBA_master_maneuverer_idea_version
@@ -197,7 +197,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = al_saadi_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Al-Saadi Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = al_saadi_gaddafi_vain_football_star }
 				add_ideas = LBA_vain_football_star_idea_version
@@ -217,7 +217,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = mutassim_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Al-Saadi Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = mutassim_gaddafi_77th_tank_battalion }
 				add_ideas = LBA_77th_tank_battalion_idea_version
@@ -241,7 +241,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = hannibal_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Hannibal Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = hannibal_gaddafi_bachelor_of_marine_navigation }
 				add_ideas = LBA_bachelor_of_marine_navigation_idea_version
@@ -265,7 +265,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = ayesha_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Ayesha Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = ayesha_gaddafi_claudia_schiffer }
 				add_ideas = LBA_claudia_schiffer_of_north_africa_idea_version
@@ -289,7 +289,7 @@ update_gaddafi_family_ideas = {
 				NOT = { has_country_flag = saif_al_arab_gaddafi_dead }
 				NOT = { has_country_leader = { name = "Saif al-Arab Gaddafi" ruling_only = yes } }
 			}
-			add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+			add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			if = {
 				limit = { has_country_flag = saif_al_arab_gaddafi_convicted_criminal }
 				add_ideas = LBA_convicted_criminal_idea_version
@@ -303,7 +303,7 @@ update_gaddafi_family_ideas = {
 			}
 			if = {
 				limit = { NOT = { has_country_flag = khamis_gaddafi_underage } }
-				add_to_variable = { gaddafi_family_instability_decay = -0.25 }
+				add_to_variable = { gaddafi_family_instability_decay = -0.20 }
 			}
 			if = {
 				limit = { has_country_flag = khamis_gaddafi_khamis_brigade }


### PR DESCRIPTION
  1. Flawed AI decision weights - The two main decisions that reduce family instability (libya_gaddafi_family_hold_tv_speech_gaddafi and libya_gaddafi_family_sue_sunday_telegraph_saif_al_islam) had ai_will_do logic that prevented the AI from taking them until stability was already critically low (<20%)
  2. Unchecked instability accumulation - Each of the 8 Gaddafi family members added -0.25 to instability decay monthly, meaning +2.0 instability/month with no proactive AI countermeasures

 1. common/decisions/libya.txt
  - libya_gaddafi_family_hold_tv_speech_gaddafi (line 4174-4193): Changed AI logic to take the decision proactively based on gaddafi_family_instability variable thresholds (50, 100, 150) and stability <0.30
  - libya_gaddafi_family_sue_sunday_telegraph_saif_al_islam (line 2054-2065): Increased base factor and added urgency based on instability levels

  2. common/scripted_effects/99_LBA_scripted_effects.txt
  - Reduced family instability decay rate from -0.25 to -0.20 per family member (lines 160, 180, 200, 220, 244, 268, 292, 306)
  - This reduces instability growth from +24/year to +19.2/year, giving the AI more time to respond

fix #231 