### PR TITLE
Kashmir border war fix

### DIFF
--- a/common/decisions/kasmir_war_decisions.txt
+++ b/common/decisions/kasmir_war_decisions.txt
@@ -284,31 +284,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_427_from_420"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 427
-						defender = 420
-					}
+					420 = { has_border_war = yes }
+					427 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 420
-						num_provinces = 2
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 420
+						NOT = { controls_state = 427 }
 					}
-					defender = {
-						state = 427
-						num_provinces = 3
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 420
+							num_provinces = 2
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 427
+							num_provinces = 3
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -362,31 +369,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_420_from_427"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 420
-						defender = 427
-					}
+					427 = { has_border_war = yes }
+					420 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 427
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 427
+						NOT = { controls_state = 420 }
 					}
-					defender = {
-						state = 420
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 427
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 420
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -440,31 +454,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_429_from_563"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 429
-						defender = 563
-					}
+					563 = { has_border_war = yes }
+					429 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 563
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 563
+						NOT = { controls_state = 429 }
 					}
-					defender = {
-						state = 429
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 563
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 429
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -518,31 +539,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_563_from_429"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 563
-						defender = 429
-					}
+					429 = { has_border_war = yes }
+					563 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 429
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 429
+						NOT = { controls_state = 563 }
 					}
-					defender = {
-						state = 563
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 429
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 563
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -596,31 +624,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_984_from_573"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 984
-						defender = 573
-					}
+					573 = { has_border_war = yes }
+					984 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 573
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 573
+						NOT = { controls_state = 984 }
 					}
-					defender = {
-						state = 984
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 573
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 984
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -674,31 +709,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_573_from_984"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 573
-						defender = 984
-					}
+					984 = { has_border_war = yes }
+					573 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 984
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 984
+						NOT = { controls_state = 573 }
 					}
-					defender = {
-						state = 573
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 984
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 573
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -752,31 +794,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_984_from_426"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 984
-						defender = 426
-					}
+					426 = { has_border_war = yes }
+					984 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 426
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 426
+						NOT = { controls_state = 984 }
 					}
-					defender = {
-						state = 984
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 426
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 984
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -830,31 +879,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_426_from_984"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 426
-						defender = 984
-					}
+					984 = { has_border_war = yes }
+					426 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 984
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 984
+						NOT = { controls_state = 426 }
 					}
-					defender = {
-						state = 426
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 984
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 426
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -908,31 +964,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_426_from_987"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 426
-						defender = 987
-					}
+					987 = { has_border_war = yes }
+					426 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 987
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 987
+						NOT = { controls_state = 426 }
 					}
-					defender = {
-						state = 426
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 987
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 426
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -986,31 +1049,38 @@ kasmir_war_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_987_from_426"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 987
-						defender = 426
-					}
+					426 = { has_border_war = yes }
+					987 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 426
-						num_provinces = 3
-						on_win = kasmir_war.10
-						on_lose = kasmir_war.11
-						on_cancel = kasmir_war.12
+				if = {
+					limit = {
+						controls_state = 426
+						NOT = { controls_state = 987 }
 					}
-					defender = {
-						state = 987
-						num_provinces = 2
-						on_win = kasmir_war.14
-						on_lose = kasmir_war.13
-						on_cancel = kasmir_war.15
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 426
+							num_provinces = 3
+							on_win = kasmir_war.10
+							on_lose = kasmir_war.11
+							on_cancel = kasmir_war.12
+						}
+						defender = {
+							state = 987
+							num_provinces = 2
+							on_win = kasmir_war.14
+							on_lose = kasmir_war.13
+							on_cancel = kasmir_war.15
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir
 				}
 			}
 		}
@@ -1697,31 +1767,38 @@ kasmir_war_china_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_591_from_993"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 993
-						defender = 591
-					}
+					993 = { has_border_war = yes }
+					591 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 993
-						num_provinces = 2
-						on_win = kasmir_war.20
-						on_lose = kasmir_war.21
-						on_cancel = kasmir_war.22
+				if = {
+					limit = {
+						controls_state = 993
+						NOT = { controls_state = 591 }
 					}
-					defender = {
-						state = 591
-						num_provinces = 3
-						on_win = kasmir_war.24
-						on_lose = kasmir_war.23
-						on_cancel = kasmir_war.25
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 993
+							num_provinces = 2
+							on_win = kasmir_war.20
+							on_lose = kasmir_war.21
+							on_cancel = kasmir_war.22
+						}
+						defender = {
+							state = 591
+							num_provinces = 3
+							on_win = kasmir_war.24
+							on_lose = kasmir_war.23
+							on_cancel = kasmir_war.25
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir_China
 				}
 			}
 		}
