### PR TITLE
AI improvements inspired by Ebby submods

### DIFF
--- a/common/ai_strategy/ISR.txt
+++ b/common/ai_strategy/ISR.txt
@@ -157,3 +157,38 @@ ISR_confederate_states_america_help = {
 	ai_strategy = { type = send_volunteers_desire id = "CSA" value = 1000 }
 	ai_strategy = { type = send_lend_lease_desire id = "CSA" value = 400 }
 }
+
+# Wartime execution — air-dominant doctrine against Iran
+ISR_total_war_against_iran = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_war_with = PER
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = antagonize id = PER value = 300 }
+	ai_strategy = { type = contain id = PER value = 300 }
+	ai_strategy = { type = force_build_armies value = 100 }
+	ai_strategy = { type = unit_ratio id = fighter value = 12 }
+	ai_strategy = { type = unit_ratio id = cas value = 8 }
+	ai_strategy = { type = unit_ratio id = tactical_bomber value = 10 }
+	ai_strategy = { type = unit_ratio id = strategic_bomber value = 12 }
+	ai_strategy = { type = air_factory_balance value = 14 }
+}
+
+# Bombardment doctrine when fighting distant enemies (excludes PER — covered by ISR_total_war_against_iran)
+ISR_bombardment_when_enemy_is_distant = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_war = yes
+		NOT = { has_war_with = PER }
+		any_enemy_country = {
+			NOT = { is_neighbor_of = ISR }
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = fighter value = 8 }
+	ai_strategy = { type = unit_ratio id = strategic_bomber value = 8 }
+	ai_strategy = { type = unit_ratio id = tactical_bomber value = 8 }
+}

--- a/common/ai_strategy/KOR.txt
+++ b/common/ai_strategy/KOR.txt
@@ -88,6 +88,36 @@ KOR_fuck_the_south = {
 	}
 }
 
