### PR TITLE
Remove 8 idea-mirror country flags

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -928,7 +928,7 @@ v2.0.0
   - Standardized the elections enable/disable scripted effects across the mod by removing the duplicate Italian-defined helpers and folding ~7 inline copies of the has_government election-toggle chain into the canonical helper effects (Issue #628)
   - Reduced duplicate model definitions to improve performance by relying on graphical culture groups
   - Removed 249 orphaned pdxmesh definitions to reduce mod load time and memory footprint (Issue #1393)
-  - Removed 8 redundant country flags that mirrored idea lifetimes by swapping check sites to has_idea ([POL] depression flag, [NKO] 7 SPA bonus flags)
+  - Removed 9 redundant country flags that mirrored idea lifetimes by swapping check sites to has_idea ([POL] depression flag, [NKO] 8 SPA bonus flags)
 
  Quality of Life:
   - [GER] BFV GUI now updates immediately on button clicks instead of waiting for the next daily tick

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -928,6 +928,7 @@ v2.0.0
   - Standardized the elections enable/disable scripted effects across the mod by removing the duplicate Italian-defined helpers and folding ~7 inline copies of the has_government election-toggle chain into the canonical helper effects (Issue #628)
   - Reduced duplicate model definitions to improve performance by relying on graphical culture groups
   - Removed 249 orphaned pdxmesh definitions to reduce mod load time and memory footprint (Issue #1393)
+  - Removed 8 redundant country flags that mirrored idea lifetimes by swapping check sites to has_idea ([POL] depression flag, [NKO] 7 SPA bonus flags)
 
  Quality of Life:
   - [GER] BFV GUI now updates immediately on button clicks instead of waiting for the next daily tick

--- a/common/decisions/Poland.txt
+++ b/common/decisions/Poland.txt
@@ -5406,7 +5406,7 @@ POL_cua_category = {
 				}
 			}
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5493,7 +5493,7 @@ POL_cua_category = {
 			}
 			communism > 0.1
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5557,7 +5557,7 @@ POL_cua_category = {
 			}
 			communism > 0.1
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5618,7 +5618,7 @@ POL_cua_category = {
 			}
 			communism > 0.1
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5677,7 +5677,7 @@ POL_cua_category = {
 			communism > 0.25
 			NOT = {
 				OR = {
-					has_country_flag = POL_great_depression_active
+					has_idea = POL_economy_status7_idea
 					has_decision = POL_pact_with_the_government
 					has_decision = POL_hire_secret_army_to_gain_control_over_government
 				}
@@ -5729,7 +5729,7 @@ POL_cua_category = {
 			}
 			communism > 0.1
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5836,7 +5836,7 @@ POL_cua_category = {
 					has_decision = POL_restoration_of_the_old_penal_system
 					has_decision = POL_limiting_activities_at_night
 				}
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5875,7 +5875,7 @@ POL_cua_category = {
 					has_decision = POL_restoration_of_the_old_penal_system
 					has_decision = POL_hunt_the_new_solidarity_politicians
 				}
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5916,7 +5916,7 @@ POL_cua_category = {
 					has_decision = POL_limiting_activities_at_night
 					has_decision = POL_hunt_the_new_solidarity_politicians
 				}
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5955,7 +5955,7 @@ POL_cua_category = {
 					has_decision = POL_limiting_activities_at_night
 					has_decision = POL_hunt_the_new_solidarity_politicians
 				}
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -5991,7 +5991,7 @@ POL_cua_category = {
 			has_country_flag = POL_crush_new_solidarity3
 			has_country_flag = POL_crush_new_solidarity4
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -6033,7 +6033,7 @@ POL_cua_category = {
 			communism > 0.25
 			NOT = {
 				OR = {
-					has_country_flag = POL_great_depression_active
+					has_idea = POL_economy_status7_idea
 					has_country_flag = POL_prepare_the_coup_fail
 					has_decision = POL_prepare_the_coup
 					has_decision = POL_hire_secret_army_to_gain_control_over_government
@@ -6094,7 +6094,7 @@ POL_cua_category = {
 			communism > 0.25
 			NOT = {
 				OR = {
-					has_country_flag = POL_great_depression_active
+					has_idea = POL_economy_status7_idea
 					has_decision = POL_prepare_the_coup
 					has_decision = POL_pact_with_the_government
 					has_country_flag = POL_prepare_the_coup_fail3
@@ -6153,7 +6153,7 @@ POL_cua_category = {
 			has_country_flag = POL_prepare_the_coup_fail
 			has_country_flag = POL_prepare_the_coup_fail2
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -6301,7 +6301,7 @@ POL_cua_category = {
 			}
 			communism > 0.5
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 				has_country_flag = POL_prepare_the_coup_activation
 			}
 		}
@@ -6353,7 +6353,7 @@ POL_cua_category = {
 			}
 			communism > 0.5
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 			}
 		}
 
@@ -6398,7 +6398,7 @@ POL_cua_category = {
 			}
 			communism > 0.5
 			NOT = {
-				has_country_flag = POL_great_depression_active
+				has_idea = POL_economy_status7_idea
 				has_country_flag = POL_prepare_the_coup_activation
 			}
 		}

--- a/common/decisions/north_korea.txt
+++ b/common/decisions/north_korea.txt
@@ -1141,7 +1141,9 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_research_active }
+				NOT = { has_idea = NKO_spa_bonus_research }
+				NOT = { has_idea = NKO_spa_bonus_research_half }
+				NOT = { has_idea = NKO_spa_bonus_research_quarter }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -1174,7 +1176,11 @@ NKO_Arduous_March = {
 			base = 75
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_research_active
+				OR = {
+					has_idea = NKO_spa_bonus_research
+					has_idea = NKO_spa_bonus_research_half
+					has_idea = NKO_spa_bonus_research_quarter
+				}
 			}
 		}
 	}

--- a/common/decisions/north_korea.txt
+++ b/common/decisions/north_korea.txt
@@ -909,7 +909,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_industry_active }
+				NOT = { has_idea = NKO_spa_bonus_industry }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -945,7 +945,7 @@ NKO_Arduous_March = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_industry_active
+				has_idea = NKO_spa_bonus_industry
 			}
 		}
 	}
@@ -966,7 +966,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_production_active }
+				NOT = { has_idea = NKO_spa_bonus_production }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -999,7 +999,7 @@ NKO_Arduous_March = {
 			base = 90
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_production_active
+				has_idea = NKO_spa_bonus_production
 			}
 			modifier = {
 				add = 30
@@ -1024,7 +1024,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_military_active }
+				NOT = { has_idea = NKO_spa_bonus_military }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -1057,7 +1057,7 @@ NKO_Arduous_March = {
 			base = 80
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_military_active
+				has_idea = NKO_spa_bonus_military
 			}
 			modifier = {
 				add = 50
@@ -1082,7 +1082,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_economy_active }
+				NOT = { has_idea = NKO_spa_bonus_economy }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -1117,7 +1117,7 @@ NKO_Arduous_March = {
 			base = 70
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_economy_active
+				has_idea = NKO_spa_bonus_economy
 			}
 		}
 	}
