### PR TITLE
Fix: Addressed investment exploit by implementing runtime validation to prevent treasury bypass while paused (Issue #374)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -194,6 +194,7 @@ v2.0.0
   - Added per-level construction cost increase to microchips (+2500 per level)
 
  Bugfix:
+  - Fixed investment exploit allowing players to bypass treasury checks while game is paused by adding runtime validation (Issue #374)
   - [JAP] Fixed missing interface files for Japan in the Tank Designer - created new _jap.gui files for all tank chassis types using USA layout (Issue #349)
   - Fixed ship experience gain modifiers not showing ship type in tooltips (Issue #354)
     - All naval unit experience modifiers now display their ship type (e.g., "Destroyer Training Experience Gain")

--- a/common/scripted_guis/01_investment_scripted_gui.txt
+++ b/common/scripted_guis/01_investment_scripted_gui.txt
@@ -90,7 +90,27 @@ scripted_gui = {
 			}
 			# Begins project or cancels the project if you have one active in a given state
 			AC_build_button_click = {
-				if = { limit = { NOT = { is_in_array = { array = THIS.projects_in_state value = ROOT.id } } }
+				# Runtime validation to prevent exploit when game is paused (issue #374)
+				# These checks mirror the trigger conditions but are enforced at execution time
+				if = {
+					limit = {
+						NOT = { is_in_array = { array = THIS.projects_in_state value = ROOT.id } }
+						ROOT = {
+							has_available_treasury_investment = yes
+							NOT = { has_active_mission = cheap_loan_from_the_imf_mission }
+							# Game rule check for bankruptcy collapse lock
+							# Either the rule is disabled, OR (if enabled) no collapse mission is active
+							OR = {
+								NOT = {
+									has_game_rule = {
+										rule = rule_enable_investment_collapse_lock
+										option = yes
+									}
+								}
+								NOT = { has_active_mission = bankruptcy_incoming_collapse }
+							}
+						}
+					}
 					# PREV is the state target
 					THIS = {
 						set_variable = { ROOT.AC_state_target = THIS.id }


### PR DESCRIPTION
 In 01_investment_scripted_gui.txt, the AC_build_button_click effect executed investments without runtime validation. The checks were only in the         
  AC_build_button_click_enabled trigger, which controls button visibility/enablement but doesn't prevent queued clicks while paused                                   
                                                                                                                                                                       
  Fix Applied (common/scripted_guis/01_investment_scripted_gui.txt:92-113):                                                                                            
  Added runtime validation in the AC_build_button_click effect that checks:                                                                                            
  1. has_available_treasury_investment = yes - Ensures player has sufficient funds                                                                                     
  2. NOT = { has_active_mission = cheap_loan_from_the_imf_mission } - Blocks if IMF loan active                                                                        
  3. NOT = { has_active_mission = bankruptcy_incoming_collapse } - Blocks if collapse mission active (when game rule enabled)                                          
                                                        
fix #374 