### PR TITLE
Bug bundle: Petrov coup warnings + shore bombardment swap

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -240,6 +240,8 @@ v2.0.0
   - [FRA] France now gains +12% influence change against countries holding the_eco
 
  Bugfix:
+  - Fixed shore bombardment gun-attack multipliers being swapped, making ASHM (heavy attack) dominate shore bombardment instead of cannons (Issue #1274)
+  - [SOV] Strengthened Constantine Petrov coup-chain warnings so the player can see that "Do nothing" guarantees the coup and that arresting the general is the way out (Issue #1273)
   - Fixed drone reconnaissance raid granting no reward on success; now grants the targeted drone recon buff scaling with success level
   - Fixed influence military aid not deducting equipment from the sender; also added equipment quantity previews to the package size picker
   - Fixed PMC units failing to spawn after hiring while still charging the player

--- a/common/defines/MD_defines.lua
+++ b/common/defines/MD_defines.lua
@@ -604,8 +604,8 @@
 	NDefines.NNavy.SUB_DETECTION_CHANCE_SPOTTING_SPEED_EFFECT = 1.2 -- 2.0
 	NDefines.NNavy.SUB_DETECTION_CHANCE_BASE_SPOTTING_POW_EFFECT = 1.01
 	NDefines.NNavy.SHORE_BOMBARDMENT_CAP = 1 -- Reduced to 100% from 200% -- 25% is vanilla
-	NDefines.NNavy.HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.99 -- HGA / (VAL * 100) = Add to Shore Bombard Mod
-	NDefines.NNavy.LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.025 -- LGA / (VAL * 100) = Add to Shore Bombard Mod
+	NDefines.NNavy.HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.001 -- HGA / (VAL * 100) = Add to Shore Bombard Mod
+	NDefines.NNavy.LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.85 -- LGA / (VAL * 100) = Add to Shore Bombard Mod
 	NDefines.NNavy.COMBAT_MIN_HIT_CHANCE = 0.05	-- never less hit chance then this?
 	NDefines.NNavy.MIN_HIT_PROFILE_MULT = 0.1 -- largest hit profile penalty to hitting (higher value of the define makes ships easier to hit, i assume by reducing the penalty caused by small hit profile of target ship)
 	NDefines.NNavy.GUN_HIT_PROFILES = { -- hit profiles for guns, if target ih profile is lower the gun will have lower accuracy

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -5930,6 +5930,7 @@ country_event = {
 		name = sov_other.36.a
 		log = "[GetDateText]: [This.GetName]: sov_other.36.a executed"
 		ai_chance = { base = 90 }
+		custom_effect_tooltip = SOV_petrov_coup_imminent_tt
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		set_temp_variable = { temp_outlook_increase = 0.15 }
@@ -5942,6 +5943,7 @@ country_event = {
 		name = sov_other.36.b
 		log = "[GetDateText]: [This.GetName]: sov_other.36.b executed"
 		ai_chance = { base = 10 }
+		custom_effect_tooltip = SOV_petrov_coup_prevented_tt
 		add_stability = -0.09
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = -0.15 }

--- a/localisation/english/MD_focus_SOV_l_english.yml
+++ b/localisation/english/MD_focus_SOV_l_english.yml
@@ -849,7 +849,9 @@
  russia_news.8.o2: "Good"
 
  ## custom tooltips
- SOV_koba_tooltip: "If you allow the general to speak, it may lead to a coup in the future."
+ SOV_koba_tooltip: "§RWarning:§! Allowing the general to speak will spread his ideas in the military. Unless we arrest him at the next event, he §Rwill§! launch a coup within a year."
+ SOV_petrov_coup_imminent_tt: "§RWarning:§! Without action, General Petrov will launch a coup against the government within 100 days."
+ SOV_petrov_coup_prevented_tt: "§GArresting the general now will prevent his coup attempt.§!"
  SOV_appease_chechnya_tooltip: "§GThis will end the Chechen terror attacks.§! This will also cause the Communist to gain §G5%§! Support and Social Liberals to gain §G3%§! Support in our country.\n"
  SOV_coalition_pipec: "We will form a coalition with some opposition parties\n"
  wagner_rebellion: "£SOV_Nat_Autocracy_wagner §YYevgeny Prigozhin§! did not commit a military coup"


### PR DESCRIPTION
Closes #1273
Closes #1274

## Summary

Bundle of two unrelated but small, self-contained bug fixes.

### #1273 — Constantine Petrov coup chain warnings (SOV)

The Constantine Petrov coup chain (`sov_other.35` → `.36` → `.37`) was firing without making clear to the player that picking *"We'll let him speak anyway"* followed by *"Do nothing"* guarantees the coup. The existing `SOV_koba_tooltip` only said *"may lead to a coup in the future"*, and `sov_other.36`'s options had no tooltip at all — players (rightly) reported that the coup *"always launches regardless of the speech choice"*.

**Root cause:** The chain logic is intentional, but UX-wise there was no clear signal that:
1. Option `.35.a` ("let him speak") arms the chain.
2. Option `.36.a` ("Do nothing") guarantees the coup.
3. Option `.36.b` ("Arrest the general") is the way out.

**Fix:**
- Strengthened `SOV_koba_tooltip` so it explicitly states the coup is inevitable unless the general is arrested at the next event.
- Added `SOV_petrov_coup_imminent_tt` (on `.36.a`) — warns the player the coup is 100 days away.
- Added `SOV_petrov_coup_prevented_tt` (on `.36.b`) — confirms the arrest stops the coup.

### #1274 — Shore bombardment gun-attack multipliers swapped

PR #300 ("AI Combat Adjustments Pt. 1") accidentally swapped `HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT` and `LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT`. As reported, this made ASHM (heavy attack) the dominant shore-bombardment stat — opposite of the intended design where cannons (light attack) handle shore bombardment.

**Root cause:** Values were transposed in `common/defines/MD_defines.lua` during the AI combat balance pass.

**Fix:** Restored the pre-#300 values:
- `HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT`: 0.99 → 0.001
- `LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT`: 0.025 → 0.85

## Test plan

### #1273
- Start as Russia (SOV), take `SOV_reign_of_yeltsin`.
- 100 days later, `sov_other.35` fires. Hover the option *"We'll let him speak anyway"* — the new warning should make the coup chain consequence clear.
- Pick *"let him speak"*. 100 days later, `sov_other.36` fires.
- Hover *"Do nothing"* — should show the new "coup imminent" tooltip.
- Hover *"Arrest the general"* — should show the new "coup prevented" tooltip.
- Verify the underlying behavior is unchanged: `.36.a` still fires `sov_other.37` in 100 days, `.36.b` still ends the chain.

### #1274
- Design a ship with high light-attack (cannons) but low heavy-attack — confirm shore bombardment % is now substantial.
- Design a ship with high heavy-attack (ASHM) but low light-attack — confirm shore bombardment % is now negligible.
- Compare against the reporter's playtest numbers in #1274.