### PR TITLE
FIJ Game Rule fix for Annex Microstates

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -143,6 +143,7 @@ v1.12.4
  Game Rules:
   - Added a new game rule for Enabling/Disabling Energy Load Sharing system
   - Added a new game rule for the price per GW for the Energy Load Sharing system
+  - The Game Rule annex microstates for the Oceania tags will now annex into Fiji so you can play w/ the tree (yes I know this is a buff to them)
 
  Localization:
   - Adjusted some of the wording in the Serbia joins the United Nation event so it doesn't say Yugoslavia when Serbia still exists

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -114,9 +114,8 @@ on_actions = {
 						remove_core_of = MLD
 					}
 				}
-				SAM = {
+				FIJ = {
 					add_state_core = 533
-					add_state_core = 535
 					add_state_core = 543
 					add_state_core = 546
 					add_state_core = 551
@@ -127,8 +126,9 @@ on_actions = {
 					add_state_core = 1115
 					add_state_core = 1116
 					add_state_core = 1117
+					add_state_core = 569
 					annex_country = { target = SOL transfer_troops = yes }
-					annex_country = { target = FIJ transfer_troops = yes }
+					annex_country = { target = SAM transfer_troops = yes }
 					annex_country = { target = MIC transfer_troops = yes }
 					annex_country = { target = PAU transfer_troops = yes }
 					annex_country = { target = MAR transfer_troops = yes }
@@ -140,7 +140,7 @@ on_actions = {
 					for_each_scope_loop = {
 						array = core_states
 						remove_core_of = SOL
-						remove_core_of = FIJ
+						remove_core_of = SAM
 						remove_core_of = MIC
 						remove_core_of = PAU
 						remove_core_of = MAR


### PR DESCRIPTION
* Annexes all Oceania microstates into FIJ instead of SAM so we aren't deleting a tree with the game rule 