### PR TITLE
Fix VEN_chevron, ALG_tamazgha, replace raw is_in_array with named triggers

### DIFF
--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -139,6 +139,32 @@ check_variable = {
 
 Valid `compare` values: `equals`, `greater_than`, `less_than`, `greater_than_or_equals`, `less_than_or_equals`, `not_equals`.
 
+## Variable and array operations do not auto-tooltip
+
+Variable operations — `check_variable`, `is_in_array`, `add_to_variable`, `subtract_from_variable`, `set_variable`, `multiply_variable`, `divide_variable`, `clamp_variable`, `set_temp_variable`, `add_to_temp_variable`, `add_to_array`, `remove_from_array` — produce **no automatic tooltip text**. When used bare in `available`, `visible`, or trigger blocks the player sees nothing (triggers) or a blank line (effects).
+
+If the player needs to see why a focus/decision is locked or what an effect does, wrap the operation:
+
+- **Triggers:** use `custom_trigger_tooltip` with a loc key
+- **Effects:** use `custom_effect_tooltip` before or after the operation
+
+```
+# Wrong — player sees no explanation for why the focus is unavailable
+available = {
+	check_variable = { my_var > 10 }
+}
+
+# Correct — player sees the loc string
+available = {
+	custom_trigger_tooltip = {
+		tooltip = my_requirement_tt
+		check_variable = { my_var > 10 }
+	}
+}
+```
+
+Named scripted triggers (e.g., `my_trigger = yes`) **do** auto-tooltip using the trigger's name as a loc key, so they are safe to use bare in player-facing blocks. Prefer named triggers over raw variable checks in `available`/`visible` when the player needs feedback.
+
 ## is_in_faction vs is_in_faction_with
 
 `is_in_faction` is a **boolean** trigger (`yes`/`no`). To check faction membership with a specific country, use `is_in_faction_with = TAG`. Using `is_in_faction = TAG` silently fails. **Caught by `check_common_mistakes.py`.**

--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -585,7 +585,7 @@ EGY_coptic_decision = {
 		}
 
 		available = {
-			NOT = { is_in_array = { gov_coalition_array = 13 } }
+			NOT = { neutrality_neutral_autocracy_are_in_coalition = yes }
 			custom_trigger_tooltip = {
 				check_variable = { EGY_coptic_people_opinion > 80 }
 				check_variable = { EGY_copts_political_influence > 60 }

--- a/common/decisions/Arab Spring.txt
+++ b/common/decisions/Arab Spring.txt
@@ -341,7 +341,7 @@ arab_spring_category = {
 
 			# Global Arab Spring has started... our own protests can begin
 			check_variable = { arab_spring > 199 }
-			NOT = { is_in_array = { ruling_party = 12 } }
+			NOT = { neutrality_neutral_muslim_brotherhood_are_in_power = yes }
 			has_war = no
 		}
 		available = {

--- a/common/decisions/China.txt
+++ b/common/decisions/China.txt
@@ -4106,8 +4106,8 @@ one_china_category = {
 			custom_trigger_tooltip = {
 				tooltip = TAI_DPP_ruling_tt
 				OR = {
-					is_in_array = { ruling_party = 2 }
-					is_in_array = { ruling_party = 18 }
+					western_liberals_are_in_power = yes
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 			custom_trigger_tooltip = {
@@ -4362,8 +4362,8 @@ one_china_category = {
 			custom_trigger_tooltip = {
 				tooltip = TAI_DPP_ruling_tt
 				OR = {
-					is_in_array = { ruling_party = 2 }
-					is_in_array = { ruling_party = 18 }
+					western_liberals_are_in_power = yes
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}

--- a/common/decisions/Coalition Decisions.txt
+++ b/common/decisions/Coalition Decisions.txt
@@ -577,8 +577,8 @@ coalition_decisions = {
 							#won't join coalition if:
 							emerging_communist_state_are_in_coalition = yes #Communist-State
 							emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
-							emerging_reactionaries_are_in_coalition = yes #Autocracy
-							emerging_autocracy_are_in_coalition = yes #Conservative (reactionary)
+							emerging_reactionaries_are_in_coalition = yes #Conservative (reactionary)
+							emerging_autocracy_are_in_coalition = yes #Autocracy
 							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
 							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
 							salafist_kingdom_are_in_coalition = yes #Kingdom
@@ -590,8 +590,8 @@ coalition_decisions = {
 							#won't join coalition if:
 							emerging_communist_state_are_in_power = yes #Communist-State
 							emerging_anarchist_communism_are_in_power = yes #anarchist_communism
-							emerging_reactionaries_are_in_power = yes #Autocracy
-							emerging_autocracy_are_in_power = yes #Conservative (reactionary)
+							emerging_reactionaries_are_in_power = yes #Conservative (reactionary)
+							emerging_autocracy_are_in_power = yes #Autocracy
 							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
 							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
 							salafist_kingdom_are_in_power = yes #Kingdom
@@ -737,8 +737,8 @@ coalition_decisions = {
 							bigger_than_ruling_elect_three = yes
 						}
 						#won't join coalition if:
-						emerging_reactionaries_are_in_coalition = yes #Autocracy
-						emerging_autocracy_are_in_coalition = yes #Conservative (reactionary)
+						emerging_reactionaries_are_in_coalition = yes #Conservative (reactionary)
+						emerging_autocracy_are_in_coalition = yes #Autocracy
 						emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
 						emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
 						salafist_kingdom_are_in_coalition = yes #Kingdom
@@ -755,8 +755,8 @@ coalition_decisions = {
 						nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
 						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						emerging_reactionaries_are_in_power = yes #Autocracy
-						emerging_autocracy_are_in_power = yes #Conservative (reactionary)
+						emerging_reactionaries_are_in_power = yes #Conservative (reactionary)
+						emerging_autocracy_are_in_power = yes #Autocracy
 						emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
 						emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
 						salafist_kingdom_are_in_power = yes #Kingdom

--- a/common/decisions/Coalition Decisions.txt
+++ b/common/decisions/Coalition Decisions.txt
@@ -281,8 +281,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^0 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 0 } #is already in coalition
-					is_in_array = { ruling_party = 0 } #is already in coalition
+					western_autocrats_are_in_coalition = yes #is already in coalition
+					western_autocrats_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -310,29 +310,29 @@ coalition_decisions = {
 							bigger_than_ruling_elect_zero = yes
 						}
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 4 } #emerging communist
-						is_in_array = { gov_coalition_array = 5 } #left-wing radical
-						is_in_array = { gov_coalition_array = 8 } #mod shiite islamist
-						is_in_array = { gov_coalition_array = 9 } #shiite islamist
-						is_in_array = { gov_coalition_array = 11 } #jihadist
-						is_in_array = { gov_coalition_array = 19 } #neutral communist
+						emerging_communist_state_are_in_coalition = yes #emerging communist
+						emerging_anarchist_communism_are_in_coalition = yes #left-wing radical
+						emerging_moderate_shiite_are_in_coalition = yes #mod shiite islamist
+						emerging_hardline_shiite_are_in_coalition = yes #shiite islamist
+						salafist_caliphate_are_in_coalition = yes #jihadist
+						neutrality_neutral_communism_are_in_coalition = yes #neutral communist
 						AND = {
 							NOT = {
 								tag = ISR
 							}
-							is_in_array = { gov_coalition_array = 21 } #fascist
+							nationalist_fascist_are_in_coalition = yes #fascist
 						}
-						is_in_array = { ruling_party = 4 } #emerging communist
-						is_in_array = { ruling_party = 5 } #left-wing radical
-						is_in_array = { ruling_party = 8 } #mod shiite islamist
-						is_in_array = { ruling_party = 9 } #shiite islamist
-						is_in_array = { ruling_party = 11 } #jihadist
-						is_in_array = { ruling_party = 19 } #neutral communist
+						emerging_communist_state_are_in_power = yes #emerging communist
+						emerging_anarchist_communism_are_in_power = yes #left-wing radical
+						emerging_moderate_shiite_are_in_power = yes #mod shiite islamist
+						emerging_hardline_shiite_are_in_power = yes #shiite islamist
+						salafist_caliphate_are_in_power = yes #jihadist
+						neutrality_neutral_communism_are_in_power = yes #neutral communist
 						AND = {
 							NOT = {
 								tag = ISR
 							}
-							is_in_array = { gov_coalition_array = 21 } #fascist
+							nationalist_fascist_are_in_coalition = yes #fascist
 						}
 					}
 				}
@@ -367,7 +367,7 @@ coalition_decisions = {
 	Western_Autocracy_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 0 } }
+		visible = { western_autocrats_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -406,8 +406,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^1 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 1 } #is already in coalition
-					is_in_array = { ruling_party = 1 } #is already in coalition
+					western_conservatism_are_in_coalition = yes #is already in coalition
+					western_conservatism_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -435,27 +435,27 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 4 } #emerging communist
-							is_in_array = { gov_coalition_array = 5 } #left-wing radical
-							is_in_array = { gov_coalition_array = 8 } #mod shiite islamist
-							is_in_array = { gov_coalition_array = 9 } #shiite islamist
-							is_in_array = { gov_coalition_array = 11 } #jihadist
-							is_in_array = { gov_coalition_array = 19 } #neutral communist
-							is_in_array = { gov_coalition_array = 21 } #fascist
-							is_in_array = { ruling_party = 4 } #emerging communist
-							is_in_array = { ruling_party = 5 } #left-wing radical
-							is_in_array = { ruling_party = 8 } #mod shiite islamist
-							is_in_array = { ruling_party = 9 } #shiite islamist
-							is_in_array = { ruling_party = 11 } #jihadist
-							is_in_array = { ruling_party = 19 } #neutral communist
-							is_in_array = { ruling_party = 21 } #fascist
+							emerging_communist_state_are_in_coalition = yes #emerging communist
+							emerging_anarchist_communism_are_in_coalition = yes #left-wing radical
+							emerging_moderate_shiite_are_in_coalition = yes #mod shiite islamist
+							emerging_hardline_shiite_are_in_coalition = yes #shiite islamist
+							salafist_caliphate_are_in_coalition = yes #jihadist
+							neutrality_neutral_communism_are_in_coalition = yes #neutral communist
+							nationalist_fascist_are_in_coalition = yes #fascist
+							emerging_communist_state_are_in_power = yes #emerging communist
+							emerging_anarchist_communism_are_in_power = yes #left-wing radical
+							emerging_moderate_shiite_are_in_power = yes #mod shiite islamist
+							emerging_hardline_shiite_are_in_power = yes #shiite islamist
+							salafist_caliphate_are_in_power = yes #jihadist
+							neutrality_neutral_communism_are_in_power = yes #neutral communist
+							nationalist_fascist_are_in_power = yes #fascist
 						#}
 						#won't join social democrats if both are strong
 						custom_trigger_tooltip = {
 							tooltip = mutual_socialism_20_tt
 							OR = {
-								is_in_array = { gov_coalition_array = 3 } #social democrats
-								is_in_array = { ruling_party = 3 } #social democrats
+								western_social_democrats_are_in_coalition = yes #social democrats
+								western_social_democrats_are_in_power = yes #social democrats
 							}
 							check_variable = { party_pop_elect_array^3 > 0.2 } #social democrats
 							check_variable = { party_pop_elect_array^1 > 0.2 } #western conservative
@@ -465,8 +465,8 @@ coalition_decisions = {
 							tooltip = mutual_neutral_Social_20_tt
 							#won't join democratic socialists if both are strong
 							OR = {
-								is_in_array = { gov_coalition_array = 18 } #social democrats
-								is_in_array = { ruling_party = 18 } #social democrats
+								neutrality_neutral_social_are_in_coalition = yes #social democrats
+								neutrality_neutral_social_are_in_power = yes #social democrats
 							}
 							check_variable = { party_pop_elect_array^18 > 0.2 } #social democrats
 							check_variable = { party_pop_elect_array^1 > 0.2 } #western conservative
@@ -505,7 +505,7 @@ coalition_decisions = {
 	conservatism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 1 } }
+		visible = { western_conservatism_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -544,8 +544,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^2 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 2 } #is already in coalition
-					is_in_array = { ruling_party = 2 } #is already in coalition
+					western_liberals_are_in_coalition = yes #is already in coalition
+					western_liberals_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -575,38 +575,38 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 4 } #Communist-State
-							is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-							is_in_array = { gov_coalition_array = 6 } #Autocracy
-							is_in_array = { gov_coalition_array = 7 } #Conservative (reactionary)
-							is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							emerging_communist_state_are_in_coalition = yes #Communist-State
+							emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+							emerging_reactionaries_are_in_coalition = yes #Autocracy
+							emerging_autocracy_are_in_coalition = yes #Conservative (reactionary)
+							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 4 } #Communist-State
-							is_in_array = { ruling_party = 5 } #anarchist_communism
-							is_in_array = { ruling_party = 6 } #Autocracy
-							is_in_array = { ruling_party = 7 } #Conservative (reactionary)
-							is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 19 } #Neutral_Communism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 22 } #Nat_Autocracy
-							is_in_array = { ruling_party = 23 } #Monarchist
+							emerging_communist_state_are_in_power = yes #Communist-State
+							emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+							emerging_reactionaries_are_in_power = yes #Autocracy
+							emerging_autocracy_are_in_power = yes #Conservative (reactionary)
+							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 						custom_trigger_tooltip = {
 							tooltip = mutual_conservatism_25_tt
 							#won't join conservatives if both are strong
 							OR = {
-								is_in_array = { gov_coalition_array = 1 } #conservatives
-								is_in_array = { ruling_party = 1 } #conservatives
+								western_conservatism_are_in_coalition = yes #conservatives
+								western_conservatism_are_in_power = yes #conservatives
 							}
 							check_variable = { party_pop_elect_array^1 > 0.25 } #conservatives
 							check_variable = { party_pop_elect_array^2 > 0.25 } #liberalism
@@ -616,8 +616,8 @@ coalition_decisions = {
 							#won't join social democrats if both are strong
 							NOT = { tag = USA }
 							OR = {
-								is_in_array = { gov_coalition_array = 3 } #social democrats
-								is_in_array = { ruling_party = 3 } #social democrats
+								western_social_democrats_are_in_coalition = yes #social democrats
+								western_social_democrats_are_in_power = yes #social democrats
 							}
 							check_variable = { party_pop_elect_array^3 > 0.25 } #social democrats
 							check_variable = { party_pop_elect_array^2 > 0.25 } #liberalism
@@ -627,15 +627,15 @@ coalition_decisions = {
 							#USA - Democrats (liberalism) and Republicans can't team up unless one is insignificant
 							TAG = USA
 							OR = {
-								is_in_array = { gov_coalition_array = 1 } #conservatives
-								is_in_array = { ruling_party = 1 } #conservatives
+								western_conservatism_are_in_coalition = yes #conservatives
+								western_conservatism_are_in_power = yes #conservatives
 							}
 							check_variable = { party_pop_elect_array^1 > 0.05 } #conservatives
 							check_variable = { party_pop_elect_array^2 > 0.05 } #liberalism
 							TAG = USA
 							OR = {
-								is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-								is_in_array = { ruling_party = 14 } #Neutral_conservatism
+								neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+								neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
 							}
 						}
 					}
@@ -670,7 +670,7 @@ coalition_decisions = {
 	liberalism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 2 } }
+		visible = { western_liberals_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -707,8 +707,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^3 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 3 } #is already in coalition
-					is_in_array = { ruling_party = 3 } #is already in coalition
+					western_social_democrats_are_in_coalition = yes #is already in coalition
+					western_social_democrats_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -737,47 +737,47 @@ coalition_decisions = {
 							bigger_than_ruling_elect_three = yes
 						}
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 6 } #Autocracy
-						is_in_array = { gov_coalition_array = 7 } #Conservative (reactionary)
-						is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 11 } #Caliphate
+						emerging_reactionaries_are_in_coalition = yes #Autocracy
+						emerging_autocracy_are_in_coalition = yes #Conservative (reactionary)
+						emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						salafist_caliphate_are_in_coalition = yes #Caliphate
 						AND = {
 							NOT = {
 								tag = ITA
 							}
-							is_in_array = { gov_coalition_array = 14 } #neutral conservatives
+							neutrality_neutral_conservatism_are_in_coalition = yes #neutral conservatives
 						}
-						is_in_array = { gov_coalition_array = 16 } #libertarians
-						is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-						is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-						is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-						is_in_array = { gov_coalition_array = 23 } #Monarchist
+						neutrality_neutral_libertarians_are_in_coalition = yes #libertarians
+						nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+						nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+						nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						is_in_array = { ruling_party = 6 } #Autocracy
-						is_in_array = { ruling_party = 7 } #Conservative (reactionary)
-						is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 11 } #Caliphate
+						emerging_reactionaries_are_in_power = yes #Autocracy
+						emerging_autocracy_are_in_power = yes #Conservative (reactionary)
+						emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+						salafist_kingdom_are_in_power = yes #Kingdom
+						salafist_caliphate_are_in_power = yes #Caliphate
 						AND = {
 							NOT = {
 								tag = ITA
 							}
-							is_in_array = { ruling_party = 14 } #neutral conservatives
+							neutrality_neutral_conservatism_are_in_power = yes #neutral conservatives
 						}
-						is_in_array = { ruling_party = 16 } #libertarians
-						is_in_array = { ruling_party = 20 } #Nat_Populism
-						is_in_array = { ruling_party = 21 } #Nat_Fascism
-						is_in_array = { ruling_party = 22 } #Nat_Autocracy
-						is_in_array = { ruling_party = 23 } #Monarchist
+						neutrality_neutral_libertarians_are_in_power = yes #libertarians
+						nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+						nationalist_fascist_are_in_power = yes #Nat_Fascism
+						nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+						nationalist_monarchists_are_in_power = yes #Monarchist
 						#won't join conservatives if both are strong
 						custom_trigger_tooltip = {
 							tooltip = mutual_conservatism_20_tt
 							OR = {
-								is_in_array = { gov_coalition_array = 1 } #conservatives
-								is_in_array = { ruling_party = 1 } #conservatives
+								western_conservatism_are_in_coalition = yes #conservatives
+								western_conservatism_are_in_power = yes #conservatives
 							}
 							check_variable = { party_pop_elect_array^1 > 0.2 } #conservatives
 							check_variable = { party_pop_elect_array^3 > 0.2 } #socialism
@@ -788,8 +788,8 @@ coalition_decisions = {
 							tooltip = USA_dems_reps_tt
 							tag = USA
 							OR = {
-								is_in_array = { gov_coalition_array = 1 } #conservatives
-								is_in_array = { ruling_party = 1 } #conservatives
+								western_conservatism_are_in_coalition = yes #conservatives
+								western_conservatism_are_in_power = yes #conservatives
 							}
 						}
 					}
@@ -824,7 +824,7 @@ coalition_decisions = {
 	socialism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 3 } }
+		visible = { western_social_democrats_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -862,8 +862,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^4 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 4 } #is already in coalition
-					is_in_array = { ruling_party = 4 } #is already in coalition
+					emerging_communist_state_are_in_coalition = yes #is already in coalition
+					emerging_communist_state_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -889,35 +889,35 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-							is_in_array = { gov_coalition_array = 1 } #conservatism
-							is_in_array = { gov_coalition_array = 2 } #liberalism
-							is_in_array = { gov_coalition_array = 6 } #Conservative (reactionary)
-							is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-							is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-							is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							western_autocrats_are_in_coalition = yes #Western_Autocracy
+							western_conservatism_are_in_coalition = yes #conservatism
+							western_liberals_are_in_coalition = yes #liberalism
+							emerging_reactionaries_are_in_coalition = yes #Conservative (reactionary)
+							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+							neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 0 } #Western_Autocracy
-							is_in_array = { ruling_party = 1 } #conservatism
-							is_in_array = { ruling_party = 2 } #liberalism
-							is_in_array = { ruling_party = 6 } #Conservative (reactionary)
-							is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { ruling_party = 14 } #Neutral_conservatism
-							is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-							is_in_array = { ruling_party = 20 } #Nat_Populism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 23 } #Monarchist
+							western_autocrats_are_in_power = yes #Western_Autocracy
+							western_conservatism_are_in_power = yes #conservatism
+							western_liberals_are_in_power = yes #liberalism
+							emerging_reactionaries_are_in_power = yes #Conservative (reactionary)
+							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+							neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 					}
 				}
@@ -953,7 +953,7 @@ coalition_decisions = {
 	Communist-State_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 4 } }
