### PR TITLE
Simplify AI law desire system: eliminate wants_* flags and dead code

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -889,6 +889,7 @@ v2.0.0
   - [BUL] Replaced ~30 static hidden ideas with 3 dynamic modifiers and removed associated scripted localisation
   - Optimized all influence check triggers to use efficient array iteration instead of hardcoded index checks
   - Removed several unused influence and government comparison triggers
+  - Streamlined the AI budget law system to reduce monthly processing overhead per country
   - [SOV] [SUB] [UKR] Consolidated repetitive per-country triggers into compact loops and removed unused triggers
   - Moved a check for the social conservatism and optimized a check for the Gulf Countries
   - Moved some more checks for the counter terror to monthly for more performance

--- a/common/decisions/05_SWE_decision.txt
+++ b/common/decisions/05_SWE_decision.txt
@@ -409,18 +409,7 @@ SWE_decision_Forsvarsmarkten_category = {
 				limit = { has_idea = defence_04 }
 				swap_ideas = { remove_idea = defence_04 add_idea = defence_05 }
 			}
-			if = {
-				limit = { has_idea = police_01 }
-				swap_ideas = { remove_idea = police_01 add_idea = police_02 }
-			}
-			else_if = {
-				limit = { has_idea = police_02 }
-				swap_ideas = { remove_idea = police_02 add_idea = police_03 }
-			}
-			else_if = {
-				limit = { has_idea = police_03 }
-				swap_ideas = { remove_idea = police_03 add_idea = police_04 }
-			}
+			increase_policing_budget = yes
 			increase_conscription_effect = yes
 		}
 		ai_will_do = {
@@ -454,18 +443,7 @@ SWE_decision_Forsvarsmarkten_category = {
 				limit = { has_idea = defence_06 }
 				swap_ideas = { remove_idea = defence_06 add_idea = defence_02 }
 			}
-			if = {
-				limit = { has_idea = police_02 }
-				swap_ideas = { remove_idea = police_02 add_idea = police_01 }
-			}
-			else_if = {
-				limit = { has_idea = police_03 }
-				swap_ideas = { remove_idea = police_03 add_idea = police_02 }
-			}
-			else_if = {
-				limit = { has_idea = police_04 }
-				swap_ideas = { remove_idea = police_04 add_idea = police_02 }
-			}
+			decrease_policing_budget = yes
 			decrease_conscription_effect = yes
 			hidden_effect = {
 				SWE = { news_event = { id = Sweden_news.7 days = 1 } }

--- a/common/decisions/Germany.txt
+++ b/common/decisions/Germany.txt
@@ -1978,18 +1978,7 @@ GER_V_fall_Decision = {
 				limit = { has_idea = defence_04 }
 				swap_ideas = { remove_idea = defence_04 add_idea = defence_05 }
 			}
-			if = {
-				limit = { has_idea = police_01 }
-				swap_ideas = { remove_idea = police_01 add_idea = police_02 }
-			}
-			else_if = {
-				limit = { has_idea = police_02 }
-				swap_ideas = { remove_idea = police_02 add_idea = police_03 }
-			}
-			else_if = {
-				limit = { has_idea = police_03 }
-				swap_ideas = { remove_idea = police_03 add_idea = police_04 }
-			}
+			increase_policing_budget = yes
 			increase_conscription_effect = yes
 			hidden_effect = {
 				news_event = { id = GER_news.01 hours = 6 }
@@ -2336,18 +2325,7 @@ GER_V_fall_Decision = {
 				limit = { has_idea = defence_06 }
 				swap_ideas = { remove_idea = defence_06 add_idea = defence_02 }
 			}
-			if = {
-				limit = { has_idea = police_02 }
-				swap_ideas = { remove_idea = police_02 add_idea = police_01 }
-			}
-			else_if = {
-				limit = { has_idea = police_03 }
-				swap_ideas = { remove_idea = police_03 add_idea = police_02 }
-			}
-			else_if = {
-				limit = { has_idea = police_04 }
-				swap_ideas = { remove_idea = police_04 add_idea = police_02 }
-			}
+			decrease_policing_budget = yes
 			decrease_conscription_effect = yes
 			GER = {
 				every_country_division = {

--- a/common/ideas/AA_law_budget.txt
+++ b/common/ideas/AA_law_budget.txt
@@ -71,14 +71,14 @@ ideas = {
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 50
 					has_idea = bureau_02
-					has_country_flag = wants_bureau_01
+					check_variable = { expected_adm_spending = 1 }
 				}
 				# Killswitch for the AI
 				# reference 00_desire_law_triggers.txt
 				modifier = {
 					factor = 0
 					OR = {
-						NOT = { has_country_flag = wants_bureau_01 }
+						check_variable = { expected_adm_spending > 1 }
 						has_bureau_idea_law_desired = yes
 					}
 				}
@@ -170,20 +170,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = bureau_01
-					OR = {
-						has_country_flag = wants_bureau_02
-						has_country_flag = wants_bureau_03
-						has_country_flag = wants_bureau_04
-						has_country_flag = wants_bureau_05
-					}
+					check_variable = { expected_adm_spending > 1 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = bureau_03
-					OR = {
-						has_country_flag = wants_bureau_01
-						has_country_flag = wants_bureau_02
-					}
+					check_variable = { expected_adm_spending < 3 }
 				}
 				modifier = {
 					factor = 0
@@ -278,20 +270,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = bureau_02
-					OR = {
-						has_country_flag = wants_bureau_03
-						has_country_flag = wants_bureau_04
-						has_country_flag = wants_bureau_05
-					}
+					check_variable = { expected_adm_spending > 2 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = bureau_04
-					OR = {
-						has_country_flag = wants_bureau_01
-						has_country_flag = wants_bureau_02
-						has_country_flag = wants_bureau_03
-					}
+					check_variable = { expected_adm_spending < 4 }
 				}
 				modifier = {
 					factor = 0
@@ -404,20 +388,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = bureau_03
-					OR = {
-						has_country_flag = wants_bureau_04
-						has_country_flag = wants_bureau_05
-					}
+					check_variable = { expected_adm_spending > 3 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = bureau_05
-					OR = {
-						has_country_flag = wants_bureau_01
-						has_country_flag = wants_bureau_02
-						has_country_flag = wants_bureau_03
-						has_country_flag = wants_bureau_04
-					}
+					check_variable = { expected_adm_spending < 5 }
 				}
 				modifier = {
 					factor = 0
@@ -529,7 +505,7 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = bureau_04
-					has_country_flag = wants_bureau_05
+					check_variable = { expected_adm_spending > 4 }
 				}
 				modifier = {
 					factor = 0
@@ -616,7 +592,7 @@ ideas = {
 				modifier = { # Make law more appealing to reduce if is above desired level
 					factor = 15
 					has_idea = police_02
-					has_country_flag = wants_police_01
+					check_variable = { expected_police_spending = 1 }
 				}
 				modifier = {
 					factor = 0
@@ -713,20 +689,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = police_01
-					OR = {
-						has_country_flag = wants_police_02
-						has_country_flag = wants_police_03
-						has_country_flag = wants_police_04
-						has_country_flag = wants_police_05
-					}
+					check_variable = { expected_police_spending > 1 }
 				}
 				modifier = {
 					add = 25
 					has_idea = police_03
-					OR = {
-						has_country_flag = wants_police_01
-						has_country_flag = wants_police_02
-					}
+					check_variable = { expected_police_spending < 3 }
 				}
 				modifier = {
 					factor = 0
@@ -831,20 +799,12 @@ ideas = {
 				modifier = { #Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = police_02
-					OR = {
-						has_country_flag = wants_police_03
-						has_country_flag = wants_police_04
-						has_country_flag = wants_police_05
-					}
+					check_variable = { expected_police_spending > 2 }
 				}
 				modifier = {
 					add = 25
 					has_idea = police_04
-					OR = {
-						has_country_flag = wants_police_01
-						has_country_flag = wants_police_02
-						has_country_flag = wants_police_03
-					}
+					check_variable = { expected_police_spending < 4 }
 				}
 				modifier = {
 					factor = 0
@@ -947,20 +907,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = police_03
-					OR = {
-						has_country_flag = wants_police_04
-						has_country_flag = wants_police_05
-					}
+					check_variable = { expected_police_spending > 3 }
 				}
 				modifier = {
 					add = 25
 					has_idea = police_05
-					OR = {
-						has_country_flag = wants_police_01
-						has_country_flag = wants_police_02
-						has_country_flag = wants_police_03
-						has_country_flag = wants_police_04
-					}
+					check_variable = { expected_police_spending < 5 }
 				}
 				modifier = {
 					factor = 0
@@ -1058,7 +1010,7 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = police_04
-					has_country_flag = wants_police_05
+					check_variable = { expected_police_spending > 4 }
 				}
 				modifier = {
 					factor = 0
@@ -1142,7 +1094,7 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = edu_02
-					has_country_flag = wants_edu_01
+					check_variable = { expected_edu_spending = 1 }
 				}
 				modifier = {
 					factor = 0
@@ -1241,20 +1193,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = edu_03
-					OR = {
-						has_country_flag = wants_edu_02
-						has_country_flag = wants_edu_01
-					}
+					check_variable = { expected_edu_spending < 3 }
 				}
 				modifier = {
 					add = 25
 					has_idea = edu_01
-					OR = {
-						has_country_flag = wants_edu_02
-						has_country_flag = wants_edu_03
-						has_country_flag = wants_edu_04
-						has_country_flag = wants_edu_05
-					}
+					check_variable = { expected_edu_spending > 1 }
 				}
 				modifier = {
 					factor = 0
@@ -1350,20 +1294,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = edu_02
-					OR = {
-						has_country_flag = wants_edu_03
-						has_country_flag = wants_edu_04
-						has_country_flag = wants_edu_05
-					}
+					check_variable = { expected_edu_spending > 2 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
-				add = 25
+					add = 25
 					has_idea = edu_04
-					OR = {
-						has_country_flag = wants_edu_01
-						has_country_flag = wants_edu_02
-						has_country_flag = wants_edu_03
-					}
+					check_variable = { expected_edu_spending < 4 }
 				}
 				modifier = {
 					factor = 0
@@ -1475,20 +1411,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = edu_03
-					OR = {
-						has_country_flag = wants_edu_04
-						has_country_flag = wants_edu_05
-					}
+					check_variable = { expected_edu_spending > 3 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = edu_05
-					OR = {
-						has_country_flag = wants_edu_01
-						has_country_flag = wants_edu_02
-						has_country_flag = wants_edu_03
-						has_country_flag = wants_edu_04
-					}
+					check_variable = { expected_edu_spending < 5 }
 				}
 				modifier = { # no money
 					factor = 0
@@ -1566,7 +1494,7 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = edu_04
-					has_country_flag = wants_edu_05
+					check_variable = { expected_edu_spending > 4 }
 				}
 				modifier = { #for BRIKS members
 					factor = 0
@@ -1656,7 +1584,7 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = health_02
-					has_country_flag = wants_health_01
+					check_variable = { expected_health_spending = 1 }
 				}
 				modifier = {
 					factor = 0
@@ -1744,21 +1672,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = health_01
-					OR = {
-						has_country_flag = wants_health_02
-						has_country_flag = wants_health_03
-						has_country_flag = wants_health_04
-						has_country_flag = wants_health_05
-						has_country_flag = wants_health_06
-					}
+					check_variable = { expected_health_spending > 1 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = health_03
-					OR = {
-						has_country_flag = wants_health_01
-						has_country_flag = wants_health_02
-					}
+					check_variable = { expected_health_spending < 3 }
 				}
 				modifier = {
 					factor = 0
@@ -1856,21 +1775,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					factor = 10
 					has_idea = health_02
-					OR = {
-						has_country_flag = wants_health_03
-						has_country_flag = wants_health_04
-						has_country_flag = wants_health_05
-						has_country_flag = wants_health_06
-					}
+					check_variable = { expected_health_spending > 2 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					factor = 10
 					has_idea = health_04
-					OR = {
-						has_country_flag = wants_health_01
-						has_country_flag = wants_health_02
-						has_country_flag = wants_health_03
-					}
+					check_variable = { expected_health_spending < 4 }
 				}
 				modifier = {
 					factor = 0
@@ -1971,21 +1881,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					factor = 10
 					has_idea = health_03
-					OR = {
-						has_country_flag = wants_health_04
-						has_country_flag = wants_health_05
-						has_country_flag = wants_health_06
-					}
+					check_variable = { expected_health_spending > 3 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					factor = 10
 					has_idea = health_05
-					OR = {
-						has_country_flag = wants_health_01
-						has_country_flag = wants_health_02
-						has_country_flag = wants_health_03
-						has_country_flag = wants_health_04
-					}
+					check_variable = { expected_health_spending < 5 }
 				}
 				modifier = {
 					factor = 0
@@ -2086,21 +1987,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = health_04
-					OR = {
-						has_country_flag = wants_health_05
-						has_country_flag = wants_health_06
-					}
+					check_variable = { expected_health_spending > 4 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = health_06
-					OR = {
-						has_country_flag = wants_health_01
-						has_country_flag = wants_health_02
-						has_country_flag = wants_health_03
-						has_country_flag = wants_health_04
-						has_country_flag = wants_health_05
-					}
+					check_variable = { expected_health_spending < 6 }
 				}
 				modifier = {
 					factor = 0
@@ -2195,7 +2087,7 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = health_05
-					has_country_flag = wants_health_06
+					check_variable = { expected_health_spending > 5 }
 				}
 				modifier = {
 					factor = 0
@@ -2290,7 +2182,7 @@ ideas = {
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = social_02
-					has_country_flag = wants_social_01
+					check_variable = { expected_welfare_spending = 1 }
 				}
 				modifier = {
 					factor = 0
@@ -2381,21 +2273,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = social_01
-					OR = {
-						has_country_flag = wants_social_02
-						has_country_flag = wants_social_03
-						has_country_flag = wants_social_04
-						has_country_flag = wants_social_05
-						has_country_flag = wants_social_06
-					}
+					check_variable = { expected_welfare_spending > 1 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = social_03
-					OR = {
-						has_country_flag = wants_social_01
-						has_country_flag = wants_social_02
-					}
+					check_variable = { expected_welfare_spending < 3 }
 				}
 				modifier = {
 					factor = 0
@@ -2489,21 +2372,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = social_02
-					OR = {
-						has_country_flag = wants_social_03
-						has_country_flag = wants_social_04
-						has_country_flag = wants_social_05
-						has_country_flag = wants_social_06
-					}
+					check_variable = { expected_welfare_spending > 2 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = social_04
-					OR = {
-						has_country_flag = wants_social_01
-						has_country_flag = wants_social_02
-						has_country_flag = wants_social_03
-					}
+					check_variable = { expected_welfare_spending < 4 }
 				}
 				modifier = {
 					factor = 0
@@ -2600,21 +2474,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = social_03
-					OR = {
-						has_country_flag = wants_social_04
-						has_country_flag = wants_social_05
-						has_country_flag = wants_social_06
-					}
+					check_variable = { expected_welfare_spending > 3 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 10
 					has_idea = social_05
-					OR = {
-						has_country_flag = wants_social_01
-						has_country_flag = wants_social_02
-						has_country_flag = wants_social_03
-						has_country_flag = wants_social_04
-					}
+					check_variable = { expected_welfare_spending < 5 }
 				}
 				modifier = {
 					factor = 0
@@ -2710,21 +2575,12 @@ ideas = {
 				modifier = { # Make law more appealing to raise if is below desired level
 					add = 25
 					has_idea = social_04
-					OR = {
-						has_country_flag = wants_social_05
-						has_country_flag = wants_social_06
-					}
+					check_variable = { expected_welfare_spending > 4 }
 				}
 				modifier = { # Make law more appealing to reduce if is above desired level
 					add = 25
 					has_idea = social_06
-					OR = {
-						has_country_flag = wants_social_01
-						has_country_flag = wants_social_02
-						has_country_flag = wants_social_03
-						has_country_flag = wants_social_04
-						has_country_flag = wants_social_05
-					}
+					check_variable = { expected_welfare_spending < 6 }
 				}
 				modifier = {
 					factor = 0
@@ -2802,7 +2658,7 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = social_05
-					has_country_flag = wants_social_06
+					check_variable = { expected_welfare_spending > 5 }
 				}
 				modifier = {
 					factor = 0

--- a/common/ideas/AA_law_budget.txt
+++ b/common/ideas/AA_law_budget.txt
@@ -431,11 +431,7 @@ ideas = {
 					limit = { original_tag = GER }
 					custom_trigger_tooltip = {
 						tooltip = GER_Grundgesetz_tt
-					}
-					NOT = {
-						hidden_trigger = {
-							has_country_flag = GER_Grundgesetz
-						}
+						NOT = { has_country_flag = GER_Grundgesetz }
 					}
 				}
 				if = {

--- a/common/ideas/AA_law_military_ideas.txt
+++ b/common/ideas/AA_law_military_ideas.txt
@@ -155,21 +155,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_00
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 0 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_02
-					has_country_flag = wants_military_01
+					check_variable = { expected_military_sp = 1 }
 				}
 				modifier = {
 					factor = 0
@@ -258,23 +249,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_01
-					OR = {
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 1 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_03
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-					}
+					check_variable = { expected_military_sp < 3 }
 				}
 				modifier = {
 					factor = 0
@@ -361,23 +341,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_02
-					OR = {
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 2 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_04
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-					}
+					check_variable = { expected_military_sp < 4 }
 				}
 				modifier = {
 					factor = 0
@@ -473,23 +442,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_03
-					OR = {
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 3 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_05
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-					}
+					check_variable = { expected_military_sp < 5 }
 				}
 				modifier = {
 					factor = 0
@@ -589,23 +547,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_04
-					OR = {
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 4 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_06
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-					}
+					check_variable = { expected_military_sp < 6 }
 				}
 				modifier = {
 					factor = 0
@@ -704,23 +651,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_05
-					OR = {
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 5 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_07
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-					}
+					check_variable = { expected_military_sp < 7 }
 				}
 				modifier = {
 					factor = 0
@@ -821,23 +757,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_06
-					OR = {
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp > 6 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_08
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-					}
+					check_variable = { expected_military_sp < 8 }
 				}
 				modifier = {
 					factor = 0
@@ -945,21 +870,12 @@ ideas = {
 				modifier = {
 					add = 25
 					has_idea = defence_07
-					has_country_flag = wants_military_08
+					check_variable = { expected_military_sp = 8 }
 				}
 				modifier = {
 					add = 25
 					has_idea = defence_09
-					OR = {
-						has_country_flag = wants_military_01
-						has_country_flag = wants_military_02
-						has_country_flag = wants_military_03
-						has_country_flag = wants_military_04
-						has_country_flag = wants_military_05
-						has_country_flag = wants_military_06
-						has_country_flag = wants_military_07
-						has_country_flag = wants_military_08
-					}
+					check_variable = { expected_military_sp < 9 }
 				}
 				modifier = {
 					factor = 0
@@ -1064,13 +980,13 @@ ideas = {
 					#Higher chance if doing badly
 					add = 3
 					has_idea = defence_08
-					has_country_flag = wants_military_08
+					check_variable = { expected_military_sp = 8 }
 					surrender_progress > 0.3
 				}
 				modifier = { # Urgent military buildup if at war with a major.
 					add = 5
 					has_idea = defence_08
-					has_country_flag = wants_military_08
+					check_variable = { expected_military_sp = 8 }
 					any_enemy_country = {
 						is_major = yes
 					}

--- a/common/scripted_effects/00_budget_effects.txt
+++ b/common/scripted_effects/00_budget_effects.txt
@@ -64,26 +64,6 @@ decrease_economic_growth = {
 	clr_country_flag = disable_cycle_costs
 }
 
-increase_two_level_economic_growth = {
-	set_country_flag = disable_cycle_costs
-	if = { limit = { has_idea = depression }
-		swap_ideas = { remove_idea = depression add_idea = stagnation }
-	}
-	else_if = { limit = { has_idea = recession }
-		swap_ideas = { remove_idea = recession add_idea = stable_growth }
-	}
-	else_if = { limit = { has_idea = stagnation }
-		swap_ideas = { remove_idea = stagnation add_idea = fast_growth }
-	}
-	else_if = { limit = { has_idea = stable_growth }
-		swap_ideas = { remove_idea = stable_growth add_idea = economic_boom }
-	}
-	else_if = { limit = { has_idea = fast_growth }
-		swap_ideas = { remove_idea = fast_growth add_idea = economic_boom }
-	}
-	clr_country_flag = disable_cycle_costs
-}
-
 decrease_two_level_economic_growth = {
 	set_country_flag = disable_cycle_costs
 	if = { limit = { has_idea = economic_boom }
@@ -145,31 +125,6 @@ decrease_centralization_2 = {
 		add_political_power = 150
 	}
 }
-decrease_centralization_3 = {
-	if = {
-		limit = { has_idea = bureau_05 }
-		swap_ideas = { remove_idea = bureau_05 add_idea = bureau_02 }
-	}
-	else_if = {
-		limit = { has_idea = bureau_04 }
-		swap_ideas = { remove_idea = bureau_04 add_idea = bureau_01 }
-	}
-	else_if = {
-		limit = { has_idea = bureau_03 }
-		swap_ideas = { remove_idea = bureau_03 add_idea = bureau_01 }
-		add_political_power = 75
-	}
-	else_if = {
-		limit = { has_idea = bureau_02 }
-		swap_ideas = { remove_idea = bureau_02 add_idea = bureau_01 }
-		add_political_power = 150
-	}
-	else_if = {
-		limit = { has_idea = bureau_01 }
-		add_political_power = 225
-	}
-}
-
 #Increases Bureau Law
 increase_centralization = {
 	if = {
@@ -1191,122 +1146,6 @@ decrease_policing_budget_2 = {
 	}
 }
 
-
-# Set Social Spending to the Maximum
-max_social_spending = {
-	if = {
-		limit = { has_idea = social_01 }
-		swap_ideas = { remove_idea = social_01 add_idea = social_06 }
-	}
-	else_if = {
-		limit = { has_idea = social_02 }
-		swap_ideas = { remove_idea = social_02 add_idea = social_06 }
-	}
-	else_if = {
-		limit = { has_idea = social_03 }
-		swap_ideas = { remove_idea = social_03 add_idea = social_06 }
-	}
-	else_if = {
-		limit = { has_idea = social_04 }
-		swap_ideas = { remove_idea = social_04 add_idea = social_06 }
-	}
-	else_if = {
-		limit = { has_idea = social_05 }
-		swap_ideas = { remove_idea = social_05 add_idea = social_06 }
-	}
-	else_if = {
-		limit = { has_idea = social_06 }
-		add_political_power = 150	#If country has maximum level it earns political power instead.
-	}
-}
-
-# Set Education Budget to the Maximum
-max_education_budget = {
-	if = {
-		limit = { has_idea = edu_01 }
-		swap_ideas = { remove_idea = edu_01 add_idea = edu_05 }
-	}
-	else_if = {
-		limit = { has_idea = edu_02 }
-		swap_ideas = { remove_idea = edu_02 add_idea = edu_05 }
-	}
-	else_if = {
-		limit = { has_idea = edu_03 }
-		swap_ideas = { remove_idea = edu_03 add_idea = edu_05 }
-	}
-	else_if = {
-		limit = { has_idea = edu_04 }
-		swap_ideas = { remove_idea = edu_04 add_idea = edu_05 }
-	}
-	else_if = {
-		limit = { has_idea = edu_05 }
-		add_political_power = 150	#If country has maximum level it earns political power instead.
-	}
-}
-
-# Set Healthcare Budget to the Maximum
-max_healthcare_budget = {
-	if = {
-		limit = { has_idea = health_01 }
-		swap_ideas = { remove_idea = health_01 add_idea = health_06 }
-	}
-	else_if = {
-		limit = { has_idea = health_02 }
-		swap_ideas = { remove_idea = health_02 add_idea = health_06 }
-	}
-	else_if = {
-		limit = { has_idea = health_03 }
-		swap_ideas = { remove_idea = health_03 add_idea = health_06 }
-	}
-	else_if = {
-		limit = { has_idea = health_04 }
-		swap_ideas = { remove_idea = health_04 add_idea = health_06 }
-	}
-	else_if = {
-		limit = { has_idea = health_05 }
-		swap_ideas = { remove_idea = health_05 add_idea = health_06 }
-	}
-	else_if = {
-		limit = { has_idea = health_06 }
-		add_political_power = 150	#If country has maximum level it earns political power instead.
-	}
-}
-
-# Set Military Spending to the Sizeable
-sizeable_military_spending = {
-	if = {
-		limit = { has_idea = defence_00 }
-		swap_ideas = { remove_idea = defence_00 add_idea = defence_05 }
-	}
-	else_if = {
-		limit = { has_idea = defence_01 }
-		swap_ideas = { remove_idea = defence_01 add_idea = defence_05 }
-	}
-	else_if = {
-		limit = { has_idea = defence_02 }
-		swap_ideas = { remove_idea = defence_02 add_idea = defence_05 }
-	}
-	else_if = {
-		limit = { has_idea = defence_03 }
-		swap_ideas = { remove_idea = defence_03 add_idea = defence_05 }
-	}
-	else_if = {
-		limit = { has_idea = defence_04 }
-		swap_ideas = { remove_idea = defence_04 add_idea = defence_05 }
-	}
-	else_if = {
-		limit = {
-			OR = {
-				has_idea = defence_05
-				has_idea = defence_06
-				has_idea = defence_07
-				has_idea = defence_08
-				has_idea = defence_09
-			}
-		}
-		add_political_power = 150
-	}
-}
 
 # Set Economic Growth to Depression
 depression = {

--- a/common/scripted_effects/00_desired_law_calculations.txt
+++ b/common/scripted_effects/00_desired_law_calculations.txt
@@ -1,41 +1,4 @@
 # Author(s): Angriest Bird, Mkemper, Crocomoth
-clear_law_desire_flags = {
-	clr_country_flag = wants_bureau_01
-	clr_country_flag = wants_bureau_02
-	clr_country_flag = wants_bureau_03
-	clr_country_flag = wants_bureau_04
-	clr_country_flag = wants_bureau_05
-	clr_country_flag = wants_police_01
-	clr_country_flag = wants_police_02
-	clr_country_flag = wants_police_03
-	clr_country_flag = wants_police_04
-	clr_country_flag = wants_police_05
-	clr_country_flag = wants_edu_01
-	clr_country_flag = wants_edu_02
-	clr_country_flag = wants_edu_03
-	clr_country_flag = wants_edu_04
-	clr_country_flag = wants_edu_05
-	clr_country_flag = wants_health_01
-	clr_country_flag = wants_health_02
-	clr_country_flag = wants_health_03
-	clr_country_flag = wants_health_04
-	clr_country_flag = wants_health_05
-	clr_country_flag = wants_health_06
-	clr_country_flag = wants_social_01
-	clr_country_flag = wants_social_02
-	clr_country_flag = wants_social_03
-	clr_country_flag = wants_social_04
-	clr_country_flag = wants_social_05
-	clr_country_flag = wants_social_06
-	clr_country_flag = wants_military_01
-	clr_country_flag = wants_military_02
-	clr_country_flag = wants_military_03
-	clr_country_flag = wants_military_04
-	clr_country_flag = wants_military_05
-	clr_country_flag = wants_military_06
-	clr_country_flag = wants_military_07
-	clr_country_flag = wants_military_08
-}
 
 # Bureaucracy desire is chiefly determined by the size/strength of the nation. More powerful the nation, more it wants a higher level of bureaucracy.
 # Secondary to size and power of the nation is the GDP of the nation - impoverished nations can't afford an extensive bureaucracy.
@@ -54,25 +17,6 @@ recalculate_bureaucracy_desire = {
 		}
 	}
 
-	if = {
-		limit = { check_variable = { expected_adm_spending = 5 } }
-		set_country_flag = wants_bureau_05
-	}
-	else_if = {
-		limit = { check_variable = { expected_adm_spending = 4 } }
-		set_country_flag = wants_bureau_04
-	}
-	else_if = {
-		limit = { check_variable = { expected_adm_spending = 3 } }
-		set_country_flag = wants_bureau_03
-	}
-	else_if = {
-		limit = { check_variable = { expected_adm_spending = 2 } }
-		set_country_flag = wants_bureau_02
-	}
-	else = {
-		set_country_flag = wants_bureau_01
-	}
 }
 
 # Police desire should tend to gravitate toward the middle (police_03) in most nations. This is also affected by politics - repressive governments
@@ -92,21 +36,6 @@ recalculate_police_desire = {
 		}
 	}
 
-	if = { limit = { check_variable = { expected_police_spending = 5 } }
-		set_country_flag = wants_police_05
-	}
-	else_if = { limit = { check_variable = { expected_police_spending = 4 } }
-		set_country_flag = wants_police_04
-	}
-	else_if = { limit = { check_variable = { expected_police_spending = 3 } }
-		set_country_flag = wants_police_03
-	}
-	else_if = { limit = { check_variable = { expected_police_spending = 2 } }
-		set_country_flag = wants_police_02
-	}
-	else = {
-		set_country_flag = wants_police_01
-	}
 }
 
 # Education desire is highly dependent on wealth and development level. Underdeveloped or developing nations should have edu_01 or edu_02.
@@ -126,21 +55,6 @@ recalculate_edu_desire = {
 		}
 	}
 
-	if = { limit = { check_variable = { expected_edu_spending = 5 } }
-		set_country_flag = wants_edu_05
-	}
-	else_if = { limit = { check_variable = { expected_edu_spending = 4 } }
-		set_country_flag = wants_edu_04
-	}
-	else_if = { limit = { check_variable = { expected_edu_spending = 3 } }
-		set_country_flag = wants_edu_03
-	}
-	else_if = { limit = { check_variable = { expected_edu_spending = 2 } }
-		set_country_flag = wants_edu_02
-	}
-	else = {
-		set_country_flag = wants_edu_01
-	}
 }
 
 # Health is again highly dependent on development.
@@ -159,29 +73,6 @@ recalculate_health_desire = {
 		}
 	}
 
-	if = {
-		limit = { check_variable = { expected_health_spending = 6 } }
-		set_country_flag = wants_health_06
-	}
-	else_if = {
-		limit = { check_variable = { expected_health_spending = 5 } }
-		set_country_flag = wants_health_05
-	}
-	else_if = {
-		limit = { check_variable = { expected_health_spending = 4 } }
-		set_country_flag = wants_health_04
-	}
-	else_if = {
-		limit = { check_variable = { expected_health_spending = 3 } }
-		set_country_flag = wants_health_03
-	}
-	else_if = {
-		limit = { check_variable = { expected_health_spending = 2 } }
-		set_country_flag = wants_health_02
-	}
-	else = {
-		set_country_flag = wants_health_01
-	}
 }
 
 # Welfare is highly dependent on development, but with more GDP categories skewing lower.
@@ -200,25 +91,6 @@ recalculate_social_desire = {
 		}
 	}
 
-	# Finally, set country flag based on result.
-	if = { limit = { check_variable = { expected_welfare_spending = 6 } }
-		set_country_flag = wants_social_06
-	}
-	else_if = { limit = { check_variable = { expected_welfare_spending = 5 } }
-		set_country_flag = wants_social_05
-	}
-	else_if = { limit = { check_variable = { expected_welfare_spending = 4 } }
-		set_country_flag = wants_social_04
-	}
-	else_if = { limit = { check_variable = { expected_welfare_spending = 3 } }
-		set_country_flag = wants_social_03
-	}
-	else_if = { limit = { check_variable = { expected_welfare_spending = 2 } }
-		set_country_flag = wants_social_02
-	}
-	else = {
-		set_country_flag = wants_social_01
-	}
 }
 
 ##Military Laws
@@ -309,36 +181,11 @@ recalculate_defence_desire_change = {
 	}
 
 
-	if = { limit = { check_variable = { expected_military_sp = 8 } }
-		set_country_flag = wants_military_08
-	}
-	else_if = { limit = { check_variable = { expected_military_sp = 7 } }
-		set_country_flag = wants_military_07
-	}
-	else_if = { limit = { check_variable = { expected_military_sp = 6 } }
-		set_country_flag = wants_military_06
-	}
-	else_if = { limit = { check_variable = { expected_military_sp = 5 } }
-		set_country_flag = wants_military_05
-	}
-	else_if = { limit = { check_variable = { expected_military_sp = 4 } }
-		set_country_flag = wants_military_04
-	}
-	else_if = { limit = { check_variable = { expected_military_sp = 3 } }
-		set_country_flag = wants_military_03
-	}
-	else_if = { limit = { check_variable = { expected_military_sp = 2 } }
-		set_country_flag = wants_military_02
-	}
-	else = {
-		set_country_flag = wants_military_01
-	}
 }
 
 # Wrapper function to do everything in one place.
 recalculate_law_desires = {
-	clear_law_desire_flags = yes # First, clear law desire flags.
-	focus_on_laws_due_to_economic_despair = yes # This should trigger economic despair
+	focus_on_laws_due_to_economic_despair = yes
 	recalculate_bureaucracy_desire = yes
 	recalculate_police_desire = yes
 	recalculate_edu_desire = yes
@@ -509,7 +356,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { social_budget > expected_welfare_spending }
 				}
 				decrease_social_spending = yes
-				set_law_vars = yes
 			}
 			if = {
 				limit = {
@@ -517,7 +363,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { crime_fighting > expected_police_spending }
 				}
 				decrease_policing_budget = yes
-				set_law_vars = yes
 			}
 			if = {
 				limit = {
@@ -525,7 +370,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { education_budget > expected_edu_spending }
 				}
 				decrease_education_budget = yes
-				set_law_vars = yes
 			}
 			if = {
 				limit = {
@@ -533,7 +377,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { health_budget > expected_health_spending }
 				}
 				decrease_healthcare_budget = yes
-				set_law_vars = yes
 			}
 			if = {
 				limit = {
@@ -541,7 +384,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { bureaucracy > expected_adm_spending }
 				}
 				decrease_centralization = yes
-				set_law_vars = yes
 			}
 
 			# Military cut LAST: only reduce if above expected level
@@ -551,7 +393,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { Military_Spending > expected_military_sp }
 				}
 				decrease_military_spending = yes
-				set_law_vars = yes
 			}
 		}
 
@@ -571,7 +412,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { social_budget > education_budget }
 				}
 				decrease_social_spending = yes
-				set_law_vars = yes
 			}
 			else_if = {
 				limit = {
@@ -580,22 +420,18 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { health_budget > education_budget }
 				}
 				decrease_healthcare_budget = yes
-				set_law_vars = yes
 			}
 			else_if = {
 				limit = { check_variable = { education_budget > 1 } }
 				decrease_education_budget = yes
-				set_law_vars = yes
 			}
 			else_if = {
 				limit = { check_variable = { crime_fighting > 1 } }
 				decrease_policing_budget = yes
-				set_law_vars = yes
 			}
 			else_if = {
 				limit = { check_variable = { bureaucracy > 1 } }
 				decrease_centralization = yes
-				set_law_vars = yes
 			}
 			# Military LAST: only cut if all civilian categories are at minimum (level 1)
 			else_if = {
@@ -608,7 +444,6 @@ ai_reduce_spending_on_deficit = {
 					check_variable = { bureaucracy < 2 }
 				}
 				decrease_military_spending = yes
-				set_law_vars = yes
 			}
 		}
 	}

--- a/common/scripted_effects/00_desired_law_calculations.txt
+++ b/common/scripted_effects/00_desired_law_calculations.txt
@@ -3,94 +3,59 @@
 # Bureaucracy desire is chiefly determined by the size/strength of the nation. More powerful the nation, more it wants a higher level of bureaucracy.
 # Secondary to size and power of the nation is the GDP of the nation - impoverished nations can't afford an extensive bureaucracy.
 recalculate_bureaucracy_desire = {
-	if = {
-		limit = {
-			has_variable = bureau_desire_offset
-		}
-
-		add_to_variable = { expected_adm_spending = bureau_desire_offset }
-		round_variable = bureau_desire_offset
-		clamp_variable = {
-			var = expected_adm_spending
-			min = 1
-			max = 5
-		}
+	add_to_variable = { expected_adm_spending = bureau_desire_offset }
+	round_variable = bureau_desire_offset
+	clamp_variable = {
+		var = expected_adm_spending
+		min = 1
+		max = 5
 	}
-
 }
 
 # Police desire should tend to gravitate toward the middle (police_03) in most nations. This is also affected by politics - repressive governments
 # want more police apparatus than more liberal/libertarian ones. Also influenced by GDP - impoverished nations cannot afford large police forces.
 recalculate_police_desire = {
-	if = {
-		limit = {
-			has_variable = police_desire_offset
-		}
-
-		add_to_variable = { expected_police_spending = police_desire_offset }
-		round_variable = police_desire_offset
-		clamp_variable = {
-			var = expected_police_spending
-			min = 1
-			max = 5
-		}
+	add_to_variable = { expected_police_spending = police_desire_offset }
+	round_variable = police_desire_offset
+	clamp_variable = {
+		var = expected_police_spending
+		min = 1
+		max = 5
 	}
-
 }
 
 # Education desire is highly dependent on wealth and development level. Underdeveloped or developing nations should have edu_01 or edu_02.
 # Most developed nations should never go below edu_03. Richer nations should have edu_04. Also dependent on political policies.
 recalculate_edu_desire = {
-	if = {
-		limit = {
-			has_variable = education_desire_offset
-		}
-
-		add_to_variable = { expected_edu_spending = education_desire_offset }
-		round_variable = education_desire_offset
-		clamp_variable = {
-			var = expected_edu_spending
-			min = 1
-			max = 5
-		}
+	add_to_variable = { expected_edu_spending = education_desire_offset }
+	round_variable = education_desire_offset
+	clamp_variable = {
+		var = expected_edu_spending
+		min = 1
+		max = 5
 	}
-
 }
 
 # Health is again highly dependent on development.
 recalculate_health_desire = {
-	if = {
-		limit = {
-			has_variable = health_desire_offset
-		}
-
-		add_to_variable = { expected_health_spending = health_desire_offset }
-		round_variable = health_desire_offset
-		clamp_variable = {
-			var = expected_health_spending
-			min = 1
-			max = 6
-		}
+	add_to_variable = { expected_health_spending = health_desire_offset }
+	round_variable = health_desire_offset
+	clamp_variable = {
+		var = expected_health_spending
+		min = 1
+		max = 6
 	}
-
 }
 
 # Welfare is highly dependent on development, but with more GDP categories skewing lower.
 recalculate_social_desire = {
-	if = {
-		limit = {
-			has_variable = social_desire_offset
-		}
-
-		add_to_variable = { expected_welfare_spending = social_desire_offset }
-		round_variable = social_desire_offset
-		clamp_variable = {
-			var = expected_welfare_spending
-			min = 1
-			max = 6
-		}
+	add_to_variable = { expected_welfare_spending = social_desire_offset }
+	round_variable = social_desire_offset
+	clamp_variable = {
+		var = expected_welfare_spending
+		min = 1
+		max = 6
 	}
-
 }
 
 ##Military Laws
@@ -146,7 +111,7 @@ recalculate_defence_desire_change = {
 		}
 
 		if = {
-			limit = { has_variable = expected_miltary_sp }
+			limit = { has_variable = expected_military_sp }
 			clamp_variable = {
 				var = expected_military_sp
 				min = 1

--- a/common/scripted_effects/00_law_attitudes.txt
+++ b/common/scripted_effects/00_law_attitudes.txt
@@ -1,4 +1,7 @@
 # Author(s): Yard1, Killerrabbit, AngriestBird
+# Required at startup — on_add does not fire during history load.
+# At runtime, each law idea's on_add sets these variables via swap_ideas,
+# so do not add new set_law_vars calls after budget effects.
 set_law_vars = {
 	if = {
 		limit = { has_idea = bureau_01 }

--- a/common/scripted_triggers/00_desired_law_triggers.txt
+++ b/common/scripted_triggers/00_desired_law_triggers.txt
@@ -2,10 +2,6 @@ has_bureau_idea_law_desired = {
 	check_variable = { bureaucracy = expected_adm_spending }
 }
 
-has_military_idea_law_desired = {
-	check_variable = { Military_Spending = expected_military_sp }
-}
-
 has_police_idea_law_desired = {
 	check_variable = { crime_fighting = expected_police_spending }
 }

--- a/common/scripted_triggers/00_desired_law_triggers.txt
+++ b/common/scripted_triggers/00_desired_law_triggers.txt
@@ -1,173 +1,23 @@
 has_bureau_idea_law_desired = {
-	OR = {
-		AND = {
-			has_country_flag = wants_bureau_01
-			has_idea = bureau_01
-		}
-		AND = {
-			has_country_flag = wants_bureau_02
-			has_idea = bureau_02
-		}
-		AND = {
-			has_country_flag = wants_bureau_03
-			has_idea = bureau_03
-		}
-		AND = {
-			has_country_flag = wants_bureau_04
-			has_idea = bureau_04
-		}
-		AND = {
-			has_country_flag = wants_bureau_05
-			has_idea = bureau_05
-		}
-	}
+	check_variable = { bureaucracy = expected_adm_spending }
 }
 
 has_military_idea_law_desired = {
-	OR = {
-		AND = {
-			has_country_flag = wants_military_01
-			has_idea = defence_01
-		}
-		AND = {
-			has_country_flag = wants_military_02
-			has_idea = defence_02
-		}
-		AND = {
-			has_country_flag = wants_military_03
-			has_idea = defence_03
-		}
-		AND = {
-			has_country_flag = wants_military_04
-			has_idea = defence_04
-		}
-		AND = {
-			has_country_flag = wants_military_05
-			has_idea = defence_05
-		}
-		AND = {
-			has_country_flag = wants_military_06
-			has_idea = defence_06
-		}
-		AND = {
-			has_country_flag = wants_military_07
-			has_idea = defence_07
-		}
-		AND = {
-			has_country_flag = wants_military_07
-			has_idea = defence_07
-		}
-		AND = {
-			has_country_flag = wants_military_07
-			has_idea = defence_07
-		}
-	}
+	check_variable = { Military_Spending = expected_military_sp }
 }
 
 has_police_idea_law_desired = {
-	OR = {
-		AND = {
-			has_country_flag = wants_police_01
-			has_idea = police_01
-		}
-		AND = {
-			has_country_flag = wants_police_02
-			has_idea = police_02
-		}
-		AND = {
-			has_country_flag = wants_police_03
-			has_idea = police_03
-		}
-		AND = {
-			has_country_flag = wants_police_04
-			has_idea = police_04
-		}
-		AND = {
-			has_country_flag = wants_police_05
-			has_idea = police_05
-		}
-	}
+	check_variable = { crime_fighting = expected_police_spending }
 }
 
 has_education_law_desired = {
-	OR = {
-		AND = {
-			has_country_flag = wants_edu_01
-			has_idea = edu_01
-		}
-		AND = {
-			has_country_flag = wants_edu_02
-			has_idea = edu_02
-		}
-		AND = {
-			has_country_flag = wants_edu_03
-			has_idea = edu_03
-		}
-		AND = {
-			has_country_flag = wants_edu_04
-			has_idea = edu_04
-		}
-		AND = {
-			has_country_flag = wants_edu_05
-			has_idea = edu_05
-		}
-	}
+	check_variable = { education_budget = expected_edu_spending }
 }
 
 has_health_law_desired = {
-	OR = {
-		AND = {
-			has_country_flag = wants_health_01
-			has_idea = health_01
-		}
-		AND = {
-			has_country_flag = wants_health_02
-			has_idea = health_02
-		}
-		AND = {
-			has_country_flag = wants_health_03
-			has_idea = health_03
-		}
-		AND = {
-			has_country_flag = wants_health_04
-			has_idea = health_04
-		}
-		AND = {
-			has_country_flag = wants_health_05
-			has_idea = health_05
-		}
-		AND = {
-			has_country_flag = wants_health_06
-			has_idea = health_06
-		}
-	}
+	check_variable = { health_budget = expected_health_spending }
 }
 
 has_social_law_desired = {
-	OR = {
-		AND = {
-			has_country_flag = wants_social_01
-			has_idea = social_01
-		}
-		AND = {
-			has_country_flag = wants_social_02
-			has_idea = social_02
-		}
-		AND = {
-			has_country_flag = wants_social_03
-			has_idea = social_03
-		}
-		AND = {
-			has_country_flag = wants_social_04
-			has_idea = social_04
-		}
-		AND = {
-			has_country_flag = wants_social_05
-			has_idea = social_05
-		}
-		AND = {
-			has_country_flag = wants_social_06
-			has_idea = social_06
-		}
-	}
+	check_variable = { social_budget = expected_welfare_spending }
 }


### PR DESCRIPTION
## Summary

- Replaces 37 `wants_*` country flags with direct variable comparisons against `expected_*_spending`, removing a redundant indirection layer from the AI budget law system
- Removes 12 redundant `set_law_vars` calls from the monthly AI deficit-reduction path — each law idea's `on_add` already sets the variable at runtime via `swap_ideas`
- Deletes 6 dead budget effects with zero callers (`decrease_centralization_3`, `increase_two_level_economic_growth`, `max_social_spending`, `max_education_budget`, `max_healthcare_budget`, `sizeable_military_spending`)
- Rewrites 6 scripted triggers from 174 lines of OR/AND chains to 1-line variable comparisons
- Fixes a copy-paste bug in `has_military_idea_law_desired` where `wants_military_07`/`defence_07` was repeated 3 times, missing higher levels
- Replaces raw police `swap_ideas` in Sweden and Germany mobilization decisions with canonical budget effects

8 files changed, 78 insertions, 823 deletions.

## Test plan

- [ ] Load a save, enable `tdebug`, hover countries to verify `expected_*_spending` and law variables (`bureaucracy`, `crime_fighting`, etc.) are set correctly
- [ ] Let AI run 6+ months, confirm AI changes laws toward expected spending levels
- [ ] Trigger deficit via console (`add_money -50000`), confirm AI austerity cuts fire correctly
- [ ] Verify protest system still detects spending gaps (protests fire when actual < expected)
- [ ] Test Sweden `SWE_launch_total_defence` and `SWE_back_to_normality` decisions — police changes now use standard budget effects
- [ ] Test Germany `GER_launch_v_fall` and `GER_end_v_fall` — same pattern as Sweden