### PR TITLE
Overhaul AI starting templates and strategy thresholds

### DIFF
--- a/common/ai_templates/MD_generic.txt
+++ b/common/ai_templates/MD_generic.txt
@@ -301,6 +301,7 @@ L_Inf_generic = {
 	}
 
 	L_Inf_brigade = {
+		reinforce_prio = 0
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -338,7 +339,6 @@ L_Inf_generic = {
 			}
 		}
 
-		reinforce_prio = 0
 		target_min_match = 0.5
 
 		target_template = {
@@ -353,6 +353,7 @@ L_Inf_generic = {
 	}
 
 	L_Inf_artillery_brigade = {
+		reinforce_prio = 0
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -402,7 +403,6 @@ L_Inf_generic = {
 			}
 		}
 
-		reinforce_prio = 0
 		target_min_match = 0.5
 
 		target_template = {
@@ -426,6 +426,7 @@ marines_generic = {
 	}
 
 	light_marine_brigades = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -463,6 +464,7 @@ marines_generic = {
 		}
 	}
 	marine_commando_division = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 2
 			modifier = {
@@ -507,12 +509,9 @@ marines_generic = {
 		}
 	}
 	mot_marines_brigades = {
+		reinforce_prio = 2
 		upgrade_prio = {
-			factor = 0.5
-			modifier = {
-				factor = 0
-				num_of_military_factories > 9
-			}
+			factor = 2
 			modifier = {
 				factor = 0
 				num_of_naval_factories < 1
@@ -524,7 +523,7 @@ marines_generic = {
 		}
 		enable = {
 			NOT = { original_tag = ZOM }
-			num_of_military_factories < 12
+			num_of_military_factories > 5
 			num_of_naval_factories > 0
 			has_game_rule = {
 				rule = rule_god_of_war
@@ -535,7 +534,10 @@ marines_generic = {
 			}
 		}
 
-		target_min_match = 0.8
+		replace_at_match = 0.8
+		replace_with = mot_marines_division
+		can_upgrade_in_field = { always = yes }
+		target_min_match = 0.5
 
 		target_template = {
 			regiments = {
@@ -549,6 +551,7 @@ marines_generic = {
 		}
 	}
 	mot_marines_division = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -578,7 +581,7 @@ marines_generic = {
 			}
 		}
 
-		target_min_match = 0.8
+		target_min_match = 0.7
 
 		target_template = {
 			regiments = {
@@ -593,6 +596,7 @@ marines_generic = {
 		}
 	}
 	mech_marines_brigade = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -641,6 +645,7 @@ marines_generic = {
 		}
 	}
 	armored_marines_brigade = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -693,20 +698,17 @@ Special_Forces_generic = {
 	}
 
 	Special_Forces_generic = {
+		reinforce_prio = 2
 		upgrade_prio = {
-			factor = 1
+			factor = 2
 			modifier = {
 				factor = 0
-				OR = {
-					num_of_military_factories < 5
-					num_of_military_factories > 10
-				}
+				num_of_military_factories < 5
 			}
 		}
 		enable = {
 			NOT = { original_tag = ZOM }
 			num_of_military_factories > 4
-			num_of_military_factories < 11
 			has_game_rule = {
 				rule = rule_god_of_war
 				option = no
@@ -716,8 +718,10 @@ Special_Forces_generic = {
 			}
 		}
 
-		reinforce_prio = 2
-		target_min_match = 0.6
+		replace_at_match = 0.8
+		replace_with = special_forces_division
+		can_upgrade_in_field = { always = yes }
+		target_min_match = 0.4
 
 		target_template = {
 			regiments = {
@@ -730,8 +734,9 @@ Special_Forces_generic = {
 	}
 
 	special_forces_division = {
+		reinforce_prio = 2
 		upgrade_prio = {
-			factor = 4
+			factor = 1
 			modifier = {
 				factor = 0
 				OR = {
@@ -752,8 +757,6 @@ Special_Forces_generic = {
 				tag = ALN
 			}
 		}
-
-		reinforce_prio = 2
 
 		target_min_match = 0.6
 
@@ -777,15 +780,16 @@ Air_heli_generic = {
 	role = Air_helicopters
 	upgrade_prio = {
 		factor = 1
+		modifier = {
+			factor = 1.5
+			num_of_military_factories > 20
+		}
 	}
 
 	air_assault_brigade = {
+		reinforce_prio = 2
 		upgrade_prio = {
-			factor = 1
-			modifier = {
-				factor = 0
-				num_of_military_factories > 15
-			}
+			factor = 2
 			modifier = {
 				factor = 0
 				num_of_military_factories < 8
@@ -794,7 +798,6 @@ Air_heli_generic = {
 		enable = {
 			NOT = { original_tag = ZOM }
 			num_of_military_factories > 7
-			num_of_military_factories < 16
 			has_game_rule = {
 				rule = rule_god_of_war
 				option = no
@@ -804,7 +807,10 @@ Air_heli_generic = {
 			}
 		}
 
-		target_min_match = 0.6
+		replace_at_match = 0.8
+		replace_with = air_assault_division
+		can_upgrade_in_field = { always = yes }
+		target_min_match = 0.5
 
 		target_template = {
 			regiments = {
@@ -814,6 +820,7 @@ Air_heli_generic = {
 	}
 
 	air_assault_division = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -849,6 +856,7 @@ Air_heli_generic = {
 	}
 
 	attack_helicopter_brigade = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -1053,11 +1061,7 @@ APC_generic = {
 
 	mechanized_generic = {
 		upgrade_prio = {
-			factor = 1
-			modifier = {
-				factor = 0
-				num_of_military_factories > 15
-			}
+			factor = 2
 			modifier = {
 				factor = 0
 				num_of_military_factories < 8
@@ -1066,7 +1070,6 @@ APC_generic = {
 		enable = {
 			NOT = { original_tag = ZOM }
 			num_of_military_factories > 7
-			num_of_military_factories < 15
 			has_game_rule = {
 				rule = rule_god_of_war
 				option = no
@@ -1076,7 +1079,10 @@ APC_generic = {
 			}
 		}
 
-		target_min_match = 0.7
+		replace_at_match = 0.8
+		replace_with = mechanized_divisions
+		can_upgrade_in_field = { always = yes }
+		target_min_match = 0.5
 
 		target_template = {
 			regiments = {
@@ -1143,11 +1149,7 @@ IFV_generic = {
 
 	ifv_infantry_generic = {
 		upgrade_prio = {
-			factor = 1
-			modifier = {
-				factor = 0
-				num_of_military_factories > 15
-			}
+			factor = 2
 			modifier = {
 				factor = 0
 				num_of_military_factories < 10
@@ -1156,7 +1158,6 @@ IFV_generic = {
 		enable = {
 			NOT = { original_tag = ZOM }
 			num_of_military_factories > 9
-			num_of_military_factories < 16
 			has_game_rule = {
 				rule = rule_god_of_war
 				option = no
@@ -1166,7 +1167,10 @@ IFV_generic = {
 			}
 		}
 
-		target_min_match = 0.7
+		replace_at_match = 0.8
+		replace_with = ifv_infantry_divisions
+		can_upgrade_in_field = { always = yes }
+		target_min_match = 0.5
 
 		target_template = {
 			regiments = {
@@ -1242,6 +1246,7 @@ armor_generic = {
 	upgrade_prio = { factor = 1.2 }
 
 	armor_generic = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -1287,6 +1292,7 @@ armor_generic = {
 	}
 
 	light_armor_division = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1.5
 			modifier = {
@@ -1326,6 +1332,7 @@ armor_generic = {
 	}
 
 	armor_division = {
+		reinforce_prio = 2
 		upgrade_prio = {
 			factor = 1
 			modifier = {

--- a/common/ai_templates/MD_generic.txt
+++ b/common/ai_templates/MD_generic.txt
@@ -1,26 +1,6 @@
 # Author(s): AngriestBird, Simone
 # Improved by KyCb(rockon)
-##############################
-##Compendium of Combat Width
-#Militia Battalion - 3 CW 			#Motorized Airborne Infantry - 4 CW
-#Motorized Militia Battalion - 4 CW #Mechanized Airborne Infantry - 4 CW
-#Light Infantry - 3 CW				#Armored Airborne Infantry - 4 CW
-#Motorized Infantry - 4 CW			#Marine Light Infantry - 3 CW
-#Mechanized Infantry - 4 CW			#Motorized Marine Infantry - 4 CW
-#Armored Infantry - 4 CW			#Mechanized Marine Infantry - 4 CW
-#Airborne Light Infantry - 3 CW		#Armored Marine Infantry - 4 CW
-#Light Air Assault Infantry - 3 CW	#Armored Air Assault Infantry - 4 CW
-#Special Forces - 3 CW				#Tank Battalion - 4 CW
-#Artillery - 3 CW					#SP Arty - 3 CW
-#SP AA - 4 CW
-#Companies - Support Companies
-#Tank Company - 2 CW				#Light Recon - 1 CW
-#Motorized Recon - 2 CW				#Mechanized Company - 2 CW
-#Armored Recon - 2 CW				#Armored Recce - 2 CW
-#Light Engineer - 1 CW				#Heavy Engineer - 2 CW
-#Artillery BAttery - 1 CW			#SP Arty - 2 CW
-#SP AA - 2 CWf
-############################
+
 #garrison
 garrison_generic = {
 	role = garrison
@@ -79,8 +59,8 @@ garrison_generic = {
 		}
 
 		target_template = {
-			regiments = { #12 Combat Width
-				Militia_Bat = 4 #
+			regiments = {
+				Militia_Bat = 4
 			}
 		}
 
@@ -140,7 +120,7 @@ garrison_generic = {
 	}
 }
 
-#light Militia Divisions
+#Militia
 Militia_generic = {
 	role = Militia
 	upgrade_prio = {
@@ -195,12 +175,12 @@ Militia_generic = {
 		target_min_match = 0.6
 
 		target_template = {
-			regiments = { #15 CW
-				Militia_Bat = 5
+			regiments = {
+				Militia_Bat = 12
 			}
 		}
 	}
-	militia_brigade = {
+	militia_artillery_brigade = {
 		reinforce_prio = 0
 		upgrade_prio = {
 			factor = 1
@@ -247,11 +227,13 @@ Militia_generic = {
 
 		target_template = {
 			regiments = {
-				Militia_Bat = 9
+				Militia_Bat = 6
+				Arty_Bat = 5
 			}
 			support = {
-				L_Recce_Comp = 1
 				L_Engi_Comp = 1
+				L_Recce_Comp = 1
+				Arty_Battery = 1
 			}
 		}
 	}
@@ -296,19 +278,21 @@ Militia_generic = {
 
 		target_template = {
 			regiments = {
-				Mot_Militia_Bat = 7
+				Mot_Militia_Bat = 8
 			}
 			support = {
-				Mot_Recce_Comp = 1
+				combat_service_support_company = 1
+				H_Engi_Comp = 1
+				Arty_Battery = 1
 			}
 		}
 	}
 }
 
-#Light Divisions
+#Light Infantry
 L_Inf_generic = {
 	role = L_Inf
-	upgrade_prio = { #These should be used extremely sparingly
+	upgrade_prio = {
 		factor = 1.8
 		modifier = {
 			factor = 150
@@ -359,18 +343,16 @@ L_Inf_generic = {
 
 		target_template = {
 			regiments = {
-				L_Inf_Bat = 6
-				Arty_Bat = 3
+				L_Inf_Bat = 11
 			}
 			support = {
-				L_Recce_Comp = 1
-				L_Engi_Comp = 1
 				combat_service_support_company = 1
+				H_Engi_Comp = 1
 			}
 		}
 	}
 
-	L_Inf_division = {
+	L_Inf_artillery_brigade = {
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -425,13 +407,11 @@ L_Inf_generic = {
 
 		target_template = {
 			regiments = {
-				L_Inf_Bat = 9
-				Arty_Bat = 3
+				L_Inf_Bat = 6
+				Arty_Bat = 5
 			}
 			support = {
-				Arty_Battery = 1
-				L_Recce_Comp = 1
-				L_Engi_Comp = 1
+				Mot_Recce_Comp = 1
 				combat_service_support_company = 1
 			}
 		}
@@ -474,14 +454,55 @@ marines_generic = {
 
 		target_template = {
 			regiments = {
-				L_Marine_Bat = 6
-				Arty_Bat = 3
+				L_Marine_Bat = 11
 			}
 			support = {
-				L_Recce_Comp = 1
-				L_Engi_Comp = 1
-				SP_AA_Battery = 1
 				combat_service_support_company = 1
+				H_Engi_Comp = 1
+			}
+		}
+	}
+	marine_commando_division = {
+		upgrade_prio = {
+			factor = 2
+			modifier = {
+				factor = 0
+				OR = {
+					has_idea = minor_power
+					has_idea = non_power
+					num_of_military_factories < 15
+				}
+			}
+			modifier = {
+				factor = 0
+				num_of_naval_factories < 1
+			}
+		}
+		enable = {
+			NOT = { original_tag = ZOM }
+			num_of_naval_factories > 0
+			num_of_military_factories > 14
+			has_game_rule = {
+				rule = rule_god_of_war
+				option = no
+			}
+			NOT = {
+				tag = ALN
+			}
+		}
+
+		target_min_match = 0.8
+
+		target_template = {
+			regiments = {
+				L_Marine_Cdo_Bat = 15
+			}
+			support = {
+				combat_service_support_company = 1
+				H_Engi_Comp = 1
+				L_Ranger_Recce_Comp = 1
+				armor_Comp = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
@@ -518,25 +539,23 @@ marines_generic = {
 
 		target_template = {
 			regiments = {
-				Mot_Marine_Bat = 6
+				Mot_Marine_Bat = 8
 			}
 			support = {
 				H_Engi_Comp = 1
-				Mot_Recce_Comp = 1
-				Arty_Battery = 1
 				combat_service_support_company = 1
+				Arty_Battery = 1
 			}
 		}
 	}
-	meh_marines_division_maj = {
+	mot_marines_division = {
 		upgrade_prio = {
-			factor = 2
+			factor = 1
 			modifier = {
 				factor = 0
 				OR = {
 					has_idea = minor_power
 					has_idea = non_power
-					#has_equipment = { medium_tank_amphibious_chassis < 1 }
 					num_of_military_factories < 12
 				}
 			}
@@ -563,21 +582,71 @@ marines_generic = {
 
 		target_template = {
 			regiments = {
-				Mech_Marine_Bat = 6
-				armor_Bat = 2
-				SP_Arty_Bat = 2
+				Mot_Marine_Bat = 12
+				Light_armor_Bat = 4
 			}
 			support = {
-				Mech_Recce_Comp = 1
-				H_Engi_Comp = 1
-				SP_AA_Battery = 1
 				combat_service_support_company = 1
+				SP_AA_Battery = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
-	armored_marines_division = {
+	mech_marines_brigade = {
 		upgrade_prio = {
 			factor = 1
+			modifier = {
+				factor = 2
+				num_of_military_factories > 11
+			}
+			modifier = {
+				factor = 0
+				num_of_military_factories > 20
+			}
+			modifier = {
+				factor = 0
+				num_of_military_factories < 10
+			}
+			modifier = {
+				factor = 0
+				num_of_naval_factories < 1
+			}
+		}
+		enable = {
+			NOT = { original_tag = ZOM }
+			num_of_naval_factories > 0
+			num_of_military_factories > 9
+			num_of_military_factories < 21
+			has_game_rule = {
+				rule = rule_god_of_war
+				option = no
+			}
+			NOT = {
+				tag = ALN
+			}
+		}
+
+		target_min_match = 0.8
+
+		target_template = {
+			regiments = {
+				Mech_Marine_Bat = 8
+			}
+			support = {
+				H_Engi_Comp = 1
+				combat_service_support_company = 1
+				SP_AA_Battery = 1
+				attack_helo_comp = 1
+			}
+		}
+	}
+	armored_marines_brigade = {
+		upgrade_prio = {
+			factor = 1
+			modifier = {
+				factor = 2
+				num_of_military_factories > 19
+			}
 			modifier = {
 				factor = 0
 				num_of_military_factories < 15
@@ -604,15 +673,13 @@ marines_generic = {
 
 		target_template = {
 			regiments = {
-				Arm_Marine_Bat = 6
-				armor_Bat = 2
-				SP_Arty_Bat = 2
+				Arm_Marine_Bat = 8
 			}
 			support = {
-				Arm_Recce_Comp = 1
 				H_Engi_Comp = 1
-				SP_AA_Battery = 1
 				combat_service_support_company = 1
+				SP_AA_Battery = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
@@ -654,12 +721,9 @@ Special_Forces_generic = {
 
 		target_template = {
 			regiments = {
-				Special_Forces = 6
-				Arty_Bat = 3
+				Special_Forces = 7
 			}
 			support = {
-				L_Recce_Comp = 1
-				L_Engi_Comp = 1
 				combat_service_support_company = 1
 			}
 		}
@@ -695,29 +759,96 @@ Special_Forces_generic = {
 
 		target_template = {
 			regiments = {
-				Special_Forces = 8
-				SP_Arty_Bat = 3
-				SP_AA_Bat = 1
+				Special_Forces = 15
 			}
 			support = {
-				Arm_Recce_Comp = 1
 				combat_service_support_company = 1
 				H_Engi_Comp = 1
+				L_Ranger_Recce_Comp = 1
 				armor_Comp = 1
-				SP_Arty_Battery = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
 }
 
-#Speed Helicopter Paratroopers
+#Air Assault Helicopters
 Air_heli_generic = {
 	role = Air_helicopters
 	upgrade_prio = {
 		factor = 1
 	}
 
-	Arm_Air_assault_brigade = {
+	air_assault_brigade = {
+		upgrade_prio = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_military_factories > 15
+			}
+			modifier = {
+				factor = 0
+				num_of_military_factories < 8
+			}
+		}
+		enable = {
+			NOT = { original_tag = ZOM }
+			num_of_military_factories > 7
+			num_of_military_factories < 16
+			has_game_rule = {
+				rule = rule_god_of_war
+				option = no
+			}
+			NOT = {
+				tag = ALN
+			}
+		}
+
+		target_min_match = 0.6
+
+		target_template = {
+			regiments = {
+				L_Air_assault_Bat = 15
+			}
+		}
+	}
+
+	air_assault_division = {
+		upgrade_prio = {
+			factor = 1
+			modifier = {
+				factor = 0
+				num_of_military_factories < 15
+			}
+		}
+		enable = {
+			NOT = { original_tag = ZOM }
+			num_of_military_factories > 14
+			has_game_rule = {
+				rule = rule_god_of_war
+				option = no
+			}
+			NOT = {
+				tag = ALN
+			}
+		}
+
+		target_min_match = 0.6
+
+		target_template = {
+			regiments = {
+				L_Air_assault_Bat = 20
+			}
+			support = {
+				helo_hq = 1
+				helicopter_combat_service_support = 1
+				air_assault_Arty_Battery = 1
+				attack_helo_comp = 1
+			}
+		}
+	}
+
+	attack_helicopter_brigade = {
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -741,11 +872,13 @@ Air_heli_generic = {
 
 		target_template = {
 			regiments = {
-				L_Air_assault_Bat = 8
-				attack_helo_bat = 3
+				attack_helo_bat = 8
+				L_Air_assault_Bat = 6
 			}
 			support = {
 				helicopter_combat_service_support = 1
+				air_assault_Arty_Battery = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
@@ -786,18 +919,12 @@ Air_mech_generic = {
 
 		target_template = {
 			regiments = {
-				Mech_Air_Inf_Bat = 6
-				Arty_Bat = 2
-			}
-			support = {
-				H_Engi_Comp = 1
-				SP_AA_Battery = 1
-				helicopter_combat_service_support = 1
+				Mech_Air_Inf_Bat = 9
 			}
 		}
 	}
 
-	Air_Mech_division = {
+	Air_Arm_generic = {
 		upgrade_prio = {
 			factor = 1
 			modifier = {
@@ -825,25 +952,22 @@ Air_mech_generic = {
 
 		target_template = {
 			regiments = {
-				Arty_Bat = 4
-				Arm_Air_Inf_Bat = 6
-			}
-			support = {
-				armor_Recce_Comp = 1
-				H_Engi_Comp = 1
-				SP_AA_Battery = 1
-				helicopter_combat_service_support = 1
-				armor_Comp = 1
+				Arm_Air_Inf_Bat = 9
 			}
 		}
 	}
 }
 
-#this is related to AI Motorized Brigade
+#Motorized Infantry
 infantry_generic = {
 	role = infantry
 	upgrade_prio = {
-		factor = 0.7
+		factor = 1.2
+		modifier = {
+			factor = 1.5
+			num_of_military_factories > 7
+			num_of_military_factories < 16
+		}
 	}
 
 	infantry_generic = {
@@ -870,10 +994,9 @@ infantry_generic = {
 
 		target_template = {
 			regiments = {
-				Mot_Inf_Bat = 6
+				Mot_Inf_Bat = 8
 			}
 			support = {
-				Mot_Recce_Comp = 1
 				H_Engi_Comp = 1
 				combat_service_support_company = 1
 				Arty_Battery = 1
@@ -881,7 +1004,7 @@ infantry_generic = {
 		}
 	}
 
-	infantry_division = {
+	infantry_artillery_brigade = {
 		upgrade_prio = {
 			factor = 1.5
 			modifier = {
@@ -909,21 +1032,19 @@ infantry_generic = {
 
 		target_template = {
 			regiments = {
-				Mot_Inf_Bat = 6
-				Arty_Bat = 4
+				Mot_Inf_Bat = 4
+				Arty_Bat = 5
 			}
 			support = {
+				combat_service_support_company = 1
 				Mot_Recce_Comp = 1
 				H_Engi_Comp = 1
-				armor_Comp = 1
-				combat_service_support_company = 1
-				SP_AA_Battery = 1
 			}
 		}
 	}
 }
 
-#Mechanized Generic - Related to APC
+#Mechanized Generic - Related to APC (SP Rocket Arty)
 APC_generic = {
 	role = apc_mechanized
 	upgrade_prio = {
@@ -933,13 +1054,18 @@ APC_generic = {
 	mechanized_generic = {
 		upgrade_prio = {
 			factor = 1
-			modifier = { #Ignore if you don't have the APCS
+			modifier = {
 				factor = 0
 				num_of_military_factories > 15
+			}
+			modifier = {
+				factor = 0
+				num_of_military_factories < 8
 			}
 		}
 		enable = {
 			NOT = { original_tag = ZOM }
+			num_of_military_factories > 7
 			num_of_military_factories < 15
 			has_game_rule = {
 				rule = rule_god_of_war
@@ -954,15 +1080,14 @@ APC_generic = {
 
 		target_template = {
 			regiments = {
-				Mech_Inf_Bat = 4
-				armor_Bat = 2
-				SP_Arty_Bat = 2
+				Mech_Inf_Bat = 6
+				SP_R_Arty_Bat = 2
 			}
 			support = {
-				H_Engi_Comp = 1
 				Mech_Recce_Comp = 1
-				SP_AA_Battery = 1
+				H_Engi_Comp = 1
 				combat_service_support_company = 1
+				SP_AA_Battery = 1
 			}
 		}
 	}
@@ -995,21 +1120,21 @@ APC_generic = {
 
 		target_template = {
 			regiments = {
-				Mech_Inf_Bat = 6
-				armor_Bat = 2
-				SP_Arty_Bat = 3
+				Mech_Inf_Bat = 10
+				SP_R_Arty_Bat = 6
 			}
 			support = {
 				Mech_Recce_Comp = 1
 				H_Engi_Comp = 1
 				combat_service_support_company = 1
 				SP_AA_Battery = 1
+				armor_Comp = 1
 			}
 		}
 	}
 }
 
-#Mechanized Generic - Related to IFV
+#Mechanized Generic - Related to IFV (SP Arty)
 IFV_generic = {
 	role = ifv_mechanized
 	upgrade_prio = {
@@ -1023,9 +1148,14 @@ IFV_generic = {
 				factor = 0
 				num_of_military_factories > 15
 			}
+			modifier = {
+				factor = 0
+				num_of_military_factories < 10
+			}
 		}
 		enable = {
 			NOT = { original_tag = ZOM }
+			num_of_military_factories > 9
 			num_of_military_factories < 16
 			has_game_rule = {
 				rule = rule_god_of_war
@@ -1040,15 +1170,14 @@ IFV_generic = {
 
 		target_template = {
 			regiments = {
-				Arm_Inf_Bat = 4
-				armor_Bat = 2
+				Arm_Inf_Bat = 6
 				SP_Arty_Bat = 2
 			}
 			support = {
+				Mech_Recce_Comp = 1
 				H_Engi_Comp = 1
-				Arm_Recce_Comp = 1
-				SP_AA_Battery = 1
 				combat_service_support_company = 1
+				SP_AA_Battery = 1
 			}
 		}
 	}
@@ -1092,15 +1221,15 @@ IFV_generic = {
 
 		target_template = {
 			regiments = {
-				Arm_Inf_Bat = 6
-				armor_Bat = 2
-				SP_Arty_Bat = 3
+				Arm_Inf_Bat = 10
+				SP_Arty_Bat = 6
 			}
 			support = {
-				Arm_Recce_Comp = 1
+				Mech_Recce_Comp = 1
 				H_Engi_Comp = 1
 				combat_service_support_company = 1
 				SP_AA_Battery = 1
+				armor_Comp = 1
 			}
 		}
 	}
@@ -1108,29 +1237,29 @@ IFV_generic = {
 
 #Armored Generic
 armor_generic = {
-	# AI will try to have one template per role
 	role = armor
 
-	# MTTH block that decides the 'importance' of the role template compared to other role templates for spending experience on improving
 	upgrade_prio = { factor = 1.2 }
 
 	armor_generic = {
-		# MTTH block that determines how likely the AI is to upgrade
 		upgrade_prio = {
 			factor = 1
+			modifier = {
+				factor = 2
+				num_of_military_factories > 14
+			}
 			modifier = {
 				factor = 0
 				OR = {
 					num_of_military_factories > 20
-					num_of_military_factories < 12
+					num_of_military_factories < 15
 				}
 			}
 		}
-		# Determines the Production importance similar to above
 		enable = {
 			NOT = { original_tag = ZOM }
+			num_of_military_factories > 14
 			num_of_military_factories < 21
-			num_of_military_factories > 10
 			has_game_rule = {
 				rule = rule_god_of_war
 				option = no
@@ -1142,18 +1271,56 @@ armor_generic = {
 
 		target_min_match = 0.5
 
-		# The actual template is designed here
 		target_template = {
 			regiments = {
-				armor_Bat = 4
-				Arm_Inf_Bat = 3
-				SP_AA_Battery = 1
-				SP_Arty_Bat = 2
+				armor_Bat = 10
+				Arm_Inf_Bat = 4
 			}
 			support = {
+				arm_hq = 1
+				armor_Comp = 1
 				H_Engi_Comp = 1
+				SP_AA_Battery = 1
 				combat_service_support_company = 1
-				armor_Recce_Comp = 1
+			}
+		}
+	}
+
+	light_armor_division = {
+		upgrade_prio = {
+			factor = 1.5
+			modifier = {
+				factor = 0
+				OR = {
+					num_of_military_factories > 15
+					num_of_military_factories < 8
+				}
+			}
+		}
+		enable = {
+			NOT = { original_tag = ZOM }
+			num_of_military_factories > 7
+			num_of_military_factories < 16
+			has_game_rule = {
+				rule = rule_god_of_war
+				option = no
+			}
+			NOT = {
+				tag = ALN
+			}
+		}
+
+		target_min_match = 0.5
+
+		target_template = {
+			regiments = {
+				Light_armor_Bat = 10
+				Mech_Inf_Bat = 6
+			}
+			support = {
+				SP_AA_Battery = 1
+				combat_service_support_company = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
@@ -1190,16 +1357,15 @@ armor_generic = {
 
 		target_template = {
 			regiments = {
-				armor_Bat = 6
-				Arm_Inf_Bat = 6
-				SP_Arty_Bat = 2
-				SP_AA_Bat = 1
+				armor_Bat = 10
+				Arm_Inf_Bat = 4
 			}
 			support = {
-				Arm_Recce_Comp = 1
+				arm_hq = 1
+				armor_Comp = 1
 				H_Engi_Comp = 1
-				combat_service_support_company = 1
 				SP_AA_Battery = 1
+				combat_service_support_company = 1
 			}
 		}
 	}

--- a/common/ai_templates/MD_god_of_war.txt
+++ b/common/ai_templates/MD_god_of_war.txt
@@ -20,13 +20,13 @@ Air_heli_god_of_war = {
 
 		target_template = {
 			regiments = {
-				L_Air_assault_Bat = 6
 				attack_helo_bat = 8
+				L_Air_assault_Bat = 6
 			}
 			support = {
 				helicopter_combat_service_support = 1
-				H_Engi_Comp = 1
-				SP_AA_Battery = 1
+				air_assault_Arty_Battery = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
@@ -54,15 +54,15 @@ Mech_inf_god_of_war = {
 
 		target_template = {
 			regiments = {
-				Arm_Inf_Bat = 6
-				armor_Bat = 2
-				SP_Arty_Bat = 2
+				Arm_Inf_Bat = 10
+				SP_Arty_Bat = 6
 			}
 			support = {
-				Arm_Recce_Comp = 1
+				Mech_Recce_Comp = 1
 				H_Engi_Comp = 1
 				combat_service_support_company = 1
 				SP_AA_Battery = 1
+				armor_Comp = 1
 			}
 		}
 	}
@@ -90,15 +90,15 @@ Tank_god_of_war = {
 
 		target_template = {
 			regiments = {
-				Arm_Inf_Bat = 5
-				armor_Bat = 4
-				attack_helo_bat = 1
+				armor_Bat = 10
+				Arm_Inf_Bat = 4
 			}
 			support = {
-				Arm_Recce_Comp = 1
+				arm_hq = 1
+				armor_Comp = 1
 				H_Engi_Comp = 1
-				combat_service_support_company = 1
 				SP_AA_Battery = 1
+				combat_service_support_company = 1
 			}
 		}
 	}
@@ -127,14 +127,13 @@ Marines_god_of_war = {
 
 		target_template = {
 			regiments = {
-				Arm_Marine_Bat = 9
+				Arm_Marine_Bat = 8
 			}
 			support = {
-				Arm_Recce_Comp = 1
 				H_Engi_Comp = 1
 				combat_service_support_company = 1
 				SP_AA_Battery = 1
-				armor_Comp = 1
+				attack_helo_comp = 1
 			}
 		}
 	}
@@ -162,15 +161,14 @@ Special_forces_god_of_war = {
 
 		target_template = {
 			regiments = {
-				Special_Forces = 12
-				SP_Arty_Bat = 5
+				Special_Forces = 15
 			}
 			support = {
-				armor_Recce_Comp = 1
-				H_Engi_Comp = 1
 				combat_service_support_company = 1
-				SP_AA_Battery = 1
+				H_Engi_Comp = 1
+				L_Ranger_Recce_Comp = 1
 				armor_Comp = 1
+				attack_helo_comp = 1
 			}
 		}
 	}

--- a/common/scripted_effects/00_AI_templates.txt
+++ b/common/scripted_effects/00_AI_templates.txt
@@ -1,23 +1,4 @@
 # Author(s): Yard1, Simone-Traiano
-##Compendium of Combat Width
-#Militia Battalion - 3 CW 			#Motorized Airborne Infantry - 4 CW
-#Motorized Militia Battalion - 4 CW #Mechanized Airborne Infantry - 4 CW
-#Light Infantry - 3 CW				#Armored Airborne Infantry - 4 CW
-#Motorized Infantry - 4 CW			#Marine Light Infantry - 3 CW
-#Mechanized Infantry - 4 CW			#Motorized Marine Infantry - 4 CW
-#Armored Infantry - 4 CW			#Mechanized Marine Infantry - 4 CW
-#Airborne Light Infantry - 3 CW		#Armored Marine Infantry - 4 CW
-#Light Air Assault Infantry - 3 CW	#Armored Air Assault Infantry - 4 CW
-#Special Forces - 3 CW				#Tank Battalion - 4 CW
-#Artillery - 3 CW					#SP Arty - 3 CW
-#SP AA - 4 CW
-#Companies - Support Companies
-#Tank Company - 2 CW				#Light Recon - 1 CW
-#Motorized Recon - 2 CW				#Mechanized Company - 2 CW
-#Armored Recon - 2 CW				#Armored Recce - 2 CW
-#Light Engineer - 1 CW				#Heavy Engineer - 2 CW
-#Artillery BAttery - 1 CW			#SP Arty - 2 CW
-#SP AA - 2 CWf
 
 give_AI_templates = {
 	if = {
@@ -39,7 +20,7 @@ give_AI_templates = {
 	}
 	else = {
 		if = {
-			limit = { NOT = { has_template = "AI Militia Brigade - 15w" } }
+			limit = { NOT = { has_template = "AI Militia Brigade" } }
 			Militia_AI_templates = yes
 		}
 		if = {
@@ -61,7 +42,7 @@ give_AI_templates = {
 }
 
 generic_AI_templates = {
-	#Light Infantry - Supports the L_Inf role
+	# AI Light Infantry Brigade - 11x L_Inf + CSS + H_Engi
 	division_template = {
 		name = "AI Light Infantry Brigade"
 		priority = 0
@@ -69,69 +50,47 @@ generic_AI_templates = {
 			L_Inf_Bat = { x = 0 y = 0 }
 			L_Inf_Bat = { x = 0 y = 1 }
 			L_Inf_Bat = { x = 0 y = 2 }
+			L_Inf_Bat = { x = 0 y = 3 }
 			L_Inf_Bat = { x = 1 y = 0 }
 			L_Inf_Bat = { x = 1 y = 1 }
 			L_Inf_Bat = { x = 1 y = 2 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-			Arty_Bat = { x = 2 y = 2 }
+			L_Inf_Bat = { x = 1 y = 3 }
+			L_Inf_Bat = { x = 2 y = 0 }
+			L_Inf_Bat = { x = 2 y = 1 }
+			L_Inf_Bat = { x = 2 y = 2 }
 		}
 		support = {
-			L_Engi_Comp = { x = 0 y = 0 }
-			L_Recce_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
+			combat_service_support_company = { x = 0 y = 0 }
+			H_Engi_Comp = { x = 0 y = 1 }
 		}
 	}
+
+	# AI Light Artillery Brigade - 6x L_Inf + 5x Arty + Mot_Recce + CSS
 	division_template = {
-		name = "AI Light Infantry Division"
+		name = "AI Light Artillery Brigade"
 		priority = 0
 		regiments = {
 			L_Inf_Bat = { x = 0 y = 0 }
 			L_Inf_Bat = { x = 0 y = 1 }
 			L_Inf_Bat = { x = 0 y = 2 }
-			Arty_Bat = { x = 0 y = 3 }
 			L_Inf_Bat = { x = 1 y = 0 }
 			L_Inf_Bat = { x = 1 y = 1 }
 			L_Inf_Bat = { x = 1 y = 2 }
-			Arty_Bat = { x = 1 y = 3 }
-			L_Inf_Bat = { x = 2 y = 0 }
-			L_Inf_Bat = { x = 2 y = 1 }
-			L_Inf_Bat = { x = 2 y = 2 }
-			Arty_Bat = { x = 2 y = 3 }
-		}
-		support = {
-			L_Recce_Comp = { x = 0 y = 0 }
-			L_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
-			Arty_Battery = { x = 0 y = 3 }
-		}
-	}
-
-	#Light Marine Brigades - Supports the marines Roles
-	division_template = {
-		name = "AI Light Marine Brigade"
-		priority = 1
-		regiments = {
-			L_Marine_Bat = { x = 0 y = 0 }
-			L_Marine_Bat = { x = 0 y = 1 }
-			L_Marine_Bat = { x = 0 y = 2 }
-			L_Marine_Bat = { x = 1 y = 0 }
-			L_Marine_Bat = { x = 1 y = 1 }
-			L_Marine_Bat = { x = 1 y = 2 }
 			Arty_Bat = { x = 2 y = 0 }
 			Arty_Bat = { x = 2 y = 1 }
 			Arty_Bat = { x = 2 y = 2 }
+			Arty_Bat = { x = 3 y = 0 }
+			Arty_Bat = { x = 3 y = 1 }
 		}
 		support = {
-			L_Engi_Comp = { x = 0 y = 0 }
+			Mot_Recce_Comp = { x = 0 y = 0 }
 			combat_service_support_company = { x = 0 y = 1 }
-			L_Recce_Comp = { x = 0 y = 2 }
-			SP_AA_Battery = { x = 0 y = 3 }
 		}
 	}
 
+	# AI Light Marine Brigade - 11x L_Marine + CSS + H_Engi
 	division_template = {
-		name = "AI Light Marine Division"
+		name = "AI Light Marine Brigade"
 		priority = 1
 		regiments = {
 			L_Marine_Bat = { x = 0 y = 0 }
@@ -142,44 +101,49 @@ generic_AI_templates = {
 			L_Marine_Bat = { x = 1 y = 1 }
 			L_Marine_Bat = { x = 1 y = 2 }
 			L_Marine_Bat = { x = 1 y = 3 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-			SP_Arty_Bat = { x = 2 y = 2 }
-			SP_Arty_Bat = { x = 2 y = 3 }
+			L_Marine_Bat = { x = 2 y = 0 }
+			L_Marine_Bat = { x = 2 y = 1 }
+			L_Marine_Bat = { x = 2 y = 2 }
 		}
 		support = {
-			L_Recce_Comp = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 0 }
 			H_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
-			armor_Comp = { x = 0 y = 3 }
-			SP_AA_Battery = { x = 0 y = 4 }
 		}
 	}
 
-	#AI Special Forces Regiments - Sastifiies the special_forces role
+	# AI Marine Commando Division - 15x L_Marine_Cdo + CSS + H_Engi + L_Ranger_Recce + armor_Comp + attack_helo_comp
+	division_template = {
+		name = "AI Marine Commando Division"
+		priority = 1
+		regiments = {
+			L_Marine_Cdo_Bat = { x = 0 y = 0 }
+			L_Marine_Cdo_Bat = { x = 0 y = 1 }
+			L_Marine_Cdo_Bat = { x = 0 y = 2 }
+			L_Marine_Cdo_Bat = { x = 0 y = 3 }
+			L_Marine_Cdo_Bat = { x = 0 y = 4 }
+			L_Marine_Cdo_Bat = { x = 1 y = 0 }
+			L_Marine_Cdo_Bat = { x = 1 y = 1 }
+			L_Marine_Cdo_Bat = { x = 1 y = 2 }
+			L_Marine_Cdo_Bat = { x = 1 y = 3 }
+			L_Marine_Cdo_Bat = { x = 1 y = 4 }
+			L_Marine_Cdo_Bat = { x = 2 y = 0 }
+			L_Marine_Cdo_Bat = { x = 2 y = 1 }
+			L_Marine_Cdo_Bat = { x = 2 y = 2 }
+			L_Marine_Cdo_Bat = { x = 2 y = 3 }
+			L_Marine_Cdo_Bat = { x = 2 y = 4 }
+		}
+		support = {
+			combat_service_support_company = { x = 0 y = 0 }
+			H_Engi_Comp = { x = 0 y = 1 }
+			L_Ranger_Recce_Comp = { x = 0 y = 2 }
+			armor_Comp = { x = 0 y = 3 }
+			attack_helo_comp = { x = 0 y = 4 }
+		}
+	}
+
+	# AI Special Operations Brigade - 7x Special_Forces + CSS
 	division_template = {
 		name = "AI Special Operation Brigade"
-		priority = 2
-		regiments = {
-			Special_Forces = { x = 0 y = 0 }
-			Special_Forces = { x = 0 y = 1 }
-			Special_Forces = { x = 0 y = 2 }
-			Special_Forces = { x = 1 y = 0 }
-			Special_Forces = { x = 1 y = 1 }
-			Special_Forces = { x = 1 y = 2 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-			Arty_Bat = { x = 2 y = 2 }
-		}
-		support = {
-			L_Recce_Comp = { x = 0 y = 0 }
-			L_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
-		}
-	}
-
-	division_template = {
-		name = "AI Special Operation Division"
 		priority = 2
 		regiments = {
 			Special_Forces = { x = 0 y = 0 }
@@ -189,24 +153,45 @@ generic_AI_templates = {
 			Special_Forces = { x = 1 y = 0 }
 			Special_Forces = { x = 1 y = 1 }
 			Special_Forces = { x = 1 y = 2 }
-			Special_Forces = { x = 1 y = 3 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-			SP_Arty_Bat = { x = 2 y = 2 }
-			SP_AA_Bat = { x = 2 y = 3 }
 		}
 		support = {
-			H_Engi_Comp = { x = 0 y = 0 }
-			Arm_Recce_Comp = { x = 0 y = 1 }
-			armor_Comp = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
-			SP_Arty_Battery = { x = 0 y = 4 }
+			combat_service_support_company = { x = 0 y = 0 }
 		}
 	}
 
-	#AI Air Assault Brigades
+	# AI Special Operations Division - 15x Special_Forces + CSS + H_Engi + L_Ranger_Recce + armor_Comp + attack_helo_comp
 	division_template = {
-		name = "AI Light Air Assault Brigade"
+		name = "AI Special Operation Division"
+		priority = 2
+		regiments = {
+			Special_Forces = { x = 0 y = 0 }
+			Special_Forces = { x = 0 y = 1 }
+			Special_Forces = { x = 0 y = 2 }
+			Special_Forces = { x = 0 y = 3 }
+			Special_Forces = { x = 0 y = 4 }
+			Special_Forces = { x = 1 y = 0 }
+			Special_Forces = { x = 1 y = 1 }
+			Special_Forces = { x = 1 y = 2 }
+			Special_Forces = { x = 1 y = 3 }
+			Special_Forces = { x = 1 y = 4 }
+			Special_Forces = { x = 2 y = 0 }
+			Special_Forces = { x = 2 y = 1 }
+			Special_Forces = { x = 2 y = 2 }
+			Special_Forces = { x = 2 y = 3 }
+			Special_Forces = { x = 2 y = 4 }
+		}
+		support = {
+			combat_service_support_company = { x = 0 y = 0 }
+			H_Engi_Comp = { x = 0 y = 1 }
+			L_Ranger_Recce_Comp = { x = 0 y = 2 }
+			armor_Comp = { x = 0 y = 3 }
+			attack_helo_comp = { x = 0 y = 4 }
+		}
+	}
+
+	# AI Air Assault Brigade - 15x L_Air_assault
+	division_template = {
+		name = "AI Air Assault Brigade"
 		priority = 2
 		regiments = {
 			L_Air_assault_Bat = { x = 0 y = 0 }
@@ -214,29 +199,54 @@ generic_AI_templates = {
 			L_Air_assault_Bat = { x = 0 y = 2 }
 			L_Air_assault_Bat = { x = 0 y = 3 }
 			L_Air_assault_Bat = { x = 0 y = 4 }
+			L_Air_assault_Bat = { x = 1 y = 0 }
+			L_Air_assault_Bat = { x = 1 y = 1 }
+			L_Air_assault_Bat = { x = 1 y = 2 }
+			L_Air_assault_Bat = { x = 1 y = 3 }
+			L_Air_assault_Bat = { x = 1 y = 4 }
+			L_Air_assault_Bat = { x = 2 y = 0 }
+			L_Air_assault_Bat = { x = 2 y = 1 }
+			L_Air_assault_Bat = { x = 2 y = 2 }
+			L_Air_assault_Bat = { x = 2 y = 3 }
+			L_Air_assault_Bat = { x = 2 y = 4 }
 		}
 	}
+
+	# AI Air Assault Division - 20x L_Air_assault + helo_hq + helicopter_css + air_assault_Arty_Battery + attack_helo_comp
 	division_template = {
-		name = "AI Light Air Assault Division"
+		name = "AI Air Assault Division"
 		priority = 2
 		regiments = {
 			L_Air_assault_Bat = { x = 0 y = 0 }
 			L_Air_assault_Bat = { x = 0 y = 1 }
 			L_Air_assault_Bat = { x = 0 y = 2 }
+			L_Air_assault_Bat = { x = 0 y = 3 }
+			L_Air_assault_Bat = { x = 0 y = 4 }
 			L_Air_assault_Bat = { x = 1 y = 0 }
 			L_Air_assault_Bat = { x = 1 y = 1 }
 			L_Air_assault_Bat = { x = 1 y = 2 }
+			L_Air_assault_Bat = { x = 1 y = 3 }
+			L_Air_assault_Bat = { x = 1 y = 4 }
 			L_Air_assault_Bat = { x = 2 y = 0 }
 			L_Air_assault_Bat = { x = 2 y = 1 }
 			L_Air_assault_Bat = { x = 2 y = 2 }
+			L_Air_assault_Bat = { x = 2 y = 3 }
+			L_Air_assault_Bat = { x = 2 y = 4 }
+			L_Air_assault_Bat = { x = 3 y = 0 }
+			L_Air_assault_Bat = { x = 3 y = 1 }
+			L_Air_assault_Bat = { x = 3 y = 2 }
+			L_Air_assault_Bat = { x = 3 y = 3 }
+			L_Air_assault_Bat = { x = 3 y = 4 }
 		}
 		support = {
-			helicopter_combat_service_support = { x = 0 y = 0 }
-			Arm_Recce_Comp = { x = 0 y = 1 }
+			helo_hq = { x = 0 y = 0 }
+			helicopter_combat_service_support = { x = 0 y = 1 }
+			air_assault_Arty_Battery = { x = 0 y = 2 }
+			attack_helo_comp = { x = 0 y = 3 }
 		}
 	}
 
-	#extensions of marines
+	# AI Motorized Marine Brigade - 8x Mot_Marine + H_Engi + CSS + Arty_Battery
 	division_template = {
 		name = "AI Motorized Marine Brigade"
 		priority = 1
@@ -244,17 +254,20 @@ generic_AI_templates = {
 			Mot_Marine_Bat = { x = 0 y = 0 }
 			Mot_Marine_Bat = { x = 0 y = 1 }
 			Mot_Marine_Bat = { x = 0 y = 2 }
+			Mot_Marine_Bat = { x = 0 y = 3 }
 			Mot_Marine_Bat = { x = 1 y = 0 }
 			Mot_Marine_Bat = { x = 1 y = 1 }
 			Mot_Marine_Bat = { x = 1 y = 2 }
+			Mot_Marine_Bat = { x = 1 y = 3 }
 		}
 		support = {
 			H_Engi_Comp = { x = 0 y = 0 }
-			Mot_Recce_Comp = { x = 0 y = 1 }
+			combat_service_support_company = { x = 0 y = 1 }
 			Arty_Battery = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
 		}
 	}
+
+	# AI Motorized Marine Division - 12x Mot_Marine + 4x Light_armor + CSS + SP_AA_Battery + attack_helo_comp
 	division_template = {
 		name = "AI Motorized Marine Division"
 		priority = 1
@@ -263,21 +276,27 @@ generic_AI_templates = {
 			Mot_Marine_Bat = { x = 0 y = 1 }
 			Mot_Marine_Bat = { x = 0 y = 2 }
 			Mot_Marine_Bat = { x = 0 y = 3 }
-			Mot_Marine_Bat = { x = 0 y = 4 }
 			Mot_Marine_Bat = { x = 1 y = 0 }
 			Mot_Marine_Bat = { x = 1 y = 1 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-			Arty_Bat = { x = 2 y = 2 }
-			Arty_Bat = { x = 2 y = 3 }
+			Mot_Marine_Bat = { x = 1 y = 2 }
+			Mot_Marine_Bat = { x = 1 y = 3 }
+			Mot_Marine_Bat = { x = 2 y = 0 }
+			Mot_Marine_Bat = { x = 2 y = 1 }
+			Mot_Marine_Bat = { x = 2 y = 2 }
+			Mot_Marine_Bat = { x = 2 y = 3 }
+			Light_armor_Bat = { x = 3 y = 0 }
+			Light_armor_Bat = { x = 3 y = 1 }
+			Light_armor_Bat = { x = 3 y = 2 }
+			Light_armor_Bat = { x = 3 y = 3 }
 		}
 		support = {
-			Mot_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
+			combat_service_support_company = { x = 0 y = 0 }
+			SP_AA_Battery = { x = 0 y = 1 }
+			attack_helo_comp = { x = 0 y = 2 }
 		}
 	}
 
+	# AI Motorized Infantry Brigade - 8x Mot_Inf + H_Engi + CSS + Arty_Battery
 	division_template = {
 		name = "AI Motorized Infantry Brigade"
 		priority = 1
@@ -285,45 +304,44 @@ generic_AI_templates = {
 			Mot_Inf_Bat = { x = 0 y = 0 }
 			Mot_Inf_Bat = { x = 0 y = 1 }
 			Mot_Inf_Bat = { x = 0 y = 2 }
+			Mot_Inf_Bat = { x = 0 y = 3 }
 			Mot_Inf_Bat = { x = 1 y = 0 }
 			Mot_Inf_Bat = { x = 1 y = 1 }
 			Mot_Inf_Bat = { x = 1 y = 2 }
+			Mot_Inf_Bat = { x = 1 y = 3 }
 		}
 		support = {
-			Mot_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
-			Arty_Battery = { x = 0 y = 3 }
+			H_Engi_Comp = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 1 }
+			Arty_Battery = { x = 0 y = 2 }
 		}
 	}
 
-	# Mot_Inf_Bat x
+	# AI Motorized Artillery Brigade - 4x Mot_Inf + 5x Arty + CSS + Mot_Recce + H_Engi
 	division_template = {
-		name = "AI Motorized Infantry Division"
+		name = "AI Motorized Artillery Brigade"
 		priority = 1
 		regiments = {
 			Mot_Inf_Bat = { x = 0 y = 0 }
 			Mot_Inf_Bat = { x = 0 y = 1 }
 			Mot_Inf_Bat = { x = 0 y = 2 }
-			Mot_Inf_Bat = { x = 1 y = 0 }
-			Mot_Inf_Bat = { x = 1 y = 1 }
-			Mot_Inf_Bat = { x = 1 y = 2 }
+			Mot_Inf_Bat = { x = 0 y = 3 }
+			Arty_Bat = { x = 1 y = 0 }
+			Arty_Bat = { x = 1 y = 1 }
+			Arty_Bat = { x = 1 y = 2 }
 			Arty_Bat = { x = 2 y = 0 }
 			Arty_Bat = { x = 2 y = 1 }
-			Arty_Bat = { x = 2 y = 2 }
-			Arty_Bat = { x = 2 y = 3 }
 		}
 		support = {
-			Mot_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			armor_Comp = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
-			SP_AA_Battery = { x = 0 y = 4 }
+			combat_service_support_company = { x = 0 y = 0 }
+			Mot_Recce_Comp = { x = 0 y = 1 }
+			H_Engi_Comp = { x = 0 y = 2 }
 		}
 	}
 
+	# AI Mechanized Airborne Brigade - 9x Mech_Air_Inf
 	division_template = {
-		name = "AI Air Assault Brigade"
+		name = "AI Mechanized Airborne Brigade"
 		priority = 2
 		regiments = {
 			Mech_Air_Inf_Bat = { x = 0 y = 0 }
@@ -332,19 +350,15 @@ generic_AI_templates = {
 			Mech_Air_Inf_Bat = { x = 1 y = 0 }
 			Mech_Air_Inf_Bat = { x = 1 y = 1 }
 			Mech_Air_Inf_Bat = { x = 1 y = 2 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-		}
-		support = {
-			Mech_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			helicopter_combat_service_support = { x = 0 y = 2 }
-			SP_AA_Battery = { x = 0 y = 3 }
+			Mech_Air_Inf_Bat = { x = 2 y = 0 }
+			Mech_Air_Inf_Bat = { x = 2 y = 1 }
+			Mech_Air_Inf_Bat = { x = 2 y = 2 }
 		}
 	}
 
+	# AI Armored Airborne Brigade - 9x Arm_Air_Inf
 	division_template = {
-		name = "AI Air Assault Division"
+		name = "AI Armored Airborne Brigade"
 		priority = 2
 		regiments = {
 			Arm_Air_Inf_Bat = { x = 0 y = 0 }
@@ -353,77 +367,25 @@ generic_AI_templates = {
 			Arm_Air_Inf_Bat = { x = 1 y = 0 }
 			Arm_Air_Inf_Bat = { x = 1 y = 1 }
 			Arm_Air_Inf_Bat = { x = 1 y = 2 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-			Arty_Bat = { x = 2 y = 2 }
-			Arty_Bat = { x = 2 y = 3 }
-		}
-		support = {
-			armor_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			helicopter_combat_service_support = { x = 0 y = 2 }
-			SP_AA_Battery = { x = 0 y = 3 }
-			armor_Comp = { x = 0 y = 4 }
+			Arm_Air_Inf_Bat = { x = 2 y = 0 }
+			Arm_Air_Inf_Bat = { x = 2 y = 1 }
+			Arm_Air_Inf_Bat = { x = 2 y = 2 }
 		}
 	}
 
-	division_template = {
-		name = "AI Heavy Air Assault Brigade"
-		priority = 2
-		regiments = {
-			L_Air_assault_Bat = { x = 0 y = 0 }
-			L_Air_assault_Bat = { x = 0 y = 1 }
-			L_Air_assault_Bat = { x = 0 y = 2 }
-			L_Air_assault_Bat = { x = 0 y = 3 }
-			L_Air_assault_Bat = { x = 1 y = 0 }
-			L_Air_assault_Bat = { x = 1 y = 1 }
-			L_Air_assault_Bat = { x = 1 y = 2 }
-			L_Air_assault_Bat = { x = 1 y = 3 }
-			attack_helo_bat = { x = 2 y = 0 }
-			attack_helo_bat = { x = 2 y = 1 }
-			attack_helo_bat = { x = 2 y = 2 }
-		}
-		support = {
-			helicopter_combat_service_support = { x = 0 y = 0 }
-		}
-	}
-
+	# AI Mechanized Infantry Brigade - 6x Mech_Inf + 2x SP_R_Arty + Mech_Recce + H_Engi + CSS + SP_AA_Battery
 	division_template = {
 		name = "AI Mechanized Brigade"
 		priority = 1
 		regiments = {
 			Mech_Inf_Bat = { x = 0 y = 0 }
 			Mech_Inf_Bat = { x = 0 y = 1 }
-			armor_Bat = { x = 0 y = 2 }
-			Mech_Inf_Bat = { x = 1 y = 0 }
-			Mech_Inf_Bat = { x = 1 y = 1 }
-			armor_Bat = { x = 1 y = 2 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-		}
-		support = {
-			SP_AA_Battery = { x = 0 y = 0 }
-			Mech_Recce_Comp = { x = 0 y = 1 }
-			H_Engi_Comp = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
-		}
-	}
-
-	division_template = {
-		name = "AI Mechanized Division"
-		priority = 1
-		regiments = {
-			Mech_Inf_Bat = { x = 0 y = 0 }
-			Mech_Inf_Bat = { x = 0 y = 1 }
 			Mech_Inf_Bat = { x = 0 y = 2 }
-			armor_Bat = { x = 0 y = 3 }
 			Mech_Inf_Bat = { x = 1 y = 0 }
 			Mech_Inf_Bat = { x = 1 y = 1 }
 			Mech_Inf_Bat = { x = 1 y = 2 }
-			armor_Bat = { x = 1 y = 3 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-			SP_Arty_Bat = { x = 2 y = 2 }
+			SP_R_Arty_Bat = { x = 2 y = 0 }
+			SP_R_Arty_Bat = { x = 2 y = 1 }
 		}
 		support = {
 			Mech_Recce_Comp = { x = 0 y = 0 }
@@ -433,52 +395,38 @@ generic_AI_templates = {
 		}
 	}
 
+	# AI Mechanized Infantry Division - 10x Mech_Inf + 6x SP_R_Arty + Mech_Recce + H_Engi + CSS + SP_AA_Battery + armor_Comp
 	division_template = {
-		name = "AI Mechanized Marine Brigade"
+		name = "AI Mechanized Division"
 		priority = 1
 		regiments = {
-			Mech_Marine_Bat = { x = 0 y = 0 }
-			Mech_Marine_Bat = { x = 0 y = 1 }
-			Mech_Marine_Bat = { x = 0 y = 2 }
-			armor_Bat = { x = 0 y = 3 }
-			Mech_Marine_Bat = { x = 1 y = 0 }
-			Mech_Marine_Bat = { x = 1 y = 1 }
-			Mech_Marine_Bat = { x = 1 y = 2 }
-			armor_Bat = { x = 1 y = 3 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
+			Mech_Inf_Bat = { x = 0 y = 0 }
+			Mech_Inf_Bat = { x = 0 y = 1 }
+			Mech_Inf_Bat = { x = 0 y = 2 }
+			Mech_Inf_Bat = { x = 0 y = 3 }
+			Mech_Inf_Bat = { x = 0 y = 4 }
+			Mech_Inf_Bat = { x = 1 y = 0 }
+			Mech_Inf_Bat = { x = 1 y = 1 }
+			Mech_Inf_Bat = { x = 1 y = 2 }
+			Mech_Inf_Bat = { x = 1 y = 3 }
+			Mech_Inf_Bat = { x = 1 y = 4 }
+			SP_R_Arty_Bat = { x = 2 y = 0 }
+			SP_R_Arty_Bat = { x = 2 y = 1 }
+			SP_R_Arty_Bat = { x = 2 y = 2 }
+			SP_R_Arty_Bat = { x = 3 y = 0 }
+			SP_R_Arty_Bat = { x = 3 y = 1 }
+			SP_R_Arty_Bat = { x = 3 y = 2 }
 		}
 		support = {
-			combat_service_support_company = { x = 0 y = 0 }
-			Mech_Recce_Comp = { x = 0 y = 1 }
-			H_Engi_Comp = { x = 0 y = 2 }
+			Mech_Recce_Comp = { x = 0 y = 0 }
+			H_Engi_Comp = { x = 0 y = 1 }
+			combat_service_support_company = { x = 0 y = 2 }
 			SP_AA_Battery = { x = 0 y = 3 }
+			armor_Comp = { x = 0 y = 4 }
 		}
 	}
 
-	division_template = {
-		name = "AI Armored Marine Brigade"
-		priority = 2
-		regiments = {
-			Arm_Marine_Bat = { x = 0 y = 0 }
-			Arm_Marine_Bat = { x = 0 y = 1 }
-			Arm_Marine_Bat = { x = 0 y = 2 }
-			armor_Bat = { x = 0 y = 3 }
-			Arm_Marine_Bat = { x = 1 y = 0 }
-			Arm_Marine_Bat = { x = 1 y = 1 }
-			Arm_Marine_Bat = { x = 1 y = 2 }
-			armor_Bat = { x = 1 y = 3 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-		}
-		support = {
-			combat_service_support_company = { x = 0 y = 0 }
-			Arm_Recce_Comp = { x = 0 y = 1 }
-			H_Engi_Comp = { x = 0 y = 2 }
-			SP_AA_Battery = { x = 0 y = 3 }
-		}
-	}
-
+	# AI Armored Infantry Brigade - 6x Arm_Inf + 2x SP_Arty + Mech_Recce + H_Engi + CSS + SP_AA_Battery
 	division_template = {
 		name = "AI Armored Infantry Brigade"
 		priority = 2
@@ -486,20 +434,21 @@ generic_AI_templates = {
 			Arm_Inf_Bat = { x = 0 y = 0 }
 			Arm_Inf_Bat = { x = 0 y = 1 }
 			Arm_Inf_Bat = { x = 0 y = 2 }
-			Arm_Inf_Bat = { x = 0 y = 3 }
-			armor_Bat = { x = 1 y = 0 }
-			armor_Bat = { x = 1 y = 1 }
+			Arm_Inf_Bat = { x = 1 y = 0 }
+			Arm_Inf_Bat = { x = 1 y = 1 }
+			Arm_Inf_Bat = { x = 1 y = 2 }
 			SP_Arty_Bat = { x = 2 y = 0 }
 			SP_Arty_Bat = { x = 2 y = 1 }
 		}
 		support = {
-			SP_AA_Battery = { x = 0 y = 0 }
-			Arm_Recce_Comp = { x = 0 y = 1 }
-			H_Engi_Comp = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
+			Mech_Recce_Comp = { x = 0 y = 0 }
+			H_Engi_Comp = { x = 0 y = 1 }
+			combat_service_support_company = { x = 0 y = 2 }
+			SP_AA_Battery = { x = 0 y = 3 }
 		}
 	}
 
+	# AI Armored Infantry Division - 10x Arm_Inf + 6x SP_Arty + Mech_Recce + H_Engi + CSS + SP_AA_Battery + armor_Comp
 	division_template = {
 		name = "AI Armored Infantry Division"
 		priority = 2
@@ -507,23 +456,74 @@ generic_AI_templates = {
 			Arm_Inf_Bat = { x = 0 y = 0 }
 			Arm_Inf_Bat = { x = 0 y = 1 }
 			Arm_Inf_Bat = { x = 0 y = 2 }
-			armor_Bat = { x = 0 y = 3 }
+			Arm_Inf_Bat = { x = 0 y = 3 }
+			Arm_Inf_Bat = { x = 0 y = 4 }
 			Arm_Inf_Bat = { x = 1 y = 0 }
 			Arm_Inf_Bat = { x = 1 y = 1 }
 			Arm_Inf_Bat = { x = 1 y = 2 }
-			armor_Bat = { x = 1 y = 3 }
+			Arm_Inf_Bat = { x = 1 y = 3 }
+			Arm_Inf_Bat = { x = 1 y = 4 }
 			SP_Arty_Bat = { x = 2 y = 0 }
 			SP_Arty_Bat = { x = 2 y = 1 }
 			SP_Arty_Bat = { x = 2 y = 2 }
+			SP_Arty_Bat = { x = 3 y = 0 }
+			SP_Arty_Bat = { x = 3 y = 1 }
+			SP_Arty_Bat = { x = 3 y = 2 }
 		}
 		support = {
-			Arm_Recce_Comp = { x = 0 y = 0 }
+			Mech_Recce_Comp = { x = 0 y = 0 }
 			H_Engi_Comp = { x = 0 y = 1 }
 			combat_service_support_company = { x = 0 y = 2 }
 			SP_AA_Battery = { x = 0 y = 3 }
+			armor_Comp = { x = 0 y = 4 }
 		}
 	}
 
+	# AI Mechanized Marine Brigade - 8x Mech_Marine + H_Engi + CSS + SP_AA_Battery + attack_helo_comp
+	division_template = {
+		name = "AI Mechanized Marine Brigade"
+		priority = 1
+		regiments = {
+			Mech_Marine_Bat = { x = 0 y = 0 }
+			Mech_Marine_Bat = { x = 0 y = 1 }
+			Mech_Marine_Bat = { x = 0 y = 2 }
+			Mech_Marine_Bat = { x = 0 y = 3 }
+			Mech_Marine_Bat = { x = 1 y = 0 }
+			Mech_Marine_Bat = { x = 1 y = 1 }
+			Mech_Marine_Bat = { x = 1 y = 2 }
+			Mech_Marine_Bat = { x = 1 y = 3 }
+		}
+		support = {
+			H_Engi_Comp = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 1 }
+			SP_AA_Battery = { x = 0 y = 2 }
+			attack_helo_comp = { x = 0 y = 3 }
+		}
+	}
+
+	# AI Armored Marine Brigade - 8x Arm_Marine + H_Engi + CSS + SP_AA_Battery + attack_helo_comp
+	division_template = {
+		name = "AI Armored Marine Brigade"
+		priority = 2
+		regiments = {
+			Arm_Marine_Bat = { x = 0 y = 0 }
+			Arm_Marine_Bat = { x = 0 y = 1 }
+			Arm_Marine_Bat = { x = 0 y = 2 }
+			Arm_Marine_Bat = { x = 0 y = 3 }
+			Arm_Marine_Bat = { x = 1 y = 0 }
+			Arm_Marine_Bat = { x = 1 y = 1 }
+			Arm_Marine_Bat = { x = 1 y = 2 }
+			Arm_Marine_Bat = { x = 1 y = 3 }
+		}
+		support = {
+			H_Engi_Comp = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 1 }
+			SP_AA_Battery = { x = 0 y = 2 }
+			attack_helo_comp = { x = 0 y = 3 }
+		}
+	}
+
+	# AI Armored Brigade - 10x armor + 4x Arm_Inf + arm_hq + armor_Comp + H_Engi + SP_AA_Battery + CSS
 	division_template = {
 		name = "AI Armored Brigade"
 		priority = 2
@@ -532,22 +532,85 @@ generic_AI_templates = {
 			armor_Bat = { x = 0 y = 1 }
 			armor_Bat = { x = 0 y = 2 }
 			armor_Bat = { x = 0 y = 3 }
-			Arm_Inf_Bat = { x = 1 y = 0 }
-			Arm_Inf_Bat = { x = 1 y = 1 }
-			Arm_Inf_Bat = { x = 1 y = 2 }
-			SP_AA_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-			SP_Arty_Bat = { x = 2 y = 2 }
+			armor_Bat = { x = 0 y = 4 }
+			armor_Bat = { x = 1 y = 0 }
+			armor_Bat = { x = 1 y = 1 }
+			armor_Bat = { x = 1 y = 2 }
+			armor_Bat = { x = 1 y = 3 }
+			armor_Bat = { x = 1 y = 4 }
+			Arm_Inf_Bat = { x = 2 y = 0 }
+			Arm_Inf_Bat = { x = 2 y = 1 }
+			Arm_Inf_Bat = { x = 2 y = 2 }
+			Arm_Inf_Bat = { x = 2 y = 3 }
 		}
 		support = {
-			armor_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
+			arm_hq = { x = 0 y = 0 }
+			armor_Comp = { x = 0 y = 1 }
+			H_Engi_Comp = { x = 0 y = 2 }
+			SP_AA_Battery = { x = 0 y = 3 }
+			combat_service_support_company = { x = 0 y = 4 }
+		}
+	}
+
+	# AI Light Armored Division - 10x Light_armor + 6x Mech_Inf + SP_AA_Battery + CSS + attack_helo_comp
+	division_template = {
+		name = "AI Light Armored Division"
+		priority = 2
+		regiments = {
+			Light_armor_Bat = { x = 0 y = 0 }
+			Light_armor_Bat = { x = 0 y = 1 }
+			Light_armor_Bat = { x = 0 y = 2 }
+			Light_armor_Bat = { x = 0 y = 3 }
+			Light_armor_Bat = { x = 0 y = 4 }
+			Light_armor_Bat = { x = 1 y = 0 }
+			Light_armor_Bat = { x = 1 y = 1 }
+			Light_armor_Bat = { x = 1 y = 2 }
+			Light_armor_Bat = { x = 1 y = 3 }
+			Light_armor_Bat = { x = 1 y = 4 }
+			Mech_Inf_Bat = { x = 2 y = 0 }
+			Mech_Inf_Bat = { x = 2 y = 1 }
+			Mech_Inf_Bat = { x = 2 y = 2 }
+			Mech_Inf_Bat = { x = 3 y = 0 }
+			Mech_Inf_Bat = { x = 3 y = 1 }
+			Mech_Inf_Bat = { x = 3 y = 2 }
+		}
+		support = {
+			SP_AA_Battery = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 1 }
+			attack_helo_comp = { x = 0 y = 2 }
+		}
+	}
+
+	# AI Attack Helicopter Brigade - 8x attack_helo_bat + 6x L_Air_assault + heli_css + air_assault_Arty_Battery + attack_helo_comp
+	division_template = {
+		name = "AI Attack Helicopter Brigade"
+		priority = 2
+		regiments = {
+			attack_helo_bat = { x = 0 y = 0 }
+			attack_helo_bat = { x = 0 y = 1 }
+			attack_helo_bat = { x = 0 y = 2 }
+			attack_helo_bat = { x = 0 y = 3 }
+			attack_helo_bat = { x = 1 y = 0 }
+			attack_helo_bat = { x = 1 y = 1 }
+			attack_helo_bat = { x = 1 y = 2 }
+			attack_helo_bat = { x = 1 y = 3 }
+			L_Air_assault_Bat = { x = 2 y = 0 }
+			L_Air_assault_Bat = { x = 2 y = 1 }
+			L_Air_assault_Bat = { x = 2 y = 2 }
+			L_Air_assault_Bat = { x = 3 y = 0 }
+			L_Air_assault_Bat = { x = 3 y = 1 }
+			L_Air_assault_Bat = { x = 3 y = 2 }
+		}
+		support = {
+			helicopter_combat_service_support = { x = 0 y = 0 }
+			air_assault_Arty_Battery = { x = 0 y = 1 }
+			attack_helo_comp = { x = 0 y = 2 }
 		}
 	}
 }
 
 Major_Power_AI_templates = {
+	# AI Armored Division - 10x armor + 4x Arm_Inf + arm_hq + armor_Comp + H_Engi + SP_AA_Battery + CSS
 	division_template = {
 		name = "AI Armored Division"
 		priority = 2
@@ -555,71 +618,28 @@ Major_Power_AI_templates = {
 			armor_Bat = { x = 0 y = 0 }
 			armor_Bat = { x = 0 y = 1 }
 			armor_Bat = { x = 0 y = 2 }
-			SP_Arty_Bat = { x = 0 y = 3 }
+			armor_Bat = { x = 0 y = 3 }
+			armor_Bat = { x = 0 y = 4 }
 			armor_Bat = { x = 1 y = 0 }
 			armor_Bat = { x = 1 y = 1 }
 			armor_Bat = { x = 1 y = 2 }
-			SP_Arty_Bat = { x = 1 y = 3 }
+			armor_Bat = { x = 1 y = 3 }
+			armor_Bat = { x = 1 y = 4 }
 			Arm_Inf_Bat = { x = 2 y = 0 }
 			Arm_Inf_Bat = { x = 2 y = 1 }
 			Arm_Inf_Bat = { x = 2 y = 2 }
-			Arm_Inf_Bat = { x = 3 y = 0 }
-			Arm_Inf_Bat = { x = 3 y = 1 }
-			Arm_Inf_Bat = { x = 3 y = 2 }
-			SP_AA_Bat = { x = 3 y = 3 }
+			Arm_Inf_Bat = { x = 2 y = 3 }
 		}
 		support = {
-			Arm_Recce_Comp = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			combat_service_support_company = { x = 0 y = 2 }
+			arm_hq = { x = 0 y = 0 }
+			armor_Comp = { x = 0 y = 1 }
+			H_Engi_Comp = { x = 0 y = 2 }
 			SP_AA_Battery = { x = 0 y = 3 }
+			combat_service_support_company = { x = 0 y = 4 }
 		}
 	}
 
-	division_template = {
-		name = "AI Heavy Airborne Brigade"
-		priority = 2
-		regiments = {
-			Mech_Air_Inf_Bat = { x = 0 y = 0 }
-			Mech_Air_Inf_Bat = { x = 0 y = 1 }
-			Mech_Air_Inf_Bat = { x = 0 y = 2 }
-			Mech_Air_Inf_Bat = { x = 1 y = 0 }
-			Mech_Air_Inf_Bat = { x = 1 y = 1 }
-			Mech_Air_Inf_Bat = { x = 1 y = 2 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-		}
-		support = {
-			helicopter_combat_service_support = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			SP_AA_Battery = { x = 0 y = 2 }
-		}
-	}
-
-	division_template = {
-		name = "AI Heavy Armored Airborne Brigade"
-		priority = 2
-		regiments = {
-			Arm_Air_Inf_Bat = { x = 0 y = 0 }
-			Arm_Air_Inf_Bat = { x = 0 y = 1 }
-			Arm_Air_Inf_Bat = { x = 0 y = 2 }
-			Arm_Air_Inf_Bat = { x = 1 y = 0 }
-			Arm_Air_Inf_Bat = { x = 1 y = 1 }
-			Arm_Air_Inf_Bat = { x = 1 y = 2 }
-			Arty_Bat = { x = 2 y = 0 }
-			Arty_Bat = { x = 2 y = 1 }
-			Arty_Bat = { x = 2 y = 2 }
-			Arty_Bat = { x = 2 y = 3 }
-		}
-		support = {
-			combat_service_support_company = { x = 0 y = 0 }
-			H_Engi_Comp = { x = 0 y = 1 }
-			SP_AA_Battery = { x = 0 y = 2 }
-			Arm_Recce_Comp = { x = 0 y = 3 }
-			armor_Comp = { x = 0 y = 4 }
-		}
-	}
-
+	# AI Armored Marine Division (same composition as generic Armored Marine Brigade but division-scale)
 	division_template = {
 		name = "AI Armored Marine Division"
 		priority = 2
@@ -627,22 +647,21 @@ Major_Power_AI_templates = {
 			Arm_Marine_Bat = { x = 0 y = 0 }
 			Arm_Marine_Bat = { x = 0 y = 1 }
 			Arm_Marine_Bat = { x = 0 y = 2 }
-			armor_Bat = { x = 0 y = 3 }
-			Arm_Marine_Bat = { x = 0 y = 4 }
+			Arm_Marine_Bat = { x = 0 y = 3 }
 			Arm_Marine_Bat = { x = 1 y = 0 }
 			Arm_Marine_Bat = { x = 1 y = 1 }
-			armor_Bat = { x = 1 y = 2 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
+			Arm_Marine_Bat = { x = 1 y = 2 }
+			Arm_Marine_Bat = { x = 1 y = 3 }
 		}
 		support = {
 			H_Engi_Comp = { x = 0 y = 0 }
-			Arm_Recce_Comp = { x = 0 y = 1 }
+			combat_service_support_company = { x = 0 y = 1 }
 			SP_AA_Battery = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
+			attack_helo_comp = { x = 0 y = 3 }
 		}
 	}
 
+	# AI Mechanized Marine Division
 	division_template = {
 		name = "AI Mechanized Marine Division"
 		priority = 1
@@ -651,23 +670,16 @@ Major_Power_AI_templates = {
 			Mech_Marine_Bat = { x = 0 y = 1 }
 			Mech_Marine_Bat = { x = 0 y = 2 }
 			Mech_Marine_Bat = { x = 0 y = 3 }
-			Mech_Marine_Bat = { x = 0 y = 4 }
 			Mech_Marine_Bat = { x = 1 y = 0 }
 			Mech_Marine_Bat = { x = 1 y = 1 }
 			Mech_Marine_Bat = { x = 1 y = 2 }
 			Mech_Marine_Bat = { x = 1 y = 3 }
-			Mech_Marine_Bat = { x = 1 y = 4 }
-			SP_Arty_Bat = { x = 2 y = 0 }
-			SP_Arty_Bat = { x = 2 y = 1 }
-			SP_Arty_Bat = { x = 2 y = 2 }
-			SP_Arty_Bat = { x = 2 y = 3 }
 		}
 		support = {
-			armor_Comp = { x = 0 y = 0 }
-			armor_Recce_Comp = { x = 0 y = 1 }
-			H_Engi_Comp = { x = 0 y = 2 }
-			combat_service_support_company = { x = 0 y = 3 }
-			SP_AA_Battery = { x = 0 y = 4 }
+			H_Engi_Comp = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 1 }
+			SP_AA_Battery = { x = 0 y = 2 }
+			attack_helo_comp = { x = 0 y = 3 }
 		}
 	}
 }
@@ -797,58 +809,68 @@ god_of_war_templates = {
 }
 
 Militia_AI_templates = {
-	##civil war nations use these. Its to mimic the need for men with low IC cost.
+	# AI Militia Brigade - 12x Militia
 	division_template = {
-		name = "AI Militia Brigade - 15w"
+		name = "AI Militia Brigade"
 		priority = 0
 		regiments = {
 			Militia_Bat = { x = 0 y = 0 }
 			Militia_Bat = { x = 0 y = 1 }
 			Militia_Bat = { x = 0 y = 2 }
 			Militia_Bat = { x = 0 y = 3 }
-			Militia_Bat = { x = 0 y = 4 }
-		}
-	}
-
-	division_template = {
-		name = "AI Militia Brigade - 32w"
-		priority = 0
-		regiments = {
-			Militia_Bat = { x = 0 y = 0 }
-			Militia_Bat = { x = 0 y = 1 }
-			Militia_Bat = { x = 0 y = 2 }
-			Militia_Bat = { x = 0 y = 3 }
-			Militia_Bat = { x = 0 y = 4 }
 			Militia_Bat = { x = 1 y = 0 }
 			Militia_Bat = { x = 1 y = 1 }
 			Militia_Bat = { x = 1 y = 2 }
 			Militia_Bat = { x = 1 y = 3 }
-			Militia_Bat = { x = 1 y = 4 }
-		}
-		support = {
-			L_Recce_Comp = { x = 0 y = 0 }
-			L_Engi_Comp = { x = 0 y = 1 }
+			Militia_Bat = { x = 2 y = 0 }
+			Militia_Bat = { x = 2 y = 1 }
+			Militia_Bat = { x = 2 y = 2 }
+			Militia_Bat = { x = 2 y = 3 }
 		}
 	}
 
+	# AI Militia Artillery Brigade - 6x Militia + 5x Arty + L_Engi + L_Recce + Arty_Battery
 	division_template = {
-		name = "AI Motorized Militia Brigade - 32w"
+		name = "AI Militia Artillery Brigade"
+		priority = 0
+		regiments = {
+			Militia_Bat = { x = 0 y = 0 }
+			Militia_Bat = { x = 0 y = 1 }
+			Militia_Bat = { x = 0 y = 2 }
+			Militia_Bat = { x = 1 y = 0 }
+			Militia_Bat = { x = 1 y = 1 }
+			Militia_Bat = { x = 1 y = 2 }
+			Arty_Bat = { x = 2 y = 0 }
+			Arty_Bat = { x = 2 y = 1 }
+			Arty_Bat = { x = 2 y = 2 }
+			Arty_Bat = { x = 3 y = 0 }
+			Arty_Bat = { x = 3 y = 1 }
+		}
+		support = {
+			L_Engi_Comp = { x = 0 y = 0 }
+			L_Recce_Comp = { x = 0 y = 1 }
+			Arty_Battery = { x = 0 y = 2 }
+		}
+	}
+
+	# AI Motorized Militia - 8x Mot_Militia + CSS + H_Engi + Arty_Battery
+	division_template = {
+		name = "AI Motorized Militia Brigade"
 		priority = 0
 		regiments = {
 			Mot_Militia_Bat = { x = 0 y = 0 }
 			Mot_Militia_Bat = { x = 0 y = 1 }
 			Mot_Militia_Bat = { x = 0 y = 2 }
+			Mot_Militia_Bat = { x = 0 y = 3 }
 			Mot_Militia_Bat = { x = 1 y = 0 }
 			Mot_Militia_Bat = { x = 1 y = 1 }
 			Mot_Militia_Bat = { x = 1 y = 2 }
-			Mot_Militia_Bat = { x = 2 y = 0 }
+			Mot_Militia_Bat = { x = 1 y = 3 }
 		}
 		support = {
-			Mot_Recce_Comp = { x = 0 y = 0 }
+			combat_service_support_company = { x = 0 y = 0 }
 			H_Engi_Comp = { x = 0 y = 1 }
+			Arty_Battery = { x = 0 y = 2 }
 		}
 	}
 }
-
-	#Simone_likes_80_width_SOF
-	#Simone. AI doesn't need this :tongue:


### PR DESCRIPTION
## Summary
- Rewrote all generic, militia, and major power AI division templates to match updated compositions (new unit counts, support companies, and structure)
- Added new template types: Marine Commando Division, Light Armored Division, Attack Helicopter Brigade, Mechanized/Armored Airborne Brigades, Light/Motorized Artillery Brigades
- Tuned AI strategy factory thresholds to make the AI more responsive to industrial capacity:
  - Added lower factory bounds to APC Mech (8+), IFV (10+), and Air Assault (8+) brigades so weak nations don't attempt expensive templates
  - Raised Motorized Infantry role priority from 0.7 to 1.2 with a 1.5x boost at 8-15 MIL factories
  - Separated Light Armor (8-15 MIL, prio 1.5) and Heavy Armor (15-20 MIL, prio 2) into distinct factory bands
  - Added scaling modifiers to Mech Marine (2x at 12+ MIL) and Armored Marine (2x at 20+ MIL) brigades
- Updated God of War AI templates to match new compositions

## Test plan
- [ ] Observe AI nations build appropriate templates based on factory count
- [ ] Verify small nations (<8 MIL) stick to militia/light infantry/motorized and don't attempt mech or air assault
- [ ] Verify mid-tier nations (8-15 MIL) transition to motorized artillery, light armor, and mechanized brigades
- [ ] Verify major powers (20+ MIL) build armored divisions, attack helicopter brigades, and armored marine brigades
- [ ] Check God of War game rule templates still spawn correctly