### PR TITLE
Fix invalid scope in send_raid_event_to_victim

### DIFF
--- a/common/scripted_effects/00_raid_scripted_effects.txt
+++ b/common/scripted_effects/00_raid_scripted_effects.txt
@@ -75,14 +75,14 @@ send_events_to_others = {
 }
 
 send_raid_event_to_victim = {
-	var:actor_country = {
-		if = {
-			limit = {
-				NOT = { has_war_with = var:ROOT.victim_country }
-			}
-			hidden_effect = {
-				set_variable = { THIS.target_country = var:ROOT.victim_country }
-				set_variable = { THIS.actor_country = var:ROOT.actor_country }
+	hidden_effect = {
+		var:actor_country = {
+			set_variable = { THIS.target_country = var:ROOT.victim_country }
+			set_variable = { THIS.actor_country = var:ROOT.actor_country }
+			if = {
+				limit = {
+					NOT = { has_war_with = var:target_country }
+				}
 				country_event = { id = MD_raid.8 }
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes a scripting scope error in `send_raid_event_to_victim` (common/scripted_effects/00_raid_scripted_effects.txt) where `has_war_with` and `country_event` were executing in State scope instead of Country scope.
- Root cause: `has_war_with = var:ROOT.victim_country` inside `var:actor_country = {}` failed because HOI4 resolves raid framework variables differently in trigger vs effect context when called from `victim_effects` (where ROOT is the target state).
- Fix: set `THIS.target_country` on the actor country first (using `set_variable`, which works correctly in effects), then check `has_war_with = var:target_country` — this looks up the variable on the current country scope and runs fully in Country scope as expected.

The fix mirrors the working pattern already used in `send_ct_raid_events_to_victim`.

## Test plan

- [ ] Launch a raid against a country you are NOT at war with — verify MD_raid.8 fires and the raid event notification appears on the victim country
- [ ] Launch a raid against a country you ARE at war with — verify MD_raid.8 does NOT fire (no duplicate war notification)
- [ ] Confirm no `Invalid Scope, supported: Country, provided: State` errors appear in the log for `00_raid_scripted_effects.txt:81` or `00_raid_scripted_effects.txt:86` during any raid

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)