### PR TITLE
Add internal faction events, decisions, and timed ideas (10 factions)

### DIFF
--- a/common/decisions/Internal Factions.txt
+++ b/common/decisions/Internal Factions.txt
@@ -501,4 +501,614 @@ decision_category_internal_factions = {
 			}
 		}
 	}
+
+	# Communist Cadres
+	establish_political_commissars_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = communist_cadres
+		}
+
+		days_remove = 180
+		days_re_enable = 180
+		cost = 100
+
+		modifier = {
+			army_org_regain = 0.05
+			army_morale_factor = 0.03
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove establish_political_commissars_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_communist_cadres_opinion = yes
+			if = {
+				limit = { has_idea = the_military }
+				set_temp_variable = { temp_opinion = -5 }
+				change_the_military_opinion = yes
+			}
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { communist_cadres_opinion < 50 }
+			}
+		}
+	}
+
+	worker_reeducation_programme_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = communist_cadres
+		}
+
+		days_remove = 120
+		days_re_enable = 90
+		cost = 75
+
+		modifier = {
+			consumer_goods_factor = -0.03
+			stability_factor = 0.02
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete worker_reeducation_programme_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = -0.002 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_communist_cadres_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { communist_cadres_opinion < 50 }
+			}
+		}
+	}
+
+	# Maritime Industry
+	maritime_safety_inspections_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = maritime_industry
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 75
+
+		modifier = {
+			industrial_capacity_dockyard = 0.05
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove maritime_safety_inspections_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_maritime_industry_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { maritime_industry_opinion < 50 }
+			}
+		}
+	}
+
+	naval_shipping_subsidy_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = maritime_industry
+		}
+
+		days_remove = 90
+		days_re_enable = 90
+		cost = 100
+
+		modifier = {
+			navy_max_range_factor = 0.10
+			industrial_capacity_dockyard = 0.05
+			dockyard_income_tax_modifier = 0.05
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove naval_shipping_subsidy_decision"
+			set_temp_variable = { temp_opinion = 5 }
+			change_maritime_industry_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { maritime_industry_opinion < 50 }
+			}
+		}
+	}
+
+	# Intelligence Community
+	counter_intelligence_sweep_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = intelligence_community
+		}
+
+		days_remove = 90
+		days_re_enable = 90
+		cost = 100
+
+		modifier = {
+			foreign_subversive_activities_upkeep = -0.15
+			encryption_factor = 0.05
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove counter_intelligence_sweep_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_intelligence_community_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { intelligence_community_opinion < 50 }
+			}
+		}
+	}
+
+	expand_intelligence_network_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = intelligence_community
+		}
+
+		days_remove = 180
+		days_re_enable = 180
+		cost = 150
+
+		modifier = {
+			decryption_factor = 0.10
+			encryption_factor = 0.05
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete expand_intelligence_network_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = -0.003 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_intelligence_community_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { intelligence_community_opinion < 50 }
+			}
+		}
+	}
+
+	# Foreign Jihadis
+	jihadi_recruitment_drive_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = foreign_jihadis
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 75
+
+		modifier = {
+			special_forces_cap = 0.05
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete jihadi_recruitment_drive_decision"
+			add_manpower = 5000
+			set_temp_variable = { temp_opinion = 5 }
+			change_foreign_jihadis_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { foreign_jihadis_opinion < 50 }
+			}
+		}
+	}
+
+	martyr_glorification_campaign_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = foreign_jihadis
+		}
+
+		days_remove = 180
+		days_re_enable = 180
+		cost = 100
+
+		modifier = {
+			war_support_factor = 0.05
+			fascism_drift = 0.01
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete martyr_glorification_campaign_decision"
+			add_stability = -0.01
+			set_temp_variable = { temp_opinion = 5 }
+			change_foreign_jihadis_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { foreign_jihadis_opinion < 50 }
+			}
+			modifier = {
+				factor = 0
+				has_war = no
+			}
+		}
+	}
+
+	# Iranian Quds Force
+	support_proxy_networks_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = iranian_quds_force
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 100
+
+		modifier = {
+			foreign_subversive_activities_upkeep = -0.10
+			political_power_factor = 0.05
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete support_proxy_networks_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = -0.002 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_iranian_quds_force_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { iranian_quds_force_opinion < 50 }
+			}
+		}
+	}
+
+	quds_force_training_programme_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = iranian_quds_force
+		}
+
+		days_remove = 90
+		days_re_enable = 90
+		cost = 75
+
+		modifier = {
+			special_forces_cap = 0.05
+			army_org_regain = 0.03
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove quds_force_training_programme_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_iranian_quds_force_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { iranian_quds_force_opinion < 50 }
+			}
+		}
+	}
+
+	# Defense Industry
+	defense_procurement_programme_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = defense_industry
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 100
+
+		modifier = {
+			military_industry_tax_modifier = 0.08
+			consumer_goods_factor = -0.02
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove defense_procurement_programme_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_defense_industry_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { defense_industry_opinion < 50 }
+			}
+		}
+	}
+
+	classified_research_programme_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = defense_industry
+		}
+
+		days_remove = 180
+		days_re_enable = 180
+		cost = 150
+
+		modifier = {
+			research_speed_factor = 0.05
+			encryption_factor = 0.03
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete classified_research_programme_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = -0.003 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_defense_industry_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { defense_industry_opinion < 50 }
+			}
+		}
+	}
+
+	# International Bankers
+	issue_government_bonds_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = international_bankers
+		}
+
+		days_remove = 120
+		days_re_enable = 90
+		cost = 75
+
+		modifier = {
+			interest_rate_multiplier_modifier = 0.02
+			stability_factor = 0.02
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete issue_government_bonds_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = 0.02 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_international_bankers_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { international_bankers_opinion < 50 }
+			}
+		}
+	}
+
+	attract_foreign_investment_decision = {
+		icon = GFX_decisions_tax_down_button
+		visible = {
+			has_idea = international_bankers
+		}
+
+		days_remove = 90
+		days_re_enable = 90
+		cost = 100
+
+		modifier = {
+			receiving_investment_duration_modifier = -0.15
+			receiving_investment_cost_modifier = -0.10
+			tax_gain_multiplier_modifier = 0.03
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove attract_foreign_investment_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_international_bankers_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { international_bankers_opinion < 50 }
+			}
+		}
+	}
+
+	# Wahabi Ulema
+	fund_religious_schools_decision = {
+		icon = GFX_decisions_religion_government_button
+		visible = {
+			has_idea = wahabi_ulema
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 75
+
+		modifier = {
+			literacy_rate_education_modifier = 0.05
+			stability_factor = 0.02
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove fund_religious_schools_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_the_wahabi_ulema_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { wahabi_ulema_opinion < 50 }
+			}
+		}
+	}
+
+	enforce_moral_codes_decision = {
+		icon = GFX_decisions_religion_government_button
+		visible = {
+			has_idea = wahabi_ulema
+		}
+
+		days_remove = 180
+		days_re_enable = 180
+		cost = 100
+
+		modifier = {
+			stability_factor = 0.03
+			consumer_goods_factor = 0.02
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete enforce_moral_codes_decision"
+			set_temp_variable = { temp_opinion = 5 }
+			change_the_wahabi_ulema_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { wahabi_ulema_opinion < 50 }
+			}
+		}
+	}
+
+	# Farmers
+	agricultural_subsidies_decision = {
+		icon = GFX_decisions_tax_down_button
+		visible = {
+			has_idea = farmers
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 100
+
+		modifier = {
+			agricolture_productivity_modifier = 0.08
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete agricultural_subsidies_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = -0.002 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_farmers_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { farmers_opinion < 50 }
+			}
+		}
+	}
+
+	rural_infrastructure_fund_decision = {
+		icon = GFX_decision_bancru_ask_button
+		visible = {
+			has_idea = farmers
+		}
+
+		days_remove = 90
+		days_re_enable = 90
+		cost = 75
+
+		modifier = {
+			agriculture_district_worker_requirement_modifier = -0.05
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision complete rural_infrastructure_fund_decision"
+			set_temp_variable = { treasury_change = gdp_total }
+			multiply_temp_variable = { treasury_change = -0.002 }
+			modify_treasury_effect = yes
+			set_temp_variable = { temp_opinion = 5 }
+			change_farmers_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { farmers_opinion < 50 }
+			}
+		}
+	}
+
+	# Industrial Conglomerates
+	infrastructure_investment_programme_decision = {
+		icon = GFX_decisions_foreign_military_button
+		visible = {
+			has_idea = industrial_conglomerates
+		}
+
+		days_remove = 120
+		days_re_enable = 120
+		cost = 100
+
+		modifier = {
+			civilian_factories_productivity = 0.05
+			offices_productivity = 0.03
+		}
+
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: decision remove infrastructure_investment_programme_decision"
+			set_temp_variable = { temp_opinion = 10 }
+			change_industrial_conglomerates_opinion = yes
+		}
+
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				check_variable = { industrial_conglomerates_opinion < 50 }
+			}
+		}
+	}
 }

