### PR TITLE
Fixx for algeria

### DIFF
--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -5639,18 +5639,18 @@ focus_tree = {
 
 		cost = 8
 
-	  prerequisite = { focus = ALG_restoring_the_broken_economy }
-	  prerequisite = { focus = ALG_arresting_extremists }
+		prerequisite = { focus = ALG_restoring_the_broken_economy }
+		prerequisite = { focus = ALG_arresting_extremists }
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_STABILITY }
 
-	  completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus ALG_economic_recovery"
-		add_political_power = 50
-		add_stability = 0.05
-		set_temp_variable = { treasury_change = 30 }
-		modify_treasury_effect = yes
-	 }
+		completion_reward = {
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_economic_recovery"
+			add_political_power = 50
+			add_stability = 0.05
+			set_temp_variable = { treasury_change = 31 }
+			modify_treasury_effect = yes
+		}
 
 		ai_will_do = {
 			base = 50

--- a/events/Algeria.txt
+++ b/events/Algeria.txt
@@ -1649,6 +1649,7 @@ country_event = {
 				set_variable = { deep_state_power = 15 }
 				add_stability = -0.15
 				clr_country_flag = deep_state_coup_fired
+				clr_country_flag = alg_civil_war_risk
 				set_politics = {
 					ruling_party = democratic
 					elections_allowed = yes
@@ -1659,6 +1660,7 @@ country_event = {
 				add_stability = -0.20
 				add_war_support = -0.10
 				# Civil war potential
+				set_country_flag = alg_civil_war_risk
 				country_event = { id = alg_deep_state.202 days = 30 }
 			}
 		}
@@ -1684,6 +1686,9 @@ country_event = {
 	}
 
 	immediate = {
+		if = {
+			limit = { NOT = { has_country_flag = alg_civil_war_risk } }
+		}
 		clr_country_flag = alg_civil_war_risk
 	}
 
@@ -7280,6 +7285,7 @@ country_event = {
 	option = {
 		name = alg.402.a
 		log = "[GetDateText]: [This.GetName]: alg.402.a executed"
+		set_country_flag = ALG_civil_war_triggered
 		start_civil_war = {
 			ideology = democratic
 			size = 0.35

--- a/localisation/english/MD_focus_ALG_l_english.yml
+++ b/localisation/english/MD_focus_ALG_l_english.yml
@@ -6508,4 +6508,5 @@
  ALG_supp_mali: "Supported Mali"
  ALG_supp_tuareg: "Supported Tuareg"
  ALG_ffs_in_power: "FFS in Power"
+ ALG_civil_war_triggered: "Civil War Triggered"
  ALG_military_coup_path: "Chooses Military Coup Path"


### PR DESCRIPTION
so bouteflika appearing twice due to him being the first leader of that party (RND) set in ALG_political_leaders and also being the president representing FLN ( he represented FLN and RND cuz both of them formed the Presidential Alliance supporting bouteflika )

as for the civil war erupting early in 2000 i hope its fixed now

as for the "No effect of The focus « economic recovery »" idk what is he talking about there is effect there