@@ -1195,7 +1195,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_agriculture_active }
+				NOT = { has_idea = NKO_spa_bonus_agriculture }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -1228,7 +1228,7 @@ NKO_Arduous_March = {
 			base = 70
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_agriculture_active
+				has_idea = NKO_spa_bonus_agriculture
 			}
 		}
 	}
@@ -1249,7 +1249,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_foreign_active }
+				NOT = { has_idea = NKO_spa_bonus_foreign }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -1282,7 +1282,7 @@ NKO_Arduous_March = {
 			base = 60
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_foreign_active
+				has_idea = NKO_spa_bonus_foreign
 			}
 		}
 	}
@@ -1303,7 +1303,7 @@ NKO_Arduous_March = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_domain_unlocked_tt
-				NOT = { has_country_flag = NKO_spa_bonus_construction_active }
+				NOT = { has_idea = NKO_spa_bonus_construction }
 			}
 			custom_trigger_tooltip = {
 				tooltip = NKO_spa_picks_remaining_tt
@@ -1336,7 +1336,7 @@ NKO_Arduous_March = {
 			base = 65
 			modifier = {
 				factor = 0
-				has_country_flag = NKO_spa_bonus_construction_active
+				has_idea = NKO_spa_bonus_construction
 			}
 		}
 	}

--- a/common/ideas/Polish.txt
+++ b/common/ideas/Polish.txt
@@ -3444,12 +3444,10 @@ local_resources_chromium_factor = 0.06
 				stability_factor = -0.25
 			}
 			on_add = {
-				set_country_flag = POL_great_depression_active
 				depression = yes
 			}
 			on_remove = {
 				increase_economic_growth = yes
-				clr_country_flag = POL_great_depression_active
 				sre_economy_status_decrease = yes
 				custom_effect_tooltip = POL_decrease_es_TT
 			}

