### PR TITLE
Fix MIO trait errors and focus/NS issues for AAT DLC

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -103,6 +103,8 @@ v1.12.4
   - Removed the double definition of support in Motorized Recon Company
   - Fixed Dutch Focus "Modernize MRAD" not being available while having the tech that was needed. Also added a bypass when all you states are maxed out on Anti-Air
   - Fixed an issue where an internal faction check in various nations (most noticeable in China) would allow you to take a decision or focus despite it not having enough opinion
+  - Fixed Errors for Non-AAT owners trying to complete MIO traits.
+  - Fixed 'Increasing Military Capabilities' Venezualan National Spirit to be canceled when completing the focus giving it
 
  Content:
   - The Generic focus "Military Education Reform" now gives a +1 skill level to all generals while also increasing your education law for unit leaders

--- a/common/ideas/Venezuelan.txt
+++ b/common/ideas/Venezuelan.txt
@@ -550,13 +550,6 @@ ideas = {
 			allowed = {
 				original_tag = VEN
 			}
-			cancel = {
-				NOT = {
-					OR = {
-						nationalist_monarchists_are_in_power_or_coalition = yes
-					}
-				}
-			}
 			modifier = {
 				consumer_goods_factor = 0.10
 				industrial_capacity_factory = 0.10

--- a/common/national_focus/netherlands.txt
+++ b/common/national_focus/netherlands.txt
@@ -8612,7 +8612,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_Hollandklasse_Frigate"
 			create_equipment_variant = {
 				name = "Hollandklasse"
-				type = frigate_hull_4
+				type = frigate_hull_3
 				parent_version = 3
 				allow_without_tech = yes
 				modules = {
@@ -9062,14 +9062,14 @@ focus_tree = {
 					fixed_ship_auxillary_slot = module_vls_sub_asm_3
 					fixed_ship_battery_slot = module_anti_ship_torpedoes_3
 				}
-				design_team = mio:FRA_naval_group_naval_manufacturer
+				design_team = mio:HOL_Naval_Group_naval_equipment_organisation
 			}
 			add_equipment_production = {
 				equipment = {
 					version_name = "Barracuda Class"
 					type = attack_submarine_hull_4
 				}
-				industrial_manufacturer = mio:FRA_naval_group_naval_manufacturer
+				industrial_manufacturer = mio:HOL_Naval_Group_naval_equipment_organisation
 				amount = 1
 				progress = 0.15
 				requested_factories = 1
@@ -9079,7 +9079,7 @@ focus_tree = {
 					version_name = "Barracuda Class"
 					type = attack_submarine_hull_4
 				}
-				industrial_manufacturer = mio:FRA_naval_group_naval_manufacturer
+				industrial_manufacturer = mio:HOL_Naval_Group_naval_equipment_organisation
 				amount = 1
 				progress = 0.15
 				requested_factories = 1
@@ -9089,7 +9089,7 @@ focus_tree = {
 					version_name = "Barracuda Class"
 					type = attack_submarine_hull_4
 				}
-				industrial_manufacturer = mio:FRA_naval_group_naval_manufacturer
+				industrial_manufacturer = mio:HOL_Naval_Group_naval_equipment_organisation
 				amount = 1
 				progress = 0.15
 				requested_factories = 1
@@ -9099,7 +9099,7 @@ focus_tree = {
 					version_name = "Barracuda Class"
 					type = attack_submarine_hull_4
 				}
-				industrial_manufacturer = mio:FRA_naval_group_naval_manufacturer
+				industrial_manufacturer = mio:HOL_Naval_Group_naval_equipment_organisation
 				amount = 1
 				progress = 0.15
 				requested_factories = 1

--- a/history/countries/SOV - Russia.txt
+++ b/history/countries/SOV - Russia.txt
@@ -21,90 +21,93 @@ capital = 652
 
 	complete_special_project = sp:sp_aircraft_project
 
-	mio:SOV_rostec_materiel_manufacturer = {
+	if = {
+		limit = { has_dlc = "Arms Against Tyranny" }
+		mio:SOV_rostec_materiel_manufacturer = {
 		complete_mio_trait = generic_mio_inf_trait_inf_rel
 		complete_mio_trait = generic_mio_inf_trait_art_stats
 		complete_mio_trait = generic_mio_inf_trait_inf_eq_cost
-	}
+		}
 
-	mio:SOV_military_industry_company_tank_manufacturer = {
-		complete_mio_trait = generic_mio_tank_trait_prod_growth
-		complete_mio_trait = generic_mio_tank_trait_research
-		complete_mio_trait = generic_mio_tank_trait_production
-	}
+		mio:SOV_military_industry_company_tank_manufacturer = {
+			complete_mio_trait = generic_mio_tank_trait_prod_growth
+			complete_mio_trait = generic_mio_tank_trait_research
+			complete_mio_trait = generic_mio_tank_trait_production
+		}
 
-	mio:SOV_rostec_tank_manufacturer = {
-		complete_mio_trait = generic_mio_tank_trait_light_veh_rel
-		complete_mio_trait = generic_mio_tank_trait_speed
-		complete_mio_trait = generic_mio_tank_trait_light_eff
-	}
+		mio:SOV_rostec_tank_manufacturer = {
+			complete_mio_trait = generic_mio_tank_trait_light_veh_rel
+			complete_mio_trait = generic_mio_tank_trait_speed
+			complete_mio_trait = generic_mio_tank_trait_light_eff
+		}
 
-	mio:SOV_kurganmashzavod_tank_manufacturer = {
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_ifv_stats
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_prod_eff
-		complete_mio_trait = generic_mio_spec_tank_trait_research
-	}
+		mio:SOV_kurganmashzavod_tank_manufacturer = {
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_ifv_stats
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_prod_eff
+			complete_mio_trait = generic_mio_spec_tank_trait_research
+		}
 
-	mio:SOV_uralvagonzavod_tank_manufacturer = {
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_tank_stats
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_prod_eff
-		complete_mio_trait = generic_mio_spec_tank_trait_research
-	}
+		mio:SOV_uralvagonzavod_tank_manufacturer = {
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_tank_stats
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_prod_eff
+			complete_mio_trait = generic_mio_spec_tank_trait_research
+		}
 
-	mio:SOV_almaz_antey_materiel_manufacturer = {
-		complete_mio_trait = generic_mio_inf_trait_inf_rel
-		complete_mio_trait = generic_mio_inf_trait_cnc_prod_cost
-		complete_mio_trait = generic_mio_inf_reass_buff
-	}
+		mio:SOV_almaz_antey_materiel_manufacturer = {
+			complete_mio_trait = generic_mio_inf_trait_inf_rel
+			complete_mio_trait = generic_mio_inf_trait_cnc_prod_cost
+			complete_mio_trait = generic_mio_inf_reass_buff
+		}
 
-	mio:SOV_jsc_defense_systems_materiel_manufacturer = {
-		complete_mio_trait = generic_mio_at_aa_trait_rel
-		complete_mio_trait = generic_mio_at_aa_trait_at_stats
-		complete_mio_trait = generic_mio_at_aa_prod_eff
-	}
+		mio:SOV_jsc_defense_systems_materiel_manufacturer = {
+			complete_mio_trait = generic_mio_at_aa_trait_rel
+			complete_mio_trait = generic_mio_at_aa_trait_at_stats
+			complete_mio_trait = generic_mio_at_aa_prod_eff
+		}
 
-	mio:SOV_russian_helicopters_tank_manufacturer = {
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_prod_eff
-	}
+		mio:SOV_russian_helicopters_tank_manufacturer = {
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_prod_eff
+		}
 
-	mio:SOV_rostec_tank_manufacturer2 = {
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_heli_trait_research
-		complete_mio_trait = generic_mio_spec_heli_trait_production
-	}
+		mio:SOV_rostec_tank_manufacturer2 = {
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_heli_trait_research
+			complete_mio_trait = generic_mio_spec_heli_trait_production
+		}
 
-	mio:SOV_mil_helicopters_tank_manufacturer = {
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats_2
-	}
+		mio:SOV_mil_helicopters_tank_manufacturer = {
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats_2
+		}
 
-	mio:SOV_united_aircraft_corporation_aircraft_manufacturer = {
-		complete_mio_trait = generic_mio_fixed_wing_trait_med_rel
-		complete_mio_trait = generic_mio_fixed_wing_trait_med_speed
-		complete_mio_trait = generic_mio_fixed_wing_trait_ind_xp
-	}
+		mio:SOV_united_aircraft_corporation_aircraft_manufacturer = {
+			complete_mio_trait = generic_mio_fixed_wing_trait_med_rel
+			complete_mio_trait = generic_mio_fixed_wing_trait_med_speed
+			complete_mio_trait = generic_mio_fixed_wing_trait_ind_xp
+		}
 
-	mio:SOV_irkut_aircraft_manufacturer = {
-		complete_mio_trait = generic_mio_air_trait_light_rel
-		complete_mio_trait = generic_mio_air_trait_light_agility
-		complete_mio_trait = generic_mio_air_trait_light_strk
-	}
+		mio:SOV_irkut_aircraft_manufacturer = {
+			complete_mio_trait = generic_mio_air_trait_light_rel
+			complete_mio_trait = generic_mio_air_trait_light_agility
+			complete_mio_trait = generic_mio_air_trait_light_strk
+		}
 
-	mio:SOV_united_shipbuilding_corporation_naval_manufacturer = {
-		complete_mio_trait = generic_mio_nav_trait_light_cost
-		complete_mio_trait = generic_mio_nav_trait_light_torpedo
-		complete_mio_trait = generic_mio_nav_trait_light_speed
-	}
+		mio:SOV_united_shipbuilding_corporation_naval_manufacturer = {
+			complete_mio_trait = generic_mio_nav_trait_light_cost
+			complete_mio_trait = generic_mio_nav_trait_light_torpedo
+			complete_mio_trait = generic_mio_nav_trait_light_speed
+		}
 
-	mio:SOV_united_shipbuilding_corporation_naval_manufacturer2 = {
-		complete_mio_trait = generic_mio_sub_trait_sub_cost
-		complete_mio_trait = generic_mio_sub_trait_sub_attack
-		complete_mio_trait = generic_mio_sub_trait_sub_range
+		mio:SOV_united_shipbuilding_corporation_naval_manufacturer2 = {
+			complete_mio_trait = generic_mio_sub_trait_sub_cost
+			complete_mio_trait = generic_mio_sub_trait_sub_attack
+			complete_mio_trait = generic_mio_sub_trait_sub_range
+		}
 	}
 
 	if = {

--- a/history/countries/USA - USA.txt
+++ b/history/countries/USA - USA.txt
@@ -12,7 +12,9 @@ capital = 1182
 	# Order of Battles
 	complete_special_project = sp:sp_aircraft_project
 
-	mio:USA_lockheed_martin_aircraft_manufacturer = {
+	if = {
+		limit = { has_dlc = "Arms Against Tyranny" }
+		mio:USA_lockheed_martin_aircraft_manufacturer = {
 		complete_mio_trait = generic_mio_air_trait_med_rel
 		complete_mio_trait = generic_mio_air_trait_med_agility
 		complete_mio_trait = generic_mio_air_trait_med_defense
@@ -20,168 +22,169 @@ capital = 1182
 		complete_mio_trait = generic_mio_air_trait_light_rel
 		complete_mio_trait = generic_mio_air_trait_ind_xp
 		complete_mio_trait = generic_mio_air_trait_heavy_conv
-	}
+		}
 
-	mio:USA_alliant_techsystems_materiel_manufacturer = {
-		complete_mio_trait = generic_mio_at_aa_trait_rel
-		complete_mio_trait = generic_mio_at_aa_trait_aa_stats
-		complete_mio_trait = generic_mio_at_aa_prod_eff
-		complete_mio_trait = generic_mio_at_aa_reass_buff
-		complete_mio_trait = generic_mio_at_aa_research_buff
-		complete_mio_trait = generic_mio_at_aa_xp_gain
-	}
+		mio:USA_alliant_techsystems_materiel_manufacturer = {
+			complete_mio_trait = generic_mio_at_aa_trait_rel
+			complete_mio_trait = generic_mio_at_aa_trait_aa_stats
+			complete_mio_trait = generic_mio_at_aa_prod_eff
+			complete_mio_trait = generic_mio_at_aa_reass_buff
+			complete_mio_trait = generic_mio_at_aa_research_buff
+			complete_mio_trait = generic_mio_at_aa_xp_gain
+		}
 
-	mio:USA_raytheon_materiel_manufacturer = {
-		complete_mio_trait = generic_mio_at_aa_trait_rel
-		complete_mio_trait = generic_mio_at_aa_trait_at_stats
-		complete_mio_trait = generic_mio_at_aa_prod_eff
-		complete_mio_trait = generic_mio_at_aa_at_ap
-		complete_mio_trait = generic_mio_at_aa_reass_buff
-		complete_mio_trait = generic_mio_at_aa_research_buff
-	}
+		mio:USA_raytheon_materiel_manufacturer = {
+			complete_mio_trait = generic_mio_at_aa_trait_rel
+			complete_mio_trait = generic_mio_at_aa_trait_at_stats
+			complete_mio_trait = generic_mio_at_aa_prod_eff
+			complete_mio_trait = generic_mio_at_aa_at_ap
+			complete_mio_trait = generic_mio_at_aa_reass_buff
+			complete_mio_trait = generic_mio_at_aa_research_buff
+		}
 
-	mio:USA_colt_defense_materiel_manufacturer = {
-		complete_mio_trait = generic_mio_inf_trait_inf_rel
-		complete_mio_trait = generic_mio_inf_trait_art_stats
-		complete_mio_trait = generic_mio_inf_trait_inf_eq_stats
-		complete_mio_trait = generic_mio_inf_trait_util_eq_cost
-		complete_mio_trait = generic_mio_inf_reass_buff
-		complete_mio_trait = generic_mio_inf_research_buff
-	}
+		mio:USA_colt_defense_materiel_manufacturer = {
+			complete_mio_trait = generic_mio_inf_trait_inf_rel
+			complete_mio_trait = generic_mio_inf_trait_art_stats
+			complete_mio_trait = generic_mio_inf_trait_inf_eq_stats
+			complete_mio_trait = generic_mio_inf_trait_util_eq_cost
+			complete_mio_trait = generic_mio_inf_reass_buff
+			complete_mio_trait = generic_mio_inf_research_buff
+		}
 
-	mio:USA_bell_helicopter_textron_tank_manufacturer = {
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_prod_eff
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats_2
-		complete_mio_trait = generic_mio_spec_heli_trait_research
-		complete_mio_trait = generic_mio_spec_heli_trait_capacity
-	}
+		mio:USA_bell_helicopter_textron_tank_manufacturer = {
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_prod_eff
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats_2
+			complete_mio_trait = generic_mio_spec_heli_trait_research
+			complete_mio_trait = generic_mio_spec_heli_trait_capacity
+		}
 
-	mio:USA_sikorsky_aircraft_tank_manufacturer = {
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_prod_eff
-		complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats_2
-		complete_mio_trait = generic_mio_spec_heli_trait_cost
-		complete_mio_trait = generic_mio_spec_heli_trait_small_stats
-		complete_mio_trait = generic_mio_spec_heli_trait_research
-	}
+		mio:USA_sikorsky_aircraft_tank_manufacturer = {
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_prod_eff
+			complete_mio_trait = generic_mio_spec_heli_trait_heavy_tank_stats_2
+			complete_mio_trait = generic_mio_spec_heli_trait_cost
+			complete_mio_trait = generic_mio_spec_heli_trait_small_stats
+			complete_mio_trait = generic_mio_spec_heli_trait_research
+		}
 
-	mio:USA_boeing_aircraft_manufacturer = {
-		complete_mio_trait = generic_mio_fixed_wing_trait_med_rel
-		complete_mio_trait = generic_mio_fixed_wing_trait_med_agility
-		complete_mio_trait = generic_mio_fixed_wing_trait_med_defense
-		complete_mio_trait = generic_mio_fixed_wing_trait_med_attack
-		complete_mio_trait = generic_mio_fixed_wing_trait_ind_xp
-		complete_mio_trait = generic_mio_fixed_wing_trait_heavy_research
-	}
+		mio:USA_boeing_aircraft_manufacturer = {
+			complete_mio_trait = generic_mio_fixed_wing_trait_med_rel
+			complete_mio_trait = generic_mio_fixed_wing_trait_med_agility
+			complete_mio_trait = generic_mio_fixed_wing_trait_med_defense
+			complete_mio_trait = generic_mio_fixed_wing_trait_med_attack
+			complete_mio_trait = generic_mio_fixed_wing_trait_ind_xp
+			complete_mio_trait = generic_mio_fixed_wing_trait_heavy_research
+		}
 
-	mio:USA_northrop_grumman_aircraft_manufacturer = {
-		complete_mio_trait = generic_mio_air_trait_heavy_rel
-		complete_mio_trait = generic_mio_air_trait_heavy_cas
-		complete_mio_trait = generic_mio_air_trait_heavy_bombing
-		complete_mio_trait = generic_mio_air_trait_heavy_naval
-		complete_mio_trait = generic_mio_air_trait_ind_xp
-		complete_mio_trait = generic_mio_air_trait_heavy_research
-	}
+		mio:USA_northrop_grumman_aircraft_manufacturer = {
+			complete_mio_trait = generic_mio_air_trait_heavy_rel
+			complete_mio_trait = generic_mio_air_trait_heavy_cas
+			complete_mio_trait = generic_mio_air_trait_heavy_bombing
+			complete_mio_trait = generic_mio_air_trait_heavy_naval
+			complete_mio_trait = generic_mio_air_trait_ind_xp
+			complete_mio_trait = generic_mio_air_trait_heavy_research
+		}
 
-	mio:USA_textron_aviation_defense_manufacturer = {
-		complete_mio_trait = generic_mio_light_aircraft_trait_med_rel
-		complete_mio_trait = generic_mio_light_aircraft_trait_med_speed
-		complete_mio_trait = generic_mio_light_aircraft_trait_med_defense
-		complete_mio_trait = generic_mio_light_aircraft_trait_med_bombing
-		complete_mio_trait = generic_mio_light_aircraft_trait_ind_xp
-		complete_mio_trait = generic_mio_light_aircraft_trait_heavy_research
-	}
+		mio:USA_textron_aviation_defense_manufacturer = {
+			complete_mio_trait = generic_mio_light_aircraft_trait_med_rel
+			complete_mio_trait = generic_mio_light_aircraft_trait_med_speed
+			complete_mio_trait = generic_mio_light_aircraft_trait_med_defense
+			complete_mio_trait = generic_mio_light_aircraft_trait_med_bombing
+			complete_mio_trait = generic_mio_light_aircraft_trait_ind_xp
+			complete_mio_trait = generic_mio_light_aircraft_trait_heavy_research
+		}
 
-	mio:USA_general_dynamics_electric_boat_naval_manufacturer = {
-		complete_mio_trait = generic_mio_sub_trait_sub_cost
-		complete_mio_trait = generic_mio_sub_trait_sub_attack
-		complete_mio_trait = generic_mio_sub_trait_sub_range
-		complete_mio_trait = generic_mio_sub_trait_sub_shore
-		complete_mio_trait = generic_mio_sub_trait_ind_research
-		complete_mio_trait = generic_mio_sub_trait_ind_xp
-	}
+		mio:USA_general_dynamics_electric_boat_naval_manufacturer = {
+			complete_mio_trait = generic_mio_sub_trait_sub_cost
+			complete_mio_trait = generic_mio_sub_trait_sub_attack
+			complete_mio_trait = generic_mio_sub_trait_sub_range
+			complete_mio_trait = generic_mio_sub_trait_sub_shore
+			complete_mio_trait = generic_mio_sub_trait_ind_research
+			complete_mio_trait = generic_mio_sub_trait_ind_xp
+		}
 
-	mio:USA_northrop_grumman_newport_news_naval_manufacturer = {
-		complete_mio_trait = generic_mio_sub_trait_sub_cost
-		complete_mio_trait = generic_mio_sub_trait_sub_vis
-		complete_mio_trait = generic_mio_sub_trait_sub_speed
-		complete_mio_trait = generic_mio_sub_trait_sub_shore
-		complete_mio_trait = generic_mio_sub_trait_ind_research
-		complete_mio_trait = generic_mio_sub_trait_ind_xp
-	}
+		mio:USA_northrop_grumman_newport_news_naval_manufacturer = {
+			complete_mio_trait = generic_mio_sub_trait_sub_cost
+			complete_mio_trait = generic_mio_sub_trait_sub_vis
+			complete_mio_trait = generic_mio_sub_trait_sub_speed
+			complete_mio_trait = generic_mio_sub_trait_sub_shore
+			complete_mio_trait = generic_mio_sub_trait_ind_research
+			complete_mio_trait = generic_mio_sub_trait_ind_xp
+		}
 
-	mio:USA_bath_iron_works_naval_manufacturer = {
-		complete_mio_trait = generic_mio_nav_trait_light_cost
-		complete_mio_trait = generic_mio_nav_trait_light_torpedo
-		complete_mio_trait = generic_mio_nav_trait_light_detection
-		complete_mio_trait = generic_mio_nav_trait_light_aa
-		complete_mio_trait = generic_mio_nav_trait_ind_research
-		complete_mio_trait = generic_mio_nav_trait_ind_xp
-	}
+		mio:USA_bath_iron_works_naval_manufacturer = {
+			complete_mio_trait = generic_mio_nav_trait_light_cost
+			complete_mio_trait = generic_mio_nav_trait_light_torpedo
+			complete_mio_trait = generic_mio_nav_trait_light_detection
+			complete_mio_trait = generic_mio_nav_trait_light_aa
+			complete_mio_trait = generic_mio_nav_trait_ind_research
+			complete_mio_trait = generic_mio_nav_trait_ind_xp
+		}
 
-	mio:USA_national_steel_and_shipbuilding_company_naval_manufacturer = {
-		complete_mio_trait = generic_mio_nav_trait_heavy_cost
-		complete_mio_trait = generic_mio_nav_trait_heavy_str
-		complete_mio_trait = generic_mio_nav_trait_heavy_la
-		complete_mio_trait = generic_mio_nav_trait_heavy_aa
-		complete_mio_trait = generic_mio_nav_trait_ind_research
-		complete_mio_trait = generic_mio_nav_trait_ind_xp
-	}
+		mio:USA_national_steel_and_shipbuilding_company_naval_manufacturer = {
+			complete_mio_trait = generic_mio_nav_trait_heavy_cost
+			complete_mio_trait = generic_mio_nav_trait_heavy_str
+			complete_mio_trait = generic_mio_nav_trait_heavy_la
+			complete_mio_trait = generic_mio_nav_trait_heavy_aa
+			complete_mio_trait = generic_mio_nav_trait_ind_research
+			complete_mio_trait = generic_mio_nav_trait_ind_xp
+		}
 
-	mio:USA_ingalls_shipbuilding_naval_manufacturer = {
-		complete_mio_trait = generic_mio_nav_light_trait_light_cost
-		complete_mio_trait = generic_mio_nav_light_trait_light_visibility
-		complete_mio_trait = generic_mio_nav_light_trait_light_fuel
-		complete_mio_trait = generic_mio_nav_light_trait_light_detection_2
-		complete_mio_trait = generic_mio_nav_light_trait_ind_research
-		complete_mio_trait = generic_mio_nav_light_trait_ind_xp
-	}
+		mio:USA_ingalls_shipbuilding_naval_manufacturer = {
+			complete_mio_trait = generic_mio_nav_light_trait_light_cost
+			complete_mio_trait = generic_mio_nav_light_trait_light_visibility
+			complete_mio_trait = generic_mio_nav_light_trait_light_fuel
+			complete_mio_trait = generic_mio_nav_light_trait_light_detection_2
+			complete_mio_trait = generic_mio_nav_light_trait_ind_research
+			complete_mio_trait = generic_mio_nav_light_trait_ind_xp
+		}
 
-	mio:USA_northrop_grumman_newport_news_naval_manufacturer2 = {
-		complete_mio_trait = generic_mio_nav_light_trait_heavy_cost
-		complete_mio_trait = generic_mio_nav_light_trait_heavy_str
-		complete_mio_trait = generic_mio_nav_light_trait_heavy_ha
-		complete_mio_trait = generic_mio_nav_light_trait_heavy_aa
-		complete_mio_trait = generic_mio_nav_light_trait_ind_research
-		complete_mio_trait = generic_mio_nav_light_trait_ind_xp
-	}
+		mio:USA_northrop_grumman_newport_news_naval_manufacturer2 = {
+			complete_mio_trait = generic_mio_nav_light_trait_heavy_cost
+			complete_mio_trait = generic_mio_nav_light_trait_heavy_str
+			complete_mio_trait = generic_mio_nav_light_trait_heavy_ha
+			complete_mio_trait = generic_mio_nav_light_trait_heavy_aa
+			complete_mio_trait = generic_mio_nav_light_trait_ind_research
+			complete_mio_trait = generic_mio_nav_light_trait_ind_xp
+		}
 
-	mio:USA_textron_tank_manufacturer = {
-		complete_mio_trait = generic_mio_inf_trait_inf_rel
-		complete_mio_trait = generic_mio_inf_trait_cnc_prod_cost
-		complete_mio_trait = generic_mio_inf_trait_aa_stats
-		complete_mio_trait = generic_mio_inf_prod_eff
-		complete_mio_trait = generic_mio_inf_reass_buff
-		complete_mio_trait = generic_mio_inf_production
-	}
+		mio:USA_textron_tank_manufacturer = {
+			complete_mio_trait = generic_mio_inf_trait_inf_rel
+			complete_mio_trait = generic_mio_inf_trait_cnc_prod_cost
+			complete_mio_trait = generic_mio_inf_trait_aa_stats
+			complete_mio_trait = generic_mio_inf_prod_eff
+			complete_mio_trait = generic_mio_inf_reass_buff
+			complete_mio_trait = generic_mio_inf_production
+		}
 
-	mio:USA_united_defense_tank_manufacturer = {
-		complete_mio_trait = generic_mio_tank_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_tank_trait_heavy_ifv_stats
-		complete_mio_trait = generic_mio_tank_trait_heavy_prod_eff
-		complete_mio_trait = generic_mio_tank_trait_heavy_ifv_stats_2
-		complete_mio_trait = generic_mio_tank_trait_prod_growth
-		complete_mio_trait = generic_mio_tank_trait_research
-	}
+		mio:USA_united_defense_tank_manufacturer = {
+			complete_mio_trait = generic_mio_tank_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_tank_trait_heavy_ifv_stats
+			complete_mio_trait = generic_mio_tank_trait_heavy_prod_eff
+			complete_mio_trait = generic_mio_tank_trait_heavy_ifv_stats_2
+			complete_mio_trait = generic_mio_tank_trait_prod_growth
+			complete_mio_trait = generic_mio_tank_trait_research
+		}
 
-	mio:USA_general_dynamics_APC_manufacturer = {
-		complete_mio_trait = generic_mio_tank_trait_light_veh_rel
-		complete_mio_trait = generic_mio_tank_trait_light_def
-		complete_mio_trait = generic_mio_tank_trait_light_eff
-		complete_mio_trait = generic_mio_tank_trait_light_apc_stats
-		complete_mio_trait = generic_mio_tank_trait_prod_growth
-		complete_mio_trait = generic_mio_tank_trait_research
-	}
+		mio:USA_general_dynamics_APC_manufacturer = {
+			complete_mio_trait = generic_mio_tank_trait_light_veh_rel
+			complete_mio_trait = generic_mio_tank_trait_light_def
+			complete_mio_trait = generic_mio_tank_trait_light_eff
+			complete_mio_trait = generic_mio_tank_trait_light_apc_stats
+			complete_mio_trait = generic_mio_tank_trait_prod_growth
+			complete_mio_trait = generic_mio_tank_trait_research
+		}
 
-	mio:USA_general_dynamics_materiel_manufacturer = {
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_veh_rel
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_tank_stats
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_prod_eff
-		complete_mio_trait = generic_mio_spec_tank_trait_heavy_tank_stats_2
-		complete_mio_trait = generic_mio_spec_tank_trait_research
-		complete_mio_trait = generic_mio_spec_tank_trait_production
+		mio:USA_general_dynamics_materiel_manufacturer = {
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_veh_rel
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_tank_stats
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_prod_eff
+			complete_mio_trait = generic_mio_spec_tank_trait_heavy_tank_stats_2
+			complete_mio_trait = generic_mio_spec_tank_trait_research
+			complete_mio_trait = generic_mio_spec_tank_trait_production
+		}
 	}
 
 	if = {


### PR DESCRIPTION
Fixed errors for non-Arms Against Tyranny (AAT) owners attempting to complete MIO traits by gating trait completions behind DLC checks for SOV and USA. Updated Dutch focus to use correct equipment and manufacturer, and fixed the Venezuelan 'Increasing Military Capabilities' national spirit to be canceled properly when its focus is completed.