### PR TITLE
Fixed issue #234: Iranian Majles Mission "Kermanshah's Oxygen" Not Getting Completed

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -77,6 +77,7 @@ v1.12.4
   - Disabled North Korea from Retiring Leader to Avoid breaking the Focuses and blocking you from Choosing one of the Kim brothers
   - Removed a spamming error in the error log regarding the "Israeli Settlements" idea which no longer exists
   - Fixed an Ecuadorian politician not correctly being parsed due to a missed placed comment
+  - [PER] Fixed Kermanshah's Oxygen mission checking wrong province (12773 instead of city province 16155) (Issue #234)
   - Fixed the Zusana design not being correctly parsed on game start
   - Fixed a spamming error regarding the MNF when they're not quite existing yet
   - Fixed the Swedish Division Name List "Amfiberegemente" being available to all countries

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -7841,8 +7841,7 @@ PER_new_majlis = {
 				1139 = {
 					any_province_building_level = {
 						province = {
-							id = 12773
-							limit_to_border = yes
+							id = 16155
 						}
 						building = supply_node
 						level > 0


### PR DESCRIPTION
The mission was checking for a supply hub in the wrong province:
  - Checked: Province 12773 (hills terrain)
  - Correct: Province 16155 (urban terrain with victory points - the actual city of Kermanshah)

Additionally, the code had an unnecessary limit_to_border = yes condition that could cause issues

fix #234 