### PR TITLE
Main menu error fix

### DIFF
--- a/interface/frontendmainview.gui
+++ b/interface/frontendmainview.gui
@@ -266,6 +266,16 @@ guiTypes = {
 			name = "Background"
 			quadTextureSprite ="GFX_tiled_window"
 		}
+		#should be to prevent error in logs after loading bookmarks.Fit to the container size.
+		positionType = {
+			name = "subscription_size"
+			position = { x = 650 y = 500}
+		}
+		#should be to prevent error in logs after loading bookmarks.Match the text position.
+		positionType = {
+			name = "version_label_subscription_position"
+			position = { x = 35 y = 420 }
+		}
 
 		ButtonType = {
 			name = "single_player_button"
@@ -455,19 +465,12 @@ guiTypes = {
 		}
 
 		containerWindowType = {
-			name = "mainmenu_social_buttons"
+			name = "mainmenu_social_buttons_appear"
 			position = { x=-0 y=135 }
 			size = { width = 240 height = 90 }
 			Orientation = center
 			origo = center
 
-			ButtonType = {
-				name = "homepage_button"
-				position = { x=0 y=999 }
-				quadTextureSprite ="homepage"
-				clicksound = click_default
-				pdx_tooltip = "MENU_HOMEPAGE"
-			}
 			ButtonType = {
 				name = "steamworkshop_button"
 				position = { x = -192 y = 12 }
@@ -516,14 +519,6 @@ guiTypes = {
 				pdx_tooltip = "MENU_REDDIT"
 				web_link = "https://www.reddit.com/r/MillenniumDawn/"
 			}
-			#privacy button should be to prevent error in logs after loading bookmarks
-			ButtonType = {
-				name = "privacy_policy_button"
-				position = { x = 99999 y = 99999 } #99999 should be to don't show this on player screen
-				quadTextureSprite ="privacy"
-				#clicksound = click_default
-				pdx_tooltip = "MENU_PRIVACY_POLICY"
-			}
 		}
 
 		instantTextBoxType = {
@@ -552,6 +547,44 @@ guiTypes = {
 			position = { x = 0 y = 0 }
 			quadTextureSprite ="achievements"
 			pdx_tooltip = "MENU_ACHIEVEMENTS"
+		}
+	}
+
+	#should be to prevent error in logs after loading bookmarks
+	containerWindowType = {
+		name = "mainmenu_social_buttons"
+		position = { x=99999 y=99999 }
+		size = { width = 100 height = 100 }
+
+		positionType = {
+			name = "subscription_position_without_social_gui"
+			position = { x = 99999 y = 99999 }
+		}
+		positionType = {
+			name = "position_without_social_gui"
+			position = { x = 99999 y = 999999 }
+		}
+
+		containerWindowType = {
+			name = "social_view_interface_window"
+			position = { x=99999 y=99999 }
+			size = { width = 10 height = 10 }
+		}
+
+		ButtonType = {
+			name = "homepage_button"
+			position = { x=99999 y=99999 }
+			quadTextureSprite ="homepage"
+			clicksound = click_default
+			pdx_tooltip = "MENU_HOMEPAGE"
+		}
+
+		ButtonType = {
+			name = "privacy_policy_button"
+			position = { x = 99999 y = 99999 } #99999 should be to don't show this on player screen
+			quadTextureSprite ="privacy"
+			#clicksound = click_default
+			pdx_tooltip = "MENU_PRIVACY_POLICY"
 		}
 	}
 }


### PR DESCRIPTION
It looks like a few elements required by the engine were missing, so I restored them.

For anything that affects what’s shown, I matched the coordinates to the existing content. For everything else, I moved the coordinates far off-screen as a dummy placement.

It looks fine on my PC, but please double-check that there aren’t any visual/layout issues and then merge if all good.