### PR TITLE
special forces fix

### DIFF
--- a/history/units/BRA_2000_nonnsb.txt
+++ b/history/units/BRA_2000_nonnsb.txt
@@ -2,8 +2,8 @@
 	name = "Brig. Operacoes Especiais"
 
 	regiments = {
-		special_forces = { x = 0 y = 0 }
-		special_forces = { x = 0 y = 1 }
+		Special_Forces = { x = 0 y = 0 }
+		Special_Forces = { x = 0 y = 1 }
 	}
 	priority = 2
 }

--- a/history/units/BRA_2000_nsb.txt
+++ b/history/units/BRA_2000_nsb.txt
@@ -2,8 +2,8 @@
 	name = "Brig. Operacoes Especiais"
 
 	regiments = {
-		special_forces = { x = 0 y = 0 }
-		special_forces = { x = 0 y = 1 }
+		Special_Forces = { x = 0 y = 0 }
+		Special_Forces = { x = 0 y = 1 }
 	}
 	priority = 2
 }

--- a/history/units/HOL_2000_nonnsb.txt
+++ b/history/units/HOL_2000_nonnsb.txt
@@ -50,7 +50,7 @@ division_template = {
 	name = "Korps Commandotroepen"
 
 	regiments = {
-		special_forces = { x = 0 y = 0 }
+		Special_Forces = { x = 0 y = 0 }
 	}
 	priority = 2
 }
@@ -61,8 +61,8 @@ division_template = {
 	regiments = {
 		Arm_Marine_Bat = { x = 0 y = 0 }
 		Mot_Marine_Bat = { x = 0 y = 1 }
-		special_forces = { x = 1 y = 0 }
-		special_forces = { x = 1 y = 1 }
+		Special_Forces = { x = 1 y = 0 }
+		Special_Forces = { x = 1 y = 1 }
 		Arty_Bat = { x = 2 y = 0 }
 	}
 	support = {

--- a/history/units/HOL_2000_nsb.txt
+++ b/history/units/HOL_2000_nsb.txt
@@ -43,8 +43,8 @@ division_template = {
 	name = "Korps Commandotroepen"
 
 	regiments = {
-		special_forces = { x = 0 y = 0 }
-		special_forces = { x = 0 y = 1 }
+		Special_Forces = { x = 0 y = 0 }
+		Special_Forces = { x = 0 y = 1 }
 	}
 
 	priority = 2
@@ -58,7 +58,7 @@ division_template = {
 
 		Mot_Marine_Bat = { x = 1 y = 0 }
 
-		special_forces = { x = 2 y = 0 }
+		Special_Forces = { x = 2 y = 0 }
 		Arty_Bat = { x = 2 y = 1 }
 	}
 	support = {


### PR DESCRIPTION
These are fixes for the possible causes of the crash identified by Codex's analysis.

Below is Codex's summary
----------------
Crash investigation suggests the save was already corrupted before the final crash. The strongest candidate was an invalid regiment/subunit key, special_forces, used in several MD OOB templates even though the defined unit key is Special_Forces. Once this incorrect key was written into the save, the game later reported Invalid subunit: none on load, which likely contributed to the access violation crash. We fixed the source OOB files for Brazil and the Netherlands by renaming special_forces to Special_Forces. This should prevent new saves from inheriting the malformed unit data, but already-corrupted saves may still remain broken.