--- a/common/ideas/AA_law_internal_factions.txt
+++ b/common/ideas/AA_law_internal_factions.txt
@@ -1,4 +1,4 @@
-# The Internal Faction System:
+﻿# The Internal Faction System:
 # Authored: Killerrabbit, Angriest Bird
 # ---
 # The Internal Faction System is meant to represent internal politics and strife within a country.
@@ -981,6 +981,109 @@ ideas = {
 				police_cost_multiplier_modifier = 0.05
 				drift_defence_factor = 0.10
 				stability_factor = 0.05
+			}
+		}
+	}
+
+	country = {
+		# Ideas for new internal faction events
+		internal_factions_cadre_purge = {
+			picture = democracy
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				drift_defence_factor = 0.05
+			}
+		}
+
+		internal_factions_collectivisation_drive = {
+			picture = central_management
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				consumer_goods_factor = 0.05
+			}
+		}
+
+		internal_factions_convoy_escort = {
+			picture = escort_effort
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				experience_gain_navy_factor = 0.05
+			}
+		}
+
+		internal_factions_piracy_losses = {
+			picture = poor_economy
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				stability_factor = -0.03
+			}
+		}
+
+		internal_factions_neutralised_spies = {
+			picture = Disorganization_Military_3
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				decryption_factor = 0.05
+			}
+		}
+
+		internal_factions_transparency_costs = {
+			picture = Disorganization_Military_3
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				encryption_factor = -0.05
+			}
+		}
+
+		internal_factions_jihadi_frontline = {
+			picture = license_production
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				army_attack_factor = 0.02
+				army_defence_factor = -0.03
+			}
+		}
+
+		internal_factions_jihadi_autonomy = {
+			picture = license_production
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				special_forces_cap = 0.1
+			}
+		}
+
+		internal_factions_jihadi_integrated = {
+			picture = license_production
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				army_org_regain = 0.03
+			}
+		}
+
+		internal_factions_quds_expanded = {
+			picture = foreign_capital
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				foreign_subversive_activities_upkeep = -0.10
+			}
+		}
+
+		internal_factions_quds_operation = {
+			picture = foreign_capital
+			allowed_civil_war = { always = yes }
+
+			modifier = {
+				army_attack_factor = 0.03
 			}
 		}
 	}

