### PR TITLE
Validator fixes: parametric modifier families + hidden-event checks

### DIFF
--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -208,7 +208,9 @@ jobs:
             title: "Cosmetic Tags"
             sparse: |
               common
+              events
               gfx/flags
+              history
               localisation
               tools
           - script: validate_localisation.py

--- a/localisation/english/MD_focus_CHI_l_english.yml
+++ b/localisation/english/MD_focus_CHI_l_english.yml
@@ -998,10 +998,6 @@
  china.10.d: "Suspected members of the Turkistan Islamic Party have launched coordinated bomb attacks on several Chinese rail networks, killing scores of innocents. Our security analysts have expressed surprise over the level of sophistication demonstrated by these attacks. We must employ more drastic measures in order to prevent a repeat of this terrible incident."
  china.10.a: "We will hunt them down."
 
- china.11.t: ""
- china.11.d: ""
- china.11.a: ""
-
  china.12.t: "China Draws International Condemnation for Uighur Internment Camps"
  china.12.d: "Human Rights Watch has called upon the Chinese government to put a stop to its policy of interning Uighur Muslims in Xinjiang province in \"re-education camps\". The NGO condemned this recently accelerated practice as a blatant violation of both international human rights law and China's own constitution."
  china.12.a: "This practice must be condemned!"

--- a/localisation/english/MD_focus_SYR_l_english.yml
+++ b/localisation/english/MD_focus_SYR_l_english.yml
@@ -1418,8 +1418,6 @@
  SyriaFocus.42.a: "Send him more toys to showcase"
  SyriaFocus.42.b: "Let the little boy play with his toys"
  SyriaFocus.42.c: "Take away his toys"
- SyriaFocus.43.t: "Rif'at al Assad and his hunger for power"
- SyriaFocus.43.d: "After the death of Hafez, his brother, it seems Rif'at has the best opportunity to gain the reign that he always deserved. Hence, he is now looking for many alternatives. And surely with them, the question of some... additional support comes too. Let's see how it goes. "
  SyriaFocus.44.t: "Rifaat al-Assad Asks for Support"
  SyriaFocus.44.d: "Now that the Syrian President Hafez al-Assad is dead, his brother, Rifaat is asking for our support. Rifaat was the vice-president of Syria until he was kicked out of the country in 1998. He says his removal was unconstitutional, and in the event of the death of the president he should become the next president. There are rumours of a popular uprising that is going to take place in Syria, and Rifaat says that that is his opportunity for power. He just needs a bit of money to help his plans along."
  SyriaFocus.44.a: "Give him some funds"

--- a/localisation/english/MD_military_raids_l_english.yml
+++ b/localisation/english/MD_military_raids_l_english.yml
@@ -167,7 +167,6 @@
  MD_raid.14.d: "[FROM.FROM.GetLeader] has requested that the international community sanction [FROM.GetName] following their refusal to pay the requested reparations after their military strike against [FROM.FROM.GetName]. The world now must respond to their request:"
  MD_raid.14.a: "We Will Join the Sanctions!"
  MD_raid.14.b: "No, not right now."
- MD_raid.15.t: "Don't fucking touch this"
  MD_raid.16.t: "Crisis Looms Following [FROM.FROM.GetAdjective] Strikes On [FROM.GetName]"
  MD_raid.16.d: "Following [FROM.FROM.GetName]'s provocative strikes on [FROM.GetAdjective] territory, tensions have reached a boiling point. In an uncompromising statement, [FROM.GetLeader], the leader of [FROM.GetName], declared that their government will respond decisively. They announced plans to mobilize troops and advance into [FROM.FROM.GetAdjective] territory, vowing to \"Subdue the rabid tyrants in [FROM.FROM.capital.GetCapitalVictoryPointName]\" and to \"Restore order through force if necessary\". This move underscores regional and global stability, showing the dangers that could arise from a lack of diplomacy. As it stands, diplomatic channels remain silent, heightening fears that this escalation could spiral into an uncontrollable confrontation with dire consequences for international peace and security."
  MD_raid.16.a: "What happens next?"

--- a/tools/validation/validate_events.py
+++ b/tools/validation/validate_events.py
@@ -14,6 +14,8 @@
 #   8. mean_time_to_happen with is_triggered_only (MTTH does nothing)
 #   9. Duplicate event IDs
 #  10. Event namespace not declared via add_namespace
