### PR TITLE
Fix CIS missing Uzbekistan (#1147)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -274,7 +274,7 @@ v2.0.0
   - Fixed purchase_reactor_grade_material reject log format to be consistent with other diplomatic actions
   - Added missing localisation keys for close_embassy_action accept/reject titles and descriptions
   - [ISR] Fixed liberal leader selection logic preventing Yair Lapid from ever appearing - NOT block incorrectly checked all five party flags as a group instead of individually, causing Yitzhak Mordechai to always trigger first
-  - [SOV] Fixed Uzbekistan missing from CIS democratic foreign policy focuses - added UZB to SOV_russia_inivte_to_cis_former_member, SOV_russia_create_unite_cis_forces, and SOV_russia_create_unite_cis_state scripted effects (Issue #1147)
+  - [SOV] Fixed Uzbekistan missing from CIS democratic foreign policy focuses - added UZB to SOV_russia_inivte_to_cis_former_member, SOV_russia_create_unite_cis_forces, and SOV_russia_create_unite_cis_state scripted effects, plus the autonomy_state_cis allowed block (Issue #1147)
   - Fixed cyber warfare operations not clearing the target attack flag on mission failure, permanently blocking future operations against that country
   - [GAH] Fixed leader succession for conservatism, socialism, Communist-State, Neutral_green, Neutral_Communism, and Monarchist ideologies — successor leaders were in unreachable else_if blocks and could never appear
   - [ZAM] Fixed leader succession for liberalism, socialism, and Neutral_green ideologies — successor leaders were in unreachable else_if blocks and could never appear

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -274,6 +274,7 @@ v2.0.0
   - Fixed purchase_reactor_grade_material reject log format to be consistent with other diplomatic actions
   - Added missing localisation keys for close_embassy_action accept/reject titles and descriptions
   - [ISR] Fixed liberal leader selection logic preventing Yair Lapid from ever appearing - NOT block incorrectly checked all five party flags as a group instead of individually, causing Yitzhak Mordechai to always trigger first
+  - [SOV] Fixed Uzbekistan missing from CIS democratic foreign policy focuses - added UZB to SOV_russia_inivte_to_cis_former_member, SOV_russia_create_unite_cis_forces, and SOV_russia_create_unite_cis_state scripted effects (Issue #1147)
   - Fixed cyber warfare operations not clearing the target attack flag on mission failure, permanently blocking future operations against that country
   - [GAH] Fixed leader succession for conservatism, socialism, Communist-State, Neutral_green, Neutral_Communism, and Monarchist ideologies — successor leaders were in unreachable else_if blocks and could never appear
   - [ZAM] Fixed leader succession for liberalism, socialism, and Neutral_green ideologies — successor leaders were in unreachable else_if blocks and could never appear

--- a/common/autonomous_states/MD_russian_autonomies.txt
+++ b/common/autonomous_states/MD_russian_autonomies.txt
@@ -817,6 +817,7 @@ autonomy_state = {
 			original_tag = BLR
 			original_tag = UKR
 			original_tag = KAZ
+			original_tag = UZB
 			original_tag = TRK
 			original_tag = TAJ
 			original_tag = MLV

--- a/common/scripted_effects/99_SOV_scripted_effects.txt
+++ b/common/scripted_effects/99_SOV_scripted_effects.txt
@@ -8801,6 +8801,21 @@ SOV_russia_inivte_to_cis_former_member = {
 	}
 	if = {
 		limit = {
+			country_exists = UZB
+			UZB = {
+				is_subject = no
+				NOT = {
+					has_idea = CIS_member_state_idea
+					is_in_faction = yes
+				}
+			}
+		}
+		UZB = {
+			country_event = { id = sov_liberals.11 days = 1 }
+		}
+	}
+	if = {
+		limit = {
 			country_exists = UKR
 			UKR = {
 				is_subject = no
@@ -9054,6 +9069,17 @@ SOV_russia_create_unite_cis_forces = {
 			}
 		}
 		KAZ = {
+			country_event = { id = sov_liberals.17 days = 1 }
+		}
+	}
+	if = {
+		limit = {
+			country_exists = UZB
+			UZB = {
+				has_autonomy_state = autonomy_state_cis
+			}
+		}
+		UZB = {
 			country_event = { id = sov_liberals.17 days = 1 }
 		}
 	}
@@ -9318,6 +9344,21 @@ SOV_russia_create_unite_cis_state = {
 			}
 		}
 		KAZ = {
+			country_event = { id = sov_liberals.14 days = 1 }
+		}
+	}
+	if = {
+		limit = {
+			country_exists = UZB
+			UZB = {
+				has_idea = CIS_member_state_idea
+				is_subject = no
+				NOT = {
+					is_in_faction = yes
+				}
+			}
+		}
+		UZB = {
 			country_event = { id = sov_liberals.14 days = 1 }
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes Uzbekistan being excluded from Russia's democratic CIS foreign policy path.

## Root Cause

Uzbekistan (UZB) was missing from three key scripted effects in `99_SOV_scripted_effects.txt`:
- `SOV_russia_inivte_to_cis_former_member` - Former CIS members invitation effect
- `SOV_russia_create_unite_cis_forces` - Creating united CIS forces effect  
- `SOV_russia_create_unite_cis_state` - Creating united CIS state effect

The scripted effects included all other former Soviet republics (AZE, BLR, ARM, GEO, KAZ, TRK, TAJ, KYR, UKR, MLV, EST, LAT, LIT, PMR, ABK, SOO) but UZB was conspicuously absent.

## Fix

Added Uzbekistan blocks to all three scripted effects following the same pattern as other countries:
- `SOV_russia_inivte_to_cis_former_member`: UZB now gets invited to CIS via `sov_liberals.11`
- `SOV_russia_create_unite_cis_forces`: UZB now included in unified forces via `sov_liberals.17`
- `SOV_russia_create_unite_cis_state`: UZB now included in united state via `sov_liberals.14`

## Test Plan

- [ ] Load a Russia democratic game
- [ ] Complete the CIS foreign policy focuses
- [ ] Verify Uzbekistan receives invitation events when criteria are met
- [ ] Verify Uzbekistan is included in unified forces/state when conditions are met

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/code)