### PR TITLE
Fix ISR leader selection, cyber op flag, and UN vote influence scoping

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -264,6 +264,9 @@ v2.0.0
   - Electricity Infrastructure buildings had some stat changes
 
  Bugfix:
+  - [ISR] Fixed liberal leader selection logic preventing Yair Lapid from ever appearing - NOT block incorrectly checked all five party flags as a group instead of individually, causing Yitzhak Mordechai to always trigger first
+  - Fixed cyber warfare operations not clearing the target attack flag on mission failure, permanently blocking future operations against that country
+  - Fixed UN vote influence (both GA and SC) showing effects applying to the player instead of the target country, caused by incorrect scope resolution of THIS.id in scripted GUI dynamic list effects
   - [SMA] Fixed economy balance focuses (SMA_more_economy, SMA_more_economy_deep) incorrectly referencing SMA_balance_economy_ii instead of cycling through the full tourism/economy idea chain
   - [SMA] Fixed SMA_tourism_support_ii containing a duplicate idea swap block
   - [SMA] Removed incorrect SMA_balance_tourism_ii availability blockers from hotel building focuses (SMA_build_hotel_hetel_rosa, SMA_build_hotel_public_palace, SMA_build_hotel_prima_torre)

--- a/common/scripted_effects/00_cyber_effects.txt
+++ b/common/scripted_effects/00_cyber_effects.txt
@@ -442,6 +442,14 @@ cyber_execute_operation = {
 		}
 	}else = {
 		ROOT = { country_event = { id = MD_cyber.4 } }
+		var:cur_target_nation = {
+			meta_effect = {
+				text = {
+					clr_country_flag = is_under_[TYPE]_attack_by_@ROOT
+				}
+				TYPE = "[cyber_clear_name_check]"
+			}
+		}
 		#TODO: add an event here where nations can detect a failed cyber attack and react accordingly
 	}
 

