### PR TITLE
Wiki: new syntax highlighting

### DIFF
--- a/docs/src/shared/lib/shiki-hoiscript.ts
+++ b/docs/src/shared/lib/shiki-hoiscript.ts
@@ -1,8 +1,9 @@
 import type { LanguageRegistration } from "shiki";
 
 /**
- * HOI4 / Paradox script syntax highlighting aligned with docs/public/assets/hoi4.xml
- * (Kate KSyntaxHighlighting). Same categories and token roles for consistent look.
+ * HOI4 / Paradox script syntax highlighting aligned with
+ * https://github.com/AngriestBird/kate-paradox-hoi4-syntax (Kate KSyntaxHighlighting).
+ * Same categories and token roles for consistent look.
  */
 
 const BOOLEANS = ["yes", "no"] as const;

--- a/docs/src/shared/lib/shiki-hoiscript.ts
+++ b/docs/src/shared/lib/shiki-hoiscript.ts
@@ -1,241 +1,373 @@
 import type { LanguageRegistration } from "shiki";
 
-/** Control flow and block structure keywords */
-const HOISCRIPT_KEYWORDS = [
-  "if",
-  "else",
-  "else_if",
-  "elseif",
-  "limit",
-  "hidden_effect",
-  "trigger",
-  "effect",
-  "random_list",
-  "random_owned_state",
-  "every_country",
-  "any_country",
-  "every_state",
-  "any_state",
-  "every_owned_state",
-  "any_owned_state",
-  "every_unit_leader",
-  "any_unit_leader",
-  "random_country",
-  "random_state",
-  "random_scope",
+/**
+ * HOI4 / Paradox script syntax highlighting aligned with docs/public/assets/hoi4.xml
+ * (Kate KSyntaxHighlighting). Same categories and token roles for consistent look.
+ */
+
+const BOOLEANS = ["yes", "no"] as const;
+
+const SCOPES = [
+	"ROOT",
+	"THIS",
+	"FROM",
+	"PREV",
+	"OVERLORD",
+	"FACTION_LEADER",
+	"CAPITAL",
+	"OWNER",
+	"CONTROLLER",
 ] as const;
 
-/** Logical operators in triggers/effects */
-const HOISCRIPT_LOGICAL = ["OR", "AND", "NOT"] as const;
-
-/** Scope references and boolean literals */
-const HOISCRIPT_BUILTINS = ["ROOT", "FROM", "PREV", "THIS", "yes", "no", "always"] as const;
-
-/** Common block/entity type keywords (focus, decision, event blocks) */
-const HOISCRIPT_BLOCK_TYPES = [
-  "focus",
-  "id",
-  "allowed",
-  "visible",
-  "available",
-  "bypass",
-  "cancel",
-  "complete_effect",
-  "completion_reward",
-  "fire_only_once",
-  "major",
-  "is_triggered_only",
+const EFFECTS = [
+	"add_ideas",
+	"remove_ideas",
+	"add_equipment_to_stockpile",
+	"add_manpower",
+	"add_political_power",
+	"add_stability",
+	"add_war_support",
+	"add_opinion_modifier",
+	"add_relation_modifier",
+	"add_state_claim",
+	"add_state_core",
+	"add_tech_bonus",
+	"add_timed_idea",
+	"add_to_faction",
+	"add_to_variable",
+	"annex_country",
+	"capital_scope",
+	"clamp_variable",
+	"country_event",
+	"create_country_leader",
+	"create_faction",
+	"custom_effect_tooltip",
+	"declare_war_on",
+	"division_template",
+	"effect_tooltip",
+	"every_country",
+	"every_owned_state",
+	"every_state",
+	"hidden_effect",
+	"if",
+	"else_if",
+	"else",
+	"load_focus_tree",
+	"mark_focus_tree_layout_dirty",
+	"news_event",
+	"random_country",
+	"random_list",
+	"random_owned_state",
+	"release_autonomy",
+	"remove_from_faction",
+	"remove_opinion_modifier",
+	"remove_relation_modifier",
+	"set_autonomy",
+	"set_capital",
+	"set_country_flag",
+	"set_global_flag",
+	"set_politics",
+	"set_popularities",
+	"set_state_flag",
+	"set_technology",
+	"set_variable",
+	"start_civil_war",
+	"state_event",
+	"transfer_state",
+	"unlock_decision_tooltip",
+	"white_peace",
 ] as const;
 
-/** Common effects and triggers (highlighted as function-like) */
-const HOISCRIPT_EFFECTS_TRIGGERS = [
-  "add_ideas",
-  "add_ideas_from_tech",
-  "add_dynamic_modifier",
-  "remove_dynamic_modifier",
-  "country_event",
-  "state_event",
-  "add_to_variable",
-  "subtract_from_variable",
-  "multiply_variable",
-  "divide_variable",
-  "set_variable",
-  "set_temp_variable",
-  "add_country_modifier",
-  "remove_country_modifier",
-  "add_timed_idea",
-  "log",
-  "has_country_flag",
-  "has_character_flag",
-  "country_exists",
-  "has_government",
-  "has_autonomy_state",
-  "original_tag",
-  "modifier",
-  "search_filters",
-  "prerequisite",
-  "mutually_exclusive",
-  "relative_position_id",
-  "ai_will_do",
-  "cost",
-  "days_remove",
+const TRIGGERS = [
+	"always",
+	"AND",
+	"OR",
+	"NOT",
+	"can_declare_war_on",
+	"check_variable",
+	"controls_state",
+	"date",
+	"enemies_strength_ratio",
+	"focus_progress",
+	"has_capitulated",
+	"has_country_flag",
+	"has_dlc",
+	"has_equipment",
+	"has_global_flag",
+	"has_government",
+	"has_idea",
+	"has_non_aggression_pact_with",
+	"has_opinion",
+	"has_political_power",
+	"has_stability",
+	"has_state_flag",
+	"has_tech",
+	"has_trade_embargo_with_us",
+	"has_war",
+	"has_war_support",
+	"has_war_with",
+	"is_ally_with",
+	"is_faction_leader",
+	"is_fully_controlled_by",
+	"is_in_faction",
+	"is_in_faction_with",
+	"is_neighbor_of",
+	"is_owned_and_controlled_by",
+	"is_puppet",
+	"is_puppet_of",
+	"is_subject",
+	"is_subject_of",
+	"manpower",
+	"num_divisions",
+	"original_tag",
+	"owns_state",
+	"stability",
+	"strength_ratio",
+	"tag",
+	"threat",
+] as const;
+
+const KEYWORDS = [
+	"focus",
+	"id",
+	"icon",
+	"cost",
+	"x",
+	"y",
+	"relative_position_id",
+	"prerequisite",
+	"mutually_exclusive",
+	"bypass",
+	"available",
+	"cancel_if_invalid",
+	"continue_if_invalid",
+	"completion_reward",
+	"search_filters",
+	"ai_will_do",
+	"will_lead_to_war_with",
+	"select_effect",
+	"name",
+	"desc",
+	"picture",
+	"allowed",
+	"allowed_civil_war",
+	"cancel",
+	"modifier",
+	"targeted_modifier",
+	"rule",
+	"research_bonus",
+	"equipment_bonus",
+	"traits",
+	"factor",
+	"add",
+	"base",
+	"value",
+	"token",
+	"limit",
+	"chance",
+	"days",
+	"hours",
+	"random",
+	"mean_time_to_happen",
+	"trigger",
+	"option",
+	"title",
+	"fire_only_once",
+	"is_triggered_only",
+	"immediate",
+	"hidden",
+	"major",
+	"province",
+	"state",
+	"color",
+	"colors",
+	"frames",
+	"ribbon",
+	"category",
+	"path",
+	"research_cost",
+	"start_year",
+	"folder",
+	"enable",
+	"on_research_complete",
+	"ai_research_weights",
+	"dependencies",
+	"sub_technologies",
+	"doctrine",
+	"type",
+	"parent",
+	"gfx_type",
+	"group",
+	"division_types",
+	"position",
+	"map_icon_category",
+	"priority",
+	"active",
+	"default",
 ] as const;
 
 function toWordPattern(words: readonly string[]): string {
-  return `\\b(?:${words.join("|")})\\b`;
+	return `\\b(?:${words.join("|")})\\b`;
 }
 
 export const hoiscriptLanguage: LanguageRegistration = {
-  name: "hoiscript",
-  displayName: "HOI Script",
-  scopeName: "source.hoiscript",
-  aliases: ["hoi", "hoi4", "paradox-script"],
-  patterns: [
-    { include: "#comments" },
-    { include: "#strings" },
-    { include: "#numbers" },
-    { include: "#keywords" },
-    { include: "#logical" },
-    { include: "#builtins" },
-    { include: "#effectsTriggers" },
-    { include: "#blockTypes" },
-    { include: "#countryTag" },
-    { include: "#gfxRef" },
-    { include: "#locKey" },
-    { include: "#properties" },
-    { include: "#operators" },
-    { include: "#punctuation" },
-  ],
-  repository: {
-    comments: {
-      patterns: [
-        {
-          begin: "#",
-          beginCaptures: {
-            0: { name: "punctuation.definition.comment.hoiscript" },
-          },
-          end: "$",
-          name: "comment.line.number-sign.hoiscript",
-        },
-      ],
-    },
-    strings: {
-      patterns: [
-        {
-          begin: '"',
-          beginCaptures: {
-            0: { name: "punctuation.definition.string.begin.hoiscript" },
-          },
-          end: '"',
-          endCaptures: {
-            0: { name: "punctuation.definition.string.end.hoiscript" },
-          },
-          name: "string.quoted.double.hoiscript",
-          patterns: [
-            { match: '\\\\[\\\\"nrt]', name: "constant.character.escape.hoiscript" },
-            { match: "£[A-Za-z0-9_]+", name: "constant.other.placeholder.hoiscript" },
-          ],
-        },
-        {
-          begin: "'",
-          beginCaptures: {
-            0: { name: "punctuation.definition.string.begin.hoiscript" },
-          },
-          end: "'",
-          endCaptures: {
-            0: { name: "punctuation.definition.string.end.hoiscript" },
-          },
-          name: "string.quoted.single.hoiscript",
-          patterns: [{ match: "\\\\.", name: "constant.character.escape.hoiscript" }],
-        },
-      ],
-    },
-    numbers: {
-      patterns: [{ match: "\\b-?\\d+(?:\\.\\d+)?\\b", name: "constant.numeric.hoiscript" }],
-    },
-    keywords: {
-      patterns: [{ match: toWordPattern(HOISCRIPT_KEYWORDS), name: "keyword.control.hoiscript" }],
-    },
-    logical: {
-      patterns: [{ match: toWordPattern(HOISCRIPT_LOGICAL), name: "keyword.operator.logical.hoiscript" }],
-    },
-    builtins: {
-      patterns: [{ match: toWordPattern(HOISCRIPT_BUILTINS), name: "constant.language.hoiscript" }],
-    },
-    effectsTriggers: {
-      patterns: [
-        {
-          match: `\\b(${HOISCRIPT_EFFECTS_TRIGGERS.join("|")})\\b(?=\\s*=)`,
-          captures: {
-            1: { name: "entity.name.function.hoiscript" },
-          },
-        },
-      ],
-    },
-    blockTypes: {
-      patterns: [
-        {
-          match: `\\b(${HOISCRIPT_BLOCK_TYPES.join("|")})\\b(?=\\s*=)`,
-          captures: {
-            1: { name: "storage.type.hoiscript" },
-          },
-        },
-      ],
-    },
-    countryTag: {
-      patterns: [
-        {
-          match: "\\b([A-Z][A-Z0-9]{2})(?=\\s*=\\s*\\{)",
-          captures: {
-            1: { name: "constant.other.country-tag.hoiscript" },
-          },
-        },
-      ],
-    },
-    gfxRef: {
-      patterns: [
-        {
-          match: "\\b(GFX_[A-Za-z0-9_]+)\\b",
-          captures: {
-            1: { name: "constant.other.asset.hoiscript" },
-          },
-        },
-        {
-          match: "\\b(CAT_[A-Za-z0-9_]+)\\b",
-          captures: {
-            1: { name: "constant.other.asset.hoiscript" },
-          },
-        },
-      ],
-    },
-    locKey: {
-      patterns: [
-        {
-          match: "\\b([A-Za-z][A-Za-z0-9_]*\\.[a-z0-9_.]+)\\b",
-          captures: {
-            1: { name: "entity.name.tag.hoiscript" },
-          },
-        },
-      ],
-    },
-    properties: {
-      patterns: [
-        {
-          match: "\\b([A-Za-z_][A-Za-z0-9_.-]*)(?=\\s*=)",
-          captures: {
-            1: { name: "variable.other.property.hoiscript" },
-          },
-        },
-      ],
-    },
-    operators: {
-      patterns: [
-        { match: "=", name: "keyword.operator.assignment.hoiscript" },
-        { match: ">=|<=|>|<|!=|==", name: "keyword.operator.comparison.hoiscript" },
-      ],
-    },
-    punctuation: {
-      patterns: [{ match: "[{}()\\[\\],.;]", name: "punctuation.section.block.hoiscript" }],
-    },
-  },
+	name: "hoiscript",
+	displayName: "HOI4 Script",
+	scopeName: "source.hoiscript",
+	aliases: ["hoi", "hoi4", "paradox-script"],
+	patterns: [
+		{ include: "#comments" },
+		{ include: "#strings" },
+		{ include: "#numbers" },
+		{ include: "#booleans" },
+		{ include: "#scopes" },
+		{ include: "#effects" },
+		{ include: "#triggers" },
+		{ include: "#keywords" },
+		{ include: "#countryTag" },
+		{ include: "#gfxRef" },
+		{ include: "#locKey" },
+		{ include: "#properties" },
+		{ include: "#operators" },
+		{ include: "#punctuation" },
+	],
+	repository: {
+		comments: {
+			patterns: [
+				{
+					begin: "#",
+					beginCaptures: {
+						0: { name: "punctuation.definition.comment.hoiscript" },
+					},
+					end: "$",
+					name: "comment.line.number-sign.hoiscript",
+				},
+			],
+		},
+		strings: {
+			patterns: [
+				{
+					begin: '"',
+					beginCaptures: {
+						0: { name: "punctuation.definition.string.begin.hoiscript" },
+					},
+					end: '"',
+					endCaptures: {
+						0: { name: "punctuation.definition.string.end.hoiscript" },
+					},
+					name: "string.quoted.double.hoiscript",
+					patterns: [
+						{ match: '\\\\[\\\\"nrt]', name: "constant.character.escape.hoiscript" },
+						{ match: "£[A-Za-z0-9_]+", name: "constant.other.placeholder.hoiscript" },
+					],
+				},
+			],
+		},
+		numbers: {
+			patterns: [
+				{
+					match: "\\b-?\\d+(?:\\.\\d+)?\\b",
+					name: "constant.numeric.hoiscript",
+				},
+			],
+		},
+		booleans: {
+			patterns: [
+				{
+					match: toWordPattern([...BOOLEANS]),
+					name: "constant.language.boolean.hoiscript",
+				},
+			],
+		},
+		scopes: {
+			patterns: [
+				{
+					match: toWordPattern([...SCOPES]),
+					name: "constant.language.scope.hoiscript",
+				},
+			],
+		},
+		effects: {
+			patterns: [
+				{
+					match: toWordPattern([...EFFECTS]),
+					name: "entity.name.function.hoiscript",
+				},
+			],
+		},
+		triggers: {
+			patterns: [
+				{
+					match: toWordPattern([...TRIGGERS]),
+					name: "entity.other.attribute.name.hoiscript",
+				},
+			],
+		},
+		keywords: {
+			patterns: [
+				{
+					match: toWordPattern([...KEYWORDS]),
+					name: "keyword.other.hoiscript",
+				},
+			],
+		},
+		countryTag: {
+			patterns: [
+				{
+					match: "\\b[A-Z][A-Z0-9]{1,2}\\b",
+					name: "variable.other.hoiscript",
+				},
+			],
+		},
+		gfxRef: {
+			patterns: [
+				{
+					match: "\\b(GFX_[A-Za-z0-9_]+)\\b",
+					captures: {
+						1: { name: "constant.other.asset.hoiscript" },
+					},
+				},
+				{
+					match: "\\b(CAT_[A-Za-z0-9_]+)\\b",
+					captures: {
+						1: { name: "constant.other.asset.hoiscript" },
+					},
+				},
+			],
+		},
+		locKey: {
+			patterns: [
+				{
+					match: "\\b([A-Za-z][A-Za-z0-9_]*\\.[a-z0-9_.]+)\\b",
+					captures: {
+						1: { name: "entity.name.tag.hoiscript" },
+					},
+				},
+			],
+		},
+		properties: {
+			patterns: [
+				{
+					match: "\\b([A-Za-z_][A-Za-z0-9_.-]*)(?=\\s*=)",
+					captures: {
+						1: { name: "variable.other.property.hoiscript" },
+					},
+				},
+			],
+		},
+		operators: {
+			patterns: [
+				{ match: "=", name: "keyword.operator.assignment.hoiscript" },
+				{ match: ">=|<=|>|<|!=|==", name: "keyword.operator.comparison.hoiscript" },
+			],
+		},
+		punctuation: {
+			patterns: [
+				{
+					match: "[{}()\\[\\],.;]",
+					name: "punctuation.section.block.hoiscript",
+				},
+			],
+		},
+	},
 };


### PR DESCRIPTION
I saw that @AngriestBird [created a config for Kate for hoi4 syntax](https://github.com/AngriestBird/kate-paradox-hoi4-syntax), so I borrowed it and asked Cursor's Composer model to migrate it to shiki for website. That's it.

<img width="884" height="752" alt="image" src="https://github.com/user-attachments/assets/134ab1c3-569d-4ea6-a8bd-6d026393ba88" />

<img width="956" height="757" alt="image" src="https://github.com/user-attachments/assets/01aae9dc-0f70-4e36-87ef-2cfcabfcd088" />

<img width="851" height="739" alt="image" src="https://github.com/user-attachments/assets/e6e1d041-821a-4fe6-862e-a702a5b807bc" />

