### PR TITLE
Fix Power Ranking For Released Nations (#1573)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -289,6 +289,7 @@ v2.0.0
   - Rebalanced landmark bonuses to a small stability boost plus tourism income for whichever country owns the state
 
  Bugfix:
+  - Fixed nations released after game start (US collapse breakaways, freed puppets) never getting a Power Status or Naval Power of the Continent idea; they now register into the power ranking and counter-terror systems on creation (Issue #1573)
   - [FRA] Fixed "Strength in the EU" applying the European Commitment opinion modifier to France itself; the loop now skips ROOT (Issue #1553)
   - Removed the empty political_advisor slots in the government idea category that left the engine "You can select a: Political Advisor" alert nagging forever with no UI to fill them (Issue #786); intel advisor characters remain defined pending a follow-up assignment system
   - Fixed divisions auto-deploying with as little as 60% equipment during wartime; restored vanilla 90% threshold (DEPLOY_MIN_EQUIPMENT_WAR_FACTOR)

--- a/common/scripted_effects/00_power_ranking_effects.txt
+++ b/common/scripted_effects/00_power_ranking_effects.txt
@@ -1,4 +1,79 @@
 # Author(s): Yard1, AngriestBird
+#
+# POWER RANKING — sorts every country into a Power Status idea each quarter (super/great/large/
+# minor/non_power, plus regional_power and naval_power_of_the_continent).
+#
+# Per-country state:
+#   power_ranking_contribution      GDP scaled by independence from foreign influence
+#   percentage_of_global_factories  contribution / world total; sets the tier, shown in-game
+#   power_ranking_name_var          tier id 1..5, see assign_power_ranking_value
+# Regional arrays (european_nations, sub_saharan_nations, middle_eastern_nations, asian_nations,
+#   american_nations) hold each region's members, sorted descending by contribution.
+#
+# Schedule, from 00_on_actions.txt:
+#   startup         set_power_ranking_ideas_for_every_country  build arrays, sort, assign ideas
+#   month 1/4/7/10  calculate_power_ranking_contributions      recompute tiers + naval hegemons
+#   month 2/5/8/11  sort_and_assign_power_rankings             re-sort, flag regional powers
+# Idea text is re-applied per country over the weekly CT staggered cycle during that window.
+# Mid-game nations register via add_country_to_power_ranking.
+
+# Shared: compute a country's power_ranking_contribution (GDP weighted by domestic
+# influence) and fold it into the global denominator. Run in country scope.
+accumulate_power_ranking_contribution = {
+	set_variable = { power_ranking_contribution = gdp_total }
+	set_temp_variable = { domestic_influence_amount_temp = domestic_influence_amount }
+	multiply_temp_variable = { domestic_influence_amount_temp = 0.01 }
+	multiply_variable = { power_ranking_contribution = domestic_influence_amount_temp?0.5 }
+	multiply_variable = { power_ranking_contribution = 0.01 }
+	add_to_variable = { global.global_num_of_factories = power_ranking_contribution }
+}
+
+# Shared: slot a country into its regional array. Idempotent — the is_in_array guards
+# keep mid-game callers from double-adding a tag that is already registered.
+register_in_power_ranking_array = {
+	if = {
+		limit = { has_country_flag = european_nation_flag NOT = { is_in_array = { global.european_nations = THIS } } }
+		add_to_array = { global.european_nations = THIS }
+	}
+	else_if = {
+		limit = { has_country_flag = african_nation_flag NOT = { is_in_array = { global.sub_saharan_nations = THIS } } }
+		add_to_array = { global.sub_saharan_nations = THIS }
+	}
+	else_if = {
+		limit = { has_country_flag = middle_east_nation_flag NOT = { is_in_array = { global.middle_eastern_nations = THIS } } }
+		add_to_array = { global.middle_eastern_nations = THIS }
+	}
+	else_if = {
+		limit = { has_country_flag = asian_nation_flag NOT = { is_in_array = { global.asian_nations = THIS } } }
+		add_to_array = { global.asian_nations = THIS }
+	}
+	else_if = {
+		limit = { has_country_flag = american_nation_flag NOT = { is_in_array = { global.american_nations = THIS } } }
+		add_to_array = { global.american_nations = THIS }
+	}
+}
+
+# Registers a nation created after game start (released/breakaway) into the system. Arrays are
+# only built at on_startup and the quarterly passes just iterate existing members, so without
+# this a mid-game nation never gets a Power Status or naval idea. Run in the new country's scope
+# after its economy is set up (needs gdp_total).
+add_country_to_power_ranking = {
+	set_country_group_flags = yes	# released nations skip on_startup, so set continent flags now
+	accumulate_power_ranking_contribution = yes
+	register_in_power_ranking_array = yes
+
+	# Give an immediate ranking + idea so it isn't blank until the next quarterly pass.
+	if = {
+		limit = { check_variable = { global.global_num_of_factories > 0 } }
+		set_variable = { percentage_of_global_factories = power_ranking_contribution }
+		divide_variable = { percentage_of_global_factories = global.global_num_of_factories }
+		assign_power_ranking_value = yes
+	}
+	else = {
+		set_variable = { power_ranking_name_var = 1 }
+	}
+	assign_power_ranking_ideas = yes
+}
 
 # STARTUP ONLY: Full clear + build + sort (called once at game start from 00_on_actions.txt)
 set_power_ranking_ideas_for_every_country = {
@@ -11,34 +86,12 @@ set_power_ranking_ideas_for_every_country = {
 
 	every_country = {
 		clr_country_flag = regional_power
-
-		set_variable = { power_ranking_contribution = gdp_total }
-		set_temp_variable = { domestic_influence_amount_temp = domestic_influence_amount }
-		multiply_temp_variable = { domestic_influence_amount_temp = 0.01 }
-		multiply_variable = { power_ranking_contribution = domestic_influence_amount_temp?0.5 }
-		multiply_variable = { power_ranking_contribution = 0.01 }
-		add_to_variable = { global.global_num_of_factories = power_ranking_contribution }
+		accumulate_power_ranking_contribution = yes
+		register_in_power_ranking_array = yes
 
 		if = {
 			limit = { has_country_flag = european_nation_flag }
-			add_to_array = { global.european_nations = THIS }
 			add_to_array = { global.sc_updates_euro_america = THIS }
-		}
-		else_if = {
-			limit = { has_country_flag = african_nation_flag }
-			add_to_array = { global.sub_saharan_nations = THIS }
-		}
-		else_if = {
-			limit = { has_country_flag = middle_east_nation_flag }
-			add_to_array = { global.middle_eastern_nations = THIS }
-		}
-		else_if = {
-			limit = { has_country_flag = asian_nation_flag }
-			add_to_array = { global.asian_nations = THIS }
-		}
-		else_if = {
-			limit = { has_country_flag = american_nation_flag }
-			add_to_array = { global.american_nations = THIS }
 		}
 	}
 
@@ -46,106 +99,14 @@ set_power_ranking_ideas_for_every_country = {
 	add_to_array = { global.sc_updates_euro_america = MEX }
 	add_to_array = { global.sc_updates_euro_america = USA }
 
-	# Sort each regional array by power_ranking_contribution (descending)
 	power_ranking_selection_sort_european = yes
 	power_ranking_selection_sort_sub_saharan = yes
 	power_ranking_selection_sort_middle_east = yes
 	power_ranking_selection_sort_asian = yes
 	power_ranking_selection_sort_american = yes
 
-	# Calculate percentages, find naval hegemons, and assign power ranking values
-	set_temp_variable = { largest_value = 0 }
-	for_each_loop = {
-		array = global.european_nations
-		value = v
-		var:v = {
-			set_variable = { percentage_of_global_factories = power_ranking_contribution }
-			divide_variable = { percentage_of_global_factories = global.global_num_of_factories }
-
-			if = { limit = { check_variable = { deployed_navy_manpower_k > largest_value } }
-				set_temp_variable = { largest_value = THIS.deployed_navy_manpower_k }
-				set_temp_variable = { largest_european_navy = THIS.id }
-			}
-
-			assign_power_ranking_value = yes
-		}
-	}
-	var:largest_european_navy = { add_ideas = naval_power_of_the_continent }
-
-	set_temp_variable = { largest_value = 0 }
-	for_each_loop = {
-		array = global.sub_saharan_nations
-		value = v
-		var:v = {
-			set_variable = { percentage_of_global_factories = power_ranking_contribution }
-			divide_variable = { percentage_of_global_factories = global.global_num_of_factories }
-
-			if = { limit = { check_variable = { deployed_navy_manpower_k > largest_value } }
-				set_temp_variable = { largest_value = THIS.deployed_navy_manpower_k }
-				set_temp_variable = { largest_sub_saharan_nations = THIS.id }
-			}
-
-			assign_power_ranking_value = yes
-		}
-	}
-	var:largest_sub_saharan_nations = { add_ideas = naval_power_of_the_continent }
-
-	set_temp_variable = { largest_value = 0 }
-	for_each_loop = {
-		array = global.middle_eastern_nations
-		value = v
-		var:v = {
-			set_variable = { percentage_of_global_factories = power_ranking_contribution }
-			divide_variable = { percentage_of_global_factories = global.global_num_of_factories }
-
-			if = { limit = { check_variable = { deployed_navy_manpower_k > largest_value } }
-				set_temp_variable = { largest_value = THIS.deployed_navy_manpower_k }
-				set_temp_variable = { largest_middle_east_navy = THIS.id }
-			}
-
-			assign_power_ranking_value = yes
-		}
-	}
-	var:largest_middle_east_navy = { add_ideas = naval_power_of_the_continent }
-
-	set_temp_variable = { largest_value = 0 }
-	for_each_loop = {
-		array = global.asian_nations
-		value = v
-		var:v = {
-			set_variable = { percentage_of_global_factories = power_ranking_contribution }
-			divide_variable = { percentage_of_global_factories = global.global_num_of_factories }
-
-			if = { limit = { check_variable = { deployed_navy_manpower_k > largest_value } }
-				set_temp_variable = { largest_value = THIS.deployed_navy_manpower_k }
-				set_temp_variable = { largest_asian_navy = THIS.id }
-			}
-
-			assign_power_ranking_value = yes
-		}
-	}
-	var:largest_asian_navy = { add_ideas = naval_power_of_the_continent }
-
-	set_temp_variable = { largest_value = 0 }
-	for_each_loop = {
-		array = global.american_nations
-		value = v
-		var:v = {
-			set_variable = { percentage_of_global_factories = power_ranking_contribution }
-			divide_variable = { percentage_of_global_factories = global.global_num_of_factories }
-
-			if = { limit = { check_variable = { deployed_navy_manpower_k > largest_value } }
-				set_temp_variable = { largest_value = THIS.deployed_navy_manpower_k }
-				set_temp_variable = { largest_american_navy = THIS.id }
-			}
-
-			assign_power_ranking_value = yes
-		}
-	}
-	var:largest_american_navy = { add_ideas = naval_power_of_the_continent }
-
+	power_ranking_evaluate_all_regions = yes
 	determine_regional_powers = yes
-
 	game_startup_idea_set = yes
 }
 
@@ -156,16 +117,16 @@ calculate_power_ranking_contributions = {
 	every_country = {
 		clr_country_flag = regional_power
 		remove_ideas = naval_power_of_the_continent
-
-		set_variable = { power_ranking_contribution = gdp_total }
-		set_temp_variable = { domestic_influence_amount_temp = domestic_influence_amount }
-		multiply_temp_variable = { domestic_influence_amount_temp = 0.01 }
-		multiply_variable = { power_ranking_contribution = domestic_influence_amount_temp?0.5 }
-		multiply_variable = { power_ranking_contribution = 0.01 }
-		add_to_variable = { global.global_num_of_factories = power_ranking_contribution }
+		accumulate_power_ranking_contribution = yes
 	}
 
-	# Calculate Power Ranking
+	power_ranking_evaluate_all_regions = yes
+}
+
+# Shared: for each region, set every member's percentage_of_global_factories, assign its
+# power ranking value, and grant naval_power_of_the_continent to that region's naval hegemon.
+# Called by both the startup build and the quarterly recalculation.
+power_ranking_evaluate_all_regions = {
 	set_temp_variable = { largest_value = 0 }
 	for_each_loop = {
 		array = global.european_nations
@@ -257,6 +218,10 @@ calculate_power_ranking_contributions = {
 	var:largest_american_navy = { add_ideas = naval_power_of_the_continent }
 }
 
+# Map contribution share to a tier id power_ranking_name_var:
+#   1 non_power (<0.2%)  2 super (>15%)  3 great (>6.5%)  4 large (>2.5%)  5 minor (else)
+# regional_power is layered onto tier 5 by determine_regional_powers; PRGetIdeaName turns the
+# id into the idea name.
 assign_power_ranking_value = {
 	if = { limit = { check_variable = { percentage_of_global_factories < 0.002 } }
 		set_variable = { power_ranking_name_var = 1 }
@@ -270,15 +235,15 @@ assign_power_ranking_value = {
 		}
 		else_if = { limit = { check_variable = { percentage_of_global_factories > 0.025 } }
 			set_variable = { power_ranking_name_var = 4 }
-		} else_if = { limit = { always = yes }
+		}
+		else = {
 			set_variable = { power_ranking_name_var = 5 }
 		}
 	}
 }
 
-# MONTH 2/5/8/11: Sort arrays by pre-calculated contribution, then assign power ranking ideas
+# MONTH 2/5/8/11: re-sort arrays by the contribution computed in the calculate pass, then flag.
 sort_and_assign_power_rankings = {
-	# Sort each regional array (descending by power_ranking_contribution)
 	power_ranking_selection_sort_european = yes
 	power_ranking_selection_sort_sub_saharan = yes
 	power_ranking_selection_sort_middle_east = yes
@@ -288,6 +253,9 @@ sort_and_assign_power_rankings = {
 	determine_regional_powers = yes
 }
 
+# Selection sort of a region, descending by power_ranking_contribution: copy to temp arrays,
+# clear, then pull the highest back in repeatedly. One copy per region — script can't
+# parameterise a global array name into for_each_loop/add_to_array.
 power_ranking_selection_sort_european = {
 	for_each_loop = {
 		array = global.european_nations
@@ -440,6 +408,8 @@ remove_power_ideas = {
 	}
 }
 
+# Startup only: apply the idea to every ranked country in one pass. Post-startup this work is
+# instead spread across the weekly CT staggered cycle to avoid a single-tick spike.
 game_startup_idea_set = {
 	for_each_loop = {
 		array = global.european_nations
@@ -449,7 +419,6 @@ game_startup_idea_set = {
 		}
 	}
 
-	# Sub-Saharan Africa (top 3 regional, find naval hegemon)
 	for_each_loop = {
 		array = global.sub_saharan_nations
 		value = v
@@ -458,7 +427,6 @@ game_startup_idea_set = {
 		}
 	}
 
-	# Middle East (top 3 regional, find naval hegemon)
 	for_each_loop = {
 		array = global.middle_eastern_nations
 		value = v
@@ -467,7 +435,6 @@ game_startup_idea_set = {
 		}
 	}
 
-	# Asia (top 7 regional, find naval hegemon)
 	for_each_loop = {
 		array = global.asian_nations
 		value = v
@@ -476,7 +443,6 @@ game_startup_idea_set = {
 		}
 	}
 
-	# Americas (top 4 regional, find naval hegemon)
 	for_each_loop = {
 		array = global.american_nations
 		value = v
@@ -486,7 +452,8 @@ game_startup_idea_set = {
 	}
 }
 
-# Shared: Calculate percentage and assign power ranking ideas to every country
+# Apply the idea matching power_ranking_name_var (+ regional_power flag) via PRGetIdeaName,
+# skipping the remove/add churn if the country already holds the right one.
 assign_power_ranking_ideas = {
 	set_variable = { global.cur_nation_idea_pull = power_ranking_name_var }
 	meta_effect = {
@@ -502,10 +469,10 @@ assign_power_ranking_ideas = {
 }
 
 
-# Combined: Set regional power flags (top N) and find naval hegemons in one pass per array
+# Flag the top-N of each sorted region as regional_power (arrays are pre-sorted, so index = rank).
+# N differs per region. Naval hegemons are handled in power_ranking_evaluate_all_regions, not here.
 determine_regional_powers = {
-	# Europe (top 7 regional, find naval hegemon)
-	for_each_loop = {
+	for_each_loop = {	# Europe: top 7
 		array = global.european_nations
 		value = v
 		var:v = {
@@ -515,8 +482,7 @@ determine_regional_powers = {
 		}
 	}
 
-	# Sub-Saharan Africa (top 3 regional, find naval hegemon)
-	for_each_loop = {
+	for_each_loop = {	# Sub-Saharan Africa: top 3
 		array = global.sub_saharan_nations
 		value = v
 		var:v = {
@@ -526,8 +492,7 @@ determine_regional_powers = {
 		}
 	}
 
-	# Middle East (top 3 regional, find naval hegemon)
-	for_each_loop = {
+	for_each_loop = {	# Middle East: top 3
 		array = global.middle_eastern_nations
 		value = v
 		var:v = {
@@ -537,8 +502,7 @@ determine_regional_powers = {
 		}
 	}
 
-	# Asia (top 7 regional, find naval hegemon)
-	for_each_loop = {
+	for_each_loop = {	# Asia: top 7
 		array = global.asian_nations
 		value = v
 		var:v = {
@@ -548,8 +512,7 @@ determine_regional_powers = {
 		}
 	}
 
-	# Americas (top 4 regional, find naval hegemon)
-	for_each_loop = {
+	for_each_loop = {	# Americas: top 4
 		array = global.american_nations
 		value = v
 		var:v = {

--- a/common/scripted_effects/00_scripted_effects.txt
+++ b/common/scripted_effects/00_scripted_effects.txt
@@ -2297,6 +2297,17 @@ ingame_startup_nations_effect = {
 		calculate_expected_spending = yes
 		setup_missile_configuration_effect = yes
 		microchip_startup = yes
+		add_country_to_power_ranking = yes
+		# Released nations skip on_startup, so enroll them in the counter-terror staggered
+		# cycle. That cycle is also what re-applies each nation's power ranking idea every
+		# quarter, so without this their Power Status idea would freeze at its release value.
+		# counter_terror_nation_startup appends to per-country arrays, so only run it for a
+		# nation that has not been set up yet (empty CT intel array = never initialised).
+		if = {
+			limit = { NOT = { check_variable = { international_terror_org_intel^num > 0 } } }
+			counter_terror_nation_startup = yes
+			add_on_creation = yes
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1573

### Summary

#### Bug Fixes

- **Fixes #1573: Breakaway states after US collapse lack dynamic ideas (Power Status & Naval Power).** The regional power ranking arrays (`global.american_nations`, etc.) are only built at `on_startup`, and the quarterly passes only iterate existing members, so nations released mid-game were never registered and got no Power Status idea nor were they eligible for `naval_power_of_the_continent`. New `add_country_to_power_ranking` (called from `ingame_startup_nations_effect`) sets the continent flags, slots the nation into its regional array, and assigns an immediate ranking.
- **Fixes #1573: Power Status idea froze after release.** Post-startup, `assign_power_ranking_ideas` only runs from the weekly counter-terror staggered cycle, which released nations were never enrolled in (the `add_on_creation` effect was dead code). `ingame_startup_nations_effect` now runs `counter_terror_nation_startup` + `add_on_creation` once per nation, guarded on the CT intel array so it can't double-initialise.

#### Performance

- Deduped the power ranking system: the identical five-region naval/contribution block (copied across the startup build and the quarterly recalc) and the per-country contribution math are now shared effects (`power_ranking_evaluate_all_regions`, `accumulate_power_ranking_contribution`, `register_in_power_ranking_array`). Net 126 lines removed. Added a system-overview header and corrected stale comments.

### Test plan

**Playthrough A: USA 2000 (covers #1573)**

Trigger the collapse, before unpausing the successor states:

- [ ] `tag USA`, fire the US collapse chain, confirm breakaway tags (TEX, CAS, Free States, etc.) spawn (#1573).
- [ ] `tag` into a breakaway, open the national ideas panel, confirm it has a Power Status idea (super/great/large/minor/non_power) rather than a blank slot (#1573).
- [ ] Confirm the breakaway with the largest fleet on the continent holds Naval Power of the Continent (#1573).

Mid-game checks (advance past the next quarter boundary, month 2/5/8/11):

- [ ] Build up a breakaway's economy, advance a full quarter, confirm its Power Status idea updates to the new tier instead of staying frozen (#1573).
- [ ] Confirm the USA remnant and the breakaways share the same American power ranking group (their tiers are ranked against each other) (#1573).

**Playthrough B: any nation freeing a puppet (covers #1573)**

- [ ] Release an existing puppet as free, advance a quarter, confirm the freed nation receives and then updates a Power Status idea (#1573).