+		visible = { emerging_communist_state_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -991,8 +991,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^5 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 5 } #is already in coalition
-					is_in_array = { ruling_party = 5 } #is already in coalition
+					emerging_anarchist_communism_are_in_coalition = yes #is already in coalition
+					emerging_anarchist_communism_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -1019,35 +1019,35 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-							is_in_array = { gov_coalition_array = 1 } #conservatism
-							is_in_array = { gov_coalition_array = 2 } #liberalism
-							is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-							is_in_array = { gov_coalition_array = 15 } #oligarchism
-							is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-							is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							western_autocrats_are_in_coalition = yes #Western_Autocracy
+							western_conservatism_are_in_coalition = yes #conservatism
+							western_liberals_are_in_coalition = yes #liberalism
+							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+							neutrality_neutral_oligarch_are_in_coalition = yes #oligarchism
+							neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 0 } #Western_Autocracy
-							is_in_array = { ruling_party = 1 } #conservatism
-							is_in_array = { ruling_party = 2 } #liberalism
-							is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 14 } #Neutral_conservatism
-							is_in_array = { ruling_party = 15 } #oligarchism
-							is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-							is_in_array = { ruling_party = 20 } #Nat_Populism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 22 } #Nat_Autocracy
-							is_in_array = { ruling_party = 23 } #Monarchist
+							western_autocrats_are_in_power = yes #Western_Autocracy
+							western_conservatism_are_in_power = yes #conservatism
+							western_liberals_are_in_power = yes #liberalism
+							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+							neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+							neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 					}
 				}
@@ -1083,7 +1083,7 @@ coalition_decisions = {
 	anarchist_communism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 5 } }
+		visible = { emerging_anarchist_communism_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1121,8 +1121,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^6 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 6 } #is already in coalition
-					is_in_array = { ruling_party = 6 } #is already in coalition
+					emerging_reactionaries_are_in_coalition = yes #is already in coalition
+					emerging_reactionaries_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -1148,39 +1148,39 @@ coalition_decisions = {
 							bigger_than_ruling_elect_six = yes
 						}
 					#won't join coalition if:
-						is_in_array = { gov_coalition_array = 1 } #conservatism
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
+						western_conservatism_are_in_coalition = yes #conservatism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
 						AND = {
 							NOT = {
 								tag = ITA
 							}
-							is_in_array = { gov_coalition_array = 5 } #anarchist_communism
+							emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
 						}
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 11 } #Caliphate
-						is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 18 } #neutral_Social
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						salafist_caliphate_are_in_coalition = yes #Caliphate
+						neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 					#won't join coalition if:
-						is_in_array = { ruling_party = 1 } #conservatism
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
+						western_conservatism_are_in_power = yes #conservatism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
 						AND = {
 							NOT = {
 								tag = ITA
 							}
-							is_in_array = { ruling_party = 5 } #anarchist_communism
+							emerging_anarchist_communism_are_in_power = yes #anarchist_communism
 						}
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 11 } #Caliphate
-						is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 18 } #neutral_Social
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
+						salafist_kingdom_are_in_power = yes #Kingdom
+						salafist_caliphate_are_in_power = yes #Caliphate
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_social_are_in_power = yes #neutral_Social
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 					}
 				}
 			}
@@ -1215,7 +1215,7 @@ coalition_decisions = {
 	Conservative_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 6 } }
+		visible = { emerging_reactionaries_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1253,8 +1253,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^7 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 7 } #is already in coalition
-					is_in_array = { ruling_party = 7 } #is already in coalition
+					emerging_autocracy_are_in_coalition = yes #is already in coalition
+					emerging_autocracy_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -1288,31 +1288,31 @@ coalition_decisions = {
 									NOT = {
 										tag = ISR
 									}
-									is_in_array = { gov_coalition_array = 1 } #conservatism
+									western_conservatism_are_in_coalition = yes #conservatism
 								}
-								is_in_array = { gov_coalition_array = 2 } #liberalism
-								is_in_array = { gov_coalition_array = 3 } #socialism
-								is_in_array = { gov_coalition_array = 4 } #Communist-State
-								is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-								is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-								is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-								is_in_array = { gov_coalition_array = 18 } #neutral_Social
-								is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+								western_liberals_are_in_coalition = yes #liberalism
+								western_social_democrats_are_in_coalition = yes #socialism
+								emerging_communist_state_are_in_coalition = yes #Communist-State
+								emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+								neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+								neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+								neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+								neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 								#won't join coalition if:
 								AND = {
 									NOT = {
 										tag = ISR
 									}
-									is_in_array = { ruling_party = 1 } #conservatism
+									western_conservatism_are_in_power = yes #conservatism
 								}
-								is_in_array = { ruling_party = 2 } #liberalism
-								is_in_array = { ruling_party = 3 } #socialism
-								is_in_array = { ruling_party = 4 } #Communist-State
-								is_in_array = { ruling_party = 5 } #anarchist_communism
-								is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-								is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-								is_in_array = { ruling_party = 18 } #neutral_Social
-								is_in_array = { ruling_party = 19 } #Neutral_Communism
+								western_liberals_are_in_power = yes #liberalism
+								western_social_democrats_are_in_power = yes #socialism
+								emerging_communist_state_are_in_power = yes #Communist-State
+								emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+								neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+								neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+								neutrality_neutral_social_are_in_power = yes #neutral_Social
+								neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 							#}
 						}
 					}
@@ -1349,7 +1349,7 @@ coalition_decisions = {
 	Autocracy_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 7 } }
+		visible = { emerging_autocracy_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1386,8 +1386,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^8 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 8 } #is already in coalition
-					is_in_array = { ruling_party = 8 } #is already in coalition
+					emerging_moderate_shiite_are_in_coalition = yes #is already in coalition
+					emerging_moderate_shiite_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -1413,29 +1413,29 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-						is_in_array = { gov_coalition_array = 1 } #conservatism
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 11 } #Caliphate
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 23 } #Monarchist
+						western_autocrats_are_in_coalition = yes #Western_Autocracy
+						western_conservatism_are_in_coalition = yes #conservatism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						salafist_caliphate_are_in_coalition = yes #Caliphate
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						is_in_array = { ruling_party = 0 } #Western_Autocracy
-						is_in_array = { ruling_party = 1 } #conservatism
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 11 } #Caliphate
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 23 } #Monarchist
+						western_autocrats_are_in_power = yes #Western_Autocracy
+						western_conservatism_are_in_power = yes #conservatism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						salafist_kingdom_are_in_power = yes #Kingdom
+						salafist_caliphate_are_in_power = yes #Caliphate
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						nationalist_monarchists_are_in_power = yes #Monarchist
 					#}
 				}
 			}
@@ -1470,7 +1470,7 @@ coalition_decisions = {
 	Mod_Vilayat_e_Faqih_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 8 } }
+		visible = { emerging_moderate_shiite_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1508,8 +1508,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^9 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 9 } #is already in coalition
-					is_in_array = { ruling_party = 9 } #is already in coalition
+					emerging_hardline_shiite_are_in_coalition = yes #is already in coalition
+					emerging_hardline_shiite_are_in_power = yes #is already in coalition
 
 				}
 			}
@@ -1536,29 +1536,29 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-						is_in_array = { gov_coalition_array = 1 } #conservatism
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 11 } #Caliphate
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 23 } #Monarchist
+						western_autocrats_are_in_coalition = yes #Western_Autocracy
+						western_conservatism_are_in_coalition = yes #conservatism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						salafist_caliphate_are_in_coalition = yes #Caliphate
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						is_in_array = { ruling_party = 0 } #Western_Autocracy
-						is_in_array = { ruling_party = 1 } #conservatism
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 11 } #Caliphate
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 23 } #Monarchist
+						western_autocrats_are_in_power = yes #Western_Autocracy
+						western_conservatism_are_in_power = yes #conservatism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						salafist_kingdom_are_in_power = yes #Kingdom
+						salafist_caliphate_are_in_power = yes #Caliphate
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						nationalist_monarchists_are_in_power = yes #Monarchist
 					#}
 				}
 			}
@@ -1593,7 +1593,7 @@ coalition_decisions = {
 	Vilayat_e_Faqih_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 9 } }
+		visible = { emerging_hardline_shiite_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1633,8 +1633,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^10 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 10 } #is already in coalition
-					is_in_array = { ruling_party = 10 } #is already in coalition
+					salafist_kingdom_are_in_coalition = yes #is already in coalition
+					salafist_kingdom_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -1660,33 +1660,33 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 1 } #conservatism
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-						is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 18 } #neutral_Social
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 23 } #Monarchist
+						western_conservatism_are_in_coalition = yes #conservatism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+						emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+						neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						is_in_array = { ruling_party = 1 } #conservatism
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 5 } #anarchist_communism
-						is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-						is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 18 } #neutral_Social
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 23 } #Monarchist
+						western_conservatism_are_in_power = yes #conservatism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+						emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_social_are_in_power = yes #neutral_Social
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						nationalist_monarchists_are_in_power = yes #Monarchist
 					#}
 				}
 			}
@@ -1721,7 +1721,7 @@ coalition_decisions = {
 	Kingdom_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 10 } }
+		visible = { salafist_kingdom_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1758,8 +1758,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^11 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 11 } #is already in coalition
-					is_in_array = { ruling_party = 11 } #is already in coalition
+					salafist_caliphate_are_in_coalition = yes #is already in coalition
+					salafist_caliphate_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -1785,41 +1785,41 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 1 } #conservatism
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-						is_in_array = { gov_coalition_array = 6 } #Conservative
-						is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-						is_in_array = { gov_coalition_array = 15 } #oligarchism
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 18 } #neutral_Social
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-						is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-						is_in_array = { gov_coalition_array = 23 } #Monarchist
+						western_conservatism_are_in_coalition = yes #conservatism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+						emerging_reactionaries_are_in_coalition = yes #Conservative
+						emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+						neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+						neutrality_neutral_oligarch_are_in_coalition = yes #oligarchism
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+						nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						is_in_array = { ruling_party = 1 } #conservatism
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 5 } #anarchist_communism
-						is_in_array = { ruling_party = 6 } #Conservative
-						is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-						is_in_array = { ruling_party = 14 } #Neutral_conservatism
-						is_in_array = { ruling_party = 15 } #oligarchism
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 18 } #neutral_Social
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 20 } #Nat_Populism
-						is_in_array = { ruling_party = 21 } #Nat_Fascism
-						is_in_array = { ruling_party = 23 } #Monarchist
+						western_conservatism_are_in_power = yes #conservatism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+						emerging_reactionaries_are_in_power = yes #Conservative
+						emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+						neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+						neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_social_are_in_power = yes #neutral_Social
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+						nationalist_fascist_are_in_power = yes #Nat_Fascism
+						nationalist_monarchists_are_in_power = yes #Monarchist
 					#}
 				}
 			}
@@ -1854,7 +1854,7 @@ coalition_decisions = {
 	Caliphate_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 11 } }
+		visible = { salafist_caliphate_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -1892,8 +1892,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^12 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 12 } #is already in coalition
-					is_in_array = { ruling_party = 12 } #is already in coalition
+					neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_muslim_brotherhood_are_in_power = yes #is already in coalition
 
 				}
 			}
@@ -1920,35 +1920,35 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 7 } #Autocracy
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 13 } #Neutral_Autocracy
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-						is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-						is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-						is_in_array = { gov_coalition_array = 23 } #Monarchist
+						western_autocrats_are_in_coalition = yes #Western_Autocracy
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_autocracy_are_in_coalition = yes #Autocracy
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						neutrality_neutral_autocracy_are_in_coalition = yes #Neutral_Autocracy
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+						nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+						nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+						nationalist_monarchists_are_in_coalition = yes #Monarchist
 						#won't join coalition if:
-						is_in_array = { ruling_party = 0 } #Western_Autocracy
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 7 } #Autocracy
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 20 } #Nat_Populism
-						is_in_array = { ruling_party = 21 } #Nat_Fascism
-						is_in_array = { ruling_party = 22 } #Nat_Autocracy
-						is_in_array = { ruling_party = 23 } #Monarchist
+						western_autocrats_are_in_power = yes #Western_Autocracy
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_autocracy_are_in_power = yes #Autocracy
+						salafist_kingdom_are_in_power = yes #Kingdom
+						neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+						nationalist_fascist_are_in_power = yes #Nat_Fascism
+						nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+						nationalist_monarchists_are_in_power = yes #Monarchist
 					#}
 				}
 			}
@@ -1983,7 +1983,7 @@ coalition_decisions = {
 	Neutral_Muslim_Brotherhood_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 12 } }
+		visible = { neutrality_neutral_muslim_brotherhood_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2021,8 +2021,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^13 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 13 } #is already in coalition
-					is_in_array = { ruling_party = 13 } #is already in coalition
+					neutrality_neutral_autocracy_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_autocracy_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2052,27 +2052,27 @@ coalition_decisions = {
 							}
 							#hidden_trigger = {
 								#won't join coalition if:
-								is_in_array = { gov_coalition_array = 1 } #conservatism
-								is_in_array = { gov_coalition_array = 2 } #liberalism
-								is_in_array = { gov_coalition_array = 3 } #socialism
-								is_in_array = { gov_coalition_array = 4 } #Communist-State
-								is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-								is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-								is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-								is_in_array = { gov_coalition_array = 17 } #Neutral_green
-								is_in_array = { gov_coalition_array = 18 } #neutral_Social
-								is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+								western_conservatism_are_in_coalition = yes #conservatism
+								western_liberals_are_in_coalition = yes #liberalism
+								western_social_democrats_are_in_coalition = yes #socialism
+								emerging_communist_state_are_in_coalition = yes #Communist-State
+								emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+								neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+								neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+								neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+								neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+								neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 								#won't join coalition if:
-								is_in_array = { ruling_party = 1 } #conservatism
-								is_in_array = { ruling_party = 2 } #liberalism
-								is_in_array = { ruling_party = 3 } #socialism
-								is_in_array = { ruling_party = 4 } #Communist-State
-								is_in_array = { ruling_party = 5 } #anarchist_communism
-								is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-								is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-								is_in_array = { ruling_party = 17 } #Neutral_green
-								is_in_array = { ruling_party = 18 } #neutral_Social
-								is_in_array = { ruling_party = 19 } #Neutral_Communism
+								western_conservatism_are_in_power = yes #conservatism
+								western_liberals_are_in_power = yes #liberalism
+								western_social_democrats_are_in_power = yes #socialism
+								emerging_communist_state_are_in_power = yes #Communist-State
+								emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+								neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+								neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+								neutrality_neutral_green_are_in_power = yes #Neutral_green
+								neutrality_neutral_social_are_in_power = yes #neutral_Social
+								neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 							#}
 						}
 					}
@@ -2109,7 +2109,7 @@ coalition_decisions = {
 	Neutral_Autocracy_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 13 } }
+		visible = { neutrality_neutral_autocracy_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2147,8 +2147,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^14 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 14 } #is already in coalition
-					is_in_array = { ruling_party = 14 } #is already in coalition
+					neutrality_neutral_conservatism_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_conservatism_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2180,31 +2180,31 @@ coalition_decisions = {
 							NOT = {
 								tag = ITA
 							}
-							is_in_array = { gov_coalition_array = 3 } #socialist
+							western_social_democrats_are_in_coalition = yes #socialist
 						}
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 11 } #Caliphate
-						is_in_array = { gov_coalition_array = 18 } #neutral_Social
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-						is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						salafist_caliphate_are_in_coalition = yes #Caliphate
+						neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+						nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
 						#won't join coalition if:
 						AND = {
 							NOT = {
 								tag = ITA
 							}
-							is_in_array = { ruling_party = 3 } #socialist
+							western_social_democrats_are_in_power = yes #socialist
 						}
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 5 } #anarchist_communism
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 11 } #Caliphate
-						is_in_array = { ruling_party = 18 } #neutral_Social
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 21 } #Nat_Fascism
-						is_in_array = { ruling_party = 22 } #Nat_Autocracy
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+						salafist_kingdom_are_in_power = yes #Kingdom
+						salafist_caliphate_are_in_power = yes #Caliphate
+						neutrality_neutral_social_are_in_power = yes #neutral_Social
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						nationalist_fascist_are_in_power = yes #Nat_Fascism
+						nationalist_military_junta_are_in_power = yes #Nat_Autocracy
 					}
 				}
 			}
@@ -2239,7 +2239,7 @@ coalition_decisions = {
 	Neutral_conservatism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 14 } }
+		visible = { neutrality_neutral_conservatism_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2277,8 +2277,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^15 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 15 } #is already in coalition
-					is_in_array = { ruling_party = 15 } #is already in coalition
+					neutrality_neutral_oligarch_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_oligarch_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2303,23 +2303,23 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 11 } #Caliphate
-						is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-						is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						salafist_caliphate_are_in_coalition = yes #Caliphate
+						nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+						neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
 						#won't join coalition if:
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 11 } #Caliphate
-						is_in_array = { ruling_party = 21 } #Nat_Fascism
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 5 } #anarchist_communism
-						is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
+						salafist_kingdom_are_in_power = yes #Kingdom
+						salafist_caliphate_are_in_power = yes #Caliphate
+						nationalist_fascist_are_in_power = yes #Nat_Fascism
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
 					#}
 				}
 			}
@@ -2354,7 +2354,7 @@ coalition_decisions = {
 	oligarchism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 15 } }
+		visible = { neutrality_neutral_oligarch_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2392,8 +2392,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^16 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 16 } #is already in coalition
-					is_in_array = { ruling_party = 16 } #is already in coalition
+					neutrality_neutral_libertarians_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_libertarians_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2420,41 +2420,41 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-							is_in_array = { gov_coalition_array = 3 } #socialism
-							is_in_array = { gov_coalition_array = 4 } #Communist-State
-							is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-							is_in_array = { gov_coalition_array = 7 } #Autocracy
-							is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { gov_coalition_array = 13 } #Neutral_Autocracy
-							is_in_array = { gov_coalition_array = 15 } #oligarchism
-							is_in_array = { gov_coalition_array = 18 } #neutral_Social
-							is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							western_autocrats_are_in_coalition = yes #Western_Autocracy
+							western_social_democrats_are_in_coalition = yes #socialism
+							emerging_communist_state_are_in_coalition = yes #Communist-State
+							emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+							emerging_autocracy_are_in_coalition = yes #Autocracy
+							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_autocracy_are_in_coalition = yes #Neutral_Autocracy
+							neutrality_neutral_oligarch_are_in_coalition = yes #oligarchism
+							neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+							neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 0 } #Western_Autocracy
-							is_in_array = { ruling_party = 3 } #socialism
-							is_in_array = { ruling_party = 4 } #Communist-State
-							is_in_array = { ruling_party = 5 } #anarchist_communism
-							is_in_array = { ruling_party = 7 } #Autocracy
-							is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-							is_in_array = { ruling_party = 15 } #oligarchism
-							is_in_array = { ruling_party = 18 } #neutral_Social
-							is_in_array = { ruling_party = 19 } #Neutral_Communism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 22 } #Nat_Autocracy
-							is_in_array = { ruling_party = 23 } #Monarchist
+							western_autocrats_are_in_power = yes #Western_Autocracy
+							western_social_democrats_are_in_power = yes #socialism
+							emerging_communist_state_are_in_power = yes #Communist-State
+							emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+							emerging_autocracy_are_in_power = yes #Autocracy
+							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+							neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+							neutrality_neutral_social_are_in_power = yes #neutral_Social
+							neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 					}
 				}
@@ -2490,7 +2490,7 @@ coalition_decisions = {
 	Neutral_Libertarian_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 16 } }
+		visible = { neutrality_neutral_libertarians_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2528,8 +2528,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^17 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 17 } #is already in coalition
-					is_in_array = { ruling_party = 17 } #is already in coalition
+					neutrality_neutral_green_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_green_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2556,31 +2556,31 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-							is_in_array = { gov_coalition_array = 6 } #Conservative
-							is_in_array = { gov_coalition_array = 7 } #Autocracy
-							is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 13 } #Neutral_Autocracy
-							is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							western_autocrats_are_in_coalition = yes #Western_Autocracy
+							emerging_reactionaries_are_in_coalition = yes #Conservative
+							emerging_autocracy_are_in_coalition = yes #Autocracy
+							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_autocracy_are_in_coalition = yes #Neutral_Autocracy
+							nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 0 } #Western_Autocracy
-							is_in_array = { ruling_party = 6 } #Conservative
-							is_in_array = { ruling_party = 7 } #Autocracy
-							is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-							is_in_array = { ruling_party = 20 } #Nat_Populism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 22 } #Nat_Autocracy
-							is_in_array = { ruling_party = 23 } #Monarchist
+							western_autocrats_are_in_power = yes #Western_Autocracy
+							emerging_reactionaries_are_in_power = yes #Conservative
+							emerging_autocracy_are_in_power = yes #Autocracy
+							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+							nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 					}
 				}
@@ -2616,7 +2616,7 @@ coalition_decisions = {
 	Neutral_green_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 17 } }
+		visible = { neutrality_neutral_green_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2654,8 +2654,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^18 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 18 } #is already in coalition
-					is_in_array = { ruling_party = 18 } #is already in coalition
+					neutrality_neutral_social_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_social_are_in_power = yes #is already in coalition
 
 				}
 			}
