### PR TITLE
[VALIDATOR] Fix Scope Simplification Validation

### DIFF
--- a/common/decisions/India.txt
+++ b/common/decisions/India.txt
@@ -862,76 +862,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression"
-			if = {
-				limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					456 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					456 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_456 }
-				}
-			}
-			else_if = {
-				limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					456 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					456 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_456 }
-				}
-			}
-			else_if = {
-				limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					456 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					456 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_456 }
-				}
-			}
-			else_if = {
-				limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					456 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					456 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_456 }
-				}
-			}
-			else_if = {
-				limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 456 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					456 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_456 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			456 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_456 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1024,76 +957,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_459"
-			if = {
-				limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					459 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					459 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_459 }
-				}
-			}
-			else_if = {
-				limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					459 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					459 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_459 }
-				}
-			}
-			else_if = {
-				limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					459 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					459 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_459 }
-				}
-			}
-			else_if = {
-				limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					459 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					459 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_459 }
-				}
-			}
-			else_if = {
-				limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 459 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					459 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_459 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			459 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_459 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1185,76 +1051,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_991"
-			if = {
-				limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					991 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					991 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_991 }
-				}
-			}
-			else_if = {
-				limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					991 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					991 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_991 }
-				}
-			}
-			else_if = {
-				limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					991 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					991 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_991 }
-				}
-			}
-			else_if = {
-				limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					991 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					991 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_991 }
-				}
-			}
-			else_if = {
-				limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 991 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					991 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_991 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			991 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_991 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1346,76 +1145,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_989"
-			if = {
-				limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					989 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					989 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_989 }
-				}
-			}
-			else_if = {
-				limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					989 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					989 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_989 }
-				}
-			}
-			else_if = {
-				limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					989 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					989 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_989 }
-				}
-			}
-			else_if = {
-				limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					989 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					989 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_989 }
-				}
-			}
-			else_if = {
-				limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 989 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					989 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_989 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			989 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_989 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1507,76 +1239,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_451"
-			if = {
-				limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					451 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					451 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_451 }
-				}
-			}
-			else_if = {
-				limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					451 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					451 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_451 }
-				}
-			}
-			else_if = {
-				limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					451 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					451 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_451 }
-				}
-			}
-			else_if = {
-				limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					451 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					451 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_451 }
-				}
-			}
-			else_if = {
-				limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 451 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					451 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_451 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			451 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_451 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1668,76 +1333,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_452"
-			if = {
-				limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					452 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					452 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_452 }
-				}
-			}
-			else_if = {
-				limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					452 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					452 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_452 }
-				}
-			}
-			else_if = {
-				limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					452 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					452 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_452 }
-				}
-			}
-			else_if = {
-				limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					452 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					452 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_452 }
-				}
-			}
-			else_if = {
-				limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 452 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					452 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_452 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			452 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_452 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1829,76 +1427,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_447"
-			if = {
-				limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					447 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					447 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_447 }
-				}
-			}
-			else_if = {
-				limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					447 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					447 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_447 }
-				}
-			}
-			else_if = {
-				limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					447 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					447 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_447 }
-				}
-			}
-			else_if = {
-				limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					447 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					447 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_447 }
-				}
-			}
-			else_if = {
-				limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 447 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					447 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_447 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			447 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_447 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -1990,76 +1521,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_458"
-			if = {
-				limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					458 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					458 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_458 }
-				}
-			}
-			else_if = {
-				limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					458 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					458 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_458 }
-				}
-			}
-			else_if = {
-				limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					458 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					458 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_458 }
-				}
-			}
-			else_if = {
-				limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					458 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					458 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_458 }
-				}
-			}
-			else_if = {
-				limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 458 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					458 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_458 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			458 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_458 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -2151,76 +1615,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_988"
-			if = {
-				limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					988 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					988 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_988 }
-				}
-			}
-			else_if = {
-				limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					988 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					988 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_988 }
-				}
-			}
-			else_if = {
-				limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					988 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					988 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_988 }
-				}
-			}
-			else_if = {
-				limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					988 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					988 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_988 }
-				}
-			}
-			else_if = {
-				limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 988 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					988 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_988 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			988 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_988 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {
@@ -2312,76 +1709,9 @@ maoist_decision_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression_470"
-			if = {
-				limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-				if = {
-					limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
-					470 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
-					470 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					RAJ = { clr_country_flag = cleared_470 }
-				}
-			}
-			else_if = {
-				limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-				if = {
-					limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
-					470 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
-					470 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					RAJ = { clr_country_flag = cleared_470 }
-				}
-			}
-			else_if = {
-				limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-				if = {
-					limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
-					470 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
-					470 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					RAJ = { clr_country_flag = cleared_470 }
-				}
-			}
-			else_if = {
-				limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-				if = {
-					limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
-					470 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
-					470 = { add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_470 }
-				}
-			}
-			else_if = {
-				limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-				if = {
-					limit = { 470 = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
-					470 = { remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
-					RAJ = { clr_country_flag = cleared_470 }
-				}
-			}
-			random_list = {
-				20 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 1000
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.1
-				}
-				40 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 500
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.3
-				}
-				10 = {
-					add_equipment_to_stockpile = {
-						type = infantry_weapons_2
-						amount = 250
-						producer = SOV
-					}
-					country_event = RAJ_mao_reb.2
-				}
-			}
+			470 = { RAJ_suppress_maoist_in_state = yes }
+			RAJ = { clr_country_flag = cleared_470 }
+			RAJ_maoist_suppression_loot = yes
 		}
 
 		ai_will_do = {

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -3297,8 +3297,6 @@ PER_domestic_politics = {
 					level = 1
 					instant_build = yes
 				}
-			}
-			978 = {
 				add_building_construction = {
 					type = dockyard
 					level = 1

--- a/common/decisions/Israel.txt
+++ b/common/decisions/Israel.txt
@@ -82,14 +82,8 @@ israel_bombing_category = {
 					NOT = {
 						PER = {
 							has_tech = IRBM7
-						}
-						PER = {
 							has_tech = IRBM8
-						}
-						PER = {
 							has_tech = GLCM7
-						}
-						PER = {
 							has_tech = GLCM8
 						}
 					}

--- a/common/decisions/Serbia.txt
+++ b/common/decisions/Serbia.txt
@@ -972,8 +972,6 @@ SER_ter_oborona_category = {
 		available = {
 			owns_state = 124
 		}
-		visible = {
-		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SER_ter_oborona_slovenia"
 			random_owned_controlled_state = {

--- a/common/decisions/Tajikistan.txt
+++ b/common/decisions/Tajikistan.txt
@@ -939,8 +939,6 @@ iranic_confederation = {
 				NOT = {
 					is_subject_of = ROOT
 				}
-			}
-			TRK = {
 				influence_higher_20 = yes
 			}
 		}
@@ -978,8 +976,6 @@ iranic_confederation = {
 				NOT = {
 					is_subject_of = ROOT
 				}
-			}
-			UZB = {
 				influence_higher_20 = yes
 			}
 		}
@@ -1017,8 +1013,6 @@ iranic_confederation = {
 				NOT = {
 					is_subject_of = ROOT
 				}
-			}
-			ARM = {
 				influence_higher_20 = yes
 			}
 		}
@@ -1109,11 +1103,7 @@ TAJ_badakhshani_unrest = {
 			}
 			722 = {
 				resistance < 5
-			}
-			722 = {
 				compliance > 90
-			}
-			722 = {
 				infrastructure > 4
 			}
 			custom_trigger_tooltip = {

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -992,9 +992,6 @@ TUR_hizmet_gulen_struggle = {
 
 		days_mission_timeout = 35
 		is_good = yes
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TUR_random_rally_akp_gulen"
-		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision TUR_random_rally_akp_gulen"
 			hidden_effect = {
@@ -1164,11 +1161,9 @@ TUR_pan_turkic_dream = {
 
 		available = {
 			nationalist_right_wing_populists_are_in_power = yes
-			UZB = { has_opinion = { target = TUR value > 59 } }
 			UZB = {
+				has_opinion = { target = TUR value > 59 }
 				nationalist > 0.30
-			}
-			UZB = {
 				influence_higher_50 = yes
 			}
 		}
@@ -1202,11 +1197,9 @@ TUR_pan_turkic_dream = {
 
 		available = {
 			nationalist_right_wing_populists_are_in_power = yes
-			TRK = { has_opinion = { target = TUR value > 59 } }
 			TRK = {
+				has_opinion = { target = TUR value > 59 }
 				nationalist > 0.30
-			}
-			TRK = {
 				influence_higher_50 = yes
 			}
 		}
@@ -2562,8 +2555,6 @@ TUR_mafia_influence_mechanic = {
 			}
 			GER = {
 				add_stability = -0.01
-			}
-			GER = {
 				add_equipment_to_stockpile = {
 					type = util_vehicle_3
 					amount = -30
@@ -3316,8 +3307,6 @@ TUR_mafia_influence_mechanic = {
 			}
 			BEL = {
 				influence_higher_60 = yes
-			}
-			BEL = {
 				neutrality > 0.40
 			}
 			hidden_trigger = {

--- a/common/decisions/UnitedArabRepublic.txt
+++ b/common/decisions/UnitedArabRepublic.txt
@@ -136,9 +136,11 @@ form_UAR_category = {
 		}
 
 		target_trigger = {
-			FROM = { is_subject = no }
-			FROM = { NOT = { is_baathist_uar = yes } }
-			FROM = { exists = yes }
+			FROM = {
+				is_subject = no
+				NOT = { is_baathist_uar = yes }
+				exists = yes
+			}
 		}
 
 		days_re_enable = 365
@@ -296,9 +298,11 @@ form_UAR_category = {
 		}
 
 		target_trigger = {
-			FROM = { is_subject = no }
-			FROM = { NOT = { is_neo_baathist_uar = yes } }
-			FROM = { exists = yes }
+			FROM = {
+				is_subject = no
+				NOT = { is_neo_baathist_uar = yes }
+				exists = yes
+			}
 		}
 
 		days_re_enable = 365
@@ -451,9 +455,11 @@ form_UAR_category = {
 		target_array = global.arabic_countries
 
 		target_trigger = {
-			FROM = { is_subject_of = ROOT }
-			FROM = { has_autonomy_state = autonomy_uar_state }
-			FROM = { OVERLORD = { has_country_flag = formed_neo_baathist_uar } }
+			FROM = {
+				is_subject_of = ROOT
+				has_autonomy_state = autonomy_uar_state
+				OVERLORD = { has_country_flag = formed_neo_baathist_uar }
+			}
 			if = {
 				limit = {
 					ROOT = { original_tag = LBA }
@@ -513,17 +519,11 @@ form_UAR_category = {
 				OR = {
 					FROM = { nationalist_fascist_are_in_power = yes }
 					FROM = {
-						NOT = {
-							emerging_autocracy_are_in_power = yes
-							has_government = communism
-							influence_higher_10 = yes
-							has_government = neutrality
-							influence_higher_30 = yes
-							has_government = nationalist
-							influence_higher_40 = yes
-							has_government = democratic
-							influence_higher_50 = yes
-						}
+						NOT = { emerging_autocracy_are_in_power = yes }
+						NOT = { has_government = communism influence_higher_10 = yes }
+						NOT = { has_government = neutrality influence_higher_30 = yes }
+						NOT = { has_government = nationalist influence_higher_40 = yes }
+						NOT = { has_government = democratic influence_higher_50 = yes }
 					}
 				}
 			}
@@ -531,17 +531,11 @@ form_UAR_category = {
 				OR = {
 					FROM = { nationalist_fascist_are_in_power = yes }
 					FROM = {
-						NOT = {
-							emerging_autocracy_are_in_power = yes
-							has_government = communism
-							influence_higher_20 = yes
-							has_government = neutrality
-							influence_higher_40 = yes
-							has_government = nationalist
-							influence_higher_50 = yes
-							has_government = democratic
-							influence_higher_60 = yes
-						}
+						NOT = { emerging_autocracy_are_in_power = yes }
+						NOT = { has_government = communism influence_higher_20 = yes }
+						NOT = { has_government = neutrality influence_higher_40 = yes }
+						NOT = { has_government = nationalist influence_higher_50 = yes }
+						NOT = { has_government = democratic influence_higher_60 = yes }
 					}
 				}
 			}
@@ -560,8 +554,8 @@ form_UAR_category = {
 			OR = {
 				FROM = { NOT = { has_autonomy_state = autonomy_uar_state } }
 				AND = {
-					FROM = { nationalist_fascist_are_in_power = no }
 					FROM = {
+						nationalist_fascist_are_in_power = no
 						OR = {
 							emerging_autocracy_are_in_power = yes
 							AND = {
@@ -610,9 +604,11 @@ form_UAR_category = {
 		target_array = global.arabic_countries
 
 		target_trigger = {
-			FROM = { is_subject_of = ROOT }
-			FROM = { has_autonomy_state = autonomy_uar_state }
-			FROM = { OVERLORD = { has_country_flag = formed_baathist_uar } }
+			FROM = {
+				is_subject_of = ROOT
+				has_autonomy_state = autonomy_uar_state
+				OVERLORD = { has_country_flag = formed_baathist_uar }
+			}
 			if = {
 				limit = {
 					ROOT = { original_tag = LBA }
@@ -669,42 +665,30 @@ form_UAR_category = {
 						}
 					}
 				}
-				OR = {
-					FROM = { emerging_autocracy_are_in_power = yes }
-					FROM = {
-						NOT = {
-							nationalist_fascist_are_in_power = yes
-							has_government = nationalist
-							influence_higher_10 = yes
-							has_government = neutrality
-							influence_higher_30 = yes
-							has_government = communism
-							influence_higher_40 = yes
-							has_government = democratic
-							influence_higher_50 = yes
-						}
+				FROM = {
+					OR = {
+						emerging_autocracy_are_in_power = yes
+						NOT = { nationalist_fascist_are_in_power = yes }
+						NOT = { has_government = nationalist influence_higher_10 = yes }
+						NOT = { has_government = neutrality influence_higher_30 = yes }
+						NOT = { has_government = communism influence_higher_40 = yes }
+						NOT = { has_government = democratic influence_higher_50 = yes }
 					}
 				}
 			}
 			else = {
-				OR = {
-					FROM = { emerging_autocracy_are_in_power = yes }
-					FROM = {
-						NOT = {
-							nationalist_fascist_are_in_power = yes
-							has_government = nationalist
-							influence_higher_20 = yes
-							has_government = neutrality
-							influence_higher_40 = yes
-							has_government = communism
-							influence_higher_50 = yes
-							has_government = democratic
-							influence_higher_60 = yes
-						}
+				FROM = {
+					OR = {
+						emerging_autocracy_are_in_power = yes
+						NOT = { nationalist_fascist_are_in_power = yes }
+						NOT = { has_government = nationalist influence_higher_20 = yes }
+						NOT = { has_government = neutrality influence_higher_40 = yes }
+						NOT = { has_government = communism influence_higher_50 = yes }
+						NOT = { has_government = democratic influence_higher_60 = yes }
 					}
 				}
 			}
-			FROM = { exists = yes }
+			country_exists = FROM
 		}
 
 		activation = {
@@ -719,8 +703,8 @@ form_UAR_category = {
 			OR = {
 				FROM = { NOT = { has_autonomy_state = autonomy_uar_state } }
 				AND = {
-					FROM = { emerging_autocracy_are_in_power = no }
 					FROM = {
+						emerging_autocracy_are_in_power = no
 						OR = {
 							nationalist_fascist_are_in_power = yes
 							AND = {

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -3144,8 +3144,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: AFG_emerging"
 			AFG = {
 				add_opinion_modifier = { target = SOV modifier = declaration_of_friendship }
-			}
-			AFG = {
 				add_opinion_modifier = { target = CHI modifier = declaration_of_friendship }
 			}
 			SOV = {

--- a/common/national_focus/05_cuba.txt
+++ b/common/national_focus/05_cuba.txt
@@ -9925,8 +9925,8 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			KAZ = { influence_higher_60 = yes }
 			KAZ = {
+				influence_higher_60 = yes
 				NOT = { has_government = nationalist }
 			}
 		}

--- a/common/national_focus/05_transnistria.txt
+++ b/common/national_focus/05_transnistria.txt
@@ -7186,8 +7186,8 @@ focus_tree = {
 
 		available = {
 			nationalist_military_junta_are_in_power = yes
-			UKR = { owns_state = 695 }
 			UKR = {
+				owns_state = 695
 				NOT = { is_in_faction_with = PMR }
 			}
 			NOT = { country_exists = OPR }
@@ -7279,11 +7279,7 @@ focus_tree = {
 								division = "name = \"Black Sea Cossack Regiment\" division_template = \"Cossack Regiment\" start_experience_factor = 0.3"
 								owner = OPR
 								prioritize_location = 9698
-							}
-							create_unit = {
-								division = "name = \"Black Sea Cossack Regiment\" division_template = \"Cossack Regiment\" start_experience_factor = 0.3"
-								owner = OPR
-								prioritize_location = 9698
+								count = 2
 							}
 						}
 						if = {

--- a/common/national_focus/Crimea.txt
+++ b/common/national_focus/Crimea.txt
@@ -1399,8 +1399,6 @@ focus_tree = {
 					province = 11649
 					instant_build = yes
 					}
-			}
-			1112 = {
 				add_building_construction = {
 					type = coastal_bunker
 					level = 1

--- a/common/national_focus/iraq2.txt
+++ b/common/national_focus/iraq2.txt
@@ -8457,8 +8457,6 @@ focus_tree = {
 						province = 11191
 						instant_build = yes
 					}
-				}
-				168 = {
 					add_building_construction = {
 						type = bunker
 						level = 2

--- a/common/national_focus/tajikistan.txt
+++ b/common/national_focus/tajikistan.txt
@@ -852,8 +852,6 @@ focus_tree = {
 				NOT = {
 					is_subject = yes
 				}
-			}
-			PER = {
 				OR = {
 					emerging_hardline_shiite_are_in_power = yes
 					emerging_moderate_shiite_are_in_power = yes
@@ -867,8 +865,6 @@ focus_tree = {
 			}
 			PER = {
 				is_subject = yes
-			}
-			PER = {
 				emerging_hardline_shiite_are_in_power = no
 				emerging_moderate_shiite_are_in_power = no
 			}
@@ -2840,8 +2836,6 @@ focus_tree = {
 							prioritize_location = 11687
 						}
 					}
-				}
-				UZI = {
 					create_country_leader = {
 						name = "Sa'dulla Abdullaev"
 						picture = "Sadulla_Abdullaev.dds"
@@ -9750,9 +9744,6 @@ focus_tree = {
 						prioritize_location = 1384
 						owner = TAJ
 					}
-				}
-
-				724 = {
 					create_unit = {
 						division = "name = \"1st. Gvardiyai Milli\" division_template = \"Gvardiyai Milli\""
 						prioritize_location = 1384

--- a/common/on_actions/MD_event_on_actions.txt
+++ b/common/on_actions/MD_event_on_actions.txt
@@ -1545,11 +1545,7 @@ on_actions = {
 					country_exists = NKO
 				}
 				subtract_from_variable = { SFR = 0.1 }
-				clamp_variable = {
-					var = SFR
-					min = 0
-					max = 100
-				}
+				clamp_variable = { var = SFR min = 0 max = 100 }
 			}
 		}
 	}
@@ -1558,10 +1554,8 @@ on_actions = {
 		effect = {
 			if = {
 				limit = {
-					NOT = {
-						has_completed_focus = SIN_singaporeans_first
-						has_completed_focus = SIN_restrict_migration
-					}
+					NOT = { has_completed_focus = SIN_singaporeans_first }
+					NOT = { has_completed_focus = SIN_restrict_migration }
 					has_country_flag = SIN_allowed_the_new_migration_policy
 					OR = {
 						check_variable = { global.month = 4 }
@@ -1577,21 +1571,25 @@ on_actions = {
 	on_weekly_SPR = {
 		effect = {
 			#calculate cap for regulares divisions
-			set_variable = { SPR_regulare_cap = 0 }
-			every_owned_state = {
-				limit = { NOT = { is_core_of = SPR } }
-				add_to_variable = { PREV.SPR_regulare_cap = state_population_k }
+			if = { limit = { has_completed_focus = SPR_expand_the_regulares }
+				set_variable = { SPR_regulare_cap = 0 }
+				every_owned_state = {
+					limit = { NOT = { is_core_of = SPR } }
+					add_to_variable = { PREV.SPR_regulare_cap = state_population_k }
+				}
+
+				divide_variable = { SPR_regulare_cap = SPR_regulare_cap_ratio }
+				round_variable = SPR_regulare_cap
 			}
 
-			divide_variable = { SPR_regulare_cap = SPR_regulare_cap_ratio }
-			round_variable = SPR_regulare_cap
+			if = { limit = { has_completed_focus = SPR_the_foreign_legion }
+				#calculate cap for foreign legion divisions
+				set_variable = { SPR_legion_cap = max_available_manpower_k }
+				set_variable = { SPR_legion_cap_ratio = 40 }
 
-			#calculate cap for foreign legion divisions
-			set_variable = { SPR_legion_cap = max_available_manpower_k }
-			set_variable = { SPR_legion_cap_ratio = 40 }
-
-			divide_variable = { SPR_legion_cap = SPR_legion_cap_ratio }
-			round_variable = SPR_legion_cap
+				divide_variable = { SPR_legion_cap = SPR_legion_cap_ratio }
+				round_variable = SPR_legion_cap
+			}
 
 			if = { limit = { has_completed_focus = SPR_sector_servicios_espanol }
 				if = {
@@ -1639,38 +1637,34 @@ on_actions = {
 								has_country_flag = SPR_metropol_parsol_project_complete
 							}
 						}
-						random_list = {
-							40 = {
-								modifier = {
-									factor = 1.25
-									has_country_flag = { flag = SPR_metropol_parasol_project_money value < 2 }
-								}
-								modifier = {
-									factor = 1.25
-									has_country_flag = { flag = SPR_metropol_parasol_project_money value > 1 }
-								}
-								modifier = {
-									factor = 1.05
-									has_country_flag = SPR_metropol_parasol_project_political
-								}
-								country_event = { id = spain.247 random_days = 180 random_hours = 24 }
+						random = {
+							chance = 40
+							modifier = {
+								factor = 1.25
+								has_country_flag = { flag = SPR_metropol_parasol_project_money value < 2 }
 							}
-							60 = {}
+							modifier = {
+								factor = 1.25
+								has_country_flag = { flag = SPR_metropol_parasol_project_money value > 1 }
+							}
+							modifier = {
+								factor = 1.05
+								has_country_flag = SPR_metropol_parasol_project_political
+							}
+							country_event = { id = spain.247 random_days = 180 random_hours = 24 }
 						}
 
 					}
 				}
 				if = { limit = { check_variable = { global.year > 2016 } }
 					if = { limit = { NOT = { has_country_flag = SPR_sagrada_familia_complete_flag } }
-						random_list = {
-							30 = {
-								modifier = {
-									factor = 1.5
-									has_country_flag = SPR_sagra_familia_additional_funding_flag
-								}
-								country_event = { id = spain.254 random_days = 180 }
+						random = {
+							chance = 30
+							modifier = {
+								factor = 1.5
+								has_country_flag = SPR_sagra_familia_additional_funding_flag
 							}
-							70 = {}
+							country_event = { id = spain.254 random_days = 180 }
 						}
 
 					}

--- a/common/scripted_effects/99_ARM_scripted_effects.txt
+++ b/common/scripted_effects/99_ARM_scripted_effects.txt
@@ -851,10 +851,7 @@ ARM_chechen_battalions_script = {
 		create_unit = {
 			division = "name = \"Sheikh Mansur Battalion\" division_template = \"Chechen Battalion\" start_experience_factor = 1.0"
 			owner = CHE
-		}
-		create_unit = {
-			division = "name = \"Sheikh Mansur Battalion\" division_template = \"Chechen Battalion\" start_experience_factor = 1.0"
-			owner = CHE
+			count = 2
 		}
 	}
 }
@@ -2403,27 +2400,7 @@ ARM_cored_state_azer_revoult_script = {
 				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
 				prioritize_location = 7661
 				owner = AZE
-			}
-		}
-		713 = {
-			create_unit = {
-				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
-				prioritize_location = 7661
-				owner = AZE
-			}
-		}
-		713 = {
-			create_unit = {
-				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
-				prioritize_location = 7661
-				owner = AZE
-			}
-		}
-		713 = {
-			create_unit = {
-				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
-				prioritize_location = 7661
-				owner = AZE
+				count = 4
 			}
 		}
 	}
@@ -2450,27 +2427,7 @@ ARM_cored_state_kubanoid_revoult_script = {
 				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
 				prioritize_location = 7661
 				owner = KUB
-			}
-		}
-		668 = {
-			create_unit = {
-				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
-				prioritize_location = 7661
-				owner = KUB
-			}
-		}
-		668 = {
-			create_unit = {
-				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
-				prioritize_location = 7661
-				owner = KUB
-			}
-		}
-		668 = {
-			create_unit = {
-				division = "name = \"Rebel Battalion\" division_template = \"Rebel Battalion\" start_experience_factor = 0.1"
-				prioritize_location = 7661
-				owner = KUB
+				count = 4
 			}
 		}
 	}

--- a/common/scripted_effects/99_RAJ_scripted_effects.txt
+++ b/common/scripted_effects/99_RAJ_scripted_effects.txt
@@ -63,3 +63,59 @@ RAJ_change_hindu_opinion = {
 		clamp_variable = { var = RAJ_hindus_opinion min = 0 max = 100 }
 	}
 }
+
+RAJ_suppress_maoist_in_state = {
+	if = {
+		limit = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } }
+		remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency }
+		add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 }
+	}
+	else_if = {
+		limit = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } }
+		remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 }
+		add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 }
+	}
+	else_if = {
+		limit = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } }
+		remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 }
+		add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 }
+	}
+	else_if = {
+		limit = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } }
+		remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 }
+		add_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 }
+	}
+	else_if = {
+		limit = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } }
+		remove_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 }
+	}
+}
+
+RAJ_maoist_suppression_loot = {
+	random_list = {
+		20 = {
+			add_equipment_to_stockpile = {
+				type = infantry_weapons_2
+				amount = 1000
+				producer = SOV
+			}
+			country_event = RAJ_mao_reb.1
+		}
+		40 = {
+			add_equipment_to_stockpile = {
+				type = infantry_weapons_2
+				amount = 500
+				producer = SOV
+			}
+			country_event = RAJ_mao_reb.3
+		}
+		10 = {
+			add_equipment_to_stockpile = {
+				type = infantry_weapons_2
+				amount = 250
+				producer = SOV
+			}
+			country_event = RAJ_mao_reb.2
+		}
+	}
+}

--- a/common/scripted_effects/99_SOV_scripted_effects.txt
+++ b/common/scripted_effects/99_SOV_scripted_effects.txt
@@ -2218,8 +2218,6 @@ SOV_economy_cars_western_lose_script = {
 				type = industrial_complex
 				level = 1
 			}
-		}
-		644 = {
 			remove_building = {
 				type = industrial_complex
 				level = 2
@@ -2263,8 +2261,6 @@ SOV_economy_cars_western_lose_script = {
 				type = industrial_complex
 				level = 1
 			}
-		}
-		644 = {
 			remove_building = {
 				type = industrial_complex
 				level = 2
@@ -2310,8 +2306,6 @@ SOV_economy_cars_western_lose_script = {
 				type = industrial_complex
 				level = 1
 			}
-		}
-		644 = {
 			remove_building = {
 				type = industrial_complex
 				level = 2

--- a/common/scripted_effects/99_SubjectRussia_scripted_effects.txt
+++ b/common/scripted_effects/99_SubjectRussia_scripted_effects.txt
@@ -786,8 +786,7 @@ URA_ural_metro_expand = {
 		}
 		set_temp_variable = { treasury_change = -1.5 }
 		modify_treasury_effect = yes
-		676 = { remove_dynamic_modifier = { modifier = URA_metro_modifier } }
-		676 = { add_dynamic_modifier = { modifier = URA_metro1_modifier } }
+		676 = { remove_dynamic_modifier = { modifier = URA_metro_modifier } add_dynamic_modifier = { modifier = URA_metro1_modifier } }
 	}
 }
 ###########SUBJECTS OF RUSSIA - INTEGRATE RUSSIAN ECONOMIC###########
@@ -1527,8 +1526,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 8 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_8_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_9_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_8_level } add_dynamic_modifier = { modifier = MSC_city_9_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -25 }
 	}
@@ -1537,8 +1535,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 7 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_7_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_8_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_7_level } add_dynamic_modifier = { modifier = MSC_city_8_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -20 }
 	}
@@ -1547,8 +1544,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 6 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_6_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_7_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_6_level } add_dynamic_modifier = { modifier = MSC_city_7_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -20 }
 	}
@@ -1557,8 +1553,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 5 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_5_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_6_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_5_level } add_dynamic_modifier = { modifier = MSC_city_6_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -15 }
 	}
@@ -1567,8 +1562,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 4 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_4_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_5_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_4_level } add_dynamic_modifier = { modifier = MSC_city_5_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -15 }
 	}
@@ -1577,8 +1571,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 3 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_3_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_4_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_3_level } add_dynamic_modifier = { modifier = MSC_city_4_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -10 }
 	}
@@ -1587,8 +1580,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 2 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_2_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_3_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_2_level } add_dynamic_modifier = { modifier = MSC_city_3_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -10 }
 	}
@@ -1597,8 +1589,7 @@ SOV_moscow_build_script = {
 			NOT = { has_country_flag = SOV_moscow_no_more }
 			check_variable = { SUB_moscow_level = 1 }
 		}
-		652 = { remove_dynamic_modifier = { modifier = MSC_city_1_level } }
-		652 = { add_dynamic_modifier = { modifier = MSC_city_2_level } }
+		652 = { remove_dynamic_modifier = { modifier = MSC_city_1_level } add_dynamic_modifier = { modifier = MSC_city_2_level } }
 		add_to_variable = { SUB_moscow_level = 1 }
 		set_temp_variable = { treasury_change = -10 }
 	}
@@ -1611,8 +1602,7 @@ SOV_ekb_build_script = {
 			has_country_flag = SOV_moscow_no_more
 			check_variable = { SUB_ekb_level = 5 }
 		}
-		676 = { remove_dynamic_modifier = { modifier = EKB_city_5_level } }
-		676 = { add_dynamic_modifier = { modifier = EKB_city_6_level } }
+		676 = { remove_dynamic_modifier = { modifier = EKB_city_5_level } add_dynamic_modifier = { modifier = EKB_city_6_level } }
 		add_to_variable = { SUB_ekb_level = 1 }
 		set_temp_variable = { treasury_change = -15 }
 	}
@@ -1621,8 +1611,7 @@ SOV_ekb_build_script = {
 			has_country_flag = SOV_moscow_no_more
 			check_variable = { SUB_ekb_level = 4 }
 		}
-		676 = { remove_dynamic_modifier = { modifier = EKB_city_4_level } }
-		676 = { add_dynamic_modifier = { modifier = EKB_city_5_level } }
+		676 = { remove_dynamic_modifier = { modifier = EKB_city_4_level } add_dynamic_modifier = { modifier = EKB_city_5_level } }
 		add_to_variable = { SUB_ekb_level = 1 }
 		set_temp_variable = { treasury_change = -15 }
 	}
@@ -1631,8 +1620,7 @@ SOV_ekb_build_script = {
 			has_country_flag = SOV_moscow_no_more
 			check_variable = { SUB_ekb_level = 3 }
 		}
-		676 = { remove_dynamic_modifier = { modifier = EKB_city_3_level } }
-		676 = { add_dynamic_modifier = { modifier = EKB_city_4_level } }
+		676 = { remove_dynamic_modifier = { modifier = EKB_city_3_level } add_dynamic_modifier = { modifier = EKB_city_4_level } }
 		add_to_variable = { SUB_ekb_level = 1 }
 		set_temp_variable = { treasury_change = -15 }
 	}
@@ -1641,8 +1629,7 @@ SOV_ekb_build_script = {
 			has_country_flag = SOV_moscow_no_more
 			check_variable = { SUB_ekb_level = 2 }
 		}
-		676 = { remove_dynamic_modifier = { modifier = EKB_city_2_level } }
-		676 = { add_dynamic_modifier = { modifier = EKB_city_3_level } }
+		676 = { remove_dynamic_modifier = { modifier = EKB_city_2_level } add_dynamic_modifier = { modifier = EKB_city_3_level } }
 		add_to_variable = { SUB_ekb_level = 1 }
 		set_temp_variable = { treasury_change = -10 }
 	}
@@ -1651,8 +1638,7 @@ SOV_ekb_build_script = {
 			has_country_flag = SOV_moscow_no_more
 			check_variable = { SUB_ekb_level = 1 }
 		}
-		676 = { remove_dynamic_modifier = { modifier = EKB_city_1_level } }
-		676 = { add_dynamic_modifier = { modifier = EKB_city_2_level } }
+		676 = { remove_dynamic_modifier = { modifier = EKB_city_1_level } add_dynamic_modifier = { modifier = EKB_city_2_level } }
 		add_to_variable = { SUB_ekb_level = 1 }
 		set_temp_variable = { treasury_change = -10 }
 	}

--- a/common/scripted_effects/99_TAJ_scripted_effects.txt
+++ b/common/scripted_effects/99_TAJ_scripted_effects.txt
@@ -1,3 +1,69 @@
+TAJ_check_radicalism_attacks = {
+	if = { #Intense attacks
+		limit = {
+			check_variable = {
+				TAJ_radical_influence > 74
+			}
+		}
+		random_list = {
+			25 = {
+				country_event = tajik_radicalism.2
+			}
+			25 = {
+				country_event = tajik_radicalism.3
+			}
+			25 = {
+				country_event = tajik_radicalism.4
+			}
+			25 = {
+				country_event = tajik_radicalism.5
+			}
+		}
+	}
+	else_if = { #Moderate attacks
+		limit = {
+			check_variable = {
+				TAJ_radical_influence > 49
+			}
+		}
+		random_list = {
+			25 = {
+				country_event = tajik_radicalism.6
+			}
+			25 = {
+				country_event = tajik_radicalism.7
+			}
+			25 = {
+				country_event = tajik_radicalism.8
+			}
+			25 = {
+				country_event = tajik_radicalism.9
+			}
+		}
+	}
+	else_if = { #Light attacks
+		limit = {
+			check_variable = {
+				TAJ_radical_influence > 15
+			}
+		}
+		random_list = {
+			25 = {
+				country_event = tajik_radicalism.10
+			}
+			25 = {
+				country_event = tajik_radicalism.11
+			}
+			25 = {
+				country_event = tajik_radicalism.12
+			}
+			25 = {
+				country_event = tajik_radicalism.14
+			}
+		}
+	}
+}
+
 TAJ_check_radicalism = {
 	if = {
 		limit = {
@@ -10,79 +76,17 @@ TAJ_check_radicalism = {
 			days = 2
 		}
 	}
-	random_list = {
-		50 = {
-			modifier = {
-				check_variable = {
-					TAJ_radical_influence > 50
-				}
-				factor = 1.25
-			}
-			if = { #Intense attacks
-				limit = {
-					check_variable = {
-						TAJ_radical_influence > 74
-					}
-				}
-				random_list = {
-					25 = {
-						country_event = tajik_radicalism.2
-					}
-					25 = {
-						country_event = tajik_radicalism.3
-					}
-					25 = {
-						country_event = tajik_radicalism.4
-					}
-					25 = {
-						country_event = tajik_radicalism.5
-					}
-				}
-			}
-			else_if = { #Moderate attacks
-				limit = {
-					check_variable = {
-						TAJ_radical_influence > 49
-					}
-				}
-				random_list = {
-					25 = {
-						country_event = tajik_radicalism.6
-					}
-					25 = {
-						country_event = tajik_radicalism.7
-					}
-					25 = {
-						country_event = tajik_radicalism.8
-					}
-					25 = {
-						country_event = tajik_radicalism.9
-					}
-				}
-			}
-			else_if = { #Light attacks
-				limit = {
-					check_variable = {
-						TAJ_radical_influence > 15
-					}
-				}
-				random_list = {
-					25 = {
-						country_event = tajik_radicalism.10
-					}
-					25 = {
-						country_event = tajik_radicalism.11
-					}
-					25 = {
-						country_event = tajik_radicalism.12
-					}
-					25 = {
-						country_event = tajik_radicalism.14
-					}
-				}
-			}
+	if = {
+		limit = { check_variable = { TAJ_radical_influence > 50 } }
+		random = {
+			chance = 56
+			TAJ_check_radicalism_attacks = yes
 		}
-		50 = {
+	}
+	else = {
+		random = {
+			chance = 50
+			TAJ_check_radicalism_attacks = yes
 		}
 	}
 

--- a/common/scripted_effects/99_operation_strat_effects.txt
+++ b/common/scripted_effects/99_operation_strat_effects.txt
@@ -123,10 +123,8 @@ update_operation_ai = {
 					add_to_temp_array = { operation_types = token:operation_infiltrate_armed_forces_navy }
 					add_to_temp_array = { operation_types_scores = score }
 				}
-			}
 
-			# get token for boost resistance
-			var:generic_operation_target = {
+				# get token for boost resistance
 				# only do on fascist
 				if = {
 					limit = {
@@ -160,6 +158,7 @@ update_operation_ai = {
 					add_to_temp_array = { operation_types_scores = score }
 				}
 			}
+
 			# boost resistance
 			if = {
 				limit = {

--- a/tools/validation/validate_simplifications.py
+++ b/tools/validation/validate_simplifications.py
@@ -351,6 +351,7 @@ class Validator(BaseValidator):
     STAGED_EXTENSIONS = [".txt"]
 
     def run_validations(self):
+        self._log_section("Scanning for simplification opportunities...")
         # parse_files_cached reads case-preserving + comment-stripped and
         # content-caches each file's findings, so a warm run only re-scans
         # changed files.
@@ -359,6 +360,7 @@ class Validator(BaseValidator):
         )
         self.log(f"Scanned {len(parsed)} files for simplification opportunities")
 
+        self._log_section("Collecting and reporting results...")
         results = []
         for path, findings in parsed.items():
             rel = os.path.relpath(path, self.mod_path)


### PR DESCRIPTION
## Summary

Scope-simplification pass plus a few bug fixes carried over from the Korwin/EH work.

**Scope simplification (validator-driven cleanup)**
- Collapsed India's ~730 lines of repeated per-state Naxalite suppression into a single state-scoped `RAJ_suppress_maoist_in_state` scripted effect.
- Removed redundant scope expansions and duplicated `if/else_if` blocks across decisions (Iran, Israel, Poland, Serbia, Tajikistan, Turkey, United Arab Republic), focus trees (Afghanistan, Cuba, Transnistria, Crimea, Iraq, Tajikistan), and scripted effects (ARM, EH, POL, SOV, SubjectRussia, TAJ, operation_strat, yearly).
- `validate_simplifications.py`: added progress logging for the scan/report phases.

**Bug fixes**
- [POL] Polish-Ukrainian War national spirit now clears when the war with Ukraine ends instead of staying permanently. (Issue #1755)
- [POL] "Janusz Korwin-Mikke Thrown Out of Power" event no longer fires unless Poland has the active Korwin balance of power. (Issue #1755)
- [POL] Reduced the Korwin balance-of-power decision cost from 55 to 35 PP after he wins with Wałęsa.
- [EH] Fixed the convergence event chain firing inside a stray `random_country` scope so the news events dispatch correctly.

Closes #1755
