### PR TITLE
Curb Major Non-NATO Ally request spam

### DIFF
--- a/common/decisions/NATO.txt
+++ b/common/decisions/NATO.txt
@@ -2025,6 +2025,11 @@ generic_coalition_politics_decisions = {
 			is_in_faction = no
 			NOT = { has_idea = Major_Non_NATO_Ally }
 			NOT = { has_idea = NATO_member }
+			# Only nations with a real military or arms base apply. Keeps microstates (Andorra, Monaco, etc.) out of the pool.
+			OR = {
+				has_army_manpower = { size > 10000 }
+				num_of_military_factories > 2
+			}
 		}
 
 		available = {
@@ -2079,7 +2084,18 @@ generic_coalition_politics_decisions = {
 		}
 
 		ai_will_do = {
-			base = 5
+			base = 3
+			# Don't bother applying unless a NATO leader actually values us
+			modifier = {
+				factor = 0
+				NOT = {
+					any_of_scopes = {
+						array = global.nato_members
+						is_faction_leader = yes
+						has_opinion = { target = ROOT value > 25 }
+					}
+				}
+			}
 			modifier = {
 				CHI = { has_war_with = ROOT }
 				add = 5
@@ -2121,17 +2137,14 @@ generic_coalition_politics_decisions = {
 					has_government = fascism
 				}
 			}
+			# Pursue protection when the AI feels threatened; far less inclined when it does not
 			modifier = {
-				factor = 0
-				threat < 0.30
-			}
-			modifier = {
-				threat > 0.29
-				add = 3
-			}
-			modifier = {
-				threat > 0.50
+				check_variable = { ai_attitude_is_threatened > 0 }
 				add = 5
+			}
+			modifier = {
+				factor = 0.2
+				check_variable = { ai_attitude_is_threatened = 0 }
 			}
 			modifier = {
 				num_of_factories > 30


### PR DESCRIPTION
## Summary

Fixes the Major Non-NATO Ally (MNNA) request spam reported in #1588, where the US player gets a `request_MNNA_status` event every 3-5 months regardless of how they answer.

Two root causes, both in `common/decisions/NATO.txt`:

- **No relevance filter.** Every non-faction democratic/neutral nation qualified, so microstates (Andorra, Monaco, San Marino, etc.) flooded the pool.
- **Loose AI weight.** `base = 5` with no requirement that a NATO leader actually valued the applicant, plus a raw `threat`-value gate.

## Changes

- **Relevance gate (`visible`):** applicants now need a real military or arms base (`has_army_manpower > 10000` or `num_of_military_factories > 2`). Andorra and friends drop out of the pool.
- **AI: require a relationship.** The AI won't apply unless a NATO faction leader has opinion `> 25` of it.
- **AI: gate on the threatened flag.** Replaced the raw `threat` modifiers with `ai_attitude_is_threatened` — apply readily when threatened, cut weight to 20% when not.
- Lowered `base = 5` to `3`.

## Test plan

- [ ] Load as USA, fast-forward, confirm MNNA requests no longer arrive from microstates and come at a much lower rate.

Closes #1588