+#  11. Hidden events carrying option blocks (should run from immediate)
+#  12. Hidden events carrying pointless localisation (never displayed)
 # Based on Kaiserreich Autotests by Pelmen, https://github.com/Pelmen323
 # Adapted for Millennium Dawn with multiprocessing
 ##########################
@@ -111,6 +113,10 @@ _ADD_NAMESPACE_PATTERN = re.compile(r"^\s*add_namespace\s*=\s*(\S+)", re.MULTILI
 _EVENT_ID_PATTERN = re.compile(r"^\tid\s*=\s*(\S+)", re.MULTILINE)
 _RANDOM_EVENTS_PATTERN = re.compile(r"\brandom_events\s*=\s*\{")
 _RANDOM_EVENT_ID_PATTERN = re.compile(r"=\s*([A-Za-z_]\w*\.[\w.]+)")
+_OPTION_BLOCK_PATTERN = re.compile(r"\boption\s*=\s*\{")
+# Event-level (depth-1) title/desc fields — option-level name fields are
+# nested deeper and are not matched.
+_EVENT_TITLEDESC_PATTERN = re.compile(r"^\t(?:title|desc)\s*=\s*(.+)$", re.MULTILINE)
 
 
 def _extract_random_event_ids(text: str) -> set:
@@ -167,7 +173,8 @@ class Validator(BaseValidator):
         """Parse all event files and return (event_metadata_list, declared_namespaces).
 
         Each metadata dict has: id, type, file, is_major, is_hidden,
-        is_triggered_only, fire_only_once, has_mtth.
+        is_triggered_only, fire_only_once, has_mtth, option_count,
+        title_desc_refs.
         """
         if self._meta_cache is not None:
             return self._meta_cache
@@ -214,6 +221,10 @@ class Validator(BaseValidator):
                         "is_triggered_only": "is_triggered_only = yes" in body,
                         "fire_only_once": "fire_only_once = yes" in body,
                         "has_mtth": "mean_time_to_happen" in body,
+                        "option_count": len(_OPTION_BLOCK_PATTERN.findall(body)),
+                        "title_desc_refs": [
+                            v.strip() for v in _EVENT_TITLEDESC_PATTERN.findall(body)
+                        ],
                     }
                 )
 
@@ -495,6 +506,66 @@ class Validator(BaseValidator):
             category="mtth-triggered-only",
         )
 
