### PR TITLE
Fix nationalist claims adding cores instead of claims, breaking formable nations

### DIFF
--- a/common/decisions/Political Desicions.txt
+++ b/common/decisions/Political Desicions.txt
@@ -1226,7 +1226,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision FRA_nationalist_claims_BEL"
-			add_state_core = 52
+			add_state_claim = 52
 			BEL = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1267,7 +1267,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision FRA_nationalist_claims_SWI"
-			add_state_core = 72
+			add_state_claim = 72
 			SWI = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1310,8 +1310,8 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision NOR_nationalist_claims_DEN"
-			add_state_core = 1 #greenland
-			add_state_core = 2 #faroe islands
+			add_state_claim = 1 #greenland
+			add_state_claim = 2 #faroe islands
 			DEN = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1352,7 +1352,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision NOR_nationalist_claims_ICE"
-			add_state_core = 7 #iceland
+			add_state_claim = 7 #iceland
 			ICE = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1396,7 +1396,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision NOR_nationalist_claims_ENG"
-			add_state_core = 8 #shetland
+			add_state_claim = 8 #shetland
 			ENG = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1440,7 +1440,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision NOR_nationalist_claims_SCO"
-			add_state_core = 8 #shetland
+			add_state_claim = 8 #shetland
 			SCO = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1484,7 +1484,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SWE_nationalist_claims_FIN"
-			add_state_core = 104 #�land
+			add_state_claim = 104 #�land
 			FIN = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1527,7 +1527,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision DEN_nationalist_claims_SWE"
-			add_state_core = 550 #sk�ne
+			add_state_claim = 550 #sk�ne
 			SWE = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1567,7 +1567,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision DEN_nationalist_claims_GER"
-			add_state_core = 37 #sclesvig-holstein
+			add_state_claim = 37 #sclesvig-holstein
 			GER = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1610,8 +1610,8 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_nationalist_claims_BEL"
-			add_state_core = 50
-			add_state_core = 51
+			add_state_claim = 50
+			add_state_claim = 51
 			BEL = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1654,7 +1654,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HUN_nationalist_claims_UKR"
-			add_state_core = 701
+			add_state_claim = 701
 			UKR = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1695,7 +1695,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HUN_nationalist_claims_ROM"
-			add_state_core = 909
+			add_state_claim = 909
 			ROM = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1738,7 +1738,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision AUS_nationalist_claims_ITA"
-			add_state_core = 285
+			add_state_claim = 285
 			ITA = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1784,7 +1784,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ALB_nationalist_claims_KOS"
-			add_state_core = 133
+			add_state_claim = 133
 			KOS = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1827,7 +1827,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ALB_nationalist_claims_SER"
-			add_state_core = 133
+			add_state_claim = 133
 			SER = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }
@@ -1870,7 +1870,7 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ALB_nationalist_claims_FYR"
-			add_state_core = 135
+			add_state_claim = 135
 			FYR = { set_country_flag = AI_is_threatened }
 			every_neighbor_country = {
 				add_opinion_modifier = { target = PREV modifier = expansionist_agenda }

--- a/common/decisions/formable_nation_decisions.txt
+++ b/common/decisions/formable_nation_decisions.txt
@@ -1119,9 +1119,7 @@ form_SCA_category = {
 						is_subject_of = ROOT
 						has_war = no
 					}
-					all_core_state = {
-						is_owned_and_controlled_by = ROOT
-					}
+					ROOT = { is_sweden_state_owned = yes }
 				}
 			}
 			NOR = {
@@ -1130,9 +1128,7 @@ form_SCA_category = {
 						is_subject_of = ROOT
 						has_war = no
 					}
-					all_core_state = {
-						is_owned_and_controlled_by = ROOT
-					}
+					ROOT = { is_norway_state_owned = yes }
 				}
 			}
 			DEN = {
@@ -1141,9 +1137,7 @@ form_SCA_category = {
 						is_subject_of = ROOT
 						has_war = no
 					}
-					all_core_state = {
-						is_owned_and_controlled_by = ROOT
-					}
+					ROOT = { is_denmark_state_owned = yes }
 				}
 			}
 			FIN = {
@@ -1152,9 +1146,7 @@ form_SCA_category = {
 						is_subject_of = ROOT
 						has_war = no
 					}
-					all_core_state = {
-						is_owned_and_controlled_by = ROOT
-					}
+					ROOT = { is_finland_state_owned = yes }
 				}
 			}
 			ICE = {
@@ -1163,9 +1155,7 @@ form_SCA_category = {
 						is_subject_of = ROOT
 						has_war = no
 					}
-					all_core_state = {
-						is_owned_and_controlled_by = ROOT
-					}
+					ROOT = { owns_state = 7 }
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Nationalist claims decisions incorrectly used `add_state_core` instead of `add_state_claim`, adding permanent cores to foreign states. This caused `all_core_state` checks in formable nation decisions (e.g. Scandinavia) to fail, since the newly cored states weren't owned by the player.
- Hardened `SCA_integrate_start` to use explicit state ownership triggers instead of `all_core_state`, preventing similar issues in the future.

## Changes
- **`common/decisions/Political Desicions.txt`**: Changed all 16 broken nationalist claims decisions from `add_state_core` to `add_state_claim` (`BRA_nationalist_claims_URG` was already correct)
- **`common/decisions/formable_nation_decisions.txt`**: Replaced `all_core_state` in `SCA_integrate_start` with `is_sweden_state_owned`, `is_norway_state_owned`, `is_denmark_state_owned`, `is_finland_state_owned`, and `owns_state = 7` (Iceland)