### PR TITLE
Fix dev diary 057 image paths

### DIFF
--- a/docs/src/content/devDiaries/057-geenland-holiday-paradise.mdx
+++ b/docs/src/content/devDiaries/057-geenland-holiday-paradise.mdx
@@ -53,15 +53,15 @@ the new Self Government Act. The small tree at the center bottom is the
 independence tree. Whether you or Denmark chooses peace or violence will determine
 your path of completion.
 
-![picture1](assets/images/dev-diaries/057/picture-1.png)
+![picture1](/assets/images/dev-diaries/057/picture-1.png)
 
 The next pictures in order are the economic tree and political trees which will
 allow you to lead the nation and develop its economy and politics around what you
 feel can make best the ambitions you wish to hold dear.
 
-![picture2](assets/images/dev-diaries/057/picture-2.png)
+![picture2](/assets/images/dev-diaries/057/picture-2.png)
 
-![picture3](assets/images/dev-diaries/057/picture-3.png)
+![picture3](/assets/images/dev-diaries/057/picture-3.png)
 
 Following this we have the military tree and Great Ice Shelf tree. The military is
 non-existent and as such you will need to fundamentally build from scratch your
@@ -69,7 +69,7 @@ armed forces, their officer corps and of course your equipment designs. But don�
 worry, we found a couple boxes of scrap in a glacier so I’m sure we’ll be able to
 build something now.
 
-![picture4](assets/images/dev-diaries/057/picture-4.png)
+![picture4](/assets/images/dev-diaries/057/picture-4.png)
 
 Moving to the GIS tree, this is the magnum opus and the biggest hurdle to
 achieving the bliss of Greenland. There’s land under all that ice and as such
@@ -77,7 +77,7 @@ you’ll need to invest massive amounts of money to make settlements, logistical
 networks and build the economy. Do all that and you just might find out what’s
 beneath the ice after all.
 
-![picture5](assets/images/dev-diaries/057/picture-5.png)
+![picture5](/assets/images/dev-diaries/057/picture-5.png)
 
 Finally we have the foreign policy tree, with the main conclusion being the
 formation of a Nordic United Nation ... .but if you want a little more you also
@@ -85,7 +85,7 @@ have the option as well. Where will your ambitions take you after all, for
 Scandinavia is one thing but what if you could form a European Federation,
 mayhaps some may say a Frozen Federation of the continent.
 
-![picture6](assets/images/dev-diaries/057/picture-6.png)
+![picture6](/assets/images/dev-diaries/057/picture-6.png)
 
 ## Decisions and Policies
 


### PR DESCRIPTION
All six image references in `057-geenland-holiday-paradise.mdx` were missing the leading `/`, so Rollup treated them as relative module imports and failed the Astro build.

Changed `assets/images/...` → `/assets/images/...` to match every other dev diary file.

Fixes the GitHub Pages build broken by #1783.