+    def validate_hidden_event_options(self):
+        """Flag hidden events that still carry option blocks.
+
+        A hidden event shows no UI, so its option effects should run from
+        immediate = { } instead. When two or more options exist only the
+        first auto-fires — the rest are dead code.
+        """
+        self._log_section("Checking hidden events for option blocks...")
+
+        meta, _ = self._get_event_metadata()
+        results = []
+
+        for ev in meta:
+            if not ev["is_hidden"] or ev["option_count"] == 0:
+                continue
+            count = ev["option_count"]
+            detail = f"{count} option block{'s' if count != 1 else ''}"
+            if count >= 2:
+                detail += " (only the first auto-fires — the rest are dead code)"
+            results.append(f"{ev['id']} - {ev['file']}: {detail}")
+
+        self._report(
+            results,
+            "✓ No hidden events with option blocks",
+            "Hidden events with option blocks (move effects into immediate = { }):",
+            Severity.WARNING,
+            category="hidden-event-has-options",
+        )
+
+    def validate_hidden_event_localisation(self):
+        """Flag hidden events that declare a title or desc field.
+
+        A hidden event shows no window, so a ``title`` / ``desc`` field in its
+        own body is dead — the field and its loc keys should be removed.
+
+        Only fields declared in the event's own body are flagged. A loc key
+        that merely shares the event's ID prefix is NOT flagged: prefixes are
+        sometimes reused by a separate visible event (e.g. the visible
+        ``investments_event.10`` displays ``investments_event.1.t``), so the
+        hidden event ``investments_event.1`` owning no title field is correct.
+        """
+        self._log_section("Checking hidden events for pointless localisation...")
+
+        meta, _ = self._get_event_metadata()
+        results = []
+
+        for ev in meta:
+            if not ev["is_hidden"] or not ev["title_desc_refs"]:
+                continue
+            detail = "; ".join(ev["title_desc_refs"])
+            results.append(f"{ev['id']} - {ev['file']}: {detail}")
+
+        self._report(
+            results,
+            "✓ No hidden events with pointless localisation",
+            "Hidden events with localisation keys (hidden events display nothing — remove these keys):",
+            Severity.WARNING,
+            category="hidden-event-localisation",
+        )
+
     def validate_duplicate_event_ids(self):
         """Flag events that share the same ID.
 
@@ -559,6 +630,8 @@ class Validator(BaseValidator):
         self.validate_news_event_major()
         self.validate_news_fire_only_once()
         self.validate_mtth_triggered_only()
+        self.validate_hidden_event_options()
+        self.validate_hidden_event_localisation()
         self.validate_duplicate_event_ids()
         self.validate_namespace_mismatch()
 

--- a/tools/validation/validate_modifiers.py
+++ b/tools/validation/validate_modifiers.py
@@ -87,6 +87,51 @@ _MODIFIER_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$|^[A-Z][A-Za-z0-9_]*$")
 # Minimum frequency threshold for a modifier name to be "known good"
 _FREQUENCY_THRESHOLD = 3
 
+# Parametric modifier families. HOI4 generates one concrete modifier per game
+# entity for each of these — e.g. the building infrastructure yields
+# state_repair_speed_infrastructure_factor, the trait superior_tactician yields
+# trait_superior_tactician_xp_gain_factor. They are valid but appear too rarely,
+# or only in decision files, to clear the frequency threshold.
+#
+# Sourced from resources/documentation/modifiers_documentation.md. Families with
+# an over-broad generic suffix (<ModifierStat>_factor, <Technology>_cost_factor,
+# <IdeaGroup>_cost_factor, <Operation>_cost/_outcome/_risk,
+# <SpecialProject>_speed_factor) are deliberately omitted — a regex for them
+# would whitelist genuine typos.
+_PARAMETRIC_MODIFIER_PATTERNS: Tuple[re.Pattern, ...] = tuple(
+    re.compile(p)
+    for p in (
+        # <Building>-keyed
+        r"^(?:state_)?repair_speed_[a-z][a-z0-9_]*_factor$",
+        r"^(?:state_)?production_speed_[a-z][a-z0-9_]*_factor$",
+        r"^production_cost_[a-z][a-z0-9_]*_factor$",
+        r"^(?:state_)?[a-z][a-z0-9_]*_max_level_terrain_limit$",
+        # <Trait>-keyed (covers the bare and trait_-prefixed forms)
+        r"^[a-z][a-z0-9_]*_xp_gain_factor$",
+        # <Unit>-keyed
+        r"^experience_gain_[a-z][a-z0-9_]*_(?:combat|mission|training)_factor$",
+        # <Equipment> / <EquipmentModule> / <Unit>-keyed design cost
+        r"^[a-z][a-z0-9_]*_design_cost_factor$",
+        r"^production_cost_max_[a-z][a-z0-9_]*$",
+        # <Doctrine>-keyed (covers _mastery_gain and _track_mastery_gain)
+        r"^[a-z][a-z0-9_]*_mastery_gain_factor$",
+        r"^[a-z][a-z0-9_]*_doctrine_cost_factor$",
+        # <Ideology>-keyed
+        r"^[a-z][a-z0-9_]*_drift(?:_from_guarantees)?$",
+        r"^[a-z][a-z0-9_]*_acceptance$",
+        # <CombatTactic>-keyed
+        r"^[a-z][a-z0-9_]*_preferred_weight_factor$",
+        # <IdeaCategory>-keyed
+        r"^[a-z][a-z0-9_]*_category_type_cost_factor$",
+        # <Resource>-keyed
+        r"^country_resource_(?:cost_)?[a-z][a-z0-9_]*$",
+        r"^state_resource_(?:cost_)?[a-z][a-z0-9_]*$",
+        r"^state_resources_[a-z][a-z0-9_]*_factor$",
+        r"^local_resources_[a-z][a-z0-9_]*_factor$",
+        r"^temporary_state_resource_[a-z][a-z0-9_]*$",
+    )
+)
+
 
 def _extract_modifier_blocks(text: str) -> List[Tuple[int, str]]:
     """Extract the body text and start line of each top-level modifier = { } block.