@@ -2683,35 +2683,35 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-							is_in_array = { gov_coalition_array = 1 } #conservatism
-							is_in_array = { gov_coalition_array = 2 } #liberalism
-							is_in_array = { gov_coalition_array = 6 } #Conservative
-							is_in_array = { gov_coalition_array = 7 } #Autocracy
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 13 } #Neutral_Autocracy
-							is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-							is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-							is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							western_autocrats_are_in_coalition = yes #Western_Autocracy
+							western_conservatism_are_in_coalition = yes #conservatism
+							western_liberals_are_in_coalition = yes #liberalism
+							emerging_reactionaries_are_in_coalition = yes #Conservative
+							emerging_autocracy_are_in_coalition = yes #Autocracy
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_autocracy_are_in_coalition = yes #Neutral_Autocracy
+							neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+							neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 0 } #Western_Autocracy
-							is_in_array = { ruling_party = 1 } #conservatism
-							is_in_array = { ruling_party = 2 } #liberalism
-							is_in_array = { ruling_party = 6 } #Conservative
-							is_in_array = { ruling_party = 7 } #Autocracy
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-							is_in_array = { ruling_party = 14 } #Neutral_conservatism
-							is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-							is_in_array = { ruling_party = 20 } #Nat_Populism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 22 } #Nat_Autocracy
-							is_in_array = { ruling_party = 23 } #Monarchist
+							western_autocrats_are_in_power = yes #Western_Autocracy
+							western_conservatism_are_in_power = yes #conservatism
+							western_liberals_are_in_power = yes #liberalism
+							emerging_reactionaries_are_in_power = yes #Conservative
+							emerging_autocracy_are_in_power = yes #Autocracy
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+							neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+							neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 					}
 				}
@@ -2747,7 +2747,7 @@ coalition_decisions = {
 	neutral_Social_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 18 } }
+		visible = { neutrality_neutral_social_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2785,8 +2785,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^19 > election_threshold } #failed elections
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 19 } #is already in coalition
-					is_in_array = { ruling_party = 19 } #is already in coalition
+					neutrality_neutral_communism_are_in_coalition = yes #is already in coalition
+					neutrality_neutral_communism_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2813,41 +2813,41 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 0 } #Western_Autocracy
-							is_in_array = { gov_coalition_array = 1 } #conservatism
-							is_in_array = { gov_coalition_array = 2 } #liberalism
-							is_in_array = { gov_coalition_array = 6 } #Conservative
-							is_in_array = { gov_coalition_array = 7 } #Autocracy
-							is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { gov_coalition_array = 13 } #Neutral_Autocracy
-							is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-							is_in_array = { gov_coalition_array = 15 } #oligarchism
-							is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-							is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-							is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-							is_in_array = { gov_coalition_array = 23 } #Monarchist
+							western_autocrats_are_in_coalition = yes #Western_Autocracy
+							western_conservatism_are_in_coalition = yes #conservatism
+							western_liberals_are_in_coalition = yes #liberalism
+							emerging_reactionaries_are_in_coalition = yes #Conservative
+							emerging_autocracy_are_in_coalition = yes #Autocracy
+							emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_autocracy_are_in_coalition = yes #Neutral_Autocracy
+							neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+							neutrality_neutral_oligarch_are_in_coalition = yes #oligarchism
+							neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+							nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+							nationalist_monarchists_are_in_coalition = yes #Monarchist
 							#won't join coalition if:
-							is_in_array = { ruling_party = 0 } #Western_Autocracy
-							is_in_array = { ruling_party = 1 } #conservatism
-							is_in_array = { ruling_party = 2 } #liberalism
-							is_in_array = { ruling_party = 6 } #Conservative
-							is_in_array = { ruling_party = 7 } #Autocracy
-							is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-							is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-							is_in_array = { ruling_party = 14 } #Neutral_conservatism
-							is_in_array = { ruling_party = 15 } #oligarchism
-							is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-							is_in_array = { ruling_party = 20 } #Nat_Populism
-							is_in_array = { ruling_party = 21 } #Nat_Fascism
-							is_in_array = { ruling_party = 23 } #Monarchist
+							western_autocrats_are_in_power = yes #Western_Autocracy
+							western_conservatism_are_in_power = yes #conservatism
+							western_liberals_are_in_power = yes #liberalism
+							emerging_reactionaries_are_in_power = yes #Conservative
+							emerging_autocracy_are_in_power = yes #Autocracy
+							emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+							emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+							neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+							neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+							neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+							nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+							nationalist_fascist_are_in_power = yes #Nat_Fascism
+							nationalist_monarchists_are_in_power = yes #Monarchist
 						#}
 					}
 				}
@@ -2883,7 +2883,7 @@ coalition_decisions = {
 	Neutral_Communism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 19 } }
+		visible = { neutrality_neutral_communism_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -2921,8 +2921,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^20 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 20 } #is already in coalition
-					is_in_array = { ruling_party = 20 } #is already in coalition
+					nationalist_right_wing_populists_are_in_coalition = yes #is already in coalition
+					nationalist_right_wing_populists_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -2952,25 +2952,25 @@ coalition_decisions = {
 						}
 						#hidden_trigger = {
 							#won't join coalition if:
-							is_in_array = { gov_coalition_array = 3 } #socialism
-							is_in_array = { gov_coalition_array = 4 } #Communist-State
-							is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-							is_in_array = { gov_coalition_array = 10 } #Kingdom
-							is_in_array = { gov_coalition_array = 11 } #Caliphate
-							is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { gov_coalition_array = 17 } #Neutral_green
-							is_in_array = { gov_coalition_array = 18 } #neutral_Social
-							is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+							western_social_democrats_are_in_coalition = yes #socialism
+							emerging_communist_state_are_in_coalition = yes #Communist-State
+							emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+							salafist_kingdom_are_in_coalition = yes #Kingdom
+							salafist_caliphate_are_in_coalition = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+							neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+							neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 							#won't join coalition if:
-							is_in_array = { ruling_party = 3 } #socialism
-							is_in_array = { ruling_party = 4 } #Communist-State
-							is_in_array = { ruling_party = 5 } #anarchist_communism
-							is_in_array = { ruling_party = 10 } #Kingdom
-							is_in_array = { ruling_party = 11 } #Caliphate
-							is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-							is_in_array = { ruling_party = 17 } #Neutral_green
-							is_in_array = { ruling_party = 18 } #neutral_Social
-							is_in_array = { ruling_party = 19 } #Neutral_Communism
+							western_social_democrats_are_in_power = yes #socialism
+							emerging_communist_state_are_in_power = yes #Communist-State
+							emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+							salafist_kingdom_are_in_power = yes #Kingdom
+							salafist_caliphate_are_in_power = yes #Caliphate
+							neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+							neutrality_neutral_green_are_in_power = yes #Neutral_green
+							neutrality_neutral_social_are_in_power = yes #neutral_Social
+							neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 						#}
 					}
 				}
@@ -3006,7 +3006,7 @@ coalition_decisions = {
 	Nat_Populism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 20 } }
+		visible = { nationalist_right_wing_populists_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -3044,8 +3044,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^21 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 21 } #is already in coalition
-					is_in_array = { ruling_party = 21 } #is already in coalition
+					nationalist_fascist_are_in_coalition = yes #is already in coalition
+					nationalist_fascist_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -3075,39 +3075,39 @@ coalition_decisions = {
 							}
 							#hidden_trigger = {
 								#won't join coalition if:
-								is_in_array = { gov_coalition_array = 1 } #conservatism
-								is_in_array = { gov_coalition_array = 2 } #liberalism
-								is_in_array = { gov_coalition_array = 3 } #socialism
-								is_in_array = { gov_coalition_array = 4 } #Communist-State
-								is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-								is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-								is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-								is_in_array = { gov_coalition_array = 10 } #Kingdom
-								is_in_array = { gov_coalition_array = 11 } #Caliphate
-								is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-								is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-								is_in_array = { gov_coalition_array = 15 } #oligarchism
-								is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-								is_in_array = { gov_coalition_array = 17 } #Neutral_green
-								is_in_array = { gov_coalition_array = 18 } #neutral_Social
-								is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+								western_conservatism_are_in_coalition = yes #conservatism
+								western_liberals_are_in_coalition = yes #liberalism
+								western_social_democrats_are_in_coalition = yes #socialism
+								emerging_communist_state_are_in_coalition = yes #Communist-State
+								emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+								emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+								emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+								salafist_kingdom_are_in_coalition = yes #Kingdom
+								salafist_caliphate_are_in_coalition = yes #Caliphate
+								neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+								neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+								neutrality_neutral_oligarch_are_in_coalition = yes #oligarchism
+								neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+								neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+								neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+								neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 								#won't join coalition if:
-								is_in_array = { ruling_party = 1 } #conservatism
-								is_in_array = { ruling_party = 2 } #liberalism
-								is_in_array = { ruling_party = 3 } #socialism
-								is_in_array = { ruling_party = 4 } #Communist-State
-								is_in_array = { ruling_party = 5 } #anarchist_communism
-								is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-								is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-								is_in_array = { ruling_party = 10 } #Kingdom
-								is_in_array = { ruling_party = 11 } #Caliphate
-								is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-								is_in_array = { ruling_party = 14 } #Neutral_conservatism
-								is_in_array = { ruling_party = 15 } #oligarchism
-								is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-								is_in_array = { ruling_party = 17 } #Neutral_green
-								is_in_array = { ruling_party = 18 } #neutral_Social
-								is_in_array = { ruling_party = 19 } #Neutral_Communism
+								western_conservatism_are_in_power = yes #conservatism
+								western_liberals_are_in_power = yes #liberalism
+								western_social_democrats_are_in_power = yes #socialism
+								emerging_communist_state_are_in_power = yes #Communist-State
+								emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+								emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+								emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+								salafist_kingdom_are_in_power = yes #Kingdom
+								salafist_caliphate_are_in_power = yes #Caliphate
+								neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+								neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+								neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+								neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+								neutrality_neutral_green_are_in_power = yes #Neutral_green
+								neutrality_neutral_social_are_in_power = yes #neutral_Social
+								neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 							#}
 						}
 					}
@@ -3144,7 +3144,7 @@ coalition_decisions = {
 	Nat_Fascism_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 21 } }
+		visible = { nationalist_fascist_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -3181,8 +3181,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^22 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 22 } #is already in coalition
-					is_in_array = { ruling_party = 22 } #is already in coalition
+					nationalist_military_junta_are_in_coalition = yes #is already in coalition
+					nationalist_military_junta_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -3208,29 +3208,29 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 1 } #conservatism
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-						is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 18 } #neutral_Social
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+						western_conservatism_are_in_coalition = yes #conservatism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+						neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 						#won't join coalition if:
-						is_in_array = { ruling_party = 1 } #conservatism
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 5 } #anarchist_communism
-						is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { ruling_party = 14 } #Neutral_conservatism
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 18 } #neutral_Social
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
+						western_conservatism_are_in_power = yes #conservatism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_social_are_in_power = yes #neutral_Social
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 					#}
 				}
 			}
@@ -3265,7 +3265,7 @@ coalition_decisions = {
 	Nat_Autocracy_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 22 } }
+		visible = { nationalist_military_junta_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 
@@ -3302,8 +3302,8 @@ coalition_decisions = {
 			check_variable = { party_pop_elect_array^23 > election_threshold }
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 23 } #is already in coalition
-					is_in_array = { ruling_party = 23 } #is already in coalition
+					nationalist_monarchists_are_in_coalition = yes #is already in coalition
+					nationalist_monarchists_are_in_power = yes #is already in coalition
 				}
 			}
 		}
@@ -3329,31 +3329,31 @@ coalition_decisions = {
 					}
 					#hidden_trigger = {
 						#won't join coalition if:
-						is_in_array = { gov_coalition_array = 2 } #liberalism
-						is_in_array = { gov_coalition_array = 3 } #socialism
-						is_in_array = { gov_coalition_array = 4 } #Communist-State
-						is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-						is_in_array = { gov_coalition_array = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 9 } #Vilayat_e_Faqih
-						is_in_array = { gov_coalition_array = 10 } #Kingdom
-						is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-						is_in_array = { gov_coalition_array = 17 } #Neutral_green
-						is_in_array = { gov_coalition_array = 18 } #neutral_Social
-						is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+						western_liberals_are_in_coalition = yes #liberalism
+						western_social_democrats_are_in_coalition = yes #socialism
+						emerging_communist_state_are_in_coalition = yes #Communist-State
+						emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+						emerging_moderate_shiite_are_in_coalition = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_coalition = yes #Vilayat_e_Faqih
+						salafist_kingdom_are_in_coalition = yes #Kingdom
+						neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+						neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+						neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 						#won't join coalition if:
-						is_in_array = { ruling_party = 2 } #liberalism
-						is_in_array = { ruling_party = 3 } #socialism
-						is_in_array = { ruling_party = 4 } #Communist-State
-						is_in_array = { ruling_party = 5 } #anarchist_communism
-						is_in_array = { ruling_party = 8 } #Mod_Vilayat_e_Faqih
-						is_in_array = { ruling_party = 9 } #Vilayat_e_Faqih
-						is_in_array = { ruling_party = 10 } #Kingdom
-						is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-						is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-						is_in_array = { ruling_party = 17 } #Neutral_green
-						is_in_array = { ruling_party = 18 } #neutral_Social
-						is_in_array = { ruling_party = 19 } #Neutral_Communism
+						western_liberals_are_in_power = yes #liberalism
+						western_social_democrats_are_in_power = yes #socialism
+						emerging_communist_state_are_in_power = yes #Communist-State
+						emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+						emerging_moderate_shiite_are_in_power = yes #Mod_Vilayat_e_Faqih
+						emerging_hardline_shiite_are_in_power = yes #Vilayat_e_Faqih
+						salafist_kingdom_are_in_power = yes #Kingdom
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+						neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+						neutrality_neutral_green_are_in_power = yes #Neutral_green
+						neutrality_neutral_social_are_in_power = yes #neutral_Social
+						neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 					#}
 				}
 			}
@@ -3388,7 +3388,7 @@ coalition_decisions = {
 	Monarchist_remove = {
 		icon = decision
 		available = { NOT = { has_country_flag = coalition_party_negotiations } }
-		visible = { is_in_array = { gov_coalition_array = 23 } }
+		visible = { nationalist_monarchists_are_in_coalition = yes }
 
 		ai_will_do = { base = 0 }
 

--- a/common/decisions/Country Flag Decisions.txt
+++ b/common/decisions/Country Flag Decisions.txt
@@ -177,10 +177,10 @@ different_country_flags_category = {
 			}
 
 			OR = {
-				is_in_array = { ruling_party = 0 }
-				is_in_array = { ruling_party = 7 }
-				is_in_array = { ruling_party = 13 }
-				is_in_array = { ruling_party = 22 }
+				western_autocrats_are_in_power = yes
+				emerging_autocracy_are_in_power = yes
+				neutrality_neutral_autocracy_are_in_power = yes
+				nationalist_military_junta_are_in_power = yes
 
 				# Normally democratic party is AUTH
 				AND = {
@@ -207,18 +207,18 @@ different_country_flags_category = {
 						}
 					}
 					OR = {
-						is_in_array = { ruling_party = 1 }
-						is_in_array = { ruling_party = 2 }
-						is_in_array = { ruling_party = 3 }
-						is_in_array = { ruling_party = 5 }
-						is_in_array = { ruling_party = 6 }
-						is_in_array = { ruling_party = 12 }
-						is_in_array = { ruling_party = 14 }
-						is_in_array = { ruling_party = 15 }
-						is_in_array = { ruling_party = 16 }
-						is_in_array = { ruling_party = 17 }
-						is_in_array = { ruling_party = 18 }
-						is_in_array = { ruling_party = 20 }
+						western_conservatism_are_in_power = yes
+						western_liberals_are_in_power = yes
+						western_social_democrats_are_in_power = yes
+						emerging_anarchist_communism_are_in_power = yes
+						emerging_reactionaries_are_in_power = yes
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes
+						neutrality_neutral_conservatism_are_in_power = yes
+						neutrality_neutral_oligarch_are_in_power = yes
+						neutrality_neutral_libertarians_are_in_power = yes
+						neutrality_neutral_green_are_in_power = yes
+						neutrality_neutral_social_are_in_power = yes
+						nationalist_right_wing_populists_are_in_power = yes
 					}
 				}
 			}
@@ -247,14 +247,14 @@ different_country_flags_category = {
 			NOT = {
 				has_civil_war = yes
 				OR = {
-					is_in_array = { ruling_party = 22 }
+					nationalist_military_junta_are_in_power = yes
 					AND = {
 						NOT = { tag = var:temp_var }
 						var:temp_var = {
 							OR = {
-								is_in_array = { ruling_party = 0 }
-								is_in_array = { ruling_party = 7 }
-								is_in_array = { ruling_party = 13 }
+								western_autocrats_are_in_power = yes
+								emerging_autocracy_are_in_power = yes
+								neutrality_neutral_autocracy_are_in_power = yes
 							}
 						}
 					}

--- a/common/decisions/Gulf.txt
+++ b/common/decisions/Gulf.txt
@@ -2811,7 +2811,7 @@ subversive_activities = {
 				PAL = {
 					custom_trigger_tooltip = {
 						tooltip = hamas_tt
-						is_in_array = { ruling_party = 12 }
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes
 					}
 				}
 			}

--- a/common/decisions/Korea.txt
+++ b/common/decisions/Korea.txt
@@ -423,7 +423,7 @@ KOR_38th_parallel = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 				NKO = { has_government = democratic }
 				NKO = { has_government = neutrality }
@@ -489,7 +489,7 @@ KOR_38th_parallel = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 				NKO = { has_government = democratic }
 				NKO = { has_government = neutrality }
@@ -564,7 +564,7 @@ KOR_38th_parallel = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 				NKO = { has_government = democratic }
 				NKO = { has_government = neutrality }

--- a/common/decisions/Political Desicions.txt
+++ b/common/decisions/Political Desicions.txt
@@ -223,7 +223,7 @@ generic_coalition_politics_decisions = {
 				limit = { tag = USA }
 				has_country_flag = collapsed_nation
 			}
-			NOT = { is_in_array = { ruling_party = 11 } }
+			NOT = { salafist_caliphate_are_in_power = yes }
 			if = {
 				limit = { tag = PER }
 				NOT = {
@@ -294,18 +294,18 @@ generic_coalition_politics_decisions = {
 			}
 			OR = {
 				non_technocrats_western_autocrats_are_in_power = yes
-				is_in_array = { ruling_party = 4 } #Communist-State
-				is_in_array = { ruling_party = 7 } #Autocracy
-				is_in_array = { ruling_party = 10 } #Kingdom
-				is_in_array = { ruling_party = 11 } #Caliphate
-				is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-				is_in_array = { ruling_party = 19 } #neutral communist
-				is_in_array = { ruling_party = 21 } #fascist
-				is_in_array = { ruling_party = 22 } #Nat_Autocracy
-				is_in_array = { ruling_party = 23 } #Monarchist
+				emerging_communist_state_are_in_power = yes #Communist-State
+				emerging_autocracy_are_in_power = yes #Autocracy
+				salafist_kingdom_are_in_power = yes #Kingdom
+				salafist_caliphate_are_in_power = yes #Caliphate
+				neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+				neutrality_neutral_communism_are_in_power = yes #neutral communist
+				nationalist_fascist_are_in_power = yes #fascist
+				nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_power = yes #Monarchist
 
-				is_in_array = { ruling_party = 8 } #Moderate Shiite
-				is_in_array = { ruling_party = 9 } #Hardline Shiite
+				emerging_moderate_shiite_are_in_power = yes #Moderate Shiite
+				emerging_hardline_shiite_are_in_power = yes #Hardline Shiite
 			}
 			if = {
 				limit = { tag = PER }
@@ -470,7 +470,7 @@ generic_coalition_politics_decisions = {
 				has_completed_focus = GCC_free_and_fair_elections
 			}
 			NOT = {
-				is_in_array = { ruling_party = 11 }
+				salafist_caliphate_are_in_power = yes
 			}
 			if = {
 				limit = { tag = PER }
@@ -697,8 +697,8 @@ generic_coalition_politics_decisions = {
 			has_civil_war = no
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 21 } #not is in coalition
-					is_in_array = { ruling_party = 21 } #not is ruling party
+					nationalist_fascist_are_in_coalition = yes #not is in coalition
+					nationalist_fascist_are_in_power = yes #not is ruling party
 				}
 			}
 		}
@@ -765,8 +765,8 @@ generic_coalition_politics_decisions = {
 			has_civil_war = no
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 22 } #not is in coalition
-					is_in_array = { ruling_party = 22 } #not is ruling party
+					nationalist_military_junta_are_in_coalition = yes #not is in coalition
+					nationalist_military_junta_are_in_power = yes #not is ruling party
 				}
 			}
 		}
@@ -833,8 +833,8 @@ generic_coalition_politics_decisions = {
 			has_civil_war = no
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 23 } #not is in coalition
-					is_in_array = { ruling_party = 23 } #not is ruling party
+					nationalist_monarchists_are_in_coalition = yes #not is in coalition
+					nationalist_monarchists_are_in_power = yes #not is ruling party
 				}
 			}
 		}
