### PR TITLE
Fix Cuba/Egypt bugs, expand validation pipeline with 5 new validators

### DIFF
--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -46,6 +46,9 @@ jobs:
       scripted-loc:  ${{ steps.filter.outputs.scripted-loc }}
       scripted-guis: ${{ steps.filter.outputs.scripted-guis }}
       interface:     ${{ steps.filter.outputs.interface }}
+      national-focus: ${{ steps.filter.outputs.national-focus }}
+      on-actions:    ${{ steps.filter.outputs.on-actions }}
+      scripted-effects: ${{ steps.filter.outputs.scripted-effects }}
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -88,6 +91,12 @@ jobs:
             - 'common/scripted_guis/**'
           interface:
             - 'interface/**'
+          national-focus:
+            - 'common/national_focus/**'
+          on-actions:
+            - 'common/on_actions/**'
+          scripted-effects:
+            - 'common/scripted_effects/**'
 
   # ───────────────────────────────────────────────────────────────
   # Linters — run when any game content files change
@@ -315,7 +324,10 @@ jobs:
       needs.detect-changes.outputs.ai-equipment == 'true' ||
       needs.detect-changes.outputs.factions == 'true' ||
       needs.detect-changes.outputs.scripted-guis == 'true' ||
-      needs.detect-changes.outputs.interface == 'true'
+      needs.detect-changes.outputs.interface == 'true' ||
+      needs.detect-changes.outputs.national-focus == 'true' ||
+      needs.detect-changes.outputs.on-actions == 'true' ||
+      needs.detect-changes.outputs.scripted-effects == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -380,6 +392,51 @@ jobs:
               interface
               localisation/english
               tools
+          - script: validate_focus_tree.py
+            name: focus-tree
+            title: "Validate Focus Tree Structure"
+            should_run: ${{ needs.detect-changes.outputs.national-focus }}
+            sparse: |
+              common/national_focus
+              localisation/english
+              tools
+          - script: validate_on_actions.py
+            name: on-actions
+            title: "Validate On Actions"
+            should_run: ${{ needs.detect-changes.outputs.on-actions == 'true' || needs.detect-changes.outputs.events == 'true' }}
+            sparse: |
+              common/on_actions
+              events
+              tools
+          - script: validate_scripted_params.py
+            name: scripted-params
+            title: "Validate Scripted Effect Parameters"
+            should_run: ${{ needs.detect-changes.outputs.scripted-effects == 'true' || needs.detect-changes.outputs.national-focus == 'true' || needs.detect-changes.outputs.decisions == 'true' || needs.detect-changes.outputs.events == 'true' }}
+            sparse: |
+              common/scripted_effects
+              common/national_focus
+              common/decisions
+              events
+              tools
+          - script: validate_gfx_references.py
+            name: gfx-references
+            title: "Validate GFX Sprite References"
+            should_run: ${{ needs.detect-changes.outputs.interface == 'true' || needs.detect-changes.outputs.scripted-guis == 'true' }}
+            sparse: |
+              interface
+              common/scripted_guis
+              common/scripted_localisation
+              tools
+          - script: validate_modifiers.py
+            name: modifiers
+            title: "Validate Modifier Names"
+            # informational: frequency-based detection has inherent false positives
+            # for rarely-used but valid vanilla modifiers
+            strict: false
+            should_run: ${{ needs.detect-changes.outputs.common }}
+            sparse: |
+              common
+              tools
     steps:
     # Per-entry gate: only fetch + run when this validator's file group changed.
     # Steps below each carry the same `if` so a skipped entry reports cleanly
@@ -397,7 +454,9 @@ jobs:
         python-version: '3.x'
     - name: Run validation
       if: matrix.validator.should_run == 'true'
-      run: python3 tools/validation/${{ matrix.validator.script }} --strict --no-color --workers 4 --output validation-${{ matrix.validator.name }}.log
+      run: |
+        STRICT_FLAG=$( [ "${{ matrix.validator.strict }}" = "false" ] && echo "" || echo "--strict" )
+        python3 tools/validation/${{ matrix.validator.script }} $STRICT_FLAG --no-color --workers 4 --output validation-${{ matrix.validator.name }}.log
     - name: Upload results
       if: always() && matrix.validator.should_run == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,6 +225,103 @@ repos:
         language: system
         files: '(common/scripted_guis/.*\.txt|interface/.*\.(gui|gfx)|localisation/english/.*\.yml)$'
         pass_filenames: false
+      - id: md-validate-events
+        name: MD Validate event definitions
+        entry: python3 tools/validation/validate_events.py --staged --strict --no-color
+        language: system
+        files: 'events/.*\.txt$'
+        pass_filenames: false
+      - id: md-validate-scripted-localisation
+        name: MD Validate scripted localisation references
+        entry: python3 tools/validation/validate_scripted_localisation.py --staged --strict --no-color --workers 4
+        language: system
+        files: '(common/scripted_localisation/.*\.txt|interface/.*\.gfx)$'
+        pass_filenames: false
+      - id: md-validate-localisation
+        name: MD Validate localisation (duplicates, color codes, headers)
+        entry: python3 tools/validation/validate_localisation.py --staged --strict --no-color --workers 4
+        language: system
+        files: 'localisation/english/.*\.yml$'
+        pass_filenames: false
+      - id: md-validate-cosmetic-tags
+        name: MD Validate cosmetic tag references
+        entry: python3 tools/validation/validate_cosmetic_tags.py --staged --strict --no-color --workers 4
+        language: system
+        files: '(common|events|history)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-decisions
+        name: MD Validate decision definitions
+        entry: python3 tools/validation/validate_decisions.py --staged --strict --no-color --workers 4
+        language: system
+        files: '(common/decisions|common/balance_of_power)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-variables
+        name: MD Validate variable and event target references
+        entry: python3 tools/validation/validate_variables.py --staged --strict --no-color --workers 4
+        language: system
+        files: '(common|events|history)/.*\.txt$|localisation/english/.*\.yml$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-history-techs
+        name: MD Validate history technology dependencies
+        entry: python3 tools/validation/validate_history_techs.py --staged --strict --no-color
+        language: system
+        files: '(common/technologies|history/countries)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-unused-scripted
+        name: MD Validate unused scripted effects and triggers
+        entry: python3 tools/validation/validate_unused_scripted.py --staged --strict --no-color
+        language: system
+        files: '(common/scripted_effects|common/scripted_triggers)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-factions
+        name: MD Validate faction system references
+        entry: python3 tools/validation/validate_factions.py --staged --strict --no-color
+        language: system
+        files: 'common/factions/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-focus-tree
+        name: MD Validate focus tree structure (orphans, cycles, duplicates)
+        entry: python3 tools/validation/validate_focus_tree.py --staged --strict --no-color
+        language: system
+        files: 'common/national_focus/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-modifiers
+        name: MD Validate modifier names (unknown/typo detection)
+        # No --strict: frequency-based detection has inherent false positives
+        # for rarely-used but valid vanilla modifiers
+        entry: python3 tools/validation/validate_modifiers.py --staged --no-color
+        language: system
+        files: '(common/ideas|common/national_focus|common/decisions|common/dynamic_modifiers)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-on-actions
+        name: MD Validate on_actions event references
+        entry: python3 tools/validation/validate_on_actions.py --staged --strict --no-color
+        language: system
+        files: '(common/on_actions|events)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-scripted-params
+        name: MD Validate scripted effect parameter contracts
+        entry: python3 tools/validation/validate_scripted_params.py --staged --strict --no-color
+        language: system
+        files: '(common/scripted_effects|common/national_focus|common/decisions|events)/.*\.txt$'
+        pass_filenames: false
+        stages: [manual]
+      - id: md-validate-gfx-references
+        name: MD Validate GFX sprite references (.gui vs .gfx)
+        entry: python3 tools/validation/validate_gfx_references.py --staged --strict --no-color
+        language: system
+        files: '(interface/.*\.(gui|gfx)|common/scripted_guis/.*\.txt|common/scripted_localisation/.*\.txt)$'
+        pass_filenames: false
+        stages: [manual]
       - id: md-validate-unused-textures
         name: MD Validate unused textures (slow; manual)
         # Manual: full-repo scan is slow and currently reports ~22k legacy

--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -486,7 +486,17 @@ EGY_coptic_decision = {
 			set_temp_variable = { coptic_opinion_change = 4 }
 			modify_coptic_opinion_effect = yes
 		}
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 15
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+			modifier = {
+				add = 25
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 	EGY_promote_coptic_politicians = {
 		icon = GFX_decision_copts_propa_button
@@ -505,7 +515,17 @@ EGY_coptic_decision = {
 			set_temp_variable = { coptic_opinion_change = 7 }
 			modify_coptic_opinion_effect = yes
 		}
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 20
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+			modifier = {
+				add = 30
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 	#
 	EGY_raids_on_coptic_people = {
@@ -598,7 +618,15 @@ EGY_coptic_decision = {
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 25
+				check_variable = { EGY_coptic_people_opinion > 80 }
+				check_variable = { EGY_copts_political_influence > 60 }
+				NOT = { neutrality_neutral_autocracy_are_in_power = yes }
+			}
+		}
 	}
 }
 

--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -260,7 +260,7 @@ EGY_evergreen_category = {
 				ROOT = { has_opinion = { target = SYR value < -20 } }
 			}
 		}
-		complete_effect = { log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Jordan" }
+		complete_effect = { log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Syria" }
 	}
 
 	EGY_mission_to_Saudia = {
@@ -419,7 +419,10 @@ EGY_evergreen_category = {
 
 		ai_will_do = {
 			base = 20
-			modifier = { factor = 20 }
+			modifier = {
+				factor = 20
+				has_opinion = { target = UAE value < -20 }
+			}
 		}
 		complete_effect = { log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_uae" }
 	}
@@ -456,7 +459,10 @@ EGY_evergreen_category = {
 
 		ai_will_do = {
 			base = 20
-			modifier = { factor = 20 }
+			modifier = {
+				factor = 20
+				has_opinion = { target = TUR value < -20 }
+			}
 		}
 		complete_effect = { log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Turkey" }
 	}

--- a/common/national_focus/05_egypt.txt
+++ b/common/national_focus/05_egypt.txt
@@ -444,7 +444,13 @@ focus_tree = {
 			}
 			swap_ruler_traits = { remove = opposes_muslim_brotherhood add = pro_brotherhood }
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 	focus = {
 		id = EGY_ban_musl_brotherhood
@@ -482,7 +488,13 @@ focus_tree = {
 				}
 			}
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 5
+				is_historical_focus_on = yes
+			}
+		}
 	}
 	focus = {
 		id = EGY_anti_israel_prop
@@ -679,7 +691,13 @@ focus_tree = {
 			add_war_support = 0.05
 			add_stability = -0.1
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 5
+				is_historical_focus_on = yes
+			}
+		}
 	}
 	focus = {
 		id = EGY_cond_us_invasion
@@ -703,7 +721,13 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_cond_us_invasion"
 			country_event = Egypt.2
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 	focus = {
 		id = EGY_ask_us_supp
@@ -1122,7 +1146,13 @@ focus_tree = {
 			set_temp_variable = { temp_modify_social_con_government = -5 }
 			modify_social_conservatism_government = yes
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 3
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	focus = {
 		id = EGY_appeas_militar
@@ -1648,7 +1678,13 @@ focus_tree = {
 				target = PER
 			}
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 5
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	focus = {
 		id = EGY_sharia_laws
@@ -3659,7 +3695,7 @@ focus_tree = {
 			check_broken_economy_conditions_for_reducing = yes
 			add_stability = 0.005
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = { base = 5 }
 	}
 	focus = {
 		id = EGY_new_delta
@@ -5441,7 +5477,7 @@ focus_tree = {
 			set_temp_variable = { coptic_pol_influence_change = 5 }
 			modify_coptic_pol_influence_effect = yes
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = { base = 4 }
 	}
 	focus = {
 		id = EGY_dontallow_copt_pol

--- a/common/national_focus/05_egypt.txt
+++ b/common/national_focus/05_egypt.txt
@@ -57,7 +57,13 @@ focus_tree = {
 			change_The_Military_opinion = yes
 			add_political_power = 100
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 50
+				is_historical_focus_on = yes
+			}
+		}
 	}
 	focus = {
 		id = EGY_reform_legisl
@@ -452,7 +458,7 @@ focus_tree = {
 		mutually_exclusive = { focus = EGY_allow_musl_brotherhood }
 		relative_position_id = EGY_egyptian_politics
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_allow_musl_brotherhood"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_ban_musl_brotherhood"
 			add_political_power = 50
 			add_stability = -0.05
 			custom_effect_tooltip = musl_broth_egy_2_tt
@@ -879,7 +885,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_finish_syr_tur_neg focus = EGY_isr_peace_support }
 		relative_position_id = EGY_egyptian_politics
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_finish_syr_tur_neg"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_prop_us_sec_exp"
 			add_to_tech_sharing_group = Major_Non_NATO_Ally_Share
 			one_random_arms_factory = yes
 			USA = {
@@ -929,7 +935,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_morsi }
 		relative_position_id = EGY_morsi
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_morsi"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_primacy_brother"
 			remove_ideas = muslim_brotherhood_crackdown
 			set_temp_variable = { temp_opinion = -3 }
 			change_The_Military_opinion = yes
@@ -1166,7 +1172,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_revok_mub_laws }
 		relative_position_id = EGY_morsi
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_app_chris_wom"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_loyalist_dom"
 			add_political_power = 100
 			set_temp_variable = { coptic_opinion_change = -5 }
 			modify_coptic_opinion_effect = yes
@@ -1263,7 +1269,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_maintain_democr focus = EGY_unrestricted_pres }
 		relative_position_id = EGY_morsi
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_maintain_democr"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_alsisi_proposal"
 			country_event = Egypt.53
 		}
 		ai_will_do = { base = 1 }
@@ -1408,7 +1414,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_brotherhood_diplo }
 		relative_position_id = EGY_morsi
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_support_fsa"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_cond_eth_bro"
 			country_event = Egypt.40
 		}
 		ai_will_do = { base = 1 }
@@ -1496,7 +1502,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_hamas_under_wing }
 		relative_position_id = EGY_morsi
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_hamas_under_wing"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_letter_isr"
 			country_event = Egypt.45
 		}
 		ai_will_do = { base = 1 }
@@ -2147,7 +2153,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_estab_ties_with_china focus = EGY_russian_oil_deal }
 		relative_position_id = EGY_natfront_all
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_support_tourism"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_support_milindr"
 			one_random_arms_factory = yes
 		}
 		ai_will_do = { base = 1 }
