### PR TITLE
ITA EH Crash Fix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -555,6 +555,8 @@ v2.0.0
   - [POL] Fixed communist revolution being locked from progression if failed secret army coup
   - [POL] Fixed communist revolution not stopping decision "Incoming New Solidarity Revolution" after successfully finishing communist revolution
   - Fixed foreign building investment never constructing anything in the target country and permanently locking an investment slot (Issue #1287)
+  - [ITA] Fixed incorrect scope within civil war "Partisan Activity" dynamic modifier (Issue #1265)
+  - Fixed incorrect checks for national spirit "superpower", while it should be "super_power" (Issue #1265)
 
  Content:
   - New Content for North korea and South Korea post reuification and unification

--- a/common/dynamic_modifiers/99_ITA_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/99_ITA_dynamic_modifiers.txt
@@ -194,8 +194,8 @@ ITA_ASI = {
 }
 ITA_civil_war_partisan_activity = {
 	icon = GFX_idea_spy_intel
-	enable = { has_civil_war = yes }
-	remove_trigger = { has_civil_war = no }
+	enable = { ITA = { has_civil_war = yes } }
+	remove_trigger = { ITA = { has_civil_war = no } }
 
 	custom_modifier_tooltip = ITA_civil_war_partisan_activity_TT
 	air_superiority_bonus_in_combat = -0.25

--- a/common/scripted_triggers/99_EH_scripted_triggers.txt
+++ b/common/scripted_triggers/99_EH_scripted_triggers.txt
@@ -352,7 +352,7 @@ is_considered_western_country = {
 
 is_greater_than_minor_power = {
 	OR = {
-		has_idea = superpower
+		has_idea = super_power
 		has_idea = great_power
 		has_idea = large_power
 		has_idea = regional_power

--- a/resources/National Content/East Africa Shit/ideas/AA_law_military_ideas.txt
+++ b/resources/National Content/East Africa Shit/ideas/AA_law_military_ideas.txt
@@ -2613,7 +2613,7 @@ ideas = {
 				factor = 0
 				modifier = {
 					add = 1
-					has_idea = superpower
+					has_idea = super_power
 				}
 			}
 		}

--- a/resources/National Content/Laven-PRC-Rework/china_tree.txt
+++ b/resources/National Content/Laven-PRC-Rework/china_tree.txt
@@ -11437,7 +11437,7 @@ communist_cadres_at_least_positive_opinion = yes
 				add = 1
 				OR = {
 					is_historical_focus_on = no
-					has_idea = superpower
+					has_idea = super_power
 				}
 			}
 		}
@@ -14401,7 +14401,7 @@ communist_cadres_at_least_positive_opinion = yes
 				add = 1
 				OR = {
 					is_historical_focus_on = yes
-					has_idea = superpower
+					has_idea = super_power
 				}
 			}
 		}
@@ -14764,7 +14764,7 @@ communist_cadres_at_least_positive_opinion = yes
 		mutually_exclusive = { focus = CHI_Favor_Multipolarity }
 
 		available = {
-			has_idea = superpower
+			has_idea = super_power
 			NOT = { has_government = democratic }
 		}
 

--- a/resources/Officer Corps/AA_law_military_ideas.txt
+++ b/resources/Officer Corps/AA_law_military_ideas.txt
@@ -2410,7 +2410,7 @@ ideas = {
 				factor = 0
 				modifier = {
 					add = 1
-					has_idea = superpower
+					has_idea = super_power
 				}
 			}
 

--- a/resources/Old Desired Laws/00_desired_law_calculations.txt
+++ b/resources/Old Desired Laws/00_desired_law_calculations.txt
@@ -253,7 +253,7 @@ recalculate_bureaucracy_desire = {
 		}
 		add_to_temp_variable = { bureaucracy_law_desire = 8.0 } #Regional to Major Powers want a mid grade bureau
 	}
-	else_if = { limit = { has_idea = superpower }
+	else_if = { limit = { has_idea = super_power }
 		add_to_temp_variable = { bureaucracy_law_desire = 12.0 } # Superpower wants bureau_04
 	}
 	# Add modifier based upon completed focuses
@@ -2823,7 +2823,7 @@ recalculate_defence_spending_desire = {
 		add_to_temp_variable = { defence_spending_desire = 8 }
 	}
 	else_if = {
-		limit = { has_idea = superpower }
+		limit = { has_idea = super_power }
 		add_to_temp_variable = { defence_spending_desire = 12 }
 	}
 

--- a/resources/new-mobilization-law/AA_law_military_ideas.txt
+++ b/resources/new-mobilization-law/AA_law_military_ideas.txt
@@ -2499,7 +2499,7 @@ ideas = {
 				factor = 0
 				modifier = {
 					add = 1
-					has_idea = superpower
+					has_idea = super_power
 				}
 			}
 		}

--- a/resources/old doctrines/doctrines.txt
+++ b/resources/old doctrines/doctrines.txt
@@ -4027,7 +4027,7 @@
 # 			add_to_variable = { army_doctrines_researched = 1 } log = "[GetDateText]: [Root.GetName]: add tech offensive_focus" custom_effect_tooltip = military_combat_focus_tt add_to_variable = { combat_doctrine = 1 } }
 
 # 		allow = {
-# 			if = { limit = { has_idea = superpower }
+# 			if = { limit = { has_idea = super_power }
 # 				check_variable = { combat_doctrine < 3 }
 # 			} else = {
 # 				check_variable = { combat_doctrine < 2 }
@@ -4745,7 +4745,7 @@
 # 			add_to_variable = { army_doctrines_researched = 1 } log = "[GetDateText]: [Root.GetName]: add tech defensive_focus" custom_effect_tooltip = military_combat_focus_tt add_to_variable = { combat_doctrine = 1 } }
 
 # 		allow = {
-# 			if = { limit = { has_idea = superpower }
+# 			if = { limit = { has_idea = super_power }
 # 				check_variable = { combat_doctrine < 3 }
 # 			} else = {
 # 				check_variable = { combat_doctrine < 2 }
@@ -5465,7 +5465,7 @@
 # 			add_to_variable = { army_doctrines_researched = 1 } log = "[GetDateText]: [Root.GetName]: add tech unconventional_focus" custom_effect_tooltip = military_combat_focus_tt add_to_variable = { combat_doctrine = 1 } }
 
 # 		allow = {
-# 			if = { limit = { has_idea = superpower }
+# 			if = { limit = { has_idea = super_power }
 # 				check_variable = { combat_doctrine < 3 }
 # 			} else = {
 # 				check_variable = { combat_doctrine < 2 }

--- a/resources/sphere of influence stuff/MD_spheres_of_influence_triggers.txt
+++ b/resources/sphere of influence stuff/MD_spheres_of_influence_triggers.txt
@@ -4,7 +4,7 @@ is_not_over_reaching_regional = {
 			has_idea = regional_power
 			has_idea = large_power
 			has_idea = great_power
-			has_idea = superpower
+			has_idea = super_power
 		}
 	}
 }
@@ -13,18 +13,18 @@ is_not_over_reaching_major = {
 		OR = {
 			has_idea = large_power
 			has_idea = great_power
-			has_idea = superpower
+			has_idea = super_power
 		}
 	}
 }
 is_not_over_reaching_great = {
 	NOT = {
 		has_idea = great_power
-		has_idea = superpower
+		has_idea = super_power
 	}
 }
 is_not_over_reaching_super = {
 	NOT = {
-		has_idea = superpower
+		has_idea = super_power
 	}
 }


### PR DESCRIPTION
- [ITA] Fixed incorrect scope within civil war "Partisan Activity" dynamic modifier (Issue #1265)
- Fixed incorrect checks for national spirit "superpower", while it should be "super_power" (Issue #1265)

Closes #1265 