@@ -909,8 +909,8 @@ generic_coalition_politics_decisions = {
 			has_civil_war = no
 			NOT = {
 				OR = {
-					is_in_array = { gov_coalition_array = 11 } #not is in coalition
-					is_in_array = { ruling_party = 11 } #not is ruling party
+					salafist_caliphate_are_in_coalition = yes #not is in coalition
+					salafist_caliphate_are_in_power = yes #not is ruling party
 				}
 			}
 		}
@@ -976,13 +976,13 @@ generic_coalition_politics_decisions = {
 			NOT = {
 				OR = {
 					OR = {
-						is_in_array = { gov_coalition_array = 4 } #not is in coalition
-						is_in_array = { ruling_party = 4 } #not is ruling party
+						emerging_communist_state_are_in_coalition = yes #not is in coalition
+						emerging_communist_state_are_in_power = yes #not is ruling party
 					}
 					#not already communist
 					OR = {
-						is_in_array = { gov_coalition_array = 19 } #not is in coalition
-						is_in_array = { ruling_party = 19 } #not is ruling party
+						neutrality_neutral_communism_are_in_coalition = yes #not is in coalition
+						neutrality_neutral_communism_are_in_power = yes #not is ruling party
 					}
 				}
 			}
@@ -1052,13 +1052,13 @@ generic_coalition_politics_decisions = {
 			NOT = {
 				OR = {
 					OR = {
-						is_in_array = { gov_coalition_array = 4 } #not is in coalition
-						is_in_array = { ruling_party = 4 } #not is ruling party
+						emerging_communist_state_are_in_coalition = yes #not is in coalition
+						emerging_communist_state_are_in_power = yes #not is ruling party
 					}
 					#not already communist
 					OR = {
-						is_in_array = { gov_coalition_array = 19 } #not is in coalition
-						is_in_array = { ruling_party = 19 } #not is ruling party
+						neutrality_neutral_communism_are_in_coalition = yes #not is in coalition
+						neutrality_neutral_communism_are_in_power = yes #not is ruling party
 					}
 				}
 			}
@@ -1124,13 +1124,13 @@ generic_coalition_politics_decisions = {
 			NOT = {
 				OR = {
 					OR = {
-						is_in_array = { gov_coalition_array = 9 } #not is in coalition
-						is_in_array = { ruling_party = 9 } #not is ruling party
+						emerging_hardline_shiite_are_in_coalition = yes #not is in coalition
+						emerging_hardline_shiite_are_in_power = yes #not is ruling party
 					}
 					#also see if their moderate friends are there
 					OR = {
-						is_in_array = { gov_coalition_array = 8 } #not is in coalition
-						is_in_array = { ruling_party = 8 } #not is ruling party
+						emerging_moderate_shiite_are_in_coalition = yes #not is in coalition
+						emerging_moderate_shiite_are_in_power = yes #not is ruling party
 					}
 				}
 			}

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -805,8 +805,8 @@ TUR_domestic_politics_category = {
 
 		visible = {
 			OR = {
-				is_in_array = { ruling_party = 8 }
-				is_in_array = { ruling_party = 9 }
+				emerging_moderate_shiite_are_in_power = yes
+				emerging_hardline_shiite_are_in_power = yes
 			}
 		}
 		fire_only_once = yes

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -1058,7 +1058,7 @@ USA_congress_md = {
 		icon = decision
 		available = {
 			custom_trigger_tooltip = {
-				is_in_array = { ruling_party = 4 }
+				emerging_communist_state_are_in_power = yes
 				tooltip = has_communist_state_government_TT
 			}
 		}

--- a/common/decisions/categories/99_SPR_decision_categories.txt
+++ b/common/decisions/categories/99_SPR_decision_categories.txt
@@ -14,8 +14,8 @@ SPR_monarchist_spain = {
 	visible = {
 		OR = {
 			has_completed_focus = SPR_the_old_ways
-			is_in_array = { ruling_party = 0 }
-			is_in_array = { ruling_party = 23 }
+			western_autocrats_are_in_power = yes
+			nationalist_monarchists_are_in_power = yes
 		}
 	}
 	priority = 99

--- a/common/decisions/north_korea.txt
+++ b/common/decisions/north_korea.txt
@@ -113,7 +113,7 @@ NKO_united_front_department = {
 				KOR = {
 					custom_trigger_tooltip = {
 						tooltip = KOR_democratic_party_governing_tt
-						is_in_array = { ruling_party = 3 }
+						western_social_democrats_are_in_power = yes
 					}
 				}
 				NKO = { has_government = democratic }
@@ -161,7 +161,7 @@ NKO_united_front_department = {
 				KOR = {
 					custom_trigger_tooltip = {
 						tooltip = KOR_democratic_party_governing_tt
-						is_in_array = { ruling_party = 3 }
+						western_social_democrats_are_in_power = yes
 					}
 				}
 				NKO = { has_government = democratic }

--- a/common/decisions/subparty_policies_decisions.txt
+++ b/common/decisions/subparty_policies_decisions.txt
@@ -724,7 +724,7 @@ subparty_policies_category = {
 		cost = 200
 
 		visible = {
-			is_in_array = { ruling_party = 21 }	#fascists
+			nationalist_fascist_are_in_power = yes	#fascists
 		}
 
 		available = {

--- a/common/ideas/AA_law_internal_factions.txt
+++ b/common/ideas/AA_law_internal_factions.txt
@@ -184,8 +184,8 @@ ideas = {
 
 			available = {
 				OR = {
-					is_in_array = { ruling_party = 15 }
-					is_in_array = { gov_coalition_array = 15 }
+					neutrality_neutral_oligarch_are_in_power = yes
+					neutrality_neutral_oligarch_are_in_coalition = yes
 					original_tag = SOV
 					original_tag = UKR
 					original_tag = KAZ

--- a/common/national_focus/02_EU_POTEF_shared.txt
+++ b/common/national_focus/02_EU_POTEF_shared.txt
@@ -763,7 +763,7 @@ shared_focus = {
 			OR = {
 				custom_trigger_tooltip = {
 					tooltip = tooltip_focus_POTEF205_trigger
-					is_in_array = { ruling_party = 1 }
+					western_conservatism_are_in_power = yes
 				}
 				has_government = nationalist
 			}

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -96,7 +96,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			is_in_array = { ruling_party = 7 }
+			emerging_autocracy_are_in_power = yes
 		}
 
 		completion_reward = {
@@ -1659,8 +1659,8 @@ focus_tree = {
 
 		available = {
 			NOT = {
-				is_in_array = { ruling_party = 7 }
-				is_in_array = { ruling_party = 22 }
+				emerging_autocracy_are_in_power = yes
+				nationalist_military_junta_are_in_power = yes
 			}
 		}
 
@@ -19307,7 +19307,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			is_in_array = { ruling_party = 19 }
+			neutrality_neutral_communism_are_in_power = yes
 		}
 
 		bypass = {
@@ -22423,7 +22423,7 @@ focus_tree = {
 		available = {
 			OR = {
 				emerging_communist_state_are_in_power = yes
-				is_in_array = { ruling_party = 7 }
+				emerging_autocracy_are_in_power = yes
 			}
 			NOT = {
 				has_completed_focus = ALG_mend_ties_with_rabat
@@ -25860,6 +25860,7 @@ focus_tree = {
 		available = {
 			country_exists = KBY
 			has_completed_focus = ALG_kabyle_autonomy_statute
+			nationalist_right_wing_populists_are_in_power = yes
 		}
 
 		completion_reward = {
@@ -25894,7 +25895,7 @@ focus_tree = {
 
 		available = {
 			country_exists = KBY
-			is_in_array = { ruling_party = 20 }
+			nationalist_right_wing_populists_are_in_power = yes
 		}
 
 		completion_reward = {
@@ -25935,7 +25936,7 @@ focus_tree = {
 
 		available = {
 			country_exists = KBY
-			is_in_array = { ruling_party = 20 }
+			nationalist_right_wing_populists_are_in_power = yes
 		}
 
 		completion_reward = {
@@ -26305,7 +26306,7 @@ focus_tree = {
 
 		available = {
 			country_exists = KBY
-			is_in_array = { ruling_party = 20 }
+			nationalist_right_wing_populists_are_in_power = yes
 		}
 
 		completion_reward = {
@@ -28421,7 +28422,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			is_in_array = { ruling_party = 12 }
+			neutrality_neutral_muslim_brotherhood_are_in_power = yes
 		}
 
 		completion_reward = {

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -1658,10 +1658,8 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				emerging_autocracy_are_in_power = yes
-				nationalist_military_junta_are_in_power = yes
-			}
+			NOT = { emerging_autocracy_are_in_power = yes }
+			NOT = { nationalist_military_junta_are_in_power = yes }
 		}
 
 		completion_reward = {

--- a/common/national_focus/05_bosnia.txt
+++ b/common/national_focus/05_bosnia.txt
@@ -3492,7 +3492,7 @@ focus_tree = {
 
 		available = { hidden_trigger = { NOT = { has_country_flag = civil_war_focus } }
 			NOT = { has_active_mission = coalition_countdown }
-			NOT = { is_in_array = { ruling_party = 11 } }
+			NOT = { salafist_caliphate_are_in_power = yes }
 			has_elections = yes
 		}
 
@@ -3969,7 +3969,7 @@ focus_tree = {
 		available = {
 			hidden_trigger = { NOT = { has_country_flag = civil_war_focus has_country_flag = bosnian_loser } }
 			NOT = { has_active_mission = coalition_countdown }
-			NOT = { is_in_array = { ruling_party = 11 } }
+			NOT = { salafist_caliphate_are_in_power = yes }
 			has_elections = yes
 		}
 

--- a/common/national_focus/05_botswana.txt
+++ b/common/national_focus/05_botswana.txt
@@ -851,7 +851,7 @@ focus_tree = {
 				has_government = nationalist
 				custom_trigger_tooltip = {
 					tooltip = BOT_unite_bushmen_trigger_tt
-					is_in_array = { gov_coalition_array = 20 }
+					nationalist_right_wing_populists_are_in_coalition = yes
 				}
 			}
 		}

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -29479,7 +29479,7 @@ focus_tree = {
 					HAM = {
 						custom_trigger_tooltip = {
 							tooltip = hamas_tt
-							is_in_array = { ruling_party = 12 }
+							neutrality_neutral_muslim_brotherhood_are_in_power = yes
 						}
 					}
 					QAT = {

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -10440,7 +10440,7 @@ focus_tree = {
 			has_country_flag = BRA_psdb_win
 		}
 		bypass = {
-			is_in_array = { gov_coalition_array = 3 }
+			western_social_democrats_are_in_coalition = yes
 		}
 
 		completion_reward = {

--- a/common/national_focus/china.txt
+++ b/common/national_focus/china.txt
@@ -4447,12 +4447,12 @@ focus_tree = {
 				custom_trigger_tooltip = {
 					tooltip = TAI_DPP_not_ruling_tt
 					OR = {
-						is_in_array = { ruling_party = 1 }
-						is_in_array = { ruling_party = 6 }
-						is_in_array = { ruling_party = 14 }
-						is_in_array = { ruling_party = 4 }
-						is_in_array = { ruling_party = 5 }
-						is_in_array = { ruling_party = 19 }
+						western_conservatism_are_in_power = yes
+						emerging_reactionaries_are_in_power = yes
+						neutrality_neutral_conservatism_are_in_power = yes
+						emerging_communist_state_are_in_power = yes
+						emerging_anarchist_communism_are_in_power = yes
+						neutrality_neutral_communism_are_in_power = yes
 					}
 				}
 			}
@@ -4498,12 +4498,12 @@ focus_tree = {
 				custom_trigger_tooltip = {
 					tooltip = TAI_DPP_not_ruling_tt
 					OR = {
-						is_in_array = { ruling_party = 1 }
-						is_in_array = { ruling_party = 6 }
-						is_in_array = { ruling_party = 14 }
-						is_in_array = { ruling_party = 4 }
-						is_in_array = { ruling_party = 5 }
-						is_in_array = { ruling_party = 19 }
+						western_conservatism_are_in_power = yes
+						emerging_reactionaries_are_in_power = yes
+						neutrality_neutral_conservatism_are_in_power = yes
+						emerging_communist_state_are_in_power = yes
+						emerging_anarchist_communism_are_in_power = yes
+						neutrality_neutral_communism_are_in_power = yes
 					}
 				}
 			}
@@ -5236,9 +5236,9 @@ focus_tree = {
 								 custom_trigger_tooltip = {
 								   tooltip = TAI_COM_ruling_tt
 									OR = {
-									  is_in_array = { ruling_party = 4 }
-									  is_in_array = { ruling_party = 5 }
-									  is_in_array = { ruling_party = 19 }
+									  emerging_communist_state_are_in_power = yes
+									  emerging_anarchist_communism_are_in_power = yes
+									  neutrality_neutral_communism_are_in_power = yes
 								}
 							}
 						}
@@ -5285,9 +5285,9 @@ focus_tree = {
 								 custom_trigger_tooltip = {
 								   tooltip = TAI_COM_ruling_tt
 									OR = {
-									  is_in_array = { ruling_party = 4 }
-									  is_in_array = { ruling_party = 5 }
-									  is_in_array = { ruling_party = 19 }
+									  emerging_communist_state_are_in_power = yes
+									  emerging_anarchist_communism_are_in_power = yes
+									  neutrality_neutral_communism_are_in_power = yes
 								}
 							}
 						}
@@ -5330,9 +5330,9 @@ focus_tree = {
 								 custom_trigger_tooltip = {
 								   tooltip = TAI_COM_ruling_tt
 									OR = {
-									  is_in_array = { ruling_party = 4 }
-									  is_in_array = { ruling_party = 5 }
-									  is_in_array = { ruling_party = 19 }
+									  emerging_communist_state_are_in_power = yes
+									  emerging_anarchist_communism_are_in_power = yes
+									  neutrality_neutral_communism_are_in_power = yes
 								}
 							}
 						}
@@ -5410,9 +5410,9 @@ focus_tree = {
 			TAI = { custom_trigger_tooltip = {
 						tooltip = TAI_COM_ruling_tt
 							OR = {
-								is_in_array = { ruling_party = 4 }
-								is_in_array = { ruling_party = 5 }
-								is_in_array = { ruling_party = 19 }
+								emerging_communist_state_are_in_power = yes
+								emerging_anarchist_communism_are_in_power = yes
+								neutrality_neutral_communism_are_in_power = yes
 							}
 					}
 				}
@@ -5975,9 +5975,9 @@ focus_tree = {
 							 TAI = { custom_trigger_tooltip = {
 							 tooltip = TAI_COM_ruling_tt
 							 OR = {
-								is_in_array = { ruling_party = 4 }
-								is_in_array = { ruling_party = 5 }
-								is_in_array = { ruling_party = 19 }
+								emerging_communist_state_are_in_power = yes
+								emerging_anarchist_communism_are_in_power = yes
+								neutrality_neutral_communism_are_in_power = yes
 							}
 					}
 				}

--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -3182,11 +3182,9 @@ focus_tree = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = not_pro_monarchy_tt
-				NOT = {
-					western_autocrats_are_in_power = yes
-					salafist_kingdom_are_in_power = yes
-					neutrality_neutral_autocracy_are_in_power = yes
-				}
+				NOT = { western_autocrats_are_in_power = yes }
+				NOT = { salafist_kingdom_are_in_power = yes }
+				NOT = { neutrality_neutral_autocracy_are_in_power = yes }
 			}
 		}
 

--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -3183,9 +3183,9 @@ focus_tree = {
 			custom_trigger_tooltip = {
 				tooltip = not_pro_monarchy_tt
 				NOT = {
-					is_in_array = { ruling_party = 0 }
-					is_in_array = { ruling_party = 10 }
-					is_in_array = { ruling_party = 13 }
+					western_autocrats_are_in_power = yes
+					salafist_kingdom_are_in_power = yes
+					neutrality_neutral_autocracy_are_in_power = yes
 				}
 			}
 		}
@@ -3410,9 +3410,9 @@ focus_tree = {
 			custom_trigger_tooltip = {
 				tooltip = monarchy_in_power_tt
 				OR = {
-					is_in_array = { ruling_party = 0 }
-					is_in_array = { ruling_party = 10 }
-					is_in_array = { ruling_party = 13 }
+					western_autocrats_are_in_power = yes
+					salafist_kingdom_are_in_power = yes
+					neutrality_neutral_autocracy_are_in_power = yes
 				}
 			}
 		}
@@ -7063,7 +7063,7 @@ focus_tree = {
 				PAL = {
 					custom_trigger_tooltip = {
 						tooltip = hamas_tt
-						is_in_array = { ruling_party = 12 }
+						neutrality_neutral_muslim_brotherhood_are_in_power = yes
 					}
 				}
 			}

--- a/common/national_focus/korea_confederation.txt
+++ b/common/national_focus/korea_confederation.txt
@@ -22,7 +22,7 @@ joint_focus = {
 			KOR = {
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 			}
 			NKO = { has_government = democratic }
@@ -124,7 +124,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -184,7 +184,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -237,7 +237,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -293,7 +293,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -354,7 +354,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -406,7 +406,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -469,7 +469,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -592,7 +592,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse
@@ -671,7 +671,7 @@ joint_focus = {
 
 	ai_will_do = {
 		base = 1
-	
+
 		modifier = {
 			factor = 0
 			has_active_mission = bankruptcy_incoming_collapse

--- a/common/national_focus/korea_south.txt
+++ b/common/national_focus/korea_south.txt
@@ -2920,7 +2920,7 @@ focus_tree = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 			}
 			NKO = { has_war = no }
@@ -3410,8 +3410,8 @@ focus_tree = {
 			custom_trigger_tooltip = {
 				tooltip = KOR_peoples_party_tt
 				OR = {
-					is_in_array = { ruling_party = 2 } #liberalism
-					is_in_array = { gov_coalition_array = 2 } #liberalism
+					western_liberals_are_in_power = yes #liberalism
+					western_liberals_are_in_coalition = yes #liberalism
 				}
 			}
 		}
@@ -3444,8 +3444,8 @@ focus_tree = {
 			custom_trigger_tooltip = {
 				tooltip = KOR_peoples_party_tt
 				OR = {
-					is_in_array = { ruling_party = 2 } #liberalism
-					is_in_array = { gov_coalition_array = 2 } #liberalism
+					western_liberals_are_in_power = yes #liberalism
+					western_liberals_are_in_coalition = yes #liberalism
 				}
 			}
 		}
@@ -3480,8 +3480,8 @@ focus_tree = {
 			custom_trigger_tooltip = {
 				tooltip = KOR_peoples_party_tt
 				OR = {
-					is_in_array = { ruling_party = 2 } #liberalism
-					is_in_array = { gov_coalition_array = 2 } #liberalism
+					western_liberals_are_in_power = yes #liberalism
+					western_liberals_are_in_coalition = yes #liberalism
 				}
 			}
 		}
@@ -6905,7 +6905,7 @@ focus_tree = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 			}
 		}
@@ -6949,7 +6949,7 @@ focus_tree = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 			}
 		}
@@ -6988,7 +6988,7 @@ focus_tree = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 			}
 		}
@@ -7041,7 +7041,7 @@ focus_tree = {
 				KOR_has_progressive_government = yes
 				custom_trigger_tooltip = {
 					tooltip = KOR_democratic_party_governing_tt
-					is_in_array = { ruling_party = 3 }
+					western_social_democrats_are_in_power = yes
 				}
 			}
 			USA = { influence_less_10 = yes }

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -16045,13 +16045,13 @@ focus_tree = {
 					custom_trigger_tooltip = {
 						tooltip = USA_not_have_republicans_in_charge_TT
 						NOT = {
-							is_in_array = { ruling_party = 1 }
+							western_conservatism_are_in_power = yes
 						}
 					}
 					custom_trigger_tooltip = {
 						tooltip = USA_not_have_democrats_in_charge_TT
 						NOT = {
-							is_in_array = { ruling_party = 2 }
+							western_liberals_are_in_power = yes
 						}
 					}
 					has_completed_focus = USA_focus_domestic_over_foreign

--- a/common/national_focus/venezuela.txt
+++ b/common/national_focus/venezuela.txt
@@ -1127,8 +1127,8 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_chevron"
-			add_opinion_modifier = { target = ROOT modifier = large_commercial_relations }
-			reverse_add_opinion_modifier = { target = ROOT modifier = large_commercial_relations }
+			add_opinion_modifier = { target = USA modifier = large_commercial_relations }
+			reverse_add_opinion_modifier = { target = USA modifier = large_commercial_relations }
 			two_fuel_reserve = yes
 		}
 		ai_will_do = {

--- a/common/scripted_localisation/00_scripted_localisation.txt
+++ b/common/scripted_localisation/00_scripted_localisation.txt
@@ -55,8 +55,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { ruling_party = 10 }	#Kingdom
-				is_in_array = { ruling_party = 23 }	#Monarchist
+				salafist_kingdom_are_in_power = yes	#Kingdom
+				nationalist_monarchists_are_in_power = yes	#Monarchist
 			}
 		}
 		localization_key = IP_monarch_name_current_leader
@@ -72,8 +72,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { ruling_party = 4 }
-				is_in_array = { ruling_party = 19 }
+				emerging_communist_state_are_in_power = yes
+				neutrality_neutral_communism_are_in_power = yes
 			}
 		}
 		localization_key = "GFX_IP_backglow"
@@ -90,10 +90,10 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { ruling_party = 3 }	#socialsim
-				is_in_array = { ruling_party = 5 }	#anarchist_communism
-				is_in_array = { ruling_party = 17 }	#Neutral_green
-				is_in_array = { ruling_party = 18 }	#neutral_Social
+				western_social_democrats_are_in_power = yes	#socialsim
+				emerging_anarchist_communism_are_in_power = yes	#anarchist_communism
+				neutrality_neutral_green_are_in_power = yes	#Neutral_green
+				neutrality_neutral_social_are_in_power = yes	#neutral_Social
 			}
 		}
 		localization_key = "GFX_IP_backglow"
@@ -110,12 +110,12 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { ruling_party = 1 }	#conservative
-				is_in_array = { ruling_party = 6 }	#Conservative
-				is_in_array = { ruling_party = 8 }	#Mod vilayat e faqih
-				is_in_array = { ruling_party = 12 }	#muslim brotherhood
-				is_in_array = { ruling_party = 14 }	#neutral conservative
-				is_in_array = { ruling_party = 20 }	#national populist
+				western_conservatism_are_in_power = yes	#conservative
+				emerging_reactionaries_are_in_power = yes	#Conservative
+				emerging_moderate_shiite_are_in_power = yes	#Mod vilayat e faqih
+				neutrality_neutral_muslim_brotherhood_are_in_power = yes	#muslim brotherhood
+				neutrality_neutral_conservatism_are_in_power = yes	#neutral conservative
+				nationalist_right_wing_populists_are_in_power = yes	#national populist
 			}
 		}
 		localization_key = "GFX_IP_backglow"
@@ -133,8 +133,8 @@ defined_text = {
 		trigger = {
 			OR = {
 				has_country_leader_with_trait = western_technocrat
-				is_in_array = { ruling_party = 2 }	#liberalism
-				is_in_array = { ruling_party = 16 }	#Neutral_Libertarian
+				western_liberals_are_in_power = yes	#liberalism
+				neutrality_neutral_libertarians_are_in_power = yes	#Neutral_Libertarian
 			}
 		}
 		localization_key = "GFX_IP_backglow"
@@ -152,11 +152,11 @@ defined_text = {
 		trigger = {
 			OR = {
 				non_technocrats_western_autocrats_are_in_power = yes
-				is_in_array = { ruling_party = 7 }	#Emerging autocrats
-				is_in_array = { ruling_party = 13 }	#Neutral autocrats
-				is_in_array = { ruling_party = 15 }	#oligarchs
-				is_in_array = { ruling_party = 21 }	#fascists
-				is_in_array = { ruling_party = 22 }	#military junta
+				emerging_autocracy_are_in_power = yes	#Emerging autocrats
+				neutrality_neutral_autocracy_are_in_power = yes	#Neutral autocrats
+				neutrality_neutral_oligarch_are_in_power = yes	#oligarchs
+				nationalist_fascist_are_in_power = yes	#fascists
+				nationalist_military_junta_are_in_power = yes	#military junta
 			}
 		}
 		localization_key = "GFX_IP_backglow"
@@ -173,8 +173,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { ruling_party = 10 }	#Kingdom
-				is_in_array = { ruling_party = 23 }	#Monarchist
+				salafist_kingdom_are_in_power = yes	#Kingdom
+				nationalist_monarchists_are_in_power = yes	#Monarchist
 			}
 		}
 		localization_key = "GFX_IP_backglow"
@@ -191,8 +191,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { ruling_party = 9 }	#Vilayat_e_Faqih
-				is_in_array = { ruling_party = 11 }	#Caliphate
+				emerging_hardline_shiite_are_in_power = yes	#Vilayat_e_Faqih
+				salafist_caliphate_are_in_power = yes	#Caliphate
 			}
 		}
 		localization_key = "GFX_IP_backglow"

--- a/common/scripted_localisation/00_subideology_scripted_localisation.txt
+++ b/common/scripted_localisation/00_subideology_scripted_localisation.txt
@@ -13,8 +13,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 0 }
-					is_in_array = { gov_coalition_array = 0 }
+					western_autocrats_are_in_power = yes
+					western_autocrats_are_in_coalition = yes
 				}
 			}
 		}
@@ -40,8 +40,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 1 }
-					is_in_array = { gov_coalition_array = 1 }
+					western_conservatism_are_in_power = yes
+					western_conservatism_are_in_coalition = yes
 				}
 			}
 		}
@@ -67,8 +67,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 2 }
-					is_in_array = { gov_coalition_array = 2 }
+					western_liberals_are_in_power = yes
+					western_liberals_are_in_coalition = yes
 				}
 			}
 		}
@@ -94,8 +94,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 3 }
-					is_in_array = { gov_coalition_array = 3 }
+					western_social_democrats_are_in_power = yes
+					western_social_democrats_are_in_coalition = yes
 				}
 			}
 		}
@@ -121,8 +121,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 4 }
-					is_in_array = { gov_coalition_array = 4 }
+					emerging_communist_state_are_in_power = yes
+					emerging_communist_state_are_in_coalition = yes
 				}
 			}
 		}
