### PR TITLE
energy_load_sharing fix

### DIFF
--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2114,7 +2114,7 @@ on_actions = {
 					}
 					if = {
 						limit = { is_in_array = { FROM.energy_load_sharing_nations = ROOT.id } }
-						FROM = { remove_from_array = { energy_load_sharing_nations = FROM.id } }
+						FROM = { remove_from_array = { energy_load_sharing_nations = ROOT.id } }
 						ROOT = { clr_country_flag = energy_load_sharing_recipient }
 					}
 				}

--- a/common/scripted_diplomatic_actions/00_scripted_diplomatic_actions.txt
+++ b/common/scripted_diplomatic_actions/00_scripted_diplomatic_actions.txt
@@ -2280,7 +2280,10 @@ scripted_diplomatic_actions = {
 			if = {
 				limit = { THIS = { has_country_flag = energy_load_sharing_recipient } }
 				clr_country_flag = energy_load_sharing_recipient
-				remove_from_array = { ROOT.energy_load_sharing_nations = THIS.id }
+				if = {
+					limit = { is_in_array = { ROOT.energy_load_sharing_nations = THIS.id } }
+					remove_from_array = { ROOT.energy_load_sharing_nations = THIS.id }
+				}
 				clear_variable = energy_load_sharing_use_var
 				clear_variable = energy_load_sharing_gain_var
 				clear_variable = energy_load_sharing_income_var
@@ -2296,7 +2299,10 @@ scripted_diplomatic_actions = {
 					clear_variable = energy_load_sharing_use_var
 					clear_variable = energy_load_sharing_gain_var
 					clear_variable = energy_load_sharing_income_var
-					remove_from_array = { PREV.energy_load_sharing_nations = THIS.id }
+					if = {
+						limit = { is_in_array = { PREV.energy_load_sharing_nations = THIS.id } }
+						remove_from_array = { PREV.energy_load_sharing_nations = THIS.id }
+					}
 				}
 				calculate_energy_load_sharing = yes
 				ingame_update_setup = yes


### PR DESCRIPTION
This is the fix that came out of having Codex analyze the crash.

It fixes an issue around energy sharing where the limit and the removal scope were mismatched, and it also seems to have added if guards before the remove calls just in case.

Below is Codex's summary.
-------------------------------
We investigated the MD crash and the strongest root-cause candidate is the energy_load_sharing cleanup flow, not the generic startup parser warnings. The crash itself is an engine-side C0000005 / EXCEPTION_ACCESS_VIOLATION, but the gameplay log ends during the weekly economy/energy update, which points back to MD script state rather than a random graphics or UI fault.

The main issue is that energy_load_sharing_nations can become inconsistent. The diplomatic actions correctly add partner country IDs to the array, but one cleanup path in common/on_actions/00_on_actions.txt removes the wrong ID (FROM.id instead of ROOT.id). In addition, cancel_energy_load_sharing in common/scripted_diplomatic_actions/00_scripted_diplomatic_actions.txt calls remove_from_array without first checking that the target entry is still present. We already have evidence of this desync in the logs via Invalid index to remove for the same scripted diplomatic action.

Once that array/flag state is corrupted, the weekly energy and money scripts continue to read it in calculate_energy_load_sharing and the economy update path. That makes this a plausible path to the later access violation: the script leaves stale or invalid relationship state behind, and the engine eventually crashes while processing the resulting data.

Proposed fix:

Correct the cleanup removal in common/on_actions/00_on_actions.txt so it removes ROOT.id from FROM.energy_load_sharing_nations.
Add defensive is_in_array guards before both remove_from_array calls in cancel_energy_load_sharing.
Keep the existing recalculation/UI refresh after cleanup so provider and recipient state is rebuilt immediately.
There are also separate script issues in the same session, including invalid ALG_high_corruption references and parser errors when reloading several AA_* idea/law files. Those should be fixed as well, but they look like secondary stability problems rather than the primary crash trigger for this report.