--- a/common/ideas/north_korea.txt
+++ b/common/ideas/north_korea.txt
@@ -1163,7 +1163,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_research_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_research }
@@ -1185,7 +1184,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_research_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_research }
@@ -1207,7 +1205,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_research_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_research }

--- a/common/ideas/north_korea.txt
+++ b/common/ideas/north_korea.txt
@@ -1072,7 +1072,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_industry_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_industry }
@@ -1096,7 +1095,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_production_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_production }
@@ -1121,7 +1119,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_military_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_military }
@@ -1145,7 +1142,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_economy_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_economy }
@@ -1235,7 +1231,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_agriculture_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_agriculture }
@@ -1259,7 +1254,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_foreign_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_foreign }
@@ -1292,7 +1286,6 @@ ideas = {
 			}
 
 			on_remove = {
-				clr_country_flag = NKO_spa_bonus_construction_active
 				if = {
 					limit = {
 						NOT = { has_idea = NKO_spa_debuff_construction }

--- a/common/scripted_effects/99_NKO_scripted_effects.txt
+++ b/common/scripted_effects/99_NKO_scripted_effects.txt
@@ -210,7 +210,6 @@ NKO_spa_initialise = {
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_research }
-				NOT = { has_country_flag = NKO_spa_bonus_research_active }
 			}
 			add_ideas = NKO_spa_debuff_research
 		}
@@ -312,7 +311,9 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_research_active }
+					NOT = { has_idea = NKO_spa_bonus_research }
+					NOT = { has_idea = NKO_spa_bonus_research_half }
+					NOT = { has_idea = NKO_spa_bonus_research_quarter }
 					check_variable = { political_power > 74.9 }
 					check_variable = { treasury > 1.499 }
 				}
@@ -429,7 +430,6 @@ NKO_spa_pass_research = {
 		else = {
 			add_timed_idea = { idea = NKO_spa_bonus_research days = 365 }
 		}
-		set_country_flag = { flag = NKO_spa_bonus_research_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Research Drive"
 	}
@@ -613,7 +613,6 @@ NKO_spa_suppress_for_collapse = {
 		if = { limit = { has_idea = NKO_spa_bonus_agriculture } remove_ideas = NKO_spa_bonus_agriculture }
 		if = { limit = { has_idea = NKO_spa_bonus_foreign } remove_ideas = NKO_spa_bonus_foreign }
 		if = { limit = { has_idea = NKO_spa_bonus_construction } remove_ideas = NKO_spa_bonus_construction }
-		clr_country_flag = NKO_spa_bonus_research_active
 	}
 }
 

--- a/common/scripted_effects/99_NKO_scripted_effects.txt
+++ b/common/scripted_effects/99_NKO_scripted_effects.txt
@@ -182,28 +182,28 @@ NKO_spa_initialise = {
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_industry }
-				NOT = { has_country_flag = NKO_spa_bonus_industry_active }
+				NOT = { has_idea = NKO_spa_bonus_industry }
 			}
 			add_ideas = NKO_spa_debuff_industry
 		}
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_production }
-				NOT = { has_country_flag = NKO_spa_bonus_production_active }
+				NOT = { has_idea = NKO_spa_bonus_production }
 			}
 			add_ideas = NKO_spa_debuff_production
 		}
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_military }
-				NOT = { has_country_flag = NKO_spa_bonus_military_active }
+				NOT = { has_idea = NKO_spa_bonus_military }
 			}
 			add_ideas = NKO_spa_debuff_military
 		}
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_economy }
-				NOT = { has_country_flag = NKO_spa_bonus_economy_active }
+				NOT = { has_idea = NKO_spa_bonus_economy }
 			}
 			add_ideas = NKO_spa_debuff_economy
 		}
@@ -217,21 +217,21 @@ NKO_spa_initialise = {
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_agriculture }
-				NOT = { has_country_flag = NKO_spa_bonus_agriculture_active }
+				NOT = { has_idea = NKO_spa_bonus_agriculture }
 			}
 			add_ideas = NKO_spa_debuff_agriculture
 		}
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_foreign }
-				NOT = { has_country_flag = NKO_spa_bonus_foreign_active }
+				NOT = { has_idea = NKO_spa_bonus_foreign }
 			}
 			add_ideas = NKO_spa_debuff_foreign
 		}
 		if = {
 			limit = {
 				NOT = { has_idea = NKO_spa_debuff_construction }
-				NOT = { has_country_flag = NKO_spa_bonus_construction_active }
+				NOT = { has_idea = NKO_spa_bonus_construction }
 			}
 			add_ideas = NKO_spa_debuff_construction
 		}