@@ -148,8 +148,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 5 }
-					is_in_array = { gov_coalition_array = 5 }
+					emerging_anarchist_communism_are_in_power = yes
+					emerging_anarchist_communism_are_in_coalition = yes
 				}
 			}
 		}
@@ -175,8 +175,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 6 }
-					is_in_array = { gov_coalition_array = 6 }
+					emerging_reactionaries_are_in_power = yes
+					emerging_reactionaries_are_in_coalition = yes
 				}
 			}
 		}
@@ -202,8 +202,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 7 }
-					is_in_array = { gov_coalition_array = 7 }
+					emerging_autocracy_are_in_power = yes
+					emerging_autocracy_are_in_coalition = yes
 				}
 			}
 		}
@@ -229,8 +229,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 8 }
-					is_in_array = { gov_coalition_array = 8 }
+					emerging_moderate_shiite_are_in_power = yes
+					emerging_moderate_shiite_are_in_coalition = yes
 				}
 			}
 		}
@@ -256,8 +256,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 9 }
-					is_in_array = { gov_coalition_array = 9 }
+					emerging_hardline_shiite_are_in_power = yes
+					emerging_hardline_shiite_are_in_coalition = yes
 				}
 			}
 		}
@@ -283,8 +283,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 10 }
-					is_in_array = { gov_coalition_array = 10 }
+					salafist_kingdom_are_in_power = yes
+					salafist_kingdom_are_in_coalition = yes
 				}
 			}
 		}
@@ -310,8 +310,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 11 }
-					is_in_array = { gov_coalition_array = 11 }
+					salafist_caliphate_are_in_power = yes
+					salafist_caliphate_are_in_coalition = yes
 				}
 			}
 		}
@@ -337,8 +337,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 12 }
-					is_in_array = { gov_coalition_array = 12 }
+					neutrality_neutral_muslim_brotherhood_are_in_power = yes
+					neutrality_neutral_muslim_brotherhood_are_in_coalition = yes
 				}
 			}
 		}
@@ -364,8 +364,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 13 }
-					is_in_array = { gov_coalition_array = 13 }
+					neutrality_neutral_autocracy_are_in_power = yes
+					neutrality_neutral_autocracy_are_in_coalition = yes
 				}
 			}
 		}
@@ -391,8 +391,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 14 }
-					is_in_array = { gov_coalition_array = 14 }
+					neutrality_neutral_conservatism_are_in_power = yes
+					neutrality_neutral_conservatism_are_in_coalition = yes
 				}
 			}
 		}
@@ -418,8 +418,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 15 }
-					is_in_array = { gov_coalition_array = 15 }
+					neutrality_neutral_oligarch_are_in_power = yes
+					neutrality_neutral_oligarch_are_in_coalition = yes
 				}
 			}
 		}
@@ -445,8 +445,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 16 }
-					is_in_array = { gov_coalition_array = 16 }
+					neutrality_neutral_libertarians_are_in_power = yes
+					neutrality_neutral_libertarians_are_in_coalition = yes
 				}
 			}
 		}
@@ -472,8 +472,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 17 }
-					is_in_array = { gov_coalition_array = 17 }
+					neutrality_neutral_green_are_in_power = yes
+					neutrality_neutral_green_are_in_coalition = yes
 				}
 			}
 		}
@@ -499,8 +499,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 18 }
-					is_in_array = { gov_coalition_array = 18 }
+					neutrality_neutral_social_are_in_power = yes
+					neutrality_neutral_social_are_in_coalition = yes
 				}
 			}
 		}
@@ -526,8 +526,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 19 }
-					is_in_array = { gov_coalition_array = 19 }
+					neutrality_neutral_communism_are_in_power = yes
+					neutrality_neutral_communism_are_in_coalition = yes
 				}
 			}
 		}
@@ -553,8 +553,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 20 }
-					is_in_array = { gov_coalition_array = 20 }
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_right_wing_populists_are_in_coalition = yes
 				}
 			}
 		}
@@ -580,8 +580,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 21 }
-					is_in_array = { gov_coalition_array = 21 }
+					nationalist_fascist_are_in_power = yes
+					nationalist_fascist_are_in_coalition = yes
 				}
 			}
 		}
@@ -607,8 +607,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 22 }
-					is_in_array = { gov_coalition_array = 22 }
+					nationalist_military_junta_are_in_power = yes
+					nationalist_military_junta_are_in_coalition = yes
 				}
 			}
 		}
@@ -634,8 +634,8 @@ defined_text = {
 			#can't attack yourself or allies
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 23 }
-					is_in_array = { gov_coalition_array = 23 }
+					nationalist_monarchists_are_in_power = yes
+					nationalist_monarchists_are_in_coalition = yes
 				}
 			}
 		}
@@ -1179,8 +1179,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { gov_coalition_array = 1 }
-				is_in_array = { ruling_party = 1 }
+				western_conservatism_are_in_coalition = yes
+				western_conservatism_are_in_power = yes
 			}
 		}
 		localization_key = mutual_Neutral_conservatism_20_tt2
@@ -1193,8 +1193,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { gov_coalition_array = 1 }
-				is_in_array = { ruling_party = 1 }
+				western_conservatism_are_in_coalition = yes
+				western_conservatism_are_in_power = yes
 			}
 		}
 		localization_key = mutual_conservatism_20_tt2
@@ -1207,8 +1207,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { gov_coalition_array = 1 }
-				is_in_array = { ruling_party = 1 }
+				western_conservatism_are_in_coalition = yes
+				western_conservatism_are_in_power = yes
 			}
 		}
 		localization_key = mutual_conservatism_25_tt2
@@ -1221,8 +1221,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { gov_coalition_array = 3 } #social democrats
-				is_in_array = { ruling_party = 3 } #social democrats
+				western_social_democrats_are_in_coalition = yes #social democrats
+				western_social_democrats_are_in_power = yes #social democrats
 			}
 		}
 		localization_key = mutual_socialism_20_tt2
@@ -1235,8 +1235,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { gov_coalition_array = 3 } #social democrats
-				is_in_array = { ruling_party = 3 } #social democrats
+				western_social_democrats_are_in_coalition = yes #social democrats
+				western_social_democrats_are_in_power = yes #social democrats
 			}
 		}
 		localization_key = mutual_socialism_25_tt2
@@ -1249,8 +1249,8 @@ defined_text = {
 	text = {
 		trigger = {
 			OR = {
-				is_in_array = { gov_coalition_array = 18 }
-				is_in_array = { ruling_party = 18 }
+				neutrality_neutral_social_are_in_coalition = yes
+				neutrality_neutral_social_are_in_power = yes
 			}
 		}
 		localization_key = mutual_neutral_Social_20_tt2
@@ -1572,76 +1572,76 @@ defined_text = {
 defined_text = {
 	name = show_ruling_party
 
-	text = { trigger = { is_in_array = { ruling_party = 0 } }
+	text = { trigger = { western_autocrats_are_in_power = yes }
 		localization_key = "[Western_Autocracy_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 1 } }
+	text = { trigger = { western_conservatism_are_in_power = yes }
 		localization_key = "[conservatism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 2 } }
+	text = { trigger = { western_liberals_are_in_power = yes }
 		localization_key = "[liberalism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 3 } }
+	text = { trigger = { western_social_democrats_are_in_power = yes }
 		localization_key = "[socialism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 4 } }
+	text = { trigger = { emerging_communist_state_are_in_power = yes }
 		localization_key = "[Communist-State_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 5 } }
+	text = { trigger = { emerging_anarchist_communism_are_in_power = yes }
 		localization_key = "[anarchist_communism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 6 } }
+	text = { trigger = { emerging_reactionaries_are_in_power = yes }
 		localization_key = "[Conservative_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 7 } }
+	text = { trigger = { emerging_autocracy_are_in_power = yes }
 		localization_key = "[Autocracy_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 8 } }
+	text = { trigger = { emerging_moderate_shiite_are_in_power = yes }
 		localization_key = "[Mod_Vilayat_e_Faqih_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 9 } }
+	text = { trigger = { emerging_hardline_shiite_are_in_power = yes }
 		localization_key = "[Vilayat_e_Faqih_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 10 } }
+	text = { trigger = { salafist_kingdom_are_in_power = yes }
 		localization_key = "[Kingdom_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 11 } }
+	text = { trigger = { salafist_caliphate_are_in_power = yes }
 		localization_key = "[Caliphate_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 12 } }
+	text = { trigger = { neutrality_neutral_muslim_brotherhood_are_in_power = yes }
 		localization_key = "[Neutral_Muslim_Brotherhood_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 13 } }
+	text = { trigger = { neutrality_neutral_autocracy_are_in_power = yes }
 		localization_key = "[Neutral_Autocracy_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 14 } }
+	text = { trigger = { neutrality_neutral_conservatism_are_in_power = yes }
 		localization_key = "[Neutral_conservatism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 15 } }
+	text = { trigger = { neutrality_neutral_oligarch_are_in_power = yes }
 		localization_key = "[oligarchism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 16 } }
+	text = { trigger = { neutrality_neutral_libertarians_are_in_power = yes }
 		localization_key = "[Neutral_Libertarian_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 17 } }
+	text = { trigger = { neutrality_neutral_green_are_in_power = yes }
 		localization_key = "[Neutral_green_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 18 } }
+	text = { trigger = { neutrality_neutral_social_are_in_power = yes }
 		localization_key = "[neutral_Social_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 19 } }
+	text = { trigger = { neutrality_neutral_communism_are_in_power = yes }
 		localization_key = "[Neutral_Communism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 20 } }
+	text = { trigger = { nationalist_right_wing_populists_are_in_power = yes }
 		localization_key = "[Nat_Populism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 21 } }
+	text = { trigger = { nationalist_fascist_are_in_power = yes }
 		localization_key = "[Nat_Fascism_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 22 } }
+	text = { trigger = { nationalist_military_junta_are_in_power = yes }
 		localization_key = "[Nat_Autocracy_L]"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 23 } }
+	text = { trigger = { nationalist_monarchists_are_in_power = yes }
 		localization_key = "[Monarchist_L]"
 	}
 	text = { localization_key = "ERROR! RULING PARTY SHOW RULING PARTY INCORRECT" }
@@ -1650,76 +1650,76 @@ defined_text = {
 defined_text = {
 	name = show_ruling_elect_percentage
 
-	text = { trigger = { is_in_array = { ruling_party = 0 } }
+	text = { trigger = { western_autocrats_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_0_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 1 } }
+	text = { trigger = { western_conservatism_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_1_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 2 } }
+	text = { trigger = { western_liberals_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_2_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 3 } }
+	text = { trigger = { western_social_democrats_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_3_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 4 } }
+	text = { trigger = { emerging_communist_state_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_4_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 5 } }
+	text = { trigger = { emerging_anarchist_communism_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_5_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 6 } }
+	text = { trigger = { emerging_reactionaries_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_6_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 7 } }
+	text = { trigger = { emerging_autocracy_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_7_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 8 } }
+	text = { trigger = { emerging_moderate_shiite_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_8_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 9 } }
+	text = { trigger = { emerging_hardline_shiite_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_9_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 10 } }
+	text = { trigger = { salafist_kingdom_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_10_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 11 } }
+	text = { trigger = { salafist_caliphate_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_11_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 12 } }
+	text = { trigger = { neutrality_neutral_muslim_brotherhood_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_12_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 13 } }
+	text = { trigger = { neutrality_neutral_autocracy_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_13_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 14 } }
+	text = { trigger = { neutrality_neutral_conservatism_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_14_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 15 } }
+	text = { trigger = { neutrality_neutral_oligarch_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_15_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 16 } }
+	text = { trigger = { neutrality_neutral_libertarians_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_16_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 17 } }
+	text = { trigger = { neutrality_neutral_green_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_17_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 18 } }
+	text = { trigger = { neutrality_neutral_social_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_18_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 19 } }
+	text = { trigger = { neutrality_neutral_communism_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_19_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 20 } }
+	text = { trigger = { nationalist_right_wing_populists_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_20_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 21 } }
+	text = { trigger = { nationalist_fascist_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_21_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 22 } }
+	text = { trigger = { nationalist_military_junta_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_22_tt
 	}
-	text = { trigger = { is_in_array = { ruling_party = 23 } }
+	text = { trigger = { nationalist_monarchists_are_in_power = yes }
 		localization_key = show_ruling_elect_percentage_23_tt
 	}
 }
@@ -1728,76 +1728,76 @@ defined_text = {
 defined_text = {
 	name = meta_set_ruling_leader
 
-	text = { trigger = { is_in_array = { ruling_party = 0 } }
+	text = { trigger = { western_autocrats_are_in_power = yes }
 		localization_key = "set_Western_Autocracy"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 1 } }
+	text = { trigger = { western_conservatism_are_in_power = yes }
 		localization_key = "set_conservatism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 2 } }
+	text = { trigger = { western_liberals_are_in_power = yes }
 		localization_key = "set_liberalism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 3 } }
+	text = { trigger = { western_social_democrats_are_in_power = yes }
 		localization_key = "set_socialism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 4 } }
+	text = { trigger = { emerging_communist_state_are_in_power = yes }
 		localization_key = "set_Communist-State"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 5 } }
+	text = { trigger = { emerging_anarchist_communism_are_in_power = yes }
 		localization_key = "set_anarchist_communism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 6 } }
+	text = { trigger = { emerging_reactionaries_are_in_power = yes }
 		localization_key = "set_Conservative"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 7 } }
+	text = { trigger = { emerging_autocracy_are_in_power = yes }
 		localization_key = "set_Autocracy"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 8 } }
+	text = { trigger = { emerging_moderate_shiite_are_in_power = yes }
 		localization_key = "set_Mod_Vilayat_e_Faqih"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 9 } }
+	text = { trigger = { emerging_hardline_shiite_are_in_power = yes }
 		localization_key = "set_Vilayat_e_Faqih"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 10 } }
+	text = { trigger = { salafist_kingdom_are_in_power = yes }
 		localization_key = "set_Kingdom"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 11 } }
+	text = { trigger = { salafist_caliphate_are_in_power = yes }
 		localization_key = "set_Caliphate"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 12 } }
+	text = { trigger = { neutrality_neutral_muslim_brotherhood_are_in_power = yes }
 		localization_key = "set_Neutral_Muslim_Brotherhood"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 13 } }
+	text = { trigger = { neutrality_neutral_autocracy_are_in_power = yes }
 		localization_key = "set_Neutral_Autocracy"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 14 } }
+	text = { trigger = { neutrality_neutral_conservatism_are_in_power = yes }
 		localization_key = "set_Neutral_conservatism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 15 } }
+	text = { trigger = { neutrality_neutral_oligarch_are_in_power = yes }
 		localization_key = "set_oligarchism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 16 } }
+	text = { trigger = { neutrality_neutral_libertarians_are_in_power = yes }
 		localization_key = "set_Neutral_Libertarian"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 17 } }
+	text = { trigger = { neutrality_neutral_green_are_in_power = yes }
 		localization_key = "set_Neutral_green"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 18 } }
+	text = { trigger = { neutrality_neutral_social_are_in_power = yes }
 		localization_key = "set_neutral_Social"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 19 } }
+	text = { trigger = { neutrality_neutral_communism_are_in_power = yes }
 		localization_key = "set_Neutral_Communism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 20 } }
+	text = { trigger = { nationalist_right_wing_populists_are_in_power = yes }
 		localization_key = "set_Nat_Populism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 21 } }
+	text = { trigger = { nationalist_fascist_are_in_power = yes }
 		localization_key = "set_Nat_Fascism"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 22 } }
+	text = { trigger = { nationalist_military_junta_are_in_power = yes }
 		localization_key = "set_Nat_Autocracy"
 	}
-	text = { trigger = { is_in_array = { ruling_party = 23 } }
+	text = { trigger = { nationalist_monarchists_are_in_power = yes }
 		localization_key = "set_Monarchist"
 	}
 }
@@ -2580,7 +2580,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Western_Autocracy_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 0 } }
+	text = { trigger = { western_autocrats_are_in_coalition = yes }
 		localization_key = coal_Party_0
 	}
 }
@@ -2588,7 +2588,7 @@ defined_text = {
 defined_text = {
 	name = Gov_conservatism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 1 } }
+	text = { trigger = { western_conservatism_are_in_coalition = yes }
 		localization_key = coal_Party_1
 	}
 }
@@ -2596,7 +2596,7 @@ defined_text = {
 defined_text = {
 	name = Gov_liberalism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 2 } }
+	text = { trigger = { western_liberals_are_in_coalition = yes }
 		localization_key = coal_Party_2
 	}
 }
@@ -2604,7 +2604,7 @@ defined_text = {
 defined_text = {
 	name = Gov_socialism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 3 } }
+	text = { trigger = { western_social_democrats_are_in_coalition = yes }
 		localization_key = coal_Party_3
 	}
 }
@@ -2612,7 +2612,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Communist-State_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 4 } }
+	text = { trigger = { emerging_communist_state_are_in_coalition = yes }
 		localization_key = coal_Party_4
 	}
 }
@@ -2620,7 +2620,7 @@ defined_text = {
 defined_text = {
 	name = Gov_anarchist_communism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 5 } }
+	text = { trigger = { emerging_anarchist_communism_are_in_coalition = yes }
 		localization_key = coal_Party_5
 	}
 }
@@ -2628,7 +2628,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Conservative_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 6 } }
+	text = { trigger = { emerging_reactionaries_are_in_coalition = yes }
 		localization_key = coal_Party_6
 	}
 }
@@ -2636,7 +2636,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Autocracy_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 7 } }
+	text = { trigger = { emerging_autocracy_are_in_coalition = yes }
 		localization_key = coal_Party_7
 	}
 }
@@ -2644,7 +2644,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Mod_Vilayat_e_Faqih_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 8 } }
+	text = { trigger = { emerging_moderate_shiite_are_in_coalition = yes }
 		localization_key = coal_Party_8
 	}
 }
@@ -2652,7 +2652,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Vilayat_e_Faqih_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 9 } }
+	text = { trigger = { emerging_hardline_shiite_are_in_coalition = yes }
 		localization_key = coal_Party_9
 	}
 }
@@ -2660,7 +2660,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Kingdom_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 10 } }
+	text = { trigger = { salafist_kingdom_are_in_coalition = yes }
 		localization_key = coal_Party_10
 	}
 }
@@ -2668,7 +2668,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Caliphate_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 11 } }
+	text = { trigger = { salafist_caliphate_are_in_coalition = yes }
 		localization_key = coal_Party_11
 	}
 }