--- a/common/on_actions/MD_event_on_actions.txt
+++ b/common/on_actions/MD_event_on_actions.txt
@@ -79,6 +79,17 @@ on_actions = {
 			20 = internal_factions_events.50 # Prince Needs Money for Airline
 			20 = internal_factions_events.51 # Family Drama Goes Viral
 			20 = internal_factions_events.52 # Royal Prince Defects and Denounces the Government From Abroad
+			25 = internal_factions_events.53 # Communist Cadres: Party Loyalty Investigation
+			25 = internal_factions_events.54 # Communist Cadres: Cadres Demand Collectivisation Drive
+			25 = internal_factions_events.55 # Maritime Industry: Port Expansion Dispute
+			25 = internal_factions_events.56 # Maritime Industry: Piracy Threatens Shipping Lanes
+			25 = internal_factions_events.57 # Intelligence Community: Covert Operation Opportunity
+			25 = internal_factions_events.58 # Intelligence Community: Intelligence Budget Review
+			25 = internal_factions_events.59 # Foreign Jihadis: Foreign Fighters Arrive
+			25 = internal_factions_events.60 # Foreign Jihadis: Jihadi Faction Demands Autonomy
+			25 = internal_factions_events.61 # Quds Force: Quds Force Requests Expanded Operations
+			25 = internal_factions_events.62 # Quds Force: Quds Force Identifies Strategic Opportunity
+			25 = internal_factions_events.63 # Defense Industry: Defense Industry Seeks Export Contracts
 
 			#Financial collapse (only if interest_rate > 15)
 			#X party leader makes a speech

--- a/events/Internal Faction Events.txt
+++ b/events/Internal Faction Events.txt
@@ -4228,3 +4228,584 @@ country_event = {
 		}
 	}
 }
