### PR TITLE
Fix nuclear path blocking Red Dawn military path (#233)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -222,6 +222,7 @@ v2.0.0
  Bugfix:
   - Fixed terrorist_menace opinion modifier staying permanently even after a country changes away from Salafist government (Issue #399)
   - [ENG] Fixed Nigeria operation granting oil resource rights on Lagos (state 334) instead of Biafra/Niger Delta (state 332) (Issue #657)
+  - [NKO] Fixed Russia declining the Strategic Partnership Treaty still granting the friendship idea to NKO, unlocking all Russian corporation decisions regardless of Russia's choice (Issue #233)
   - [ITA] Fixed ITA_befriend_libya AI strategy incorrectly targeting ITA instead of LBA
   - Fixed reopen embassy accept description incorrectly saying "rejected" instead of "accepted" (copy-paste bug)
   - Fixed duplicate political power modifiers in propose_mutual_investment_treaty ai_desire being applied twice

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -223,6 +223,7 @@ v2.0.0
   - Fixed terrorist_menace opinion modifier staying permanently even after a country changes away from Salafist government (Issue #399)
   - [ENG] Fixed Nigeria operation granting oil resource rights on Lagos (state 334) instead of Biafra/Niger Delta (state 332) (Issue #657)
   - [NKO] Fixed Russia declining the Strategic Partnership Treaty still granting the friendship idea to NKO, unlocking all Russian corporation decisions regardless of Russia's choice (Issue #233)
+  - [NKO] Fixed nuclear path blocking the Red Dawn military path by removing NKO_Our_Pride_and_Joy requirement from NKO_Red_Dawn (Issue #233)
   - [ITA] Fixed ITA_befriend_libya AI strategy incorrectly targeting ITA instead of LBA
   - Fixed reopen embassy accept description incorrectly saying "rejected" instead of "accepted" (copy-paste bug)
   - Fixed duplicate political power modifiers in propose_mutual_investment_treaty ai_desire being applied twice

--- a/common/national_focus/korea_north.txt
+++ b/common/national_focus/korea_north.txt
@@ -3555,7 +3555,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ARMY }
 
 		available = {
-			has_completed_focus = NKO_Our_Pride_and_Joy
 			has_completed_focus = NKO_Rebuild_Kim_Il-sung_Military_University
 			has_completed_focus = NKO_construct_air_bases
 			has_completed_focus = NKO_Green-Water_Navy

--- a/events/Korea.txt
+++ b/events/Korea.txt
@@ -2969,9 +2969,9 @@ country_event = {
 		}
 	}
 	option = {
-		name = korea_russia.11.a
-		log = "[GetDateText]: [This.GetName]: korea_russia.11.a executed"
-		NKO = {
+		name = korea_russia.11.b
+		log = "[GetDateText]: [This.GetName]: korea_russia.11.b executed"
+		SOV = {
 			country_event = { id = korea_russia.13 }
 		}
 		ai_chance = {
@@ -3012,7 +3012,6 @@ country_event = {
 	option = {
 		name = korea_russia.13.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.13.a executed"
-		add_ideas = NKO_korean_russian_frienship
 	}
 }
 


### PR DESCRIPTION
Closes #233 (sub-item: "Fix the Nuclear Path From Blocking players From Going the Red Dawn Mil Path")

## Root cause

`NKO_Red_Dawn` (the military path culmination focus) had `has_completed_focus = NKO_Our_Pride_and_Joy` in its `available` block. `NKO_Our_Pride_and_Joy` is a nuclear path focus that requires NOT being in SCO and NOT being allied with Russia or China. Since many NKO gameplay paths involve allying with these countries, the nuclear requirement made the entire military path (Red Dawn and everything downstream) permanently inaccessible.

## Fix

Removed `has_completed_focus = NKO_Our_Pride_and_Joy` from `NKO_Red_Dawn`'s available conditions. The nuclear path is now independent from the military path — players can pursue Red Dawn without being forced down the nuclear independence route.

The other four required focuses (Military University, Air Bases, Green-Water Navy, SPAA) are standard military focuses with no conflicting conditions and remain required.

## Test plan

- [ ] Play as NKO, ally with Russia/China or join SCO
- [ ] Complete the military branch focuses (Military University, Air Bases, Green-Water Navy, SPAA)
- [ ] Verify NKO_Red_Dawn becomes available without needing NKO_Our_Pride_and_Joy
- [ ] Verify the nuclear path still works independently for players who choose independence

🤖 Generated with [Claude Code](https://claude.com/claude-code)