### PR TITLE
crash error fix

### DIFF
--- a/common/scripted_effects/99_eu_scripted_effects.txt
+++ b/common/scripted_effects/99_eu_scripted_effects.txt
@@ -109,14 +109,20 @@ EU_update_vars = {
 			set_variable = { THIS.EU_pop_ratio = 0 }
 			add_to_variable = { THIS.EU_pop_ratio = THIS.max_manpower_k }
 			multiply_variable = { THIS.EU_pop_ratio = 0.01 }
-			divide_variable = { THIS.EU_pop_ratio = global.var_EUpopTotal }
+			if = {
+				limit = { check_variable = { global.var_EUpopTotal > 0 } }
+				divide_variable = { THIS.EU_pop_ratio = global.var_EUpopTotal }
+			}
 		}
 		for_each_scope_loop = {
 			array = global.EU_member
 			set_variable = { THIS.EU_pop_ratio = 0 }
 			add_to_variable = { THIS.EU_pop_ratio = THIS.max_manpower_k }
 			multiply_variable = { THIS.EU_pop_ratio = 0.01 }
-			divide_variable = { THIS.EU_pop_ratio = global.var_EUpopTotal }
+			if = {
+				limit = { check_variable = { global.var_EUpopTotal > 0 } }
+				divide_variable = { THIS.EU_pop_ratio = global.var_EUpopTotal }
+			}
 		}
 		# End of EU Population Calculations
 
@@ -160,7 +166,10 @@ EU_update_vars = {
 			array = global.EU_member
 			add_to_variable = { global.var_europeanism = THIS.var_proeuropean }
 		}
-		divide_variable = { global.var_europeanism = global.var_EUpopTotal }
+		if = {
+			limit = { check_variable = { global.var_EUpopTotal > 0 } }
+			divide_variable = { global.var_europeanism = global.var_EUpopTotal }
+		}
 		###End of Europeanism update
 
 		# Calculate the Total var for QMV


### PR DESCRIPTION
I had Codex analyze the crash, and these are the fixes it produced.

Below is Codex’s summary:
-------------------
During the April 5, 2026 CTD investigation, the crash dump itself only showed a generic C0000005 access violation, so I traced the last successful scripted action in the logs instead. game.log stops immediately after EU_update_vars_mission fires at 21:00 on 2001-09-01, which led me to EU_update_vars in common/scripted_effects/99_eu_scripted_effects.txt. That effect divides by global.var_EUpopTotal without checking whether the value is greater than zero. If the EU member array is empty or inconsistent, the denominator can become 0, which is a plausible crash trigger. I added a zero-denominator guard so those divisions only run when global.var_EUpopTotal > 0; otherwise the computed values stay at 0 and the update completes safely.