@@ -276,7 +276,7 @@ NKO_spa_force_pick_fallback = {
 			limit = { check_variable = { NKO_spa_picks_made < 2 } }
 			if = {
 				limit = {
-					NOT = { has_country_flag = NKO_spa_bonus_foreign_active }
+					NOT = { has_idea = NKO_spa_bonus_foreign }
 					check_variable = { political_power > 39.9 }
 					check_variable = { treasury > 0.699 }
 				}
@@ -288,7 +288,7 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_industry_active }
+					NOT = { has_idea = NKO_spa_bonus_industry }
 					check_variable = { political_power > 49.9 }
 					check_variable = { treasury > 0.499 }
 				}
@@ -300,7 +300,7 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_production_active }
+					NOT = { has_idea = NKO_spa_bonus_production }
 					check_variable = { political_power > 49.9 }
 					check_variable = { treasury > 0.699 }
 				}
@@ -324,7 +324,7 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_agriculture_active }
+					NOT = { has_idea = NKO_spa_bonus_agriculture }
 					check_variable = { political_power > 59.9 }
 					check_variable = { treasury > 0.499 }
 				}
@@ -336,7 +336,7 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_construction_active }
+					NOT = { has_idea = NKO_spa_bonus_construction }
 					check_variable = { political_power > 59.9 }
 					check_variable = { treasury > 0.749 }
 				}
@@ -348,7 +348,7 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_military_active }
+					NOT = { has_idea = NKO_spa_bonus_military }
 					check_variable = { political_power > 74.9 }
 					check_variable = { treasury > 0.399 }
 				}
@@ -360,7 +360,7 @@ NKO_spa_force_pick_fallback = {
 			if = {
 				limit = {
 					check_variable = { NKO_spa_picks_made < 2 }
-					NOT = { has_country_flag = NKO_spa_bonus_economy_active }
+					NOT = { has_idea = NKO_spa_bonus_economy }
 					check_variable = { political_power > 74.9 }
 					check_variable = { treasury > 0.299 }
 				}
@@ -383,7 +383,6 @@ NKO_spa_pass_industry = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_industry } remove_ideas = NKO_spa_debuff_industry }
 		add_timed_idea = { idea = NKO_spa_bonus_industry days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_industry_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Industrial Acceleration"
 	}
@@ -393,7 +392,6 @@ NKO_spa_pass_production = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_production } remove_ideas = NKO_spa_debuff_production }
 		add_timed_idea = { idea = NKO_spa_bonus_production days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_production_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Equipment Production Mandate"
 	}
@@ -403,7 +401,6 @@ NKO_spa_pass_military = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_military } remove_ideas = NKO_spa_debuff_military }
 		add_timed_idea = { idea = NKO_spa_bonus_military days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_military_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Songun Resolution"
 	}
@@ -413,7 +410,6 @@ NKO_spa_pass_economy = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_economy } remove_ideas = NKO_spa_debuff_economy }
 		add_timed_idea = { idea = NKO_spa_bonus_economy days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_economy_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Juche Self-Reliance"
 	}
@@ -443,7 +439,6 @@ NKO_spa_pass_agriculture = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_agriculture } remove_ideas = NKO_spa_debuff_agriculture }
 		add_timed_idea = { idea = NKO_spa_bonus_agriculture days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_agriculture_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Agricultural Drive"
 	}
@@ -453,7 +448,6 @@ NKO_spa_pass_foreign = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_foreign } remove_ideas = NKO_spa_debuff_foreign }
 		add_timed_idea = { idea = NKO_spa_bonus_foreign days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_foreign_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Foreign Policy Directive"
 	}
@@ -463,7 +457,6 @@ NKO_spa_pass_construction = {
 	hidden_effect = {
 		if = { limit = { has_idea = NKO_spa_debuff_construction } remove_ideas = NKO_spa_debuff_construction }
 		add_timed_idea = { idea = NKO_spa_bonus_construction days = 365 }
-		set_country_flag = { flag = NKO_spa_bonus_construction_active days = 366 value = 1 }
 		add_to_variable = { NKO_spa_picks_made = 1 }
 		log = "[GetDateText]: [Root.GetName]: SPA mandate passed: Construction Battalion"
 	}
@@ -620,14 +613,7 @@ NKO_spa_suppress_for_collapse = {
 		if = { limit = { has_idea = NKO_spa_bonus_agriculture } remove_ideas = NKO_spa_bonus_agriculture }
 		if = { limit = { has_idea = NKO_spa_bonus_foreign } remove_ideas = NKO_spa_bonus_foreign }
 		if = { limit = { has_idea = NKO_spa_bonus_construction } remove_ideas = NKO_spa_bonus_construction }
-		clr_country_flag = NKO_spa_bonus_industry_active
-		clr_country_flag = NKO_spa_bonus_production_active
-		clr_country_flag = NKO_spa_bonus_military_active
-		clr_country_flag = NKO_spa_bonus_economy_active
 		clr_country_flag = NKO_spa_bonus_research_active
-		clr_country_flag = NKO_spa_bonus_agriculture_active
-		clr_country_flag = NKO_spa_bonus_foreign_active
-		clr_country_flag = NKO_spa_bonus_construction_active
 	}
 }
 

