### PR TITLE
Fix Armenia/Artsakh integration bugs

### DIFF
--- a/common/decisions/Armenia.txt
+++ b/common/decisions/Armenia.txt
@@ -1359,6 +1359,34 @@ ARM_ministry_of_external_category = {
 			factor = 355
 		}
 	}
+
+	ARM_open_borders_with_AZE = {
+		icon = GFX_decision_negotiate_icon
+		cost = 50
+		fire_only_once = yes
+		days_remove = 30
+
+		visible = {
+			has_country_flag = karabakh_regulated_flag
+			country_exists = AZE
+			NOT = { has_war_with = AZE }
+			NOT = { has_country_flag = arm_aze_borders_open }
+		}
+
+		available = {
+			NOT = { has_war_with = AZE }
+			AZE = { has_country_flag = karabakh_regulated_flag }
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ARM_open_borders_with_AZE"
+			AZE = { country_event = { id = karabakh.30 days = 1 } }
+		}
+
+		ai_will_do = {
+			factor = 100
+		}
+	}
 }
 ###########SPECIAL SERVICES DECISIONS###########
 ARM_special_services_category = {

--- a/common/decisions/karabakh.txt
+++ b/common/decisions/karabakh.txt
@@ -541,6 +541,7 @@ karabakh_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: NKR_armenia_annex_nkr"
 			add_country_leader_trait = ARM_united_armenians_trait
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes

--- a/common/ideas/Armenian.txt
+++ b/common/ideas/Armenian.txt
@@ -5591,10 +5591,11 @@ ideas = {
 		ARM_has_artsakh_idea = {
 			picture = arm_no_beznal_idea
 			cancel = {
-				NKR = {
-					NOT = {
-						has_idea = NKR_marz_arm
+				OR = {
+					NKR = {
+						NOT = { has_idea = NKR_marz_arm }
 					}
+					NOT = { country_exists = NKR }
 				}
 			}
 			modifier = {

--- a/events/Karabakh.txt
+++ b/events/Karabakh.txt
@@ -433,6 +433,7 @@ country_event = {
 		}
 		ARM = {
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -514,6 +515,7 @@ country_event = {
 		set_country_flag = karabakh_regulated_flag
 		ARM = {
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -599,6 +601,7 @@ country_event = {
 		set_country_flag = karabakh_regulated_flag
 		ARM = {
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -679,6 +682,7 @@ country_event = {
 		}
 		ARM = {
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -756,6 +760,7 @@ country_event = {
 		set_country_flag = karabakh_regulated_flag
 		ARM = {
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -830,6 +835,7 @@ country_event = {
 		add_stability = 0.3
 		add_political_power = -200
 		set_country_flag = karabakh_regulated_flag
+		remove_ideas = ARM_has_artsakh_idea
 		annex_country = {
 			target = NKR
 			transfer_troops = yes
@@ -916,6 +922,7 @@ country_event = {
 		set_country_flag = karabakh_regulated_flag
 		ARM = {
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -966,6 +973,7 @@ country_event = {
 		add_stability = 0.2
 		add_political_power = -200
 		set_country_flag = karabakh_regulated_flag
+		remove_ideas = ARM_has_artsakh_idea
 		annex_country = {
 			target = NKR
 			transfer_troops = yes
@@ -1032,6 +1040,7 @@ country_event = {
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 			set_country_flag = karabakh_regulated_flag
+			remove_ideas = ARM_has_artsakh_idea
 			annex_country = {
 				target = NKR
 				transfer_troops = yes
@@ -1379,5 +1388,60 @@ country_event = {
 			target = NKR
 			type = annex_everything
 		}
+	}
+}
+
+# Border Opening Events
+country_event = {
+	id = karabakh.30
+
+	title = karabakh.30.t
+	desc = karabakh.30.d
+	picture = GFX_armaze_negot
+
+	is_triggered_only = yes
+
+	option = {
+		log = "[GetDateText]: [This.GetName]: karabakh.30.a executed"
+		name = karabakh.30.a
+		set_country_flag = arm_aze_borders_open
+		add_stability = 0.05
+		add_opinion_modifier = { target = ARM modifier = large_increase }
+		ARM = {
+			set_country_flag = arm_aze_borders_open
+			country_event = { id = karabakh.31 days = 1 }
+			add_stability = 0.05
+			add_opinion_modifier = { target = AZE modifier = large_increase }
+		}
+		ai_chance = {
+			base = 5
+		}
+	}
+	option = {
+		log = "[GetDateText]: [This.GetName]: karabakh.30.b executed"
+		name = karabakh.30.b
+		add_opinion_modifier = { target = ARM modifier = medium_decrease }
+		ARM = {
+			country_event = { id = karabakh.31 days = 1 }
+			add_opinion_modifier = { target = AZE modifier = medium_decrease }
+		}
+		ai_chance = {
+			base = 3
+		}
+	}
+}
+
+country_event = {
+	id = karabakh.31
+
+	title = karabakh.31.t
+	desc = karabakh.31.d
+	picture = GFX_armaze_negot
+
+	is_triggered_only = yes
+
+	option = {
+		name = karabakh.31.a
+		log = "[GetDateText]: [This.GetName]: karabakh.31.a executed"
 	}
 }

--- a/localisation/english/MD_focus_ARM_l_english.yml
+++ b/localisation/english/MD_focus_ARM_l_english.yml
@@ -3555,6 +3555,18 @@ karabakh.29.t: "Second Offensive on Nagorno-Karabakh!"
 karabakh.29.d: "Time has come to attack Nagorno-Karabakh again and take all that was left."
 karabakh.29.a: "Forwards!"
 
+ ARM_open_borders_with_AZE: "Propose Opening Borders with [AZE.GetNamewithFlag]"
+ ARM_open_borders_with_AZE_desc: "With the Karabakh conflict resolved, we can propose to Azerbaijan to open our shared borders, normalizing relations and enabling trade between our nations."
+
+ karabakh.30.t: "[ARM.GetNamewithFlag] Proposes Opening Borders"
+ karabakh.30.d: "Armenia has proposed to open the borders between our two nations. With the Nagorno-Karabakh conflict now resolved, they argue that there is no longer any reason to maintain the blockade. Opening the borders would allow trade and movement of people between our countries, benefiting both economies."
+ karabakh.30.a: "Accept the proposal."
+ karabakh.30.b: "Reject the proposal."
+
+ karabakh.31.t: "Response from [AZE.GetNamewithFlag]"
+ karabakh.31.d: "Azerbaijan has responded to our proposal regarding the opening of borders between our two nations."
+ karabakh.31.a: "We see."
+
 ##REACTIONS
 
 arm_reaction.1.t: "Georgia Annexed Abkhazia"


### PR DESCRIPTION

- **Bug 1**: Fixed `ARM_has_artsakh_idea` persisting after NKR annexation. The cancel condition now also triggers when NKR no longer exists as a country. Added `remove_ideas = ARM_has_artsakh_idea` as a safety net in all 9 Karabakh negotiation event options and the `NKR_armenia_annex_nkr` decision where ARM annexes NKR.
- **Bug 2**: Added `ARM_open_borders_with_AZE` decision and `karabakh.30`/`karabakh.31` events, allowing Armenia to propose opening borders with Azerbaijan after the Karabakh conflict is resolved (`karabakh_regulated_flag`). Includes English and Russian localisation.