@@ -2732,7 +2738,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_purge_islamist }
 		relative_position_id = EGY_natfront_all
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_supp_musl_bros"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_help_sahara"
 			SHA = { country_event = egypt_sahar.1 }
 		}
 		ai_will_do = { base = 1 }
@@ -3166,7 +3172,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_befr_libya }
 		relative_position_id = EGY_natfront_all
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_befr_libya"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_pan_arab_effort"
 			add_political_power = -250
 			if = {
 				limit = { emerging_autocracy_are_in_power = yes }
@@ -4816,6 +4822,10 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
 		}
 	}
 	focus = {
@@ -5383,7 +5393,7 @@ focus_tree = {
 		relative_position_id = EGY_copts_in_power
 		available = { neutrality_neutral_autocracy_are_in_power = yes }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_supp_christians_in_palestine"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_encourage_church_building"
 			two_office_construction = yes
 		}
 		ai_will_do = { base = 1 }
@@ -5401,7 +5411,13 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_egyptian_divide_foc"
 			add_political_power = 100
 		}
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 	focus = {
 		id = EGY_allow_copt_pol
@@ -5754,7 +5770,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_egyptian_economy }
 		relative_position_id = EGY_egyptian_economy
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_agricultural_issues"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_find_oil"
 			add_ideas = EGY_oil_prospects_idea1
 			random_owned_state = {
 				add_resource = {
@@ -6267,11 +6283,11 @@ focus_tree = {
 			newline = yes
 			set_temp_variable = { treasury_change = -8.00 }
 			modify_treasury_effect = yes
-			TUN = { country_event = Egypt.28 }
-			MOR = { country_event = Egypt.28 }
-			MAU = { country_event = Egypt.28 }
-			LBA = { country_event = Egypt.28 }
-			ALG = { country_event = Egypt.28 }
+			if = { limit = { country_exists = TUN } TUN = { country_event = Egypt.28 } }
+			if = { limit = { country_exists = MOR } MOR = { country_event = Egypt.28 } }
+			if = { limit = { country_exists = MAU } MAU = { country_event = Egypt.28 } }
+			if = { limit = { country_exists = LBA } LBA = { country_event = Egypt.28 } }
+			if = { limit = { country_exists = ALG } ALG = { country_event = Egypt.28 } }
 		}
 		ai_will_do = { base = 1 }
 	}
@@ -8529,7 +8545,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_air }
 		relative_position_id = EGY_lessons
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_domestic_air"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_arab_uk_helis"
 			one_random_arms_factory = yes
 			add_tech_bonus = {
 				name = EGY_arab_uk_helis
@@ -8626,7 +8642,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_roc }
 		relative_position_id = EGY_lessons
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_f16"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_buy_buk"
 			custom_effect_tooltip = EGY_buk_TT
 			SOV = { country_event = egypt.160 }
 		}
