### PR TITLE
Fix for issue #342: Change the color of the Axis of Resistance alliance

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -161,6 +161,7 @@ v2.0.0
   - Fixed the tax cost modifier missing from the Iranian Economy Spirit
   - [PER] Fixed Kermanshah's Oxygen mission checking wrong province (12773 instead of city province 16155) (Issue #234)
   - [PER] Fixed "General Max Army Size" modifier from Concessions to the Army focus not working (Issue #235)
+  - [PER] Added distinct color to Axis of Resistance faction to differentiate from CSTO on F10 map mode (Issue #342)
   - Removed the double definition of support in Motorized Recon Company
   - Fixed Dutch Focus "Modernize MRAD" not being available while having the tech that was needed. Also added a bypass when all you states are maxed out on Anti-Air
   - Fixed an issue where an internal faction check in various nations (most noticeable in China) would allow you to take a decision or focus despite it not having enough opinion

--- a/common/factions/templates/99_PER.txt
+++ b/common/factions/templates/99_PER.txt
@@ -1,6 +1,7 @@
 faction_template_aor = {
 	name = axis_of_resistance
 	icon = GFX_faction_icon_aor
+	color = { 0 107 56 }	# Dark green to differentiate from CSTO's red
 	manifest = faction_manifest_containment_of_decadence
 	can_leader_join_other_factions = no
 	visible = {


### PR DESCRIPTION
Add unique color for Axis of Resistance faction in F10 map mode

fix #342