@@ -2676,7 +2676,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Muslim_Brotherhood_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 12 } }
+	text = { trigger = { neutrality_neutral_muslim_brotherhood_are_in_coalition = yes }
 		localization_key = coal_Party_12
 	}
 }
@@ -2684,7 +2684,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Autocracy_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 13 } }
+	text = { trigger = { neutrality_neutral_autocracy_are_in_coalition = yes }
 		localization_key = coal_Party_13
 	}
 }
@@ -2692,7 +2692,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_conservatism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 14 } }
+	text = { trigger = { neutrality_neutral_conservatism_are_in_coalition = yes }
 		localization_key = coal_Party_14
 	}
 }
@@ -2700,7 +2700,7 @@ defined_text = {
 defined_text = {
 	name = Gov_oligarchism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 15 } }
+	text = { trigger = { neutrality_neutral_oligarch_are_in_coalition = yes }
 		localization_key = coal_Party_15
 	}
 }
@@ -2708,7 +2708,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Libertarian_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 16 } }
+	text = { trigger = { neutrality_neutral_libertarians_are_in_coalition = yes }
 		localization_key = coal_Party_16
 	}
 }
@@ -2716,7 +2716,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_green_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 17 } }
+	text = { trigger = { neutrality_neutral_green_are_in_coalition = yes }
 		localization_key = coal_Party_17
 	}
 }
@@ -2724,7 +2724,7 @@ defined_text = {
 defined_text = {
 	name = Gov_neutral_Social_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 18 } }
+	text = { trigger = { neutrality_neutral_social_are_in_coalition = yes }
 		localization_key = coal_Party_18
 	}
 }
@@ -2732,7 +2732,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Communism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 19 } }
+	text = { trigger = { neutrality_neutral_communism_are_in_coalition = yes }
 		localization_key = coal_Party_19
 	}
 }
@@ -2740,7 +2740,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Nat_Populism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 20 } }
+	text = { trigger = { nationalist_right_wing_populists_are_in_coalition = yes }
 		localization_key = coal_Party_20
 	}
 }
@@ -2748,7 +2748,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Nat_Fascism_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 21 } }
+	text = { trigger = { nationalist_fascist_are_in_coalition = yes }
 		localization_key = coal_Party_21
 	}
 }
@@ -2756,7 +2756,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Nat_Autocracy_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 22 } }
+	text = { trigger = { nationalist_military_junta_are_in_coalition = yes }
 		localization_key = coal_Party_22
 	}
 }
@@ -2764,7 +2764,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Monarchist_loc
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 23 } }
+	text = { trigger = { nationalist_monarchists_are_in_coalition = yes }
 		localization_key = coal_Party_23
 	}
 }
@@ -2774,7 +2774,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_0
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 0 } }
+	text = { trigger = { western_autocrats_are_in_coalition = yes }
 		localization_key = coal_Party_percent_0
 	}
 }
@@ -2782,7 +2782,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_1
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 1 } }
+	text = { trigger = { western_conservatism_are_in_coalition = yes }
 		localization_key = coal_Party_percent_1
 	}
 }
@@ -2790,7 +2790,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_2
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 2 } }
+	text = { trigger = { western_liberals_are_in_coalition = yes }
 		localization_key = coal_Party_percent_2
 	}
 }
@@ -2798,7 +2798,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_3
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 3 } }
+	text = { trigger = { western_social_democrats_are_in_coalition = yes }
 		localization_key = coal_Party_percent_3
 	}
 }
@@ -2806,7 +2806,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_4
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 4 } }
+	text = { trigger = { emerging_communist_state_are_in_coalition = yes }
 		localization_key = coal_Party_percent_4
 	}
 }
@@ -2814,7 +2814,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_5
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 5 } }
+	text = { trigger = { emerging_anarchist_communism_are_in_coalition = yes }
 		localization_key = coal_Party_percent_5
 	}
 }
@@ -2822,7 +2822,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_6
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 6 } }
+	text = { trigger = { emerging_reactionaries_are_in_coalition = yes }
 		localization_key = coal_Party_percent_6
 	}
 }
@@ -2830,7 +2830,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_7
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 7 } }
+	text = { trigger = { emerging_autocracy_are_in_coalition = yes }
 		localization_key = coal_Party_percent_7
 	}
 }
@@ -2838,7 +2838,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_8
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 8 } }
+	text = { trigger = { emerging_moderate_shiite_are_in_coalition = yes }
 		localization_key = coal_Party_percent_8
 	}
 }
@@ -2846,7 +2846,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_9
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 9 } }
+	text = { trigger = { emerging_hardline_shiite_are_in_coalition = yes }
 		localization_key = coal_Party_percent_9
 	}
 }
@@ -2854,7 +2854,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_10
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 10 } }
+	text = { trigger = { salafist_kingdom_are_in_coalition = yes }
 		localization_key = coal_Party_percent_10
 	}
 }
@@ -2862,7 +2862,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_11
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 11 } }
+	text = { trigger = { salafist_caliphate_are_in_coalition = yes }
 		localization_key = coal_Party_percent_11
 	}
 }
@@ -2870,7 +2870,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_12
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 12 } }
+	text = { trigger = { neutrality_neutral_muslim_brotherhood_are_in_coalition = yes }
 		localization_key = coal_Party_percent_12
 	}
 }
@@ -2878,7 +2878,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_13
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 13 } }
+	text = { trigger = { neutrality_neutral_autocracy_are_in_coalition = yes }
 		localization_key = coal_Party_percent_13
 	}
 }
@@ -2886,7 +2886,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_14
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 14 } }
+	text = { trigger = { neutrality_neutral_conservatism_are_in_coalition = yes }
 		localization_key = coal_Party_percent_14
 	}
 }
@@ -2894,7 +2894,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_15
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 15 } }
+	text = { trigger = { neutrality_neutral_oligarch_are_in_coalition = yes }
 		localization_key = coal_Party_percent_15
 	}
 }
@@ -2902,7 +2902,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_16
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 16 } }
+	text = { trigger = { neutrality_neutral_libertarians_are_in_coalition = yes }
 		localization_key = coal_Party_percent_16
 	}
 }
@@ -2910,7 +2910,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_17
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 17 } }
+	text = { trigger = { neutrality_neutral_green_are_in_coalition = yes }
 		localization_key = coal_Party_percent_17
 	}
 }
@@ -2918,7 +2918,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_18
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 18 } }
+	text = { trigger = { neutrality_neutral_social_are_in_coalition = yes }
 		localization_key = coal_Party_percent_18
 	}
 }
@@ -2926,7 +2926,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_19
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 19 } }
+	text = { trigger = { neutrality_neutral_communism_are_in_coalition = yes }
 		localization_key = coal_Party_percent_19
 	}
 }
@@ -2934,7 +2934,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_20
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 20 } }
+	text = { trigger = { nationalist_right_wing_populists_are_in_coalition = yes }
 		localization_key = coal_Party_percent_20
 	}
 }
@@ -2942,7 +2942,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_21
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 21 } }
+	text = { trigger = { nationalist_fascist_are_in_coalition = yes }
 		localization_key = coal_Party_percent_21
 	}
 }
@@ -2950,7 +2950,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_22
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 22 } }
+	text = { trigger = { nationalist_military_junta_are_in_coalition = yes }
 		localization_key = coal_Party_percent_22
 	}
 }
@@ -2958,7 +2958,7 @@ defined_text = {
 defined_text = {
 	name = L_coal_elect_percent_23
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 23 } }
+	text = { trigger = { nationalist_monarchists_are_in_coalition = yes }
 		localization_key = coal_Party_percent_23
 	}
 }
@@ -2968,7 +2968,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Western_Autocracy_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 0 } }
+	text = { trigger = { western_autocrats_are_in_coalition = yes }
 		localization_key = "[Western_Autocracy_L_icon] "
 	}
 }
@@ -2976,7 +2976,7 @@ defined_text = {
 defined_text = {
 	name = Gov_conservatism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 1 } }
+	text = { trigger = { western_conservatism_are_in_coalition = yes }
 		localization_key = "[conservatism_L_icon] "
 	}
 }
@@ -2984,7 +2984,7 @@ defined_text = {
 defined_text = {
 	name = Gov_liberalism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 2 } }
+	text = { trigger = { western_liberals_are_in_coalition = yes }
 		localization_key = "[liberalism_L_icon] "
 	}
 }
@@ -2992,7 +2992,7 @@ defined_text = {
 defined_text = {
 	name = Gov_socialism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 3 } }
+	text = { trigger = { western_social_democrats_are_in_coalition = yes }
 		localization_key = "[socialism_L_icon] "
 	}
 }
@@ -3000,7 +3000,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Communist-State_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 4 } }
+	text = { trigger = { emerging_communist_state_are_in_coalition = yes }
 		localization_key = "[Communist-State_L_icon] "
 	}
 }
@@ -3008,7 +3008,7 @@ defined_text = {
 defined_text = {
 	name = Gov_anarchist_communism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 5 } }
+	text = { trigger = { emerging_anarchist_communism_are_in_coalition = yes }
 		localization_key = "[anarchist_communism_L_icon] "
 	}
 }
@@ -3016,7 +3016,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Conservative_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 6 } }
+	text = { trigger = { emerging_reactionaries_are_in_coalition = yes }
 		localization_key = "[Conservative_L_icon] "
 	}
 }
@@ -3024,7 +3024,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Autocracy_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 7 } }
+	text = { trigger = { emerging_autocracy_are_in_coalition = yes }
 		localization_key = "[Autocracy_L_icon] "
 	}
 }
@@ -3032,7 +3032,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Mod_Vilayat_e_Faqih_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 8 } }
+	text = { trigger = { emerging_moderate_shiite_are_in_coalition = yes }
 		localization_key = "[Mod_Vilayat_e_Faqih_L_icon] "
 	}
 }
@@ -3040,7 +3040,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Vilayat_e_Faqih_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 9 } }
+	text = { trigger = { emerging_hardline_shiite_are_in_coalition = yes }
 		localization_key = "[Vilayat_e_Faqih_L_icon] "
 	}
 }
@@ -3048,7 +3048,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Kingdom_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 10 } }
+	text = { trigger = { salafist_kingdom_are_in_coalition = yes }
 		localization_key = "[Kingdom_L_icon] "
 	}
 }
@@ -3056,7 +3056,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Caliphate_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 11 } }
+	text = { trigger = { salafist_caliphate_are_in_coalition = yes }
 		localization_key = "[Caliphate_L_icon] "
 	}
 }
@@ -3064,7 +3064,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Muslim_Brotherhood_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 12 } }
+	text = { trigger = { neutrality_neutral_muslim_brotherhood_are_in_coalition = yes }
 		localization_key = "[Neutral_Muslim_Brotherhood_L_icon] "
 	}
 }
@@ -3072,7 +3072,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Autocracy_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 13 } }
+	text = { trigger = { neutrality_neutral_autocracy_are_in_coalition = yes }
 		localization_key = "[Neutral_Autocracy_L_icon] "
 	}
 }
@@ -3080,7 +3080,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_conservatism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 14 } }
+	text = { trigger = { neutrality_neutral_conservatism_are_in_coalition = yes }
 		localization_key = "[Neutral_conservatism_L_icon] "
 	}
 }
@@ -3088,7 +3088,7 @@ defined_text = {
 defined_text = {
 	name = Gov_oligarchism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 15 } }
+	text = { trigger = { neutrality_neutral_oligarch_are_in_coalition = yes }
 		localization_key = "[oligarchism_L_icon] "
 	}
 }
@@ -3096,7 +3096,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Libertarian_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 16 } }
+	text = { trigger = { neutrality_neutral_libertarians_are_in_coalition = yes }
 		localization_key = "[Neutral_Libertarian_L_icon] "
 	}
 }
@@ -3104,7 +3104,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_green_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 17 } }
+	text = { trigger = { neutrality_neutral_green_are_in_coalition = yes }
 		localization_key = "[Neutral_green_L_icon] "
 	}
 }
@@ -3112,7 +3112,7 @@ defined_text = {
 defined_text = {
 	name = Gov_neutral_Social_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 18 } }
+	text = { trigger = { neutrality_neutral_social_are_in_coalition = yes }
 		localization_key = "[neutral_Social_L_icon] "
 	}
 }
@@ -3120,7 +3120,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Neutral_Communism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 19 } }
+	text = { trigger = { neutrality_neutral_communism_are_in_coalition = yes }
 		localization_key = "[Neutral_Communism_L_icon] "
 	}
 }
@@ -3128,7 +3128,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Nat_Populism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 20 } }
+	text = { trigger = { nationalist_right_wing_populists_are_in_coalition = yes }
 		localization_key = "[Nat_Populism_L_icon] "
 	}
 }
@@ -3136,7 +3136,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Nat_Fascism_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 21 } }
+	text = { trigger = { nationalist_fascist_are_in_coalition = yes }
 		localization_key = "[Nat_Fascism_L_icon] "
 	}
 }
@@ -3144,7 +3144,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Nat_Autocracy_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 22 } }
+	text = { trigger = { nationalist_military_junta_are_in_coalition = yes }
 		localization_key = "[Nat_Autocracy_L_icon] "
 	}
 }
@@ -3152,7 +3152,7 @@ defined_text = {
 defined_text = {
 	name = Gov_Monarchist_icon
 
-	text = { trigger = { is_in_array = { gov_coalition_array = 23 } }
+	text = { trigger = { nationalist_monarchists_are_in_coalition = yes }
 		localization_key = "[Monarchist_L_icon] "
 	}
 }

--- a/common/scripted_localisation/02_arab_spring_scripted_localisation.txt
+++ b/common/scripted_localisation/02_arab_spring_scripted_localisation.txt
@@ -163,28 +163,28 @@ defined_text = {
 	text = {
 		trigger = {
 			original_tag = TUN
-			is_in_array = { ruling_party = 0 }
+			western_autocrats_are_in_power = yes
 		}
 		localization_key = AS_impact_of_historical_context_tunisia_tt
 	}
 	text = {
 		trigger = {
 			original_tag = SYR
-			is_in_array = { ruling_party = 7 }
+			emerging_autocracy_are_in_power = yes
 		}
 		localization_key = AS_impact_of_historical_context_syria_tt
 	}
 	text = {
 		trigger = {
 			original_tag = EGY
-			is_in_array = { ruling_party = 0 }
+			western_autocrats_are_in_power = yes
 		}
 		localization_key = AS_impact_of_historical_context_egypt_tt
 	}
 	text = {
 		trigger = {
 			original_tag = LBA
-			is_in_array = { ruling_party = 7 }
+			emerging_autocracy_are_in_power = yes
 		}
 		localization_key = AS_impact_of_historical_context_libya_tt
 	}

--- a/common/scripted_triggers/99_EU_scripted_triggers.txt
+++ b/common/scripted_triggers/99_EU_scripted_triggers.txt
@@ -608,9 +608,9 @@ gov_is_eurosceptical = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 1 } ### conservatism
-				is_in_array = { ruling_party = 6 } ### Conservative
-				is_in_array = { ruling_party = 14 } ### Neutral_conservatism
+				western_conservatism_are_in_power = yes ### conservatism
+				emerging_reactionaries_are_in_power = yes ### Conservative
+				neutrality_neutral_conservatism_are_in_power = yes ### Neutral_conservatism
 			}
 		}
 		custom_trigger_tooltip = {
@@ -621,8 +621,8 @@ gov_is_eurosceptical = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 2 } ### liberalism
-				is_in_array = { ruling_party = 16 } ### Neutral_Libertarian
+				western_liberals_are_in_power = yes ### liberalism
+				neutrality_neutral_libertarians_are_in_power = yes ### Neutral_Libertarian
 			}
 		}
 		custom_trigger_tooltip = {
@@ -633,9 +633,9 @@ gov_is_eurosceptical = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 3 } ### socialism
-				is_in_array = { ruling_party = 18 } ### neutral_Social
-				is_in_array = { ruling_party = 17 } ### Neutral_green
+				western_social_democrats_are_in_power = yes ### socialism
+				neutrality_neutral_social_are_in_power = yes ### neutral_Social
+				neutrality_neutral_green_are_in_power = yes ### Neutral_green
 			}
 		}
 		custom_trigger_tooltip = {
@@ -646,18 +646,18 @@ gov_is_eurosceptical = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 4 } ### Communist-State
-				is_in_array = { ruling_party = 5 } ### anarchist_communism
-				is_in_array = { ruling_party = 19 } ### Neutral_Communism
+				emerging_communist_state_are_in_power = yes ### Communist-State
+				emerging_anarchist_communism_are_in_power = yes ### anarchist_communism
+				neutrality_neutral_communism_are_in_power = yes ### Neutral_Communism
 			}
 		}
 		custom_trigger_tooltip = {
 			tooltip = tooltip_nats_are_eurosceptical
 				OR = {
-					is_in_array = { ruling_party = 20 } ### Nat_Populism
-					is_in_array = { ruling_party = 21 } ### Nat_Fascism
-					is_in_array = { ruling_party = 22 } ### Nat_Autocracy
-					is_in_array = { ruling_party = 23 } ### Monarchist
+					nationalist_right_wing_populists_are_in_power = yes ### Nat_Populism
+					nationalist_fascist_are_in_power = yes ### Nat_Fascism
+					nationalist_military_junta_are_in_power = yes ### Nat_Autocracy
+					nationalist_monarchists_are_in_power = yes ### Monarchist
 				}
 		}
 		custom_trigger_tooltip = {
@@ -669,21 +669,21 @@ gov_is_eurosceptical = {
 			}
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 1 } ### conservatism
-					is_in_array = { ruling_party = 6 } ### Conservative
-					is_in_array = { ruling_party = 14 } ### Neutral_conservatism
-					is_in_array = { ruling_party = 2 } ### liberalism
-					is_in_array = { ruling_party = 16 } ### Neutral_Libertarian
-					is_in_array = { ruling_party = 3 } ### socialism
-					is_in_array = { ruling_party = 18 } ### neutral_Social
-					is_in_array = { ruling_party = 17 } ### Neutral_green
-					is_in_array = { ruling_party = 4 } ### Communist-State
-					is_in_array = { ruling_party = 5 } ### anarchist_communism
-					is_in_array = { ruling_party = 19 } ### Neutral_Communism
-					is_in_array = { ruling_party = 20 } ### Nat_Populism
-					is_in_array = { ruling_party = 21 } ### Nat_Fascism
-					is_in_array = { ruling_party = 22 } ### Nat_Autocracy
-					is_in_array = { ruling_party = 23 } ### Monarchist
+					western_conservatism_are_in_power = yes ### conservatism
+					emerging_reactionaries_are_in_power = yes ### Conservative
+					neutrality_neutral_conservatism_are_in_power = yes ### Neutral_conservatism
+					western_liberals_are_in_power = yes ### liberalism
+					neutrality_neutral_libertarians_are_in_power = yes ### Neutral_Libertarian
+					western_social_democrats_are_in_power = yes ### socialism
+					neutrality_neutral_social_are_in_power = yes ### neutral_Social
+					neutrality_neutral_green_are_in_power = yes ### Neutral_green
+					emerging_communist_state_are_in_power = yes ### Communist-State
+					emerging_anarchist_communism_are_in_power = yes ### anarchist_communism
+					neutrality_neutral_communism_are_in_power = yes ### Neutral_Communism
+					nationalist_right_wing_populists_are_in_power = yes ### Nat_Populism
+					nationalist_fascist_are_in_power = yes ### Nat_Fascism
+					nationalist_military_junta_are_in_power = yes ### Nat_Autocracy
+					nationalist_monarchists_are_in_power = yes ### Monarchist
 				}
 			}
 		}