@@ -1775,31 +1852,38 @@ kasmir_war_china_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_993_from_591"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 591
-						defender = 993
-					}
+					591 = { has_border_war = yes }
+					993 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 591
-						num_provinces = 3
-						on_win = kasmir_war.20
-						on_lose = kasmir_war.21
-						on_cancel = kasmir_war.22
+				if = {
+					limit = {
+						controls_state = 591
+						NOT = { controls_state = 993 }
 					}
-					defender = {
-						state = 993
-						num_provinces = 2
-						on_win = kasmir_war.24
-						on_lose = kasmir_war.23
-						on_cancel = kasmir_war.25
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 591
+							num_provinces = 3
+							on_win = kasmir_war.20
+							on_lose = kasmir_war.21
+							on_cancel = kasmir_war.22
+						}
+						defender = {
+							state = 993
+							num_provinces = 2
+							on_win = kasmir_war.24
+							on_lose = kasmir_war.23
+							on_cancel = kasmir_war.25
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir_China
 				}
 			}
 		}
@@ -1853,31 +1937,38 @@ kasmir_war_china_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_591_from_993"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 993
-						defender = 589
-					}
+					993 = { has_border_war = yes }
+					589 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 993
-						num_provinces = 2
-						on_win = kasmir_war.20
-						on_lose = kasmir_war.21
-						on_cancel = kasmir_war.22
+				if = {
+					limit = {
+						controls_state = 993
+						NOT = { controls_state = 589 }
 					}
-					defender = {
-						state = 589
-						num_provinces = 1
-						on_win = kasmir_war.24
-						on_lose = kasmir_war.23
-						on_cancel = kasmir_war.25
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 993
+							num_provinces = 2
+							on_win = kasmir_war.20
+							on_lose = kasmir_war.21
+							on_cancel = kasmir_war.22
+						}
+						defender = {
+							state = 589
+							num_provinces = 1
+							on_win = kasmir_war.24
+							on_lose = kasmir_war.23
+							on_cancel = kasmir_war.25
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir_China
 				}
 			}
 		}
@@ -1931,31 +2022,38 @@ kasmir_war_china_decisions_category = {
 			log = "[GetDateText]: [Root.GetName]: Remove attack_993_from_589"
 			if = {
 				limit = {
-					has_border_war_between = {
-						attacker = 589
-						defender = 993
-					}
+					589 = { has_border_war = yes }
+					993 = { has_border_war = yes }
 				}
 
 				country_event = kasmir_war.6
 			}
 			else = {
-				start_border_war = {
-					change_state_after_war = no
-					attacker = {
-						state = 589
-						num_provinces = 1
-						on_win = kasmir_war.20
-						on_lose = kasmir_war.21
-						on_cancel = kasmir_war.22
+				if = {
+					limit = {
+						controls_state = 589
+						NOT = { controls_state = 993 }
 					}
-					defender = {
-						state = 993
-						num_provinces = 2
-						on_win = kasmir_war.24
-						on_lose = kasmir_war.23
-						on_cancel = kasmir_war.25
+					start_border_war = {
+						change_state_after_war = no
+						attacker = {
+							state = 589
+							num_provinces = 1
+							on_win = kasmir_war.20
+							on_lose = kasmir_war.21
+							on_cancel = kasmir_war.22
+						}
+						defender = {
+							state = 993
+							num_provinces = 2
+							on_win = kasmir_war.24
+							on_lose = kasmir_war.23
+							on_cancel = kasmir_war.25
+						}
 					}
+				}
+				else = {
+					clr_country_flag = Attacking_in_Kasmir_China
 				}
 			}
 		}


### PR DESCRIPTION
I had Codex analyze the crash, and these are the fixes it produced.

Below is Codex’s summary:
---------------------------
During the April 5, 2026 MD crash investigation, the crash dump itself was only a generic access violation, so I traced the surrounding script errors from the logs instead. While the main CTD path pointed elsewhere, the logs repeatedly exposed a separate Kashmir border-war issue in common/decisions/kasmir_war_decisions.txt: some India/Pak decisions had mismatched attacker/defender definitions between the border-war check and start_border_war, and all of the Kashmir attack decisions could still reach start_border_war after the 10-day timer even if state control had changed in the meantime. I fixed this by aligning the attacker/defender setup, adding a controller re-check immediately before start_border_war, and clearing the temporary attack flag when the conditions are no longer valid. In follow-up testing, one remaining log spam issue came from using has_border_war_between as an existence check, so I replaced those checks with per-state has_border_war = yes checks. After that, the Kashmir repro no longer produced the related errors.