### PR TITLE
fix(ALG): prevent Casablanca Accord mission from flickering daily (#1014)

### DIFF
--- a/common/decisions/Algeria.txt
+++ b/common/decisions/Algeria.txt
@@ -4758,6 +4758,11 @@ ALG_casablanca_decisions = {
 
 		visible = { has_country_flag = algeria_casablanca_unlocked }
 
+		activation = {
+			has_country_flag = algeria_casablanca_unlocked
+			NOT = { check_variable = { algeria_casablanca_approach = 0 } }
+		}
+
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = ALG_casablanca_mission_tt
@@ -4839,13 +4844,15 @@ ALG_casablanca_decisions = {
 				hidden_effect = { news_event = { id = AlgeriaFocusNews.AU_result_low hours = 6 } }
 			}
 
-			# clear unlock flag so player can't spam decisions immediately
+			# clear unlock flag and reset approach so it can't auto-activate again
+			set_variable = { algeria_casablanca_approach = 0 }
 			clr_country_flag = algeria_casablanca_unlocked
 		}
 
 		timeout_effect = {
 			# mission timed out: failure
 			set_variable = { algeria_casablanca_result = 0 }
+			set_variable = { algeria_casablanca_approach = 0 }
 			add_stability = -0.03
 			hidden_effect = { news_event = { id = AlgeriaFocusNews.AU_timeout hours = 6 } }
 			clr_country_flag = algeria_casablanca_unlocked


### PR DESCRIPTION
## Summary

- `ALG_casablanca_mission` had no `activation` block, making it an unguarded auto-mission that HOI4 evaluates against `available` every tick
- Because `algeria_casablanca_approach` is uninitialized at game start, HOI4's variable equality check can treat it as non-zero, causing `available` to evaluate true before any focus is completed
- The mission would then activate and immediately cancel via `cancel_if_not_visible = yes` (flag not set), producing the "pops up and disappears every 24 hours from game start" behavior reported in #1014

## Changes

- Add `activation = { has_country_flag = algeria_casablanca_unlocked  NOT = { check_variable = { algeria_casablanca_approach = 0 } } }` so the mission only starts after the focus is completed AND an approach decision is taken — never at game start
- Reset `algeria_casablanca_approach = 0` in both `complete_effect` and `timeout_effect` so a leftover non-zero approach value cannot cause re-activation if the flag is ever set again

## Test plan

- [ ] Start a new Algeria game — verify no Casablanca Accord decision appears in the decision panel
- [ ] Complete focus `ALG_internationalize_conflict`, pick an approach decision — verify the 180-day mission countdown starts correctly
- [ ] Let the mission complete — verify it disappears and does not re-appear
- [ ] Let the mission time out — verify stability penalty fires, mission disappears, and does not re-appear

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)