+
+# Communist Cadres: Party Loyalty Investigation
+country_event = {
+	id = internal_factions_events.53
+	title = internal_factions_events.53.t
+	desc = internal_factions_events.53.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_cadre_loyalty_investigation }
+		has_idea = communist_cadres
+		check_variable = { communist_cadres_opinion > 60 }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_cadre_loyalty_investigation value = 1 days = 365 }
+	}
+
+	# Comply with the purge
+	option = {
+		name = internal_factions_events.53.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.53.o1 executed"
+		set_temp_variable = { treasury_change = gdp_total }
+		multiply_temp_variable = { treasury_change = -0.003 }
+		modify_treasury_effect = yes
+		set_temp_variable = { temp_opinion = 10 }
+		change_communist_cadres_opinion = yes
+		if = {
+			limit = { has_idea = the_military }
+			set_temp_variable = { temp_opinion = -5 }
+			change_the_military_opinion = yes
+		}
+		add_timed_idea = { idea = internal_factions_cadre_purge days = 180 }
+		ai_chance = { base = 1 }
+	}
+
+	# Refuse the purge
+	option = {
+		name = internal_factions_events.53.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.53.o2 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_communist_cadres_opinion = yes
+		if = {
+			limit = { has_idea = the_military }
+			set_temp_variable = { temp_opinion = 5 }
+			change_the_military_opinion = yes
+		}
+		ai_chance = { base = 1 }
+	}
+
+	# Compromise
+	option = {
+		name = internal_factions_events.53.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.53.o3 executed"
+		add_political_power = -75
+		set_temp_variable = { temp_opinion = 5 }
+		change_communist_cadres_opinion = yes
+		ai_chance = { base = 1 }
+	}
+}
+
+# Communist Cadres: Cadres Demand Collectivisation Drive
+country_event = {
+	id = internal_factions_events.54
+	title = internal_factions_events.54.t
+	desc = internal_factions_events.54.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_cadre_collectivisation }
+		has_idea = communist_cadres
+		check_variable = { agriculture_district_total > 0 }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_cadre_collectivisation value = 1 days = 365 }
+	}
+
+	# Support collectivisation
+	option = {
+		name = internal_factions_events.54.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.54.o1 executed"
+		set_temp_variable = { temp_opinion = 10 }
+		change_communist_cadres_opinion = yes
+		if = {
+			limit = { has_idea = farmers }
+			set_temp_variable = { temp_opinion = -10 }
+			change_farmers_opinion = yes
+		}
+		if = {
+			limit = { has_idea = landowners }
+			set_temp_variable = { temp_opinion = -10 }
+			change_landowners_opinion = yes
+		}
+		add_timed_idea = { idea = internal_factions_collectivisation_drive days = 365 }
+		ai_chance = { base = 1 }
+	}
+
+	# Refuse collectivisation
+	option = {
+		name = internal_factions_events.54.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.54.o2 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_communist_cadres_opinion = yes
+		if = {
+			limit = { has_idea = farmers }
+			set_temp_variable = { temp_opinion = 5 }
+			change_farmers_opinion = yes
+		}
+		ai_chance = { base = 1 }
+	}
+
+	# Partial reform
+	option = {
+		name = internal_factions_events.54.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.54.o3 executed"
+		add_political_power = -100
+		set_temp_variable = { temp_opinion = 5 }
+		change_communist_cadres_opinion = yes
+		if = {
+			limit = { has_idea = farmers }
+			set_temp_variable = { temp_opinion = -5 }
+			change_farmers_opinion = yes
+		}
+		ai_chance = { base = 1 }
+	}
+}
+
+# Maritime Industry: Port Expansion Dispute
+country_event = {
+	id = internal_factions_events.55
+	title = internal_factions_events.55.t
+	desc = internal_factions_events.55.d
+	picture = GFX_carrier
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_port_expansion_dispute }
+		has_idea = maritime_industry
+		any_owned_state = { is_coastal = yes }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_port_expansion_dispute value = 1 days = 365 }
+	}
+
+	# Approve expansion
+	option = {
+		name = internal_factions_events.55.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.55.o1 executed"
+		set_temp_variable = { treasury_change = gdp_total }
+		multiply_temp_variable = { treasury_change = -0.015 }
+		modify_treasury_effect = yes
+		set_temp_variable = { temp_opinion = 10 }
+		change_maritime_industry_opinion = yes
+		random_owned_state = {
+			limit = { is_coastal = yes }
+			add_building_construction = { type = dockyard level = 1 instant_build = yes }
+		}
+		ai_chance = { base = 1 }
+	}
+
+	# Deny expansion
+	option = {
+		name = internal_factions_events.55.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.55.o2 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_maritime_industry_opinion = yes
+		if = {
+			limit = { has_idea = landowners }
+			set_temp_variable = { temp_opinion = 5 }
+			change_landowners_opinion = yes
+		}
+		ai_chance = { base = 1 }
+	}
+
+	# Negotiate
+	option = {
+		name = internal_factions_events.55.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.55.o3 executed"
+		add_political_power = -75
+		set_temp_variable = { temp_opinion = 5 }
+		change_maritime_industry_opinion = yes
+		if = {
+			limit = { has_idea = landowners }
+			set_temp_variable = { temp_opinion = 5 }
+			change_landowners_opinion = yes
+		}
+		ai_chance = { base = 1 }
+	}
+}
+
+# Maritime Industry: Piracy Threatens Shipping Lanes
+country_event = {
+	id = internal_factions_events.56
+	title = internal_factions_events.56.t
+	desc = internal_factions_events.56.d
+	picture = GFX_carrier
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_piracy_threat }
+		has_idea = maritime_industry
+		has_war = no
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_piracy_threat value = 1 days = 365 }
+	}
+
+	# Fund naval escort
+	option = {
+		name = internal_factions_events.56.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.56.o1 executed"
+		set_temp_variable = { temp_opinion = 5 }
+		change_maritime_industry_opinion = yes
+		add_timed_idea = { idea = internal_factions_convoy_escort days = 180 }
+		ai_chance = { base = 1 }
+	}
+
+	# Ignore the threat
+	option = {
+		name = internal_factions_events.56.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.56.o2 executed"
+		set_temp_variable = { temp_opinion = -5 }
+		change_maritime_industry_opinion = yes
+		add_timed_idea = { idea = internal_factions_piracy_losses days = 90 }
+		ai_chance = { base = 1 }
+	}
+
+	# Request international cooperation
+	option = {
+		name = internal_factions_events.56.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.56.o3 executed"
+		set_temp_variable = { temp_opinion = 5 }
+		change_maritime_industry_opinion = yes
+		add_political_power = 25
+		ai_chance = { base = 1 }
+	}
+}
+
+# Intelligence Community: Covert Operation Opportunity
+country_event = {
+	id = internal_factions_events.57
+	title = internal_factions_events.57.t
+	desc = internal_factions_events.57.d
+	picture = GFX_politics_surveillence
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_covert_op_opportunity }
+		has_idea = intelligence_community
+		check_variable = { intelligence_community_opinion > 49 }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_covert_op_opportunity value = 1 days = 365 }
+	}
+
+	# Expose publicly
+	option = {
+		name = internal_factions_events.57.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.57.o1 executed"
+		add_political_power = -50
+		set_temp_variable = { temp_opinion = 5 }
+		change_intelligence_community_opinion = yes
+		add_stability = 0.02
+		add_world_tension = 0.1
+		ai_chance = { base = 1 }
+	}
+
+	# Quietly neutralise
+	option = {
+		name = internal_factions_events.57.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.57.o2 executed"
+		set_temp_variable = { temp_opinion = 10 }
+		change_intelligence_community_opinion = yes
+		add_timed_idea = { idea = internal_factions_neutralised_spies days = 180 }
+		ai_chance = { base = 1 }
+	}
+
+	# Ignore the threat
+	option = {
+		name = internal_factions_events.57.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.57.o3 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_intelligence_community_opinion = yes
+		ai_chance = { base = 1 }
+	}
+}
+
+# Intelligence Community: Intelligence Budget Review
+country_event = {
+	id = internal_factions_events.58
+	title = internal_factions_events.58.t
+	desc = internal_factions_events.58.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_intel_budget_review }
+		has_idea = intelligence_community
+		has_elections = yes
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_intel_budget_review value = 1 days = 365 }
+	}
+
+	# Defend budget fully
+	option = {
+		name = internal_factions_events.58.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.58.o1 executed"
+		lose_pp_for_2_months = yes
+		set_temp_variable = { temp_opinion = 10 }
+		change_intelligence_community_opinion = yes
+		ai_chance = { base = 1 }
+	}
+
+	# Reveal partial info
+	option = {
+		name = internal_factions_events.58.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.58.o2 executed"
+		set_temp_variable = { temp_opinion = -5 }
+		change_intelligence_community_opinion = yes
+		add_stability = 0.01
+		add_political_power = -50
+		ai_chance = { base = 1 }
+	}
+
+	# Increase transparency
+	option = {
+		name = internal_factions_events.58.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.58.o3 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_intelligence_community_opinion = yes
+		add_timed_idea = { idea = internal_factions_transparency_costs days = 180 }
+		set_party_index_to_ruling_party = yes
+		set_temp_variable = { party_popularity_increase = 0.02 }
+		add_relative_party_popularity = yes
+		ai_chance = { base = 1 }
+	}
+}
+
+# Foreign Jihadis: Foreign Fighters Arrive
+country_event = {
+	id = internal_factions_events.59
+	title = internal_factions_events.59.t
+	desc = internal_factions_events.59.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_foreign_fighters_arrive }
+		has_idea = foreign_jihadis
+		has_war = yes
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_foreign_fighters_arrive value = 1 days = 365 }
+	}
+
+	# Integrate into forces
+	option = {
+		name = internal_factions_events.59.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.59.o1 executed"
+		set_temp_variable = { temp_opinion = 10 }
+		change_foreign_jihadis_opinion = yes
+		add_manpower = 5000
+		add_timed_idea = { idea = internal_factions_jihadi_integrated days = 180 }
+		ai_chance = { base = 1 }
+	}
+
+	# Assign to frontlines
+	option = {
+		name = internal_factions_events.59.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.59.o2 executed"
+		set_temp_variable = { temp_opinion = 5 }
+		change_foreign_jihadis_opinion = yes
+		add_timed_idea = { idea = internal_factions_jihadi_frontline days = 180 }
+		ai_chance = { base = 1 }
+	}
+
+	# Turn them away
+	option = {
+		name = internal_factions_events.59.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.59.o3 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_foreign_jihadis_opinion = yes
+		add_stability = 0.01
+		ai_chance = { base = 1 }
+	}
+}
+
+# Foreign Jihadis: Jihadi Faction Demands Autonomy
+country_event = {
+	id = internal_factions_events.60
+	title = internal_factions_events.60.t
+	desc = internal_factions_events.60.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_jihadi_autonomy_demand }
+		has_idea = foreign_jihadis
+		check_variable = { foreign_jihadis_opinion > 60 }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_jihadi_autonomy_demand value = 1 days = 365 }
+	}
+
+	# Grant autonomy
+	option = {
+		name = internal_factions_events.60.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.60.o1 executed"
+		add_stability = -0.02
+		set_temp_variable = { temp_opinion = 15 }
+		change_foreign_jihadis_opinion = yes
+		add_timed_idea = { idea = internal_factions_jihadi_autonomy days = 365 }
+		ai_chance = { base = 1 }
+	}
+
+	# Deny autonomy
+	option = {
+		name = internal_factions_events.60.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.60.o2 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_foreign_jihadis_opinion = yes
+		add_stability = 0.01
+		ai_chance = { base = 1 }
+	}
+
+	# Integrate formally
+	option = {
+		name = internal_factions_events.60.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.60.o3 executed"
+		set_temp_variable = { temp_opinion = -5 }
+		change_foreign_jihadis_opinion = yes
+		add_manpower = 5000
+		add_timed_idea = { idea = internal_factions_jihadi_integrated days = 180 }
+		ai_chance = { base = 1 }
+	}
+}
+
+# Iranian Quds Force: Quds Force Requests Expanded Operations
+country_event = {
+	id = internal_factions_events.61
+	title = internal_factions_events.61.t
+	desc = internal_factions_events.61.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_quds_expansion_request }
+		has_idea = iranian_quds_force
+		check_variable = { iranian_quds_force_opinion > 49 }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_quds_expansion_request value = 1 days = 365 }
+	}
+
+	# Fund fully
+	option = {
+		name = internal_factions_events.61.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.61.o1 executed"
+		set_temp_variable = { treasury_change = gdp_total }
+		multiply_temp_variable = { treasury_change = -0.01 }
+		modify_treasury_effect = yes
+		set_temp_variable = { temp_opinion = 10 }
+		change_iranian_quds_force_opinion = yes
+		add_timed_idea = { idea = internal_factions_quds_expanded days = 270 }
+		ai_chance = { base = 1 }
+	}
+
+	# Partial support
+	option = {
+		name = internal_factions_events.61.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.61.o2 executed"
+		add_political_power = -50
+		set_temp_variable = { temp_opinion = 5 }
+		change_iranian_quds_force_opinion = yes
+		ai_chance = { base = 1 }
+	}
+
+	# Deny request
+	option = {
+		name = internal_factions_events.61.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.61.o3 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_iranian_quds_force_opinion = yes
+		add_political_power = 75
+		ai_chance = { base = 1 }
+	}
+}
+
+# Iranian Quds Force: Quds Force Identifies Strategic Opportunity
+country_event = {
+	id = internal_factions_events.62
+	title = internal_factions_events.62.t
+	desc = internal_factions_events.62.d
+	picture = GFX_politics_talks
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_quds_strategic_op }
+		has_idea = iranian_quds_force
+		any_neighbor_country = { has_war = yes }
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_quds_strategic_op value = 1 days = 365 }
+	}
+
+	# Exploit the opportunity
+	option = {
+		name = internal_factions_events.62.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.62.o1 executed"
+		add_political_power = -75
+		add_timed_idea = { idea = internal_factions_quds_operation days = 180 }
+		set_temp_variable = { temp_opinion = 5 }
+		change_iranian_quds_force_opinion = yes
+		ai_chance = { base = 1 }
+	}
+
+	# Share intelligence with allies
+	option = {
+		name = internal_factions_events.62.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.62.o2 executed"
+		set_temp_variable = { temp_opinion = 5 }
+		change_iranian_quds_force_opinion = yes
+		add_political_power = 25
+		ai_chance = { base = 1 }
+	}
+
+	# Ignore the opportunity
+	option = {
+		name = internal_factions_events.62.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.62.o3 executed"
+		set_temp_variable = { temp_opinion = -5 }
+		change_iranian_quds_force_opinion = yes
+		add_political_power = 50
+		ai_chance = { base = 1 }
+	}
+}
+
+# Defense Industry: Defense Industry Seeks Export Contracts
+country_event = {
+	id = internal_factions_events.63
+	title = internal_factions_events.63.t
+	desc = internal_factions_events.63.d
+	picture = GFX_politics_economy
+	is_triggered_only = yes
+	trigger = {
+		NOT = { has_country_flag = INT_recently_had_defense_export_contracts }
+		has_idea = defense_industry
+		has_war = no
+	}
+	immediate = {
+		set_country_flag = { flag = INT_recently_had_defense_export_contracts value = 1 days = 365 }
+	}
+
+	# Approve exports
+	option = {
+		name = internal_factions_events.63.o1
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.63.o1 executed"
+		add_political_power = -50
+		set_temp_variable = { temp_opinion = 10 }
+		change_defense_industry_opinion = yes
+		add_world_tension = 0.5
+		set_temp_variable = { treasury_change = gdp_total }
+		multiply_temp_variable = { treasury_change = -0.003 }
+		modify_treasury_effect = yes
+		ai_chance = { base = 1 }
+	}
+
+	# Restrict to allied buyers only
+	option = {
+		name = internal_factions_events.63.o2
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.63.o2 executed"
+		set_temp_variable = { temp_opinion = 5 }
+		change_defense_industry_opinion = yes
+		set_temp_variable = { treasury_change = gdp_total }
+		multiply_temp_variable = { treasury_change = -0.002 }
+		modify_treasury_effect = yes
+		ai_chance = { base = 1 }
+	}
+
+	# Deny
+	option = {
+		name = internal_factions_events.63.o3
+		log = "[GetDateText]: [This.GetName]: internal_factions_events.63.o3 executed"
+		set_temp_variable = { temp_opinion = -10 }
+		change_defense_industry_opinion = yes
+		add_political_power = 50
+		ai_chance = { base = 1 }
+	}
+}