--- a/common/scripted_localisation/99_NKO_scripted_localisation.txt
+++ b/common/scripted_localisation/99_NKO_scripted_localisation.txt
@@ -152,7 +152,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_industry_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_industry_active }
+		trigger = { has_idea = NKO_spa_bonus_industry }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {
@@ -165,7 +165,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_production_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_production_active }
+		trigger = { has_idea = NKO_spa_bonus_production }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {
@@ -178,7 +178,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_military_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_military_active }
+		trigger = { has_idea = NKO_spa_bonus_military }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {
@@ -191,7 +191,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_economy_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_economy_active }
+		trigger = { has_idea = NKO_spa_bonus_economy }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {
@@ -217,7 +217,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_agriculture_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_agriculture_active }
+		trigger = { has_idea = NKO_spa_bonus_agriculture }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {
@@ -230,7 +230,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_foreign_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_foreign_active }
+		trigger = { has_idea = NKO_spa_bonus_foreign }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {
@@ -243,7 +243,7 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_construction_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_construction_active }
+		trigger = { has_idea = NKO_spa_bonus_construction }
 		localization_key = NKO_spa_caption_active
 	}
 	text = {

--- a/common/scripted_localisation/99_NKO_scripted_localisation.txt
+++ b/common/scripted_localisation/99_NKO_scripted_localisation.txt
@@ -204,7 +204,13 @@ defined_text = {
 defined_text = {
 	name = NKO_spa_research_state
 	text = {
-		trigger = { has_country_flag = NKO_spa_bonus_research_active }
+		trigger = {
+			OR = {
+				has_idea = NKO_spa_bonus_research
+				has_idea = NKO_spa_bonus_research_half
+				has_idea = NKO_spa_bonus_research_quarter
+			}
+		}
 		localization_key = NKO_spa_caption_active
 	}
 	text = {

--- a/localisation/english/MD_focus_POL_l_english.yml
+++ b/localisation/english/MD_focus_POL_l_english.yml
@@ -3725,7 +3725,6 @@
  POL_new_solidarity_revolution_crushed: "New Solidarity revolution crushed"
  POL_prepare_the_coup_activation2: "§RMilitary assassination succeed§!"
  POL_communism_uprising_again_activation: "§RCommunism Uprising Again§! §Yis active§!"
- POL_great_depression_active: "§G Great Depression§! is active"
  POL_this_will_kick_poland_from_nato_TT: "§Y[POL.GetName]§! §Rwill be kicked from NATO after that!§!§W§!"
  POL_zkp_p_unhappy_TT: "§RZKP-P Communists will criticize that decision§!"
  POL_zkp_p_warning_TT: "§RZKP-P Communists will warn us about consequences of the EU integration§!"


### PR DESCRIPTION
### Summary

#### Performance

- **[POL]** — Removed `POL_great_depression_active` flag (mirrored `POL_economy_status7_idea`). 17 check sites in `decisions/Poland.txt` swapped to `has_idea`.
- **[NKO]** — Removed 7 `NKO_spa_bonus_*_active` flags (industry, production, military, economy, agriculture, foreign, construction) that 1:1 mirrored their bonus ideas. 23 check sites across decisions, scripted localisation, and `NKO_spa_initialise` / `NKO_spa_force_pick_fallback` swapped to `has_idea`. Bulk-clear in the reset effect collapsed.
- `NKO_spa_bonus_research_active` retained — abstracts three idea variants (`research`, `_half`, `_quarter`).

Net: -23 lines, single source of truth (the idea itself) for each gated state.

### Test plan

- Play POL → enter great depression (status 7 idea) → verify all gated decisions become unavailable, then improve economy and verify they re-unlock.
- Play NKO → SPA session → pick a mandate (e.g. Industrial Acceleration) → verify the matching resolution decision is locked while the bonus idea is active, and the GUI caption shows "active".
- Wait 365 days for a NKO bonus idea to expire → verify the resolution decision becomes available again and the corresponding debuff idea reapplies.