@@ -702,9 +702,9 @@ gov_is_EUexiteer = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 1 } ### conservatism
-				is_in_array = { ruling_party = 6 } ### Conservative
-				is_in_array = { ruling_party = 14 } ### Neutral_conservatism
+				western_conservatism_are_in_power = yes ### conservatism
+				emerging_reactionaries_are_in_power = yes ### Conservative
+				neutrality_neutral_conservatism_are_in_power = yes ### Neutral_conservatism
 			}
 		}
 		custom_trigger_tooltip = {
@@ -715,8 +715,8 @@ gov_is_EUexiteer = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 2 } ### liberalism
-				is_in_array = { ruling_party = 16 } ### Neutral_Libertarian
+				western_liberals_are_in_power = yes ### liberalism
+				neutrality_neutral_libertarians_are_in_power = yes ### Neutral_Libertarian
 			}
 		}
 		custom_trigger_tooltip = {
@@ -727,9 +727,9 @@ gov_is_EUexiteer = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 3 } ### socialism
-				is_in_array = { ruling_party = 18 } ### neutral_Social
-				is_in_array = { ruling_party = 17 } ### Neutral_green
+				western_social_democrats_are_in_power = yes ### socialism
+				neutrality_neutral_social_are_in_power = yes ### neutral_Social
+				neutrality_neutral_green_are_in_power = yes ### Neutral_green
 			}
 		}
 		custom_trigger_tooltip = {
@@ -740,18 +740,18 @@ gov_is_EUexiteer = {
 					compare = greater_than_or_equals
 			}
 			OR = {
-				is_in_array = { ruling_party = 4 } ### Communist-State
-				is_in_array = { ruling_party = 5 } ### anarchist_communism
-				is_in_array = { ruling_party = 19 } ### Neutral_Communism
+				emerging_communist_state_are_in_power = yes ### Communist-State
+				emerging_anarchist_communism_are_in_power = yes ### anarchist_communism
+				neutrality_neutral_communism_are_in_power = yes ### Neutral_Communism
 			}
 		}
 		custom_trigger_tooltip = {
 			tooltip = tooltip_nats_are_eurosceptical
 				OR = {
-					is_in_array = { ruling_party = 20 } ### Nat_Populism
-					is_in_array = { ruling_party = 21 } ### Nat_Fascism
-					is_in_array = { ruling_party = 22 } ### Nat_Autocracy
-					is_in_array = { ruling_party = 23 } ### Monarchist
+					nationalist_right_wing_populists_are_in_power = yes ### Nat_Populism
+					nationalist_fascist_are_in_power = yes ### Nat_Fascism
+					nationalist_military_junta_are_in_power = yes ### Nat_Autocracy
+					nationalist_monarchists_are_in_power = yes ### Monarchist
 				}
 		}
 		custom_trigger_tooltip = {
@@ -763,21 +763,21 @@ gov_is_EUexiteer = {
 			}
 			NOT = {
 				OR = {
-					is_in_array = { ruling_party = 1 } ### conservatism
-					is_in_array = { ruling_party = 6 } ### Conservative
-					is_in_array = { ruling_party = 14 } ### Neutral_conservatism
-					is_in_array = { ruling_party = 2 } ### liberalism
-					is_in_array = { ruling_party = 16 } ### Neutral_Libertarian
-					is_in_array = { ruling_party = 3 } ### socialism
-					is_in_array = { ruling_party = 18 } ### neutral_Social
-					is_in_array = { ruling_party = 17 } ### Neutral_green
-					is_in_array = { ruling_party = 4 } ### Communist-State
-					is_in_array = { ruling_party = 5 } ### anarchist_communism
-					is_in_array = { ruling_party = 19 } ### Neutral_Communism
-					is_in_array = { ruling_party = 20 } ### Nat_Populism
-					is_in_array = { ruling_party = 21 } ### Nat_Fascism
-					is_in_array = { ruling_party = 22 } ### Nat_Autocracy
-					is_in_array = { ruling_party = 23 } ### Monarchist
+					western_conservatism_are_in_power = yes ### conservatism
+					emerging_reactionaries_are_in_power = yes ### Conservative
+					neutrality_neutral_conservatism_are_in_power = yes ### Neutral_conservatism
+					western_liberals_are_in_power = yes ### liberalism
+					neutrality_neutral_libertarians_are_in_power = yes ### Neutral_Libertarian
+					western_social_democrats_are_in_power = yes ### socialism
+					neutrality_neutral_social_are_in_power = yes ### neutral_Social
+					neutrality_neutral_green_are_in_power = yes ### Neutral_green
+					emerging_communist_state_are_in_power = yes ### Communist-State
+					emerging_anarchist_communism_are_in_power = yes ### anarchist_communism
+					neutrality_neutral_communism_are_in_power = yes ### Neutral_Communism
+					nationalist_right_wing_populists_are_in_power = yes ### Nat_Populism
+					nationalist_fascist_are_in_power = yes ### Nat_Fascism
+					nationalist_military_junta_are_in_power = yes ### Nat_Autocracy
+					nationalist_monarchists_are_in_power = yes ### Monarchist
 				}
 			}
 		}

--- a/common/scripted_triggers/99_EU_voting_scripted_triggers.txt
+++ b/common/scripted_triggers/99_EU_voting_scripted_triggers.txt
@@ -8,49 +8,49 @@
 
 is_liberal_block = {
 	OR = {
-		is_in_array = { ruling_party = 2 }
-		is_in_array = { ruling_party = 16 }
+		western_liberals_are_in_power = yes
+		neutrality_neutral_libertarians_are_in_power = yes
 	}
 }
 
 is_conservative_block = {
 	OR = {
-		is_in_array = { ruling_party = 1 }
-		is_in_array = { ruling_party = 6 }
-		is_in_array = { ruling_party = 14 }
+		western_conservatism_are_in_power = yes
+		emerging_reactionaries_are_in_power = yes
+		neutrality_neutral_conservatism_are_in_power = yes
 	}
 }
 
 is_communist_block = {
 	OR = {
-		is_in_array = { ruling_party = 4 }
-		is_in_array = { ruling_party = 5 }
-		is_in_array = { ruling_party = 19 }
+		emerging_communist_state_are_in_power = yes
+		emerging_anarchist_communism_are_in_power = yes
+		neutrality_neutral_communism_are_in_power = yes
 	}
 }
 
 is_socialist_block = {
 	OR = {
-		is_in_array = { ruling_party = 3 }
-		is_in_array = { ruling_party = 18 }
+		western_social_democrats_are_in_power = yes
+		neutrality_neutral_social_are_in_power = yes
 	}
 }
 
 is_fascist_block = {
 	OR = {
-		is_in_array = { ruling_party = 20 }
-		is_in_array = { ruling_party = 21 }
-		is_in_array = { ruling_party = 22 }
-		is_in_array = { ruling_party = 23 }
+		nationalist_right_wing_populists_are_in_power = yes
+		nationalist_fascist_are_in_power = yes
+		nationalist_military_junta_are_in_power = yes
+		nationalist_monarchists_are_in_power = yes
 	}
 }
 
 is_autocratic_block = {
 	OR = {
-		is_in_array = { ruling_party = 7 }
-		is_in_array = { ruling_party = 13 }
-		is_in_array = { ruling_party = 15 }
-		is_in_array = { ruling_party = 0 }
+		emerging_autocracy_are_in_power = yes
+		neutrality_neutral_autocracy_are_in_power = yes
+		neutrality_neutral_oligarch_are_in_power = yes
+		western_autocrats_are_in_power = yes
 	}
 }
 

--- a/common/scripted_triggers/99_GCC_scripted_triggers.txt
+++ b/common/scripted_triggers/99_GCC_scripted_triggers.txt
@@ -3,8 +3,8 @@ jihadist_government = {
 		tooltip = GCC_jihadist_government_tt
 		hidden_trigger = {
 			OR = {
-				is_in_array = { ruling_party = 11 }
-				is_in_array = { gov_coalition_array = 11 }
+				salafist_caliphate_are_in_power = yes
+				salafist_caliphate_are_in_coalition = yes
 			}
 		}
 	}
@@ -15,8 +15,8 @@ no_jihadist_government = {
 		tooltip = GCC_jihadist_government_tt_NOT
 		hidden_trigger = {
 			NOT = {
-				is_in_array = { ruling_party = 11 }
-				is_in_array = { gov_coalition_array = 11 }
+				salafist_caliphate_are_in_power = yes
+				salafist_caliphate_are_in_coalition = yes
 			}
 		}
 	}

--- a/common/scripted_triggers/99_GCC_scripted_triggers.txt
+++ b/common/scripted_triggers/99_GCC_scripted_triggers.txt
@@ -14,10 +14,8 @@ no_jihadist_government = {
 	custom_trigger_tooltip = {
 		tooltip = GCC_jihadist_government_tt_NOT
 		hidden_trigger = {
-			NOT = {
-				salafist_caliphate_are_in_power = yes
-				salafist_caliphate_are_in_coalition = yes
-			}
+			NOT = { salafist_caliphate_are_in_power = yes }
+			NOT = { salafist_caliphate_are_in_coalition = yes }
 		}
 	}
 }

--- a/common/scripted_triggers/99_ITA_scripted_triggers.txt
+++ b/common/scripted_triggers/99_ITA_scripted_triggers.txt
@@ -4,37 +4,37 @@ has_statalist_government_or_in_coalition = {
 	custom_trigger_tooltip = {
 		tooltip = has_statalist_government_or_in_coalition_TT
 		OR = {
-			is_in_array = { ruling_party = 3 } #socialism
+			western_social_democrats_are_in_power = yes #socialism
 
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 5 } #anarchist_communism
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 7 } #Autocracy
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+			emerging_reactionaries_are_in_power = yes #Conservative
+			emerging_autocracy_are_in_power = yes #Autocracy
 
-			is_in_array = { ruling_party = 17 } #Neutral_green
-			is_in_array = { ruling_party = 18 } #neutral_Social
-			is_in_array = { ruling_party = 19 } #Neutral_Communism
+			neutrality_neutral_green_are_in_power = yes #Neutral_green
+			neutrality_neutral_social_are_in_power = yes #neutral_Social
+			neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 
-			is_in_array = { ruling_party = 20 } #Nat_Populism
-			is_in_array = { ruling_party = 21 } #Nat_Fascism
-			is_in_array = { ruling_party = 22 } #Nat_Autocracy
-			is_in_array = { ruling_party = 23 } #Monarchist
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+			nationalist_fascist_are_in_power = yes #Nat_Fascism
+			nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+			nationalist_monarchists_are_in_power = yes #Monarchist
 
-			is_in_array = { gov_coalition_array = 3 } #socialism
+			western_social_democrats_are_in_coalition = yes #socialism
 
-			is_in_array = { gov_coalition_array = 4 } #Communist-State
-			is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-			is_in_array = { gov_coalition_array = 6 } #Conservative
-			is_in_array = { gov_coalition_array = 7 } #Autocracy
+			emerging_communist_state_are_in_coalition = yes #Communist-State
+			emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+			emerging_reactionaries_are_in_coalition = yes #Conservative
+			emerging_autocracy_are_in_coalition = yes #Autocracy
 
-			is_in_array = { gov_coalition_array = 17 } #Neutral_green
-			is_in_array = { gov_coalition_array = 18 } #neutral_Social
-			is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+			neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+			neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+			neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 
-			is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-			is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-			is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-			is_in_array = { gov_coalition_array = 23 } #Monarchist
+			nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+			nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+			nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+			nationalist_monarchists_are_in_coalition = yes #Monarchist
 		}
 	}
 }
@@ -43,21 +43,21 @@ has_statalist_government = {
 	custom_trigger_tooltip = {
 		tooltip = has_statalist_government_TT
 		OR = {
-			is_in_array = { ruling_party = 3 } #socialism
+			western_social_democrats_are_in_power = yes #socialism
 
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 5 } #anarchist_communism
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 7 } #Autocracy
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+			emerging_reactionaries_are_in_power = yes #Conservative
+			emerging_autocracy_are_in_power = yes #Autocracy
 
-			is_in_array = { ruling_party = 17 } #Neutral_green
-			is_in_array = { ruling_party = 18 } #neutral_Social
-			is_in_array = { ruling_party = 19 } #Neutral_Communism
+			neutrality_neutral_green_are_in_power = yes #Neutral_green
+			neutrality_neutral_social_are_in_power = yes #neutral_Social
+			neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 
-			is_in_array = { ruling_party = 20 } #Nat_Populism
-			is_in_array = { ruling_party = 21 } #Nat_Fascism
-			is_in_array = { ruling_party = 22 } #Nat_Autocracy
-			is_in_array = { ruling_party = 23 } #Monarchist
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+			nationalist_fascist_are_in_power = yes #Nat_Fascism
+			nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+			nationalist_monarchists_are_in_power = yes #Monarchist
 		}
 	}
 }
@@ -67,37 +67,37 @@ not_has_statalist_government_or_in_coalition = {
 		tooltip = not_has_statalist_government_or_in_coalition_TT
 		NOT = {
 			OR = {
-				is_in_array = { ruling_party = 3 } #socialism
+				western_social_democrats_are_in_power = yes #socialism
 
-				is_in_array = { ruling_party = 4 } #Communist-State
-				is_in_array = { ruling_party = 5 } #anarchist_communism
-				is_in_array = { ruling_party = 6 } #Conservative
-				is_in_array = { ruling_party = 7 } #Autocracy
+				emerging_communist_state_are_in_power = yes #Communist-State
+				emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+				emerging_reactionaries_are_in_power = yes #Conservative
+				emerging_autocracy_are_in_power = yes #Autocracy
 
-				is_in_array = { ruling_party = 17 } #Neutral_green
-				is_in_array = { ruling_party = 18 } #neutral_Social
-				is_in_array = { ruling_party = 19 } #Neutral_Communism
+				neutrality_neutral_green_are_in_power = yes #Neutral_green
+				neutrality_neutral_social_are_in_power = yes #neutral_Social
+				neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 
-				is_in_array = { ruling_party = 20 } #Nat_Populism
-				is_in_array = { ruling_party = 21 } #Nat_Fascism
-				is_in_array = { ruling_party = 22 } #Nat_Autocracy
-				is_in_array = { ruling_party = 23 } #Monarchist
+				nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+				nationalist_fascist_are_in_power = yes #Nat_Fascism
+				nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_power = yes #Monarchist
 
-				is_in_array = { gov_coalition_array = 3 } #socialism
+				western_social_democrats_are_in_coalition = yes #socialism
 
-				is_in_array = { gov_coalition_array = 4 } #Communist-State
-				is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-				is_in_array = { gov_coalition_array = 6 } #Conservative
-				is_in_array = { gov_coalition_array = 7 } #Autocracy
+				emerging_communist_state_are_in_coalition = yes #Communist-State
+				emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+				emerging_reactionaries_are_in_coalition = yes #Conservative
+				emerging_autocracy_are_in_coalition = yes #Autocracy
 
-				is_in_array = { gov_coalition_array = 17 } #Neutral_green
-				is_in_array = { gov_coalition_array = 18 } #neutral_Social
-				is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+				neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+				neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+				neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 
-				is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-				is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-				is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-				is_in_array = { gov_coalition_array = 23 } #Monarchist
+				nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+				nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+				nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_coalition = yes #Monarchist
 			}
 		}
 	}
@@ -108,35 +108,35 @@ not_has_statalist_government_or_in_coalition_except_nat_pop = {
 		tooltip = not_has_statalist_government_or_in_coalition_except_nat_pop_TT
 		NOT = {
 			OR = {
-				is_in_array = { ruling_party = 3 } #socialism
+				western_social_democrats_are_in_power = yes #socialism
 
-				is_in_array = { ruling_party = 4 } #Communist-State
-				is_in_array = { ruling_party = 5 } #anarchist_communism
-				is_in_array = { ruling_party = 6 } #Conservative
-				is_in_array = { ruling_party = 7 } #Autocracy
+				emerging_communist_state_are_in_power = yes #Communist-State
+				emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+				emerging_reactionaries_are_in_power = yes #Conservative
+				emerging_autocracy_are_in_power = yes #Autocracy
 
-				is_in_array = { ruling_party = 17 } #Neutral_green
-				is_in_array = { ruling_party = 18 } #neutral_Social
-				is_in_array = { ruling_party = 19 } #Neutral_Communism
+				neutrality_neutral_green_are_in_power = yes #Neutral_green
+				neutrality_neutral_social_are_in_power = yes #neutral_Social
+				neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 
-				is_in_array = { ruling_party = 21 } #Nat_Fascism
-				is_in_array = { ruling_party = 22 } #Nat_Autocracy
-				is_in_array = { ruling_party = 23 } #Monarchist
+				nationalist_fascist_are_in_power = yes #Nat_Fascism
+				nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_power = yes #Monarchist
 
-				is_in_array = { gov_coalition_array = 3 } #socialism
+				western_social_democrats_are_in_coalition = yes #socialism
 
-				is_in_array = { gov_coalition_array = 4 } #Communist-State
-				is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-				is_in_array = { gov_coalition_array = 6 } #Conservative
-				is_in_array = { gov_coalition_array = 7 } #Autocracy
+				emerging_communist_state_are_in_coalition = yes #Communist-State
+				emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+				emerging_reactionaries_are_in_coalition = yes #Conservative
+				emerging_autocracy_are_in_coalition = yes #Autocracy
 
-				is_in_array = { gov_coalition_array = 17 } #Neutral_green
-				is_in_array = { gov_coalition_array = 18 } #neutral_Social
-				is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+				neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+				neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+				neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 
-				is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-				is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-				is_in_array = { gov_coalition_array = 23 } #Monarchist
+				nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+				nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_coalition = yes #Monarchist
 			}
 		}
 	}
@@ -146,10 +146,10 @@ has_antistatalist_government_or_in_coalition = {
 	custom_trigger_tooltip = {
 		tooltip = has_antistatalist_government_or_in_coalition_TT
 		OR = {
-			is_in_array = { ruling_party = 2 } #liberalism
-			is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-			is_in_array = { gov_coalition_array = 2 } #liberalism
-			is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
+			western_liberals_are_in_power = yes #liberalism
+			neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+			western_liberals_are_in_coalition = yes #liberalism
+			neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
 		}
 	}
 }
@@ -159,10 +159,10 @@ not_has_antistatalist_government_or_in_coalition = {
 		tooltip = not_has_antistatalist_government_or_in_coalition_TT
 		NOT = {
 			OR = {
-				is_in_array = { ruling_party = 2 } #liberalism
-				is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-				is_in_array = { gov_coalition_array = 2 } #liberalism
-				is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
+				western_liberals_are_in_power = yes #liberalism
+				neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+				western_liberals_are_in_coalition = yes #liberalism
+				neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
 			}
 		}
 	}
