### PR TITLE
agri tech fix

### DIFF
--- a/common/technologies/industry.txt
+++ b/common/technologies/industry.txt
@@ -6960,7 +6960,7 @@ technologies = {
 	agi_maintained_agricultural_developments = {
 
 		research_cost = 1.75
-		start_year = 2035
+		start_year = 2030
 
 		agricolture_productivity_modifier = 0.10
 		agriculture_workers_modifier = -0.10


### PR DESCRIPTION
In the UI, the agricultural technology (agi_maintained_agricultural_developments) is placed in the 2030 column, but it is actually set as a 2035 technology.
I suggest changing it to a 2030 technology to match the others in the same tier.

<img width="2360" height="918" alt="image" src="https://github.com/user-attachments/assets/103c715d-c71e-4113-836b-3b0a7fc9148a" />

Closes #678