@@ -8923,7 +8939,7 @@ focus_tree = {
 		prerequisite = { focus = EGY_fra_fleet }
 		relative_position_id = EGY_lessons
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EGY_new_doctrine"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_new_naval_doctrine"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_doctrine_cost_reduction = {
@@ -9040,7 +9056,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		relative_position_id = EGY_lessons
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus buy_arms"
+			log = "[GetDateText]: [Root.GetName]: Focus EGY_buy_arms"
 			add_political_power = 50
 			add_timed_idea = {
 				idea = EGY_arms_purch_idea

--- a/events/Cuba.txt
+++ b/events/Cuba.txt
@@ -146,7 +146,7 @@ country_event = {
 	is_triggered_only = yes
 	option = {
 		name = cuba.12.a
-		log = "[GetDateText]: [This.GetName]: cuba.11.a"
+		log = "[GetDateText]: [This.GetName]: cuba.12.a"
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = 0 }
 			set_temp_variable = { disable_elections = 1 }
@@ -159,7 +159,7 @@ country_event = {
 		create_country_leader = {
 			name = "Fidel Castro"
 			picture = "fidel_castro.dds"
-			ideology = liberalism
+			ideology = Western_Autocracy
 			traits = {
 				western_liberalism
 				western_socialism

--- a/events/Cuba.txt
+++ b/events/Cuba.txt
@@ -161,8 +161,7 @@ country_event = {
 			picture = "fidel_castro.dds"
 			ideology = Western_Autocracy
 			traits = {
-				western_liberalism
-				western_socialism
+				western_Western_Autocracy
 				political_dancer
 			}
 		}

--- a/events/Egypt.txt
+++ b/events/Egypt.txt
@@ -1844,7 +1844,13 @@ country_event = {
 		set_temp_variable = { party_index = 11 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 30
+			modifier = {
+				factor = 0.1
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	option = {
 		name = egypt_copts.1.b
@@ -1861,7 +1867,13 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 70
+			modifier = {
+				factor = 2
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 }
 country_event = {
@@ -1890,7 +1902,13 @@ country_event = {
 		set_temp_variable = { party_index = 11 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 30
+			modifier = {
+				factor = 0.1
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	option = {
 		name = egypt_copts.2.b
@@ -1907,7 +1925,13 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 70
+			modifier = {
+				factor = 2
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 }
 country_event = {
@@ -1936,7 +1960,13 @@ country_event = {
 		set_temp_variable = { party_index = 11 }
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 30
+			modifier = {
+				factor = 0.1
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	option = {
 		name = egypt_copts.3.b
@@ -1953,7 +1983,13 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 70
+			modifier = {
+				factor = 2
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 }
 country_event = {
@@ -1982,7 +2018,13 @@ country_event = {
 		set_temp_variable = { party_index = 11 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 30
+			modifier = {
+				factor = 0.1
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	option = {
 		name = egypt_copts.4.b
@@ -1999,7 +2041,13 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 70
+			modifier = {
+				factor = 2
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 }
 country_event = {
@@ -2028,7 +2076,13 @@ country_event = {
 		set_temp_variable = { party_index = 11 }
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 30
+			modifier = {
+				factor = 0.1
+				check_variable = { EGY_coptic_people_opinion < 50 }
+			}
+		}
 	}
 	option = {
 		name = egypt_copts.5.b
@@ -2045,7 +2099,13 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
-		ai_chance = { base = 1 }
+		ai_chance = {
+			base = 70
+			modifier = {
+				factor = 2
+				check_variable = { EGY_coptic_people_opinion < 30 }
+			}
+		}
 	}
 }
 country_event = {

--- a/events/Egypt.txt
+++ b/events/Egypt.txt
@@ -2467,10 +2467,10 @@ country_event = {
 		add_stability = -0.1
 		set_temp_variable = { temp_opinion = -10 }
 		change_The_Military_opinion = yes
-		SYR = { country_event = Egypt.121 }
-		KUW = { country_event = Egypt.121 }
-		ARM = { country_event = Egypt.121 }
-		GRE = { country_event = Egypt.121 }
+		SYR = { country_event = egypt.121 }
+		KUW = { country_event = egypt.121 }
+		ARM = { country_event = egypt.121 }
+		GRE = { country_event = egypt.121 }
 		set_temp_variable = { wargoal_on = TUR }
 		set_temp_variable = { wargoal_type = 1 }
 		add_threat_from_wargoal_effect = yes
@@ -3205,7 +3205,7 @@ country_event = {
 			}
 		}
 		EGY = {
-			country_event = Egypt.147
+			country_event = egypt.147
 			add_to_faction = ROOT
 		}
 	}
@@ -3222,7 +3222,7 @@ country_event = {
 				}
 			}
 		}
-		EGY = { country_event = Egypt.148 }
+		EGY = { country_event = egypt.148 }
 	}
 }
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    ".claude/rules/**/*.md"
+  ]
+}

--- a/tools/validate_staged.py
+++ b/tools/validate_staged.py
@@ -21,6 +21,13 @@ files themselves (CI handles the full cross-reference validation).
     common/scripted_effects/          -> validate_oob_units.py
   - common/ideas/, common/national_focus/,
     common/decisions/, events/        -> validate_ideas.py
+  - common/factions/                  -> validate_factions.py
+  - common/national_focus/            -> validate_focus_tree.py
+  - common/on_actions/                -> validate_on_actions.py
+  - common/scripted_effects/,
+    common/national_focus/,
+    common/decisions/, events/        -> validate_scripted_params.py
+  - interface/*.gui                   -> validate_gfx_references.py
 
 Opt-out via environment variable:
     MD_SKIP_VALIDATE=1 git commit -m "..."
@@ -180,6 +187,73 @@ VALIDATORS = [
         "cmd": [
             "python3",
             "tools/validation/validate_scripted_gui.py",
+            "--staged",
+            "--strict",
+            "--no-color",
+        ],
+    },
+    {
+        "name": "factions",
+        "prefixes": [
+            "common/factions/",
+        ],
+        "suffix": ".txt",
+        "cmd": [
+            "python3",
+            "tools/validation/validate_factions.py",
+            "--staged",
+            "--strict",
+            "--no-color",
+        ],
+    },
+    {
+        "name": "focus tree",
+        "prefixes": ["common/national_focus/"],
+        "suffix": ".txt",
+        "cmd": [
+            "python3",
+            "tools/validation/validate_focus_tree.py",
+            "--staged",
+            "--strict",
+            "--no-color",
+        ],
+    },
+    {
+        "name": "on actions",
+        "prefixes": ["common/on_actions/"],
+        "suffix": ".txt",
+        "cmd": [
+            "python3",
+            "tools/validation/validate_on_actions.py",
+            "--staged",
+            "--strict",
+            "--no-color",
+        ],
+    },
+    {
+        "name": "scripted params",
+        "prefixes": [
+            "common/scripted_effects/",
+            "common/national_focus/",
+            "common/decisions/",
+            "events/",
+        ],
+        "suffix": ".txt",
+        "cmd": [
+            "python3",
+            "tools/validation/validate_scripted_params.py",
+            "--staged",
+            "--strict",
+            "--no-color",
+        ],
+    },
+    {
+        "name": "gfx references",
+        "prefixes": ["interface/"],
+        "suffix": ".gui",
+        "cmd": [
+            "python3",
+            "tools/validation/validate_gfx_references.py",
             "--staged",
             "--strict",
             "--no-color",

--- a/tools/validation/validate_focus_tree.py
+++ b/tools/validation/validate_focus_tree.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+##########################
+# Focus Tree Structural Validation Script
+# Validates focus tree definitions for structural integrity
+# Checks for:
+#   1. Duplicate focus IDs across all files
+#   2. Orphan focuses (prerequisite targets not found in the same tree)
+#   3. Missing prerequisite targets (referenced focus IDs not defined anywhere)
+#   4. Missing localisation keys (focus ID and focus ID_desc)
+#   5. Dependency cycles in prerequisite chains
+##########################
+import os
+import re
+from collections import defaultdict
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+
+from validator_common import (
+    BaseValidator,
+    Colors,
+    Severity,
+    run_validator_main,
+    should_skip_file,
+    strip_comments,
+)
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+# Opening of a focus_tree or shared_focus block
+_FOCUS_TREE_START = re.compile(r"\bfocus_tree\s*=\s*\{")
+_SHARED_FOCUS_DEF_START = re.compile(r"\bshared_focus\s*=\s*\{")
+
+# focus ID extraction
+_FOCUS_ID_RE = re.compile(r"\bfocus\s*=\s*\{")
+_ID_LINE_RE = re.compile(r"\bid\s*=\s*(\S+)")
+
+# prerequisite blocks: prerequisite = { focus = A  focus = B }
+_PREREQ_BLOCK_RE = re.compile(r"\bprerequisite\s*=\s*\{([^}]*)\}", re.DOTALL)
+_PREREQ_FOCUS_RE = re.compile(r"\bfocus\s*=\s*(\S+)")
+
+# shared_focus reference inside a focus_tree block (not a definition)
+_SHARED_REF_RE = re.compile(r"\bshared_focus\s*=\s*(\w+)")
+
+
+# ---------------------------------------------------------------------------
+# Per-file parsing (pool workers)
+# ---------------------------------------------------------------------------
+
+
+def _extract_block(text: str, start: int) -> Tuple[str, int]:
+    """Return the content between the first { after *start* and its matching },
+    and the position right after the closing }.  Returns ("", start) on failure."""
+    open_pos = text.find("{", start)
+    if open_pos == -1:
+        return "", start
+    depth = 1
+    i = open_pos + 1
+    while i < len(text) and depth > 0:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return "", start
+    return text[open_pos + 1 : i - 1], i
+
+
+def _line_of(text: str, pos: int) -> int:
+    """Return the 1-based line number of *pos* in *text*."""
+    return text[:pos].count("\n") + 1
+
+
+def _parse_focus_ids_from_block(block: str) -> List[Tuple[str, int, List[List[str]]]]:
+    """Parse all focus = { ... } blocks from a tree/shared block body.
+
+    Returns a list of (focus_id, relative_line_offset, prerequisite_groups).
+    prerequisite_groups is a list of lists — each inner list is the OR-group
+    of focus IDs from one prerequisite = { ... } block.
+    """
+    results: List[Tuple[str, int, List[List[str]]]] = []
+    search_start = 0
+    while True:
+        m = _FOCUS_ID_RE.search(block, search_start)
+        if not m:
+            break
+        body, end = _extract_block(block, m.start())
+        if not body:
+            search_start = m.end()
+            continue
+
+        id_match = _ID_LINE_RE.search(body)
+        if not id_match:
+            search_start = end
+            continue
+
+        focus_id = id_match.group(1)
+        line_offset = block[: m.start()].count("\n")
+
+        prereq_groups: List[List[str]] = []
+        for pb in _PREREQ_BLOCK_RE.finditer(body):
+            group = _PREREQ_FOCUS_RE.findall(pb.group(1))
+            if group:
+                prereq_groups.append(group)
+
+        results.append((focus_id, line_offset, prereq_groups))
+        search_start = end
+    return results
+
+
+def parse_focus_file(
+    filepath: str,
+) -> Dict:
+    """Parse one focus tree file and return a structured result dict.
+
+    Keys:
+      "filepath"      — absolute path
+      "trees"         — list of tree dicts (see below)
+      "shared_defs"   — dict of shared_focus_id -> (line, filepath)
+
+    Each tree dict:
+      "focuses"       — list of (focus_id, abs_line, prereq_groups)
+      "shared_refs"   — set of shared_focus IDs referenced inside the tree
+    """
+    result = {
+        "filepath": filepath,
+        "trees": [],
+        "shared_defs": {},
+    }
+    try:
+        with open(filepath, "r", encoding="utf-8-sig", errors="ignore") as fh:
+            raw = fh.read()
+    except Exception:
+        return result
+
+    text = strip_comments(raw)
+
+    # --- collect shared_focus definitions (top-level) ---
+    pos = 0
+    while True:
+        m = _SHARED_FOCUS_DEF_START.search(text, pos)
+        if not m:
+            break
+        body, end = _extract_block(text, m.start())
+        if not body:
+            pos = m.end()
+            continue
+        id_match = _ID_LINE_RE.search(body)
+        if id_match:
+            sfid = id_match.group(1)
+            abs_line = _line_of(text, m.start())
+            prereq_groups: List[List[str]] = []
+            for pb in _PREREQ_BLOCK_RE.finditer(body):
+                group = _PREREQ_FOCUS_RE.findall(pb.group(1))
+                if group:
+                    prereq_groups.append(group)
+            # Store shared focus definition for the global duplicate check and
+            # prerequisite resolution.  We also expose (line, filepath) so the
+            # caller can report accurate locations.
+            result["shared_defs"][sfid] = {
+                "line": abs_line,
+                "filepath": filepath,
+                "prereq_groups": prereq_groups,
+            }
+        pos = end
+
+    # --- collect focus_tree blocks ---
+    pos = 0
+    while True:
+        m = _FOCUS_TREE_START.search(text, pos)
+        if not m:
+            break
+        body, end = _extract_block(text, m.start())
+        if not body:
+            pos = m.end()
+            continue
+
+        tree_focuses: List[Tuple[str, int, List[List[str]]]] = []
+        for focus_id, line_offset, prereq_groups in _parse_focus_ids_from_block(body):
+            abs_line = _line_of(text, m.start()) + line_offset
+            tree_focuses.append((focus_id, abs_line, prereq_groups))
+
+        # shared_focus references inside the tree (not definitions)
+        shared_refs: Set[str] = set()
+        for sr in _SHARED_REF_RE.finditer(body):
+            # Only consider bare `shared_focus = NAME` (not `shared_focus = {`)
+            next_non_ws = body[sr.end() :].lstrip()
+            if next_non_ws.startswith("{"):
+                continue
+            shared_refs.add(sr.group(1))
+
+        result["trees"].append(
+            {
+                "focuses": tree_focuses,
+                "shared_refs": shared_refs,
+            }
+        )
+        pos = end
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+class Validator(BaseValidator):
+    TITLE = "FOCUS TREE STRUCTURAL VALIDATION"
+    STAGED_EXTENSIONS = [".txt", ".yml"]
+
+    def __init__(self, mod_path: str, **kwargs):
+        super().__init__(mod_path, **kwargs)
+        self._parsed_cache: Optional[List[Dict]] = None
+        self._staged_paths: Optional[Set[str]] = None
+
+    # -----------------------------------------------------------------------
+    # Data collection
+    # -----------------------------------------------------------------------
+
+    def _get_staged_paths(self) -> Set[str]:
+        """Return the set of staged focus file paths (relative to mod_path).
+
+        In non-staged mode returns an empty set (meaning: report all files).
+        """
+        if self._staged_paths is not None:
+            return self._staged_paths
+        if self.staged_only:
+            staged = self._collect_files(["common/national_focus/*.txt"])
+            self._staged_paths = {os.path.relpath(f, self.mod_path) for f in staged}
+        else:
+            self._staged_paths = set()
+        return self._staged_paths
+
+    def _is_reportable(self, filepath: str) -> bool:
+        """Return True if issues in this file should be reported.
+
+        In staged mode, only report for staged files. In full mode, report all.
+        """
+        staged = self._get_staged_paths()
+        if not staged and self.staged_only:
+            return False
+        if not self.staged_only:
+            return True
+        rel = os.path.relpath(filepath, self.mod_path)
+        return rel in staged
+
+    def _get_parsed_files(self) -> List[Dict]:
+        if self._parsed_cache is not None:
+            return self._parsed_cache
+        files = self._collect_files(["common/national_focus/*.txt"], ignore_staged=True)
+        self._parsed_cache = self._pool_map(parse_focus_file, files, chunksize=10)
+        return self._parsed_cache
+
+    def _build_focus_registry(
+        self, parsed_files: List[Dict]
+    ) -> Tuple[
+        Dict[str, List[Tuple[str, int]]], Dict[str, Tuple[str, int, List[List[str]]]]
+    ]:
+        """Build two lookup structures from parsed data.
+
+        Returns:
+          all_focuses   — focus_id -> list of (filepath, line)  (for dup detection)
+          focus_info    — focus_id -> (filepath, line, prereq_groups)  (first seen)
+        """
+        all_focuses: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
+        focus_info: Dict[str, Tuple[str, int, List[List[str]]]] = {}
+
+        for parsed in parsed_files:
+            fp = parsed["filepath"]
+            # shared focus definitions
+            for sfid, sdata in parsed["shared_defs"].items():
+                all_focuses[sfid].append((fp, sdata["line"]))
+                if sfid not in focus_info:
+                    focus_info[sfid] = (fp, sdata["line"], sdata["prereq_groups"])
+            # focuses inside trees
+            for tree in parsed["trees"]:
+                for focus_id, line, prereq_groups in tree["focuses"]:
+                    all_focuses[focus_id].append((fp, line))
+                    if focus_id not in focus_info:
+                        focus_info[focus_id] = (fp, line, prereq_groups)
+
+        return all_focuses, focus_info
+
+    # -----------------------------------------------------------------------
+    # Check 1: Duplicate focus IDs
+    # -----------------------------------------------------------------------
+
+    def validate_duplicate_focus_ids(self):
+        self._log_section("Checking for duplicate focus IDs...")
+
+        parsed = self._get_parsed_files()
+        all_focuses, _ = self._build_focus_registry(parsed)
+
+        results = []
+        for focus_id, locations in sorted(all_focuses.items()):
+            if len(locations) < 2:
+                continue
+            if not any(self._is_reportable(fp) for fp, _ in locations):
+                continue
+            loc_strs = ", ".join(
+                f"{os.path.relpath(fp, self.mod_path)}:{ln}" for fp, ln in locations
+            )
+            results.append(
+                (
+                    f"Duplicate focus ID '{focus_id}' defined {len(locations)} times: {loc_strs}",
+                    os.path.relpath(locations[0][0], self.mod_path),
+                    locations[0][1],
+                )
+            )
+
+        self._report(
+            results,
+            "No duplicate focus IDs found",
+            "Duplicate focus IDs (second definition overwrites the first):",
+            Severity.ERROR,
+            category="duplicate-focus-id",
+        )
+
+    # -----------------------------------------------------------------------
+    # Check 2: Orphan focuses
+    # -----------------------------------------------------------------------
+
+    def validate_orphan_focuses(self):
+        self._log_section(
+            "Checking for orphan focuses (missing prerequisite targets in tree)..."
+        )
+
+        parsed = self._get_parsed_files()
+        # Build global set of all defined focus IDs for missing-prereq resolution
+        _, focus_info = self._build_focus_registry(parsed)
+        all_defined: FrozenSet[str] = frozenset(focus_info.keys())
+
+        results = []
+        for pf in parsed:
+            fp = pf["filepath"]
+            if not self._is_reportable(fp):
+                continue
+            rel = os.path.relpath(fp, self.mod_path)
+            for tree in pf["trees"]:
+                # The IDs in this tree (NOT counting shared refs)
+                tree_ids: Set[str] = {f[0] for f in tree["focuses"]}
+                # Include shared focuses referenced into this tree
+                effective_ids = tree_ids | tree["shared_refs"]
+
+                for focus_id, line, prereq_groups in tree["focuses"]:
+                    if not prereq_groups:
+                        continue  # root focus — no prerequisites
+                    # A focus is orphaned if ANY prerequisite block is entirely
+                    # unsatisfied (none of its focus alternatives exist in the tree).
+                    for group in prereq_groups:
+                        group_satisfied = any(fid in effective_ids for fid in group)
+                        if not group_satisfied:
+                            # Also check if ALL alternatives are simply missing
+                            # from the entire mod (that's a missing-prereq bug,
+                            # not an orphan bug — only report orphan here when at
+                            # least one alternative actually exists somewhere).
+                            all_missing_globally = all(
+                                fid not in all_defined for fid in group
+                            )
+                            if all_missing_globally:
+                                # Will be caught by missing-prerequisite check; skip.
+                                continue
+                            results.append(
+                                (
+                                    f"Orphan focus '{focus_id}': prerequisite group {group} not present in tree",
+                                    rel,
+                                    line,
+                                )
+                            )
+                            break  # one report per focus is enough
+
+        self._report(
+            results,
+            "No orphan focuses found",
+            "Orphan focuses (prerequisite group not found in same tree):",
+            Severity.WARNING,
+            category="orphan-focus",
+        )
+
+    # -----------------------------------------------------------------------
+    # Check 3: Missing prerequisite targets
+    # -----------------------------------------------------------------------
+
+    def validate_missing_prerequisite_targets(self):
+        self._log_section(
+            "Checking for prerequisite targets that don't exist anywhere in the mod..."
+        )
+
+        parsed = self._get_parsed_files()
+        _, focus_info = self._build_focus_registry(parsed)
+        all_defined: FrozenSet[str] = frozenset(focus_info.keys())
+
+        results = []
+        seen_missing: Set[str] = set()
+        for pf in parsed:
+            fp = pf["filepath"]
+            if not self._is_reportable(fp):
+                continue
+            rel = os.path.relpath(fp, self.mod_path)
+            # Check shared focus defs
+            for sfid, sdata in pf["shared_defs"].items():
+                for group in sdata["prereq_groups"]:
+                    for prereq_id in group:
+                        if (
+                            prereq_id not in all_defined
+                            and prereq_id not in seen_missing
+                        ):
+                            seen_missing.add(prereq_id)
+                            results.append(
+                                (
+                                    f"Missing prerequisite target '{prereq_id}' (referenced by '{sfid}')",
+                                    rel,
+                                    sdata["line"],
+                                )
+                            )
+            # Check focuses inside trees
+            for tree in pf["trees"]:
+                for focus_id, line, prereq_groups in tree["focuses"]:
+                    for group in prereq_groups:
+                        for prereq_id in group:
+                            if (
+                                prereq_id not in all_defined
+                                and prereq_id not in seen_missing
+                            ):
+                                seen_missing.add(prereq_id)
+                                results.append(
+                                    (
+                                        f"Missing prerequisite target '{prereq_id}' (referenced by '{focus_id}')",
+                                        rel,
+                                        line,
+                                    )
+                                )
+
+        self._report(
+            results,
+            "No missing prerequisite targets found",
+            "Missing prerequisite targets (focus ID not defined anywhere — likely a typo):",
+            Severity.ERROR,
+            category="missing-prerequisite",
+        )
+
+    # -----------------------------------------------------------------------
+    # Check 4: Missing localisation keys
+    # -----------------------------------------------------------------------
+
+    def validate_missing_loc_keys(self):
+        self._log_section(
+            "Checking for missing localisation keys (focus ID and _desc)..."
+        )
+
+        parsed = self._get_parsed_files()
+        _, focus_info = self._build_focus_registry(parsed)
+
+        # Load all English loc keys (always full repo scan)
+        loc_keys = self._load_localisation_keys()
+        self.log(
+            f"  Found {len(focus_info)} focuses, {len(loc_keys)} localisation keys"
+        )
+
+        results = []
+        for focus_id, (fp, line, _) in sorted(focus_info.items()):
+            if not self._is_reportable(fp):
+                continue
+            rel = os.path.relpath(fp, self.mod_path)
+            missing_keys = []
+            if focus_id not in loc_keys:
+                missing_keys.append(focus_id)
+            desc_key = f"{focus_id}_desc"
+            if desc_key not in loc_keys:
+                missing_keys.append(desc_key)
+            for key in missing_keys:
+                results.append(
+                    (
+                        f"Missing loc key '{key}' for focus '{focus_id}'",
+                        rel,
+                        line,
+                    )
+                )
+
+        self._report(
+            results,
+            "No missing localisation keys found",
+            "Focuses with missing localisation keys (may use inline name= override — verify before fixing):",
+            Severity.WARNING,
+            category="missing-loc-key",
+        )
+
+    # -----------------------------------------------------------------------
+    # Check 5: Dependency cycles
+    # -----------------------------------------------------------------------
+
+    def validate_dependency_cycles(self):
+        self._log_section("Checking for dependency cycles in prerequisite chains...")
+
+        parsed = self._get_parsed_files()
+
+        results = []
+        for pf in parsed:
+            fp = pf["filepath"]
+            if not self._is_reportable(fp):
+                continue
+            rel = os.path.relpath(fp, self.mod_path)
+            for tree in pf["trees"]:
+                # Build adjacency: focus_id -> set of direct prerequisite IDs
+                # (flatten OR-groups — for cycle detection any edge matters)
+                tree_ids: Set[str] = {f[0] for f in tree["focuses"]}
+                adjacency: Dict[str, Set[str]] = {fid: set() for fid in tree_ids}
+                id_to_line: Dict[str, int] = {}
+
+                for focus_id, line, prereq_groups in tree["focuses"]:
+                    id_to_line[focus_id] = line
+                    for group in prereq_groups:
+                        for prereq_id in group:
+                            if prereq_id in tree_ids:
+                                adjacency[focus_id].add(prereq_id)
+
+                # DFS cycle detection
+                WHITE, GRAY, BLACK = 0, 1, 2
+                color: Dict[str, int] = {fid: WHITE for fid in tree_ids}
+                stack: List[str] = []
+
+                def dfs(node: str) -> Optional[List[str]]:
+                    color[node] = GRAY
+                    stack.append(node)
+                    for neighbor in adjacency.get(node, set()):
+                        if color[neighbor] == GRAY:
+                            # Found a cycle — extract it from the stack
+                            cycle_start = stack.index(neighbor)
+                            return stack[cycle_start:] + [neighbor]
+                        if color[neighbor] == WHITE:
+                            cycle = dfs(neighbor)
+                            if cycle:
+                                return cycle
+                    stack.pop()
+                    color[node] = BLACK
+                    return None
+
+                reported_cycles: Set[FrozenSet] = set()
+                for fid in tree_ids:
+                    if color[fid] == WHITE:
+                        cycle = dfs(fid)
+                        if cycle:
+                            cycle_key = frozenset(cycle)
+                            if cycle_key not in reported_cycles:
+                                reported_cycles.add(cycle_key)
+                                cycle_str = " -> ".join(cycle)
+                                line = id_to_line.get(cycle[0], 0)
+                                results.append(
+                                    (
+                                        f"Dependency cycle detected: {cycle_str}",
+                                        rel,
+                                        line,
+                                    )
+                                )
+
+        self._report(
+            results,
+            "No dependency cycles found",
+            "Dependency cycles in prerequisite chains:",
+            Severity.ERROR,
+            category="dependency-cycle",
+        )
+
+    # -----------------------------------------------------------------------
+    # Entry point
+    # -----------------------------------------------------------------------
+
+    def run_validations(self):
+        self.validate_duplicate_focus_ids()
+        self.validate_missing_prerequisite_targets()
+        self.validate_orphan_focuses()
+        self.validate_dependency_cycles()
+        self.validate_missing_loc_keys()
+
+
+if __name__ == "__main__":
+    run_validator_main(
+        Validator, "Validate focus tree structure in Millennium Dawn mod"
+    )

--- a/tools/validation/validate_gfx_references.py
+++ b/tools/validation/validate_gfx_references.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+##########################
+# GFX Sprite Reference Validation Script
+#
+# Validates that sprite names referenced in .gui files, scripted GUIs, and
+# scripted localisation are defined in interface/*.gfx files.
+#
+# Checks:
+#   1. Build GFX definition set from all interface/*.gfx files
+#   2. Validate spriteType / quadTextureSprite / background references in .gui files
+#   3. Validate image = "GFX_xxx" references in common/scripted_guis/*.txt
+#   4. Validate localization_key = "GFX_xxx" in common/scripted_localisation/*.txt
+#   5. Unused GFX definitions (warning; skipped in staged mode; capped at 50)
+#
+# Note: validate_scripted_gui.py already checks spriteType/quadTextureSprite in
+# .gui files at WARNING level. This validator promotes those to ERROR, adds
+# background= and scripted-GUI image= coverage, and adds unused-sprite reporting.
+#
+# Usage:
+#   python3 tools/validation/validate_gfx_references.py [OPTIONS]
+#
+# Options:
+#   --path PATH         Path to mod root (default: auto-detected)
+#   --strict            Exit 1 if any errors found
+#   --no-color          Disable colour output
+#   --staged            Only validate staged .gui/.gfx/.txt files
+#   --workers N         Worker processes (default: CPU count / 2)
+##########################
+import os
+import re
+import sys
+from typing import List, Optional, Set, Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from validator_common import BaseValidator, Colors, Severity, run_validator_main
+
+# ---------------------------------------------------------------------------
+# MD-authored file detection
+# ---------------------------------------------------------------------------
+# .gui files in MD fall into two categories:
+#   1. MD-authored: files the mod team wrote from scratch (scripted GUIs,
+#      country-specific GUIs, feature GUIs). Missing sprites here are real bugs.
+#   2. Vanilla overrides: copies of vanilla .gui files with small patches. These
+#      reference thousands of vanilla sprites the mod doesn't redefine. Missing
+#      sprites here are almost always vanilla refs — flag as WARNING only.
+#
+# Heuristic: a .gui file is MD-authored if its basename (without extension) starts
+# with a known MD or country prefix. Everything else is treated as a vanilla override.
+
+_MD_GUI_PREFIXES = (
+    "MD_",
+    "EH_",
+    "ENG_",
+    "GER_",
+    "LBA_",
+    "Iran_",
+    "Iraq_",
+    "bos_",
+    "cze_",
+    "Counter_",
+    "agriculture_",
+    "SIN_",
+    "HKG_",
+    "HOL_",
+    "NKO_",
+    "GRE_",
+    "CYP_",
+    "SCO_",
+    "RAJ_",
+    "SUB_",
+    "PER_",
+    "ALG_",
+    "artsakh_",
+    "israel_",
+    "singapore_",
+    "divisions_summary",
+    "!MD_",
+)
+
+
+def _is_md_gui_file(filepath: str) -> bool:
+    """Return True if this .gui file is MD-authored (not a vanilla override)."""
+    basename = os.path.basename(filepath)
+    return any(basename.startswith(p) for p in _MD_GUI_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — HOI4/Clausewitz comment stripping for .gfx and .gui files
+# These use C-style // and /* */ comments, NOT the # used by .txt scripts.
+# strip_comments() from shared_utils strips # comments; do NOT use it here.
+# ---------------------------------------------------------------------------
+
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//.*")
+
+
+def _strip_cstyle_comments(text: str) -> str:
+    """Remove // line comments and /* block comments from Clausewitz GUI/GFX text."""
+    text = _BLOCK_COMMENT_RE.sub("", text)
+    text = _LINE_COMMENT_RE.sub("", text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Regex constants
+# ---------------------------------------------------------------------------
+
+# All sprite type block openers in .gfx files; all use `name = "GFX_xxx"`.
+# We collect any `name = "GFX_xxx"` inside any of these blocks.
+_GFX_SPRITE_TYPES = re.compile(
+    r"\b(?:spriteType|frameAnimatedSpriteType|corneredTileSpriteType|"
+    r"maskedShieldType|progressbartype|textSpriteType)\s*=\s*\{",
+    re.IGNORECASE,
+)
+
+# name = "GFX_xxx" inside a block
+_GFX_NAME = re.compile(r'\bname\s*=\s*"(GFX_[A-Za-z0-9_]+)"')
+
+# GUI references — spriteType / quadTextureSprite / background
+_GUI_REF = re.compile(
+    r'\b(spriteType|quadTextureSprite|background)\s*=\s*"(GFX_[^"\[]+)"'
+)
+
+# Scripted GUI properties: image = "GFX_xxx"
+_SGUI_IMAGE_REF = re.compile(r'\bimage\s*=\s*"(GFX_[^"\[]+)"')
+
+# Scripted localisation: localization_key = "GFX_xxx"
+_SLOC_KEY_REF = re.compile(r'\blocalization_key\s*=\s*"(GFX_[^"\[]+)"')
+
+# Auto-generated flag sprites — never defined in .gfx, built by the engine.
+# Matches GFX_flag_TAG, GFX_TAG_flag, GFX_shield_TAG etc.
+_FLAG_SPRITE_RE = re.compile(
+    r"^GFX_(?:flag_|.*_flag$|.*_coat_of_arms$|.*_shield$)", re.IGNORECASE
+)
+
+# Sprites defined purely in vanilla (game install) that we can't track.
+# We accept all vanilla-looking names rather than false-positiving on them.
+# The heuristic: if the name has no MD-identifying prefix and a short common
+# suffix, it's probably vanilla. We limit false-positive suppression to a
+# small explicit allowlist of patterns, not a broad sweep.
+_VANILLA_PREFIXES = (
+    "GFX_zoom_",
+    "GFX_topbar_",
+    "GFX_icon_",
+    "GFX_console_",
+    "GFX_tutorial_",
+    "GFX_empty_",
+    "GFX_war_support_",
+    "GFX_stability_",
+    "GFX_pp_",
+    "GFX_politics_",
+)
+
+# Max unused sprites to list before summarising remainder
+_UNUSED_SPRITE_LIMIT = 50
+
+
+def _is_dynamic(name: str) -> bool:
+    """Return True if name contains template substitution markers."""
+    return "[" in name or "]" in name
+
+
+def _is_flag_sprite(name: str) -> bool:
+    """Return True for engine-generated flag/shield sprites."""
+    return bool(_FLAG_SPRITE_RE.match(name))
+
+
+def _is_likely_vanilla(name: str) -> bool:
+    """Return True for names that are almost certainly vanilla sprites."""
+    return any(name.startswith(p) for p in _VANILLA_PREFIXES)
+
+
+def _balance_braces(text: str, start: int) -> Optional[int]:
+    """Return position of the closing '}' matching the '{' at text[start-1].
+
+    ``start`` is the index *after* the opening brace. Returns None if the
+    text is unbalanced.
+    """
+    depth = 1
+    i = start
+    n = len(text)
+    in_str = False
+    while i < n:
+        c = text[i]
+        if c == '"' and (i == 0 or text[i - 1] != "\\"):
+            in_str = not in_str
+        elif not in_str:
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    return i
+        i += 1
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-file worker functions (top-level so they're picklable)
+# ---------------------------------------------------------------------------
+
+
+def _parse_gfx_file(filepath: str) -> Set[str]:
+    """Return the set of GFX sprite names defined in a .gfx file."""
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as fh:
+            raw = fh.read()
+    except Exception:
+        return set()
+
+    text = _strip_cstyle_comments(raw)
+    names: Set[str] = set()
+
+    # Walk sprite-type block openers and extract the name inside each block.
+    for m in _GFX_SPRITE_TYPES.finditer(text):
+        block_start = m.end()
+        block_end = _balance_braces(text, block_start)
+        if block_end is None:
+            # Fallback: scan remainder of line for name
+            line_end = text.find("\n", m.start())
+            snippet = text[
+                block_start : line_end if line_end != -1 else block_start + 200
+            ]
+        else:
+            snippet = text[block_start:block_end]
+        nm = _GFX_NAME.search(snippet)
+        if nm:
+            names.add(nm.group(1))
+
+    return names
+
+
+def _parse_gui_file(
+    filepath: str,
+) -> List[Tuple[str, str, int]]:
+    """Return list of (sprite_name, rel_filepath, line_number) from a .gui file."""
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as fh:
+            raw = fh.read()
+    except Exception:
+        return []
+
+    text = _strip_cstyle_comments(raw)
+    results = []
+    for m in _GUI_REF.finditer(text):
+        sprite = m.group(2)
+        if _is_dynamic(sprite):
+            continue
+        line = raw.count("\n", 0, m.start()) + 1
+        results.append((sprite, filepath, line))
+    return results
+
+
+def _parse_sgui_file(
+    filepath: str,
+) -> List[Tuple[str, str, int]]:
+    """Return list of (sprite_name, rel_filepath, line_number) from a scripted_gui .txt file."""
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as fh:
+            raw = fh.read()
+    except Exception:
+        return []
+
+    # scripted_gui .txt files use # comments (Clausewitz script style)
+    # but the image = "GFX_xxx" attribute pattern is the same.
+    # We don't strip # comments here to avoid stripping scripted loc keys
+    # that start with # — just use raw text.
+    results = []
+    for m in _SGUI_IMAGE_REF.finditer(raw):
+        sprite = m.group(1)
+        if _is_dynamic(sprite):
+            continue
+        line = raw.count("\n", 0, m.start()) + 1
+        results.append((sprite, filepath, line))
+    return results
+
+
+def _parse_sloc_file(
+    filepath: str,
+) -> List[Tuple[str, str, int]]:
+    """Return list of (sprite_name, rel_filepath, line_number) from a scripted_localisation .txt file."""
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as fh:
+            raw = fh.read()
+    except Exception:
+        return []
+
+    results = []
+    for m in _SLOC_KEY_REF.finditer(raw):
+        sprite = m.group(1)
+        if _is_dynamic(sprite):
+            continue
+        line = raw.count("\n", 0, m.start()) + 1
+        results.append((sprite, filepath, line))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+class GfxReferenceValidator(BaseValidator):
+    TITLE = "GFX SPRITE REFERENCE VALIDATION"
+    STAGED_EXTENSIONS = [".gui", ".gfx", ".txt"]
+
+    def __init__(self, mod_path: str, **kwargs):
+        super().__init__(mod_path, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Build phases
+    # ------------------------------------------------------------------
+
+    def _build_gfx_definitions(self) -> Set[str]:
+        """Scan all interface/*.gfx and return the complete set of GFX sprite names."""
+        self._log_section("Building GFX sprite definition set")
+        # Always scan the full repo — definitions must come from anywhere.
+        gfx_files = self._collect_files(["interface/*.gfx"], ignore_staged=True)
+        results = self._pool_map(_parse_gfx_file, gfx_files)
+        defined: Set[str] = set()
+        for s in results:
+            defined.update(s)
+        self.log(
+            f"  Found {len(defined)} GFX sprite names across {len(gfx_files)} .gfx files"
+        )
+        return defined
+
+    def _collect_gui_refs(self, defined: Set[str]) -> List[Tuple[str, str, int]]:
+        """Return undefined GUI sprite references from interface/*.gui files."""
+        self._log_section("Collecting GFX references from interface/*.gui files")
+        gui_files = self._collect_files(["interface/*.gui"])
+        all_refs: List[Tuple[str, str, int]] = []
+        for batch in self._pool_map(_parse_gui_file, gui_files):
+            all_refs.extend(batch)
+        self.log(
+            f"  Scanned {len(gui_files)} .gui files; found {len(all_refs)} GFX references"
+        )
+        return all_refs
+
+    def _collect_sgui_refs(self, defined: Set[str]) -> List[Tuple[str, str, int]]:
+        """Return undefined image= references from common/scripted_guis/*.txt."""
+        self._log_section("Collecting GFX image= references from scripted_guis/*.txt")
+        sgui_files = self._collect_files(["common/scripted_guis/*.txt"])
+        all_refs: List[Tuple[str, str, int]] = []
+        for batch in self._pool_map(_parse_sgui_file, sgui_files):
+            all_refs.extend(batch)
+        self.log(
+            f"  Scanned {len(sgui_files)} scripted_gui files; found {len(all_refs)} GFX image= references"
+        )
+        return all_refs
+
+    def _collect_sloc_refs(self, defined: Set[str]) -> List[Tuple[str, str, int]]:
+        """Return GFX references from common/scripted_localisation/*.txt."""
+        self._log_section(
+            "Collecting GFX localization_key= references from scripted_localisation/*.txt"
+        )
+        sloc_files = self._collect_files(["common/scripted_localisation/*.txt"])
+        all_refs: List[Tuple[str, str, int]] = []
+        for batch in self._pool_map(_parse_sloc_file, sloc_files):
+            all_refs.extend(batch)
+        self.log(
+            f"  Scanned {len(sloc_files)} scripted_localisation files; found {len(all_refs)} GFX references"
+        )
+        return all_refs
+
+    # ------------------------------------------------------------------
+    # Check phases
+    # ------------------------------------------------------------------
+
+    def _check_undefined_refs(
+        self,
+        refs: List[Tuple[str, str, int]],
+        defined: Set[str],
+        source_label: str,
+        category: str,
+        gui_mode: bool = False,
+    ) -> None:
+        """Report any sprite names in refs that are not in defined.
+
+        When gui_mode is True, .gui files that are vanilla overrides (not
+        MD-authored) are reported as WARNINGs rather than ERRORs, because
+        those files legitimately reference vanilla sprites the mod doesn't
+        redefine. MD-authored .gui files and all scripted_gui/.txt files
+        get ERROR severity.
+        """
+        errors: List[Tuple[str, str, int]] = []
+        warnings: List[Tuple[str, str, int]] = []
+        seen: Set[Tuple[str, str, int]] = set()
+
+        for sprite, filepath, line in refs:
+            if sprite in defined:
+                continue
+            if _is_flag_sprite(sprite):
+                continue
+            if _is_likely_vanilla(sprite):
+                continue
+            rel = os.path.relpath(filepath, self.mod_path)
+            key = (sprite, rel, line)
+            if key in seen:
+                continue
+            seen.add(key)
+            entry = (f"Undefined sprite '{sprite}'", rel, line)
+            if gui_mode and not _is_md_gui_file(filepath):
+                warnings.append(entry)
+            else:
+                errors.append(entry)
+
+        self._report(
+            errors,
+            ok_msg=f"All MD-authored {source_label} GFX sprite references are defined.",
+            fail_msg=f"Undefined GFX sprite references in MD-authored {source_label}:",
+            severity=Severity.ERROR,
+            category=category,
+        )
+        if warnings:
+            self._report(
+                warnings,
+                ok_msg=f"All vanilla-override {source_label} GFX sprite references are defined.",
+                fail_msg=(
+                    f"Undefined GFX sprite references in vanilla-override {source_label} "
+                    f"(likely vanilla sprites not redefined in MD — expected):"
+                ),
+                severity=Severity.WARNING,
+                category=category + "-vanilla",
+            )
+
+    def _check_unused_sprites(
+        self,
+        defined: Set[str],
+        all_refs: Set[str],
+    ) -> None:
+        """Report GFX sprites that are defined but never referenced (warning only).
+
+        Skipped entirely in staged mode to avoid noise — this check needs a
+        full-repo scan to be meaningful, but in staged mode we only see a
+        subset of files.
+        """
+        self._log_section("Checking for unused GFX sprite definitions")
+        if self.staged_only:
+            self.log("  Skipping unused-sprite check in staged mode.")
+            return
+
+        unused = sorted(
+            s
+            for s in defined
+            if s not in all_refs
+            and not _is_flag_sprite(s)
+            and not _is_likely_vanilla(s)
+        )
+
+        if not unused:
+            self.log(
+                f"{Colors.GREEN if self.use_colors else ''}  All defined GFX sprites are referenced.{Colors.ENDC if self.use_colors else ''}"
+            )
+            return
+
+        display = unused[:_UNUSED_SPRITE_LIMIT]
+        remainder = len(unused) - len(display)
+
+        issues = [
+            (f"Unused GFX sprite '{s}' (defined but never referenced)", "", 0)
+            for s in display
+        ]
+        if remainder > 0:
+            issues.append(
+                (
+                    f"... and {remainder} more unused sprites (run without --staged to see all)",
+                    "",
+                    0,
+                )
+            )
+
+        self._report(
+            issues,
+            ok_msg="All defined GFX sprites are referenced.",
+            fail_msg=f"Unused GFX sprite definitions ({len(unused)} total; first {_UNUSED_SPRITE_LIMIT} shown):",
+            severity=Severity.WARNING,
+            category="unused-sprite",
+        )
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run_validations(self) -> None:
+        # Phase 1: build the complete definition set (always full-repo scan)
+        defined = self._build_gfx_definitions()
+
+        # Phase 2: collect all references from the (possibly staged) files
+        gui_refs = self._collect_gui_refs(defined)
+        sgui_refs = self._collect_sgui_refs(defined)
+        sloc_refs = self._collect_sloc_refs(defined)
+
+        # Phase 3: cross-reference checks
+        self._log_section("Checking undefined GFX sprite references in .gui files")
+        self._check_undefined_refs(
+            gui_refs,
+            defined,
+            source_label=".gui files",
+            category="undefined-sprite",
+            gui_mode=True,
+        )
+
+        self._log_section("Checking undefined GFX sprite references in scripted_guis")
+        self._check_undefined_refs(
+            sgui_refs,
+            defined,
+            source_label="scripted_guis",
+            category="undefined-sprite",
+        )
+
+        self._log_section(
+            "Checking undefined GFX sprite references in scripted_localisation"
+        )
+        self._check_undefined_refs(
+            sloc_refs,
+            defined,
+            source_label="scripted_localisation",
+            category="undefined-sprite",
+        )
+
+        # Phase 4: unused sprites (full-repo only)
+        all_referenced: Set[str] = {r[0] for r in gui_refs + sgui_refs + sloc_refs}
+        self._check_unused_sprites(defined, all_referenced)
+
+
+def main() -> int:
+    return run_validator_main(
+        GfxReferenceValidator,
+        description="Validate GFX sprite references in Millennium Dawn mod.",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validation/validate_modifiers.py
+++ b/tools/validation/validate_modifiers.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+##########################
+# Modifier Name Validation Script
+# Validates modifier names used inside modifier = { } blocks in Millennium Dawn
+# Checks for:
+#   1. Unknown modifier names (not seen 3+ times across the codebase)
+#   2. Possible typos (single-occurrence names that don't match known-good patterns)
+#
+# Approach: build a known-good set from codebase frequency (3+ uses = valid).
+# Custom MD modifiers in common/modifiers/ and common/dynamic_modifiers/ are
+# always valid. Single-use names that start with md_ or MD_ are also valid.
+# Targeted modifiers (XXX_opinion, XXX_autonomy_gain) are skipped.
+##########################
+import os
+import re
+import sys
+from collections import Counter
+from typing import Dict, FrozenSet, List, Set, Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from validator_common import (
+    BaseValidator,
+    FileOpener,
+    Severity,
+    run_validator_main,
+    should_skip_file,
+)
+
+# ---------------------------------------------------------------------------
+# Keys that can appear inside modifier = { } blocks but are NOT modifier names
+# ---------------------------------------------------------------------------
+
+# These are HOI4 structural / ai-weight / targeted-modifier keys that appear
+# inside blocks named "modifier" but carry no game-modifier meaning.
+_NON_MODIFIER_KEYS: FrozenSet[str] = frozenset(
+    {
+        # AI weight modifier fields
+        "factor",
+        "base",
+        "add",
+        # Structural keys
+        "tag",
+        "scope",
+        "days",
+        "value",
+        "icon",
+        "enable",
+        "remove_trigger",
+        "var",
+        "compare",
+        # HOI4 logic blocks (can nest inside modifier)
+        "if",
+        "else",
+        "else_if",
+        "AND",
+        "OR",
+        "NOT",
+        "limit",
+    }
+)
+
+# Keys whose block-level usage means the enclosing modifier = {} is an
+# ai_will_do-style weight modifier, not a game modifier block.
+# We detect these by looking for them as the FIRST assignment key in the block.
+_AI_WEIGHT_INDICATOR_KEYS: FrozenSet[str] = frozenset({"factor", "base", "add"})
+
+# Keys that introduce sub-blocks we should skip when looking for modifier names
+_SKIP_BLOCK_KEYS: FrozenSet[str] = frozenset(
+    {
+        "targeted_modifier",
+        "equipment_bonus",
+        "research_bonus",
+        "ai_will_do",
+        "ai_research_weights",
+    }
+)
+
+# Regex patterns for skipping obviously parametric / targeted modifier entries
+# e.g. TAG_opinion, TAG_autonomy_gain, TAG_acceptance where TAG is a 3-letter tag.
+_TARGETED_MODIFIER_RE = re.compile(r"^[A-Z]{2,3}_[a-z]")
+
+# A modifier name is lowercase with underscores (and optionally digits).
+# Some MD custom modifiers use mixed case (e.g. MD_something) — allow those.
+_MODIFIER_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$|^[A-Z][A-Za-z0-9_]*$")
+
+# Minimum frequency threshold for a modifier name to be "known good"
+_FREQUENCY_THRESHOLD = 3
+
+
+def _extract_modifier_blocks(text: str) -> List[Tuple[int, str]]:
+    """Extract the body text and start line of each top-level modifier = { } block.
+
+    Returns a list of (line_number, block_body) tuples.
+    Skips modifier blocks that are clearly AI weight blocks (first non-empty
+    key is factor/base/add followed by a trigger condition, not a number-only
+    value that a pure game modifier would have).
+
+    Only returns blocks that are NOT inside ai_will_do, ai_research_weights,
+    targeted_modifier, equipment_bonus, or research_bonus parents.
+    """
+    results: List[Tuple[int, str]] = []
+    i = 0
+    n = len(text)
+
+    # Track contextual depth — when we're inside a skip-block, don't harvest
+    # modifier blocks from within it.
+    skip_depth_stack: List[int] = []  # stack of depths at which skip-blocks started
+    current_depth = 0
+
+    lines = text.split("\n")
+    # Build a cumulative-offset table so we can map char offset → line number
+    cum_offsets: List[int] = []
+    off = 0
+    for line in lines:
+        cum_offsets.append(off)
+        off += len(line) + 1  # +1 for \n
+
+    def char_to_lineno(pos: int) -> int:
+        lo, hi = 0, len(cum_offsets) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if cum_offsets[mid] <= pos:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo + 1  # 1-based
+
+    # Tokenise the text into assignment-like tokens and braces.
+    # We walk character by character tracking brace depth.
+    i = 0
+    current_depth = 0
+    in_string = False
+
+    while i < n:
+        ch = text[i]
+
+        if ch == '"':
+            in_string = not in_string
+            i += 1
+            continue
+
+        if in_string:
+            i += 1
+            continue
+
+        if ch == "{":
+            current_depth += 1
+            i += 1
+            continue
+
+        if ch == "}":
+            if skip_depth_stack and current_depth == skip_depth_stack[-1]:
+                skip_depth_stack.pop()
+            current_depth -= 1
+            i += 1
+            continue
+
+        # Look for `WORD = {` patterns
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < n and (text[j].isalnum() or text[j] == "_"):
+                j += 1
+            word = text[i:j]
+            # Skip whitespace after word
+            k = j
+            while k < n and text[k] in " \t":
+                k += 1
+            if k < n and text[k] == "=":
+                k += 1
+                while k < n and text[k] in " \t":
+                    k += 1
+                if k < n and text[k] == "{":
+                    # This is a WORD = { block
+                    if word in _SKIP_BLOCK_KEYS:
+                        # Mark depth at which this skip-block opens
+                        # The { hasn't been counted yet, so after we pass it
+                        # depth becomes current_depth + 1
+                        skip_depth_stack.append(current_depth + 1)
+                    elif word == "modifier" and not skip_depth_stack:
+                        # This is a modifier = { block we care about
+                        block_lineno = char_to_lineno(i)
+                        # Extract the block body
+                        body_start = k + 1
+                        depth = 1
+                        p = body_start
+                        in_str2 = False
+                        while p < n and depth > 0:
+                            c = text[p]
+                            if c == '"':
+                                in_str2 = not in_str2
+                            elif not in_str2:
+                                if c == "{":
+                                    depth += 1
+                                elif c == "}":
+                                    depth -= 1
+                            p += 1
+                        body = text[body_start : p - 1]
+                        results.append((block_lineno, body))
+                        i = p
+                        continue
+            i = j
+            continue
+
+        i += 1
+
+    return results
+
+
+def _is_ai_weight_block(body: str) -> bool:
+    """Return True if this modifier block body looks like an AI weight modifier.
+
+    AI weight modifier blocks (inside ai_will_do, random_list, etc.) contain
+    ``factor``, ``base``, or ``add`` as a key. Game modifier blocks contain
+    only modifier_name = <number> lines. If either of those indicator keys
+    appears anywhere in the block, it is an AI weight block.
+
+    Also flags blocks whose first key has a non-numeric value (trigger conditions
+    like ``has_idea``, ``OR = {``, comparison operators) — these are always weight
+    blocks even if factor/base/add hasn't been seen yet.
+    """
+    # Quick check: if any AI weight indicator key appears in the raw body text
+    # as a standalone token, treat this as an AI weight block.
+    # This handles cases like:  has_decision = X \n factor = 1.25
+    for indicator in _AI_WEIGHT_INDICATOR_KEYS:
+        # Look for `factor =`, `base =`, `add =` as standalone assignments
+        if re.search(r"\b" + indicator + r"\s*=", body):
+            return True
+
+    # Also flag blocks whose first non-comment key has a non-numeric value
+    for line in body.split("\n"):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)", stripped)
+        if m:
+            val = m.group(2).strip()
+            # Non-numeric values (trigger conditions, booleans, block openers)
+            if val.startswith("{") or any(op in val for op in ("<", ">", "yes", "no")):
+                return True
+        break
+    return False
+
+
+def _extract_modifier_names_from_body(body: str) -> List[str]:
+    """Extract modifier key names from a modifier block body.
+
+    Skips:
+    - Lines that open sub-blocks (key = { ... })
+    - Non-modifier structural keys (factor, base, tag, icon, etc.)
+    - Targeted modifier entries (XXX_opinion where XXX is a country tag)
+    - Anything that doesn't look like a valid modifier name
+    """
+    names: List[str] = []
+    # Only look at top-level keys in the body (depth 0)
+    depth = 0
+    in_string = False
+    lines = body.split("\n")
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        # Track depth changes
+        opens = stripped.count("{") - stripped.count("}")
+        # Check if this line opens a sub-block — skip the key itself
+        if "{" in stripped:
+            depth += opens
+            continue
+        if "}" in stripped:
+            depth += opens  # opens is negative here
+            continue
+
+        if depth != 0:
+            continue
+
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=", stripped)
+        if not m:
+            continue
+        key = m.group(1)
+
+        if key in _NON_MODIFIER_KEYS:
+            continue
+        if _TARGETED_MODIFIER_RE.match(key):
+            continue
+        if not _MODIFIER_NAME_RE.match(key):
+            continue
+
+        names.append(key)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Pool workers (module-level for pickling)
+# ---------------------------------------------------------------------------
+
+
+def _harvest_modifiers_from_file(filepath: str) -> List[str]:
+    """Pool worker: extract all modifier names from a single file.
+
+    Used for building the known-good frequency table.
+    """
+    if should_skip_file(filepath):
+        return []
+    text = FileOpener.open_text_file(
+        filepath, lowercase=False, strip_comments_flag=True
+    )
+    if not text or "modifier" not in text:
+        return []
+
+    names: List[str] = []
+    for _lineno, body in _extract_modifier_blocks(text):
+        if _is_ai_weight_block(body):
+            continue
+        names.extend(_extract_modifier_names_from_body(body))
+    return names
+
+
+def _harvest_flat_modifiers_from_traits_file(filepath: str) -> List[str]:
+    """Pool worker: extract top-level modifier keys from traits files.
+
+    Traits files (common/country_leader/*.txt, common/characters/*.txt) often
+    place modifier keys directly at the trait body level (not in modifier = {}).
+    We harvest these to supplement the known-good set.
+    """
+    if should_skip_file(filepath):
+        return []
+    text = FileOpener.open_text_file(
+        filepath, lowercase=False, strip_comments_flag=True
+    )
+    if not text:
+        return []
+
+    # Collect keys that appear at depth 2 (inside leader_traits = { trait = { KEY = VAL } })
+    # We do a simple heuristic: any `[a-z_]+ = <number>` at exactly 2 braces deep.
+    names: List[str] = []
+    depth = 0
+    in_string = False
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        opens = stripped.count("{")
+        closes = stripped.count("}")
+        new_depth = depth + opens - closes
+        # At depth 2 we're inside a trait body
+        if depth == 2 and opens == 0 and closes == 0:
+            m = re.match(r"^([a-z][a-z0-9_]*)\s*=\s*(-?[0-9])", stripped)
+            if m:
+                key = m.group(1)
+                if key not in _NON_MODIFIER_KEYS and _MODIFIER_NAME_RE.match(key):
+                    names.append(key)
+        depth = new_depth
+    return names
+
+
+def _check_file_for_unknown_modifiers(
+    args: Tuple[str, FrozenSet[str], str],
+) -> List[Tuple[str, str, int]]:
+    """Pool worker: find unknown modifier names in a single file.
+
+    Returns a list of (modifier_name, rel_path, line_number) tuples.
+    """
+    filepath, known_good, mod_path = args
+    if should_skip_file(filepath):
+        return []
+    text = FileOpener.open_text_file(
+        filepath, lowercase=False, strip_comments_flag=True
+    )
+    if not text or "modifier" not in text:
+        return []
+
+    results: List[Tuple[str, str, int]] = []
+    rel = os.path.relpath(filepath, mod_path)
+
+    for lineno, body in _extract_modifier_blocks(text):
+        if _is_ai_weight_block(body):
+            continue
+        for name in _extract_modifier_names_from_body(body):
+            if name not in known_good:
+                results.append((name, rel, lineno))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Validator class
+# ---------------------------------------------------------------------------
+
+
+class Validator(BaseValidator):
+    TITLE = "MODIFIER NAME VALIDATION"
+    STAGED_EXTENSIONS = [".txt"]
+
+    # Source directories for harvesting the known-good modifier set.
+    # Always scanned in full regardless of staged mode.
+    _HARVEST_PATTERNS: List[str] = [
+        "common/ideas/**/*.txt",
+        "common/national_focus/**/*.txt",
+        "common/country_leader/**/*.txt",
+        "common/characters/**/*.txt",
+        "common/dynamic_modifiers/**/*.txt",
+        "common/modifiers/**/*.txt",
+        "common/opinion_modifiers/**/*.txt",
+    ]
+
+    # Explicit modifier definition directories — every top-level key is a valid
+    # modifier name regardless of usage frequency.
+    _DEFINITION_PATTERNS: List[str] = [
+        "common/modifiers/**/*.txt",
+        "common/dynamic_modifiers/**/*.txt",
+        "common/modifier_definitions/**/*.txt",
+    ]
+
+    # Source patterns for validation targets
+    _VALIDATE_PATTERNS: List[str] = [
+        "common/ideas/**/*.txt",
+        "common/national_focus/**/*.txt",
+        "common/dynamic_modifiers/**/*.txt",
+        "common/decisions/**/*.txt",
+    ]
+
+    def __init__(self, mod_path: str, **kwargs):
+        super().__init__(mod_path, **kwargs)
+
+    def _build_known_good_set(self) -> FrozenSet[str]:
+        """Scan the codebase to build a frequency table of modifier names.
+
+        Names that appear 3+ times across all source files are considered
+        "known good". Names from custom MD modifier definition files are
+        always added regardless of frequency.
+
+        Returns a frozenset of known-good modifier names.
+        """
+        self.log("  Building known-good modifier set from codebase...")
+
+        # Always scan the full codebase for the reference set
+        saved = self.staged_only
+        self.staged_only = False
+        harvest_files = self._collect_files(self._HARVEST_PATTERNS)
+        self.staged_only = saved
+
+        self.log(f"  Harvesting from {len(harvest_files)} files...")
+
+        # Traits files use flat modifier keys, not modifier = {} blocks
+        traits_files = [
+            f for f in harvest_files if "country_leader" in f or "characters" in f
+        ]
+        other_files = [f for f in harvest_files if f not in set(traits_files)]
+
+        all_names: List[str] = []
+
+        # Harvest modifier = {} blocks from main files
+        block_results = self._pool_map(
+            _harvest_modifiers_from_file, other_files, chunksize=50
+        )
+        for batch in block_results:
+            all_names.extend(batch)
+
+        # Harvest flat keys from traits files
+        trait_results = self._pool_map(
+            _harvest_flat_modifiers_from_traits_file, traits_files, chunksize=50
+        )
+        for batch in trait_results:
+            all_names.extend(batch)
+
+        freq = Counter(all_names)
+        known_good: Set[str] = {
+            name for name, count in freq.items() if count >= _FREQUENCY_THRESHOLD
+        }
+
+        # Also collect names explicitly defined in modifier definition files
+        # (common/modifiers/, common/dynamic_modifiers/, common/modifier_definitions/).
+        # These are always valid regardless of frequency.
+        definition_files = self._collect_files(
+            self._DEFINITION_PATTERNS,
+            ignore_staged=True,
+        )
+        def_name_re = re.compile(r"^\s*([a-z][a-z0-9_]*)\s*=\s*", re.MULTILINE)
+        for filepath in definition_files:
+            try:
+                with open(filepath, encoding="utf-8-sig") as fh:
+                    content = fh.read()
+            except Exception:
+                continue
+            # In modifier definition files, top-level keys ARE modifier names
+            # (they appear inside a named block like weather_rain = { KEY = val })
+            for m in def_name_re.finditer(content):
+                key = m.group(1)
+                if key not in _NON_MODIFIER_KEYS and _MODIFIER_NAME_RE.match(key):
+                    known_good.add(key)
+
+        self.log(
+            f"  Known-good modifier set: {len(known_good)} names "
+            f"(from {len(freq)} total harvested, threshold={_FREQUENCY_THRESHOLD})"
+        )
+        return frozenset(known_good)
+
+    def validate_modifier_names(self, known_good: FrozenSet[str]):
+        """Check modifier blocks in idea/focus/decision/dynamic_modifier files."""
+        self._log_section("Checking modifier names in ideas, focuses, and decisions...")
+
+        target_files = self._collect_files(self._VALIDATE_PATTERNS)
+        self.log(f"  Checking {len(target_files)} files...")
+
+        args_list = [(f, known_good, self.mod_path) for f in target_files]
+        raw_results = self._pool_map(
+            _check_file_for_unknown_modifiers, args_list, chunksize=30
+        )
+
+        # Collect and deduplicate
+        seen: Set[Tuple[str, str, int]] = set()
+        unknown_errors: List[Tuple[str, str, int]] = []
+
+        for batch in raw_results:
+            for name, rel, lineno in batch:
+                key = (name, rel, lineno)
+                if key in seen:
+                    continue
+                seen.add(key)
+                # Modifiers prefixed with MD_ or md_ are always valid (custom MD)
+                if name.startswith("MD_") or name.startswith("md_"):
+                    continue
+                unknown_errors.append((name, rel, lineno))
+
+        # Format for _report: (message, file, line)
+        formatted = [
+            (f"Unknown modifier '{name}'", rel, lineno)
+            for name, rel, lineno in sorted(unknown_errors, key=lambda x: (x[1], x[2]))
+        ]
+
+        self._report(
+            formatted,
+            "No unknown modifier names found",
+            "Unknown modifier names (compile silently, do nothing in-game):",
+            severity=Severity.WARNING,
+            category="unknown-modifier",
+        )
+
+    def run_validations(self):
+        known_good = self._build_known_good_set()
+        self.validate_modifier_names(known_good)
+
+
+if __name__ == "__main__":
+    run_validator_main(
+        Validator,
+        "Validate modifier names in Millennium Dawn mod",
+    )

--- a/tools/validation/validate_on_actions.py
+++ b/tools/validation/validate_on_actions.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+##########################
+# on_actions Reference Validation Script
+# Validates event references in on_actions files against defined event IDs
+# Checks for:
+#   1. Missing event references (event fired in on_actions but not defined)
+#   2. Non-triggered-only events referenced in on_actions (MTTH may double-fire)
+#   3. Duplicate event references within the same on_action trigger block
+##########################
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from validator_common import (
+    BaseValidator,
+    FileOpener,
+    Severity,
+    run_validator_main,
+    should_skip_file,
+)
+
+# ---------------------------------------------------------------------------
+# Regex patterns (module-level for pool workers)
+# ---------------------------------------------------------------------------
+
+# Declared namespaces: add_namespace = foo
+_ADD_NAMESPACE_RE = re.compile(r"^\s*add_namespace\s*=\s*(\S+)", re.MULTILINE)
+
+# Top-level event block openers (country_event, news_event, state_event, …).
+# Allow optional leading whitespace — some files indent the top-level blocks
+# with a tab (e.g. agricultural_events.txt).
+_EVENT_BLOCK_OPEN_RE = re.compile(
+    r"^[ \t]*(country_event|news_event|state_event|unit_leader_event|operative_leader_event)\s*=\s*\{",
+    re.MULTILINE,
+)
+
+# id = XXX.N inside an event block body
+_EVENT_ID_IN_BODY_RE = re.compile(r"^\s*id\s*=\s*(\S+)", re.MULTILINE)
+
+# is_triggered_only inside an event block body
+_TRIGGERED_ONLY_RE = re.compile(r"\bis_triggered_only\s*=\s*yes\b")
+
+# random_events = { ... } block opener
+_RANDOM_EVENTS_BLOCK_RE = re.compile(r"\brandom_events\s*=\s*\{")
+
+# numeric weight = event_id inside a random_events body (e.g. `50 = econvent.1`)
+# The event ID must contain a dot.
+_RANDOM_EVENT_ENTRY_RE = re.compile(r"\b\d+\s*=\s*([A-Za-z_]\w*\.[A-Za-z0-9_.]+)")
+
+# Long-form event call: country_event = { id = foo.1 ... }
+_LONG_FORM_EVENT_RE = re.compile(
+    r"\b(?:country_event|news_event|state_event|unit_leader_event|operative_leader_event)"
+    r"\s*=\s*\{\s*id\s*=\s*([A-Za-z_]\w*\.[A-Za-z0-9_.]+)",
+    re.DOTALL,
+)
+
+# Short-form event call: country_event = foo.1
+_SHORT_FORM_EVENT_RE = re.compile(
+    r"\b(?:country_event|news_event|state_event|unit_leader_event|operative_leader_event)"
+    r"\s*=\s*([A-Za-z_]\w*\.[A-Za-z0-9_.]+)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Pool workers (module-level so multiprocessing can pickle them)
+# ---------------------------------------------------------------------------
+
+
+def _scan_event_file(filepath: str) -> Tuple[Set[str], Set[str]]:
+    """Return (defined_ids, triggered_only_ids) from a single events/*.txt file."""
+    defined_ids: Set[str] = set()
+    triggered_only_ids: Set[str] = set()
+
+    try:
+        text = Path(filepath).read_text(encoding="utf-8-sig", errors="ignore")
+    except Exception:
+        return defined_ids, triggered_only_ids
+
+    # Strip comments
+    text = re.sub(r"#[^\n]*", "", text)
+
+    for m in _EVENT_BLOCK_OPEN_RE.finditer(text):
+        start = m.end()
+        depth = 1
+        i = start
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        body = text[start : i - 1]
+
+        id_match = _EVENT_ID_IN_BODY_RE.search(body)
+        if not id_match:
+            continue
+        eid = id_match.group(1)
+        defined_ids.add(eid)
+        if _TRIGGERED_ONLY_RE.search(body):
+            triggered_only_ids.add(eid)
+
+    return defined_ids, triggered_only_ids
+
+
+def _extract_random_events_ids(text: str) -> Set[str]:
+    """Return all event IDs found inside random_events = { ... } blocks."""
+    ids: Set[str] = set()
+    for m in _RANDOM_EVENTS_BLOCK_RE.finditer(text):
+        start = m.end()
+        depth = 1
+        i = start
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        body = text[start : i - 1]
+        for entry in _RANDOM_EVENT_ENTRY_RE.finditer(body):
+            ids.add(entry.group(1))
+    return ids
+
+
+def _scan_on_action_block(text: str, block_name: str, filepath: str) -> Tuple[
+    List[Tuple[str, str, int]],  # (event_id, on_action_name, line_number)
+    List[Tuple[str, str, int]],  # duplicates: (event_id, on_action_name, line_number)
+]:
+    """Extract all event references from a single on_action trigger block body.
+
+    Returns (references, duplicates) where each entry is
+    (event_id, block_name, line_number_in_file).
+    """
+    refs: List[Tuple[str, str, int]] = []
+    duplicates: List[Tuple[str, str, int]] = []
+    seen: Set[str] = set()
+
+    def _line_of(pos: int) -> int:
+        return text[:pos].count("\n") + 1
+
+    # Collect random_events entries
+    for m in _RANDOM_EVENTS_BLOCK_RE.finditer(text):
+        start = m.end()
+        depth = 1
+        i = start
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        body = text[start : i - 1]
+        body_offset = start
+        for entry in _RANDOM_EVENT_ENTRY_RE.finditer(body):
+            eid = entry.group(1)
+            line = _line_of(body_offset + entry.start())
+            if eid in seen:
+                duplicates.append((eid, block_name, line))
+            else:
+                seen.add(eid)
+                refs.append((eid, block_name, line))
+
+    # Collect long-form calls
+    for m in _LONG_FORM_EVENT_RE.finditer(text):
+        eid = m.group(1)
+        line = _line_of(m.start())
+        if eid in seen:
+            duplicates.append((eid, block_name, line))
+        else:
+            seen.add(eid)
+            refs.append((eid, block_name, line))
+
+    # Collect short-form calls — but only when the match isn't already inside a
+    # long-form call (the long-form pattern consumes the id= part, so a
+    # short-form match immediately following an event keyword and = is the
+    # actual token we want).
+    long_form_spans = {(m.start(), m.end()) for m in _LONG_FORM_EVENT_RE.finditer(text)}
+
+    def _in_long_form(pos: int) -> bool:
+        for start, end in long_form_spans:
+            if start <= pos < end:
+                return True
+        return False
+
+    for m in _SHORT_FORM_EVENT_RE.finditer(text):
+        if _in_long_form(m.start()):
+            continue
+        eid = m.group(1)
+        line = _line_of(m.start())
+        if eid in seen:
+            duplicates.append((eid, block_name, line))
+        else:
+            seen.add(eid)
+            refs.append((eid, block_name, line))
+
+    return refs, duplicates
+
+
+def _parse_on_actions_file(
+    filepath: str,
+) -> Tuple[
+    List[Tuple[str, str, int, str]],  # (event_id, block_name, line, relpath)
+    List[Tuple[str, str, int, str]],  # duplicates
+]:
+    """Parse a single on_actions file and return all event references."""
+    all_refs: List[Tuple[str, str, int, str]] = []
+    all_dupes: List[Tuple[str, str, int, str]] = []
+
+    try:
+        text = Path(filepath).read_text(encoding="utf-8-sig", errors="ignore")
+    except Exception:
+        return all_refs, all_dupes
+
+    relpath = filepath
+    # Strip comments
+    text_clean = re.sub(r"#[^\n]*", "", text)
+
+    # Locate the outer on_actions = { ... } wrapper and iterate on_action blocks
+    outer_re = re.compile(r"\bon_actions\s*=\s*\{")
+    trigger_open_re = re.compile(r"\b([A-Za-z_]\w*)\s*=\s*\{")
+
+    for outer_m in outer_re.finditer(text_clean):
+        # Find the body of the on_actions block
+        start = outer_m.end()
+        depth = 1
+        i = start
+        while i < len(text_clean) and depth > 0:
+            if text_clean[i] == "{":
+                depth += 1
+            elif text_clean[i] == "}":
+                depth -= 1
+            i += 1
+        outer_body = text_clean[start : i - 1]
+        outer_offset = start
+
+        # Each top-level key inside on_actions is an on_action trigger name
+        pos = 0
+        while pos < len(outer_body):
+            tm = trigger_open_re.search(outer_body, pos)
+            if not tm:
+                break
+            block_name = tm.group(1)
+            # Skip known HOI4 sub-blocks that aren't on_action names
+            if block_name in (
+                "effect",
+                "random_events",
+                "if",
+                "else",
+                "else_if",
+                "limit",
+                "AND",
+                "OR",
+                "NOT",
+                "hidden_effect",
+                "random_list",
+                "modifier",
+            ):
+                pos = tm.end()
+                continue
+
+            # Extract this trigger block's body
+            bstart = tm.end()
+            bdepth = 1
+            bi = bstart
+            while bi < len(outer_body) and bdepth > 0:
+                if outer_body[bi] == "{":
+                    bdepth += 1
+                elif outer_body[bi] == "}":
+                    bdepth -= 1
+                bi += 1
+            block_body = outer_body[bstart : bi - 1]
+
+            refs, dupes = _scan_on_action_block(
+                block_body,
+                block_name,
+                filepath,
+            )
+            # Adjust line numbers: outer_offset accounts for the on_actions = { header,
+            # and bstart for the trigger block's own header
+            body_line_base = text_clean[: outer_offset + bstart].count("\n")
+            for eid, bname, lno in refs:
+                all_refs.append((eid, bname, body_line_base + lno, relpath))
+            for eid, bname, lno in dupes:
+                all_dupes.append((eid, bname, body_line_base + lno, relpath))
+
+            pos = bi
+
+    return all_refs, all_dupes
+
+
+class Validator(BaseValidator):
+    TITLE = "ON_ACTIONS REFERENCE VALIDATION"
+    STAGED_EXTENSIONS = [".txt"]
+
+    def __init__(self, mod_path: str, **kwargs):
+        super().__init__(mod_path, **kwargs)
+        self._defined_ids_cache: Optional[Set[str]] = None
+        self._triggered_only_cache: Optional[Set[str]] = None
+
+    # ------------------------------------------------------------------
+    # Data collection
+    # ------------------------------------------------------------------
+
+    def _get_defined_event_ids(self) -> Tuple[Set[str], Set[str]]:
+        """Return (all_defined_ids, triggered_only_ids) from the full events tree.
+
+        Always scans the full repo (ignore_staged=True) so that on_actions
+        references can be resolved even when the event definition file itself
+        is not staged.
+        """
+        if self._defined_ids_cache is not None:
+            return self._defined_ids_cache, self._triggered_only_cache
+
+        event_files = self._collect_files(["events/**/*.txt"], ignore_staged=True)
+        results = self._pool_map(_scan_event_file, event_files, chunksize=20)
+
+        all_defined: Set[str] = set()
+        all_triggered: Set[str] = set()
+        for defined, triggered in results:
+            all_defined.update(defined)
+            all_triggered.update(triggered)
+
+        self._defined_ids_cache = all_defined
+        self._triggered_only_cache = all_triggered
+        return all_defined, all_triggered
+
+    def _get_on_actions_refs(self) -> Tuple[
+        List[Tuple[str, str, int, str]],
+        List[Tuple[str, str, int, str]],
+    ]:
+        """Return (all_references, all_duplicates) from on_actions files.
+
+        In staged mode, only scans staged on_actions files.
+        """
+        on_actions_files = self._collect_files(["common/on_actions/**/*.txt"])
+        all_refs: List[Tuple[str, str, int, str]] = []
+        all_dupes: List[Tuple[str, str, int, str]] = []
+
+        results = self._pool_map(_parse_on_actions_file, on_actions_files, chunksize=10)
+        for refs, dupes in results:
+            all_refs.extend(refs)
+            all_dupes.extend(dupes)
+
+        return all_refs, all_dupes
+
+    # ------------------------------------------------------------------
+    # Checks
+    # ------------------------------------------------------------------
+
+    def validate_missing_event_refs(self):
+        """Report event IDs referenced in on_actions that are not defined anywhere."""
+        self._log_section("Checking for missing event references in on_actions...")
+
+        all_defined, _ = self._get_defined_event_ids()
+        all_refs, _ = self._get_on_actions_refs()
+        self.log(
+            f"  Defined event IDs: {len(all_defined)}, on_actions references: {len(all_refs)}"
+        )
+
+        results = []
+        for eid, block_name, line, filepath in sorted(all_refs, key=lambda x: x[2]):
+            if eid not in all_defined:
+                relpath = os.path.relpath(filepath, self.mod_path)
+                results.append(
+                    (
+                        f"Undefined event '{eid}' referenced in on_action '{block_name}'",
+                        relpath,
+                        line,
+                    )
+                )
+
+        self._report(
+            results,
+            "All event references in on_actions are defined",
+            "on_actions references to undefined events (event will silently never fire):",
+            Severity.ERROR,
+            category="missing-event-ref",
+        )
+
+    def validate_non_triggered_on_action_refs(self):
+        """Warn when an on_actions reference points to an event without is_triggered_only.
+
+        Such events have a mean_time_to_happen block of their own, so they can
+        fire both on their MTTH schedule and from on_actions — almost always
+        unintended. Add is_triggered_only = yes to the event if on_actions is
+        the only intended trigger, or remove the on_actions reference.
+        """
+        self._log_section(
+            "Checking for on_actions references to non-triggered-only events..."
+        )
+
+        all_defined, triggered_only = self._get_defined_event_ids()
+        all_refs, _ = self._get_on_actions_refs()
+
+        results = []
+        for eid, block_name, line, filepath in sorted(all_refs, key=lambda x: x[2]):
+            if eid not in all_defined:
+                continue  # already reported by validate_missing_event_refs
+            if eid in triggered_only:
+                continue
+            relpath = os.path.relpath(filepath, self.mod_path)
+            results.append(
+                (
+                    f"Event '{eid}' in on_action '{block_name}' lacks is_triggered_only = yes"
+                    " (may also fire on its own MTTH)",
+                    relpath,
+                    line,
+                )
+            )
+
+        self._report(
+            results,
+            "All on_actions event references point to triggered-only events",
+            "on_actions references to events without is_triggered_only = yes"
+            " (event may double-fire from MTTH):",
+            Severity.WARNING,
+            category="non-triggered-on-action",
+        )
+
+    def validate_duplicate_event_refs(self):
+        """Warn when the same event ID appears more than once in the same on_action block."""
+        self._log_section(
+            "Checking for duplicate event references within on_action blocks..."
+        )
+
+        _, all_dupes = self._get_on_actions_refs()
+
+        results = []
+        for eid, block_name, line, filepath in sorted(all_dupes, key=lambda x: x[2]):
+            relpath = os.path.relpath(filepath, self.mod_path)
+            results.append(
+                (
+                    f"Duplicate event reference '{eid}' in on_action '{block_name}'",
+                    relpath,
+                    line,
+                )
+            )
+
+        self._report(
+            results,
+            "No duplicate event references within on_action blocks",
+            "Duplicate event references in on_action blocks (event may fire twice per trigger):",
+            Severity.WARNING,
+            category="duplicate-event-ref",
+        )
+
+    def run_validations(self):
+        self.validate_missing_event_refs()
+        self.validate_non_triggered_on_action_refs()
+        self.validate_duplicate_event_refs()
+
+
+if __name__ == "__main__":
+    run_validator_main(
+        Validator, "Validate on_actions event references in Millennium Dawn mod"
+    )

--- a/tools/validation/validate_scripted_params.py
+++ b/tools/validation/validate_scripted_params.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+##########################
+# Scripted Effect Parameter Validation Script
+# Validates that callers of documented scripted effects pass required temp variables.
+#
+# Checks:
+#   1. Auto-discover parameter contracts from scripted effect comment blocks and
+#      usage patterns in common/scripted_effects/*.txt
+#   2. Validate that each call site sets required temp variables before the call
+#      in the same or outer scope (temp vars set earlier in the scope chain are
+#      visible to callers at deeper non-scope-changing nesting)
+#   3. Warn on orphaned temp variable sets (set but no matching effect call anywhere
+#      in the same scope block)
+#   4. Warn on scope boundary violations (temp vars set inside a scope-changing
+#      block, e.g. random_other_country = { ... }, but the effect call is outside)
+##########################
+import glob
+import os
+import re
+from typing import Dict, List, Set, Tuple
+
+from validator_common import BaseValidator, Severity, run_validator_main, strip_comments
+
+# ---------------------------------------------------------------------------
+# Hardcoded contracts for well-documented effects.  Auto-discovery below fills
+# in additional contracts from "# Parameters:" comment blocks.
+# ---------------------------------------------------------------------------
+
+# Mapping: effect_name -> { "required": [...], "optional": [...] }
+HARDCODED_CONTRACTS: Dict[str, Dict[str, List[str]]] = {
+    "change_influence_percentage": {
+        "required": ["percent_change"],
+        "optional": ["tag_index", "influence_target"],
+    },
+    "change_domestic_influence_percentage": {
+        "required": ["percent_change"],
+        "optional": ["influencer_index"],
+    },
+    "change_current_influencer_index_percentage": {
+        "required": ["percent_change", "influencer_index"],
+        "optional": [],
+    },
+    "steal_from_party": {
+        "required": ["steal_party_index"],
+        "optional": [],
+    },
+    "remove_coalition_members_effect": {
+        "required": ["remove_col_one"],
+        "optional": [],
+    },
+    "modify_missile_inventory_count": {
+        "required": ["missile_index", "missile_count"],
+        "optional": ["missile_type"],
+    },
+    "change_arab_spring_strength": {
+        "required": ["temp_strength"],
+        "optional": [],
+    },
+    "add_hydroelectric_energy_production_effect": {
+        "required": ["electric_addition", "storage_addition"],
+        "optional": [],
+    },
+    "get_pol_distance": {
+        "required": ["pol_dist_target_index", "pol_dist_source_index"],
+        "optional": [],
+    },
+    "configure_religious_setup": {
+        "required": ["nation_to_copy_from"],
+        "optional": [],
+    },
+    "set_elections_with_frequency": {
+        "required": ["election_freq"],
+        "optional": ["election_year_param", "election_month_param"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Keywords that introduce a new scripting scope (country/state/leader scopes).
+# When a temp variable is set inside one of these blocks it is local to that
+# scope and NOT available in the parent scope after the block closes.
+# ---------------------------------------------------------------------------
+SCOPE_CHANGING_KEYWORDS: Set[str] = {
+    "every_country",
+    "random_country",
+    "every_possible_country",
+    "random_possible_country",
+    "every_other_country",
+    "random_other_country",
+    "every_allied_country",
+    "random_allied_country",
+    "every_enemy_country",
+    "random_enemy_country",
+    "every_neighbor_country",
+    "random_neighbor_country",
+    "every_occupied_country",
+    "random_occupied_country",
+    "every_country_with_original_tag",
+    "random_country_with_original_tag",
+    "every_state",
+    "random_state",
+    "every_owned_state",
+    "random_owned_state",
+    "every_army_leader",
+    "random_army_leader",
+    "every_navy_leader",
+    "random_navy_leader",
+    "every_unit_leader",
+    "random_unit_leader",
+    "capital_scope",
+    "owner",
+    "controller",
+    "overlord",
+    "faction_leader",
+    "ROOT",
+    "PREV",
+    "FROM",
+    "var",  # var:X = { } scope
+    "for_each_scope_loop",
+    "while_loop_effect",
+    "for_loop_effect",
+    "for_each_loop",
+}
+
+# Regex patterns
+_SET_TEMP_RE = re.compile(
+    r"\bset_temp_variable\s*=\s*\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=",
+)
+_CALL_RE = re.compile(r"\b([a-z][a-z0-9_]*)\s*=\s*yes\b")
+_KW_OPEN_RE = re.compile(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*\{")
+
+
+def _parse_effect_contracts_from_file(
+    filepath: str,
+) -> Dict[str, Dict[str, List[str]]]:
+    """Parse a scripted_effects file and extract parameter contracts from comment blocks.
+
+    Looks for the pattern:
+        # Parameters:
+        # - param_name: description
+        effect_name = {
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as fh:
+            content = fh.read()
+    except Exception:
+        return {}
+
+    contracts: Dict[str, Dict[str, List[str]]] = {}
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+
+        # Look for "# Parameters:" or "# Parameter:" comment block
+        if re.match(r"^#\s*[Pp]arameters?\s*:", stripped):
+            params_required: List[str] = []
+            params_optional: List[str] = []
+            j = i + 1
+
+            while j < len(lines):
+                pline = lines[j].strip()
+                if not pline.startswith("#"):
+                    break
+                inner = pline.lstrip("#").strip()
+                if not inner or re.match(r"^[-=*]+$", inner):
+                    j += 1
+                    continue
+
+                # "# set_temp_variable = { param_name = ... }"
+                stv_m = re.search(
+                    r"set_temp_variable\s*=\s*\{\s*([a-z][a-z0-9_]*)\s*=", inner
+                )
+                if stv_m:
+                    pname = stv_m.group(1)
+                    if "optional" in inner.lower():
+                        params_optional.append(pname)
+                    else:
+                        params_required.append(pname)
+                    j += 1
+                    continue
+
+                # "# - param_name: ..." or "# - param_name - ..."
+                plain_m = re.match(r"^[-\*]?\s*([a-z][a-z0-9_]*)\s*[-:]", inner)
+                if plain_m:
+                    pname = plain_m.group(1)
+                    skip_words = {
+                        "note",
+                        "purpose",
+                        "effect",
+                        "function",
+                        "output",
+                        "how",
+                        "example",
+                        "null",
+                        "none",
+                        "n",
+                        "a",
+                        "the",
+                        "this",
+                        "see",
+                        "usage",
+                    }
+                    if pname.lower() not in skip_words:
+                        if "optional" in inner.lower():
+                            params_optional.append(pname)
+                        else:
+                            params_required.append(pname)
+                j += 1
+
+            # Find the effect definition immediately after the comment block
+            k = j
+            while k < len(lines) and not lines[k].strip():
+                k += 1
+            if k < len(lines):
+                def_m = re.match(r"^([a-z][a-z0-9_]*)\s*=\s*\{", lines[k].strip())
+                if def_m and (params_required or params_optional):
+                    eff_name = def_m.group(1)
+                    if eff_name not in HARDCODED_CONTRACTS:
+                        contracts[eff_name] = {
+                            "required": params_required,
+                            "optional": params_optional,
+                        }
+            i = j
+            continue
+        i += 1
+
+    return contracts
+
+
+# ---------------------------------------------------------------------------
+# Token-based scope walker
+# ---------------------------------------------------------------------------
+
+
+def _normalize_multiline_set_temp(text: str) -> str:
+    """Collapse multi-line set_temp_variable blocks onto a single line.
+
+    HOI4 files sometimes write:
+        set_temp_variable = {
+            param_name = value
+        }
+    This collapses such blocks into the single-line form
+        set_temp_variable = { param_name = value }
+    so that the tokenizer can match them with a single-line regex.
+
+    Only collapses blocks that are clearly set_temp_variable (not deeper nesting).
+    """
+    result = re.sub(
+        r"set_temp_variable\s*=\s*\{\s*\n\s*([a-zA-Z_][a-zA-Z0-9_]*\s*=\s*[^\n}]+?)\s*\n\s*\}",
+        r"set_temp_variable = { \1 }",
+        text,
+    )
+    return result
+
+
+def _tokenize(text: str) -> List[Tuple[str, int, str]]:
+    """Tokenize comment-stripped script text into a flat token list.
+
+    Each token is (kind, line_number, value):
+      "set_temp"   — set_temp_variable = { NAME = ... }
+      "call"       — NAME = yes
+      "scope_open" — NAME = {  where NAME is a scope-changing keyword
+      "plain_open" — { (non-scope-changing open, including if/hidden_effect/etc.)
+      "close"      — }
+    """
+    # Collapse multi-line set_temp_variable = { ... } blocks so the regex can
+    # match them on a single line.
+    text = _normalize_multiline_set_temp(text)
+
+    tokens: List[Tuple[str, int, str]] = []
+    lines = text.splitlines()
+
+    for lineno, raw in enumerate(lines, start=1):
+        # Inline comment stripping
+        ci = raw.find("#")
+        if ci >= 0:
+            raw = raw[:ci]
+
+        # set_temp_variable = { NAME = ... }
+        for m in _SET_TEMP_RE.finditer(raw):
+            tokens.append(("set_temp", lineno, m.group(1)))
+
+        # Keyword = { openers — detect before closing braces so order is right
+        for m in _KW_OPEN_RE.finditer(raw):
+            kw = m.group(1)
+            tokens.append(
+                (
+                    "scope_open" if kw in SCOPE_CHANGING_KEYWORDS else "plain_open",
+                    lineno,
+                    kw,
+                )
+            )
+
+        # Closing braces
+        for _ in re.finditer(r"\}", raw):
+            tokens.append(("close", lineno, ""))
+
+        # Effect calls: NAME = yes
+        for m in _CALL_RE.finditer(raw):
+            tokens.append(("call", lineno, m.group(1)))
+
+    return tokens
+
+
+def _validate_call_sites_in_file(
+    args: Tuple[str, Dict[str, Dict[str, List[str]]], str],
+) -> List[Tuple[str, str, int]]:
+    """Validate one file for missing required params and orphaned sets.
+
+    Returns a list of (category, message, line_number) tuples.
+    """
+    filepath, contracts, mod_path = args
+
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as fh:
+            raw = fh.read()
+    except Exception:
+        return []
+
+    text = strip_comments(raw)
+    rel = os.path.relpath(filepath, mod_path)
+
+    # Quick pre-check: does this file reference any contracted effect?
+    contracted_names = set(contracts.keys())
+    if not any(name in text for name in contracted_names):
+        return []
+
+    results: List[Tuple[str, str, int]] = []
+    tokens = _tokenize(text)
+
+    # Scope stack.  Each frame:
+    #   "scope_changing": bool — True if opened by a scope-changing keyword
+    #   "temps": Dict[str, int]  — temp vars SET at this frame level -> line number
+    #   "depth": int — count of non-scope-changing { } nesting inside this frame
+    #
+    # Temp variables set in a frame are visible to all descendants until the
+    # frame is popped.  This means a set_temp at depth 0 is visible inside any
+    # if/hidden_effect/etc. at deeper non-scope-changing levels, which is the
+    # correct HOI4 behaviour.
+    #
+    # When a scope-changing keyword opens, we push a new frame.  Temp vars from
+    # outer frames are NOT passed into the inner frame's "temps", but they are
+    # still technically visible to the inner scope in the game engine.  However,
+    # if a param is set ONLY in the inner frame and the CALL is outside, that is
+    # a scope-boundary violation.
+
+    stack: List[Dict] = [{"scope_changing": False, "temps": {}, "depth": 0}]
+
+    for kind, lineno, value in tokens:
+        if kind == "scope_open":
+            # Push a new scope frame
+            stack.append({"scope_changing": True, "temps": {}, "depth": 0})
+
+        elif kind == "plain_open":
+            # Non-scope-changing open: increment depth counter on current frame
+            stack[-1]["depth"] += 1
+
+        elif kind == "close":
+            if stack[-1]["depth"] > 0:
+                stack[-1]["depth"] -= 1
+            elif len(stack) > 1:
+                stack.pop()
+            # else: extra close at root, ignore
+
+        elif kind == "set_temp":
+            # Record in the current frame
+            stack[-1]["temps"][value] = lineno
+
+        elif kind == "call":
+            if value not in contracts:
+                continue
+
+            contract = contracts[value]
+            required = contract.get("required", [])
+
+            # Collect all temp vars visible in the current scope chain
+            # (frames at all levels, since even outer scope vars are visible
+            # unless a scope-changing frame was introduced after they were set)
+            #
+            # The visibility model: temp vars set before a scope-changing block
+            # are visible inside it; temp vars set inside a scope-changing block
+            # are NOT visible outside.  Since we track frames, any temp var in
+            # any frame on the stack at this point was set in the current or an
+            # ancestor scope, so it is visible.
+            visible: Set[str] = set()
+            for frame in stack:
+                visible.update(frame["temps"].keys())
+
+            for param in required:
+                if param not in visible:
+                    results.append(
+                        (
+                            "missing-required-param",
+                            f"{rel}:{lineno} - '{value}' called without required "
+                            f"temp variable '{param}'",
+                            lineno,
+                        )
+                    )
+
+            # Scope-boundary violations (temp set inside a popped scope-changing
+            # frame, call outside) are already caught by the missing-param check:
+            # once the inner frame is popped, the param is no longer in any
+            # frame on the stack, so the param check above will fire.
+
+    return results
+
+
+class Validator(BaseValidator):
+    TITLE = "SCRIPTED EFFECT PARAMETER VALIDATION"
+    STAGED_EXTENSIONS = [".txt"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._contracts: Dict[str, Dict[str, List[str]]] = {}
+
+    def _build_contracts(self):
+        """Build the parameter contract registry from hardcoded + auto-discovered data."""
+        self._log_section("Building scripted effect parameter contracts")
+
+        self._contracts.update(HARDCODED_CONTRACTS)
+
+        # Auto-discover from scripted effect files (always full scan — definitions
+        # are the truth set and must be complete even in staged mode)
+        effect_files = glob.glob(
+            os.path.join(self.mod_path, "common", "scripted_effects", "*.txt")
+        )
+        discovered = 0
+        for filepath in sorted(effect_files):
+            parsed = _parse_effect_contracts_from_file(filepath)
+            for eff_name, contract in parsed.items():
+                if eff_name not in self._contracts and contract["required"]:
+                    self._contracts[eff_name] = contract
+                    discovered += 1
+
+        self.log(f"  Hardcoded contracts:              {len(HARDCODED_CONTRACTS)}")
+        self.log(f"  Auto-discovered contracts:        {discovered}")
+        self.log(f"  Total contracts:                  {len(self._contracts)}")
+        for eff_name, c in sorted(self._contracts.items()):
+            req = ", ".join(c.get("required", [])) or "(none)"
+            opt = ", ".join(c.get("optional", [])) or "(none)"
+            self.log(f"    {eff_name}: required=[{req}] optional=[{opt}]")
+
+    def _validate_callers(self):
+        """Validate all caller files against the contract registry."""
+        self._log_section("Checking scripted effect parameter usage")
+
+        if not self._contracts:
+            self.log("  No contracts found — nothing to validate")
+            return
+
+        scan_patterns = [
+            "common/national_focus/*.txt",
+            "common/scripted_effects/*.txt",
+            "common/decisions/*.txt",
+            "common/decisions/**/*.txt",
+            "events/*.txt",
+        ]
+        files = self._collect_files(scan_patterns)
+        self.log(f"  Scanning {len(files)} files for effect calls")
+
+        args_list = [(f, self._contracts, self.mod_path) for f in files]
+        all_results = self._pool_map(
+            _validate_call_sites_in_file, args_list, chunksize=20
+        )
+
+        missing_param_results = []
+        scope_violation_results = []
+
+        for file_results in all_results:
+            for category, message, _line in file_results:
+                if category == "missing-required-param":
+                    missing_param_results.append(message)
+                elif category == "scope-boundary-violation":
+                    scope_violation_results.append(message)
+
+        self._report(
+            missing_param_results,
+            "All contracted effect calls have required temp variables set",
+            "Effect calls missing required temp variable setup:",
+            severity=Severity.ERROR,
+            category="missing-required-param",
+        )
+
+        self._report(
+            scope_violation_results,
+            "No scope-boundary violations found",
+            "Scope-boundary violations (temp var set in inner scope, call in outer scope):",
+            severity=Severity.ERROR,
+            category="scope-boundary-violation",
+        )
+
+    def run_validations(self):
+        self._build_contracts()
+        self._validate_callers()
+
+
+if __name__ == "__main__":
+    run_validator_main(
+        Validator,
+        "Validate scripted effect parameters in Millennium Dawn mod",
+    )


### PR DESCRIPTION
## Summary

### Bug Fixes
- **Fixes #1354** — Cuba's "The New Castro" focus set wrong ruling party. Event `cuba.12` created Fidel Castro with `ideology = liberalism` instead of `ideology = Western_Autocracy`, causing the generic "Western Outlook" to display instead of "Partido Comunista de Cuba - Pro-Western Wing".
- **Fixes #1261** — Egypt's "Maghreb Petrochemical Industry Investment" focus (`EGY_petrochemichal_ind`) fired events to TUN, MOR, MAU, LBA, ALG without `country_exists` guards, causing effects on non-existent countries.
- **Egypt AI (historical)** — AI Egypt could turn Coptic on historical because `EGY_egyptian_divide_foc` and `EGY_copts_in_power` had no `is_historical_focus_on` guards. Added `factor = 0` on historical for both. Boosted `EGY_Hosni_mubarak` with `add = 50` on historical so the AI prioritizes the correct path.
- **Egypt AI (overspending)** — UAE and Turkey evergreen mission decisions had unconditional `factor = 20` AI weight modifiers (no condition), making their effective weight 400 instead of 20. Added the missing `has_opinion` condition to match the other 8 mission decisions.
- **Egypt event namespace** — Fixed 6 event calls using uppercase `Egypt.121/147/148` when the declared namespace is lowercase `egypt`. These events were silently never firing.
- **Log cleanup** — Fixed 16 focus log ID copy-paste errors and 1 decision log mismatch across the Egypt tree, plus 1 log fix in Cuba event `cuba.12`.

### Validation Pipeline Expansion

**Wired 9 existing unwired validators into pre-commit:**
- Auto (every commit): `validate_events`, `validate_scripted_localisation`, `validate_localisation`
- Manual: `validate_cosmetic_tags`, `validate_decisions`, `validate_variables`, `validate_history_techs`, `validate_unused_scripted`, `validate_factions`
- Added `validate_factions` to `validate_staged.py` (was CI-only)

**5 new validators built and wired into pre-commit + CI:**

| Validator | What it catches | Findings on main |
|---|---|---|
| `validate_focus_tree` | Orphan focuses, dependency cycles, duplicate IDs, missing loc keys | 2 missing prereq bugs (CZE), 144 loc warnings |
| `validate_modifiers` | Unknown/typo modifier names via frequency analysis | 158 warnings |
| `validate_on_actions` | Missing/duplicate event references in on_actions | 127 duplicate event warnings |
| `validate_scripted_params` | Missing temp variables for scripted effect contracts (e.g. `change_influence_percentage`) | 25 missing param errors across SGP, ISR, ITA, GEO, etc. |
| `validate_gfx_references` | Undefined sprite references in .gui/.gfx files | 48 undefined sprite errors |

All run in CI with proper change-detection gating. `validate_modifiers` runs informational (no `--strict`) due to inherent false positives for rarely-used vanilla modifiers.

## Test plan
- [ ] Play Cuba, take "The New Castro" focus → verify "Partido Comunista de Cuba - Pro-Western Wing" becomes ruling party
- [ ] Play Egypt on historical, observe AI stays on Mubarak/Sisi path and does not take the Coptic divide branch
- [ ] Play Egypt, complete "Maghreb Petrochemical Industry Investment" focus when a Maghreb country has been annexed → verify no errors
- [ ] Verify Egypt event `egypt.120` option B fires events to SYR/KUW/ARM/GRE correctly
- [ ] CI pipeline runs all new validators successfully