### PR TITLE
Japanese font fix

### DIFF
--- a/interface/core.gfx
+++ b/interface/core.gfx
@@ -2006,7 +2006,8 @@ bitmapfonts = {
 	bitmapfont_override = {
 		name = "tahoma_60"
 		fontfiles = {
-			"gfx/fonts/japanese/hoi_mapfont4"
+			"gfx/fonts/japanese/hoi_mapfont4_0"
+			"gfx/fonts/japanese/hoi_mapfont4_1"
 		}
 		languages = { "l_japanese" }
 	}


### PR DESCRIPTION
The Japanese garbled-text issue has been fixed.

The cause was that, after a vanilla update changed the Japanese map font to two new map fonts, MD hadn’t been updated to match. As a result, I updated MD’s Japanese map font settings to use those two new map fonts (basically, I changed the entries to match vanilla).