### PR TITLE
Further Naval Vessels

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -800,7 +800,7 @@ v2.0.0
   - [PER] Added 'NOHED' brigade to Iran's OOB
 
  Database:
-  - [FRA] Added Tripartite and P400 class ships to start date, given to their operating countries FRA, BEL, HOL with historical vessel names.
+  - [FRA] Added Tripartite, Flamant, Lapérouse and P400 class ships to start date, given to their operating countries FRA, BEL, HOL with historical vessel names.
   - Land drone technologies now properly give the Ranger Light Recce company recon bonuses like all other recon units
   - Updated the Ukraine OOB to be more historically accurate including the additions of GLCMs, variants that were produced in Ukraine etc
   - China now starts with the "Microprocessor" tech

--- a/docs/src/content/misc/authors.md
+++ b/docs/src/content/misc/authors.md
@@ -187,6 +187,7 @@ The following page is a non-exhaustive list of contributors from over the years 
 | Raun139              | -                               | @Raun139       | -             | -                             |
 | Karandash1984        | @karandash1984                  | @Karandash1984 | -             | -                             |
 | Natin                | @nothing4182                    | @NothingMD     | -             | -                             |
+| Ironfury             | -                               | -              | -             | -                             |
 
 # Fellow Modders/Teams
 

--- a/history/countries/FRA - France.txt
+++ b/history/countries/FRA - France.txt
@@ -2144,6 +2144,43 @@ capital = 56
 			icon = "gfx/interface/technologies/FRA/NAV/K1.dds"
 			obsolete = yes
 		}
+		#Lapérouse class
+		create_equipment_variant = {
+			name = "Lapérouse Class"
+			type = corvette_hull_2
+			#name_group = FRA_DD_HISTORICAL
+			parent_version = 0
+			role_icon_index = 1
+			modules = {
+				fixed_ship_battery_slot=module_chain_gun
+				fixed_ship_radar_slot=module_sonar_3
+				fixed_ship_auxillary_slot = module_mineclearing
+				fixed_ship_fire_control_system_slot=module_analog_fire_control
+				fixed_ship_engine_slot=module_light_surface_diesel_power_1
+				front_1_custom_slot = empty
+				rear_1_custom_slot = empty
+			}
+			icon = "gfx/interface/technologies/FRA/NAV/K2.dds"
+			obsolete = yes
+		}
+		#Flamant Class
+		create_equipment_variant = {
+			name = "Flamant Class"
+			type = corvette_hull_3
+			#name_group = FRA_DD_HISTORICAL
+			parent_version = 0
+			role_icon_index = 1
+			modules = {
+				fixed_ship_battery_slot=module_chain_gun
+				fixed_ship_auxillary_slot=empty
+				fixed_ship_radar_slot=module_radar_3
+				fixed_ship_fire_control_system_slot=module_analog_fire_control
+				fixed_ship_engine_slot=module_light_surface_diesel_power_1
+				front_1_custom_slot = empty
+				rear_1_custom_slot= empty
+			}
+			icon = "gfx/interface/technologies/ENG/NAV/K4.dds"
+		}
 		#D'Estienne d'Ovres Class
 		create_equipment_variant = {
 			name = "D'Estienne d'Orves Class"

--- a/history/units/FRA_2000_naval_mtg.txt
+++ b/history/units/FRA_2000_naval_mtg.txt
@@ -152,7 +152,7 @@
 			location = 3552
 			ship = { name = "Lapérouse (A791)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
 			ship = { name = "Borda (A792)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
-			ship = { name = "Thetis (785)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
+			ship = { name = "Thetis (A785)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
 			ship = { name = "Laplace (A793)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
 			ship = { name = "Arago (A794)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
 		}

--- a/history/units/FRA_2000_naval_mtg.txt
+++ b/history/units/FRA_2000_naval_mtg.txt
@@ -21,6 +21,9 @@
 			ship = { name = "Siroco (L9012)" definition = helicopter_operator start_experience_factor = 0.65 equipment = { helicopter_operator_hull_2 = { amount = 1 owner = FRA version_name = "Foudre Class" } } }
 			ship = { name = "Ouragan (L9021)" definition = helicopter_operator start_experience_factor = 0.65 equipment = { helicopter_operator_hull_1 = { amount = 1 owner = FRA version_name = "Ouragan Class" } } }
 			ship = { name = "Orage (L9022)" definition = helicopter_operator start_experience_factor = 0.65 equipment = { helicopter_operator_hull_1 = { amount = 1 owner = FRA version_name = "Ouragan Class" } } }
+			ship = { name = "Flamant (P676)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_3 = { amount = 1 owner = FRA version_name = "Flamant Class" } } }
+			ship = { name = "Cormoran (P677)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_3 = { amount = 1 owner = FRA version_name = "Flamant Class" } } }
+			ship = { name = "Pluvier (P678)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_3 = { amount = 1 owner = FRA version_name = "Flamant Class" } } }
 		}
 	task_force = {
 			name = "Groupe Aéronaval"
@@ -143,6 +146,15 @@
 			ship = { name = "Verseau (M651)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
 			ship = { name = "Céphée (M652)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
 			ship = { name = "Capricorne (M652)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_1 = { amount = 1 owner = FRA version_name = "Tripartite Class" } } }
+		}
+		task_force = {
+			name = "Bâtiment Hydrographique"
+			location = 3552
+			ship = { name = "Lapérouse (A791)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
+			ship = { name = "Borda (A792)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
+			ship = { name = "Thetis (785)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
+			ship = { name = "Laplace (A793)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
+			ship = { name = "Arago (A794)" definition = corvette start_experience_factor = 0.65 equipment = { corvette_hull_2 = { amount = 1 owner = FRA version_name = "Lapérouse Class" } } }
 		}
 	}
 }


### PR DESCRIPTION
This update adds the Lapérouse class Naval Survey and Mine Countermeasures as well as the Flamant Class OPV Search&Rescue ships, Flamant Class assigned to escort Amphibie Fleet while Laperouse are in Naval Survey Subfleet under Reserve Forces at Port of Brest.

Realistically Neither of these vessel classes are fit for peer to peer combat, but are designed to be capable of anti-piracy, patrol and mine clearing (Lapérouse ) or search and rescue (Flamant). 

One Lapérouse Class ship IRL has been refitted to be a naval patrol vessel instead of survey in mid 2000s but has not been reflected here as it is year 2000 January