@@ -180,26 +180,26 @@ not_has_conservative_government_or_in_coalition = {
 		tooltip = not_has_conservative_government_or_in_coalition_TT
 		NOT = {
 			OR = {
-				is_in_array = { ruling_party = 1 } #conservatism
-				is_in_array = { ruling_party = 6 } #Conservative
-				is_in_array = { ruling_party = 10 } #Kingdom
-				is_in_array = { ruling_party = 11 } #Caliphate
-				is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-				is_in_array = { ruling_party = 14 } #Neutral_conservatism
-				is_in_array = { ruling_party = 20 } #Nat_Populism
-				is_in_array = { ruling_party = 21 } #Nat_Fascism
-				is_in_array = { ruling_party = 22 } #Nat_Autocracy
-				is_in_array = { ruling_party = 23 } #Monarchist
-				is_in_array = { gov_coalition_array = 1 } #conservatism
-				is_in_array = { gov_coalition_array = 6 } #Conservative
-				is_in_array = { gov_coalition_array = 10 } #Kingdom
-				is_in_array = { gov_coalition_array = 11 } #Caliphate
-				is_in_array = { gov_coalition_array = 12 } #Neutral_Muslim_Brotherhood
-				is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-				is_in_array = { gov_coalition_array = 20 } #Nat_Populism
-				is_in_array = { gov_coalition_array = 21 } #Nat_Fascism
-				is_in_array = { gov_coalition_array = 22 } #Nat_Autocracy
-				is_in_array = { gov_coalition_array = 23 } #Monarchist
+				western_conservatism_are_in_power = yes #conservatism
+				emerging_reactionaries_are_in_power = yes #Conservative
+				salafist_kingdom_are_in_power = yes #Kingdom
+				salafist_caliphate_are_in_power = yes #Caliphate
+				neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+				neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+				nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+				nationalist_fascist_are_in_power = yes #Nat_Fascism
+				nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_power = yes #Monarchist
+				western_conservatism_are_in_coalition = yes #conservatism
+				emerging_reactionaries_are_in_coalition = yes #Conservative
+				salafist_kingdom_are_in_coalition = yes #Kingdom
+				salafist_caliphate_are_in_coalition = yes #Caliphate
+				neutrality_neutral_muslim_brotherhood_are_in_coalition = yes #Neutral_Muslim_Brotherhood
+				neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+				nationalist_right_wing_populists_are_in_coalition = yes #Nat_Populism
+				nationalist_fascist_are_in_coalition = yes #Nat_Fascism
+				nationalist_military_junta_are_in_coalition = yes #Nat_Autocracy
+				nationalist_monarchists_are_in_coalition = yes #Monarchist
 			}
 		}
 	}
@@ -210,16 +210,16 @@ not_has_secular_government_or_in_coalition = {
 		tooltip = not_has_secular_government_or_in_coalition_TT
 		NOT = {
 			OR = {
-				is_in_array = { ruling_party = 3 }
-				is_in_array = { ruling_party = 4 }
-				is_in_array = { ruling_party = 16 }
-				is_in_array = { ruling_party = 17 }
-				is_in_array = { ruling_party = 18 }
-				is_in_array = { gov_coalition_array = 3 }
-				is_in_array = { gov_coalition_array = 4 }
-				is_in_array = { gov_coalition_array = 16 }
-				is_in_array = { gov_coalition_array = 17 }
-				is_in_array = { gov_coalition_array = 18 }
+				western_social_democrats_are_in_power = yes
+				emerging_communist_state_are_in_power = yes
+				neutrality_neutral_libertarians_are_in_power = yes
+				neutrality_neutral_green_are_in_power = yes
+				neutrality_neutral_social_are_in_power = yes
+				western_social_democrats_are_in_coalition = yes
+				emerging_communist_state_are_in_coalition = yes
+				neutrality_neutral_libertarians_are_in_coalition = yes
+				neutrality_neutral_green_are_in_coalition = yes
+				neutrality_neutral_social_are_in_coalition = yes
 			}
 		}
 	}
@@ -230,15 +230,15 @@ has_expansionist_government = {
 		tooltip = has_expansionist_government_TT
 		NOT = { has_country_leader_with_trait = western_technocrat }
 		OR = {
-			is_in_array = { ruling_party = 0 } #Western_Autocracy
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 7 } #Autocracy
-			is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-			is_in_array = { ruling_party = 15 } #oligarchism
-			is_in_array = { ruling_party = 19 } #Neutral_Communism
-			is_in_array = { ruling_party = 21 } #Nat_Fascism
-			is_in_array = { ruling_party = 22 } #Nat_Autocracy
-			is_in_array = { ruling_party = 23 } #Monarchist
+			western_autocrats_are_in_power = yes #Western_Autocracy
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_autocracy_are_in_power = yes #Autocracy
+			neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+			neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+			neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+			nationalist_fascist_are_in_power = yes #Nat_Fascism
+			nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+			nationalist_monarchists_are_in_power = yes #Monarchist
 		}
 	}
 }
@@ -247,11 +247,11 @@ not_has_east_aligned_government = {
 	custom_trigger_tooltip = {
 		tooltip = not_has_east_aligned_government_TT
 		NOT = {
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 5 } #anarchist_communism
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 7 } #Autocracy
-			is_in_array = { ruling_party = 20 } #Nat_Populism
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+			emerging_reactionaries_are_in_power = yes #Conservative
+			emerging_autocracy_are_in_power = yes #Autocracy
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
 		}
 	}
 }
@@ -260,11 +260,11 @@ has_east_aligned_government = {
 	custom_trigger_tooltip = {
 		tooltip = has_east_aligned_government_TT
 		OR = {
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 5 } #anarchist_communism
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 7 } #Autocracy
-			is_in_array = { ruling_party = 20 } #Nat_Populism
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+			emerging_reactionaries_are_in_power = yes #Conservative
+			emerging_autocracy_are_in_power = yes #Autocracy
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
 		}
 	}
 }
@@ -274,8 +274,8 @@ not_has_west_aligned_government = {
 		tooltip = not_has_west_aligned_government_TT
 		NOT = {
 			has_government = democratic
-			is_in_array = { ruling_party = 14 } #Neutral_conservatism
-			is_in_array = { ruling_party = 16 } #Neutral_Libertarian
+			neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+			neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
 		}
 	}
 }
@@ -285,8 +285,8 @@ has_west_aligned_government = {
 		tooltip = has_west_aligned_government_TT
 		OR = {
 			has_government = democratic
-			is_in_array = { ruling_party = 14 } #Neutral_conservatism
-			is_in_array = { ruling_party = 16 } #Neutral_Libertarian
+			neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+			neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
 		}
 	}
 }
@@ -294,7 +294,7 @@ has_west_aligned_government = {
 non_technocrats_western_autocrats_are_in_power = {
 	custom_trigger_tooltip = {
 		tooltip = non_technocrats_western_autocrats_are_in_power_TT
-		is_in_array = { ruling_party = 0 } #Western_Autocracy
+		western_autocrats_are_in_power = yes #Western_Autocracy
 		NOT = { has_country_leader_with_trait = western_technocrat }
 	}
 }
@@ -304,17 +304,17 @@ has_authoritarian_right_wing_government = {
 		tooltip = has_authoritarian_right_wing_government_TT
 		OR = {
 			AND = {
-				is_in_array = { ruling_party = 0 } #Western_Autocracy
+				western_autocrats_are_in_power = yes #Western_Autocracy
 				NOT = { has_country_leader_with_trait = western_technocrat }
 			}
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 7 } #Autocracy
-			is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-			is_in_array = { ruling_party = 15 } #oligarchism
-			is_in_array = { ruling_party = 20 } #Nat_Populism
-			is_in_array = { ruling_party = 21 } #Nat_Fascism
-			is_in_array = { ruling_party = 22 } #Nat_Autocracy
-			is_in_array = { ruling_party = 23 } #Monarchist
+			emerging_reactionaries_are_in_power = yes #Conservative
+			emerging_autocracy_are_in_power = yes #Autocracy
+			neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+			neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+			nationalist_fascist_are_in_power = yes #Nat_Fascism
+			nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+			nationalist_monarchists_are_in_power = yes #Monarchist
 		}
 	}
 }
@@ -324,26 +324,26 @@ not_has_democratic_government_or_in_coalition = {
 		tooltip = not_has_democratic_government_or_in_coalition_TT
 		NOT = {
 			OR = {
-				is_in_array = { ruling_party = 1 } #conservatism
-				is_in_array = { ruling_party = 2 } #liberalism
-				is_in_array = { ruling_party = 3 } #socialism
-				is_in_array = { ruling_party = 4 } #Communist-State
-				is_in_array = { ruling_party = 5 } #anarchist_communism
-				is_in_array = { ruling_party = 14 } #Neutral_conservatism
-				is_in_array = { ruling_party = 16 } #Neutral_Libertarian
-				is_in_array = { ruling_party = 17 } #Neutral_green
-				is_in_array = { ruling_party = 18 } #neutral_Social
-				is_in_array = { ruling_party = 19 } #Neutral_Communism
-				is_in_array = { gov_coalition_array = 1 } #conservatism
-				is_in_array = { gov_coalition_array = 2 } #liberalism
-				is_in_array = { gov_coalition_array = 3 } #socialism
-				is_in_array = { gov_coalition_array = 4 } #Communist-State
-				is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-				is_in_array = { gov_coalition_array = 14 } #Neutral_conservatism
-				is_in_array = { gov_coalition_array = 16 } #Neutral_Libertarian
-				is_in_array = { gov_coalition_array = 17 } #Neutral_green
-				is_in_array = { gov_coalition_array = 18 } #neutral_Social
-				is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+				western_conservatism_are_in_power = yes #conservatism
+				western_liberals_are_in_power = yes #liberalism
+				western_social_democrats_are_in_power = yes #socialism
+				emerging_communist_state_are_in_power = yes #Communist-State
+				emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+				neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+				neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
+				neutrality_neutral_green_are_in_power = yes #Neutral_green
+				neutrality_neutral_social_are_in_power = yes #neutral_Social
+				neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
+				western_conservatism_are_in_coalition = yes #conservatism
+				western_liberals_are_in_coalition = yes #liberalism
+				western_social_democrats_are_in_coalition = yes #socialism
+				emerging_communist_state_are_in_coalition = yes #Communist-State
+				emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+				neutrality_neutral_conservatism_are_in_coalition = yes #Neutral_conservatism
+				neutrality_neutral_libertarians_are_in_coalition = yes #Neutral_Libertarian
+				neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+				neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+				neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 			}
 		}
 	}
@@ -353,9 +353,9 @@ has_leftwing_populist_government = {
 	custom_trigger_tooltip = {
 		tooltip = has_leftwing_populist_government_TT
 		OR = {
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 20 } #Nat_Populism
-			is_in_array = { ruling_party = 21 } #Nat_Fascism
+			emerging_reactionaries_are_in_power = yes #Conservative
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+			nationalist_fascist_are_in_power = yes #Nat_Fascism
 		}
 	}
 }
@@ -364,8 +364,8 @@ has_rightwing_populist_government = {
 	custom_trigger_tooltip = {
 		tooltip = has_rightwing_populist_government_TT
 		OR = {
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 5 } #anarchist_communism
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_anarchist_communism_are_in_power = yes #anarchist_communism
 		}
 	}
 }

--- a/common/scripted_triggers/99_KOR_scripted_triggers.txt
+++ b/common/scripted_triggers/99_KOR_scripted_triggers.txt
@@ -3,11 +3,11 @@ KOR_has_progressive_government = {
 	custom_trigger_tooltip = {
 		tooltip = KOR_has_progressive_government_TT
 		OR = {
-			is_in_array = { ruling_party = 4 } #Communist-State
-			is_in_array = { ruling_party = 5 } #anarchist_communism
-			is_in_array = { ruling_party = 17 } #Neutral_green
-			is_in_array = { ruling_party = 18 } #neutral_Social
-			is_in_array = { ruling_party = 19 } #Neutral_Communism
+			emerging_communist_state_are_in_power = yes #Communist-State
+			emerging_anarchist_communism_are_in_power = yes #anarchist_communism
+			neutrality_neutral_green_are_in_power = yes #Neutral_green
+			neutrality_neutral_social_are_in_power = yes #neutral_Social
+			neutrality_neutral_communism_are_in_power = yes #Neutral_Communism
 		}
 	}
 }
@@ -16,11 +16,11 @@ KOR_has_progressive_coalition = {
 	custom_trigger_tooltip = {
 		tooltip = KOR_has_progressive_coalition_TT
 		OR = {
-			is_in_array = { gov_coalition_array = 4 } #Communist-State
-			is_in_array = { gov_coalition_array = 5 } #anarchist_communism
-			is_in_array = { gov_coalition_array = 17 } #Neutral_green
-			is_in_array = { gov_coalition_array = 18 } #neutral_Social
-			is_in_array = { gov_coalition_array = 19 } #Neutral_Communism
+			emerging_communist_state_are_in_coalition = yes #Communist-State
+			emerging_anarchist_communism_are_in_coalition = yes #anarchist_communism
+			neutrality_neutral_green_are_in_coalition = yes #Neutral_green
+			neutrality_neutral_social_are_in_coalition = yes #neutral_Social
+			neutrality_neutral_communism_are_in_coalition = yes #Neutral_Communism
 		}
 	}
 }
@@ -29,9 +29,9 @@ KOR_has_liberal_government = {
 	custom_trigger_tooltip = {
 		tooltip = KOR_has_liberal_government_TT
 		OR = {
-			is_in_array = { ruling_party = 2 } #liberalism
-			is_in_array = { ruling_party = 3 } #social democrat
-			is_in_array = { ruling_party = 16 } #Neutral_Libertarian
+			western_liberals_are_in_power = yes #liberalism
+			western_social_democrats_are_in_power = yes #social democrat
+			neutrality_neutral_libertarians_are_in_power = yes #Neutral_Libertarian
 		}
 	}
 }
@@ -39,20 +39,20 @@ KOR_has_conservative_government = {
 	custom_trigger_tooltip = {
 		tooltip = KOR_has_conservative_government_TT
 		OR = {
-			is_in_array = { ruling_party = 0 } #Western_Autocracy
-			is_in_array = { ruling_party = 1 } #conservatism
-			is_in_array = { ruling_party = 6 } #Conservative
-			is_in_array = { ruling_party = 7 } #Autocracy
-			is_in_array = { ruling_party = 10 } #Kingdom
-			is_in_array = { ruling_party = 11 } #Caliphate
-			is_in_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood
-			is_in_array = { ruling_party = 13 } #Neutral_Autocracy
-			is_in_array = { ruling_party = 14 } #Neutral_conservatism
-			is_in_array = { ruling_party = 15 } #oligarchism
-			is_in_array = { ruling_party = 20 } #Nat_Populism
-			is_in_array = { ruling_party = 21 } #Nat_Fascism
-			is_in_array = { ruling_party = 22 } #Nat_Autocracy
-			is_in_array = { ruling_party = 23 } #Monarchist
+			western_autocrats_are_in_power = yes #Western_Autocracy
+			western_conservatism_are_in_power = yes #conservatism
+			emerging_reactionaries_are_in_power = yes #Conservative
+			emerging_autocracy_are_in_power = yes #Autocracy
+			salafist_kingdom_are_in_power = yes #Kingdom
+			salafist_caliphate_are_in_power = yes #Caliphate
+			neutrality_neutral_muslim_brotherhood_are_in_power = yes #Neutral_Muslim_Brotherhood
+			neutrality_neutral_autocracy_are_in_power = yes #Neutral_Autocracy
+			neutrality_neutral_conservatism_are_in_power = yes #Neutral_conservatism
+			neutrality_neutral_oligarch_are_in_power = yes #oligarchism
+			nationalist_right_wing_populists_are_in_power = yes #Nat_Populism
+			nationalist_fascist_are_in_power = yes #Nat_Fascism
+			nationalist_military_junta_are_in_power = yes #Nat_Autocracy
+			nationalist_monarchists_are_in_power = yes #Monarchist
 		}
 	}
 }

--- a/common/scripted_triggers/99_TUR_scripted_triggesrs.txt
+++ b/common/scripted_triggers/99_TUR_scripted_triggesrs.txt
@@ -2,11 +2,11 @@ TUR_is_kemalist = {
 	custom_trigger_tooltip = {
 		tooltip = TUR_IS_KEMALIST_TT
 		OR = {
-			is_in_array = { ruling_party = 1 }
-			is_in_array = { ruling_party = 3 }
-			is_in_array = { ruling_party = 4 }
-			is_in_array = { ruling_party = 18 }
-			is_in_array = { ruling_party = 22 }
+			western_conservatism_are_in_power = yes
+			western_social_democrats_are_in_power = yes
+			emerging_communist_state_are_in_power = yes
+			neutrality_neutral_social_are_in_power = yes
+			nationalist_military_junta_are_in_power = yes
 		}
 	}
 }

--- a/common/scripted_triggers/99_UKR_scripted_triggers.txt
+++ b/common/scripted_triggers/99_UKR_scripted_triggers.txt
@@ -4,13 +4,13 @@ UKR_is_pro_west = {
 	custom_trigger_tooltip = {
 		tooltip = UKR_is_pro_west_TT
 		OR = {
-			is_in_array = { ruling_party = 0 }
-			is_in_array = { ruling_party = 1 }
-			is_in_array = { ruling_party = 2 }
-			is_in_array = { ruling_party = 3 }
-			is_in_array = { ruling_party = 14 }
-			is_in_array = { ruling_party = 15 }
-			is_in_array = { ruling_party = 16 }
+			western_autocrats_are_in_power = yes
+			western_conservatism_are_in_power = yes
+			western_liberals_are_in_power = yes
+			western_social_democrats_are_in_power = yes
+			neutrality_neutral_conservatism_are_in_power = yes
+			neutrality_neutral_oligarch_are_in_power = yes
+			neutrality_neutral_libertarians_are_in_power = yes
 		}
 	}
 }
@@ -19,16 +19,16 @@ UKR_is_pro_east = {
 	custom_trigger_tooltip = {
 		tooltip = UKR_is_pro_east_TT
 		OR = {
-			is_in_array = { ruling_party = 4 }
-			is_in_array = { ruling_party = 5 }
-			is_in_array = { ruling_party = 6 }
-			is_in_array = { ruling_party = 7 }
-			is_in_array = { ruling_party = 8 }
-			is_in_array = { ruling_party = 9 }
-			is_in_array = { ruling_party = 10 }
-			is_in_array = { ruling_party = 11 }
-			is_in_array = { ruling_party = 18 }
-			is_in_array = { ruling_party = 19 }
+			emerging_communist_state_are_in_power = yes
+			emerging_anarchist_communism_are_in_power = yes
+			emerging_reactionaries_are_in_power = yes
+			emerging_autocracy_are_in_power = yes
+			emerging_moderate_shiite_are_in_power = yes
+			emerging_hardline_shiite_are_in_power = yes
+			salafist_kingdom_are_in_power = yes
+			salafist_caliphate_are_in_power = yes
+			neutrality_neutral_social_are_in_power = yes
+			neutrality_neutral_communism_are_in_power = yes
 		}
 	}
 }
@@ -49,13 +49,13 @@ UKR_is_neutral = {
 	custom_trigger_tooltip = {
 		tooltip = UKR_is_neutral_TT
 		OR = {
-			is_in_array = { ruling_party = 12 }
-			is_in_array = { ruling_party = 13 }
-			is_in_array = { ruling_party = 17 }
-			is_in_array = { ruling_party = 20 }
-			is_in_array = { ruling_party = 21 }
-			is_in_array = { ruling_party = 22 }
-			is_in_array = { ruling_party = 23 }
+			neutrality_neutral_muslim_brotherhood_are_in_power = yes
+			neutrality_neutral_autocracy_are_in_power = yes
+			neutrality_neutral_green_are_in_power = yes
+			nationalist_right_wing_populists_are_in_power = yes
+			nationalist_fascist_are_in_power = yes
+			nationalist_military_junta_are_in_power = yes
+			nationalist_monarchists_are_in_power = yes
 		}
 	}
 }
@@ -64,8 +64,8 @@ UKR_communists_in_coalition_with_socialists = {
 	custom_trigger_tooltip = {
 		tooltip = UKR_Communists_socialists_TT
 		OR = {
-			is_in_array = { ruling_party = 4 }
-			is_in_array = { gov_coalition_array = 18 }
+			emerging_communist_state_are_in_power = yes
+			neutrality_neutral_social_are_in_coalition = yes
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replace raw `is_in_array = { ruling_party = N }` / `is_in_array = { gov_coalition_array = N }` calls with named scripted triggers across decisions, focuses, scripted triggers, and scripted localisation
- Fix `VEN_chevron` focus using `target = ROOT` (self-referencing no-op) → `target = USA`
- Add missing `nationalist_right_wing_populists_are_in_power` requirement to `ALG_tamazgha` (children already required it, parent didn't)
- Fix `no_jihadist_government` NOT-AND trap (was NOT(A AND B), now correctly NOT(A) AND NOT(B))
- Document that variable/array operations produce no automatic tooltip text

Closes #1371, closes #1372

## Test plan
- [ ] Verify VEN_chevron focus awards opinion modifier with USA
- [ ] Verify ALG_tamazgha focus requires right-wing populists in power
- [ ] Verify GCC jihadist government checks block correctly when either condition is true
- [ ] Spot-check coalition decisions still appear/lock correctly