### PR TITLE
productivity_change fix

### DIFF
--- a/common/decisions/05_ENG_decisions.txt
+++ b/common/decisions/05_ENG_decisions.txt
@@ -2241,7 +2241,7 @@ ENG_monarchy_decision_category = {
 			clr_country_flag = ENG_andrew_emerging_economy_benefits_decision_activated
 			random_owned_state = {
 				set_temp_variable = { temp_productivity_change = 0.025 }
-				flat_productivity_change_effect = yes
+				state_flat_productivity_change_effect = yes
 			}
 		}
 

--- a/common/decisions/Algeria.txt
+++ b/common/decisions/Algeria.txt
@@ -1979,7 +1979,7 @@ ALG_political_struggle = {
 			add_stability = 0.02
 			random_owned_state = {
 				set_temp_variable = { temp_productivity_change = 0.025 }
-				flat_productivity_change_effect = yes
+				state_flat_productivity_change_effect = yes
 			}
 		}
 

--- a/common/national_focus/iran.txt
+++ b/common/national_focus/iran.txt
@@ -22827,7 +22827,7 @@ focus_tree = {
 				}
 				405 = {
 					set_temp_variable = { temp_productivity_change = 60 }
-					flat_productivity_change_effect = yes
+					state_flat_productivity_change_effect = yes
 				}
 			}
 			else = {


### PR DESCRIPTION
This is the fix that came out of having Codex analyze the crash.

It fixes an issue where, when flat_productivity_change_effect was used in a state scope to modify state productivity, that effect internally ran calculations meant for a country scope, causing country-scope calculations to execute inside a state scope.

Below is Codex's summary.
-------------------------
Crash Root Cause and Fix Summary

We traced the crash back to an invalid scope transition in the productivity helper effects.

The crash log showed a large burst of errors immediately before the crash, all with the same pattern: country-only triggers were being evaluated in State scope. The relevant errors were in the economy update pipeline, for example:

has_country_flag: Invalid Scope, supported: Country, provided: State
has_idea: Invalid Scope, supported: Country, provided: State
is_ai: Invalid Scope, supported: Country, provided: State
These came from the GDP / energy / alert update chain, including:

00_money_system.txt (line 53)
00_money_system.txt (line 98)
00_money_system.txt (line 4343)
!_energy_effects.txt (line 11)
00_MD_alert_scripted_effect.txt (line 40)
The underlying issue is that flat_productivity_change_effect is only safe when called from country scope. In its current implementation it ends with a direct call to ingame_update_setup = yes:

00_money_system_utilities.txt (line 2)
That means if flat_productivity_change_effect is called from inside a state block such as random_owned_state = { ... } or a direct state ID block like 405 = { ... }, the entire economic update runs in State scope instead of Country scope. Once that happens, GDP, energy, currency, and alert code start evaluating country-only checks on a state object, which matches the exact error pattern in the crash log.

We already had a safe version of this helper:

00_money_system_utilities.txt (line 11)
state_flat_productivity_change_effect applies the productivity change in state scope, but then switches back to the state controller before calling ingame_update_setup:

hidden_effect = {
    CONTROLLER = {
        ingame_update_setup = yes
    }
}
What we changed

We searched for direct calls to flat_productivity_change_effect from state scope and replaced them with state_flat_productivity_change_effect in the following files:

05_ENG_decisions.txt (line 2244)
Algeria.txt (line 1982)
iran.txt (line 22830)
In each case, the change was:

flat_productivity_change_effect = yes
to:

state_flat_productivity_change_effect = yes
Why this fix is correct

This fix preserves gameplay intent while correcting scope handling:

The productivity change is still applied to the targeted state.
The post-change economic recalculation is now executed on the owning country, which is what the GDP / energy / alert systems expect.
It directly addresses the exact scope mismatch shown in the crash log.
Validation

After the change, we re-scanned common and events for state-scoped uses of flat_productivity_change_effect and found no remaining matches under the same detection criteria.

One important note: the crash log proves the scope corruption, but it does not identify a single exact caller with certainty. What it does show very clearly is that some code path caused ingame_update_setup to run in state scope. These three sites were direct matches for that failure mode and were therefore corrected.