+# Wartime execution — when war actually starts, commit fully
+KOR_total_response_to_north_korea = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_war_with = NKO
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = conquer id = NKO value = 300 }
+	ai_strategy = { type = front_unit_request tag = NKO value = 150 }
+	ai_strategy = { type = force_build_armies value = 100 }
+	ai_strategy = { type = unit_ratio id = fighter value = 10 }
+	ai_strategy = { type = unit_ratio id = cas value = 8 }
+	ai_strategy = { type = unit_ratio id = naval_bomber value = 6 }
+	ai_strategy = { type = air_factory_balance value = 10 }
+}
+
+# Pre-war air staging — build air when wargoal exists (prepare_for_war handled by MD_war_declaration_ai.txt)
+KOR_prewar_peninsula_staging = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = fighter value = 8 }
+	ai_strategy = { type = unit_ratio id = cas value = 6 }
+}
+
 KOR_construct_additional_microchips = {
 	allowed = { original_tag = KOR }
 	enable = {

--- a/common/ai_strategy/MD_combat_ai_strategies.txt
+++ b/common/ai_strategy/MD_combat_ai_strategies.txt
@@ -18,7 +18,7 @@ default_army_production_strategy = {
 	ai_strategy = { type = role_ratio id = apc_mechanized value = 50 }
 	ai_strategy = { type = role_ratio id = ifv_mechanized value = 50 }
 	ai_strategy = { type = role_ratio id = armor value = 35 }
-	ai_strategy = { type = role_ratio id = marines value = 10 }
+	ai_strategy = { type = role_ratio id = marines value = 15 }
 	ai_strategy = { type = role_ratio id = Air_helicopters value = 5 }
 	ai_strategy = { type = role_ratio id = Air_mech value = 10 }
 	ai_strategy = { type = role_ratio id = Special_Forces value = 40 }
@@ -42,7 +42,7 @@ default_army_production_strategy_maj = {
 	ai_strategy = { type = role_ratio id = apc_mechanized value = 35 }
 	ai_strategy = { type = role_ratio id = ifv_mechanized value = 50 }
 	ai_strategy = { type = role_ratio id = armor value = 40 }
-	ai_strategy = { type = role_ratio id = marines value = 20 }
+	ai_strategy = { type = role_ratio id = marines value = 25 }
 	ai_strategy = { type = role_ratio id = Air_helicopters value = 5 }
 	ai_strategy = { type = role_ratio id = Air_mech value = 15 }
 	ai_strategy = { type = role_ratio id = Special_Forces value = 50 }
@@ -63,7 +63,7 @@ default_army_production_strategy_global = {
 	ai_strategy = { type = role_ratio id = apc_mechanized value = 20 }
 	ai_strategy = { type = role_ratio id = ifv_mechanized value = 50 }
 	ai_strategy = { type = role_ratio id = armor value = 40 }
-	ai_strategy = { type = role_ratio id = marines value = 20 }
+	ai_strategy = { type = role_ratio id = marines value = 25 }
 	ai_strategy = { type = role_ratio id = Air_helicopters value = 5 }
 	ai_strategy = { type = role_ratio id = Air_mech value = 15 }
 	ai_strategy = { type = role_ratio id = Special_Forces value = 50 }
@@ -163,12 +163,12 @@ default_air_unit_production_low_mils = {
 	enable = { num_of_military_factories < 25 }
 	abort_when_not_enabled = yes
 	#Focus production around light multi-role fighters, to allow for a cheap and flexible air force for poor counties
-	ai_strategy = { type = unit_ratio id = fighter value = 5 }
+	ai_strategy = { type = unit_ratio id = fighter value = 15 }
 	ai_strategy = { type = unit_ratio id = cas value = 5 }
 	ai_strategy = { type = unit_ratio id = naval_bomber value = 2 }
-	ai_strategy = { type = unit_ratio id = tactical_bomber value = 20 }
+	ai_strategy = { type = unit_ratio id = tactical_bomber value = 15 }
 	ai_strategy = { type = unit_ratio id = heavy_fighter value = 2 }
-	ai_strategy = { type = unit_ratio id = interceptor value = 2 }
+	ai_strategy = { type = unit_ratio id = interceptor value = 5 }
 	ai_strategy = { type = unit_ratio id = scout_plane value = 2 }
 	ai_strategy = { type = unit_ratio id = suicide value = 2 }
 	ai_strategy = { type = unit_ratio id = strategic_bomber value = 1 }
@@ -1166,6 +1166,122 @@ plane_limiter = {
 	ai_strategy = { type = equipment_variant_production_factor id = cv_medium_plane_maritime_patrol_airframe value = -100 }
 	ai_strategy = { type = equipment_variant_production_factor id = cv_medium_plane_air_transport_airframe value = -100 }
 	ai_strategy = { type = equipment_variant_production_factor id = cv_medium_plane_scout_airframe value = -100 }
+}
+
+### WARTIME AI BEHAVIOR IMPROVEMENTS ###
+# Inspired by Ebby Warfare Overhaul
+
+# When at war with enough divisions, shift composition toward offensive units
+wartime_offensive_composition = {
+	allowed = { ai_for_units_is_not_disabled = yes }
+	enable = {
+		has_war = yes
+		num_divisions > 24
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = role_ratio id = infantry value = -5 }
+	ai_strategy = { type = role_ratio id = garrison value = -5 }
+	ai_strategy = { type = role_ratio id = apc_mechanized value = 10 }
+	ai_strategy = { type = role_ratio id = ifv_mechanized value = 10 }
+	ai_strategy = { type = role_ratio id = armor value = 10 }
+	ai_strategy = { type = role_ratio id = Air_mech value = 5 }
+	ai_strategy = { type = role_ratio id = Special_Forces value = 5 }
+}
+
+# Majors at war should build armies more aggressively
+major_wartime_commitment = {
+	allowed = { ai_for_units_is_not_disabled = yes }
+	enable = {
+		has_war = yes
+		is_major = yes
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = force_build_armies value = 35 }
+}
+
+# Wartime air superiority push — boost fighters and CAS when at war with enough industry
+wartime_air_superiority = {
+	allowed = {
+		ai_for_units_is_not_disabled = yes
+		NOT = { original_tag = USA }
+		NOT = { original_tag = CHI }
+	}
+	enable = {
+		has_war = yes
+		num_of_military_factories > 10
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = fighter value = 12 }
+	ai_strategy = { type = unit_ratio id = interceptor value = 6 }
+	ai_strategy = { type = unit_ratio id = cas value = 8 }
+	ai_strategy = { type = unit_ratio id = naval_bomber value = 4 }
+	ai_strategy = { type = air_factory_balance value = 5 }
+}
+
+# During war, stop spamming offices and internet stations — focus on military buildings
+wartime_stop_office_spam = {
+	allowed = { ai_for_units_is_not_disabled = yes }
+	enable = { has_war = yes }
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = building_target id = offices value = -10 }
+	ai_strategy = { type = building_target id = internet_station value = -5 }
+}
+
+# During war, push infrastructure for supply
+wartime_logistics_support = {
+	allowed = { ai_for_units_is_not_disabled = yes }
+	enable = { has_war = yes }
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = building_target id = infrastructure value = 8 }
+}
+
+# Wartime military factory ratio push for land majors
+land_major_wartime_industry = {
+	allowed = {
+		ai_for_units_is_not_disabled = yes
+		OR = {
+			original_tag = GER
+			original_tag = SOV
+			original_tag = CHI
+			original_tag = RAJ
+		}
+	}
+	enable = { has_war = yes }
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = building_target id = arms_factory value = 20 }
+	ai_strategy = { type = building_target id = fuel_silo value = 8 }
+	ai_strategy = { type = building_target id = synthetic_refinery value = 8 }
+	ai_strategy = { type = building_target id = infrastructure value = 14 }
+	ai_strategy = { type = added_military_to_civilian_factory_ratio value = 50 } # AI_ratio_military applies -25 baseline, so net +25 during war
+}
+
+# Wartime military factory ratio push for naval majors
+naval_major_wartime_industry = {
+	allowed = {
+		ai_for_units_is_not_disabled = yes
+		OR = {
+			original_tag = USA
+			original_tag = ENG
+			original_tag = FRA
+			original_tag = JAP
+			original_tag = ITA
+		}
+	}
+	enable = { has_war = yes }
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = building_target id = arms_factory value = 16 }
+	ai_strategy = { type = building_target id = dockyard value = 10 }
+	ai_strategy = { type = building_target id = fuel_silo value = 12 }
+	ai_strategy = { type = building_target id = synthetic_refinery value = 10 }
+	ai_strategy = { type = building_target id = infrastructure value = 10 }
+	ai_strategy = { type = added_military_to_civilian_factory_ratio value = 45 } # AI_ratio_military applies -25 baseline, so net +20 during war
 }
 
 plane_limiter_potato = {

--- a/common/ai_strategy/MD_war_declaration_ai.txt
+++ b/common/ai_strategy/MD_war_declaration_ai.txt
@@ -1,0 +1,1430 @@
+# War Declaration Intelligence Layer
+# Inspired by Ebby Warfare Overhaul
+#
+# Each conflict pairing has a 5-block readiness-gated progression:
+#   1. prepare     — fires when wargoal exists, builds up armies
+#   2. delay_demo  — democracies below threshold get declare_war penalty
+#   3. ready_demo  — democracies above threshold get declare_war bonus
+#   4. ready_nat   — nationalists/fascists fire at lower threshold with higher aggression
+#   5. ready_mid   — communism/neutrality mid-range threshold
+#   6. failsafe    — anti-stall: forces declaration when clearly overpowered
+#
+# Design notes:
+# - Democracies at war get hard -120 suppression with no positive offset (no two-front wars)
+# - Subjects lose wargoals on puppeting, so has_wargoal_against + abort_when_not_enabled gates them
+# - Neutrality and communism both route through the ready_mid tier
+
+### CHI vs TAI — Cross-Strait Conflict ###
+
+CHI_prepare_cross_strait_TAI = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = TAI
+		NOT = { has_war_with = TAI }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = TAI value = 180 }
+	ai_strategy = { type = front_unit_request tag = TAI value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+CHI_delay_demo_cross_strait_TAI = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = TAI
+		NOT = { has_war_with = TAI }
+		has_government = democratic
+		OR = {
+			num_divisions < 40
+			has_navy_size = { size < 14 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TAI value = -120 }
+}
+
+CHI_ready_demo_cross_strait_TAI = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = TAI
+		NOT = { has_war_with = TAI }
+		has_government = democratic
+		num_divisions > 40
+		has_navy_size = { size > 14 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TAI value = 55 }
+	ai_strategy = { type = conquer id = TAI value = 180 }
+}
+
+CHI_ready_nat_cross_strait_TAI = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = TAI
+		NOT = { has_war_with = TAI }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 22
+		has_navy_size = { size > 6 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TAI value = 85 }
+	ai_strategy = { type = conquer id = TAI value = 220 }
+}
+
+CHI_ready_mid_cross_strait_TAI = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = TAI
+		NOT = { has_war_with = TAI }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 28
+		has_navy_size = { size > 8 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TAI value = 65 }
+	ai_strategy = { type = conquer id = TAI value = 190 }
+}
+
+CHI_failsafe_cross_strait_TAI = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = TAI
+		NOT = { has_war_with = TAI }
+		NOT = { has_war = yes }
+		num_divisions > 55
+		has_navy_size = { size > 22 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TAI value = 110 }
+}
+
+### NKO vs KOR — Korean Peninsula ###
+
+NKO_prepare_reunification_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = KOR value = 180 }
+	ai_strategy = { type = front_unit_request tag = KOR value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+NKO_delay_demo_reunification_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+		has_government = democratic
+		OR = {
+			num_divisions < 18
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KOR value = -120 }
+}
+
+NKO_ready_demo_reunification_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+		has_government = democratic
+		num_divisions > 18
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KOR value = 55 }
+	ai_strategy = { type = conquer id = KOR value = 180 }
+}
+
+NKO_ready_nat_reunification_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 12
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KOR value = 85 }
+	ai_strategy = { type = conquer id = KOR value = 220 }
+}
+
+NKO_ready_mid_reunification_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 15
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KOR value = 65 }
+	ai_strategy = { type = conquer id = KOR value = 190 }
+}
+
+NKO_failsafe_reunification_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+		NOT = { has_war = yes }
+		num_divisions > 30
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KOR value = 110 }
+}
+
+### KOR vs NKO — Korean Peninsula (South) ###
+
+KOR_prepare_counter_reunification_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = NKO value = 180 }
+	ai_strategy = { type = front_unit_request tag = NKO value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+KOR_delay_demo_counter_reunification_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+		has_government = democratic
+		OR = {
+			num_divisions < 22
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NKO value = -120 }
+}
+
+KOR_ready_demo_counter_reunification_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+		has_government = democratic
+		num_divisions > 22
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NKO value = 55 }
+	ai_strategy = { type = conquer id = NKO value = 180 }
+}
+
+KOR_ready_nat_counter_reunification_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 15
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NKO value = 85 }
+	ai_strategy = { type = conquer id = NKO value = 220 }
+}
+
+KOR_ready_mid_counter_reunification_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 18
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NKO value = 65 }
+	ai_strategy = { type = conquer id = NKO value = 190 }
+}
+
+KOR_failsafe_counter_reunification_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_wargoal_against = NKO
+		NOT = { has_war_with = NKO }
+		NOT = { has_war = yes }
+		num_divisions > 38
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NKO value = 110 }
+}
+
+### ISR vs PER — Middle East ###
+
+ISR_prepare_iran_war_PER = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_wargoal_against = PER
+		NOT = { has_war_with = PER }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = PER value = 180 }
+	ai_strategy = { type = front_unit_request tag = PER value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+ISR_delay_demo_iran_war_PER = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_wargoal_against = PER
+		NOT = { has_war_with = PER }
+		has_government = democratic
+		OR = {
+			num_divisions < 20
+			has_navy_size = { size < 4 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PER value = -120 }
+}
+
+ISR_ready_demo_iran_war_PER = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_wargoal_against = PER
+		NOT = { has_war_with = PER }
+		has_government = democratic
+		num_divisions > 20
+		has_navy_size = { size > 4 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PER value = 55 }
+	ai_strategy = { type = conquer id = PER value = 180 }
+}
+
+ISR_ready_nat_iran_war_PER = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_wargoal_against = PER
+		NOT = { has_war_with = PER }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 12
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PER value = 85 }
+	ai_strategy = { type = conquer id = PER value = 220 }
+}
+
+ISR_ready_mid_iran_war_PER = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_wargoal_against = PER
+		NOT = { has_war_with = PER }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 16
+		has_navy_size = { size > 2 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PER value = 65 }
+	ai_strategy = { type = conquer id = PER value = 190 }
+}
+
+ISR_failsafe_iran_war_PER = {
+	allowed = { original_tag = ISR }
+	enable = {
+		has_wargoal_against = PER
+		NOT = { has_war_with = PER }
+		NOT = { has_war = yes }
+		num_divisions > 32
+		has_navy_size = { size > 12 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PER value = 110 }
+}
+
+### PER vs ISR — Middle East (Iran) ###
+
+PER_prepare_israel_war_ISR = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = ISR value = 180 }
+	ai_strategy = { type = front_unit_request tag = ISR value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+PER_delay_demo_israel_war_ISR = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		has_government = democratic
+		OR = {
+			num_divisions < 25
+			has_navy_size = { size < 8 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = -120 }
+}
+
+PER_ready_demo_israel_war_ISR = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		has_government = democratic
+		num_divisions > 25
+		has_navy_size = { size > 8 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 55 }
+	ai_strategy = { type = conquer id = ISR value = 180 }
+}
+
+PER_ready_nat_israel_war_ISR = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 18
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 85 }
+	ai_strategy = { type = conquer id = ISR value = 220 }
+}
+
+PER_ready_mid_israel_war_ISR = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 20
+		has_navy_size = { size > 4 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 65 }
+	ai_strategy = { type = conquer id = ISR value = 190 }
+}
+
+PER_failsafe_israel_war_ISR = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		NOT = { has_war = yes }
+		num_divisions > 42
+		has_navy_size = { size > 14 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 110 }
+}
+
+### RAJ vs PAK — India-Pakistan ###
+
+RAJ_prepare_pakistan_rivalry_PAK = {
+	allowed = { original_tag = RAJ }
+	enable = {
+		has_wargoal_against = PAK
+		NOT = { has_war_with = PAK }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = PAK value = 180 }
+	ai_strategy = { type = front_unit_request tag = PAK value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+RAJ_delay_demo_pakistan_rivalry_PAK = {
+	allowed = { original_tag = RAJ }
+	enable = {
+		has_wargoal_against = PAK
+		NOT = { has_war_with = PAK }
+		has_government = democratic
+		OR = {
+			num_divisions < 35
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAK value = -120 }
+}
+
+RAJ_ready_demo_pakistan_rivalry_PAK = {
+	allowed = { original_tag = RAJ }
+	enable = {
+		has_wargoal_against = PAK
+		NOT = { has_war_with = PAK }
+		has_government = democratic
+		num_divisions > 35
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAK value = 55 }
+	ai_strategy = { type = conquer id = PAK value = 180 }
+}
+
+RAJ_ready_nat_pakistan_rivalry_PAK = {
+	allowed = { original_tag = RAJ }
+	enable = {
+		has_wargoal_against = PAK
+		NOT = { has_war_with = PAK }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 22
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAK value = 85 }
+	ai_strategy = { type = conquer id = PAK value = 220 }
+}
+
+RAJ_ready_mid_pakistan_rivalry_PAK = {
+	allowed = { original_tag = RAJ }
+	enable = {
+		has_wargoal_against = PAK
+		NOT = { has_war_with = PAK }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 28
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAK value = 65 }
+	ai_strategy = { type = conquer id = PAK value = 190 }
+}
+
+RAJ_failsafe_pakistan_rivalry_PAK = {
+	allowed = { original_tag = RAJ }
+	enable = {
+		has_wargoal_against = PAK
+		NOT = { has_war_with = PAK }
+		NOT = { has_war = yes }
+		num_divisions > 55
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAK value = 110 }
+}
+
+### PAK vs RAJ — Pakistan-India ###
+
+PAK_prepare_india_rivalry_RAJ = {
+	allowed = { original_tag = PAK }
+	enable = {
+		has_wargoal_against = RAJ
+		NOT = { has_war_with = RAJ }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = RAJ value = 180 }
+	ai_strategy = { type = front_unit_request tag = RAJ value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+PAK_delay_demo_india_rivalry_RAJ = {
+	allowed = { original_tag = PAK }
+	enable = {
+		has_wargoal_against = RAJ
+		NOT = { has_war_with = RAJ }
+		has_government = democratic
+		OR = {
+			num_divisions < 28
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = RAJ value = -120 }
+}
+
+PAK_ready_demo_india_rivalry_RAJ = {
+	allowed = { original_tag = PAK }
+	enable = {
+		has_wargoal_against = RAJ
+		NOT = { has_war_with = RAJ }
+		has_government = democratic
+		num_divisions > 28
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = RAJ value = 55 }
+	ai_strategy = { type = conquer id = RAJ value = 180 }
+}
+
+PAK_ready_nat_india_rivalry_RAJ = {
+	allowed = { original_tag = PAK }
+	enable = {
+		has_wargoal_against = RAJ
+		NOT = { has_war_with = RAJ }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 18
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = RAJ value = 85 }
+	ai_strategy = { type = conquer id = RAJ value = 220 }
+}
+
+PAK_ready_mid_india_rivalry_RAJ = {
+	allowed = { original_tag = PAK }
+	enable = {
+		has_wargoal_against = RAJ
+		NOT = { has_war_with = RAJ }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 22
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = RAJ value = 65 }
+	ai_strategy = { type = conquer id = RAJ value = 190 }
+}
+
+PAK_failsafe_india_rivalry_RAJ = {
+	allowed = { original_tag = PAK }
+	enable = {
+		has_wargoal_against = RAJ
+		NOT = { has_war_with = RAJ }
+		NOT = { has_war = yes }
+		num_divisions > 45
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = RAJ value = 110 }
+}
+
+### CHI vs JAP — East China Sea (focus: CHI_liquidate_the_evil) ###
+
+CHI_prepare_east_china_sea_JAP = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = JAP
+		NOT = { has_war_with = JAP }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = JAP value = 180 }
+	ai_strategy = { type = front_unit_request tag = JAP value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+CHI_delay_demo_east_china_sea_JAP = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = JAP
+		NOT = { has_war_with = JAP }
+		has_government = democratic
+		OR = {
+			num_divisions < 40
+			has_navy_size = { size < 14 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = JAP value = -120 }
+}
+
+CHI_ready_demo_east_china_sea_JAP = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = JAP
+		NOT = { has_war_with = JAP }
+		has_government = democratic
+		num_divisions > 40
+		has_navy_size = { size > 14 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = JAP value = 55 }
+	ai_strategy = { type = conquer id = JAP value = 180 }
+}
+
+CHI_ready_nat_east_china_sea_JAP = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = JAP
+		NOT = { has_war_with = JAP }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 22
+		has_navy_size = { size > 6 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = JAP value = 85 }
+	ai_strategy = { type = conquer id = JAP value = 220 }
+}
+
+CHI_ready_mid_east_china_sea_JAP = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = JAP
+		NOT = { has_war_with = JAP }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 28
+		has_navy_size = { size > 8 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = JAP value = 65 }
+	ai_strategy = { type = conquer id = JAP value = 190 }
+}
+
+CHI_failsafe_east_china_sea_JAP = {
+	allowed = { original_tag = CHI }
+	enable = {
+		has_wargoal_against = JAP
+		NOT = { has_war_with = JAP }
+		NOT = { has_war = yes }
+		num_divisions > 55
+		has_navy_size = { size > 22 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = JAP value = 110 }
+}
+
+### GER vs FRA — Western Expansion (focus: GER_french_invasion) ###
+
+GER_prepare_westward_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = FRA value = 180 }
+	ai_strategy = { type = front_unit_request tag = FRA value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+GER_delay_demo_westward_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		has_government = democratic
+		OR = {
+			num_divisions < 40
+			has_navy_size = { size < 8 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = -120 }
+}
+
+GER_ready_demo_westward_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		has_government = democratic
+		num_divisions > 40
+		has_navy_size = { size > 8 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = 55 }
+	ai_strategy = { type = conquer id = FRA value = 180 }
+}
+
+GER_ready_nat_westward_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 25
+		has_navy_size = { size > 5 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = 85 }
+	ai_strategy = { type = conquer id = FRA value = 220 }
+}
+
+GER_ready_mid_westward_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 30
+		has_navy_size = { size > 6 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = 65 }
+	ai_strategy = { type = conquer id = FRA value = 190 }
+}
+
+GER_failsafe_westward_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		NOT = { has_war = yes }
+		num_divisions > 60
+		has_navy_size = { size > 15 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = 110 }
+}
+
+### GER vs SOV — Eastern Expansion (focus: GER_russian_invasion) ###
+
+GER_prepare_eastward_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = SOV
+		NOT = { has_war_with = SOV }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = SOV value = 180 }
+	ai_strategy = { type = front_unit_request tag = SOV value = 15 }
+	ai_strategy = { type = force_build_armies value = 25 }
+}
+
+GER_delay_demo_eastward_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = SOV
+		NOT = { has_war_with = SOV }
+		has_government = democratic
+		OR = {
+			num_divisions < 45
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = -120 }
+}
+
+GER_ready_demo_eastward_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = SOV
+		NOT = { has_war_with = SOV }
+		has_government = democratic
+		num_divisions > 45
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = 55 }
+	ai_strategy = { type = conquer id = SOV value = 180 }
+}
+
+GER_ready_nat_eastward_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = SOV
+		NOT = { has_war_with = SOV }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 28
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = 85 }
+	ai_strategy = { type = conquer id = SOV value = 220 }
+}
+
+GER_ready_mid_eastward_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = SOV
+		NOT = { has_war_with = SOV }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 35
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = 65 }
+	ai_strategy = { type = conquer id = SOV value = 190 }
+}
+
+GER_failsafe_eastward_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = SOV
+		NOT = { has_war_with = SOV }
+		NOT = { has_war = yes }
+		num_divisions > 65
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = 110 }
+}
+
+### SOV vs GER — Westward Push (focus: SOV_challenge_nato) ###
+
+SOV_prepare_westward_GER = {
+	allowed = { original_tag = SOV }
+	enable = {
+		has_wargoal_against = GER
+		NOT = { has_war_with = GER }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = GER value = 180 }
+	ai_strategy = { type = front_unit_request tag = GER value = 15 }
+	ai_strategy = { type = force_build_armies value = 25 }
+}
+
+SOV_delay_demo_westward_GER = {
+	allowed = { original_tag = SOV }
+	enable = {
+		has_wargoal_against = GER
+		NOT = { has_war_with = GER }
+		has_government = democratic
+		OR = {
+			num_divisions < 55
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = -120 }
+}
+
+SOV_ready_demo_westward_GER = {
+	allowed = { original_tag = SOV }
+	enable = {
+		has_wargoal_against = GER
+		NOT = { has_war_with = GER }
+		has_government = democratic
+		num_divisions > 55
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = 55 }
+	ai_strategy = { type = conquer id = GER value = 180 }
+}
+
+SOV_ready_nat_westward_GER = {
+	allowed = { original_tag = SOV }
+	enable = {
+		has_wargoal_against = GER
+		NOT = { has_war_with = GER }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 35
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = 85 }
+	ai_strategy = { type = conquer id = GER value = 220 }
+}
+
+SOV_ready_mid_westward_GER = {
+	allowed = { original_tag = SOV }
+	enable = {
+		has_wargoal_against = GER
+		NOT = { has_war_with = GER }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 40
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = 65 }
+	ai_strategy = { type = conquer id = GER value = 190 }
+}
+
+SOV_failsafe_westward_GER = {
+	allowed = { original_tag = SOV }
+	enable = {
+		has_wargoal_against = GER
+		NOT = { has_war_with = GER }
+		NOT = { has_war = yes }
+		num_divisions > 80
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = 110 }
+}
+
+### TUR vs KUR — Anti-Kurdish (focus: TUR_southward) ###
+
+TUR_prepare_anti_kurdish_KUR = {
+	allowed = { original_tag = TUR }
+	enable = {
+		has_wargoal_against = KUR
+		NOT = { has_war_with = KUR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = KUR value = 180 }
+	ai_strategy = { type = front_unit_request tag = KUR value = 10 }
+	ai_strategy = { type = force_build_armies value = 15 }
+}
+
+TUR_delay_demo_anti_kurdish_KUR = {
+	allowed = { original_tag = TUR }
+	enable = {
+		has_wargoal_against = KUR
+		NOT = { has_war_with = KUR }
+		has_government = democratic
+		OR = {
+			num_divisions < 22
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KUR value = -120 }
+}
+
+TUR_ready_demo_anti_kurdish_KUR = {
+	allowed = { original_tag = TUR }
+	enable = {
+		has_wargoal_against = KUR
+		NOT = { has_war_with = KUR }
+		has_government = democratic
+		num_divisions > 22
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KUR value = 55 }
+	ai_strategy = { type = conquer id = KUR value = 180 }
+}
+
+TUR_ready_nat_anti_kurdish_KUR = {
+	allowed = { original_tag = TUR }
+	enable = {
+		has_wargoal_against = KUR
+		NOT = { has_war_with = KUR }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 14
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KUR value = 85 }
+	ai_strategy = { type = conquer id = KUR value = 220 }
+}
+
+TUR_ready_mid_anti_kurdish_KUR = {
+	allowed = { original_tag = TUR }
+	enable = {
+		has_wargoal_against = KUR
+		NOT = { has_war_with = KUR }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 18
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KUR value = 65 }
+	ai_strategy = { type = conquer id = KUR value = 190 }
+}
+
+TUR_failsafe_anti_kurdish_KUR = {
+	allowed = { original_tag = TUR }
+	enable = {
+		has_wargoal_against = KUR
+		NOT = { has_war_with = KUR }
+		NOT = { has_war = yes }
+		num_divisions > 35
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = KUR value = 110 }
+}
+
+### EGY vs ISR — Arab-Israeli (focus: EGY_war_with_israel) ###
+
+EGY_prepare_arab_israeli_ISR = {
+	allowed = { original_tag = EGY }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = ISR value = 180 }
+	ai_strategy = { type = front_unit_request tag = ISR value = 10 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+EGY_delay_demo_arab_israeli_ISR = {
+	allowed = { original_tag = EGY }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		has_government = democratic
+		OR = {
+			num_divisions < 20
+			has_navy_size = { size < 3 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = -120 }
+}
+
+EGY_ready_demo_arab_israeli_ISR = {
+	allowed = { original_tag = EGY }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		has_government = democratic
+		num_divisions > 20
+		has_navy_size = { size > 3 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 55 }
+	ai_strategy = { type = conquer id = ISR value = 180 }
+}
+
+EGY_ready_nat_arab_israeli_ISR = {
+	allowed = { original_tag = EGY }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 13
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 85 }
+	ai_strategy = { type = conquer id = ISR value = 220 }
+}
+
+EGY_ready_mid_arab_israeli_ISR = {
+	allowed = { original_tag = EGY }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 16
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 65 }
+	ai_strategy = { type = conquer id = ISR value = 190 }
+}
+
+EGY_failsafe_arab_israeli_ISR = {
+	allowed = { original_tag = EGY }
+	enable = {
+		has_wargoal_against = ISR
+		NOT = { has_war_with = ISR }
+		NOT = { has_war = yes }
+		num_divisions > 32
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = 110 }
+}
+
+### GRE vs TUR — Megali Idea (focus: GRE_constantinople_not_istanbul) ###
+
+GRE_prepare_megali_TUR = {
+	allowed = { original_tag = GRE }
+	enable = {
+		has_wargoal_against = TUR
+		NOT = { has_war_with = TUR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = TUR value = 180 }
+	ai_strategy = { type = front_unit_request tag = TUR value = 10 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+GRE_delay_demo_megali_TUR = {
+	allowed = { original_tag = GRE }
+	enable = {
+		has_wargoal_against = TUR
+		NOT = { has_war_with = TUR }
+		has_government = democratic
+		OR = {
+			num_divisions < 12
+			has_navy_size = { size < 6 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUR value = -120 }
+}
+
+GRE_ready_demo_megali_TUR = {
+	allowed = { original_tag = GRE }
+	enable = {
+		has_wargoal_against = TUR
+		NOT = { has_war_with = TUR }
+		has_government = democratic
+		num_divisions > 12
+		has_navy_size = { size > 6 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUR value = 55 }
+	ai_strategy = { type = conquer id = TUR value = 180 }
+}
+
+GRE_ready_nat_megali_TUR = {
+	allowed = { original_tag = GRE }
+	enable = {
+		has_wargoal_against = TUR
+		NOT = { has_war_with = TUR }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 8
+		has_navy_size = { size > 3 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUR value = 85 }
+	ai_strategy = { type = conquer id = TUR value = 220 }
+}
+
+GRE_ready_mid_megali_TUR = {
+	allowed = { original_tag = GRE }
+	enable = {
+		has_wargoal_against = TUR
+		NOT = { has_war_with = TUR }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 10
+		has_navy_size = { size > 4 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUR value = 65 }
+	ai_strategy = { type = conquer id = TUR value = 190 }
+}
+
+GRE_failsafe_megali_TUR = {
+	allowed = { original_tag = GRE }
+	enable = {
+		has_wargoal_against = TUR
+		NOT = { has_war_with = TUR }
+		NOT = { has_war = yes }
+		num_divisions > 20
+		has_navy_size = { size > 10 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUR value = 110 }
+}
+
+### GER vs ENG — British Invasion (focus: GER_british_invasion) ###
+
+GER_prepare_channel_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = ENG
+		NOT = { has_war_with = ENG }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = ENG value = 180 }
+	ai_strategy = { type = front_unit_request tag = ENG value = 12 }
+	ai_strategy = { type = force_build_armies value = 20 }
+}
+
+GER_delay_demo_channel_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = ENG
+		NOT = { has_war_with = ENG }
+		has_government = democratic
+		OR = {
+			num_divisions < 40
+			has_navy_size = { size < 12 }
+			has_war = yes
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = -120 }
+}
+
+GER_ready_demo_channel_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = ENG
+		NOT = { has_war_with = ENG }
+		has_government = democratic
+		num_divisions > 40
+		has_navy_size = { size > 12 }
+		NOT = { has_war = yes }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = 55 }
+	ai_strategy = { type = conquer id = ENG value = 180 }
+}
+
+GER_ready_nat_channel_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = ENG
+		NOT = { has_war_with = ENG }
+		OR = {
+			has_government = nationalist
+			has_government = fascism
+		}
+		num_divisions > 25
+		has_navy_size = { size > 8 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = 85 }
+	ai_strategy = { type = conquer id = ENG value = 220 }
+}
+
+GER_ready_mid_channel_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = ENG
+		NOT = { has_war_with = ENG }
+		NOT = { has_government = democratic }
+		NOT = { has_government = nationalist }
+		NOT = { has_government = fascism }
+		num_divisions > 30
+		has_navy_size = { size > 10 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = 65 }
+	ai_strategy = { type = conquer id = ENG value = 190 }
+}
+
+GER_failsafe_channel_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_wargoal_against = ENG
+		NOT = { has_war_with = ENG }
+		NOT = { has_war = yes }
+		num_divisions > 60
+		has_navy_size = { size > 20 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = 110 }
+}

--- a/common/ai_strategy/NKO.txt
+++ b/common/ai_strategy/NKO.txt
@@ -142,3 +142,32 @@ NKO_fuck_the_south = {
 		value = 25
 	}
 }
+
+# Wartime execution — when war actually starts, commit fully
+NKO_commit_to_reunification_war = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_war_with = KOR
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = conquer id = KOR value = 400 }
+	ai_strategy = { type = invade id = KOR value = 350 }
+	ai_strategy = { type = front_unit_request tag = KOR value = 150 }
+	ai_strategy = { type = force_build_armies value = 100 }
+	ai_strategy = { type = unit_ratio id = fighter value = 6 }
+	ai_strategy = { type = unit_ratio id = cas value = 6 }
+}
+
+# Pre-war air staging — build air when wargoal exists (prepare_for_war handled by MD_war_declaration_ai.txt)
+NKO_prewar_reunification_staging = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_wargoal_against = KOR
+		NOT = { has_war_with = KOR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = fighter value = 8 }
+	ai_strategy = { type = unit_ratio id = cas value = 6 }
+}

