### PR TITLE
usa events fix

### DIFF
--- a/events/United States.txt
+++ b/events/United States.txt
@@ -3854,7 +3854,6 @@ country_event = {
 	is_triggered_only = yes
 	trigger = {
 		original_tag = USA
-		NOT = { has_country_flag = USA_triggered_early_oil_crisis }
 	}
 
 	# Well, the price of gas will be over 2.25!
@@ -3879,24 +3878,23 @@ news_event = {
 	desc = {
 		text = usa_economic_events_news.1.d1
 		trigger = {
-			has_country_flag = usa_nationalize_one
+			USA = { has_country_flag = usa_nationalize_one }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.1.d2
 		trigger = {
-			has_country_flag = usa_bailout_one
+			USA = { has_country_flag = usa_bailout_one }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.1.d3
 		trigger = {
-			has_country_flag = usa_nothing_one
+			USA = { has_country_flag = usa_nothing_one }
 		}
 	}
 	picture = GFX_world_lehmanbrothers
 	is_triggered_only = yes
-	fire_only_once = yes
 	major = yes
 	trigger = {
 		NOT = {
@@ -3920,14 +3918,12 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.1.b
 		trigger = {
-			NOT = {
-				tag = USA
-				tag = CHI
-				tag = SOV
-				is_in_faction_with = SOV
-				is_in_faction_with = CHI
-				has_government = fascism
-			}
+			NOT = { tag = USA }
+			NOT = { tag = CHI }
+			NOT = { tag = SOV }
+			NOT = { is_in_faction_with = SOV }
+			NOT = { is_in_faction_with = CHI }
+			NOT = { has_government = fascism }
 		}
 	}
 	#Pathetic
@@ -3963,23 +3959,22 @@ news_event = {
 	desc = {
 		text = usa_economic_events_news.2.d1
 		trigger = {
-			has_country_flag = usa_nationalize_two
+			USA = { has_country_flag = usa_nationalize_two }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.2.d2
 		trigger = {
-			has_country_flag = usa_bailout_two
+			USA = { has_country_flag = usa_bailout_two }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.2.d3
 		trigger = {
-			has_country_flag = usa_nothing_two
+			USA = { has_country_flag = usa_nothing_two }
 		}
 	}
 	is_triggered_only = yes
-	fire_only_once = yes
 	picture = GFX_world_fanniemae
 	major = yes
 
@@ -3994,14 +3989,12 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.2.b
 		trigger = {
-			NOT = {
-				tag = USA
-				tag = CHI
-				tag = SOV
-				is_in_faction_with = SOV
-				is_in_faction_with = CHI
-				has_government = fascism
-			}
+			NOT = { tag = USA }
+			NOT = { tag = CHI }
+			NOT = { tag = SOV }
+			NOT = { is_in_faction_with = SOV }
+			NOT = { is_in_faction_with = CHI }
+			NOT = { has_government = fascism }
 		}
 	}
 	#Pathetic
@@ -4037,23 +4030,22 @@ news_event = {
 	desc = {
 		text = usa_economic_events_news.3.d1
 		trigger = {
-			has_country_flag = usa_nationalize_three
+			USA = { has_country_flag = usa_nationalize_three }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.3.d2
 		trigger = {
-			has_country_flag = usa_bailout_three
+			USA = { has_country_flag = usa_bailout_three }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.3.d3
 		trigger = {
-			has_country_flag = usa_nothing_three
+			USA = { has_country_flag = usa_nothing_three }
 		}
 	}
 	is_triggered_only = yes
-	fire_only_once = yes
 	picture = GFX_world_bearstearns
 	major = yes
 
@@ -4068,14 +4060,12 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.3.b
 		trigger = {
-			NOT = {
-				tag = USA
-				tag = CHI
-				tag = SOV
-				is_in_faction_with = SOV
-				is_in_faction_with = CHI
-				has_government = fascism
-			}
+			NOT = { tag = USA }
+			NOT = { tag = CHI }
+			NOT = { tag = SOV }
+			NOT = { is_in_faction_with = SOV }
+			NOT = { is_in_faction_with = CHI }
+			NOT = { has_government = fascism }
 		}
 	}
 	#Pathetic
@@ -4111,23 +4101,22 @@ news_event = {
 	desc = {
 		text = usa_economic_events_news.4.d1
 		trigger = {
-			has_country_flag = usa_nationalize_four
+			USA = { has_country_flag = usa_nationalize_four }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.4.d2
 		trigger = {
-			has_country_flag = usa_bailout_four
+			USA = { has_country_flag = usa_bailout_four }
 		}
 	}
 	desc = {
 		text = usa_economic_events_news.4.d3
 		trigger = {
-			has_country_flag = usa_nothing_four
+			USA = { has_country_flag = usa_nothing_four }
 		}
 	}
 	is_triggered_only = yes
-	fire_only_once = yes
 	picture = GFX_world_aig
 	major = yes
 
@@ -4142,14 +4131,12 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.4.b
 		trigger = {
-			NOT = {
-				tag = USA
-				tag = CHI
-				tag = SOV
-				is_in_faction_with = SOV
-				is_in_faction_with = CHI
-				has_government = fascism
-			}
+			NOT = { tag = USA }
+			NOT = { tag = CHI }
+			NOT = { tag = SOV }
+			NOT = { is_in_faction_with = SOV }
+			NOT = { is_in_faction_with = CHI }
+			NOT = { has_government = fascism }
 		}
 	}
 	#Pathetic
@@ -4174,7 +4161,6 @@ news_event = {
 	title = usa_economic_events_news.6.t
 	desc = usa_economic_events_news.6.d
 	is_triggered_only = yes
-	fire_only_once = yes
 	picture = GFX_world_stockmarket
 	major = yes
 	trigger = {
@@ -4199,14 +4185,12 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.6.b
 		trigger = {
-			NOT = {
-				tag = USA
-				tag = CHI
-				tag = SOV
-				is_in_faction_with = SOV
-				is_in_faction_with = CHI
-				has_government = fascism
-			}
+			NOT = { tag = USA }
+			NOT = { tag = CHI }
+			NOT = { tag = SOV }
+			NOT = { is_in_faction_with = SOV }
+			NOT = { is_in_faction_with = CHI }
+			NOT = { has_government = fascism }
 		}
 	}
 	#Pathetic
@@ -4230,15 +4214,11 @@ news_event = {
 	title = usa_economic_events_news.7.t
 	desc = usa_economic_events_news.7.d
 	is_triggered_only = yes
-	fire_only_once = yes
 	picture = GFX_world_stockmarket
 	major = yes
 
 	option = {
 		name = usa_economic_events_news.7.a
-		trigger = {
-			tag = USA
-		}
 	}
 }
 


### PR DESCRIPTION
1. Fixed an issue where the news events related to the U.S. financial crisis (usa_economic_events_news1-4,6) were not firing for other countries. Since separate options had also been created for countries other than the U.S., I interpreted these as events that were meant to fire globally and fixed them on that basis.
(1) Fixed the issue where, despite major = yes, fire_only_once was set, which prevented the events from firing in other countries.
(2) The description trigger used a flag that only the U.S. could have, so I changed it to use the U.S. scope.
(3) Corrected the NOT usage in the options so that it matches the intended logic (A and B and C cannot all be true at the same time → neither A nor B nor C).

2.usa_economic_events.38 was set to fire via on_action, but its event trigger also required that it not have a flag that was being assigned at the same time by that on_action, which made the event impossible to fire. I fixed that issue.
I also applied the same kind of fix as in 1 to usa_economic_events_news.7, which is fired by usa_economic_events.38, but I could not determine whether it was intended to be a global event or a U.S.-only event, so it may be worth checking with the original author.