### PR TITLE
Gran Colombia fix

### DIFF
--- a/common/national_focus/Southern_Republic_of_America.txt
+++ b/common/national_focus/Southern_Republic_of_America.txt
@@ -15539,6 +15539,7 @@ focus_tree = {
 		bypass = {
 			852 = { is_core_of = CSA }
 			853 = { is_core_of = CSA }
+			1213 = { is_core_of = CSA }
 			870 = { is_core_of = CSA }
 			871 = { is_core_of = CSA }
 			872 = { is_core_of = CSA }
@@ -15564,6 +15565,7 @@ focus_tree = {
 			}
 			852 = { add_core_of = CSA }
 			853 = { add_core_of = CSA }
+			1213 = { add_core_of = CSA }
 			870 = { add_core_of = CSA }
 			871 = { add_core_of = CSA }
 			872 = { add_core_of = CSA }


### PR DESCRIPTION
Darien gap was missing from state lists involving Panama's cores.

Closes #1619 