### PR TITLE
Fixed Several Peace Deal Exploits

### DIFF
--- a/common/scripted_effects/02_peace_deal_effects.txt
+++ b/common/scripted_effects/02_peace_deal_effects.txt
@@ -80,36 +80,14 @@ CPD_demand_concede_switch = {
 	}
 	if = {
 		limit = { ROOT = { has_country_flag = CPD_giving_concessions } }
-		# ROOT = {
-		# 	# CPD_calculate_monetary_war_reparations = yes
-		# 	# more calculate things can go in here
-		# }
-		every_country = {
-			limit = {
-				has_war_with = PREV
-				OR = {
-					tag = ROOT
-					is_subject_of = ROOT
-					AND = {
-						ROOT = { is_faction_leader = yes }
-						is_in_faction_with = ROOT
-					}
-				}
-			}
+		# Concessions: only ROOT's own states — subjects' and faction allies' territory
+		# cannot be offered, preventing the puppet-territory concession exploit.
+		ROOT = {
 			for_each_loop = {
 				array = owned_states
 				if = {
-					limit = {
-						OR = {
-							controls_state = v
-							ROOT = { controls_state = v }
-							any_allied_country = {
-								has_war_with = ROOT
-								controls_state = v
-							}
-						}
-					}
-					ROOT = { add_to_array = { CPD_state_list = v } }
+					limit = { controls_state = v }
+					add_to_array = { CPD_state_list = v }
 				}
 			}
 		}

--- a/common/scripted_guis/02_conditional_peace_deals_scripted_gui.txt
+++ b/common/scripted_guis/02_conditional_peace_deals_scripted_gui.txt
@@ -119,6 +119,11 @@ scripted_gui = {
 							NOT = { has_country_flag = CPD_full_puppet_concession }
 						}
 					}
+					# Block demilitarising already-demilitarised states
+					OR = {
+						NOT = { ROOT = { check_variable = { CPD_state_option_selection = 3 } } }
+						NOT = { is_demilitarized_zone = yes }
+					}
 				}
 
 				CPD_AIA_acceptance_ICON_visible = {

--- a/common/scripted_localisation/02_conditional_peace_deal_scripted_localisation.txt
+++ b/common/scripted_localisation/02_conditional_peace_deal_scripted_localisation.txt
@@ -451,6 +451,11 @@ defined_text = {
 			multiply_temp_variable = { CPD_RSB_temp = 100 }
 			round_temp_variable = CPD_RSB_temp
 			subtract_from_temp_variable = { CPD_RSB_temp = 100 }
+			if = {
+				limit = { ROOT = { NOT = { is_in_faction = yes } } }
+				multiply_temp_variable = { CPD_RSB_temp = 0.25 }
+				round_temp_variable = CPD_RSB_temp
+			}
 			clamp_temp_variable = {
 				var = CPD_RSB_temp
 				max = 1000

--- a/common/scripted_triggers/00_peace_deal_triggers.txt
+++ b/common/scripted_triggers/00_peace_deal_triggers.txt
@@ -105,6 +105,13 @@
 				multiply_temp_variable = { CPD_RSB_temp = 100 }
 				round_temp_variable = CPD_RSB_temp
 				subtract_from_temp_variable = { CPD_RSB_temp = 100 }
+				# Dampen when ROOT has no faction — engine metric includes all
+				# co-belligerents, which massively inflates the ratio for solo senders.
+				if = {
+					limit = { ROOT = { NOT = { is_in_faction = yes } } }
+					multiply_temp_variable = { CPD_RSB_temp = 0.25 }
+					round_temp_variable = CPD_RSB_temp
+				}
 				clamp_temp_variable = {
 					var = CPD_RSB_temp
 					max = 1000

--- a/localisation/english/conditional_peace_deals_l_english.yml
+++ b/localisation/english/conditional_peace_deals_l_english.yml
@@ -228,3 +228,9 @@
  CPD_send_ready_TT: "§GThe terms of this deal are ready to send to [THIS.GetName].§!\n\n[CPD_send_status_breakdown]\n\n[CPD_deal_recap]"
  CPD_send_blocked_TT: "§RWe cannot yet send this deal.§! Sending §Ydemands§! requires §Ywar contribution§! against [THIS.GetName]: at least one battle won, or three months at war. A §Yceasefire-only§! deal can be sent without contribution. Deals composed entirely of concessions can also be sent without.\n\n[CPD_send_status_breakdown]\n\n[CPD_deal_recap]"
  CPD_deal_recap_TT: "Demands: §Y[?CPD_recap_demands|.0]§!\nConcessions: §Y[?CPD_recap_concessions|.0]§!\nNet cost: §Y[?CPD_recap_total_cost|+0]§! £victory_points"
+
+ # Receive Offer Dialog
+ CPD_receive_offer_TITLE_TEXT: "Peace Offer from [FROM.GetNameWithFlag]"
+ CPD_receive_offer_DESC_TEXT: "[FROM.GetName] has proposed terms to end the conflict. Review the demands and concessions below."
+ CPD_receive_offer_DESC_OFFENSIVE_WAR: "[FROM.GetName] seeks to negotiate an end to hostilities."
+ CPD_receive_offer_DESC_DEFENSIVE_WAR: "[FROM.GetName] wishes to discuss terms for a ceasefire."


### PR DESCRIPTION

- Block demilitarising already-demilitarised states (infinite VP exploit)
- Restrict concessions list to ROOT's own controlled states only, removing subject and faction ally territory from the pool (puppet territory exploit)
- Dampen relative strength bonus by 75% when ROOT has no faction, since the engine metric includes all co-belligerents and massively inflates the ratio for solo senders who left their faction mid-war
- Add 4 missing receive-offer dialog localisation keys

Closes #1348 