### PR TITLE
Fix Germany BFV spending level minimum (closes #682)

### DIFF
--- a/common/scripted_guis/99_GER_scripted_guis.txt
+++ b/common/scripted_guis/99_GER_scripted_guis.txt
@@ -205,7 +205,7 @@ scripted_gui = {
 			#
 			GER_SUBTRACT_EXTREMISTS_BUTTON_click = { #
 				add_to_variable = { GER_islamist_spending_level = -1 }
-				clamp_variable = { var = GER_islamist_spending_level min = 0 max = 3 }
+				clamp_variable = { var = GER_islamist_spending_level min = 1 max = 3 }
 			}
 			# # #
 			GER_ADD_RIGHTWING_BUTTON_click = { #
@@ -215,7 +215,7 @@ scripted_gui = {
 			#
 			GER_SUBTRACT_RIGHTWING_BUTTON_click = { #
 				add_to_variable = { GER_rightwing_spending_level = -1 }
-				clamp_variable = { var = GER_rightwing_spending_level min = 0 max = 3 }
+				clamp_variable = { var = GER_rightwing_spending_level min = 1 max = 3 }
 			}
 			# # #
 			GER_ADD_LEFTWING_BUTTON_click = { #
@@ -226,7 +226,7 @@ scripted_gui = {
 			#
 			GER_SUBTRACT_LEFTWING_BUTTON_click = { #
 				add_to_variable = { GER_leftwing_spending_level = -1 }
-				clamp_variable = { var = GER_leftwing_spending_level min = 0 max = 3 }
+				clamp_variable = { var = GER_leftwing_spending_level min = 1 max = 3 }
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- The BFV GUI subtract buttons used `clamp_variable { min = 0 }`, allowing spending level to drop to 0
- At spending level 0, no ideas update and no monthly status changes fire, freezing the BFV system
- Fixed by changing the clamp minimum from 0 to 1 for all three department subtract buttons (Islamist, Right-wing, Left-wing)

Closes #682

## Root Cause

A prior refactor (`29067e0efb`) removed the on_daily spending-level clamping (min=1, max=3). The GUI subtract buttons were left with `min = 0`, so clicking subtract at level 1 dropped spending to 0 — a value the on_daily and on_monthly handlers never handle, leaving the BFV system frozen.

## Test plan

- [x] Start Germany, open the BFV scripted GUI
- [x] Reduce a department to spending level 1
- [x] Click subtract — confirm it stays at 1 (does not go to 0)
- [x] Confirm ideas and monthly status changes continue to fire normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)