### PR TITLE
Fix EU Parliament/Council vote lock (#1177)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -225,6 +225,7 @@ v2.0.0
   - Increased reparation payment cap from 150 to 200
 
  Bugfix:
+  - Fixed EU Parliament and Council voting being permanently locked after a budget/MFF draft completes: draft flags were never cleared, blocking future reforms; also added ECB president guard on draft missions, fixed NOT-AND-trap in reform button trigger, and fixed typo in remove vote handler (Issue #1177)
   - [GER] Fixed Germany civil war being triggered too easily for the AI: raised ai_will_do base from 1 to 20 on the three BfV crisis purge decisions (GER_purge_banks, GER_purge_government_institutions, GER_purge_military) so the AI takes them within the 100-day mission window; also fixed NOT AND trap in their available blocks that allowed multiple purge decisions to be active simultaneously (Issue #1046)
   - [ALG] Fixed Su-30 purchase focus not granting any aircraft due to invalid variant name "Su-30MKA"; corrected to "Su-30" (Issue #1025)
   - [ALG] Fixed division-spawning focuses for special operations and marine forces silently failing because the "104th Operational Maneuvers Regiment RMO" template was never defined; added inline template creation with has_template guard (Issue #1025)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -226,6 +226,7 @@ v2.0.0
 
  Bugfix:
   - Fixed EU Parliament and Council voting being permanently locked after a budget/MFF draft completes: draft flags were never cleared, blocking future reforms; also added ECB president guard on draft missions, fixed NOT-AND-trap in reform button trigger, and fixed typo in remove vote handler (Issue #1177)
+  - Fixed United States of Europe council vote not adding 111 to EU_passed_votes (added 0 instead) because on_annex reset the vote variable during member annexations; also ensured focus_EU111_QMV_yes flag is set on the forming country for USoE focus tree progression (Issue #1071)
   - [GER] Fixed Germany civil war being triggered too easily for the AI: raised ai_will_do base from 1 to 20 on the three BfV crisis purge decisions (GER_purge_banks, GER_purge_government_institutions, GER_purge_military) so the AI takes them within the 100-day mission window; also fixed NOT AND trap in their available blocks that allowed multiple purge decisions to be active simultaneously (Issue #1046)
   - [ALG] Fixed Su-30 purchase focus not granting any aircraft due to invalid variant name "Su-30MKA"; corrected to "Su-30" (Issue #1025)
   - [ALG] Fixed division-spawning focuses for special operations and marine forces silently failing because the "104th Operational Maneuvers Regiment RMO" template was never defined; added inline template creation with has_template guard (Issue #1025)

--- a/common/decisions/EU_voting_decisions.txt
+++ b/common/decisions/EU_voting_decisions.txt
@@ -162,27 +162,25 @@ EU_voting_category = {
 						set_variable = { global.current_active_agenda_disp = 0 }
 						if = {
 							limit = {
-								has_country_flag = EU_budget_draft
+								has_country_flag = EU_budget_EP_block
 								NOT = { has_active_mission = EU_budget_draft_ongoing }
 								NOT = { has_active_mission = EU_budget_draft_preparations }
 							}
 							for_each_scope_loop = {
 								array = global.EU_member
 								tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-								clr_country_flag = EU_budget_draft
 								clr_country_flag = EU_budget_EP_block
 							}
 						}
 						if = {
 							limit = {
-								has_country_flag = EU_mff_draft
+								has_country_flag = EU_mff_EP_block
 								NOT = { has_active_mission = EU_mff_draft_ongoing }
 								NOT = { has_active_mission = EU_mff_draft_preparations }
 							}
 							for_each_scope_loop = {
 								array = global.EU_member
 								tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-								clr_country_flag = EU_mff_draft
 								clr_country_flag = EU_mff_EP_block
 							}
 						}
@@ -247,27 +245,25 @@ EU_voting_category = {
 							set_variable = { global.current_active_agenda_disp = 0 }
 							if = {
 								limit = {
-									has_country_flag = EU_budget_draft
+									has_country_flag = EU_budget_EP_block
 									NOT = { has_active_mission = EU_budget_draft_ongoing }
 									NOT = { has_active_mission = EU_budget_draft_preparations }
 								}
 								for_each_scope_loop = {
 									array = global.EU_member
 									tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-									clr_country_flag = EU_budget_draft
 									clr_country_flag = EU_budget_EP_block
 								}
 							}
 							if = {
 								limit = {
-									has_country_flag = EU_mff_draft
+									has_country_flag = EU_mff_EP_block
 									NOT = { has_active_mission = EU_mff_draft_ongoing }
 									NOT = { has_active_mission = EU_mff_draft_preparations }
 								}
 								for_each_scope_loop = {
 									array = global.EU_member
 									tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-									clr_country_flag = EU_mff_draft
 									clr_country_flag = EU_mff_EP_block
 								}
 							}
@@ -317,21 +313,27 @@ EU_voting_category = {
 								set_the_eu_parliament_delay = yes
 							}
 							if = {
-								limit = { has_country_flag = EU_budget_draft }
+								limit = {
+									has_country_flag = EU_budget_EP_block
+									NOT = { has_active_mission = EU_budget_draft_ongoing }
+									NOT = { has_active_mission = EU_budget_draft_preparations }
+								}
 								for_each_scope_loop = {
 									array = global.EU_member
 									tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-									clr_country_flag = EU_budget_draft
 									clr_country_flag = EU_budget_EP_block
 									EU_rollback_budget_values = yes
 								}
 							}
 							if = {
-								limit = { has_country_flag = EU_mff_draft }
+								limit = {
+									has_country_flag = EU_mff_EP_block
+									NOT = { has_active_mission = EU_mff_draft_ongoing }
+									NOT = { has_active_mission = EU_mff_draft_preparations }
+								}
 								for_each_scope_loop = {
 									array = global.EU_member
 									tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-									clr_country_flag = EU_mff_draft
 									clr_country_flag = EU_mff_EP_block
 									EU_rollback_mff_values = yes
 								}
@@ -914,10 +916,18 @@ EU_voting_category = {
 		timeout_effect = {
 			set_EU_gdp = yes
 			update_EU_budget_call_rate = yes
-			set_country_flag = focus_EU999_EP_agenda
-			activate_mission = EU_parliament_focus_EUXXX_approve_timer
-			activate_mission = EU_budget_yearly_timer
+			if = {
+				limit = { any_country = { has_idea = ECB_president } }
+				set_country_flag = focus_EU999_EP_agenda
+				set_country_flag = focus_on_EP_agenda
+				activate_mission = EU_parliament_focus_EUXXX_approve_timer
+			}
+			else = {
+				clr_country_flag = EU_budget_EP_block
+			}
+			clr_country_flag = EU_budget_draft
 			remove_mission = EU_budget_draft_ongoing
+			activate_mission = EU_budget_yearly_timer
 		}
 
 		ai_will_do = { base = 0 }
@@ -946,6 +956,8 @@ EU_voting_category = {
 			}
 			assess_MEP_support_party_x = yes
 			set_country_flag = focus_EU999_EP_agenda
+			set_country_flag = focus_on_EP_agenda
+			clr_country_flag = EU_budget_draft
 			activate_mission = EU_parliament_focus_EUXXX_approve
 			activate_mission = EU_budget_yearly_timer
 			set_variable = { global.current_active_agenda_disp = 999 }
@@ -1026,10 +1038,18 @@ EU_voting_category = {
 		timeout_effect = {
 			set_EU_gdp = yes
 			update_EU_budget_call_rate = yes
-			set_country_flag = focus_EU998_EP_agenda
-			activate_mission = EU_parliament_focus_EUXXX_approve_timer
-			activate_mission = EU_mff_yearly_timer
+			if = {
+				limit = { any_country = { has_idea = ECB_president } }
+				set_country_flag = focus_EU998_EP_agenda
+				set_country_flag = focus_on_EP_agenda
+				activate_mission = EU_parliament_focus_EUXXX_approve_timer
+			}
+			else = {
+				clr_country_flag = EU_mff_EP_block
+			}
+			clr_country_flag = EU_mff_draft
 			remove_mission = EU_mff_draft_ongoing
+			activate_mission = EU_mff_yearly_timer
 		}
 
 		ai_will_do = { base = 0 }
@@ -1058,6 +1078,8 @@ EU_voting_category = {
 			}
 			assess_MEP_support_party_x = yes
 			set_country_flag = focus_EU998_EP_agenda
+			set_country_flag = focus_on_EP_agenda
+			clr_country_flag = EU_mff_draft
 			activate_mission = EU_mff_yearly_timer
 			activate_mission = EU_parliament_focus_EUXXX_approve
 			set_variable = { global.current_active_agenda_disp = 998 }

--- a/common/scripted_effects/99_EU_voting_scripted_effects.txt
+++ b/common/scripted_effects/99_EU_voting_scripted_effects.txt
@@ -1662,6 +1662,11 @@ focus_EU111_QMV_result = {
 		}
 
 		hidden_effect = {
+			# Record the vote before annexations — on_annex resets current_active_vote_disp to 0
+			add_to_array = { array = global.EU_passed_votes value = 111 }
+			remove_from_array = { array = global.EU_council_votes value = 111 }
+			set_variable = { global.current_active_vote_disp = 0 }
+
 			for_each_scope_loop = {
 				array = global.EU_member
 				EUU = { inherit_technology = THIS }
@@ -1730,6 +1735,7 @@ focus_EU111_QMV_result = {
 			set_cosmetic_tag = USoE
 			clr_country_flag = dynamic_flag
 			set_country_flag = USoE
+			set_country_flag = focus_EU111_QMV_yes
 			set_variable = { global.united_states_of_europe = THIS.id }
 			clr_country_flag = GER_Final_settlement
 			add_ideas = multi_ethnic_state_idea

--- a/common/scripted_guis/01_european_union_guis.txt
+++ b/common/scripted_guis/01_european_union_guis.txt
@@ -2586,18 +2586,16 @@ scripted_gui = {
 								tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
 								if = {
 									limit = {
-										has_country_flag = EU_budget_draft
+										has_country_flag = EU_budget_EP_block
 										check_variable = { global.current_active_agenda_disp = 999 }
 									}
-									clr_country_flag = EU_budget_draft
 									clr_country_flag = EU_budget_EP_block
 								}
 								if = {
 									limit = {
-										has_country_flag = EU_mff_draft
+										has_country_flag = EU_mff_EP_block
 										check_variable = { global.current_active_agenda_disp = 998 }
 									}
-									clr_country_flag = EU_mff_draft
 									clr_country_flag = EU_mff_EP_block
 								}
 							}
@@ -2638,37 +2636,37 @@ scripted_gui = {
 								set_variable = { global.active_MEP_Support = 0 }
 							}
 							if = {
-								limit = { check_variable = { global.currenct_active_agenda_disp = 999 } }
+								limit = { check_variable = { global.current_active_agenda_disp = 999 } }
 								EU_rollback_budget_values = yes
 							}
 							if = {
-								limit = { check_variable = { global.currenct_active_agenda_disp = 998 } }
+								limit = { check_variable = { global.current_active_agenda_disp = 998 } }
 								EU_rollback_mff_values = yes
 							}
 							for_each_scope_loop = {
 								array = global.EU_member
 								if = {
 									limit = {
-										has_country_flag = EU_budget_draft
+										has_country_flag = EU_budget_EP_block
 										check_variable = { global.current_active_agenda_disp = 999 }
 									}
-									clr_country_flag = EU_budget_draft
 									clr_country_flag = EU_budget_EP_block
 								}
 								if = {
 									limit = {
-										has_country_flag = EU_mff_draft
+										has_country_flag = EU_mff_EP_block
 										check_variable = { global.current_active_agenda_disp = 998 }
 									}
-									clr_country_flag = EU_mff_draft
 									clr_country_flag = EU_mff_EP_block
 								}
 							}
 							if = {
 								limit = {
 									NOT = {
-										check_variable = { global.current_active_agenda_disp = 998 }
-										check_variable = { global.current_active_agenda_disp = 999 }
+										OR = {
+											check_variable = { global.current_active_agenda_disp = 998 }
+											check_variable = { global.current_active_agenda_disp = 999 }
+										}
 									}
 								}
 								set_the_eu_parliament_delay = yes
@@ -5049,12 +5047,8 @@ scripted_gui = {
 				}
 				custom_trigger_tooltip = {
 					tooltip = no_active_budget_mff_draft
-					NOT = {
-						has_country_flag = EU_budget_draft
-						has_country_flag = EU_mff_draft
-						has_country_flag = EU_budget_EP_block
-						has_country_flag = EU_mff_EP_block
-					}
+					NOT = { has_country_flag = EU_budget_EP_block }
+					NOT = { has_country_flag = EU_mff_EP_block }
 				}
 				custom_trigger_tooltip = {
 					tooltip = EU_no_external_chi_influence_15_tt


### PR DESCRIPTION
Closes #1177

## Root cause

Multiple interrelated bugs in the EU budget/MFF draft system caused parliament and council voting to become permanently locked:

1. **Budget/MFF draft flags never cleared** — When `EU_budget_draft_ongoing` and `EU_mff_draft_ongoing` missions completed, they started the parliament vote but never cleared the `EU_budget_draft` / `EU_mff_draft` country flags. These stuck flags blocked future parliament reform proposals.

2. **Missing ECB president guard** — The non-president draft mission path tried to start a parliament vote even when no ECB president existed, causing the vote to hang without proper cleanup.

3. **NOT-AND-trap in reform button trigger** — `NOT = { EU_budget_draft EU_mff_draft EU_budget_EP_block EU_mff_EP_block }` evaluated as NOT(all four simultaneously), which is nearly always true. Individual flags couldn't block the button on their own.

4. **Typo in remove vote handler** — `currenct_active_agenda_disp` (note the typo) meant budget/MFF rollback values were never applied when a vote was manually removed.

5. **NOT-AND-trap in remove vote delay guard** — `NOT = { A B }` instead of `NOT = { OR = { A B } }` meant the parliament delay was always set even for budget/MFF votes.

## Fix

- Added ECB president guard to `EU_budget_draft_ongoing` and `EU_mff_draft_ongoing` — if no ECB president exists, the EP_block flag is cleared instead of starting a stuck vote
- Added `clr_country_flag = EU_budget_draft` / `EU_mff_draft` to all four draft completion missions so draft flags are always cleaned up
- Changed all vote completion/rejection cleanup to check `EU_budget_EP_block` / `EU_mff_EP_block` instead of `EU_budget_draft` / `EU_mff_draft` (EP_block is the reliable flag that gates parliament reforms)
- Fixed NOT-AND-trap: split into separate `NOT` blocks so each EP_block flag independently blocks the reform button
- Fixed `currenct_active_agenda_disp` → `current_active_agenda_disp` typo (2 occurrences)
- Fixed NOT-AND-trap in remove_vote delay guard with proper `NOT = { OR = { ... } }`

## Test plan

- Start a game as any EU member (e.g., Spain)
- Wait for a budget draft cycle to complete (~1 year)
- Verify parliament reform buttons become clickable after the draft resolves
- Manually remove a vote and verify budget/MFF rollback values are applied
- Verify council voting is also accessible after draft cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)