--- a/common/ai_strategy/PER.txt
+++ b/common/ai_strategy/PER.txt
@@ -616,3 +616,69 @@ PER_support_shia_revolutions = {
 	ai_strategy = { type = send_volunteers_desire id = PER value = 200 }
 	ai_strategy = { type = support id = PER value = 200 }
 }
+
+# Wartime execution — asymmetric air/missile doctrine
+PER_asymmetric_air_war = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_war = yes
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = fighter value = 8 }
+	ai_strategy = { type = unit_ratio id = cas value = 6 }
+	ai_strategy = { type = unit_ratio id = tactical_bomber value = 6 }
+	ai_strategy = { type = unit_ratio id = strategic_bomber value = 6 }
+	ai_strategy = { type = air_factory_balance value = 12 }
+}
+
+# Counter superpower navy — boost naval bombers when outmatched at sea
+PER_counter_superpower_navy = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_war = yes
+		OR = {
+			has_war_with = USA
+			has_war_with = ENG
+			enemies_naval_strength_ratio > 1.2
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = naval_bomber value = 12 }
+	ai_strategy = { type = unit_ratio id = strategic_bomber value = 6 }
+}
+
+# Total war against Israel
+PER_total_war_against_israel = {
+	allowed = { original_tag = PER }
+	enable = {
+		has_war_with = ISR
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = antagonize id = ISR value = 300 }
+	ai_strategy = { type = contain id = ISR value = 300 }
+	ai_strategy = { type = force_build_armies value = 100 }
+	ai_strategy = { type = unit_ratio id = fighter value = 6 }
+	ai_strategy = { type = unit_ratio id = cas value = 6 }
+	ai_strategy = { type = unit_ratio id = tactical_bomber value = 10 }
+	ai_strategy = { type = unit_ratio id = strategic_bomber value = 12 }
+	ai_strategy = { type = air_factory_balance value = 14 }
+}
+
+# Pre-war air escalation — build air when tensions rise (prepare_for_war handled by MD_war_declaration_ai.txt)
+PER_prewar_regional_escalation = {
+	allowed = { original_tag = PER }
+	enable = {
+		OR = {
+			threat > 0.15
+			has_wargoal_against = ISR
+		}
+		NOT = { has_war_with = ISR }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = unit_ratio id = fighter value = 7 }
+	ai_strategy = { type = unit_ratio id = tactical_bomber value = 5 }
+}

