### PR TITLE
Financial aid for Kosovo (Issue #230)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -44,6 +44,7 @@ v1.12.4
   - Increased the trade opinion, political power gain and gave a little bit of emerging drift to the SCO member ideas
   - Increased the Oil gained from the South China Sea decisions so they're more worth their cost
   - Increased the naval max range factor from the support ships
+  - Added "International Aid" national spirit for Kosovo providing weekly income from UNMIK, USAID, and EU aid programs (Issue #230)
 
  Bugfix:
   - Added missing intelligence agency advisors for spymaster role (Issue #110)

--- a/common/ideas/Serbian.txt
+++ b/common/ideas/Serbian.txt
@@ -3301,6 +3301,16 @@ ideas = {
 				health_cost_multiplier_modifier = -0.10
 			}
 		}
+
+		KOS_international_aid = {
+
+			picture = kos_un_mission_idea
+			modifier = {
+				custom_modifier_tooltip = KOS_international_aid_income_tt
+				production_speed_buildings_factor = 0.10
+				consumer_goods_factor = 0.10
+			}
+		}
 		#
 		KOS_ethnic_troubles = {
 

--- a/common/scripted_effects/00_money_system.txt
+++ b/common/scripted_effects/00_money_system.txt
@@ -788,6 +788,14 @@ calculate_additional_income_rate = {
 			add_to_variable = { additional_income_rate = Bosnia_united_nations_aid }
 		}
 	}
+	# Kosovo
+	if = { limit = { original_tag = KOS }
+		if = {
+			limit = { has_idea = KOS_international_aid }
+			set_variable = { KOS_international_aid_income = 0.3 }
+			add_to_variable = { additional_income_rate = KOS_international_aid_income }
+		}
+	}
 	# San-Marino
 	if = {
 		limit = { original_tag = SMA }

--- a/history/countries/KOS - Kosovo.txt
+++ b/history/countries/KOS - Kosovo.txt
@@ -14,6 +14,7 @@
 		KOS_Ruined_Nations
 		KOS_bad_water_acces
 		KOS_ethnic_troubles
+		KOS_international_aid
 		sunni
 		Non_State_Actor
 		stagnation

--- a/localisation/english/MD_focus_SER_VOJ_MNT_l_english.yml
+++ b/localisation/english/MD_focus_SER_VOJ_MNT_l_english.yml
@@ -2027,6 +2027,8 @@
  KOS_Land_Mines: "Land Mines"
  KOS_bad_water_acces: "Bad Water Access"
  KOS_ethnic_troubles: "Ethnic Troubles"
+ KOS_international_aid: "International Aid"
+ KOS_international_aid_desc: "In the aftermath of the Kosovo War, international organizations such as UNMIK, USAID, and various European development agencies have provided substantial financial and developmental assistance to help rebuild our shattered economy and institutions.\n§W--------------§!\nThis national idea provides weekly income from international donors."
  CES_industry_focus_idea: "Economic Support From UN"
  CES_education_focus_idea: "Educational Support From UN"
  CES_social_focus_idea: "Social Support From UN"

--- a/localisation/english/MD_money_l_english.yml
+++ b/localisation/english/MD_money_l_english.yml
@@ -243,6 +243,8 @@
  BOS_united_nations_aid_TT: "$$[?Bosnia_united_nations_aid|+3] from §YWorld Bank, USAID, UNDP and CARDS§!\nWill §RCancel§! if the Internatial support Leaves"
  BOS_EUFOR_aid_money: "$$[?BOS_EUFOR_aid_money|+3] from §YCARDS Program Funding§!\n"
  BOS_cards_programs: "$$[?BOS_cards_programs|+3] from §YCARDS Program Funding§!\n"
+ KOS_international_aid_income_TT: "$$[?KOS_international_aid_income|+3] from §YUNMIK, USAID, and EU Aid Programs§!\n"
+ KOS_international_aid_income_tt: "Provides weekly income from §YUNMIK, USAID, and EU Aid Programs§!"
  partial_control_of_suez_TT: "$$[?additional_income_suez_partial|+3] from §Y$partial_control_of_suez$§!\n"
  full_control_of_panama_TT: "$$[?additional_income_panama|+3] from §Y$full_control_of_panama$§!\n"
  saudi_aid_TT: "$$[?additional_income_saudi_aid|+3] from §Y$saudi_aid$§!\n"


### PR DESCRIPTION
 1. New National Spirit (common/ideas/Serbian.txt:3305):
    - Added KOS_international_aid idea that provides: - +10% building construction speed - +10% consumer goods factor - Weekly income tooltip
  2. Money System Integration (common/scripted_effects/00_money_system.txt:791-798):
    - Added Kosovo to the calculate_additional_income_rate scripted effect
    - Provides 0.3 billion weekly income when Kosovo has the international aid idea (similar to Bosnia's 0.4 billion)
  3. Starting Setup (history/countries/KOS - Kosovo.txt:17):
    - Added KOS_international_aid to Kosovo's starting national spirits

  - Kosovo now receives 0.3 billion weekly income from international aid (representing UNMIK, USAID, and EU development programs)
  - This should help offset their starting financial difficulties caused by:
    - -1.00 PP/day from "Scars of The Yugoslav War"
    - High bureaucracy/building penalties from other starting debuffs
    - Low starting treasury (1 billion) with 2 billion debt

  The aid is similar in design to Bosnia's bos_international_funding system, which is historically appropriate since both countries received substantial international reconstruction assistance in the post-Yugoslav War period

fix #230 