### PR TITLE
Carrier Raids Fix

### DIFF
--- a/md_carrier_direct_raids/common/raids/carrier_raids.txt
+++ b/md_carrier_direct_raids/common/raids/carrier_raids.txt
@@ -1,0 +1,2304 @@
+types = {
+
+	# =============================================
+	# FUEL RAID - CARRIER DIRECT
+	# =============================================
+	fuel_production_storage_raid_air_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 180
+
+		category = infastructure_strikes
+		command_power = 20
+
+		show_target = {
+			NOT = { is_in_faction_with = FROM }
+			OR = {
+				AND = {
+					has_opinion = {
+						target = FROM
+						value < 0
+					}
+					if = {
+						limit = { has_idea = intervention_limited_interventionism }
+						is_neighbor_of = FROM
+					}
+					else_if = {
+						limit = { has_idea = intervention_regional_interventionism }
+						custom_trigger_tooltip = {
+							tooltip = nation_on_same_continent
+							FROM = { PREV_is_on_same_continent = yes }
+						}
+					}
+				}
+				has_war_with = FROM
+			}
+		}
+
+		available = {
+			FROM = {
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+
+		launchable = {
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+			}
+		}
+
+		target_type = {
+			state = {
+				OR = { oil > 18 fuel_silo > 0 }
+				NOT = {
+					OR = {
+						has_dynamic_modifier = { modifier = oil_refining_modifier }
+						has_dynamic_modifier = { modifier = oil_critical_refining_modifier }
+						has_dynamic_modifier = { modifier = oil_minor_refining_modifier }
+					}
+				}
+			}
+		}
+
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		arrow = { type = air }
+		launch_sound = raid_launch_air
+		target_icon = GFX_other_target_icon
+
+		success_factors = {
+			success = {
+				base = 0.20
+				experience = { weight = 0.1 start_weight = -0.1 reference = 1000 }
+				air_agility = { reference = 200 weight = 0.5 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.1 start_weight = -0.1 }
+				air_defence = { reference = 150 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.3 start_weight = -0.100 }
+				anti_air = { reference = 5 weight = -0.25 }
+				radar = { reference = 1 weight = -0.15 }
+				interception = { reference = 500 weight = -0.2 }
+				intel = { weight = 0.3 reference = 100 }
+			}
+			disaster = { base = 0.25 }
+			critical = { base = 0.05 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = { send_raid_event_to_victim = yes }
+			}
+			limited_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { ROOT.num_fuel_silos = THIS.building_level@fuel_silo }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.4 max = 0.6 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = num_fuel_silos }
+					var:target_state = {
+						if = { limit = { oil > 18 } 
+							set_temp_variable = { oil_reducer = THIS.resource@oil }
+							multiply_temp_variable = { oil_reducer = 0.75 }
+							divide_temp_variable = { ROOT.building_damage_by_missile = oil_reducer }
+							add_dynamic_modifier = { modifier = oil_minor_refining_modifier days = 150 }
+						}
+					}
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fuel_silo > 0 }
+							meta_effect = { text = { damage_building = { type = fuel_silo damage = [DAM] } } DAM = "[?building_damage_by_missile]" }
+						}
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { ROOT.num_fuel_silos = THIS.building_level@fuel_silo }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.6 max = 0.8 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = num_fuel_silos }
+					var:target_state = {
+						if = { limit = { oil > 18 } 
+							set_temp_variable = { oil_reducer = THIS.resource@oil }
+							multiply_temp_variable = { oil_reducer = 0.75 }
+							divide_temp_variable = { ROOT.building_damage_by_missile = oil_reducer }
+							add_dynamic_modifier = { modifier = oil_refining_modifier days = 200 }
+						}
+					}
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fuel_silo > 0 }
+							meta_effect = { text = { damage_building = { type = fuel_silo damage = [DAM] } } DAM = "[?building_damage_by_missile]" }
+						}
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { ROOT.num_fuel_silos = THIS.building_level@fuel_silo }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.8 max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = num_fuel_silos }
+					var:target_state = {
+						if = { limit = { oil > 18 } 
+							set_temp_variable = { oil_reducer = THIS.resource@oil }
+							multiply_temp_variable = { oil_reducer = 0.75 }
+							divide_temp_variable = { ROOT.building_damage_by_missile = oil_reducer }
+							add_dynamic_modifier = { modifier = oil_critical_refining_modifier days = 260 }
+						}
+					}
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fuel_silo > 0 }
+							meta_effect = { text = { damage_building = { type = fuel_silo damage = [DAM] } } DAM = "[?building_damage_by_missile]" }
+						}
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+	# =============================================
+	# METAL RAID - CARRIER DIRECT
+	# =============================================
+	metal_production_raid_air_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 180
+
+		category = infastructure_strikes
+		command_power = 20
+
+		show_target = {
+			NOT = { is_in_faction_with = FROM }
+			OR = {
+				AND = {
+					has_opinion = {
+						target = FROM
+						value < 0
+					}
+					if = {
+						limit = { has_idea = intervention_limited_interventionism }
+						is_neighbor_of = FROM
+					}
+					else_if = {
+						limit = { has_idea = intervention_regional_interventionism }
+						custom_trigger_tooltip = {
+							tooltip = nation_on_same_continent
+							FROM = { PREV_is_on_same_continent = yes }
+						}
+					}
+				}
+				has_war_with = FROM
+			}
+		}
+
+		available = {
+			FROM = {
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+		launchable = {
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+			}
+		}
+
+		target_type = {
+			state = {
+				OR = { tungsten > 8 steel > 24 aluminium > 24 chromium > 8 }
+				NOT = {
+					OR = {
+						has_dynamic_modifier = { modifier = tech_metal_refining_modifier }
+						has_dynamic_modifier = { modifier = tech_metal_critical_refining_modifier }
+						has_dynamic_modifier = { modifier = tech_metal_minor_refining_modifier }
+						has_dynamic_modifier = { modifier = metal_refining_modifier }
+						has_dynamic_modifier = { modifier = metal_critical_refining_modifier }
+						has_dynamic_modifier = { modifier = metal_minor_refining_modifier }
+						has_dynamic_modifier = { modifier = rare_metal_refining_modifier }
+						has_dynamic_modifier = { modifier = rare_metal_critical_refining_modifier }
+						has_dynamic_modifier = { modifier = rare_metal_minor_refining_modifier }
+					}
+				}
+			}
+		}
+
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		arrow = { type = air }
+		launch_sound = raid_launch_air
+		target_icon = GFX_other_target_icon
+
+		success_factors = {
+			success = {
+				base = 0.20
+				experience = { weight = 0.1 start_weight = -0.1 reference = 1000 }
+				air_agility = { reference = 200 weight = 0.5 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.1 start_weight = -0.1 }
+				air_defence = { reference = 150 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.3 start_weight = -0.100 }
+				anti_air = { reference = 5 weight = -0.25 }
+				radar = { reference = 1 weight = -0.15 }
+				interception = { reference = 500 weight = -0.2 }
+				intel = { weight = 0.3 reference = 100 }
+			}
+			disaster = { base = 0.25 }
+			critical = { base = 0.05 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = { send_raid_event_to_victim = yes }
+			}
+			limited_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						if = { limit = { tungsten > 8 } add_dynamic_modifier = { modifier = tech_metal_minor_refining_modifier days = 150 } }
+						if = { limit = { chromium > 8 } add_dynamic_modifier = { modifier = rare_metal_minor_refining_modifier days = 150 } }
+						if = { limit = { OR = { aluminium > 24 steel > 24 } } add_dynamic_modifier = { modifier = metal_minor_refining_modifier days = 150 } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						if = { limit = { tungsten > 8 } add_dynamic_modifier = { modifier = tech_metal_refining_modifier days = 200 } }
+						if = { limit = { chromium > 8 } add_dynamic_modifier = { modifier = rare_metal_refining_modifier days = 200 } }
+						if = { limit = { OR = { aluminium > 24 steel > 24 } } add_dynamic_modifier = { modifier = metal_refining_modifier days = 200 } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						if = { limit = { tungsten > 8 } add_dynamic_modifier = { modifier = tech_metal_critical_refining_modifier days = 280 } }
+						if = { limit = { chromium > 8 } add_dynamic_modifier = { modifier = rare_metal_critical_refining_modifier days = 280 } }
+						if = { limit = { OR = { aluminium > 24 steel > 24 } } add_dynamic_modifier = { modifier = metal_critical_refining_modifier days = 280 } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+	# =============================================
+	# POWER STRIKE - CARRIER DIRECT
+	# =============================================
+	state_power_strike_air_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 365
+
+		category = infastructure_strikes
+		command_power = 20
+
+		show_target = {
+			NOT = { is_in_faction_with = FROM }
+			FROM = { NOT = { has_country_flag = power_grid_damaged } }
+			OR = {
+				AND = {
+					has_opinion = { target = FROM value < 0 }
+					if = { limit = { has_idea = intervention_limited_interventionism } is_neighbor_of = FROM }
+					else_if = { limit = { has_idea = intervention_regional_interventionism } custom_trigger_tooltip = { tooltip = nation_on_same_continent FROM = { PREV_is_on_same_continent = yes } } }
+				}
+				has_war_with = FROM
+			}
+		}
+
+		available = {
+			FROM = {
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+		launchable = {
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+			}
+		}
+
+		target_type = {
+			building = { type = fossil_powerplant }
+			building = { type = synthetic_refinery }
+		}
+
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		arrow = { type = air }
+		launch_sound = raid_launch_air
+		target_icon = GFX_other_target_icon
+
+		success_factors = {
+			success = {
+				base = 0.20
+				experience = { weight = 0.3 start_weight = -0.2 reference = 1000 }
+				air_agility = { reference = 200 weight = 0.5 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.2 start_weight = -0.1 }
+				air_defence = { reference = 150 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.1 start_weight = -0.100 }
+				anti_air = { reference = 5 weight = -0.25 }
+				radar = { reference = 1 weight = -0.15 }
+				interception = { reference = 100 weight = -0.2 }
+				intel = { weight = 0.5 start_weight = -0.1 start_reference = 10 reference = 100 }
+			}
+			disaster = { base = 0.25 }
+			critical = { base = 0.05 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = { send_raid_event_to_victim = yes }
+			}
+			limited_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:victim_country = {
+						if = {
+							limit = {
+								NOT = {
+									OR = {
+										has_dynamic_modifier = { modifier = power_critical_strike_modifier }
+										has_dynamic_modifier = { modifier = power_strike_modifier }
+										has_dynamic_modifier = { modifier = power_minor_strike_modifier }
+									}
+								}
+							}
+							add_dynamic_modifier = { modifier = power_minor_strike_modifier days = 75 }
+							set_country_flag = { flag = power_grid_damaged days = 75 }
+						}
+					}
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { num_power_plants = THIS.building_level@fossil_powerplant }
+						set_temp_variable = { num_synthetic_refinery = THIS.building_level@synthetic_refinery }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.4 max = 0.6 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					if = { limit = { check_variable = { num_power_plants > 0 } check_variable = { num_synthetic_refinery > 0 } } divide_temp_variable = { building_damage_by_missile = 2 } }
+					set_temp_variable = { max_clamp = num_power_plants }
+					add_to_temp_variable = { max_clamp = num_synthetic_refinery }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					multiply_temp_variable = { building_damage_by_missile = 0.1 }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fossil_powerplant > 0 } meta_effect = { text = { damage_building = { type = fossil_powerplant damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { synthetic_refinery > 0 } meta_effect = { text = { damage_building = { type = synthetic_refinery damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:victim_country = {
+						if = {
+							limit = {
+								NOT = {
+									OR = {
+										has_dynamic_modifier = { modifier = power_critical_strike_modifier }
+										has_dynamic_modifier = { modifier = power_strike_modifier }
+										has_dynamic_modifier = { modifier = power_minor_strike_modifier }
+									}
+								}
+							}
+							add_dynamic_modifier = { modifier = power_strike_modifier days = 120 }
+							set_country_flag = { flag = power_grid_damaged days = 120 }
+						}
+					}
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { num_power_plants = THIS.building_level@fossil_powerplant }
+						set_temp_variable = { num_synthetic_refinery = THIS.building_level@synthetic_refinery }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.6 max = 0.8 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					if = { limit = { check_variable = { num_power_plants > 0 } check_variable = { num_synthetic_refinery > 0 } } divide_temp_variable = { building_damage_by_missile = 2 } }
+					set_temp_variable = { max_clamp = num_power_plants }
+					add_to_temp_variable = { max_clamp = num_synthetic_refinery }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					multiply_temp_variable = { building_damage_by_missile = 0.1 }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fossil_powerplant > 0 } meta_effect = { text = { damage_building = { type = fossil_powerplant damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { synthetic_refinery > 0 } meta_effect = { text = { damage_building = { type = synthetic_refinery damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:victim_country = {
+						if = {
+							limit = {
+								NOT = {
+									OR = {
+										has_dynamic_modifier = { modifier = power_critical_strike_modifier }
+										has_dynamic_modifier = { modifier = power_strike_modifier }
+										has_dynamic_modifier = { modifier = power_minor_strike_modifier }
+									}
+								}
+							}
+							add_dynamic_modifier = { modifier = power_critical_strike_modifier days = 180 }
+							set_country_flag = { flag = power_grid_damaged days = 180 }
+						}
+					}
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { num_power_plants = THIS.building_level@fossil_powerplant }
+						set_temp_variable = { num_synthetic_refinery = THIS.building_level@synthetic_refinery }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.8 max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					if = { limit = { check_variable = { num_power_plants > 0 } check_variable = { num_synthetic_refinery > 0 } } divide_temp_variable = { building_damage_by_missile = 2 } }
+					set_temp_variable = { max_clamp = num_power_plants }
+					add_to_temp_variable = { max_clamp = num_synthetic_refinery }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fossil_powerplant > 0 } meta_effect = { text = { damage_building = { type = fossil_powerplant damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { synthetic_refinery > 0 } meta_effect = { text = { damage_building = { type = synthetic_refinery damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+	# =============================================
+	# PRODUCTION STRIKE - CARRIER DIRECT
+	# =============================================
+	production_strike_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 356
+
+		category = infastructure_strikes
+		command_power = 20
+
+		show_target = {
+			OR = {
+				has_war_with = FROM
+				AND = {
+					has_opinion = { target = FROM value < -50 }
+					if = { limit = { has_idea = intervention_limited_interventionism } is_neighbor_of = FROM }
+					else_if = { limit = { has_idea = intervention_regional_interventionism } custom_trigger_tooltip = { tooltip = nation_on_same_continent FROM = { PREV_is_on_same_continent = yes } } }
+				}
+			}
+		}
+
+		available = {
+			FROM = {
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_war_with = FROM
+				has_opinion = { target = FROM value < -50 }
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+
+		launchable = {
+			OR = {
+				has_war_with = FROM
+				has_political_power > 99
+			}
+		}
+
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		launch_sound = raid_launch_marine
+		target_icon = GFX_other_target_icon
+
+		target_type = {
+			state = {
+				OR = {
+					industrial_complex > 0
+					arms_factory > 0
+					dockyard > 0
+					offices > 0
+					agriculture_district > 0
+				}
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		success_factors = {
+			success = {
+				base = 0.20
+				air_agility = { reference = 200 weight = 0.5 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.3 start_weight = -0.1 }
+				air_defence = { reference = 150 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.1 start_weight = -0.100 }
+				anti_air = { reference = 5 weight = -0.25 }
+				radar = { reference = 1 weight = -0.15 }
+				interception = { reference = 100 weight = -0.2 }
+				intel = { weight = 0.5 start_weight = -0.1 start_reference = 10 reference = 100 }
+			}
+			critical = { base = 0.10 }
+			disaster = { base = 0.25 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = { send_raid_event_to_victim = yes }
+			}
+			limited_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.num_mil_ind = THIS.building_level@arms_factory }
+						set_temp_variable = { ROOT.num_dockyard = THIS.building_level@dockyard }
+						set_temp_variable = { ROOT.num_industrial_complex = THIS.building_level@industrial_complex }
+						set_temp_variable = { ROOT.num_offices = THIS.building_level@offices }
+						set_temp_variable = { ROOT.num_agriculture_district = THIS.building_level@agriculture_district }
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.4 max = 0.6 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					set_temp_variable = { target_split_var = 0 }
+					if = { limit = { check_variable = { num_mil_ind > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_dockyard > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_industrial_complex > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_offices > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_agriculture_district > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					divide_temp_variable = { building_damage_by_missile = target_split_var }
+					set_temp_variable = { max_clamp = num_mil_ind }
+					add_to_temp_variable = { max_clamp = num_dockyard }
+					add_to_temp_variable = { max_clamp = num_industrial_complex }
+					add_to_temp_variable = { max_clamp = num_offices }
+					add_to_temp_variable = { max_clamp = num_agriculture_district }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { arms_factory > 0 } meta_effect = { text = { damage_building = { type = arms_factory damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { dockyard > 0 } meta_effect = { text = { damage_building = { type = dockyard damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { industrial_complex > 0 } meta_effect = { text = { damage_building = { type = industrial_complex damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { offices > 0 } meta_effect = { text = { damage_building = { type = offices damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { agriculture_district > 0 } meta_effect = { text = { damage_building = { type = agriculture_district damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.num_mil_ind = THIS.building_level@arms_factory }
+						set_temp_variable = { ROOT.num_dockyard = THIS.building_level@dockyard }
+						set_temp_variable = { ROOT.num_industrial_complex = THIS.building_level@industrial_complex }
+						set_temp_variable = { ROOT.num_offices = THIS.building_level@offices }
+						set_temp_variable = { ROOT.num_agriculture_district = THIS.building_level@agriculture_district }
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.6 max = 0.8 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					set_temp_variable = { target_split_var = 0 }
+					if = { limit = { check_variable = { num_mil_ind > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_dockyard > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_industrial_complex > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_offices > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_agriculture_district > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					divide_temp_variable = { building_damage_by_missile = target_split_var }
+					set_temp_variable = { max_clamp = num_mil_ind }
+					add_to_temp_variable = { max_clamp = num_dockyard }
+					add_to_temp_variable = { max_clamp = num_industrial_complex }
+					add_to_temp_variable = { max_clamp = num_offices }
+					add_to_temp_variable = { max_clamp = num_agriculture_district }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { arms_factory > 0 } meta_effect = { text = { damage_building = { type = arms_factory damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { dockyard > 0 } meta_effect = { text = { damage_building = { type = dockyard damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { industrial_complex > 0 } meta_effect = { text = { damage_building = { type = industrial_complex damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { offices > 0 } meta_effect = { text = { damage_building = { type = offices damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { agriculture_district > 0 } meta_effect = { text = { damage_building = { type = agriculture_district damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.num_mil_ind = THIS.building_level@arms_factory }
+						set_temp_variable = { ROOT.num_dockyard = THIS.building_level@dockyard }
+						set_temp_variable = { ROOT.num_industrial_complex = THIS.building_level@industrial_complex }
+						set_temp_variable = { ROOT.num_offices = THIS.building_level@offices }
+						set_temp_variable = { ROOT.num_agriculture_district = THIS.building_level@agriculture_district }
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.8 max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					set_temp_variable = { target_split_var = 0 }
+					if = { limit = { check_variable = { num_mil_ind > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_dockyard > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_industrial_complex > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_offices > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_agriculture_district > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					divide_temp_variable = { building_damage_by_missile = target_split_var }
+					set_temp_variable = { max_clamp = num_mil_ind }
+					add_to_temp_variable = { max_clamp = num_dockyard }
+					add_to_temp_variable = { max_clamp = num_industrial_complex }
+					add_to_temp_variable = { max_clamp = num_offices }
+					add_to_temp_variable = { max_clamp = num_agriculture_district }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { arms_factory > 0 } meta_effect = { text = { damage_building = { type = arms_factory damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { dockyard > 0 } meta_effect = { text = { damage_building = { type = dockyard damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { industrial_complex > 0 } meta_effect = { text = { damage_building = { type = industrial_complex damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { offices > 0 } meta_effect = { text = { damage_building = { type = offices damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { agriculture_district > 0 } meta_effect = { text = { damage_building = { type = agriculture_district damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+	# =============================================
+	# INFRASTRUCTURE STRIKE - CARRIER DIRECT
+	# =============================================
+	infrastructure_strike_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 356
+
+		category = infastructure_strikes
+		command_power = 20
+
+		show_target = {
+			OR = {
+				has_war_with = FROM
+				AND = {
+					has_opinion = { target = FROM value < -50 }
+					if = { limit = { has_idea = intervention_limited_interventionism } is_neighbor_of = FROM }
+					else_if = { limit = { has_idea = intervention_regional_interventionism } custom_trigger_tooltip = { tooltip = nation_on_same_continent FROM = { PREV_is_on_same_continent = yes } } }
+				}
+			}
+		}
+
+		available = {
+			FROM = {
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_war_with = FROM
+				has_opinion = { target = FROM value < -50 }
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+
+		launchable = {
+			OR = {
+				has_war_with = FROM
+				has_political_power > 99
+			}
+		}
+
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		launch_sound = raid_launch_marine
+		target_icon = GFX_other_target_icon
+
+		target_type = {
+			state = {
+				infrastructure > 0
+				internet_station > 0
+				rail_way > 0
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		success_factors = {
+			success = {
+				base = 0.20
+				air_agility = { reference = 200 weight = 0.5 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.3 start_weight = -0.1 }
+				air_defence = { reference = 150 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.1 start_weight = -0.100 }
+				anti_air = { reference = 5 weight = -0.25 }
+				radar = { reference = 1 weight = -0.15 }
+				interception = { reference = 100 weight = -0.2 }
+				intel = { weight = 0.5 start_weight = -0.1 start_reference = 10 reference = 100 }
+			}
+			critical = { base = 0.10 }
+			disaster = { base = 0.25 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = { send_raid_event_to_victim = yes }
+			}
+			limited_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.num_infrastructure = THIS.building_level@infrastructure }
+						set_temp_variable = { ROOT.num_internet_station = THIS.building_level@internet_station }
+						set_temp_variable = { ROOT.num_rail_way = THIS.building_level@rail_way }
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.4 max = 0.6 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					set_temp_variable = { target_split_var = 0 }
+					if = { limit = { check_variable = { num_infrastructure > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_internet_station > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_rail_way > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					divide_temp_variable = { building_damage_by_missile = target_split_var }
+					set_temp_variable = { max_clamp = num_infrastructure }
+					add_to_temp_variable = { max_clamp = num_internet_station }
+					add_to_temp_variable = { max_clamp = num_rail_way }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { infrastructure > 0 } meta_effect = { text = { damage_building = { type = infrastructure damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { internet_station > 0 } meta_effect = { text = { damage_building = { type = internet_station damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { rail_way > 0 } meta_effect = { text = { damage_building = { type = rail_way damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.num_infrastructure = THIS.building_level@infrastructure }
+						set_temp_variable = { ROOT.num_internet_station = THIS.building_level@internet_station }
+						set_temp_variable = { ROOT.num_rail_way = THIS.building_level@rail_way }
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.6 max = 0.8 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					set_temp_variable = { target_split_var = 0 }
+					if = { limit = { check_variable = { num_infrastructure > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_internet_station > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_rail_way > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					divide_temp_variable = { building_damage_by_missile = target_split_var }
+					set_temp_variable = { max_clamp = num_infrastructure }
+					add_to_temp_variable = { max_clamp = num_internet_station }
+					add_to_temp_variable = { max_clamp = num_rail_way }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { infrastructure > 0 } meta_effect = { text = { damage_building = { type = infrastructure damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { internet_station > 0 } meta_effect = { text = { damage_building = { type = internet_station damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { rail_way > 0 } meta_effect = { text = { damage_building = { type = rail_way damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.num_infrastructure = THIS.building_level@infrastructure }
+						set_temp_variable = { ROOT.num_internet_station = THIS.building_level@internet_station }
+						set_temp_variable = { ROOT.num_rail_way = THIS.building_level@rail_way }
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.8 max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					set_temp_variable = { target_split_var = 0 }
+					if = { limit = { check_variable = { num_infrastructure > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_internet_station > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					if = { limit = { check_variable = { num_rail_way > 0 } } add_to_temp_variable = { target_split_var = 1 } }
+					divide_temp_variable = { building_damage_by_missile = target_split_var }
+					set_temp_variable = { max_clamp = num_infrastructure }
+					add_to_temp_variable = { max_clamp = num_internet_station }
+					add_to_temp_variable = { max_clamp = num_rail_way }
+					clamp_temp_variable = { var = building_damage_by_missile min = 0 max = max_clamp }
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { infrastructure > 0 } meta_effect = { text = { damage_building = { type = infrastructure damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { internet_station > 0 } meta_effect = { text = { damage_building = { type = internet_station damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+						if = { limit = { rail_way > 0 } meta_effect = { text = { damage_building = { type = rail_way damage = [DAM] } } DAM = "[?building_damage_by_missile]" } }
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+	# =============================================
+	# FACILITY STRIKE - CARRIER DIRECT
+	# =============================================
+	facility_strike_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 365
+
+		category = infastructure_strikes
+		command_power = 20
+
+		show_target = {
+			NOT = { is_in_faction_with = FROM }
+			OR = {
+				AND = {
+					has_opinion = { target = FROM value < -50 }
+					if = { limit = { has_idea = intervention_limited_interventionism } is_neighbor_of = FROM }
+					else_if = { limit = { has_idea = intervention_regional_interventionism } custom_trigger_tooltip = { tooltip = nation_on_same_continent FROM = { PREV_is_on_same_continent = yes } } }
+				}
+				has_war_with = FROM
+			}
+		}
+
+		available = {
+			FROM = {
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+
+		launchable = {
+			OR = {
+				has_war_with = FROM
+				has_political_power > 99
+			}
+		}
+
+		target_type = {
+			building = { tags = facility }
+		}
+
+		target_icon = GFX_facility_icon
+		launch_sound = raid_launch_air
+
+		arrow = { type = air }
+
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		success_factors = {
+			success = {
+				base = 0.20
+				experience = { weight = 0.3 start_weight = -0.2 reference = 1000 }
+				air_agility = { reference = 200 weight = 0.5 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.2 start_weight = -0.1 }
+				air_defence = { reference = 150 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.1 start_weight = -0.100 }
+				anti_air = { reference = 5 weight = -0.25 }
+				radar = { reference = 1 weight = -0.15 }
+				interception = { reference = 500 weight = -0.2 }
+				intel = { weight = 0.5 start_weight = -0.1 start_reference = 10 reference = 100 }
+			}
+			disaster = { base = 0.25 }
+			critical = { base = 0.05 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = { send_raid_event_to_victim = yes }
+			}
+			limited_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.4 max = 0.6 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					divide_temp_variable = { building_damage_by_missile = aa_defense }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = 1 }
+					var:target_state = {
+						meta_effect = {
+							text = {
+								damage_building = {
+									tags = facility
+									damage = [DAM]
+									province = var:ROOT.target_province
+									repair_speed_modifier = -0.05
+								}
+							}
+							DAM = "[?building_damage_by_missile]"
+						}
+						raid_reduce_project_progress_ratio = 0.05
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.6 max = 0.8 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					divide_temp_variable = { building_damage_by_missile = aa_defense }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = 0.5 }
+					var:target_state = {
+						meta_effect = {
+							text = {
+								damage_building = {
+									tags = facility
+									damage = [DAM]
+									province = var:ROOT.target_province
+									repair_speed_modifier = -0.25
+								}
+							}
+							DAM = "[?building_damage_by_missile]"
+						}
+						raid_reduce_project_progress_ratio = 0.15
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					send_raid_event_to_victim = yes
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.8 max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					divide_temp_variable = { building_damage_by_missile = aa_defense }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = 1 }
+					var:target_state = {
+						meta_effect = {
+							text = {
+								damage_building = {
+									tags = facility
+									damage = [DAM]
+									province = var:ROOT.target_province
+									repair_speed_modifier = -0.5
+								}
+							}
+							DAM = "[?building_damage_by_missile]"
+						}
+						raid_reduce_project_progress_ratio = 0.25
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+	# =============================================
+	# PER HEZBOLLAH RAID - CARRIER DIRECT
+	# =============================================
+	PER_raid_hezbollah_carrier = {
+		days_to_prepare = 30
+		days_re_enable = 180
+
+		category = infastructure_strikes
+		command_power = 20
+
+		visible = {
+			AND = {
+				original_tag = PER
+				has_country_flag = PER_strike_hez_1_year
+			}
+		}
+
+		show_target = {
+			FROM = { original_tag = HEZ }
+		}
+
+		available = {
+			FROM = {
+				original_tag = HEZ
+				NOT = { is_subject_of = ROOT }
+				NOT = { has_non_aggression_pact_with = ROOT }
+			}
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+				hidden_trigger = { has_country_flag = promised_retaliation_against@FROM }
+			}
+		}
+		launchable = {
+			OR = {
+				has_political_power > 99
+				has_war_with = FROM
+			}
+		}
+
+		target_type = {
+			state = { infrastructure > 0 }
+		}
+		arrow = { type = air }
+		launch_sound = raid_launch_air
+		target_icon = GFX_other_target_icon
+		unit_requirements = {
+			equipment = {
+				type = { tactical_bomber cas strategic_bomber carrier_tactical_bomber carrier_cas carrier_strategic_bomber guided_missile_equipment ballistic_missile_equipment hypersonic_missile_equipment }
+				amount = { min = 10 }
+			}
+		}
+
+		starting_point = {
+			types = { carrier rocket_site submarine }
+		}
+
+		success_factors = {
+			success = {
+				base = 0.20
+				experience = { weight = 0.1 start_weight = -0.1 reference = 10 }
+				air_agility = { reference = 20 weight = 0.1 start_weight = -0.5 }
+				reliability = { reference = 1 weight = 0.1 start_weight = -0.1 }
+				air_defence = { reference = 100 weight = 0.2 start_weight = -0.2 }
+				air_superiority = { reference = 1 weight = 0.3 start_weight = -0.100 }
+				anti_air = { reference = 1 weight = -0.25 }
+				radar = { reference = 0 weight = -0.15 }
+				interception = { reference = 5 weight = -0.2 }
+				intel = { weight = 0.1 reference = 100 }
+			}
+			disaster = { base = 0.05 }
+			critical = { base = 0.01 }
+		}
+
+		success_levels = {
+			failure = {
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 8 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = 1 } }
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.5 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 2 integer = yes }
+						if = { limit = { check_variable = { random_chance_on_dead_planes = 2 } } subtract_from_temp_variable = { random_chance_on_dead_planes = 1 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+				victim_effects = {
+					if = { limit = { NOT = { var:actor_country = { has_war_with = var:ROOT.victim_country } } } 
+						hidden_effect = {
+							var:actor_country = {
+								set_variable = { THIS.target_country = var:ROOT.victim_country }
+								set_variable = { THIS.actor_country = var:ROOT.hostile_country }
+								country_event = { id = iranian_focus.74 }
+							}
+						}
+					}
+				}
+			}
+			limited_success = {
+				victim_effects = {
+					if = { limit = { NOT = { var:actor_country = { has_war_with = var:ROOT.victim_country } } } 
+						hidden_effect = {
+							var:actor_country = {
+								set_variable = { THIS.target_country = var:ROOT.victim_country }
+								set_variable = { THIS.actor_country = var:ROOT.hostile_country }
+								country_event = { id = iranian_focus.74 }
+							}
+						}
+					}
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { ROOT.num_fuel_silos = THIS.building_level@fuel_silo }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.4 max = 0.6 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = num_fuel_silos }
+					var:target_state = {
+						if = { limit = { oil > 18 } 
+							set_temp_variable = { oil_reducer = THIS.resource@oil }
+							multiply_temp_variable = { oil_reducer = 0.75 }
+							divide_temp_variable = { ROOT.building_damage_by_missile = oil_reducer }
+							add_dynamic_modifier = { modifier = oil_minor_refining_modifier days = 150 }
+						}
+					}
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fuel_silo > 0 }
+							meta_effect = { text = { damage_building = { type = fuel_silo damage = [DAM] } } DAM = "[?building_damage_by_missile]" }
+						}
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 5 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.25 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			success = {
+				victim_effects = {
+					if = { limit = { NOT = { var:actor_country = { has_war_with = var:ROOT.victim_country } } } 
+						hidden_effect = {
+							var:actor_country = {
+								set_variable = { THIS.target_country = var:ROOT.victim_country }
+								set_variable = { THIS.actor_country = var:ROOT.hostile_country }
+								country_event = { id = iranian_focus.74 }
+							}
+						}
+					}
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { ROOT.num_fuel_silos = THIS.building_level@fuel_silo }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.6 max = 0.8 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = num_fuel_silos }
+					var:target_state = {
+						if = { limit = { oil > 18 } 
+							set_temp_variable = { oil_reducer = THIS.resource@oil }
+							multiply_temp_variable = { oil_reducer = 0.75 }
+							divide_temp_variable = { ROOT.building_damage_by_missile = oil_reducer }
+							add_dynamic_modifier = { modifier = oil_refining_modifier days = 200 }
+						}
+					}
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fuel_silo > 0 }
+							meta_effect = { text = { damage_building = { type = fuel_silo damage = [DAM] } } DAM = "[?building_damage_by_missile]" }
+						}
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 3 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 1.15 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 integer = yes }
+						if = { limit = { NOT = { check_variable = { random_chance_on_dead_planes = 1 } } } set_temp_variable = { random_chance_on_dead_planes = 0 } }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+			critical_success = {
+				victim_effects = {
+					if = { limit = { NOT = { var:actor_country = { has_war_with = var:ROOT.victim_country } } } 
+						hidden_effect = {
+							var:actor_country = {
+								set_variable = { THIS.target_country = var:ROOT.victim_country }
+								set_variable = { THIS.actor_country = var:ROOT.hostile_country }
+								country_event = { id = iranian_focus.74 }
+							}
+						}
+					}
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+						set_temp_variable = { ROOT.num_fuel_silos = THIS.building_level@fuel_silo }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					set_temp_variable = { building_damage_by_missile = 1.25 }
+					set_temp_variable_to_random = { var = missile_luck_mod min = 0.8 max = 1 }
+					multiply_temp_variable = { building_damage_by_missile = missile_luck_mod }
+					if = { limit = { check_variable = { aa_defense > 0 } } divide_temp_variable = { building_damage_by_missile = aa_defense } }
+					multiply_temp_variable = { building_damage_by_missile = 10 }
+					clamp_temp_variable = { var = building_damage_by_missile max = num_fuel_silos }
+					var:target_state = {
+						if = { limit = { oil > 18 } 
+							set_temp_variable = { oil_reducer = THIS.resource@oil }
+							multiply_temp_variable = { oil_reducer = 0.75 }
+							divide_temp_variable = { ROOT.building_damage_by_missile = oil_reducer }
+							add_dynamic_modifier = { modifier = oil_critical_refining_modifier days = 260 }
+						}
+					}
+					if = { limit = { check_variable = { building_damage_by_missile < 1 } } set_temp_variable = { building_damage_by_missile = 1.25 } }
+					var:target_state = {
+						if = { limit = { fuel_silo > 0 }
+							meta_effect = { text = { damage_building = { type = fuel_silo damage = [DAM] } } DAM = "[?building_damage_by_missile]" }
+						}
+					}
+				}
+				actor_effects = {
+					set_temp_variable = { raid_planes_lost = 0 }
+					set_temp_variable_to_random = { var = raid_planes_lost max = 2 }
+					var:target_state = {
+						set_temp_variable = { ROOT.aa_defense = THIS.non_damaged_building_level@anti_air_building }
+						set_temp_variable = { ROOT.radar_mult = THIS.non_damaged_building_level@radar_station }
+						set_temp_variable = { ROOT.rocket_mult = THIS.non_damaged_building_level@rocket_site }
+					}
+					add_to_temp_variable = { radar_mult = 0.5 }
+					multiply_temp_variable = { aa_defense = radar_mult }
+					multiply_temp_variable = { rocket_mult = radar_mult }
+					if = { limit = { NOT = { check_variable = { rocket_mult = 0 } } } 
+						multiply_temp_variable = { aa_defense = rocket_mult }
+						if = { limit = { check_variable = { aa_defense = 0 } } add_to_temp_variable = { aa_defense = rocket_mult } }
+					}
+					multiply_temp_variable = { raid_planes_lost = aa_defense }
+					if = { limit = { var:actor_country = { has_war_with = var:ROOT.victim_country } } multiply_temp_variable = { raid_planes_lost = 0.95 } }
+					else = {
+						set_temp_variable_to_random = { var = random_chance_on_dead_planes max = 1 }
+						multiply_temp_variable = { raid_planes_lost = random_chance_on_dead_planes }
+					}
+					clamp_temp_variable = { var = raid_planes_lost min = 0 }
+					round_temp_variable = raid_planes_lost
+					hidden_effect = { raid_damage_units = { plane_loss = raid_planes_lost ratio = no } }
+					custom_effect_tooltip = { localization_key = plane_raid_losses_tt LOSSES = [?raid_planes_lost] }
+					var:actor_country = {
+						if = { limit = { NOT = { has_war_with = var:ROOT.victim_country } } add_political_power = -100 }
+					}
+				}
+			}
+		}
+
+		ai_will_do = { base = 0 }
+	}
+
+}

--- a/md_carrier_direct_raids/localisation/english/carrier_raids_l_english.yml
+++ b/md_carrier_direct_raids/localisation/english/carrier_raids_l_english.yml
@@ -1,0 +1,9 @@
+﻿l_english:
+
+fuel_production_storage_raid_air_carrier:0 "Fuel Raid - Carrier Direct"
+metal_production_raid_air_carrier:0 "Metal Raid - Carrier Direct"
+state_power_strike_air_carrier:0 "Power Strike - Carrier Direct"
+production_strike_carrier:0 "Production Strike - Carrier Direct"
+infrastructure_strike_carrier:0 "Infrastructure Strike - Carrier Direct"
+facility_strike_carrier:0 "Facility Strike - Carrier Direct"
+PER_raid_hezbollah_carrier:0 "Hezbollah Raid - Carrier Direct"


### PR DESCRIPTION
First of all, sorry If I uploaded the file inappropriately. I don't know anything about modding 
-When an air raid is selected from the aircraft carrier, this prevents the planes from being automatically sent to a nearby airbase. As a result, the raid is launched directly from the carrier. 
-Created with the help of AI
-AI can't use this idk why, It is player only fix
-There is localisation problem because in-game raid names appear weird like "raid_type_state_power_strike_air_carrier" etc.
-Raid icon appears as  a question mark so there is also a graphic issue.