--- a/localisation/english/MD_internal_factions_new_l_english.yml
+++ b/localisation/english/MD_internal_factions_new_l_english.yml
@@ -1,0 +1,175 @@
+﻿ l_english:
+ # Events .53-.62 — New internal faction content
+ # Communist Cadres: Party Loyalty Investigation
+ internal_factions_events.53.t: "Party Loyalty Under Scrutiny"
+ internal_factions_events.53.d: "The Communist Cadres have presented the government with a list of bureaucratic officials they consider ideologically unreliable. They are demanding a formal loyalty investigation and the removal of those who fail to meet the party's standards."
+ internal_factions_events.53.o1: "Conduct the purge"
+ internal_factions_events.53.o2: "Refuse their demands"
+ internal_factions_events.53.o3: "Launch a limited review"
+
+ # Communist Cadres: Cadres Demand Collectivisation Drive
+ internal_factions_events.54.t: "Cadres Call for Collectivisation"
+ internal_factions_events.54.d: "The Communist Cadres have grown impatient with private agricultural holdings. They are pushing the government to launch a collectivisation drive, consolidating farmland under state control to increase efficiency and ideological conformity."
+ internal_factions_events.54.o1: "Support collectivisation"
+ internal_factions_events.54.o2: "Reject the proposal"
+ internal_factions_events.54.o3: "Pursue limited land reform"
+
+ # Maritime Industry: Port Expansion Dispute
+ internal_factions_events.55.t: "Industry Demands Port Expansion"
+ internal_factions_events.55.d: "The Maritime Industry has submitted a proposal to expand port facilities along the coast, arguing that congestion is costing them millions annually. Local landowners and city planners have objected, citing displacement concerns and urban disruption."
+ internal_factions_events.55.o1: "Approve the expansion"
+ internal_factions_events.55.o2: "Deny the proposal"
+ internal_factions_events.55.o3: "Negotiate a compromise"
+
+ # Maritime Industry: Piracy Threatens Shipping Lanes
+ internal_factions_events.56.t: "Piracy Disrupts Shipping Routes"
+ internal_factions_events.56.d: "A surge in piracy has put our commercial shipping lanes under threat. Maritime industry representatives are demanding government intervention to protect their vessels and cargo, warning that inaction will drive up insurance costs and deter investment."
+ internal_factions_events.56.o1: "Fund a naval escort programme"
+ internal_factions_events.56.o2: "Ignore the problem"
+ internal_factions_events.56.o3: "Seek international cooperation"
+
+ # Intelligence Community: Covert Operation Opportunity
+ internal_factions_events.57.t: "Foreign Espionage Ring Uncovered"
+ internal_factions_events.57.d: "Intelligence analysts have identified a foreign espionage ring operating within our borders. The Intelligence Community is pressing the government to act decisively before the network extracts any further classified information."
+ internal_factions_events.57.o1: "Expose the network publicly"
+ internal_factions_events.57.o2: "Neutralise it quietly"
+ internal_factions_events.57.o3: "Take no action"
+
+ # Intelligence Community: Intelligence Budget Review
+ internal_factions_events.58.t: "Legislature Questions Intelligence Spending"
+ internal_factions_events.58.d: "Ahead of the next electoral cycle, members of the legislature have raised pointed questions about the intelligence services' opaque budget. Advocacy groups are calling for greater accountability, while the Intelligence Community warns that transparency will compromise ongoing operations."
+ internal_factions_events.58.o1: "Defend the budget in full"
+ internal_factions_events.58.o2: "Release partial information"
+ internal_factions_events.58.o3: "Commit to full transparency"
+
+ # Foreign Jihadis: Foreign Fighters Arrive
+ internal_factions_events.59.t: "Foreign Fighters Cross the Border"
+ internal_factions_events.59.d: "A wave of foreign fighters has crossed into our territory, drawn by the ongoing conflict. They are offering their services to our cause, though their reliability and discipline remain uncertain. The Foreign Jihadi networks are urging the government to find them a role."
+ internal_factions_events.59.o1: "Integrate them into regular units"
+ internal_factions_events.59.o2: "Deploy them to the front immediately"
+ internal_factions_events.59.o3: "Turn them away at the border"
+
+ # Foreign Jihadis: Jihadi Faction Demands Autonomy
+ internal_factions_events.60.t: "Jihadi Brigades Demand Autonomy"
+ internal_factions_events.60.d: "Emboldened by their growing numbers, the Foreign Jihadi brigades are demanding formal recognition as an autonomous force operating under their own command structure. They argue that operational independence will allow them to act more effectively without bureaucratic interference."
+ internal_factions_events.60.o1: "Grant them operational autonomy"
+ internal_factions_events.60.o2: "Deny the request"
+ internal_factions_events.60.o3: "Integrate them into the national command"
+
+ # Iranian Quds Force: Quds Force Requests Expanded Operations
+ internal_factions_events.61.t: "Quds Force Seeks More Resources"
+ internal_factions_events.61.d: "Quds Force leadership has submitted a formal request for additional funding and materiel to expand their regional proxy operations. They argue that the strategic opportunity is now and that underfunding risks ceding influence to rival powers."
+ internal_factions_events.61.o1: "Provide full funding"
+ internal_factions_events.61.o2: "Offer partial support"
+ internal_factions_events.61.o3: "Deny the request"
+
+ # Iranian Quds Force: Quds Force Identifies Strategic Opportunity
+ internal_factions_events.62.t: "A Neighbour's Vulnerability"
+ internal_factions_events.62.d: "Quds Force intelligence reports that a neighbouring state, currently embroiled in conflict, is vulnerable to proxy pressure. The window of opportunity is narrow, but the potential strategic gains are significant."
+ internal_factions_events.62.o1: "Exploit the situation"
+ internal_factions_events.62.o2: "Share intelligence with aligned states"
+ internal_factions_events.62.o3: "Let the opportunity pass"
+
+ # Decisions
+ establish_political_commissars_decision: "Embed Political Commissars"
+ establish_political_commissars_decision_desc: "Deploy party commissars within military units to enforce ideological loyalty and boost morale. The commissars will report directly to the Communist Cadres, strengthening their influence over the armed forces."
+
+ worker_reeducation_programme_decision: "Worker Re-Education Programme"
+ worker_reeducation_programme_decision_desc: "Fund a state-run re-education programme to reinforce party ideology among the workforce. Compliance rises and consumer demand falls as workers redirect effort toward state priorities."
+
+ maritime_safety_inspections_decision: "Mandatory Maritime Safety Inspections"
+ maritime_safety_inspections_decision_desc: "Commission a comprehensive safety inspection regime across all domestic port and shipyard facilities. Raising standards reassures the industry and improves dockyard output over the inspection period."
+
+ naval_shipping_subsidy_decision: "Naval Shipping Subsidy"
+ naval_shipping_subsidy_decision_desc: "Provide direct government subsidies to domestic long-haul shipping operators. The programme extends the operational range of our merchant fleet and improves dockyard throughput."
+
+ counter_intelligence_sweep_decision: "Counter-Intelligence Sweep"
+ counter_intelligence_sweep_decision_desc: "Authorise the Intelligence Community to conduct a systematic sweep of government and military networks for foreign penetration. Foreign espionage costs fall and our communications security improves during the operation."
+
+ expand_intelligence_network_decision: "Expand Intelligence Networks"
+ expand_intelligence_network_decision_desc: "Fund the establishment of new overseas intelligence stations and human intelligence assets. The expanded network improves our ability to decrypt enemy communications and monitor foreign military movements."
+
+ jihadi_recruitment_drive_decision: "Jihadi Recruitment Drive"
+ jihadi_recruitment_drive_decision_desc: "Sponsor an active recruitment campaign across sympathetic networks to attract foreign fighters to our cause. Additional manpower flows in and our special forces capacity grows."
+
+ martyr_glorification_campaign_decision: "Martyr Glorification Campaign"
+ martyr_glorification_campaign_decision_desc: "Launch a propaganda campaign glorifying fallen fighters and elevating martyrdom as a cultural ideal. War fervour rises sharply, though the radicalising message risks inflaming extremist sentiment."
+
+ support_proxy_networks_decision: "Support Proxy Networks"
+ support_proxy_networks_decision_desc: "Channel funds and equipment through the Quds Force to regional proxy groups operating in neighbouring states. Strengthening these networks extends our strategic reach and reduces the direct cost of maintaining pressure on rivals."
+
+ quds_force_training_programme_decision: "Quds Force Training Programme"
+ quds_force_training_programme_decision_desc: "Authorise the Quds Force to run advanced irregular warfare training for select military units. Unconventional warfare proficiency improves and special forces capacity expands."
+
+ # Defense Industry: Defense Industry Seeks Export Contracts
+ internal_factions_events.63.t: "Contractors Lobby for Export Deals"
+ internal_factions_events.63.d: "Defence contractors are pressing the government to lend its backing to a series of overseas arms export contracts. They argue the deals will bring significant revenue and sustain domestic production lines, but critics warn that broad sales could inflame regional tensions and draw unwanted international scrutiny."
+ internal_factions_events.63.o1: "Approve full exports"
+ internal_factions_events.63.o2: "Limit sales to allied buyers"
+ internal_factions_events.63.o3: "Reject the lobbying effort"
+
+ # Decisions — Defense Industry
+ defense_procurement_programme_decision: "Defense Procurement Programme"
+ defense_procurement_programme_decision_desc: "Launch a dedicated procurement cycle that guarantees steady orders for domestic arms manufacturers. Sustained contracts boost military industry tax revenue and reduce the consumer goods burden, rewarding the defense industry for its continued cooperation."
+
+ classified_research_programme_decision: "Classified Research Programme"
+ classified_research_programme_decision_desc: "Commit classified funding to military technology research conducted through defense industry partners. The investment accelerates research output and hardens communications security, with a financial transfer on programme launch."
+
+ # Decisions — International Bankers
+ issue_government_bonds_decision: "Issue Government Bonds"
+ issue_government_bonds_decision_desc: "Authorise the issuance of government bonds managed through international banking networks. The immediate injection of capital lifts stability, though servicing the debt nudges interest rates upward for the duration."
+
+ attract_foreign_investment_decision: "Attract Foreign Investment"
+ attract_foreign_investment_decision_desc: "Coordinate with international banking contacts to signal stability and reduce barriers to entry. The campaign shortens the time required to receive foreign investment and increases tax receipts from inbound capital."
+
+ # Timed idea names and descriptions
+ internal_factions_cadre_purge: "Cadre Purge"
+ internal_factions_cadre_purge_desc: "Party commissars are conducting loyalty investigations across the bureaucracy, strengthening ideological discipline at the cost of administrative disruption."
+
+ internal_factions_collectivisation_drive: "Collectivisation Drive"
+ internal_factions_collectivisation_drive_desc: "Agricultural collectivisation is underway, disrupting supply chains and increasing consumer goods shortages as private farms transition to state control."
+
+ internal_factions_convoy_escort: "Naval Escort Programme"
+ internal_factions_convoy_escort_desc: "Government-funded naval escorts are protecting commercial shipping lanes, boosting the confidence and experience of our naval personnel."
+
+ internal_factions_piracy_losses: "Piracy Disruption"
+ internal_factions_piracy_losses_desc: "Unchecked piracy is disrupting our shipping lanes, undermining trade confidence and destabilising the broader economy."
+
+ internal_factions_neutralised_spies: "Espionage Network Dismantled"
+ internal_factions_neutralised_spies_desc: "A foreign intelligence network has been quietly neutralised, improving our counter-espionage capabilities for a period."
+
+ internal_factions_transparency_costs: "Intelligence Transparency Costs"
+ internal_factions_transparency_costs_desc: "Public disclosure of intelligence operations has weakened our encryption security as adversaries adapt to newly revealed methods."
+
+ internal_factions_jihadi_frontline: "Jihadi Frontline Deployment"
+ internal_factions_jihadi_frontline_desc: "Foreign fighters deployed directly to the front are pressing enemy lines aggressively, though their lack of integration with regular forces leaves flanks exposed."
+
+ internal_factions_jihadi_autonomy: "Jihadi Autonomous Force"
+ internal_factions_jihadi_autonomy_desc: "The recognised autonomous jihadi brigades operate under their own command, significantly expanding our special forces ceiling."
+
+ internal_factions_jihadi_integrated: "Integrated Jihadi Forces"
+ internal_factions_jihadi_integrated_desc: "Foreign fighters formally integrated into the national command structure have improved unit cohesion and organisational recovery rates."
+
+ internal_factions_quds_expanded: "Quds Force Expanded Operations"
+ internal_factions_quds_expanded_desc: "Additional resources have enabled the Quds Force to broaden their proxy operations, reducing the upkeep cost of foreign subversive activities."
+
+ internal_factions_quds_operation: "Quds Force Strategic Operation"
+ internal_factions_quds_operation_desc: "The Quds Force is actively exploiting instability in a neighbouring state, providing a tactical edge in ongoing operations."
+
+ # Decisions — Wahabi Ulema
+ fund_religious_schools_decision: "Fund Religious Schools"
+ fund_religious_schools_decision_desc: "Channel government funding into a network of religious schools operating under Wahabi Ulema oversight. Literacy rates improve and social stability rises as the institutions expand their reach."
+
+ enforce_moral_codes_decision: "Enforce Moral Codes"
+ enforce_moral_codes_decision_desc: "Empower religious authorities to enforce public moral standards across the country. The measure bolsters the Ulema's influence and raises social cohesion, though tighter restrictions nudge consumer spending upward."
+
+ # Decisions — Farmers
+ agricultural_subsidies_decision: "Agricultural Subsidies"
+ agricultural_subsidies_decision_desc: "Provide direct subsidies to the farming sector to boost output and reward the Farmers faction for their cooperation. The initial outlay reduces treasury reserves, but productivity gains sustain the economy through the programme."
+
+ rural_infrastructure_fund_decision: "Rural Infrastructure Fund"
+ rural_infrastructure_fund_decision_desc: "Commit government funds to road, irrigation, and storage improvements in rural areas. The investment lightens the labour burden on agricultural districts and earns goodwill from farming communities."
+
+ # Decisions — Industrial Conglomerates
+ infrastructure_investment_programme_decision: "Infrastructure Investment Programme"
+ infrastructure_investment_programme_decision_desc: "Partner with major industrial conglomerates to fund a broad infrastructure upgrade across the country's production base. Factory and office output rises for the duration of the programme, cementing the conglomerates' role as a pillar of the economy."


