### PR TITLE
Fix for issue #284: Bulgarian focus "Embracing Orthodoxy" and territorrial expansion/integration decisions

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -151,6 +151,9 @@ v1.12.4
   - Fixed being able to do the Internal Investments for Local Conservation Efforts in any state as Brazil even though it should've been limited to the Amazon states
 
  Content:
+  - [BUL] Enhanced "Embracing Orthodoxy" focus to add Anti-LGBTQ Stance national spirit (Issue #284)
+  - [BUL] Added nationalist drift bonus to Orthodox National Values national spirit
+  - [BUL] Added Dobruja (state 284) to The Fourth Bulgarian Kingdom integration decisions
   - The Generic focus "Military Education Reform" now gives a +1 skill level to all generals while also increasing your education law for unit leaders
   - The Generic tree will now actually give doctrinal benefits and are now updated to the newest system for doctrines
   - The Vatican can join the European Union as a nation with no elections (only circumstance for this)

--- a/common/decisions/bulgaria.txt
+++ b/common/decisions/bulgaria.txt
@@ -937,6 +937,32 @@ BUL_Bolgarisation_category = {
 			factor = 355
 		}
 	}
+	BUL_284_return = {
+		icon = GFX_decision_bulgarisation
+		allowed = { original_tag = BUL }
+		fire_only_once = yes
+		days_remove = 180
+
+		available = {
+			owns_state = 284
+		}
+
+		visible = {
+			tag = BUL
+			owns_state = 284
+		}
+		remove_effect = {
+			add_political_power = -80
+			add_state_core = 284
+			add_stability = -0.05
+		}
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_284_return"
+		}
+		ai_will_do = {
+			factor = 355
+		}
+	}
 }
 
 BUL_tourism_development_category = {

--- a/common/ideas/bulgarian.txt
+++ b/common/ideas/bulgarian.txt
@@ -1486,6 +1486,18 @@ local_resources_chromium_factor = 0.10
 				stability_factor = 0.05
 				drift_defence_factor = 0.10
 				war_support_factor = 0.02
+				nationalist_drift = 0.02
+			}
+		}
+
+		BUL_anti_lgbtqa_stance_idea = {
+			allowed = { always = no }
+			picture = anti_lgbt
+
+			modifier = {
+				political_power_factor = 0.02
+				democratic_drift = -0.02
+				nationalist_drift = 0.02
 			}
 		}
 

--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -2775,6 +2775,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
 			add_ideas = BUL_orthodox_national_values
+			add_ideas = BUL_anti_lgbtqa_stance_idea
 		}
 	}
 	focus = {

--- a/localisation/english/MD_focus_BUL_l_english.yml
+++ b/localisation/english/MD_focus_BUL_l_english.yml
@@ -704,6 +704,7 @@
  BUL_934_return: "Nationalization of East Thrace"
  BUL_140_return: "Nationalization of Southern Macedonia"
  BUL_139_return: "Nationalization of Thessaly"
+ BUL_284_return: "Nationalization of Dobruja"
 
  BUL_Belarus_export_weapon_category: "Arms Purchases in Belarus"
  BUL_Belarus_export_weapon_category_desc: "Belarus is not a top arms exporter, but it can provide us with some samples of weapons useful for our army"
@@ -1062,3 +1063,5 @@
  BUL_christian_democracy_desc: "Christian Democratic values emphasize social justice, human dignity, and democratic governance rooted in Christian ethics, providing a moral foundation for our liberal reforms."
  BUL_orthodox_national_values: "Orthodox National Values"
  BUL_orthodox_national_values_desc: "The Orthodox Church reinforces our national identity and traditional values, strengthening the moral fiber of our nation and rallying support for our nationalist cause."
+ BUL_anti_lgbtqa_stance_idea: "Anti-LGBTQ Stance"
+ BUL_anti_lgbtqa_stance_idea_desc: "In alignment with traditional Orthodox values, the government has enacted legislation restricting LGBTQ propaganda and public displays, mirroring similar laws in other conservative nations. While controversial internationally, this stance strengthens support among nationalist and traditionalist voters."


### PR DESCRIPTION
 1. Enhanced "Embracing Orthodoxy" Focus (BUL_generic_ethics_for_war)

  - File: common/national_focus/bulgaria.txt:2778
  - Added BUL_anti_lgbtqa_stance_idea to the focus completion reward
  - The focus now grants both national spirits when completed

  2. Enhanced "Orthodox National Values" National Spirit

  - File: common/ideas/bulgarian.txt:1489
  - Added nationalist_drift = 0.02 (+2% monthly nationalist popularity)
  - Now gives: +5% stability, +10% drift defense, +2% war support, +2% nationalist drift

  3. New "Anti-LGBTQ Stance" National Spirit

  - File: common/ideas/bulgarian.txt:1493-1502
  - Created BUL_anti_lgbtqa_stance_idea with:
    - +2% political power
    - -2% democratic drift
    - +2% nationalist drift
  - Based on Bulgaria's real 2024 legislation (as mentioned in the issue)

  4. Added Dobruja Integration Decision

  - File: common/decisions/bulgaria.txt:940-965
  - Created BUL_284_return decision for "The Fourth Bulgarian Kingdom" category
  - Allows Bulgaria to core Dobruja (state 284, Romanian territory) after conquest
  - 180 days to complete, costs -80 political power and -5% stability

  5. Localization

  - File: localisation/english/MD_focus_BUL_l_english.yml
  - Added BUL_284_return: "Nationalization of Dobruja" (line 707)
  - Added BUL_anti_lgbtqa_stance_idea name and description (lines 1066-1067)

fix #284 