--- a/common/scripted_effects/ISR_political_leaders.txt
+++ b/common/scripted_effects/ISR_political_leaders.txt
@@ -113,7 +113,7 @@ set_leader_ISR = {
 		}
 	}
 	else_if = { limit = { has_country_flag = set_liberalism }
-		if = { limit = { check_variable = { liberalism_leader = 0 } OR = { NOT = { has_country_flag = ISR_yeshatid has_country_flag = ISR_resilance has_country_flag = ISR_newhope has_country_flag = ISR_nationalcamp has_country_flag = ISR_bluewhite } } }
+		if = { limit = { check_variable = { liberalism_leader = 0 } NOT = { has_country_flag = ISR_yeshatid } NOT = { has_country_flag = ISR_resilance } NOT = { has_country_flag = ISR_newhope } NOT = { has_country_flag = ISR_nationalcamp } NOT = { has_country_flag = ISR_bluewhite } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 
@@ -129,7 +129,7 @@ set_leader_ISR = {
 			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { liberalism_leader = 1 } }
 			if = { limit = { date < 2001.1.1 } set_temp_variable = { b = 1 } }
 		}
-		if = { limit = { check_variable = { liberalism_leader = 1 } NOT = { check_variable = { b = 1 } } OR = { NOT = { has_country_flag = ISR_yeshatid has_country_flag = ISR_resilance has_country_flag = ISR_newhope has_country_flag = ISR_nationalcamp has_country_flag = ISR_bluewhite } } }
+		if = { limit = { check_variable = { liberalism_leader = 1 } NOT = { check_variable = { b = 1 } } NOT = { has_country_flag = ISR_yeshatid } NOT = { has_country_flag = ISR_resilance } NOT = { has_country_flag = ISR_newhope } NOT = { has_country_flag = ISR_nationalcamp } NOT = { has_country_flag = ISR_bluewhite } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 

--- a/common/scripted_guis/00_missiles_scripted_guis.txt
+++ b/common/scripted_guis/00_missiles_scripted_guis.txt
@@ -7196,15 +7196,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_sc_vote_yes_button_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 2 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UNSC.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 				change_influence_percentage = yes
 
 				custom_effect_tooltip = un_sc_sway_vote_no_tt
@@ -7212,15 +7211,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_sc_vote_yes_button_right_click = {
+				set_temp_variable = { percent_change = -5 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 3 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UNSC.200
 				}
-
-				set_temp_variable = { percent_change = -5 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 
@@ -7229,15 +7227,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_sc_vote_no_button_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 1 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UNSC.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 				change_influence_percentage = yes
 
 				custom_effect_tooltip = un_sc_sway_vote_yes_tt
@@ -7245,15 +7242,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_sc_vote_no_button_right_click = {
+				set_temp_variable = { percent_change = -5 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 3 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UNSC.200
 				}
-
-				set_temp_variable = { percent_change = -5 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 
@@ -7262,15 +7258,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_sc_vote_abstain_button_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 1 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UNSC.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 
@@ -7279,15 +7274,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_sc_vote_abstain_button_right_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 2 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UNSC.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 
@@ -7542,15 +7536,14 @@ scripted_gui = {
 
 		effects = {
 			is_un_ga_vote_yes_button_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 2 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UN.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 				change_influence_percentage = yes
 
 				custom_effect_tooltip = un_sc_sway_vote_no_tt
@@ -7558,15 +7551,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_ga_vote_yes_button_right_click = {
+				set_temp_variable = { percent_change = -5 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 3 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UN.200
 				}
-
-				set_temp_variable = { percent_change = -5 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 
@@ -7616,15 +7608,14 @@ scripted_gui = {
 
 		effects = {
 			is_un_ga_vote_no_button_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 1 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UN.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 				change_influence_percentage = yes
 
 				custom_effect_tooltip = un_sc_sway_vote_yes_tt
@@ -7632,15 +7623,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_ga_vote_no_button_right_click = {
+				set_temp_variable = { percent_change = -5 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 3 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UN.200
 				}
-
-				set_temp_variable = { percent_change = -5 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 
@@ -7694,15 +7684,14 @@ scripted_gui = {
 
 		effects = {
 			is_un_ga_vote_abstain_button_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 1 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UN.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 				change_influence_percentage = yes
 
 				custom_effect_tooltip = un_sc_sway_vote_yes_tt
@@ -7710,15 +7699,14 @@ scripted_gui = {
 				missile_ui_update = yes
 			}
 			is_un_ga_vote_abstain_button_right_click = {
+				set_temp_variable = { percent_change = -10 }
 				ROOT = {
 					set_variable = { sway_target = PREV }
 					set_variable = { current_vote_sway = 2 }
+					set_temp_variable = { tag_index = THIS.id }
+					set_temp_variable = { influence_target = PREV.id }
 					country_event = UN.200
 				}
-
-				set_temp_variable = { percent_change = -10 }
-				set_temp_variable = { tag_index = ROOT.id }
-				set_temp_variable = { influence_target = THIS.id }
 
 				change_influence_percentage = yes
 


### PR DESCRIPTION
## Summary
- **[ISR] Liberal leader selection**: Fixed `NOT` block logic that grouped all five party flags together (`NOT = { flag1 flag2 ... }` = "not all at once") instead of checking each individually. This caused Yitzhak Mordechai to always trigger when `liberalism_leader = 0`, setting `b = 1` and permanently blocking Yair Lapid from appearing.
- **Cyber warfare SIGINT failure**: Fixed `is_under_[TYPE]_attack_by_@ROOT` flag not being cleared on mission failure in `cyber_execute_operation`. The flag was only cleared in the success path, so a failed operation permanently blocked future missions against that target country.
- **UN vote influence scoping (GA + SC)**: Fixed `THIS.id` in scripted GUI dynamic list effects resolving to the player (ROOT) instead of the list entry, causing the "Influencer and Influencee are the same" error and tooltips showing effects applying to the player country. Moved `tag_index`/`influence_target` assignments inside the `ROOT = { }` block where `THIS.id` = player and `PREV.id` = list entry are unambiguous.

## Test plan
- [ ] As ISR, verify Yair Lapid appears as liberal leader when `ISR_yeshatid` flag is set and no other party flags block him
- [ ] Run a cyber SIGINT mission, force it to fail (reload if needed), verify the mission becomes available again against the same target
- [ ] As any country with 15%+ influence, attempt to influence a GA vote target — verify tooltip shows effects on the target country, not the player
- [ ] Repeat SC vote influence test with 40%+ influence on a Security Council member

🤖 Generated with [Claude Code](https://claude.com/claude-code)