@@ -354,6 +399,15 @@ def _harvest_flat_modifiers_from_traits_file(filepath: str) -> List[str]:
     return names
 
 
+def _is_parametric_modifier(name: str) -> bool:
+    """True if ``name`` matches a parametric HOI4 modifier family.
+
+    See _PARAMETRIC_MODIFIER_PATTERNS — these are engine-generated per-entity
+    modifiers that are valid but too rare to clear the frequency threshold.
+    """
+    return any(pattern.match(name) for pattern in _PARAMETRIC_MODIFIER_PATTERNS)
+
+
 def _check_file_for_unknown_modifiers(
     args: Tuple[str, FrozenSet[str], str],
 ) -> List[Tuple[str, str, int]]:
@@ -520,6 +574,10 @@ class Validator(BaseValidator):
                 seen.add(key)
                 # Modifiers prefixed with MD_ or md_ are always valid (custom MD)
                 if name.startswith("MD_") or name.startswith("md_"):
+                    continue
+                # Engine-generated parametric modifier families (per building,
+                # trait, unit, doctrine, resource, etc.)
+                if _is_parametric_modifier(name):
                     continue
                 unknown_errors.append((name, rel, lineno))
 


### PR DESCRIPTION
## Summary

Validation tooling improvements — fixes false positives in `validate_modifiers.py` and adds two hidden-event checks to `validate_events.py`, plus a small dead-localisation cleanup surfaced while testing.

## 1. `validate_modifiers.py` — recognise parametric modifier families

The modifier validator built its known-good set purely from codebase frequency (a name seen 3+ times is "known good"). Engine-generated **parametric modifiers** — one per building/trait/unit/doctrine/resource — are valid but often used too rarely, or only in `common/decisions/` (which is not harvested), to clear that threshold. They were flagged as unknown.

Example: `state_repair_speed_infrastructure_factor` is a real modifier (`state_repair_speed_<Building>_factor`), used only in `common/decisions/Czech_Republic.txt`, so it was reported 4×.

**Fix:** added a regex allowlist of parametric modifier families, sourced from `resources/documentation/modifiers_documentation.md` — building, trait, unit, equipment, doctrine, ideology, combat-tactic, idea-category, and resource keyed families. Over-broad families with a generic suffix (`<ModifierStat>_factor`, `<Technology>_cost_factor`, `<Operation>_cost`, `<SpecialProject>_speed_factor`, etc.) are deliberately omitted so genuine typos are still caught.

**Result:** validator warnings dropped **141 → 75** (~66 parametric false positives removed).

## 2. `validate_events.py` — hidden-event checks

Hidden events (`hidden = yes`) show no UI, so by convention they run all logic from `immediate = { }` and carry no `option` blocks or `title`/`desc` localisation. 145 of 227 hidden events already follow this; the rest don't.

Two new checks (both `WARNING` severity):

- **`validate_hidden_event_options`** — flags hidden events carrying `option` blocks. Effects belong in `immediate`; for 2+ options it notes that only the first auto-fires (the rest are dead code). **55 events flagged.**
- **`validate_hidden_event_localisation`** — flags hidden events that declare a `title`/`desc` field in their own body. **46 events flagged.**

The localisation check scans the event's **own body** rather than keying off `<id>.t`/`<id>.d` existence. An earlier membership-based cut produced false positives: loc-key prefixes are sometimes reused by a separate visible event (e.g. the visible `investments_event.10` displays `investments_event.1.t`, so the hidden `investments_event.1` owning no title is correct).

The bulk conversion of the flagged events is tracked separately in #1389.

## 3. Dead localisation cleanup

`china.11`, `MD_raid.15`, and `SyriaFocus.43` are hidden events with unreferenced `title`/`desc`/option loc keys. Removed `china.11.t/.d/.a` (empty placeholders), `MD_raid.15.t`, and `SyriaFocus.43.t/.d` from the English loc files.

## Verification

- `validate_modifiers.py` / `validate_events.py` run clean end-to-end.
- Validator test suite passes (12/12).
- Removed loc keys confirmed unreferenced across `common/` and `events/`.

## Related

- #1389 — follow-up: convert the 82 non-conforming hidden events to `immediate`-only.