--- a/common/ai_strategy/naval.txt
+++ b/common/ai_strategy/naval.txt
@@ -68,10 +68,10 @@ peace_time_naval_missions = {
 	enable = { has_war = no }
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_PATROL" value = 50000 }
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_STRIKE_FORCE" value = 40000 }
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_CONVOY_ESCORT" value = 50000 }
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_CONVOY_RAIDING" value = 40000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_PATROL" value = 20000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_STRIKE_FORCE" value = 18000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_CONVOY_ESCORT" value = 22000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_CONVOY_RAIDING" value = 18000 }
 }
 
 
@@ -93,21 +93,24 @@ halt_sub_missions = {
 
 conserve_fuel = {
 	allowed = { ai_for_units_is_not_disabled = yes }
-	enable = { fuel_ratio < 0.25 }
+	enable = { fuel_ratio < 0.15 }
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_STRIKE_FORCE" value = 200000 }
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_CONVOY_RAIDING" value = 200000 }
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_MINES_PLANTING" value = 200000 }
-	ai_strategy = { type = naval_mission_threshold id = "MISSION_MINES_SWEEPING" value = 200000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_STRIKE_FORCE" value = 120000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_CONVOY_RAIDING" value = 120000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_MINES_PLANTING" value = 120000 }
+	ai_strategy = { type = naval_mission_threshold id = "MISSION_MINES_SWEEPING" value = 120000 }
 }
 
 conserve_fuel_if_fighting_landlocked_nations = {
 	allowed = { ai_for_units_is_not_disabled = yes }
 	enable = {
+		has_war = yes
 		all_enemy_country = {
-			any_owned_state = {
-				is_coastal = no
+			NOT = {
+				any_owned_state = {
+					is_coastal = yes
+				}
 			}
 		}
 	}
@@ -481,60 +484,60 @@ ship_limiter = {
 		has_global_flag = GAME_RULE_division_limiter_enabled
 	}
 	enable = {
-		set_temp_variable = { ship_limit = num_of_naval_factories } # 5
-		multiply_temp_variable = { ship_limit = 7 } #50
+		set_temp_variable = { ship_limit = num_of_naval_factories }
+		multiply_temp_variable = { ship_limit = 7 } # e.g. 5 factories -> 35
 
 		if = { limit = { has_war = yes }
-			multiply_temp_variable = { ship_limit = 1.15 } # 57.50
+			multiply_temp_variable = { ship_limit = 1.35 } # wartime boost -> 47
 		}
 		else = {
-			multiply_temp_variable = { ship_limit = 0.65 } # 32.50
+			multiply_temp_variable = { ship_limit = 0.80 } # peacetime reduction -> 28
 		}
 
 		if = {
 			limit = {
 				has_country_flag = AI_is_threatened
 			}
-			multiply_temp_variable = { ship_limit = 1.25 } #If the AI didn't have divisions it is now 75
+			multiply_temp_variable = { ship_limit = 1.25 } # threatened nations build more
 		}
 		if = { limit = { is_major = yes }
-			multiply_temp_variable = { ship_limit = 1.15 } #If the major is 86.25
+			multiply_temp_variable = { ship_limit = 1.35 } # majors get a larger fleet cap
 		}
 		if = { limit = { has_idea = NATO_member }
-			multiply_temp_variable = { ship_limit = 0.70 } #if the nation is in the EU 51.75
+			multiply_temp_variable = { ship_limit = 0.80 } # NATO members build fewer ships (shared security)
 		}
 		if = { limit = { has_idea = EU_member }
-			multiply_temp_variable = { ship_limit = 0.70 } #If the nation is also in NATO 31.05
+			multiply_temp_variable = { ship_limit = 0.80 } # EU members build fewer ships
 		}
 		if = { limit = { threat > 0.50 }
-			multiply_temp_variable = { ship_limit = 1.25 } #38 if true
+			multiply_temp_variable = { ship_limit = 1.25 } # high threat raises cap
 		}
 		else = {
-			multiply_temp_variable = { ship_limit = 0.85 } #26.39
+			multiply_temp_variable = { ship_limit = 0.85 } # low threat lowers cap
 		}
 
 		if = { limit = { is_in_faction = yes }
-			multiply_temp_variable = { ship_limit = 0.90 } #73.9
+			multiply_temp_variable = { ship_limit = 0.95 } # faction members build slightly fewer
 		}
 		if = { limit = { original_tag = USA }
 			multiply_temp_variable = { ship_limit = 1.25 }
 		}
-		round_temp_variable = ship_limit #27
+		round_temp_variable = ship_limit
 		check_variable = { num_ships > ship_limit }
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = unit_ratio id = convoy value = 500 }
-	ai_strategy = { type = role_ratio id = naval_corvettes value = -50 }
-	ai_strategy = { type = role_ratio id = naval_frigate value = -50 }
-	ai_strategy = { type = role_ratio id = naval_destroyer value = -50 }
-	ai_strategy = { type = role_ratio id = naval_stealth_destroyer value = -50 }
-	ai_strategy = { type = role_ratio id = naval_attack_submarine value = -50 }
-	ai_strategy = { type = role_ratio id = naval_missile_submarine value = -50 }
-	ai_strategy = { type = role_ratio id = naval_helicopter_operator value = -50 }
-	ai_strategy = { type = role_ratio id = naval_carrier value = -50 }
-	ai_strategy = { type = role_ratio id = naval_cruiser value = -50 }
-	ai_strategy = { type = role_ratio id = naval_mine_sweeper value = -50 }
+	ai_strategy = { type = unit_ratio id = convoy value = 250 }
+	ai_strategy = { type = role_ratio id = naval_corvettes value = -30 }
+	ai_strategy = { type = role_ratio id = naval_frigate value = -30 }
+	ai_strategy = { type = role_ratio id = naval_destroyer value = -30 }
+	ai_strategy = { type = role_ratio id = naval_stealth_destroyer value = -30 }
+	ai_strategy = { type = role_ratio id = naval_attack_submarine value = -30 }
+	ai_strategy = { type = role_ratio id = naval_missile_submarine value = -30 }
+	ai_strategy = { type = role_ratio id = naval_helicopter_operator value = -30 }
+	ai_strategy = { type = role_ratio id = naval_carrier value = -30 }
+	ai_strategy = { type = role_ratio id = naval_cruiser value = -30 }
+	ai_strategy = { type = role_ratio id = naval_mine_sweeper value = -30 }
 }
 
 ship_limiter_potato_edition = {
@@ -543,59 +546,59 @@ ship_limiter_potato_edition = {
 		has_global_flag = GAME_RULE_division_limiter_potato_edition_enabled
 	}
 	enable = {
-		set_temp_variable = { ship_limit = num_of_naval_factories } # 5
-		multiply_temp_variable = { ship_limit = 3 } #50
+		set_temp_variable = { ship_limit = num_of_naval_factories }
+		multiply_temp_variable = { ship_limit = 3 } # e.g. 5 factories -> 15 (stricter than standard)
 
 		if = { limit = { has_war = yes }
-			multiply_temp_variable = { ship_limit = 1.15 } # 57.50
+			multiply_temp_variable = { ship_limit = 1.35 } # wartime boost -> 20
 		}
 		else = {
-			multiply_temp_variable = { ship_limit = 0.65 } # 32.50
+			multiply_temp_variable = { ship_limit = 0.80 } # peacetime reduction -> 12
 		}
 
 		if = {
 			limit = {
 				has_country_flag = AI_is_threatened
 			}
-			multiply_temp_variable = { ship_limit = 1.25 } #If the AI didn't have divisions it is now 75
+			multiply_temp_variable = { ship_limit = 1.25 } # threatened nations build more
 		}
 		if = { limit = { is_major = yes }
-			multiply_temp_variable = { ship_limit = 1.15 } #If the major is 86.25
+			multiply_temp_variable = { ship_limit = 1.35 } # majors get a larger fleet cap
 		}
 		if = { limit = { has_idea = NATO_member }
-			multiply_temp_variable = { ship_limit = 0.50 } #if the nation is in the EU 51.75
+			multiply_temp_variable = { ship_limit = 0.60 } # NATO members build fewer ships (potato: more aggressive)
 		}
 		if = { limit = { has_idea = EU_member }
-			multiply_temp_variable = { ship_limit = 0.50 } #If the nation is also in NATO 31.05
+			multiply_temp_variable = { ship_limit = 0.60 } # EU members build fewer ships (potato: more aggressive)
 		}
 		if = { limit = { threat > 0.50 }
-			multiply_temp_variable = { ship_limit = 1.25 } #38 if true
+			multiply_temp_variable = { ship_limit = 1.25 } # high threat raises cap
 		}
 		else = {
-			multiply_temp_variable = { ship_limit = 0.85 } #26.39
+			multiply_temp_variable = { ship_limit = 0.85 } # low threat lowers cap
 		}
 
 		if = { limit = { is_in_faction = yes }
-			multiply_temp_variable = { ship_limit = 0.90 } #73.9
+			multiply_temp_variable = { ship_limit = 0.95 } # faction members build slightly fewer
 		}
 		if = { limit = { original_tag = USA }
 			multiply_temp_variable = { ship_limit = 1.25 }
 		}
-		round_temp_variable = ship_limit #27
+		round_temp_variable = ship_limit
 		check_variable = { num_ships > ship_limit }
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = equipment_variant_production_factor id = convoy value = 500 }
-	ai_strategy = { type = unit_ratio id = convoy value = 500 }
-	ai_strategy = { type = role_ratio id = naval_corvettes value = -50 }
-	ai_strategy = { type = role_ratio id = naval_frigate value = -50 }
-	ai_strategy = { type = role_ratio id = naval_destroyer value = -50 }
-	ai_strategy = { type = role_ratio id = naval_stealth_destroyer value = -50 }
-	ai_strategy = { type = role_ratio id = naval_attack_submarine value = -50 }
-	ai_strategy = { type = role_ratio id = naval_missile_submarine value = -50 }
-	ai_strategy = { type = role_ratio id = naval_helicopter_operator value = -50 }
-	ai_strategy = { type = role_ratio id = naval_carrier value = -50 }
-	ai_strategy = { type = role_ratio id = naval_cruiser value = -50 }
-	ai_strategy = { type = role_ratio id = naval_mine_sweeper value = -50 }
+	ai_strategy = { type = equipment_variant_production_factor id = convoy value = 250 }
+	ai_strategy = { type = unit_ratio id = convoy value = 250 }
+	ai_strategy = { type = role_ratio id = naval_corvettes value = -30 }
+	ai_strategy = { type = role_ratio id = naval_frigate value = -30 }
+	ai_strategy = { type = role_ratio id = naval_destroyer value = -30 }
+	ai_strategy = { type = role_ratio id = naval_stealth_destroyer value = -30 }
+	ai_strategy = { type = role_ratio id = naval_attack_submarine value = -30 }
+	ai_strategy = { type = role_ratio id = naval_missile_submarine value = -30 }
+	ai_strategy = { type = role_ratio id = naval_helicopter_operator value = -30 }
+	ai_strategy = { type = role_ratio id = naval_carrier value = -30 }
+	ai_strategy = { type = role_ratio id = naval_cruiser value = -30 }
+	ai_strategy = { type = role_ratio id = naval_mine_sweeper value = -30 }
 }

--- a/common/defines/MD_defines.lua
+++ b/common/defines/MD_defines.lua
@@ -6,6 +6,8 @@
 	NDefines.NGame.MAX_SCRIPTED_LOC_RECURSION = 40
 	NDefines.NGame.ENERGY_RESOURCE = "oil" -- sets what resource is used for energy. We can adjust this later to a proper resource that is tradeable
 	NDefines.NGame.CHECKSUM_SALT = "MillenniumDawn"
+	NDefines.NGame.COMBAT_LOG_MAX_MONTHS = 6 -- 12; halve combat log retention for performance
+	NDefines.NGame.MESSAGE_TIMEOUT_DAYS = 7 -- 60; messages expire sooner to reduce memory
 
 	-- NDiplomacy Defines
 	NDefines.NDiplomacy.MAX_OPINION_VALUE = 300
@@ -181,6 +183,13 @@
 	NDefines.NCountry.BASE_STABILITY_WAR_FACTOR = -0.15
 	NDefines.NCountry.WAR_SUPPORT_OFFNSIVE_WAR = -0.1
 	NDefines.NCountry.WAR_SUPPORT_DEFENSIVE_WAR = 0.2 -- 1
+	NDefines.NCountry.EVENT_PROCESS_OFFSET = 30 -- 20; stagger event processing across 30 ticks to reduce spike load with 200+ countries
+	NDefines.NCountry.COUNTRY_SCORE_MULTIPLIER = 0 -- 1.0; disable cosmetic VP score calculations for performance
+	NDefines.NCountry.ARMY_SCORE_MULTIPLIER = 0 -- 0.15
+	NDefines.NCountry.NAVY_SCORE_MULTIPLIER = 0 -- 1.0
+	NDefines.NCountry.AIR_SCORE_MULTIPLIER = 0 -- 0.1
+	NDefines.NCountry.INDUSTRY_SCORE_MULTIPLIER = 0 -- 1.0
+	NDefines.NCountry.PROVINCE_SCORE_MULTIPLIER = 0 -- 0.1
 	NDefines.NCountry.MAJOR_IC_RATIO = 3                            -- difference in total factories needed to be considered major with respect to other nation
 	NDefines.NCountry.MAJOR_MIN_FACTORIES = 35						-- need at least these many factories to become a major
 	NDefines.NCountry.MIN_MAJOR_COUNTRIES	= 8						-- MIN_MAJOR_COUNTRIES countries with most factories will be considered as major countries
@@ -738,6 +747,8 @@
 	NDefines.NNavy.NAVAL_COMBAT_AIR_STRENGTH_TARGET_SCORE = 5                         -- how much score factor from low health (scales between 0->this number)
 	NDefines.NNavy.NAVAL_COMBAT_AIR_LOW_AA_TARGET_SCORE = 5                           -- how much score factor from low AA guns (scales between 0->this number)
 
+	NDefines.NNavy.NAVAL_COMBAT_RESULT_TIMEOUT_YEARS = 1 -- 2; halve naval combat result history retention
+	NDefines.NNavy.CONVOY_LOSS_HISTORY_TIMEOUT_MONTHS = 3 -- 6; halve convoy loss history retention
 	NDefines.NNavy.WAR_SCORE_GAIN_FOR_SUNK_SHIP_MANPOWER_FACTOR = 0.01                        -- war score gained for every manpower killed when sinking a ship
 	NDefines.NNavy.WAR_SCORE_GAIN_FOR_SUNK_SHIP_PRODUCTION_COST_FACTOR = 0.01   --0.04                       -- war score gained for every IC of the sunk ship
 	NDefines.NNavy.WAR_SCORE_GAIN_FOR_SUNK_CONVOY = 1.25  --10                       -- war score gained for every sunk convoy
@@ -932,7 +943,6 @@
 	NDefines.NAI.LAND_COMBAT_CAS_PER_ENEMY_ARMY = 20				-- Amount of CAS planes requested per enemy army
 
 	NDefines.NAI.LAND_COMBAT_CAS_PER_COMBAT = 65
-	NDefines.NAI.LAND_COMBAT_FIGHTERS_PER_PLANE = 1.3
 	NDefines.NAI.MIN_WANTED_MAX_FUEL = 25
 	NDefines.NAI.STR_BOMB_IMPORTANCE_SCALE = 2.5 -- Reduced from 5 to 2.5/originally was 10 but caused issues with the AI being unable to use their planes on missions
 	NDefines.NAI.LAND_COMBAT_INTERCEPT_PER_PLANE = 1
@@ -969,7 +979,12 @@
 	NDefines.NAI.LAND_COMBAT_AIR_SUPERIORITY_IMPORTANCE = 1.5
 	NDefines.NAI.LAND_DEFENSE_FIGHERS_PER_PLANE = 1.8
 	NDefines.NAI.LAND_COMBAT_FIGHTERS_PER_PLANE = 1.3
+	NDefines.NAI.LAND_COMBAT_GUIDE_DISTANCE = 400.0 -- 290; wider zone for CAS plane assignment
+	NDefines.NAI.STR_BOMB_AIR_SUPERIORITY_IMPORTANCE = 0.7 -- 0.10; AI actually escorts its strategic bomber fleets
+	NDefines.NAI.LAND_DEFENSE_MIN_FACTORIES_FOR_AIR_IMPORTANCE = 2 -- 5; even small nations value air defense
 	NDefines.NAI.MAX_AIR_REGIONS_TO_CARE_ABOUT = 7
+	NDefines.NAir.ACE_WING_SIZE = 25 -- 100; smaller wing size for ace bonus scaling (MD uses smaller wings)
+	NDefines.NFocus.MAX_SAVED_FOCUS_PROGRESS = 20 -- 10; AI can restart more focuses after interruption
 	NDefines.NAI.AI_FRACTION_OF_FIGHTERS_RESERVED_FOR_INTERCEPTION = 0.10
 	NDefines.NAI.WANTED_LAND_PLANES_PER_DIVISION = 30
 	NDefines.NAI.BUILDING_TARGETS_BUILDING_PRIORITIES = {				-- buildings in order of priority when considering building targets strategies. First has the greatest priority, omitted has the lowest. NOTE: not all buildings are supported by building targets strategies.
@@ -980,6 +995,17 @@
 	NDefines.NAI.NUM_SILOS_PER_CIVILIAN_FACTORIES = 0.03		-- ai will try to build a silo per this ratio of civ factories
 	NDefines.NAI.NUM_SILOS_PER_MILITARY_FACTORIES = 0.03		-- ai will try to build a silo per this ratio of mil factories
 	NDefines.NAI.NUM_SILOS_PER_DOCKYARDS = 0.03
+
+	-- AI Refresh Frequency — reduce expensive periodic checks for 200+ nation mod
+	NDefines.NAI.DAYS_BETWEEN_CHECK_BEST_TEMPLATE = 14 -- 7; 2x less frequent template re-evaluation
+	NDefines.NAI.DAYS_BETWEEN_CHECK_BEST_EQUIPMENT = 14 -- 7; 2x less frequent equipment re-evaluation
+	NDefines.NAI.DAYS_BETWEEN_AIR_PRIORITIES_UPDATE = 14 -- 4; less frequent than vanilla to reduce CPU load
+
+	-- AI Combat Responsiveness — more frequent than vanilla for smarter wartime AI (trades CPU for quality)
+	NDefines.NAI.HOURS_BETWEEN_ENCIRCLEMENT_DISCOVERY = 24 -- 72; 3x faster encirclement detection
+	NDefines.NAI.AI_UPDATE_ROLES_FREQUENCY_HOURS = 12 -- 48; 4x faster unit role reassignment
+	NDefines.NAI.UPDATE_SUPPLY_MOTORIZATION_FREQUENCY_HOURS = 24 -- 52; 2x faster supply motorization response
+	NDefines.NAI.UPDATE_SUPPLY_BOTTLENECKS_FREQUENCY_HOURS = 48 -- 168; 3.5x faster supply bottleneck response
 
 	-- AI Research Stuff
 	NDefines.NAI.RESEARCH_WEIGHT_TRUNCATION_THRESHOLD = 0.5 -- Reduced this from 0.75

--- a/common/ideas/AA_capitulation_ai.txt
+++ b/common/ideas/AA_capitulation_ai.txt
@@ -1,0 +1,20 @@
+ideas = {
+
+	hidden_ideas = {
+		capitulated_nation_no_call_ally = {
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+
+			modifier = {
+				ai_call_ally_desire_factor = -10000
+				ai_join_ally_desire_factor = -10000
+				ai_get_ally_desire_factor = -10000
+			}
+
+			rule = {
+				can_not_declare_war = yes
+			}
+		}
+	}
+
+}

--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -212,6 +212,20 @@ on_actions = {
 	#FIRES FOR ALL SIDES
 	on_peaceconference_ended = {
 		effect = {
+			# Remove capitulation ally-call suppression on peace
+			ROOT = {
+				if = {
+					limit = { has_idea = capitulated_nation_no_call_ally }
+					remove_ideas = capitulated_nation_no_call_ally
+				}
+			}
+			FROM = {
+				if = {
+					limit = { has_idea = capitulated_nation_no_call_ally }
+					remove_ideas = capitulated_nation_no_call_ally
+				}
+			}
+
 			if = {
 				limit = {
 					ROOT = { has_offensive_war = no }
@@ -1135,6 +1149,14 @@ on_actions = {
 	# ROOT is capitulated country, FROM is winner
 	on_capitulation_immediate = {
 		effect = {
+			# Suppress capitulated nations from calling/joining allies — prevents zombie war revivals
+			ROOT = {
+				if = {
+					limit = { NOT = { has_idea = capitulated_nation_no_call_ally } }
+					add_ideas = capitulated_nation_no_call_ally
+				}
+			}
+
 			if = { limit = { FROM = { original_tag = CHI } }
 				if = {
 					limit = {

--- a/docs/src/content/knownSubmods/index.yml
+++ b/docs/src/content/knownSubmods/index.yml
@@ -56,3 +56,9 @@ groups:
         url: https://steamcommunity.com/sharedfiles/filedetails/?id=2780918607
       - title: "Millennium Dawn: Multiplayer Overhaul"
         url: https://steamcommunity.com/sharedfiles/filedetails/?id=2780631790
+      - title: "[MD] Ebby Tweaks"
+        url: https://steamcommunity.com/sharedfiles/filedetails/?id=2877723086
+      - title: "[MD] Ebby Warfare Overhaul"
+        url: https://steamcommunity.com/sharedfiles/filedetails/?id=3698291549
+      - title: "[MD] Ebby Performance Optimization"
+        url: https://steamcommunity.com/sharedfiles/filedetails/?id=3698288121

--- a/docs/src/content/misc/authors.md
+++ b/docs/src/content/misc/authors.md
@@ -182,6 +182,7 @@ The following page is a non-exhaustive list of contributors from over the years 
 | pastandrey           | @pastandrey                     | @pastandrey    | -             | -                             |
 | altair6407           | @altair6407                     | @altair6407    | -             | -                             |
 | polski_oski          | @polski_oski                    |                | -             | -                             |
+| Ebby                 | -                               | -              | -             | -                             |
 
 # Fellow Modders/Teams
 
@@ -205,6 +206,8 @@ The following page is a non-exhaustive list of contributors from over the years 
   \*Source: [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=2698816291)
 - **AI Rework: Attaché's**
   \*Source: [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3164040395)
+- **Ebby** - AI behavior, naval, performance, and warfare overhaul submods
+  _Source: [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=2877723086), [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3698291549), [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3698288121)_
 
 # Voice Lines
 


### PR DESCRIPTION
## Summary

Comprehensive AI overhaul drawing from three Ebby Workshop submods ([Tweaks](https://steamcommunity.com/sharedfiles/filedetails/?id=2877723086), [Warfare Overhaul](https://steamcommunity.com/sharedfiles/filedetails/?id=3698291549), [Performance](https://steamcommunity.com/sharedfiles/filedetails/?id=3698288121)). Changes were reviewed against vanilla defines, audited for stacking conflicts, and validated through 4 parallel review passes.

### Performance Defines
- Reduced AI template/equipment/air priority check frequency for 200+ nation mod
- Increased AI combat responsiveness (encirclement detection, role assignment, supply handling)
- Event processing stagger (`EVENT_PROCESS_OFFSET = 30`), disabled cosmetic score calculations
- Halved combat log / naval history retention, faster message expiry

### Wartime AI Behavior
- New strategy blocks: wartime offensive composition, major army commitment, air superiority push
- Wartime construction: stop office/internet spam, push infrastructure, major wartime industry
- Fighter-first air doctrine rebalance (low-mil fighter 5→15, tac bomber 20→15)
- `ACE_WING_SIZE = 25`, `MAX_SAVED_FOCUS_PROGRESS = 20`, wider CAS zone, bomber escort AI

### Naval AI
- Lowered peacetime mission thresholds (fleets patrol more actively)
- Fuel conservation threshold 0.25→0.15, softened ship limiter penalties -50→-30
- Raised wartime/major fleet cap multipliers
- Fixed `conserve_fuel_if_fighting_landlocked_nations` (was trivially true in peacetime)

### War Declaration Intelligence (15 conflict pairings)
- CHI-TAI, CHI-JAP, NKO-KOR, KOR-NKO, ISR-PER, PER-ISR, RAJ-PAK, PAK-RAJ, GER-FRA, GER-SOV, GER-ENG, SOV-GER, TUR-KUR, EGY-ISR, GRE-TUR
- 6-block readiness-gated pattern per pairing: prepare → delay (democratic) → ready (by govt type) → failsafe
- Thresholds scaled by nation size; democracies suppressed from two-front wars

### Country Wartime Execution
- NKO: full reunification commitment (conquer 400, invade 350, force_build 100, air boost)
- KOR: total response to NK (conquer 300, force_build 100, fighter/CAS/naval bomber boost)
- ISR: air-dominant doctrine vs Iran, bombardment vs distant enemies
- PER: asymmetric air/missile war, counter-superpower navy, total war vs Israel

### Other
- Capitulated nation ally-call suppression (prevents zombie war revivals)
- Marine production ratios increased 10/20/20 → 15/25/25
- Fixed duplicate `LAND_COMBAT_FIGHTERS_PER_PLANE` define, stale ship limiter comments
- Added Ebby to authors.md and knownSubmods

## Test plan
- [ ] Start as CHI (communist), take hegemony path → verify AI commits to Taiwan with ~30+ divisions and navy, not immediately
- [ ] Start as democratic nation, get into one war, acquire second wargoal → verify AI does NOT open two-front war
- [ ] Start as NKO → verify AI commits fully when Korean War fires (conquer/invade/air boost active)
- [ ] Observe late-game speed — event stagger + reduced AI checks should improve tick rate
- [ ] Verify no error.log entries from new defines, ideas, or strategy blocks
- [ ] Check fascist GER path → verify AI builds up before declaring on FRA/SOV/ENG
- [ ] Verify naval AI patrols in peacetime (lowered thresholds) without burning all fuel

🤖 Generated with [Claude Code](https://claude.com/claude-code)