### PR TITLE
raid error fix

### DIFF
--- a/common/scripted_effects/00_raid_scripted_effects.txt
+++ b/common/scripted_effects/00_raid_scripted_effects.txt
@@ -75,7 +75,7 @@ send_events_to_others = {
 }
 
 send_raid_event_to_victim = {
-	var:actor_country = {
+	var:ROOT.actor_country = {
 		if = {
 			limit = {
 				NOT = { has_war_with = var:ROOT.victim_country }
@@ -91,7 +91,7 @@ send_raid_event_to_victim = {
 
 send_ct_raid_events_to_victim = {
 	hidden_effect = {
-		var:actor_country = {
+		var:ROOT.actor_country = {
 			set_variable = { THIS.target_country = var:ROOT.victim_country }
 			set_variable = { THIS.actor_country = var:ROOT.actor_country }
 			country_event = {


### PR DESCRIPTION
This is a fix proposed by Codex.
I was unable to reproduce the environment again myself, so I have not been able to confirm whether the error was resolved.
----------------------------

ROOT. was added to make the variable source explicit and force the scope change to use the country variable stored on the raid root. Without ROOT., var:actor_country may be resolved from the current execution context, which in this case is still State scope. By changing it to var:ROOT.actor_country, the script explicitly reads the actor country from the raid root and switches into Country scope, which is required for has_war_with and country_event to work correctly.

Closes #820