### PR TITLE
fix icons for patrol_boat

### DIFF
--- a/interface/subuniticons.gfx
+++ b/interface/subuniticons.gfx
@@ -606,9 +606,9 @@ spriteTypes = {
 	spriteType = { name = "GFX_unit_patrol_boat_2_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
 	spriteType = { name = "GFX_unit_patrol_boat_3_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
 
-	spriteType = { name = "GFX_unit_patrol_boat_hull_1_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
-	spriteType = { name = "GFX_unit_patrol_boat_hull_2_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
-	spriteType = { name = "GFX_unit_patrol_boat_hull_3_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
+	#spriteType = { name = "GFX_unit_patrol_boat_hull_1_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
+	#spriteType = { name = "GFX_unit_patrol_boat_hull_2_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
+	#spriteType = { name = "GFX_unit_patrol_boat_hull_3_icon_medium"		texturefile = "gfx/interface/navalcombat/ships/patrol_boat.dds"		noOfFrames = 2 }
 
 	#spriteType = { name = "GFX_unit_transport_icon_medium"				texturefile = "gfx/interface/navalcombat/ships/transport.dds"			noOfFrames = 2 } # Removed from Database
 	spriteType = { name = "GFX_unit_convoy_1_icon_medium"				texturefile = "gfx/interface/navalcombat/ships/convoy.dds"				noOfFrames = 2 }


### PR DESCRIPTION
fix icons for patrol_boat: icons of patrol boats in fleet view are shown correctly
![photo_2026-03-24_19-41-05](https://github.com/user-attachments/assets/a02763d5-c1a1-459c-9835-95a5099f3342)
