### PR TITLE
Fix inverted naval shore bombardment stats (#1274)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -257,6 +257,7 @@ v2.0.0
   - [LBA/ETH] Fixed Mengistu's Propaganda national spirit never expiring because the Libya focus added it permanently alongside the timed event (Issue #1222)
   - Fixed attacking a political party boosting its support instead of reducing it when the party is the only one in its ideology group (Issue #1218)
   - Fixed labor regulation law charging 50 PP more than displayed when switching tiers (Issue #1234)
+  - Fixed inverted naval shore bombardment defines: HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT and LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT were accidentally swapped in beta naval AI adjustments, restoring heavy (ASHM) to 0.001 and light (cannon) to 0.85 (Issue #1274)
   - Fixed "No Terrorist Threat" faction goal requiring all global terror orgs to be eliminated instead of just having an intelligence agency (Issue #1045)
   - Fixed auto-influence slot removal being blocked for 30 days after adding a country, making it impossible to remove countries when all slots are filled (Issue #1153)
   - Restored suppression values to all land units after the tech merge stripped them, making garrison of occupied territory functional again (Issue #1039)

--- a/common/defines/MD_defines.lua
+++ b/common/defines/MD_defines.lua
@@ -604,8 +604,8 @@
 	NDefines.NNavy.SUB_DETECTION_CHANCE_SPOTTING_SPEED_EFFECT = 1.2 -- 2.0
 	NDefines.NNavy.SUB_DETECTION_CHANCE_BASE_SPOTTING_POW_EFFECT = 1.01
 	NDefines.NNavy.SHORE_BOMBARDMENT_CAP = 1 -- Reduced to 100% from 200% -- 25% is vanilla
-	NDefines.NNavy.HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.99 -- HGA / (VAL * 100) = Add to Shore Bombard Mod
-	NDefines.NNavy.LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.025 -- LGA / (VAL * 100) = Add to Shore Bombard Mod
+	NDefines.NNavy.HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.001 -- HGA / (VAL * 100) = Add to Shore Bombard Mod
+	NDefines.NNavy.LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.85 -- LGA / (VAL * 100) = Add to Shore Bombard Mod
 	NDefines.NNavy.COMBAT_MIN_HIT_CHANCE = 0.05	-- never less hit chance then this?
 	NDefines.NNavy.MIN_HIT_PROFILE_MULT = 0.1 -- largest hit profile penalty to hitting (higher value of the define makes ships easier to hit, i assume by reducing the penalty caused by small hit profile of target ship)
 	NDefines.NNavy.GUN_HIT_PROFILES = { -- hit profiles for guns, if target ih profile is lower the gun will have lower accuracy


### PR DESCRIPTION
## Summary

Closes #1274

## Root cause

In commit `a97fbab` ("AI Combat Adjustments Pt. 1"), the naval shore bombardment defines were accidentally swapped during a bulk edit:

- `HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT` was changed from `0.001` → `0.99`
- `LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT` was changed from `0.85` → `0.025`

In MD, "heavy attack" maps to ASHM (anti-ship missiles) and "light attack" maps to cannon attack. The intended design is that ASHM is terrible at shore bombardment while cannons are effective. The swapped values made ASHM 40x better than cannons at shore bombardment, producing the exact opposite outcome.

## Fix

Restore the original values:
- `HEAVY_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.001`
- `LIGHT_GUN_ATTACK_TO_SHORE_BOMBARDMENT = 0.85`

## Test plan

- [ ] Start a game as any nation with naval access
- [ ] Design a ship with cannon modules (light attack) and check its shore bombardment value
- [ ] Design a ship with ASHM modules (heavy attack) and check its shore bombardment value
- [ ] Confirm cannon ships have significantly higher shore bombardment than ASHM ships