### PR DESCRIPTION
## Summary

- Adds **11 new events** (`internal_factions_events.53–.63`) covering 6 factions with country flags for cooldown (365 days each)
- Adds **23 new decisions** across 10 factions with `modifier`, `complete_effect`/`remove_effect`, `ai_will_do`, and full logging
- Adds **11 new timed ideas** used as event outcomes, all with `allowed_civil_war = { always = yes }`
- Adds **new localisation file** (`MD_internal_factions_new_l_english.yml`) with all keys for events, decisions, and ideas

**Factions receiving new dedicated content:**
| Faction | New Events | New Decisions |
|---|---|---|
| Communist Cadres | Loyalty purge, collectivisation drive | Embed commissars, worker re-education |
| Maritime Industry | Port expansion dispute, piracy threat | Safety inspections, shipping subsidy |
| Intelligence Community | Covert op opportunity, budget review | Counter-intel sweep, expand networks |
| Foreign Jihadis | Foreign fighters arrive, autonomy demand | Recruitment drive, martyr campaign |
| Iranian Quds Force | Expanded ops request, strategic opportunity | Proxy networks, training programme |
| Defense Industry | Export contracts lobby | Procurement programme, classified R&D |
| International Bankers | — | Government bonds, attract investment |
| Wahabi Ulema | — | Fund religious schools, enforce moral codes |
| Farmers | — | Agricultural subsidies, rural infrastructure |
| Industrial Conglomerates | — | Infrastructure investment programme |

## Test plan

- [ ] Load a save with each relevant faction active and verify events fire after cooldown resets
- [ ] Confirm decisions appear in the correct faction's decision panel when the corresponding idea is held
- [ ] Check opinion variables change correctly via console: e.g. `check_variable = { communist_cadres_opinion > 0 }`
- [ ] Verify timed ideas appear in the ideas panel when granted by events

🤖 Generated with [Claude Code](https://claude.com/claude-code)