### PR TITLE
French Small Vessels

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -800,6 +800,7 @@ v2.0.0
   - [PER] Added 'NOHED' brigade to Iran's OOB
 
  Database:
+  - [FRA] Added Tripartite and P400 class ships to start date, given to their operating countries FRA, BEL, HOL with historical vessel names.
   - Land drone technologies now properly give the Ranger Light Recce company recon bonuses like all other recon units
   - Updated the Ukraine OOB to be more historically accurate including the additions of GLCMs, variants that were produced in Ukraine etc
   - China now starts with the "Microprocessor" tech

--- a/docs/src/content/misc/authors.md
+++ b/docs/src/content/misc/authors.md
@@ -185,6 +185,7 @@ The following page is a non-exhaustive list of contributors from over the years 
 | Ebby                 | -                               | -              | -             | -                             |
 | Raun139              | -                               | @Raun139       | -             | -                             |
 | Karandash1984        | @karandash1984                  | @Karandash1984 | -             | -                             |
+| Natin                | @nothing4182                    | @NothingMD     | -             | -                             |
 
 # Fellow Modders/Teams
 

--- a/history/countries/FRA - France.txt
+++ b/history/countries/FRA - France.txt
@@ -2106,6 +2106,44 @@ capital = 56
 			icon = "gfx/interface/technologies/FRA/NAV/K1.dds"
 			obsolete = yes
 		}
+		#P400 Class
+		create_equipment_variant = {
+			name = "P400 Class"
+			type = corvette_hull_2
+			#name_group = FRA_DD_HISTORICAL
+			parent_version = 0
+			role_icon_index = 1
+			modules = {
+				fixed_ship_battery_slot=module_76mm_gun_1
+				fixed_ship_radar_slot=module_radar_2
+				fixed_ship_auxillary_slot = empty
+				fixed_ship_fire_control_system_slot=module_digital_integrated_fire_control
+				fixed_ship_engine_slot=module_light_surface_diesel_power_1
+				front_1_custom_slot = empty
+				rear_1_custom_slot=module_chain_gun
+			}
+			icon = "gfx/interface/technologies/FRA/NAV/K2.dds"
+			obsolete = yes
+		}
+		#Tripartite Class
+		create_equipment_variant = {
+			name = "Tripartite Class"
+			type = corvette_hull_1
+			#name_group = FRA_DD_HISTORICAL
+			parent_version = 0
+			role_icon_index = 1
+			modules = {
+				fixed_ship_battery_slot=module_chain_gun
+				fixed_ship_auxillary_slot=module_mineclearing
+				fixed_ship_radar_slot=module_sonar_2
+				fixed_ship_fire_control_system_slot=module_analog_fire_control
+				fixed_ship_engine_slot=module_light_surface_diesel_power_1
+				front_1_custom_slot = empty
+				rear_1_custom_slot=module_minelaying
+			}
+			icon = "gfx/interface/technologies/FRA/NAV/K1.dds"
+			obsolete = yes
+		}
 		#D'Estienne d'Ovres Class
 		create_equipment_variant = {
 			name = "D'Estienne d'Orves Class"

--- a/history/units/BEL_2000_naval_mtg.txt
+++ b/history/units/BEL_2000_naval_mtg.txt
@@ -10,6 +10,14 @@
 			ship = { name = "Wielingen (F910)" definition = frigate start_experience_factor = 0.60 equipment = { frigate_hull_2 = { amount = 1 owner = BEL version_name = "Wielingen Class" } } }
 			ship = { name = "Westdiep (F912)" definition = frigate start_experience_factor = 0.60 equipment = { frigate_hull_2 = { amount = 1 owner = BEL version_name = "Wielingen Class" } } }
 			ship = { name = "Wandelaar (F913)" definition = frigate start_experience_factor = 0.60 equipment = { frigate_hull_2 = { amount = 1 owner = BEL version_name = "Wielingen Class" } } }
+
+			ship = { name = "Aster (M915)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Bellis (M916)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Crocus (M917)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Lobelia (M921)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Myosotis (M922)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Narcis (M923)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Primula (M924)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
 		}
 	}
 }

--- a/history/units/FRA_2000_naval_mtg.txt
+++ b/history/units/FRA_2000_naval_mtg.txt
@@ -84,6 +84,8 @@
 			location = 13017
 			ship = { name = "Floréal (F730)" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
 			ship = { name = "Nivôse (F732)" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
+			ship = { name = "La Boudeuse (P683)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+			ship = { name = "La Rieuse (P690)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
 		}
 	}
 	fleet = {
@@ -93,6 +95,8 @@
 			name = "Zone maritime - Polynésie"
 			location = 12148
 			ship = { name = "Prairial (F731)" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
+			ship = { name = "La Glorieuse (P686)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+			ship = { name = "La Moqueuse (P688)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
 		}
 	}
 	fleet = {
@@ -101,8 +105,10 @@
 		task_force = {
 			name = "Zone maritime - Caraïbes"
 			location = 177
-			ship = { name = "Ventôse (F733" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
+			ship = { name = "Ventôse (F733)" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
 			ship = { name = "Germinal (F735)" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
+			ship = { name = "L'Audacieuse (P682)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+			ship = { name = "La Capricieuse (P684)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
 		}
 	}
 	fleet = {
@@ -112,6 +118,31 @@
 			name = "Zone maritime - Pacifique"
 			location = 12132
 			ship = { name = "Vendémiaire (F734)" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = FRA version_name = "Floréal Class" } } }
+			ship = { name = "La Fougueuse (P685)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+			ship = { name = "La Gracieuse (P687)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+			ship = { name = "La Railleuse (P689)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+			ship = { name = "La Tapageuse (P691)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "P400 Class" } } }
+		}
+	}
+	fleet = {
+		name = "Force réserve"
+		naval_base = 911 	#Toulon
+		task_force = {
+			name = "Chasseur de mines"
+			location = 911
+			ship = { name = "Éridan (M641)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Cassiopée (M642)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Andromède (M643)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Pégase (M644)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Orion (M645)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Croix du Sud (M646)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Aigle (M647)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Lyre (M648)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Persée (M649)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Sagittaire (M650)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Verseau (M651)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Céphée (M652)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Capricorne (M652)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
 		}
 	}
 }

--- a/history/units/HOL_2000_naval_mtg.txt
+++ b/history/units/HOL_2000_naval_mtg.txt
@@ -26,6 +26,22 @@
 			ship = { name = "HNLMS Bloys van Treslong" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = HOL version_name = "Kortenaer Class" } } }
 			ship = { name = "HNLMS Jan van Brakel" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = HOL version_name = "Kortenaer Class" } } }
 			ship = { name = "HNLMS Pieter Florisse" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = HOL version_name = "Kortenaer Class" } } }
+
+			ship = { name = "Alkmaar (M850)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Delfzijl (M851)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Dordrecht (M852)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Haarlem (M853)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Harlingen (M854)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Scheveningen (M855)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Maassluis (M856)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Makkum (M857)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Middelburg (M858)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Hellevoetsluis (M859)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Schiedam (M860)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Urk (M861)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Zierikzee (M862)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Vlaardingen (M863)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+			ship = { name = "Willemstad (M864)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
 		}
 	}
 }


### PR DESCRIPTION
In MD France has a major lack of small vessels, to the point of having more destroyers than corvettes, which is not representative of the reality. I have added the P400 Class and Tripartite Class ships to the game, with P400 Class ships assigned to their historical operation zones (fleets in correct regions and ship names). Also added the Tripartite Class ships to Belgium and Netherlands as the other operators of the ship class at the time (year 2000).

_Also fixed a tiny typo in ship names_