### PR TITLE
Bug fix - Loss of building slots when state changes ownership

### DIFF
--- a/common/defines/MD_defines.lua
+++ b/common/defines/MD_defines.lua
@@ -277,7 +277,6 @@
 	NDefines.NBuildings.RADAR_INTEL_EFFECT = 60 -- 40
 	NDefines.NBuildings.BASE_FACTORY_REPAIR = 0.25
 	NDefines.NBuildings.MAX_SHARED_SLOTS = 56
-	NDefines.NBuildings.OWNER_CHANGE_EXTRA_SHARED_SLOTS_FACTOR = 0.5
 	NDefines.NBuildings.INFRASTRUCTURE_RESOURCE_BONUS = 0.05	--upped from 0.02, vanilla 0.2
 	NDefines.NBuildings.ANTI_AIR_SUPERIORITY_MULT = 3.5 -- was 4.0 --Fucked with this to see
 	-- NOTE: The below piercing values are granularized to make piercing less punishing for nations with no real tank access


### PR DESCRIPTION
Fixes issue where half of the building slots obtained via focuses, decisions, etc, are removed whenever a state changes ownership.

Removes `NBuildings.OWNER_CHANGE_EXTRA_SHARED_SLOTS_FACTOR` from the defines file.

This define sets a value to multiply the added building slots a state has whenever it changes ownership.

Mod version of the define is seemingly a redundant define set prior to version 1.16 that matches the old vanilla behavior. Both at `0.5` meaning that half of all added building slots a state has are removed whenever it changes ownership. Removal means it will default to the current vanilla setting of `1`, which does not remove added building slots when a state changes ownership.