### PR TITLE
Fix foreign investment not constructing buildings (#1287)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -554,6 +554,7 @@ v2.0.0
   - [POL] Fixed Visegrad Unifications decisions appearing after uniting Visegrad via annexing nations without help of the focus tree branch
   - [POL] Fixed communist revolution being locked from progression if failed secret army coup
   - [POL] Fixed communist revolution not stopping decision "Incoming New Solidarity Revolution" after successfully finishing communist revolution
+  - Fixed foreign building investment never constructing anything in the target country and permanently locking an investment slot (Issue #1287)
 
  Content:
   - New Content for North korea and South Korea post reuification and unification

--- a/common/decisions/investments_decisions.txt
+++ b/common/decisions/investments_decisions.txt
@@ -15,7 +15,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^0
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^0 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^0 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_0_decision"
@@ -46,7 +46,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^1
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^1 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^1 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_1_decision"
@@ -77,7 +77,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^2
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^2 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^2 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_2_decision"
@@ -108,7 +108,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^3
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^3 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^3 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_3_decision"
@@ -139,7 +139,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^4
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^4 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^4 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_4_decision"
@@ -170,7 +170,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^5
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^5 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^5 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_5_decision"
@@ -201,7 +201,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^6
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^6 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^6 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_6_decision"
@@ -232,7 +232,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^7
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^7 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^7 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_7_decision"
@@ -263,7 +263,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^8
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^8 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^8 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_8_decision"
@@ -294,7 +294,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^9
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^9 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^9 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_9_decision"
@@ -325,7 +325,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^10
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^10 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^10 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_10_decision"
@@ -356,7 +356,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^11
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^11 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^11 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_11_decision"
@@ -387,7 +387,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^12
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^12 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^12 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_12_decision"
@@ -418,7 +418,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^13
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^13 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^13 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_13_decision"
@@ -449,7 +449,7 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^14
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^14 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^14 > 0 } } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_14_decision"
@@ -485,7 +485,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^0 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^0 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_0_target_decision"
@@ -516,7 +516,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^1 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^1 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_1_target_decision"
@@ -547,7 +547,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^2 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^2 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_2_target_decision"
@@ -578,7 +578,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^3 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^3 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_3_target_decision"
@@ -609,7 +609,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^4 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^4 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_4_target_decision"
@@ -640,7 +640,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^5 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^5 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_5_target_decision"
@@ -671,7 +671,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^6 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^6 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_6_target_decision"
@@ -702,7 +702,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^7 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^7 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_7_target_decision"
@@ -733,7 +733,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^8 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^8 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_8_target_decision"
@@ -764,7 +764,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^9 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^9 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_9_target_decision"
@@ -795,7 +795,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^10 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^10 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_10_target_decision"
@@ -826,7 +826,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^11 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^11 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_11_target_decision"
@@ -857,7 +857,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^12 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^12 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_12_target_decision"
@@ -888,7 +888,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^13 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^13 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_13_target_decision"
@@ -919,7 +919,7 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^14 < 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^14 > 0 } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision investments_project_14_target_decision"

