### PR TITLE
Add missing year headers to tech trees

### DIFF
--- a/interface/countrytechtreeview.gui
+++ b/interface/countrytechtreeview.gui
@@ -322,6 +322,50 @@ guiTypes = {
 					format = left
 					Orientation = "UPPER_LEFT"
 				}
+				instantTextBoxType = {
+					name = "infantry_year11"
+					position = { x = 2380 y = 50 }
+					font = "hoi_36header"
+					borderSize = { x = 0 y = 0 }
+					text = "2045"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+				instantTextBoxType = {
+					name = "infantry_year12"
+					position = { x = 2660 y = 50 }
+					font = "hoi_36header"
+					borderSize = { x = 0 y = 0 }
+					text = "2055"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+				instantTextBoxType = {
+					name = "infantry_year13"
+					position = { x = 2940 y = 50 }
+					font = "hoi_36header"
+					borderSize = { x = 0 y = 0 }
+					text = "2065"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+				instantTextBoxType = {
+					name = "infantry_year14"
+					position = { x = 3220 y = 50 }
+					font = "hoi_36header"
+					borderSize = { x = 0 y = 0 }
+					text = "2075"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 			}
 			gridboxtype = {
 				name = "infantry_weapons_1_tree"
@@ -2936,6 +2980,39 @@ guiTypes = {
 				font = "hoi_36header"
 				borderSize = { x = 0 y = 4 }
 				text = "2055"
+				maxWidth = 170
+				maxHeight = 32
+				format = left
+				Orientation = "UPPER_LEFT"
+			}
+			instantTextBoxType = {
+				name = "airtech_year14"
+				position = { x = 3230 y = 0 }
+				font = "hoi_36header"
+				borderSize = { x = 0 y = 4 }
+				text = "2065"
+				maxWidth = 170
+				maxHeight = 32
+				format = left
+				Orientation = "UPPER_LEFT"
+			}
+			instantTextBoxType = {
+				name = "airtech_year15"
+				position = { x = 3510 y = 0 }
+				font = "hoi_36header"
+				borderSize = { x = 0 y = 4 }
+				text = "2075"
+				maxWidth = 170
+				maxHeight = 32
+				format = left
+				Orientation = "UPPER_LEFT"
+			}
+			instantTextBoxType = {
+				name = "airtech_year16"
+				position = { x = 3790 y = 0 }
+				font = "hoi_36header"
+				borderSize = { x = 0 y = 4 }
+				text = "2085"
 				maxWidth = 170
 				maxHeight = 32
 				format = left


### PR DESCRIPTION
Some of the later years in infantry and air tech where missing their year headers, so I added them.

<img width="1911" height="745" alt="image" src="https://github.com/user-attachments/assets/52baa206-5744-4f76-aa63-79693b36e8b7" />
