### PR TITLE
GNSS fix

### DIFF
--- a/common/scripted_diplomatic_actions/MD_missile_scripted_diplomatic_actions.txt
+++ b/common/scripted_diplomatic_actions/MD_missile_scripted_diplomatic_actions.txt
@@ -629,9 +629,19 @@ scripted_diplomatic_actions = {
 			log = "[GetDateText]: [Root.GetName]: diplomatic action complete_effect revoke_mil_gnss_access"
 			ROOT = {
 				remove_from_array = { array = ROOT.GNSS_mil_treaty_array value = PREV.id }
-				remove_from_array = { array = PREV.GNSS_mil_access_array value = ROOT.id }
-				remove_from_array = { array = PREV.GNSS_mil_access_system_idx_array value = ROOT.var_GNSS_mil_system_idx }
 				PREV = {
+					set_temp_variable = { temp_GNSS_mil_access_break = 0 }
+					for_each_loop = {
+						array = GNSS_mil_access_array
+						value = v
+						index = i
+						break = temp_GNSS_mil_access_break
+						if = {
+							limit = { check_variable = { v = ROOT.id } }
+							remove_from_array = { array = GNSS_mil_access_array index = i }
+							set_temp_variable = { temp_GNSS_mil_access_break = 1 }
+						}
+					}
 					add_access_GNSS_mil_vars = yes
 				}
 				set_country_flag = { flag = recently_revoke_mil_gnss_access_@PREV days = 180 value = 1 }
@@ -1409,9 +1419,19 @@ scripted_diplomatic_actions = {
 			log = "[GetDateText]: [Root.GetName]: diplomatic action complete_effect revoke_civ_gnss_access"
 			ROOT = {
 				remove_from_array = { array = ROOT.GNSS_civ_treaty_array value = PREV.id }
-				remove_from_array = { array = PREV.GNSS_civ_access_array value = ROOT.id }
-				remove_from_array = { array = PREV.GNSS_civ_access_system_idx_array value = ROOT.var_GNSS_civ_system_idx }
 				PREV = {
+					set_temp_variable = { temp_GNSS_civ_access_break = 0 }
+					for_each_loop = {
+						array = GNSS_civ_access_array
+						value = v
+						index = i
+						break = temp_GNSS_civ_access_break
+						if = {
+							limit = { check_variable = { v = ROOT.id } }
+							remove_from_array = { array = GNSS_civ_access_array index = i }
+							set_temp_variable = { temp_GNSS_civ_access_break = 1 }
+						}
+					}
 					add_access_GNSS_civ_vars = yes
 				}
 

--- a/common/scripted_effects/00_missiles_scripted_effects.txt
+++ b/common/scripted_effects/00_missiles_scripted_effects.txt
@@ -1055,6 +1055,31 @@ calculate_SPY_civ_gui_vars = {
 }
 
 add_access_GNSS_mil_vars = {
+	# Rebuild access arrays so stale country scopes cannot survive into scope loops.
+	clear_array = temp_GNSS_mil_access_array
+	for_each_loop = {
+		array = GNSS_mil_access_array
+		value = v
+		if = {
+			limit = {
+				NOT = { check_variable = { v = 0 } }
+				var:v = { exists = yes }
+				NOT = { is_in_array = { array = temp_GNSS_mil_access_array value = v } }
+			}
+			add_to_array = { array = temp_GNSS_mil_access_array value = v }
+		}
+	}
+	clear_array = GNSS_mil_access_array
+	clear_array = GNSS_mil_access_system_idx_array
+	for_each_loop = {
+		array = temp_GNSS_mil_access_array
+		value = v
+		add_to_array = { array = GNSS_mil_access_array value = v }
+		var:v = {
+			add_to_array = { array = ROOT.GNSS_mil_access_system_idx_array value = var_GNSS_mil_system_idx }
+		}
+	}
+	clear_array = temp_GNSS_mil_access_array
 	set_variable = { temp_GNSS_mil_access_system_highest_idx = 0 }
 	set_variable = { var_GNSS_mil_army_speed_factor = var_GNSS_mil_army_speed_factor_base }
 	set_variable = { var_GNSS_mil_air_cas_efficiency = var_GNSS_mil_air_cas_efficiency_base }
@@ -1128,6 +1153,31 @@ add_access_GNSS_mil_vars = {
 }
 
 add_access_GNSS_civ_vars = {
+	# Rebuild access arrays so stale country scopes cannot survive into scope loops.
+	clear_array = temp_GNSS_civ_access_array
+	for_each_loop = {
+		array = GNSS_civ_access_array
+		value = v
+		if = {
+			limit = {
+				NOT = { check_variable = { v = 0 } }
+				var:v = { exists = yes }
+				NOT = { is_in_array = { array = temp_GNSS_civ_access_array value = v } }
+			}
+			add_to_array = { array = temp_GNSS_civ_access_array value = v }
+		}
+	}
+	clear_array = GNSS_civ_access_array
+	clear_array = GNSS_civ_access_system_idx_array
+	for_each_loop = {
+		array = temp_GNSS_civ_access_array
+		value = v
+		add_to_array = { array = GNSS_civ_access_array value = v }
+		var:v = {
+			add_to_array = { array = ROOT.GNSS_civ_access_system_idx_array value = var_GNSS_civ_system_idx }
+		}
+	}
+	clear_array = temp_GNSS_civ_access_array
 	set_variable = { temp_GNSS_civ_access_system_highest_idx = 0 }
 	set_variable = { var_GNSS_civ_production_speed_buildings_factor = var_GNSS_civ_production_speed_buildings_factor_base }
 	set_variable = { var_GNSS_civ_production_speed_infrastructure_factor = var_GNSS_civ_production_speed_infrastructure_factor_base }


### PR DESCRIPTION
These are fixes for the possible causes of the crash identified by Codex's analysis.

Below is Codex's summary.
----------------------------------------
We traced the crash to a high-confidence issue in the GNSS access system. GNSS access entries were added as paired country and system-index arrays, but the revoke logic removed the system index by current value instead of removing the matching entry by array position. Over time, especially if a provider’s GNSS level changed or a stale country scope remained, the arrays could become desynchronized. When satellites.9 recalculated satellite bonuses, it could then iterate invalid GNSS access data and trigger the access violation we saw in the crash.

The fix changes GNSS revoke handling to remove the matching access entry by index and adds a self-healing rebuild step before GNSS bonus recalculation. That rebuild filters invalid/stale access entries and regenerates the system-index arrays from live country scopes. The same protection was applied to both military and civilian GNSS access so corrupted save data does not keep propagating.