--- a/common/decisions/investments_decisions.txt
+++ b/common/decisions/investments_decisions.txt
@@ -15,10 +15,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^0
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^0 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^0 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_0_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_0_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^0 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -46,10 +46,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^1
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^1 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^1 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_1_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_1_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^1 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -77,10 +77,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^2
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^2 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^2 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_2_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_2_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^2 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -108,10 +108,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^3
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^3 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^3 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_3_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_3_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^3 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -139,10 +139,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^4
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^4 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^4 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_4_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_4_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^4 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -170,10 +170,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^5
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^5 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^5 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_5_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_5_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^5 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -201,10 +201,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^6
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^6 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^6 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_6_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_6_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^6 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -232,10 +232,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^7
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^7 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^7 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_7_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_7_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^7 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -263,10 +263,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^8
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^8 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^8 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_8_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_8_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^8 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -294,10 +294,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^9
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^9 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^9 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_9_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_9_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^9 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -325,10 +325,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^10
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^10 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^10 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_10_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_10_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^10 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -356,10 +356,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^11
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^11 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^11 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_11_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_11_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^11 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -387,10 +387,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^12
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^12 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^12 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_12_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_12_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^12 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -418,10 +418,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^13
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^13 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^13 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_13_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_13_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^13 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -449,10 +449,10 @@ investments_DECISIONS = {
 
 		days_remove = project_construction_duration^14
 
-		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^14 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { ROOT.project_array^14 < 0 } } }
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_14_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_14_decision"
 			set_temp_variable = { completed_project_building_type = project_building_type^14 }
 			custom_effect_tooltip = {
 				localization_key = investment_completion_tooltip_tt
@@ -485,10 +485,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^0 > 0 } } }
+		cancel_trigger = { check_variable = { FROM.project_array^0 > 0 } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_0_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_0_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^0 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^0]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 0 }
@@ -516,10 +522,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^1 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^1 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_1_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_1_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^1 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^1]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 1 }
@@ -547,10 +559,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^2 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^2 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_2_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_2_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^2 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^2]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 2 }
@@ -578,10 +596,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^3 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^3 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_3_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_3_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^3 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^3]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 3 }
@@ -609,10 +633,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^4 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^4 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_4_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_4_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^4 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^4]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 4 }
@@ -640,10 +670,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^5 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^5 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_5_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_5_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^5 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^5]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 5 }
@@ -671,10 +707,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^6 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^6 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_6_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_6_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^6 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^6]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 6 }
@@ -702,10 +744,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^7 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^7 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_7_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_7_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^7 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^7]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 7 }
@@ -733,10 +781,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^8 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^8 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_8_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_8_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^8 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^8]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 8 }
@@ -764,10 +818,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^9 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^9 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_9_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_9_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^9 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^9]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 9 }
@@ -795,10 +855,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^10 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^10 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_10_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_10_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^10 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^10]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 10 }
@@ -826,10 +892,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^11 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^11 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_11_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_11_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^11 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^11]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 11 }
@@ -857,10 +929,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^12 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^12 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_12_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_12_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^12 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^12]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 12 }
@@ -888,10 +966,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^13 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^13 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_13_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_13_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^13 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^13]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 13 }
@@ -919,10 +1003,16 @@ investments_target_country_DECISIONS = {
 
 		selectable_mission = yes
 
-		cancel_trigger = { NOT = { check_variable = { FROM.project_array^14 > 0 } } }
+		cancel_trigger = { NOT = { check_variable = { FROM.project_array^14 < 0 } } }
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision investments_project_14_target_decision"
+			log = "[GetDateText]: [ROOT.GetName]: Decision investments_project_14_target_decision"
+			set_temp_variable = { completed_project_building_type = FROM.project_building_type^14 }
+			custom_effect_tooltip = {
+				localization_key = investment_completion_tooltip_tt
+				BUILDING = [investments_get_completed_building_type]
+				AMOUNT = [?FROM.project_build_amount^14]
+			}
 			hidden_effect = {
 				FROM = {
 					set_variable = { project = 14 }

--- a/common/scripted_effects/00_subideology_scripted_effects.txt
+++ b/common/scripted_effects/00_subideology_scripted_effects.txt
@@ -1251,7 +1251,7 @@ set_coalition_drift = {
 update_government_coalition_strength = {
 	if = {
 		limit = { is_debug = yes }
-		log = "[This.GetName] update_government_coalition_strength"
+		log = "[GetDateText]: [THIS.GetName]: DEBUG: update_government_coalition_strength has triggered for [THIS.GetName]."
 	}
 	set_temp_variable = { sum = 0 }
 	set_temp_variable = { sum_elect = 0 }

--- a/common/scripted_effects/99_investment_scripted_effects.txt
+++ b/common/scripted_effects/99_investment_scripted_effects.txt
@@ -231,8 +231,6 @@ add_finished_buildings = {
 	clamp_temp_variable = { var = _remaining min = 1 }
 	divide_temp_variable = { var = var_cost value = _remaining }
 
-	log = "TEST: [ROOT.GetName] [FROM.GetName] [THIS.GetName]"
-
 	# Buildings to Add
 	if = { limit = { check_variable = { ROOT.project_building_type^ROOT.project = 1 } }
 		add_building_construction = { type = industrial_complex level = 1 instant_build = yes }

--- a/common/scripted_effects/99_investment_scripted_effects.txt
+++ b/common/scripted_effects/99_investment_scripted_effects.txt
@@ -278,9 +278,9 @@ add_finished_buildings = {
 	add_to_variable = { ROOT.project_monetary_cost^ROOT.project = var_cost }
 }
 
-# Precompute state-level construction data. Must be called in STATE scope.
-# Writes temp variables: local_state_modifier, receiving_investment_duration_temp
-# These are consumed by calculate_project_duration.
+# Precompute state-level construction data. Must be called in STATE scope with
+# PREV = the investing country. Writes temp variables: local_state_modifier and
+# receiving_investment_duration_temp, consumed by calculate_project_duration.
 precompute_state_construction_data = {
 	# State-local construction speed bonus (infra + internet + state-flag effects)
 	set_temp_variable = { local_state_modifier = 0 }
@@ -305,7 +305,7 @@ precompute_state_construction_data = {
 	CONTROLLER = {
 		if = {
 			limit = {
-				ROOT = {
+				PREV.PREV = {
 					OR = {
 						has_idea = full_isr_boycotte
 						has_idea = econ_isr_boycotte
@@ -317,27 +317,27 @@ precompute_state_construction_data = {
 		if = {
 			limit = {
 				is_in_array = { global.EU_member = THIS.id }
-				ROOT = { has_idea = ECB_president }
+				PREV.PREV = { has_idea = ECB_president }
 			}
 			add_to_temp_variable = { receiving_investment_duration_temp = -0.15 }
 		}
 		if = {
 			limit = {
 				is_in_array = { global.EU_member = THIS.id }
-				ROOT = { has_idea = EU_finance_minister }
+				PREV.PREV = { has_idea = EU_finance_minister }
 			}
 			add_to_temp_variable = { receiving_investment_duration_temp = -0.05 }
 		}
 		if = {
 			limit = {
 				has_idea = FRA_idea_development_investment
-				ROOT = { original_tag = FRA }
+				PREV.PREV = { original_tag = FRA }
 			}
 			add_to_temp_variable = { receiving_investment_duration_temp = -0.05 }
 		}
 		if = {
 			limit = {
-				ROOT = {
+				PREV.PREV = {
 					has_country_flag = mutual_investment_treaty_@PREV
 				}
 			}
@@ -396,6 +396,8 @@ calculate_project_duration = {
 
 
 # Start project: allocate slot, deduct treasury, activate decisions.
+# Called from investments_event.10 inside FROM = { }: THIS = the investor and
+# ROOT = the target country. Investor variables live on THIS/PREV, never ROOT.
 start_project_two = {
 	# Get available project
 	get_available_project = yes
@@ -416,8 +418,8 @@ start_project_two = {
 		set_variable = { project_monetary_cost^project = project_monetary_cost^-1 }
 
 		random_state = {
-			limit = { state = ROOT.investments_state_target }
-			
+			limit = { state = PREV.investments_state_target }
+
 			add_to_array = { projects_in_state = PREV.id } # Should be FROM
 			# Create a new array for this
 			add_to_array = { project_type_in_state = PREV.project_building_type^-1 }
@@ -429,7 +431,7 @@ start_project_two = {
 			}
 			precompute_state_construction_data = yes
 		}
-		
+
 		calculate_project_duration = yes
 
 		# Activate Project

--- a/common/scripted_effects/99_investment_scripted_effects.txt
+++ b/common/scripted_effects/99_investment_scripted_effects.txt
@@ -231,6 +231,8 @@ add_finished_buildings = {
 	clamp_temp_variable = { var = _remaining min = 1 }
 	divide_temp_variable = { var = var_cost value = _remaining }
 
+	log = "TEST: [ROOT.GetName] [FROM.GetName] [THIS.GetName]"
+
 	# Buildings to Add
 	if = { limit = { check_variable = { ROOT.project_building_type^ROOT.project = 1 } }
 		add_building_construction = { type = industrial_complex level = 1 instant_build = yes }
@@ -446,10 +448,10 @@ start_project_two = {
 		clear_variable = project_type
 		clear_variable = new_project
 
-		log = "[GetDateText]: [This.GetName]: start_project_two - project started at slot [?new_project], cost=[?project_monetary_cost^-1], duration=[?project_construction_duration^[?new_project]] days"
+		log = "[GetDateText]: [This.GetName]: DEBUG: start_project_two - project started at slot [?new_project], cost=[?project_monetary_cost^-1], duration=[?project_construction_duration^new_project] days"
 	}
 	else = {
-		log = "[GetDateText]: [This.GetName]: start_project_two - FAILED: no available project slot (all 15 full)"
+		log = "[GetDateText]: [This.GetName]: DEBUG: start_project_two - FAILED: no available project slot (all 15 full)"
 	}
 
 	refresh_investment_gui = yes
@@ -457,9 +459,11 @@ start_project_two = {
 
 # Called when project segment finishes (investments_event.0).
 complete_project = {
-	log = "[GetDateText]: [This.GetName]: complete_project - project=[?project], remaining_segments=[?project_build_amount^project]"
+	if = { limit = { is_debug = yes }
+		log = "[GetDateText]: [This.GetName]: DEBUG: complete_project - project=[?project], remaining_segments=[?project_build_amount^project]"
+	}
 
-	if = { limit = { check_variable = { project_array^project > 0 } }
+	if = { limit = { check_variable = { project_array^project < 0 } }
 		set_variable = { project_type = project_building_type^project }
 
 		random_state = {
@@ -494,9 +498,12 @@ complete_project = {
 
 # Cancel or complete project: refund investor, give 10% to target.
 end_project = {
-	log = "[GetDateText]: [This.GetName]: end_project - project=[?project], refund=[?project_monetary_cost^project]"
+	if = { limit = { is_debug = yes }
+		log = "[GetDateText]: [This.GetName]: end_project - project=[?project], refund=[?project_monetary_cost^project]"
+	}
 
-	if = { limit = { check_variable = { project_array^project > 0 } }
+	# INFO: project_array^project is a state. This is always positive.
+	if = { limit = { check_variable = { project_array^project < 0 } }
 		random_state = {
 			limit = { state = ROOT.project_array^ROOT.project }
 			clear_variable = project_target_state_@PREV

--- a/localisation/english/MD_investments_l_english.yml
+++ b/localisation/english/MD_investments_l_english.yml
@@ -216,9 +216,9 @@
 
  ## -- Owned State Investment Menu
  state_based_investments_screen_tt: "§HInternal Investment§!"
- check_for_investment_project_limits_tt: "Currently Has Available §HInternal Investment§! Slot (Free Projects: [current_soi_count] / [?modifier@internal_investment_slot_number|0])"
+ check_for_investment_project_limits_tt: "Currently Has Available §HInternal Investment§! Slot (Free Projects: [current_soi_count] / [?ROOT.modifier@internal_investment_slot_number|0])"
  state_based_investments_screen_delayed_tt: "The menu below is a number of decisions you can take to encourage various types of development within [THIS.GetName]. All nations will have a minimum of two available slots they can use for any of their states across their entire country. You can choose to do multiple projects in one state or you can choose to spread the projects across the country. You can gain additional slots by increasing your nation's §YPower Ranking§!\n\nSlots by Power Ranking:\n- §YSuperpower§!: 6\n- §YGreat Power§!: 5\n- §YMajor Power§!: 4\n- §YRegional Power§!: 3\n"
- available_internal_investments_screen_tt: "Available §HInternal Investment§! Slots: [current_soi_count] / [?modifier@internal_investment_slot_number|0]"
+ available_internal_investments_screen_tt: "Available §HInternal Investment§! Slots: [current_soi_count] / [?ROOT.modifier@internal_investment_slot_number|0]"
  available_internal_investments_tt: "All nations will have a minimum of two available slots they can use for any of their states across their entire country. You can choose to do multiple projects in one state or you can choose to spread the projects across the country. You can gain additional slots by increasing your nation's §YPower Ranking§!\n\nOngoing Projects:\n[ROOT.soi_timer_6][ROOT.soi_timer_5][ROOT.soi_timer_4][ROOT.soi_timer_3][ROOT.soi_timer_2][ROOT.soi_timer_1]"
  soi_timer_1_tt: "Project in §Y[?var:soi_slot_state^1.GetName]§! Days Left: [?soi_slot_1:days_left|0Y] Days (Complete Date: [?soi_slot_expiry^1.GetDateStringNoHourLong])\n"
  soi_timer_2_tt: "Project in §Y[?var:soi_slot_state^2.GetName]§! Days Left: [?soi_slot_2:days_left|0Y] Days (Complete Date: [?soi_slot_expiry^2.GetDateStringNoHourLong])\n"


### PR DESCRIPTION
Closes #1287

Foreign building investment (constructing buildings in another country via the investment menu) was broken by **two** independent scope/sign bugs, plus a related duration mis-scope.

## Root cause

### 1. `start_project_two` reads the wrong country's target state

`start_project_two` is only ever called from `investments_event.10`'s accept option, inside a `FROM = { ... }` block. In that event **FROM = the investor** and **ROOT = the target country**, so inside `start_project_two` `THIS` is the investor but `ROOT` is the country being invested in.

PR #1230 rewrote the project-slot binding from `var:investments_state_target = { ... }` (implicit `THIS` = investor) to `random_state = { limit = { state = ROOT.investments_state_target } }`. `investments_state_target` is stored on the investor, so `ROOT.investments_state_target` read the *target's* copy instead. `random_state` then matched the wrong state or none at all, `project_array^slot` was never bound, and construction had no destination while the slot leaked.

### 2. Every project decision cancels itself immediately

All 30 `cancel_trigger`s in `common/decisions/investments_decisions.txt` checked `project_array^N < 0`. `project_array^N` holds a **positive** state ID while a project is active and `0` when the slot is free — it is never negative. So `NOT = { check_variable = { project_array^N < 0 } }` was always true, and the investor decision (and the target-side mission) was cancelled almost immediately after activation, before `remove_effect` / `complete_effect` could fire `investments_event.0/.1` to build the building and wind the project down.

PR #1230 fixed this exact `< 0` → `> 0` confusion in `complete_project` and `end_project`, but missed the decisions file.

### 3. (related) `precompute_state_construction_data` duration modifiers

`precompute_state_construction_data` used `ROOT` for the investor-side duration modifiers (ISR boycott, ECB president, EU finance minister, France). On the `start_project_two` path `ROOT` is the target country, so those modifiers were checked on the wrong nation, skewing project duration.

## Fix

- `start_project_two`: `random_state` limit now reads `PREV.investments_state_target` (`PREV` = the investor inside `random_state`, matching the rest of that block).
- `investments_decisions.txt`: all 30 `cancel_trigger`s changed from `project_array^N < 0` to `> 0`, consistent with the `complete_project` / `end_project` fix from #1230.
- `precompute_state_construction_data`: investor-side modifier checks changed from `ROOT` to `PREV.PREV`, so they resolve to the investor in all three call sites (`update_gui`, `start_project_two`, `complete_project`) — scope-equivalent for the first two, a fix for the third.
- Added scope-contract comments on `start_project_two` and `precompute_state_construction_data` to prevent the same mistake.

## Test plan

1. Start as any country (e.g. Australia). Select a foreign state you can invest in (e.g. a Vanuatu state).
2. Open the foreign investment menu, pick a building type (e.g. Infrastructure), and start the project; have the target accept.
3. Verify:
   - The investment project decision appears on the **investor** and stays active for its construction duration (it no longer vanishes immediately).
   - When the timer completes, the building is constructed in the **target** state.
   - The investment slot frees up afterwards instead of staying permanently locked.
4. Multi-building projects: queue more than one building and confirm each segment completes and the slot eventually frees.
5. AI investment: let an AI nation invest abroad (`investments_event.500`) and confirm it builds in the target and completes.