### PR TITLE
Migrate party popularity to add_relative_party_popularity (cross-country)

### DIFF
--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -598,8 +598,10 @@ EGY_coptic_decision = {
 			custom_effect_tooltip = EGY_copt_coalition_create
 			hidden_effect = {
 				add_to_array = { gov_coalition_array = 13 }
-				subtract_from_variable = { party_pop_array^13 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 13 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
 				update_government_coalition_strength = yes
 				set_coalition_drift = yes
 			}

--- a/common/decisions/Belarus.txt
+++ b/common/decisions/Belarus.txt
@@ -336,12 +336,10 @@ BLR_baltic_revolution_category = {
 			set_temp_variable = { influence_target = LIT }
 			change_influence_percentage = yes
 			LIT = {
-				add_to_variable = { party_pop_array^4 = 0.05 }
-				recalculate_party = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.05
-				}
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
+				add_relative_party_popularity = yes
 				add_stability = -0.01
 				country_event = { id = belarus_LTB.3 days = 3 }
 			}
@@ -575,12 +573,10 @@ BLR_baltic_revolution_category = {
 			set_temp_variable = { influence_target = LAT }
 			change_influence_percentage = yes
 			LAT = {
-				add_to_variable = { party_pop_array^4 = 0.05 }
-				recalculate_party = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.05
-				}
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
+				add_relative_party_popularity = yes
 				add_stability = -0.01
 				country_event = { id = belarus_LTB.3 days = 3 }
 			}
@@ -983,6 +979,7 @@ BLR_Lukashenko_category = {
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
+			add_relative_party_popularity = yes
 		}
 		ai_will_do = {
 			base = 20

--- a/common/decisions/Belarus.txt
+++ b/common/decisions/Belarus.txt
@@ -280,11 +280,8 @@ BLR_baltic_revolution_category = {
 			LIT = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.02 }
+				set_temp_variable = { temp_outlook_increase = 0.02 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.02
-				}
 			}
 		}
 		complete_effect = {
@@ -310,11 +307,8 @@ BLR_baltic_revolution_category = {
 			LIT = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.03 }
+				set_temp_variable = { temp_outlook_increase = 0.03 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.03
-				}
 				country_event = { id = belarus_LTB.2 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -525,11 +519,8 @@ BLR_baltic_revolution_category = {
 			LAT = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.02 }
+				set_temp_variable = { temp_outlook_increase = 0.02 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.02
-				}
 			}
 		}
 		complete_effect = {
@@ -555,11 +546,8 @@ BLR_baltic_revolution_category = {
 			LAT = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.03 }
+				set_temp_variable = { temp_outlook_increase = 0.03 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.03
-				}
 				country_event = { id = belarus_LTB.2 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -836,11 +824,8 @@ BLR_pol_revol_category = {
 			POL = {
 				set_temp_variable = { party_index = 20 }
 				set_temp_variable = { party_popularity_increase = 0.03 }
+				set_temp_variable = { temp_outlook_increase = 0.03 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = nationalist
-					popularity = 0.03
-				}
 				add_stability = -0.04
 			}
 		}
@@ -876,11 +861,8 @@ BLR_pol_revol_category = {
 			POL = {
 				set_temp_variable = { party_index = 20 }
 				set_temp_variable = { party_popularity_increase = 0.08 }
+				set_temp_variable = { temp_outlook_increase = 0.08 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = nationalist
-					popularity = 0.08
-				}
 			}
 		}
 		complete_effect = {

--- a/common/decisions/Belarus.txt
+++ b/common/decisions/Belarus.txt
@@ -278,8 +278,9 @@ BLR_baltic_revolution_category = {
 			set_temp_variable = { influence_target = LIT }
 			change_influence_percentage = yes
 			LIT = {
-				add_to_variable = { party_pop_array^4 = 0.02 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.02 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.02
@@ -307,8 +308,9 @@ BLR_baltic_revolution_category = {
 			set_temp_variable = { influence_target = LIT }
 			change_influence_percentage = yes
 			LIT = {
-				add_to_variable = { party_pop_array^4 = 0.03 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.03 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.03
@@ -521,8 +523,9 @@ BLR_baltic_revolution_category = {
 			set_temp_variable = { influence_target = LAT }
 			change_influence_percentage = yes
 			LAT = {
-				add_to_variable = { party_pop_array^4 = 0.02 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.02 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.02
@@ -550,8 +553,9 @@ BLR_baltic_revolution_category = {
 			set_temp_variable = { influence_target = LAT }
 			change_influence_percentage = yes
 			LAT = {
-				add_to_variable = { party_pop_array^4 = 0.03 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.03 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.03
@@ -830,8 +834,9 @@ BLR_pol_revol_category = {
 			set_temp_variable = { influence_target = POL }
 			change_influence_percentage = yes
 			POL = {
-				add_to_variable = { party_pop_array^20 = 0.03 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.03 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = nationalist
 					popularity = 0.03
@@ -869,8 +874,9 @@ BLR_pol_revol_category = {
 			set_temp_variable = { influence_target = POL }
 			change_influence_percentage = yes
 			POL = {
-				add_to_variable = { party_pop_array^20 = 0.08 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.08 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = nationalist
 					popularity = 0.08

--- a/common/decisions/Chechnya.txt
+++ b/common/decisions/Chechnya.txt
@@ -154,8 +154,9 @@ CHE_caucasian_revol_category = {
 						ideology = neutrality
 						popularity = 0.03
 					}
-					add_to_variable = { party_pop_array^19 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 19 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 			}
 		}
@@ -333,8 +334,9 @@ CHE_caucasian_revol_category = {
 					ideology = neutrality
 					popularity = 0.35
 				}
-				add_to_variable = { party_pop_array^19 = 0.5 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 19 }
+				set_temp_variable = { party_popularity_increase = 0.5 }
+				add_relative_party_popularity = yes
 				start_civil_war = {
 					ideology = democratic
 					size = 0.3
@@ -547,8 +549,9 @@ CHE_caucasian_revol_category = {
 					ideology = neutrality
 					popularity = 0.35
 				}
-				add_to_variable = { party_pop_array^4 = 0.5 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.5 }
+				add_relative_party_popularity = yes
 				start_civil_war = {
 					ideology = democratic
 					size = 0.3
@@ -761,8 +764,9 @@ CHE_caucasian_revol_category = {
 					ideology = neutrality
 					popularity = 0.35
 				}
-				add_to_variable = { party_pop_array^4 = 0.5 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.5 }
+				add_relative_party_popularity = yes
 				start_civil_war = {
 					ideology = democratic
 					size = 0.3
@@ -802,8 +806,9 @@ CHE_caucasians_revol_category = {
 						ideology = communism
 						popularity = 0.03
 					}
-					add_to_variable = { party_pop_array^4 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 4 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 			}
 		}

--- a/common/decisions/Chechnya.txt
+++ b/common/decisions/Chechnya.txt
@@ -150,12 +150,9 @@ CHE_caucasian_revol_category = {
 			set_country_flag = Establish_connections_aze_kom
 			AZE = {
 				hidden_effect = {
-					add_popularity = {
-						ideology = neutrality
-						popularity = 0.03
-					}
 					set_temp_variable = { party_index = 19 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
+					set_temp_variable = { temp_outlook_increase = 0.03 }
 					add_relative_party_popularity = yes
 				}
 			}
@@ -330,12 +327,9 @@ CHE_caucasian_revol_category = {
 				}
 				change_ruling_party_effect = yes
 
-				add_popularity = {
-					ideology = neutrality
-					popularity = 0.35
-				}
 				set_temp_variable = { party_index = 19 }
 				set_temp_variable = { party_popularity_increase = 0.5 }
+				set_temp_variable = { temp_outlook_increase = 0.35 }
 				add_relative_party_popularity = yes
 				start_civil_war = {
 					ideology = democratic
@@ -545,12 +539,9 @@ CHE_caucasian_revol_category = {
 				}
 				change_ruling_party_effect = yes
 
-				add_popularity = {
-					ideology = neutrality
-					popularity = 0.35
-				}
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.5 }
+				set_temp_variable = { temp_outlook_increase = 0.35 }
 				add_relative_party_popularity = yes
 				start_civil_war = {
 					ideology = democratic
@@ -760,12 +751,9 @@ CHE_caucasian_revol_category = {
 				}
 				change_ruling_party_effect = yes
 
-				add_popularity = {
-					ideology = neutrality
-					popularity = 0.35
-				}
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.5 }
+				set_temp_variable = { temp_outlook_increase = 0.35 }
 				add_relative_party_popularity = yes
 				start_civil_war = {
 					ideology = democratic
@@ -802,12 +790,9 @@ CHE_caucasians_revol_category = {
 			set_country_flag = Establish_connections_aze_com
 			AZE = {
 				hidden_effect = {
-					add_popularity = {
-						ideology = communism
-						popularity = 0.03
-					}
 					set_temp_variable = { party_index = 4 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
+					set_temp_variable = { temp_outlook_increase = 0.03 }
 					add_relative_party_popularity = yes
 				}
 			}

--- a/common/decisions/EU_POTEF_decisions.txt
+++ b/common/decisions/EU_POTEF_decisions.txt
@@ -619,8 +619,11 @@ EU_office_category = {
 								}
 							}
 						}
-						add_to_variable = { FROM.party_pop_array^var_gov_index = 0.05 }
-						recalculate_party = yes
+						FROM = {
+							set_temp_variable = { party_index = PREV.var_gov_index }
+							set_temp_variable = { party_popularity_increase = 0.05 }
+							add_relative_party_popularity = yes
+						}
 						for_each_scope_loop = {
 							array = global.EU_member
 							tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN

--- a/common/decisions/EU_POTEF_decisions.txt
+++ b/common/decisions/EU_POTEF_decisions.txt
@@ -574,54 +574,10 @@ EU_office_category = {
 							add = -1
 							check_variable = { FROM.eurosceptic > 0.20 }
 						}
-						if = {
-							limit = { has_government = democratic }
-							FROM = {
-								add_popularity = {
-									ideology = democratic
-									popularity = 0.05
-								}
-							}
-						}
-						else_if = {
-							limit = { has_government = communism }
-							FROM = {
-								add_popularity = {
-									ideology = communism
-									popularity = 0.05
-								}
-							}
-						}
-						else_if = {
-							limit = { has_government = fascism }
-							FROM = {
-								add_popularity = {
-									ideology = fascism
-									popularity = 0.05
-								}
-							}
-						}
-						else_if = {
-							limit = { has_government = neutrality }
-							FROM = {
-								add_popularity = {
-									ideology = neutrality
-									popularity = 0.05
-								}
-							}
-						}
-						else_if = {
-							limit = { has_government = nationalist }
-							FROM = {
-								add_popularity = {
-									ideology = nationalist
-									popularity = 0.05
-								}
-							}
-						}
 						FROM = {
 							set_temp_variable = { party_index = PREV.var_gov_index }
 							set_temp_variable = { party_popularity_increase = 0.05 }
+							set_temp_variable = { temp_outlook_increase = 0.05 }
 							add_relative_party_popularity = yes
 						}
 						for_each_scope_loop = {

--- a/common/decisions/Russia.txt
+++ b/common/decisions/Russia.txt
@@ -2498,11 +2498,8 @@ SOV_mvd_category = {
 			CZE = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.04 }
+				set_temp_variable = { temp_outlook_increase = 0.09 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.09
-				}
 			}
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = SOV }

--- a/common/decisions/Russia.txt
+++ b/common/decisions/Russia.txt
@@ -2496,8 +2496,9 @@ SOV_mvd_category = {
 			set_temp_variable = { influence_target = CZE }
 			change_influence_percentage = yes
 			CZE = {
-				add_to_variable = { party_pop_array^4 = 0.04 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.04 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.09

--- a/common/decisions/South_Ossetia.txt
+++ b/common/decisions/South_Ossetia.txt
@@ -95,11 +95,8 @@ SOO_revoult_south_caucas = {
 			AZE = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.04 }
+				set_temp_variable = { temp_outlook_increase = 0.04 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.04
-				}
 			}
 		}
 		ai_will_do = {
@@ -216,11 +213,8 @@ SOO_revoult_south_caucas = {
 			AZE = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.05
-				}
 			}
 		}
 		ai_will_do = {
@@ -328,11 +322,8 @@ SOO_revoult_south_caucas = {
 			GEO = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.04 }
+				set_temp_variable = { temp_outlook_increase = 0.04 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.04
-				}
 			}
 		}
 		ai_will_do = {
@@ -449,11 +440,8 @@ SOO_revoult_south_caucas = {
 			GEO = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.05
-				}
 			}
 		}
 		ai_will_do = {
@@ -561,11 +549,8 @@ SOO_revoult_south_caucas = {
 			ABK = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.04 }
+				set_temp_variable = { temp_outlook_increase = 0.04 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.04
-				}
 			}
 		}
 		ai_will_do = {
@@ -682,11 +667,8 @@ SOO_revoult_south_caucas = {
 			ABK = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.05
-				}
 			}
 		}
 		ai_will_do = {
@@ -794,11 +776,8 @@ SOO_revoult_south_caucas = {
 			ARM = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.04 }
+				set_temp_variable = { temp_outlook_increase = 0.04 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.04
-				}
 			}
 		}
 		ai_will_do = {
@@ -915,11 +894,8 @@ SOO_revoult_south_caucas = {
 			ARM = {
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
-				add_popularity = {
-					ideology = communism
-					popularity = 0.05
-				}
 			}
 		}
 		ai_will_do = {

--- a/common/decisions/South_Ossetia.txt
+++ b/common/decisions/South_Ossetia.txt
@@ -93,8 +93,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = AZE }
 			change_influence_percentage = yes
 			AZE = {
-				add_to_variable = { party_pop_array^4 = 0.04 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.04 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.04
@@ -213,8 +214,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = AZE }
 			change_influence_percentage = yes
 			AZE = {
-				add_to_variable = { party_pop_array^4 = 0.05 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.05
@@ -324,8 +326,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = GEO }
 			change_influence_percentage = yes
 			GEO = {
-				add_to_variable = { party_pop_array^4 = 0.04 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.04 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.04
@@ -444,8 +447,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = GEO }
 			change_influence_percentage = yes
 			GEO = {
-				add_to_variable = { party_pop_array^4 = 0.05 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.05
@@ -555,8 +559,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = ABK }
 			change_influence_percentage = yes
 			ABK = {
-				add_to_variable = { party_pop_array^4 = 0.04 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.04 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.04
@@ -675,8 +680,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = ABK }
 			change_influence_percentage = yes
 			ABK = {
-				add_to_variable = { party_pop_array^4 = 0.05 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.05
@@ -786,8 +792,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = ARM }
 			change_influence_percentage = yes
 			ARM = {
-				add_to_variable = { party_pop_array^4 = 0.04 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.04 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.04
@@ -906,8 +913,9 @@ SOO_revoult_south_caucas = {
 			set_temp_variable = { influence_target = ARM }
 			change_influence_percentage = yes
 			ARM = {
-				add_to_variable = { party_pop_array^4 = 0.05 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
 				add_popularity = {
 					ideology = communism
 					popularity = 0.05

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -456,14 +456,21 @@ TUR_domestic_politics_category = {
 			multiply_temp_variable = { FP_pop_drop_neg = -1 }
 			multiply_temp_variable = { Hizmet_pop_gain = 0.10 }
 			multiply_temp_variable = { AKP_pop_gain = 0.80 }
-			subtract_from_variable = { party_pop_array^6 = FP_pop_drop }
+			set_temp_variable = { party_index = 6 }
+			set_temp_variable = { party_popularity_increase = FP_pop_drop }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_FP_POP_DROP
 			add_popularity = { ideology = communism popularity = FP_pop_drop_neg }
 			custom_effect_tooltip = TUR_FP_NEW_NAME
-			add_to_variable = { party_pop_array^0 = Hizmet_pop_gain }
+			set_temp_variable = { party_index = 0 }
+			set_temp_variable = { party_popularity_increase = Hizmet_pop_gain }
+			add_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_HIZMET_POP_GAIN
 			add_popularity = { ideology = democratic popularity = Hizmet_pop_gain }
-			add_to_variable = { party_pop_array^12 = AKP_pop_gain }
+			set_temp_variable = { party_index = 12 }
+			set_temp_variable = { party_popularity_increase = AKP_pop_gain }
+			add_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_AKP_POP_GAIN
 			add_popularity = { ideology = neutrality popularity = AKP_pop_gain }
 			custom_effect_tooltip = TUR_AKP_EMERGES
@@ -3776,16 +3783,23 @@ TUR_disaster_income = {
 					multiply_temp_variable = { Hizmet_pop_gain = 0.10 }
 					set_temp_variable = { AKP_pop_gain = party_pop_array^6 }
 					multiply_temp_variable = { AKP_pop_gain = 0.80 }
-					subtract_from_variable = { party_pop_array^6 = FP_pop_drop }
+					set_temp_variable = { party_index = 6 }
+					set_temp_variable = { party_popularity_increase = FP_pop_drop }
+					multiply_temp_variable = { party_popularity_increase = -1 }
+					add_relative_party_popularity = yes
 					custom_effect_tooltip = TUR_FP_POP_DROP
 					set_temp_variable = { FP_pop_drop_neg = FP_pop_drop }
 					multiply_temp_variable = { FP_pop_drop_neg = -1 }
 					add_popularity = { ideology = communism popularity = FP_pop_drop_neg }
 					custom_effect_tooltip = TUR_FP_NEW_NAME
-					add_to_variable = { party_pop_array^0 = Hizmet_pop_gain }
+					set_temp_variable = { party_index = 0 }
+					set_temp_variable = { party_popularity_increase = Hizmet_pop_gain }
+					add_relative_party_popularity = yes
 					custom_effect_tooltip = TUR_HIZMET_POP_GAIN
 					add_popularity = { ideology = democratic popularity = Hizmet_pop_gain }
-					add_to_variable = { party_pop_array^12 = AKP_pop_gain }
+					set_temp_variable = { party_index = 12 }
+					set_temp_variable = { party_popularity_increase = AKP_pop_gain }
+					add_relative_party_popularity = yes
 					custom_effect_tooltip = TUR_AKP_POP_GAIN
 					add_popularity = { ideology = neutrality popularity = AKP_pop_gain }
 					custom_effect_tooltip = TUR_AKP_EMERGES

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -459,22 +459,21 @@ TUR_domestic_politics_category = {
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = FP_pop_drop }
 			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { temp_outlook_increase = FP_pop_drop_neg }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_FP_POP_DROP
-			add_popularity = { ideology = communism popularity = FP_pop_drop_neg }
 			custom_effect_tooltip = TUR_FP_NEW_NAME
 			set_temp_variable = { party_index = 0 }
 			set_temp_variable = { party_popularity_increase = Hizmet_pop_gain }
+			set_temp_variable = { temp_outlook_increase = Hizmet_pop_gain }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_HIZMET_POP_GAIN
-			add_popularity = { ideology = democratic popularity = Hizmet_pop_gain }
 			set_temp_variable = { party_index = 12 }
 			set_temp_variable = { party_popularity_increase = AKP_pop_gain }
+			set_temp_variable = { temp_outlook_increase = AKP_pop_gain }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_AKP_POP_GAIN
-			add_popularity = { ideology = neutrality popularity = AKP_pop_gain }
 			custom_effect_tooltip = TUR_AKP_EMERGES
-			recalculate_party = yes
 		}
 
 		ai_will_do = {
@@ -2305,7 +2304,6 @@ TUR_mafia_influence_mechanic = {
 						add_relative_party_popularity = yes
 					}
 				}
-				recalculate_party = yes
 			}
 		}
 
@@ -3783,27 +3781,26 @@ TUR_disaster_income = {
 					multiply_temp_variable = { Hizmet_pop_gain = 0.10 }
 					set_temp_variable = { AKP_pop_gain = party_pop_array^6 }
 					multiply_temp_variable = { AKP_pop_gain = 0.80 }
+					set_temp_variable = { FP_pop_drop_neg = FP_pop_drop }
+					multiply_temp_variable = { FP_pop_drop_neg = -1 }
 					set_temp_variable = { party_index = 6 }
 					set_temp_variable = { party_popularity_increase = FP_pop_drop }
 					multiply_temp_variable = { party_popularity_increase = -1 }
+					set_temp_variable = { temp_outlook_increase = FP_pop_drop_neg }
 					add_relative_party_popularity = yes
 					custom_effect_tooltip = TUR_FP_POP_DROP
-					set_temp_variable = { FP_pop_drop_neg = FP_pop_drop }
-					multiply_temp_variable = { FP_pop_drop_neg = -1 }
-					add_popularity = { ideology = communism popularity = FP_pop_drop_neg }
 					custom_effect_tooltip = TUR_FP_NEW_NAME
 					set_temp_variable = { party_index = 0 }
 					set_temp_variable = { party_popularity_increase = Hizmet_pop_gain }
+					set_temp_variable = { temp_outlook_increase = Hizmet_pop_gain }
 					add_relative_party_popularity = yes
 					custom_effect_tooltip = TUR_HIZMET_POP_GAIN
-					add_popularity = { ideology = democratic popularity = Hizmet_pop_gain }
 					set_temp_variable = { party_index = 12 }
 					set_temp_variable = { party_popularity_increase = AKP_pop_gain }
+					set_temp_variable = { temp_outlook_increase = AKP_pop_gain }
 					add_relative_party_popularity = yes
 					custom_effect_tooltip = TUR_AKP_POP_GAIN
-					add_popularity = { ideology = neutrality popularity = AKP_pop_gain }
 					custom_effect_tooltip = TUR_AKP_EMERGES
-					recalculate_party = yes
 				}
 			}
 		}

--- a/common/national_focus/01_EU_USoE_shared.txt
+++ b/common/national_focus/01_EU_USoE_shared.txt
@@ -761,17 +761,21 @@ shared_focus = {
 			popularity = 0.05
 		}
 		custom_effect_tooltip = tooltip_USoE_conservatism_rise_5
-		add_to_variable = { party_pop_array^1 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 1 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		add_popularity = {
 			ideology = nationalist
 			popularity = 0.10
 		}
 		custom_effect_tooltip = tooltip_USoE_Nat_Autocracy_rise_5
-		add_to_variable = { party_pop_array^22 = 0.05 }
+		set_temp_variable = { party_index = 22 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_Monarchist_rise_5
-		add_to_variable = { party_pop_array^23 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		add_ideas = christian
 		#show_ideas_tooltip = christian
 		set_temp_variable = { temp_opinion = 5 }
@@ -811,10 +815,13 @@ shared_focus = {
 				popularity = 0.30
 			}
 			custom_effect_tooltip = tooltip_USoE_Nat_Autocracy_rise_15
-			add_to_variable = { party_pop_array^22 = 0.15 }
+			set_temp_variable = { party_index = 22 }
+			set_temp_variable = { party_popularity_increase = 0.15 }
+			add_relative_party_popularity = yes
 			custom_effect_tooltip = tooltip_USoE_Monarchist_rise_15
-			add_to_variable = { party_pop_array^23 = 0.15 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 23 }
+			set_temp_variable = { party_popularity_increase = 0.15 }
+			add_relative_party_popularity = yes
 		 }
 	}
 
@@ -853,12 +860,17 @@ shared_focus = {
 				popularity = 0.30
 			}
 			custom_effect_tooltip = tooltip_USoE_conservatism_rise_10
-			add_to_variable = { party_pop_array^1 = 0.10 }
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = 0.10 }
+			add_relative_party_popularity = yes
 			custom_effect_tooltip = tooltip_USoE_liberalism_rise_10
-			add_to_variable = { party_pop_array^2 = 0.10 }
+			set_temp_variable = { party_index = 2 }
+			set_temp_variable = { party_popularity_increase = 0.10 }
+			add_relative_party_popularity = yes
 			custom_effect_tooltip = tooltip_USoE_socialism_rise_10
-			add_to_variable = { party_pop_array^3 = 0.10 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 3 }
+			set_temp_variable = { party_popularity_increase = 0.10 }
+			add_relative_party_popularity = yes
 		 }
 	}
 	ai_will_do = {
@@ -1453,12 +1465,17 @@ shared_focus = {
 			popularity = 0.30
 		}
 		custom_effect_tooltip = tooltip_USoE_conservatism_rise_10
-		add_to_variable = { party_pop_array^1 = 0.10 }
+		set_temp_variable = { party_index = 1 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_liberalism_rise_10
-		add_to_variable = { party_pop_array^2 = 0.10 }
+		set_temp_variable = { party_index = 2 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_socialism_rise_10
-		add_to_variable = { party_pop_array^3 = 0.10 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 3 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 	}
 
 	ai_will_do = {
@@ -1487,12 +1504,17 @@ shared_focus = {
 			popularity = 0.15
 		}
 		custom_effect_tooltip = tooltip_USoE_conservatism_rise_5
-		add_to_variable = { party_pop_array^1 = 0.05 }
+		set_temp_variable = { party_index = 1 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_liberalism_rise_5
-		add_to_variable = { party_pop_array^2 = 0.05 }
+		set_temp_variable = { party_index = 2 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_socialism_rise_5
-		add_to_variable = { party_pop_array^3 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 3 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		add_ideas = USoE_digital_democracy
 	}
 
@@ -1524,10 +1546,13 @@ shared_focus = {
 			popularity = 0.20
 		}
 		custom_effect_tooltip = tooltip_USoE_Communist-State_rise_10
-		add_to_variable = { party_pop_array^4 = 0.10 }
+		set_temp_variable = { party_index = 4 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_anarchist_communism_rise_10
-		add_to_variable = { party_pop_array^5 = 0.10 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 5 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 	}
 
 	ai_will_do = {
@@ -1558,8 +1583,9 @@ shared_focus = {
 			ideology = communism
 			popularity = 0.30
 		}
-		add_to_variable = { party_pop_array^5 = 0.30 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 5 }
+		set_temp_variable = { party_popularity_increase = 0.30 }
+		add_relative_party_popularity = yes
 	}
 
 	ai_will_do = {
@@ -1617,8 +1643,9 @@ shared_focus = {
 			popularity = 0.20
 		}
 		custom_effect_tooltip = tooltip_USoE_Neutral_green_rise_20
-		add_to_variable = { party_pop_array^17 = 0.20 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 17 }
+		set_temp_variable = { party_popularity_increase = 0.20 }
+		add_relative_party_popularity = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_farmers_opinion = yes
 		change_small_medium_business_owners_opinion = yes
@@ -1658,8 +1685,9 @@ shared_focus = {
 			ideology = neutrality
 			popularity = 0.30
 		}
-		add_to_variable = { party_pop_array^17 = 0.30 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 17 }
+		set_temp_variable = { party_popularity_increase = 0.30 }
+		add_relative_party_popularity = yes
 	}
 
 	ai_will_do = {
@@ -1908,10 +1936,13 @@ shared_focus = {
 			popularity = 0.20
 		}
 		custom_effect_tooltip = tooltip_USoE_Nat_Autocracy_rise_10
-		add_to_variable = { party_pop_array^22 = 0.10 }
+		set_temp_variable = { party_index = 22 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_Monarchist_rise_10
-		add_to_variable = { party_pop_array^23 = 0.10 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.10 }
+		add_relative_party_popularity = yes
 		add_ideas = christian
 		#show_ideas_tooltip = christian
 		set_temp_variable = { temp_opinion = 5 }
@@ -3384,8 +3415,9 @@ shared_focus = {
 			ideology = nationalist
 			popularity = 0.20
 		}
-		add_to_variable = { party_pop_array^23 = 0.20 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.20 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE647_effect
 	}
 	ai_will_do = {
@@ -3417,8 +3449,9 @@ shared_focus = {
 			ideology = nationalist
 			popularity = 0.20
 		}
-		add_to_variable = { party_pop_array^23 = 0.20 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.20 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE647_effect
 	}
 	ai_will_do = {

--- a/common/national_focus/01_EU_USoE_shared.txt
+++ b/common/national_focus/01_EU_USoE_shared.txt
@@ -756,25 +756,20 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE302"
-		add_popularity = {
-			ideology = democratic
-			popularity = 0.05
-		}
 		custom_effect_tooltip = tooltip_USoE_conservatism_rise_5
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.10
-		}
 		custom_effect_tooltip = tooltip_USoE_Nat_Autocracy_rise_5
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_Monarchist_rise_5
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 		add_ideas = christian
 		#show_ideas_tooltip = christian
@@ -810,17 +805,15 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE303"
 		SOV = {
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.30
-			}
 			custom_effect_tooltip = tooltip_USoE_Nat_Autocracy_rise_15
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = 0.15 }
+			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = tooltip_USoE_Monarchist_rise_15
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = 0.15 }
+			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
 		 }
 	}
@@ -855,21 +848,20 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE304"
 		SOV = {
-			add_popularity = {
-				ideology = democratic
-				popularity = 0.30
-			}
 			custom_effect_tooltip = tooltip_USoE_conservatism_rise_10
 			set_temp_variable = { party_index = 1 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
+			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = tooltip_USoE_liberalism_rise_10
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
+			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = tooltip_USoE_socialism_rise_10
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
+			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
 		 }
 	}
@@ -1460,21 +1452,20 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE400"
-		add_popularity = {
-			ideology = democratic
-			popularity = 0.30
-		}
 		custom_effect_tooltip = tooltip_USoE_conservatism_rise_10
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_liberalism_rise_10
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_socialism_rise_10
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 	}
 
@@ -1499,21 +1490,20 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE401"
-		add_popularity = {
-			ideology = democratic
-			popularity = 0.15
-		}
 		custom_effect_tooltip = tooltip_USoE_conservatism_rise_5
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_liberalism_rise_5
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_socialism_rise_5
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 		add_ideas = USoE_digital_democracy
 	}
@@ -1541,17 +1531,15 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE402"
-		add_popularity = {
-			ideology = communism
-			popularity = 0.20
-		}
 		custom_effect_tooltip = tooltip_USoE_Communist-State_rise_10
 		set_temp_variable = { party_index = 4 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_anarchist_communism_rise_10
 		set_temp_variable = { party_index = 5 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 	}
 
@@ -1579,12 +1567,9 @@ shared_focus = {
 		set_temp_variable = { rul_party_temp = 5 }
 		set_temp_variable = { disable_elections = 1 }
 		change_ruling_party_effect = yes
-		add_popularity = {
-			ideology = communism
-			popularity = 0.30
-		}
 		set_temp_variable = { party_index = 5 }
 		set_temp_variable = { party_popularity_increase = 0.30 }
+		set_temp_variable = { temp_outlook_increase = 0.30 }
 		add_relative_party_popularity = yes
 	}
 
@@ -1638,13 +1623,10 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE500"
-		add_popularity = {
-			ideology = neutrality
-			popularity = 0.20
-		}
 		custom_effect_tooltip = tooltip_USoE_Neutral_green_rise_20
 		set_temp_variable = { party_index = 17 }
 		set_temp_variable = { party_popularity_increase = 0.20 }
+		set_temp_variable = { temp_outlook_increase = 0.20 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_farmers_opinion = yes
@@ -1681,12 +1663,9 @@ shared_focus = {
 		set_cosmetic_tag = USoE_green
 		set_temp_variable = { rul_party_temp = 17 }
 		change_ruling_party_effect = yes
-		add_popularity = {
-			ideology = neutrality
-			popularity = 0.30
-		}
 		set_temp_variable = { party_index = 17 }
 		set_temp_variable = { party_popularity_increase = 0.30 }
+		set_temp_variable = { temp_outlook_increase = 0.30 }
 		add_relative_party_popularity = yes
 	}
 
@@ -1931,17 +1910,15 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus USoE600"
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.20
-		}
 		custom_effect_tooltip = tooltip_USoE_Nat_Autocracy_rise_10
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE_Monarchist_rise_10
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
+		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
 		add_ideas = christian
 		#show_ideas_tooltip = christian
@@ -3411,12 +3388,9 @@ shared_focus = {
 		set_temp_variable = { rul_party_temp = 23 }
 		set_temp_variable = { disable_elections = 1 }
 		change_ruling_party_effect = yes
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.20
-		}
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.20 }
+		set_temp_variable = { temp_outlook_increase = 0.20 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE647_effect
 	}
@@ -3445,12 +3419,9 @@ shared_focus = {
 		set_USoE_flag_of_the_house = yes
 		set_temp_variable = { rul_party_temp = 23 }
 		change_ruling_party_effect = yes
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.20
-		}
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.20 }
+		set_temp_variable = { temp_outlook_increase = 0.20 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = tooltip_USoE647_effect
 	}

--- a/common/national_focus/05_bulgaria.txt
+++ b/common/national_focus/05_bulgaria.txt
@@ -1123,9 +1123,13 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
-				subtract_from_variable = { party_pop_array^19 = current_cons_popularity }
-				add_to_variable = { party_pop_array^4 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 19 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 				set_cosmetic_tag = ARM_AUTH_S_communism
 			}
 			remove_ideas = Major_Non_NATO_Ally
@@ -2615,8 +2619,9 @@ focus_tree = {
 			}
 			add_ideas = BUL_prorussian_prime_minister
 			add_stability = 0.05
-			add_to_variable = { party_pop_array^6 = 0.075 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 6 }
+			set_temp_variable = { party_popularity_increase = 0.075 }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 1 }
@@ -2957,8 +2962,9 @@ focus_tree = {
 			}
 			add_country_leader_trait = simeonII_trait
 			add_stability = 0.05
-			add_to_variable = { party_pop_array^23 = 0.075 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 23 }
+			set_temp_variable = { party_popularity_increase = 0.075 }
+			add_relative_party_popularity = yes
 			}
 
 		ai_will_do = { base = 1 }
@@ -4359,8 +4365,9 @@ focus_tree = {
 				ideology = nationalist
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^23 = 0.075 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 23 }
+			set_temp_variable = { party_popularity_increase = 0.075 }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 1 }

--- a/common/national_focus/05_bulgaria.txt
+++ b/common/national_focus/05_bulgaria.txt
@@ -1123,6 +1123,7 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
+				set_temp_variable = { temp_outlook_increase = 0 }
 				set_temp_variable = { party_index = 19 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
 				multiply_temp_variable = { party_popularity_increase = -1 }
@@ -4361,12 +4362,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BUL_controlism"
 			add_ideas = generic_nationalist_boost_idea
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.05
-			}
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = 0.075 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
 

--- a/common/national_focus/05_georgia.txt
+++ b/common/national_focus/05_georgia.txt
@@ -280,8 +280,9 @@ focus_tree = {
 				ideology = communism
 				popularity = 0.1
 			}
-			add_to_variable = { party_pop_array^4 = 0.15 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.15 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = neutrality
 				popularity = 0.1
@@ -703,9 +704,13 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
-				subtract_from_variable = { party_pop_array^19 = current_cons_popularity }
-				add_to_variable = { party_pop_array^4 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 19 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 				set_cosmetic_tag = GEO_AUTH_S_communism
 			}
 			create_country_leader = {
@@ -755,9 +760,13 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
-				subtract_from_variable = { party_pop_array^19 = current_cons_popularity }
-				add_to_variable = { party_pop_array^4 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 19 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 				set_cosmetic_tag = GEO_AUTH_S_communism
 			}
 			create_country_leader = {
@@ -834,9 +843,13 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^19 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
-				subtract_from_variable = { party_pop_array^4 = current_cons_popularity }
-				add_to_variable = { party_pop_array^19 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 4 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 19 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 				set_cosmetic_tag = GEO_AUTH_S_neutrality
 			}
 			create_country_leader = {

--- a/common/national_focus/05_georgia.txt
+++ b/common/national_focus/05_georgia.txt
@@ -276,21 +276,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GEO_red_bridge"
-			add_popularity = {
-				ideology = communism
-				popularity = 0.1
-			}
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = 0.15 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = neutrality
-				popularity = 0.1
-			}
-			add_to_variable = {
-				party_pop_array^19 = 0.15
-			}
-			recalculate_party = yes
+			set_temp_variable = { party_index = 19 }
+			set_temp_variable = { party_popularity_increase = 0.15 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
+			add_relative_party_popularity = yes
 			add_stability = 0.05
 			add_political_power = 150
 		}

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -18629,9 +18629,8 @@ focus_tree = {
 			remove_ideas = SOV_communist_opposition_idea_2
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = -0.05 }
+			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = communism popularity = -0.05 }
-			recalculate_party = yes
 		}
 
 		ai_will_do = { base = 1 }

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -2165,8 +2165,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_crush_cult_of_stalin"
-			add_to_variable = { party_pop_array^4 = -0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = -0.05 }
+			add_relative_party_popularity = yes
 			add_stability = -0.05
 			add_political_power = -50
 			SOV_warcult_script_bad = yes
@@ -4717,13 +4718,16 @@ focus_tree = {
 			hidden_effect = {
 			if = {
 				limit = { SOV = { is_ai = yes } }
-				add_to_variable = { party_pop_array^2 = 0.75 }
-				recalculate_party = yes
-				add_to_variable = { party_pop_array^6 = -0.75 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 2 }
+				set_temp_variable = { party_popularity_increase = 0.75 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = -0.75 }
+				add_relative_party_popularity = yes
 			}
-			add_to_variable = { party_pop_array^2 = 0.15 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 2 }
+			set_temp_variable = { party_popularity_increase = 0.15 }
+			add_relative_party_popularity = yes
 			}
 			add_ideas = SOV_communist_opposition_idea_1
 			if = {
@@ -5411,10 +5415,12 @@ focus_tree = {
 						ideology = nationalist
 						popularity = 0.75
 					}
-					add_to_variable = { party_pop_array^20 = 0.75 }
-					recalculate_party = yes
-					add_to_variable = { party_pop_array^6 = -0.75 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 20 }
+					set_temp_variable = { party_popularity_increase = 0.75 }
+					add_relative_party_popularity = yes
+					set_temp_variable = { party_index = 6 }
+					set_temp_variable = { party_popularity_increase = -0.75 }
+					add_relative_party_popularity = yes
 				}
 				if = {
 					limit = { NOT = { is_in_array = { ruling_party = 20 } } }
@@ -12931,10 +12937,12 @@ focus_tree = {
 			hidden_effect = {
 				if = {
 					limit = { SOV = { is_ai = yes } }
-					add_to_variable = { party_pop_array^4 = 0.75 }
-					recalculate_party = yes
-					add_to_variable = { party_pop_array^6 = -0.75 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 4 }
+					set_temp_variable = { party_popularity_increase = 0.75 }
+					add_relative_party_popularity = yes
+					set_temp_variable = { party_index = 6 }
+					set_temp_variable = { party_popularity_increase = -0.75 }
+					add_relative_party_popularity = yes
 				}
 				if = {
 					limit = { has_country_flag = sov_zug_econ }
@@ -13417,8 +13425,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_empower_the_communist_party"
 			add_stability = 0.03
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			hidden_effect = {
 				if = {
 					limit = { SOV = { is_ai = yes } }
@@ -13600,8 +13609,9 @@ focus_tree = {
 				limit = { has_idea = SOV_corrupt_oligarchy }
 				remove_ideas = SOV_corrupt_oligarchy
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_power_balance_value = {
 				id = SOV_west_east_bop
 				value = 0.20
@@ -13724,8 +13734,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_weaken_the_banks"
 			add_political_power = -250
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			decrease_corruption = yes
 		}
 
@@ -15046,8 +15057,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_expand_university_enrollment"
 			increase_education_budget = yes
-			add_to_variable = { party_pop_array^4 = 0.07 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.07 }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = {
@@ -15852,9 +15864,13 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^2 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
-				subtract_from_variable = { party_pop_array^6 = current_cons_popularity }
-				add_to_variable = { party_pop_array^2 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 2 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 				if = {
 					limit = { OR = { has_country_flag = SOV_navalny_a has_country_flag = SOV_navalny_p has_country_flag = SOV_navalny_b has_country_flag = SOV_navalny_n } }
 					clr_country_flag = SOV_navalny_a
@@ -16581,9 +16597,13 @@ focus_tree = {
 				set_temp_variable = { current_cons_popularity = party_pop_array^2 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
 				# Remove most of support, retrack it to emerg communist party
-				subtract_from_variable = { party_pop_array^6 = current_cons_popularity }
-				add_to_variable = { party_pop_array^2 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 2 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 			}
 			create_country_leader = {
 				name = "Alexei Navalny"
@@ -16643,9 +16663,13 @@ focus_tree = {
 				change_ruling_party_effect = yes
 				set_temp_variable = { current_cons_popularity = party_pop_array^1 }
 				multiply_temp_variable = { current_cons_popularity = 0.5 }
-				subtract_from_variable = { party_pop_array^6 = current_cons_popularity }
-				add_to_variable = { party_pop_array^1 = current_cons_popularity }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 1 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				add_relative_party_popularity = yes
 			}
 			create_country_leader = {
 				name = "Boris Nemtsov"
@@ -18603,7 +18627,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_ostracize_the_cprf"
 			remove_ideas = SOV_communist_opposition_idea_2
-			subtract_from_variable = { party_pop_array^4 = 0.05 }
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = -0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = { ideology = communism popularity = -0.05 }
 			recalculate_party = yes
 		}
@@ -31499,9 +31525,12 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_kob_party_start"
 			hidden_effect = {
 				add_popularity = { ideology = nationalist popularity = 0.1 }
-				add_to_variable = { party_pop_array^6 = -0.75 }
-				add_to_variable = { party_pop_array^22 = 0.1 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = -0.75 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 22 }
+				set_temp_variable = { party_popularity_increase = 0.1 }
+				add_relative_party_popularity = yes
 				set_cosmetic_tag = SOV_kobnod
 				update_party_name = yes
 				add_dynamic_modifier = { modifier = SOV_koba_politic_modifier }
@@ -31653,8 +31682,9 @@ focus_tree = {
 					ideology = nationalist
 					popularity = 0.08
 				}
-				add_to_variable = { party_pop_array^22 = 0.08 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 22 }
+				set_temp_variable = { party_popularity_increase = 0.08 }
+				add_relative_party_popularity = yes
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_koba_politic_modifier }
 			add_to_variable = { SOV_koba_politic_drift_defence_factor = 0.05 tooltip = drift_defence_factor_tt }
@@ -31835,8 +31865,9 @@ focus_tree = {
 				ideology = nationalist
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^22 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 22 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_koba_politic_modifier }
 			add_to_variable = { SOV_koba_politic_stability_factor = -0.05 tooltip = stability_factor_tt }
@@ -31957,8 +31988,9 @@ focus_tree = {
 				ideology = nationalist
 				popularity = 0.02
 			}
-			add_to_variable = { party_pop_array^22 = 0.02 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 22 }
+			set_temp_variable = { party_popularity_increase = 0.02 }
+			add_relative_party_popularity = yes
 			add_political_power = 45
 			}
 		}

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -4711,10 +4711,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_path_of_western"
-			add_popularity = {
-				ideology = democratic
-				popularity = 0.15
-			}
 			hidden_effect = {
 			if = {
 				limit = { SOV = { is_ai = yes } }
@@ -4727,6 +4723,7 @@ focus_tree = {
 			}
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = 0.15 }
+			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
 			}
 			add_ideas = SOV_communist_opposition_idea_1
@@ -5411,15 +5408,12 @@ focus_tree = {
 			hidden_effect = {
 				if = {
 					limit = { SOV = { is_ai = yes } }
-					add_popularity = {
-						ideology = nationalist
-						popularity = 0.75
-					}
-					set_temp_variable = { party_index = 20 }
-					set_temp_variable = { party_popularity_increase = 0.75 }
-					add_relative_party_popularity = yes
 					set_temp_variable = { party_index = 6 }
 					set_temp_variable = { party_popularity_increase = -0.75 }
+					add_relative_party_popularity = yes
+					set_temp_variable = { party_index = 20 }
+					set_temp_variable = { party_popularity_increase = 0.75 }
+					set_temp_variable = { temp_outlook_increase = 0.75 }
 					add_relative_party_popularity = yes
 				}
 				if = {
@@ -7024,11 +7018,8 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_embrace_monarchists"
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.1
-			}
 			hidden_effect = {
 				if = {
 					limit = { SOV = { is_ai = yes } }
@@ -27862,12 +27853,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_talks_with_left_patriots"
 			set_temp_variable = { add_col_one = 18 }
 			add_coalition_members_effect = yes
-			add_popularity = {
-				ideology = neutrality
-				popularity = 0.02
-			}
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
+		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
 		}
 
@@ -27902,15 +27890,13 @@ focus_tree = {
 			add_coalition_members_effect = yes
 			set_temp_variable = { add_col_one = 13 }
 			add_coalition_members_effect = yes
-			add_popularity = {
-				ideology = neutrality
-				popularity = 0.04
-			}
 		set_temp_variable = { party_index = 14 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
+		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
+		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
 		}
 
@@ -31523,12 +31509,12 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_kob_party_start"
 			hidden_effect = {
-				add_popularity = { ideology = nationalist popularity = 0.1 }
 				set_temp_variable = { party_index = 6 }
 				set_temp_variable = { party_popularity_increase = -0.75 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_index = 22 }
 				set_temp_variable = { party_popularity_increase = 0.1 }
+				set_temp_variable = { temp_outlook_increase = 0.1 }
 				add_relative_party_popularity = yes
 				set_cosmetic_tag = SOV_kobnod
 				update_party_name = yes
@@ -31677,12 +31663,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_establish_new_religion"
 			hidden_effect = {
-				add_popularity = {
-					ideology = nationalist
-					popularity = 0.08
-				}
 				set_temp_variable = { party_index = 22 }
 				set_temp_variable = { party_popularity_increase = 0.08 }
+				set_temp_variable = { temp_outlook_increase = 0.08 }
 				add_relative_party_popularity = yes
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_koba_politic_modifier }
@@ -31860,12 +31843,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_search_for_priests"
 			hidden_effect = {
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.05
-			}
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_koba_politic_modifier }
@@ -31983,12 +31963,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_support_nod"
 			hidden_effect = {
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.02
-			}
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = 0.02 }
+			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_political_power = 45
 			}

--- a/common/national_focus/05_transnistria.txt
+++ b/common/national_focus/05_transnistria.txt
@@ -6163,10 +6163,12 @@ focus_tree = {
 						ideology = nationalist
 						popularity = 0.55
 					}
-					add_to_variable = { party_pop_array^22 = 0.75 }
-					recalculate_party = yes
-					add_to_variable = { party_pop_array^6 = -0.75 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 22 }
+					set_temp_variable = { party_popularity_increase = 0.75 }
+					add_relative_party_popularity = yes
+					set_temp_variable = { party_index = 6 }
+					set_temp_variable = { party_popularity_increase = -0.75 }
+					add_relative_party_popularity = yes
 				}
 				if = {
 					limit = { NOT = { is_in_array = { ruling_party = 22 } } }

--- a/common/national_focus/05_transnistria.txt
+++ b/common/national_focus/05_transnistria.txt
@@ -4962,6 +4962,7 @@ focus_tree = {
 				set_cosmetic_tag = PMR_monarchy
 				clr_country_flag = dynamic_flag
 				set_temp_variable = { party_index = 23 }
+				set_temp_variable = { party_popularity_increase = 0.75 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { rul_party_temp = 23 }
 				set_temp_variable = { disable_elections = 1 }

--- a/common/national_focus/05_transnistria.txt
+++ b/common/national_focus/05_transnistria.txt
@@ -2015,12 +2015,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus PMR_against_sheriff"
 			add_political_power = -100
 			decrease_corruption = yes
-			add_popularity = {
-				ideology = neutrality
-				popularity = -0.15
-			}
 			set_temp_variable = { party_index = 15 }
 			set_temp_variable = { party_popularity_increase = -0.15 }
+			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
 		}
 
@@ -6160,15 +6157,12 @@ focus_tree = {
 			hidden_effect = {
 				if = {
 					limit = { PMR = { is_ai = yes } }
-					add_popularity = {
-						ideology = nationalist
-						popularity = 0.55
-					}
-					set_temp_variable = { party_index = 22 }
-					set_temp_variable = { party_popularity_increase = 0.75 }
-					add_relative_party_popularity = yes
 					set_temp_variable = { party_index = 6 }
 					set_temp_variable = { party_popularity_increase = -0.75 }
+					add_relative_party_popularity = yes
+					set_temp_variable = { party_index = 22 }
+					set_temp_variable = { party_popularity_increase = 0.75 }
+					set_temp_variable = { temp_outlook_increase = 0.55 }
 					add_relative_party_popularity = yes
 				}
 				if = {
@@ -7057,12 +7051,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus PMR_clean_corruption"
 			add_political_power = -100
 			decrease_corruption = yes
-			add_popularity = {
-				ideology = neutrality
-				popularity = -0.15
-			}
 			set_temp_variable = { party_index = 15 }
 			set_temp_variable = { party_popularity_increase = -0.15 }
+			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
 		}
 

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -7073,9 +7073,9 @@ focus_tree = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_absorb_left_wing"
 			custom_effect_tooltip = BRA_add_pt_annex_parties_tt
 			hidden_effect = {
-				add_popularity = { ideology = communism popularity = 0.25 }
 				set_temp_variable = { party_index = 5 }
 				set_temp_variable = { party_popularity_increase = 0.25 }
+				set_temp_variable = { temp_outlook_increase = 0.25 }
 				add_relative_party_popularity = yes
 			}
 			remove_ideas = BRA_idea_nationalism_rise
@@ -9521,9 +9521,9 @@ focus_tree = {
 				set_temp_variable = { disable_elections = 1 }
 				set_temp_variable = { col_one = 20 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = nationalist popularity = 0.05 }
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.1 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Luiz I"

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -6907,10 +6907,15 @@ focus_tree = {
 				set_temp_variable = { col_three = 19 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = democratic popularity = 0.1 }
-				add_to_variable = { party_pop_array^18 = 0.1 } #PPS
-				add_to_variable = { party_pop_array^19 = 0.1 } #PSTU
-				add_to_variable = { party_pop_array^4 = 0.1 } #PCdoB
-				recalculate_party = yes
+				set_temp_variable = { party_index = 18 } #PPS
+				set_temp_variable = { party_popularity_increase = 0.1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 19 } #PSTU
+				set_temp_variable = { party_popularity_increase = 0.1 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 4 } #PCdoB
+				set_temp_variable = { party_popularity_increase = 0.1 }
+				add_relative_party_popularity = yes
 				add_popularity = { ideology = neutrality popularity = 0.1 }
 				add_popularity = { ideology = communism popularity = 0.1 }
 			}
@@ -7069,8 +7074,9 @@ focus_tree = {
 			custom_effect_tooltip = BRA_add_pt_annex_parties_tt
 			hidden_effect = {
 				add_popularity = { ideology = communism popularity = 0.25 }
-				add_to_variable = { party_pop_array^5 = 0.25 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 5 }
+				set_temp_variable = { party_popularity_increase = 0.25 }
+				add_relative_party_popularity = yes
 			}
 			remove_ideas = BRA_idea_nationalism_rise
 		}
@@ -9516,8 +9522,9 @@ focus_tree = {
 				set_temp_variable = { col_one = 20 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = nationalist popularity = 0.05 }
-				add_to_variable = { party_pop_array^23 = 0.1 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 23 }
+				set_temp_variable = { party_popularity_increase = 0.1 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Luiz I"
 					picture = "luiz_i.dds"
@@ -9876,10 +9883,18 @@ focus_tree = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_pro_bolsonaro_parties"
 			custom_effect_tooltip = BRA_pro_bolsonaro_parties_tt
 			hidden_effect = {
-				add_to_variable = { party_pop_array^6 = 0.05 }
-				add_to_variable = { party_pop_array^23 = 0.05 }
-				add_to_variable = { party_pop_array^22 = 0.05 }
-				add_to_variable = { party_pop_array^20 = 0.05 }
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 23 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 22 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
 			}
 		}
 
@@ -10462,7 +10477,9 @@ focus_tree = {
 				popularity = 0.10
 			}
 			hidden_effect = {
-				add_to_variable = { party_pop_array^3 = 0.1 }
+				set_temp_variable = { party_index = 3 }
+				set_temp_variable = { party_popularity_increase = 0.1 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { rul_party_temp = 2 }
 				set_temp_variable = { col_one = 3 }
 				change_ruling_party_effect = yes

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -4013,12 +4013,10 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE FOCUS_FILTER_MILITARY_LAWS }
 
 		available = {
-			NOT = {
-				has_idea = BRA_idea_party_of_progress
-				has_idea = BRA_idea_modern_reformist
-				has_government = democratic
-				has_government = neutrality
-			}
+			NOT = { has_idea = BRA_idea_party_of_progress }
+			NOT = { has_idea = BRA_idea_modern_reformist }
+			NOT = { has_government = democratic }
+			NOT = { has_government = neutrality }
 		}
 
 		completion_reward = {
@@ -6909,15 +6907,16 @@ focus_tree = {
 				add_popularity = { ideology = democratic popularity = 0.1 }
 				set_temp_variable = { party_index = 18 } #PPS
 				set_temp_variable = { party_popularity_increase = 0.1 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_index = 19 } #PSTU
 				set_temp_variable = { party_popularity_increase = 0.1 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_index = 4 } #PCdoB
 				set_temp_variable = { party_popularity_increase = 0.1 }
+				set_temp_variable = { temp_outlook_increase = 0.1 }
 				add_relative_party_popularity = yes
-				add_popularity = { ideology = neutrality popularity = 0.1 }
-				add_popularity = { ideology = communism popularity = 0.1 }
 			}
 		}
 
@@ -10472,13 +10471,10 @@ focus_tree = {
 			custom_effect_tooltip = BRA_pdt_coalition_tt
 			add_stability = 0.03
 			add_political_power = 150
-			add_popularity = {
-				ideology = democratic
-				popularity = 0.10
-			}
 			hidden_effect = {
 				set_temp_variable = { party_index = 3 }
 				set_temp_variable = { party_popularity_increase = 0.1 }
+				set_temp_variable = { temp_outlook_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { rul_party_temp = 2 }
 				set_temp_variable = { col_one = 3 }

--- a/common/national_focus/poland.txt
+++ b/common/national_focus/poland.txt
@@ -18863,23 +18863,17 @@ focus_tree = {
 					set_temp_variable = { rul_party_temp = 20 }
 					change_ruling_party_effect = yes
 				}
-				add_popularity = {
-					ideology = nationalist
-					popularity = 0.075
-				}
 				set_temp_variable = { party_index = 20 }
 				set_temp_variable = { party_popularity_increase = 0.075 }
+				set_temp_variable = { temp_outlook_increase = 0.075 }
 				add_relative_party_popularity = yes
 				add_stability = -0.20
 			}
 			else_if = {
 				limit = { is_in_array = { ruling_party = 20 } }
-				add_popularity = {
-					ideology = nationalist
-					popularity = 0.075
-				}
 				set_temp_variable = { party_index = 20 }
 				set_temp_variable = { party_popularity_increase = 0.075 }
+				set_temp_variable = { temp_outlook_increase = 0.075 }
 				add_relative_party_popularity = yes
 				add_stability = -0.05
 			}

--- a/common/national_focus/poland.txt
+++ b/common/national_focus/poland.txt
@@ -13856,8 +13856,14 @@ focus_tree = {
 			}
 			multiply_temp_variable = { current_cons_popularity = 0.2 }
 			# Remove most of support, retrack it to Liberal party
-			subtract_from_variable = { party_pop_array^1 = current_cons_popularity }
-			add_to_variable = { party_pop_array^2 = current_cons_popularity }
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 2 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			add_relative_party_popularity = yes
+
 			add_stability = -0.05
 			custom_effect_tooltip = POL_soften_cons_TT
 		}
@@ -14105,8 +14111,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_pro_ecological_projects"
 			custom_effect_tooltip = POL_party_pop_TT
-			add_to_variable = { party_pop_array^2 = 0.2 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 2 }
+			set_temp_variable = { party_popularity_increase = 0.2 }
+			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 		}
@@ -15638,8 +15645,9 @@ focus_tree = {
 				set_temp_variable = { percent_change = -10 }
 				set_temp_variable = { tag_index = SOV.id }
 				change_influence_percentage = yes
-				add_to_variable = { party_pop_array^20 = 0.075 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.075 }
+				add_relative_party_popularity = yes
 			}
 		}
 
@@ -16226,9 +16234,12 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_perpetuating_democratic_values"
 			custom_effect_tooltip = POL_opposition_dec_TT
-			subtract_from_variable = { party_pop_array^5 = 0.1 }
-			subtract_from_variable = { party_pop_array^3 = 0.1 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 5 }
+			set_temp_variable = { party_popularity_increase = -0.1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 3 }
+			set_temp_variable = { party_popularity_increase = -0.1 }
+			add_relative_party_popularity = yes
 			add_timed_idea = { idea = POL_democratic_country_idea days = 730 }
 		}
 
@@ -18520,8 +18531,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_Warsaw_march"
 			add_stability = -0.05
 			add_timed_idea = { idea = POL_beginning_of_the_revolution_idea days = 365 }
-			add_to_variable = { party_pop_array^20 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 10 }
@@ -18573,8 +18585,9 @@ focus_tree = {
 			custom_effect_tooltip = POL_increase_nationalist_support_TT
 			add_war_support = 0.05
 			add_stability = -0.05
-			add_to_variable = { party_pop_array^20 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 10 }
@@ -18600,9 +18613,13 @@ focus_tree = {
 			set_temp_variable = { current_cons_popularity = party_pop_array^1 }
 			multiply_temp_variable = { current_cons_popularity = 0.5 }
 			# Remove most of support, retrack it to fascists party
-			subtract_from_variable = { party_pop_array^1 = current_cons_popularity }
-			add_to_variable = { party_pop_array^20 = current_cons_popularity }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 10 }
@@ -18680,8 +18697,10 @@ focus_tree = {
 			custom_effect_tooltip = POL_increase_nationalist_support_TT
 			custom_effect_tooltip = POL_nationalist_spending_TT
 			add_to_variable = { nationalist_debt = -5.0 }
-			add_to_variable = { party_pop_array^20 = 0.1 }
-			recalculate_party = yes
+
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 10 }
@@ -18777,8 +18796,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_localize_programs"
 			custom_effect_tooltip = POL_nationalist_spending_TT
 			add_stability = 0.05
-			add_to_variable = { party_pop_array^20 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_to_variable = { nationalist_debt = -3.0 }
 		}
 
@@ -18806,9 +18826,13 @@ focus_tree = {
 			set_temp_variable = { current_soc_popularity = party_pop_array^3 }
 			multiply_temp_variable = { current_soc_popularity = 0.25 }
 			# Remove most of support, retrack it to fascists party
-			subtract_from_variable = { party_pop_array^1 = current_soc_popularity }
-			add_to_variable = { party_pop_array^20 = current_soc_popularity }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = current_soc_popularity }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = current_soc_popularity }
+			add_relative_party_popularity = yes
 		}
 
 		ai_will_do = { base = 10 }
@@ -18843,8 +18867,9 @@ focus_tree = {
 					ideology = nationalist
 					popularity = 0.075
 				}
-				add_to_variable = { party_pop_array^20 = 0.075 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.075 }
+				add_relative_party_popularity = yes
 				add_stability = -0.20
 			}
 			else_if = {
@@ -18853,8 +18878,9 @@ focus_tree = {
 					ideology = nationalist
 					popularity = 0.075
 				}
-				add_to_variable = { party_pop_array^20 = 0.075 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.075 }
+				add_relative_party_popularity = yes
 				add_stability = -0.05
 			}
 			if = {
@@ -19067,8 +19093,9 @@ focus_tree = {
 					add_opinion_modifier = { target = ROOT modifier = POL_nationalist_ally }
 				}
 				else = {
-					add_to_variable = { party_pop_array^20 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 20 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 			}
 		}
@@ -19149,8 +19176,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_reach_to_chechz"
 			CZE = {
-				add_to_variable = { party_pop_array^20 = 0.05 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				add_relative_party_popularity = yes
 				if = {
 					limit = {
 						has_idea = medium_far_right_movement
@@ -19231,8 +19259,9 @@ focus_tree = {
 			SOV = {
 				set_temp_variable = { percent_change = 5 }
 				change_influence_percentage = yes
-				add_to_variable = { party_pop_array^20 = 0.075 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.075 }
+				add_relative_party_popularity = yes
 			}
 		}
 

--- a/common/national_focus/syria.txt
+++ b/common/national_focus/syria.txt
@@ -119,7 +119,9 @@ focus_tree = {
 			set_temp_variable = { leader_popularity = bushra_popularity }
 			multiply_temp_variable = { stability_loss = 0.005 }
 			add_popularity = { ideology = neutrality popularity = leader_popularity }
-			add_to_variable = { var = party_pop_array^15 value = leader_popularity }
+			set_temp_variable = { party_index = 15 }
+			set_temp_variable = { party_popularity_increase = leader_popularity }
+			add_relative_party_popularity = yes
 			set_politics = {
 				ruling_party = neutrality
 			}
@@ -472,7 +474,9 @@ focus_tree = {
 			set_temp_variable = { leader_popularity = bashar_popularity }
 			multiply_temp_variable = { leader_popularity = 0.005 }
 			add_popularity = { ideology = communism popularity = leader_popularity }
-			add_to_variable = { var = party_pop_array^7 value = leader_popularity }
+			set_temp_variable = { party_index = 7 }
+			set_temp_variable = { party_popularity_increase = leader_popularity }
+			add_relative_party_popularity = yes
 			set_politics = {
 				ruling_party = communism
 			}
@@ -785,7 +789,9 @@ focus_tree = {
 			set_temp_variable = { leader_popularity = maher_popularity }
 			multiply_temp_variable = { stableader_popularityility_loss = 0.005 }
 			add_popularity = { ideology = nationalist popularity = leader_popularity }
-			add_to_variable = { var = party_pop_array^22 value = leader_popularity }
+			set_temp_variable = { party_index = 22 }
+			set_temp_variable = { party_popularity_increase = leader_popularity }
+			add_relative_party_popularity = yes
 			set_politics = {
 				ruling_party = nationalist
 			}
@@ -998,7 +1004,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 15 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = neutrality popularity = 0.30 }
-				add_to_variable = { var = party_pop_array^15 value = 0.30 }
+				set_temp_variable = { party_index = 15 }
+				set_temp_variable = { party_popularity_increase = 0.30 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
 					desc = ""
@@ -1018,7 +1026,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = democratic popularity = 0.30 }
-				add_to_variable = { var = party_pop_array^0 value = 0.30 }
+				set_temp_variable = { party_index = 0 }
+				set_temp_variable = { party_popularity_increase = 0.30 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
 					desc = ""
@@ -1038,7 +1048,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 6 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = communism popularity = 0.30 }
-				add_to_variable = { var = party_pop_array^6 value = 0.30 }
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = 0.30 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
 					desc = ""
@@ -1058,7 +1070,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 15 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = neutrality popularity = 0.30 }
-				add_to_variable = { var = party_pop_array^15 value = 0.30 }
+				set_temp_variable = { party_index = 15 }
+				set_temp_variable = { party_popularity_increase = 0.30 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
 					desc = ""
@@ -1078,7 +1092,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 10 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = fascism popularity = 0.30 }
-				add_to_variable = { var = party_pop_array^10 value = 0.30 }
+				set_temp_variable = { party_index = 10 }
+				set_temp_variable = { party_popularity_increase = 0.30 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
 					desc = ""
@@ -1098,7 +1114,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 21 }
 				change_ruling_party_effect = yes
 				add_popularity = { ideology = nationalist popularity = 0.30 }
-				add_to_variable = { var = party_pop_array^21 value = 0.30 }
+				set_temp_variable = { party_index = 21 }
+				set_temp_variable = { party_popularity_increase = 0.30 }
+				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
 					desc = ""
@@ -1165,31 +1183,41 @@ focus_tree = {
 				limit = { has_government = democratic }
 				set_country_flag = Syrian_arab_democratic_party_western
 				add_popularity = { ideology = democratic popularity = 0.20 }
-				add_to_variable = { var = party_pop_array^0 value = 0.20 }
+				set_temp_variable = { party_index = 0 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = neutrality }
 				set_country_flag = Syrian_arab_democratic_party_neutrality
 				add_popularity = { ideology = neutrality popularity = 0.20 }
-				add_to_variable = { var = party_pop_array^15 value = 0.20 }
+				set_temp_variable = { party_index = 15 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = communism }
 				set_country_flag = Syrian_arab_democratic_party_emerging
 				add_popularity = { ideology = communism popularity = 0.20 }
-				add_to_variable = { var = party_pop_array^6 value = 0.20 }
+				set_temp_variable = { party_index = 6 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = fascism }
 				set_country_flag = Syrian_arab_democratic_party_salafist
 				add_popularity = { ideology = fascism popularity = 0.20 }
-				add_to_variable = { var = party_pop_array^10 value = 0.20 }
+				set_temp_variable = { party_index = 10 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = nationalist }
 				set_country_flag = Syrian_arab_democratic_party_nationalist
 				add_popularity = { ideology = nationalist popularity = 0.20 }
-				add_to_variable = { var = party_pop_array^20 value = 0.20 }
+				set_temp_variable = { party_index = 20 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 			}
 		}
 
@@ -1215,7 +1243,9 @@ focus_tree = {
 				set_variable = { Autocracy_leader = 1 }
 			}
 			add_popularity = { ideology = communism popularity = -0.20 }
-			add_to_variable = { var = party_pop_array^7 value = -0.20 }
+			set_temp_variable = { party_index = 7 }
+			set_temp_variable = { party_popularity_increase = -0.20 }
+			add_relative_party_popularity = yes
 			hidden_effect = {
 				country_event = { id = SyriaFocus.106 days = 3 }
 			}
@@ -1322,35 +1352,51 @@ focus_tree = {
 				set_temp_variable = { party_1 = random }
 				multiply_temp_variable = { party_1 = 23 }
 				round_variable = party_1
-				add_to_variable = { var = party_pop_array^party_1 value = 0.10 }
+				set_temp_variable = { party_index = party_1 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_2 = random }
 				multiply_temp_variable = { party_2 = 23 }
 				round_variable = party_2
-				add_to_variable = { var = party_pop_array^party_2 value = 0.10 }
+				set_temp_variable = { party_index = party_2 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_3 = random }
 				multiply_temp_variable = { party_3 = 23 }
 				round_variable = party_3
-				add_to_variable = { var = party_pop_array^party_3 value = 0.10 }
+				set_temp_variable = { party_index = party_3 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_4 = random }
 				multiply_temp_variable = { party_4 = 23 }
 				round_variable = party_4
-				add_to_variable = { var = party_pop_array^party_4 value = 0.10 }
+				set_temp_variable = { party_index = party_4 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_5 = random }
 				multiply_temp_variable = { party_5 = 23 }
 				round_variable = party_5
-				add_to_variable = { var = party_pop_array^party_5 value = 0.10 }
+				set_temp_variable = { party_index = party_5 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_6 = random }
 				multiply_temp_variable = { party_6 = 23 }
 				round_variable = party_6
-				add_to_variable = { var = party_pop_array^party_6 value = 0.10 }
+				set_temp_variable = { party_index = party_6 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_7 = random }
 				multiply_temp_variable = { party_7 = 23 }
 				round_variable = party_7
-				add_to_variable = { var = party_pop_array^party_7 value = 0.10 }
+				set_temp_variable = { party_index = party_7 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 				set_temp_variable = { party_8 = random }
 				multiply_temp_variable = { party_8 = 23 }
 				round_variable = party_8
-				add_to_variable = { var = party_pop_array^party_8 value = 0.10 }
+				set_temp_variable = { party_index = party_8 }
+				set_temp_variable = { party_popularity_increase = 0.10 }
+				add_relative_party_popularity = yes
 			}
 			recalculate_party = yes
 			if = { limit = { NOT = { has_idea = idea_syrian_kurds_without_citizenships } }

--- a/common/national_focus/syria.txt
+++ b/common/national_focus/syria.txt
@@ -117,7 +117,7 @@ focus_tree = {
 			multiply_temp_variable = { stability_loss = 0.01 }
 			add_stability = stability_loss
 			set_temp_variable = { leader_popularity = bushra_popularity }
-			multiply_temp_variable = { stability_loss = 0.005 }
+			multiply_temp_variable = { leader_popularity = 0.005 }
 			set_temp_variable = { party_index = 15 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
@@ -787,7 +787,7 @@ focus_tree = {
 			multiply_temp_variable = { stability_loss = 0.01 }
 			add_stability = stability_loss
 			set_temp_variable = { leader_popularity = maher_popularity }
-			multiply_temp_variable = { stableader_popularityility_loss = 0.005 }
+			multiply_temp_variable = { leader_popularity = 0.005 }
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
@@ -1349,53 +1349,46 @@ focus_tree = {
 				add_popularity = { ideology = fascism popularity = salafist_popularity }
 				add_popularity = { ideology = neutrality popularity = neutrality_popularity }
 				add_popularity = { ideology = nationalist popularity = nationalist_popularity }
+				set_temp_variable = { party_popularity_increase = 0.10 }
 				set_temp_variable = { party_1 = random }
 				multiply_temp_variable = { party_1 = 23 }
 				round_variable = party_1
 				set_temp_variable = { party_index = party_1 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_2 = random }
 				multiply_temp_variable = { party_2 = 23 }
 				round_variable = party_2
 				set_temp_variable = { party_index = party_2 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_3 = random }
 				multiply_temp_variable = { party_3 = 23 }
 				round_variable = party_3
 				set_temp_variable = { party_index = party_3 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_4 = random }
 				multiply_temp_variable = { party_4 = 23 }
 				round_variable = party_4
 				set_temp_variable = { party_index = party_4 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_5 = random }
 				multiply_temp_variable = { party_5 = 23 }
 				round_variable = party_5
 				set_temp_variable = { party_index = party_5 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_6 = random }
 				multiply_temp_variable = { party_6 = 23 }
 				round_variable = party_6
 				set_temp_variable = { party_index = party_6 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_7 = random }
 				multiply_temp_variable = { party_7 = 23 }
 				round_variable = party_7
 				set_temp_variable = { party_index = party_7 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_8 = random }
 				multiply_temp_variable = { party_8 = 23 }
 				round_variable = party_8
 				set_temp_variable = { party_index = party_8 }
-				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 			}
 			if = { limit = { NOT = { has_idea = idea_syrian_kurds_without_citizenships } }

--- a/common/national_focus/syria.txt
+++ b/common/national_focus/syria.txt
@@ -118,9 +118,9 @@ focus_tree = {
 			add_stability = stability_loss
 			set_temp_variable = { leader_popularity = bushra_popularity }
 			multiply_temp_variable = { stability_loss = 0.005 }
-			add_popularity = { ideology = neutrality popularity = leader_popularity }
 			set_temp_variable = { party_index = 15 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
+			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			add_relative_party_popularity = yes
 			set_politics = {
 				ruling_party = neutrality
@@ -473,9 +473,9 @@ focus_tree = {
 			add_stability = stability_loss
 			set_temp_variable = { leader_popularity = bashar_popularity }
 			multiply_temp_variable = { leader_popularity = 0.005 }
-			add_popularity = { ideology = communism popularity = leader_popularity }
 			set_temp_variable = { party_index = 7 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
+			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			add_relative_party_popularity = yes
 			set_politics = {
 				ruling_party = communism
@@ -788,9 +788,9 @@ focus_tree = {
 			add_stability = stability_loss
 			set_temp_variable = { leader_popularity = maher_popularity }
 			multiply_temp_variable = { stableader_popularityility_loss = 0.005 }
-			add_popularity = { ideology = nationalist popularity = leader_popularity }
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
+			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			add_relative_party_popularity = yes
 			set_politics = {
 				ruling_party = nationalist
@@ -1003,9 +1003,9 @@ focus_tree = {
 				}
 				set_temp_variable = { rul_party_temp = 15 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = neutrality popularity = 0.30 }
 				set_temp_variable = { party_index = 15 }
 				set_temp_variable = { party_popularity_increase = 0.30 }
+				set_temp_variable = { temp_outlook_increase = 0.30 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
@@ -1025,9 +1025,9 @@ focus_tree = {
 				}
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = democratic popularity = 0.30 }
 				set_temp_variable = { party_index = 0 }
 				set_temp_variable = { party_popularity_increase = 0.30 }
+				set_temp_variable = { temp_outlook_increase = 0.30 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
@@ -1047,9 +1047,9 @@ focus_tree = {
 				}
 				set_temp_variable = { rul_party_temp = 6 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = communism popularity = 0.30 }
 				set_temp_variable = { party_index = 6 }
 				set_temp_variable = { party_popularity_increase = 0.30 }
+				set_temp_variable = { temp_outlook_increase = 0.30 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
@@ -1069,9 +1069,9 @@ focus_tree = {
 				}
 				set_temp_variable = { rul_party_temp = 15 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = neutrality popularity = 0.30 }
 				set_temp_variable = { party_index = 15 }
 				set_temp_variable = { party_popularity_increase = 0.30 }
+				set_temp_variable = { temp_outlook_increase = 0.30 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
@@ -1091,9 +1091,9 @@ focus_tree = {
 				}
 				set_temp_variable = { rul_party_temp = 10 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = fascism popularity = 0.30 }
 				set_temp_variable = { party_index = 10 }
 				set_temp_variable = { party_popularity_increase = 0.30 }
+				set_temp_variable = { temp_outlook_increase = 0.30 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
@@ -1113,9 +1113,9 @@ focus_tree = {
 				}
 				set_temp_variable = { rul_party_temp = 21 }
 				change_ruling_party_effect = yes
-				add_popularity = { ideology = nationalist popularity = 0.30 }
 				set_temp_variable = { party_index = 21 }
 				set_temp_variable = { party_popularity_increase = 0.30 }
+				set_temp_variable = { temp_outlook_increase = 0.30 }
 				add_relative_party_popularity = yes
 				create_country_leader = {
 					name = "Rifaat al-Assad"
@@ -1182,41 +1182,41 @@ focus_tree = {
 			if = {
 				limit = { has_government = democratic }
 				set_country_flag = Syrian_arab_democratic_party_western
-				add_popularity = { ideology = democratic popularity = 0.20 }
 				set_temp_variable = { party_index = 0 }
 				set_temp_variable = { party_popularity_increase = 0.20 }
+				set_temp_variable = { temp_outlook_increase = 0.20 }
 				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = neutrality }
 				set_country_flag = Syrian_arab_democratic_party_neutrality
-				add_popularity = { ideology = neutrality popularity = 0.20 }
 				set_temp_variable = { party_index = 15 }
 				set_temp_variable = { party_popularity_increase = 0.20 }
+				set_temp_variable = { temp_outlook_increase = 0.20 }
 				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = communism }
 				set_country_flag = Syrian_arab_democratic_party_emerging
-				add_popularity = { ideology = communism popularity = 0.20 }
 				set_temp_variable = { party_index = 6 }
 				set_temp_variable = { party_popularity_increase = 0.20 }
+				set_temp_variable = { temp_outlook_increase = 0.20 }
 				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = fascism }
 				set_country_flag = Syrian_arab_democratic_party_salafist
-				add_popularity = { ideology = fascism popularity = 0.20 }
 				set_temp_variable = { party_index = 10 }
 				set_temp_variable = { party_popularity_increase = 0.20 }
+				set_temp_variable = { temp_outlook_increase = 0.20 }
 				add_relative_party_popularity = yes
 			}
 			if = {
 				limit = { has_government = nationalist }
 				set_country_flag = Syrian_arab_democratic_party_nationalist
-				add_popularity = { ideology = nationalist popularity = 0.20 }
 				set_temp_variable = { party_index = 20 }
 				set_temp_variable = { party_popularity_increase = 0.20 }
+				set_temp_variable = { temp_outlook_increase = 0.20 }
 				add_relative_party_popularity = yes
 			}
 		}
@@ -1242,9 +1242,9 @@ focus_tree = {
 				limit = { check_variable = { Autocracy_leader < 1 } }
 				set_variable = { Autocracy_leader = 1 }
 			}
-			add_popularity = { ideology = communism popularity = -0.20 }
 			set_temp_variable = { party_index = 7 }
 			set_temp_variable = { party_popularity_increase = -0.20 }
+			set_temp_variable = { temp_outlook_increase = -0.20 }
 			add_relative_party_popularity = yes
 			hidden_effect = {
 				country_event = { id = SyriaFocus.106 days = 3 }
@@ -1398,7 +1398,6 @@ focus_tree = {
 				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 			}
-			recalculate_party = yes
 			if = { limit = { NOT = { has_idea = idea_syrian_kurds_without_citizenships } }
 				hidden_effect = {
 					country_event = SyriaFocus.99

--- a/events/05_bulgaria.txt
+++ b/events/05_bulgaria.txt
@@ -356,8 +356,9 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.05
 		}
-		add_to_variable = { party_pop_array^23 = 0.075 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.075 }
+		add_relative_party_popularity = yes
 	}
 	option = {
 		name = bulg.8.b
@@ -368,8 +369,9 @@ country_event = {
 			ideology = communism
 			popularity = 0.05
 		}
-		add_to_variable = { party_pop_array^4 = 0.075 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 4 }
+		set_temp_variable = { party_popularity_increase = 0.075 }
+		add_relative_party_popularity = yes
 	}
 }
 
@@ -389,8 +391,9 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.05
 		}
-		add_to_variable = { party_pop_array^23 = 0.075 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.075 }
+		add_relative_party_popularity = yes
 	}
 	option = {
 		name = bulg.9.b
@@ -401,8 +404,9 @@ country_event = {
 			ideology = communism
 			popularity = 0.05
 		}
-		add_to_variable = { party_pop_array^4 = 0.075 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 4 }
+		set_temp_variable = { party_popularity_increase = 0.075 }
+		add_relative_party_popularity = yes
 	}
 }
 
@@ -421,8 +425,9 @@ country_event = {
 			ideology = nationalist
 			popularity = -0.05
 		}
-		add_to_variable = { party_pop_array^23 = -0.075 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = -0.075 }
+		add_relative_party_popularity = yes
 	}
 	option = {
 		name = bulg.10.b
@@ -432,8 +437,9 @@ country_event = {
 			ideology = communism
 			popularity = -0.05
 		}
-		add_to_variable = { party_pop_array^4 = -0.075 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 4 }
+		set_temp_variable = { party_popularity_increase = -0.075 }
+		add_relative_party_popularity = yes
 	}
 }
 
@@ -499,9 +505,13 @@ country_event = {
 			set_temp_variable = { current_cons_popularity = party_pop_array^21 }
 			multiply_temp_variable = { current_cons_popularity = 0.5 }
 			# Remove most of support, retrack it to emerg communist party
-			subtract_from_variable = { party_pop_array^6 = current_cons_popularity }
-			add_to_variable = { party_pop_array^21 = current_cons_popularity }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 6 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			add_relative_party_popularity = yes
 		}
 		create_country_leader = {
 			name = "Krasimir Karakachanov"
@@ -524,9 +534,13 @@ country_event = {
 			set_temp_variable = { current_cons_popularity = party_pop_array^20 }
 			multiply_temp_variable = { current_cons_popularity = 0.5 }
 			# Remove most of support, retrack it to emerg communist party
-			subtract_from_variable = { party_pop_array^6 = current_cons_popularity }
-			add_to_variable = { party_pop_array^20 = current_cons_popularity }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 6 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			add_relative_party_popularity = yes
 		}
 	}
 }

--- a/events/05_bulgaria.txt
+++ b/events/05_bulgaria.txt
@@ -352,12 +352,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: bulg.8.a executed"
 		country_event = { id = bulg.9 days = 15 }
 		add_political_power = -50
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.05
-		}
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.075 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 	option = {
@@ -365,12 +362,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: bulg.8.b executed"
 		country_event = { id = bulg.9 days = 15 }
 		add_political_power = -50
-		add_popularity = {
-			ideology = communism
-			popularity = 0.05
-		}
 		set_temp_variable = { party_index = 4 }
 		set_temp_variable = { party_popularity_increase = 0.075 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 }
@@ -387,12 +381,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: bulg.9.a executed"
 		country_event = { id = bulg.10 days = 30 }
 		add_political_power = -50
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.05
-		}
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.075 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 	option = {
@@ -400,12 +391,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: bulg.9.b executed"
 		country_event = { id = bulg.10 days = 30 }
 		add_political_power = -50
-		add_popularity = {
-			ideology = communism
-			popularity = 0.05
-		}
 		set_temp_variable = { party_index = 4 }
 		set_temp_variable = { party_popularity_increase = 0.075 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 }
@@ -421,24 +409,18 @@ country_event = {
 		name = bulg.10.a
 		log = "[GetDateText]: [This.GetName]: bulg.10.a executed"
 		add_political_power = -50
-		add_popularity = {
-			ideology = nationalist
-			popularity = -0.05
-		}
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.075 }
+		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
 	option = {
 		name = bulg.10.b
 		log = "[GetDateText]: [This.GetName]: bulg.10.b executed"
 		add_political_power = -50
-		add_popularity = {
-			ideology = communism
-			popularity = -0.05
-		}
 		set_temp_variable = { party_index = 4 }
 		set_temp_variable = { party_popularity_increase = -0.075 }
+		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
 }

--- a/events/Afghanistan.txt
+++ b/events/Afghanistan.txt
@@ -110,12 +110,16 @@ country_event = {
 				ideology = fascism
 				popularity = 0.15
 			}
-			add_to_variable = { var = party_pop_array^11 value = 0.15 }
+			set_temp_variable = { party_index = 11 }
+			set_temp_variable = { party_popularity_increase = 0.15 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = nationalist
 				popularity = 0.05
 			}
-			add_to_variable = { var = party_pop_array^23 value = 0.05 }
+			set_temp_variable = { party_index = 23 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		if = {
 			limit = { has_country_flag = AFG_new_administration_Rabbani }
@@ -156,7 +160,9 @@ country_event = {
 				ideology = fascism
 				popularity = 0.05
 			}
-			add_to_variable = { var = party_pop_array^11 value = 0.05 }
+			set_temp_variable = { party_index = 11 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		if = {
 			limit = { has_country_flag = AFG_new_administration_Massoud }
@@ -215,13 +221,17 @@ country_event = {
 			for_each_loop = {
 				array = ruling_party
 				value = v
-				add_to_variable = { var = party_pop_array^v value = 0.15 }
+				set_temp_variable = { party_index = v }
+				set_temp_variable = { party_popularity_increase = 0.15 }
+				add_relative_party_popularity = yes
 			}
 			add_popularity = {
 				ideology = fascism
 				popularity = 0.25
 			}
-			add_to_variable = { var = party_pop_array^11 value = 0.25 }
+			set_temp_variable = { party_index = 11 }
+			set_temp_variable = { party_popularity_increase = 0.25 }
+			add_relative_party_popularity = yes
 		}
 	}
 

--- a/events/Afghanistan.txt
+++ b/events/Afghanistan.txt
@@ -106,19 +106,13 @@ country_event = {
 				value = v
 				multiply_variable = { party_pop_array^v = 1.5 }
 			}
-			add_popularity = {
-				ideology = fascism
-				popularity = 0.15
-			}
 			set_temp_variable = { party_index = 11 }
 			set_temp_variable = { party_popularity_increase = 0.15 }
+			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.05
-			}
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
 		if = {
@@ -156,12 +150,9 @@ country_event = {
 				value = v
 				multiply_variable = { party_pop_array^v = 1.5 }
 			}
-			add_popularity = {
-				ideology = fascism
-				popularity = 0.05
-			}
 			set_temp_variable = { party_index = 11 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
 		if = {
@@ -225,12 +216,9 @@ country_event = {
 				set_temp_variable = { party_popularity_increase = 0.15 }
 				add_relative_party_popularity = yes
 			}
-			add_popularity = {
-				ideology = fascism
-				popularity = 0.25
-			}
 			set_temp_variable = { party_index = 11 }
 			set_temp_variable = { party_popularity_increase = 0.25 }
+			set_temp_variable = { temp_outlook_increase = 0.25 }
 			add_relative_party_popularity = yes
 		}
 	}

--- a/events/Armenia.txt
+++ b/events/Armenia.txt
@@ -78,12 +78,9 @@ country_event = {
 			tag = ARM
 		}
 		hidden_effect = {
-			add_popularity = {
-				ideology = communism
-				popularity = 0.05
-			}
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
 	}

--- a/events/Armenia.txt
+++ b/events/Armenia.txt
@@ -82,8 +82,9 @@ country_event = {
 				ideology = communism
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 	}
 	option = {

--- a/events/Botswana.txt
+++ b/events/Botswana.txt
@@ -159,7 +159,9 @@ country_event = {
 			custom_effect_tooltip = BOT_BNF_joins_UDC
 			set_variable = { BNF_old_popularity = party_pop_array^3 }
 			subtract_from_variable = { western_change = party_pop_array^3 }
-			add_to_variable = { party_pop_array^18 = party_pop_array^3 }
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = party_pop_array^3 }
+			add_relative_party_popularity = yes
 			set_variable = { party_pop_array^3 = 0 }
 		}
 		if = {
@@ -169,7 +171,9 @@ country_event = {
 			custom_effect_tooltip = BOT_MELS_joins_UDC
 			set_variable = { MELS_old_popularity = party_pop_array^4 }
 			subtract_from_variable = { emerging_change = party_pop_array^4 }
-			add_to_variable = { party_pop_array^18 = party_pop_array^4 }
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = party_pop_array^4 }
+			add_relative_party_popularity = yes
 			set_variable = { party_pop_array^4 = 0 }
 		}
 		if = {
@@ -179,7 +183,9 @@ country_event = {
 			custom_effect_tooltip = BOT_BPP_joins_UDC
 			set_variable = { BPP_old_popularity = party_pop_array^5 }
 			subtract_from_variable = { emerging_change = party_pop_array^5 }
-			add_to_variable = { party_pop_array^18 = party_pop_array^5 }
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = party_pop_array^5 }
+			add_relative_party_popularity = yes
 			set_variable = { party_pop_array^5 = 0 }
 		}
 		if = {
@@ -188,7 +194,9 @@ country_event = {
 			}
 			custom_effect_tooltip = BOT_BMD_joins_UDC
 			set_variable = { BMD_old_popularity = party_pop_array^16 }
-			add_to_variable = { party_pop_array^18 = party_pop_array^16 }
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = party_pop_array^16 }
+			add_relative_party_popularity = yes
 			set_variable = { party_pop_array^16 = 0 }
 		}
 		if = {
@@ -197,7 +205,9 @@ country_event = {
 			}
 			custom_effect_tooltip = BOT_ISBO_joins_UDC
 			set_variable = { ISBO_old_popularity = party_pop_array^19 }
-			add_to_variable = { party_pop_array^18 = party_pop_array^19 }
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = party_pop_array^19 }
+			add_relative_party_popularity = yes
 			set_variable = { party_pop_array^19 = 0 }
 		}
 		if = {
@@ -207,7 +217,9 @@ country_event = {
 			custom_effect_tooltip = BOT_BWF_joins_UDC
 			set_variable = { BWF_old_popularity = party_pop_array^20 }
 			subtract_from_variable = { nationalist_change = party_pop_array^20 }
-			add_to_variable = { party_pop_array^18 = party_pop_array^20 }
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = party_pop_array^20 }
+			add_relative_party_popularity = yes
 			set_variable = { party_pop_array^20 = 0 }
 		}
 		set_variable = { UDC_forming_popularity = party_pop_array^18 }

--- a/events/Botswana.txt
+++ b/events/Botswana.txt
@@ -159,9 +159,7 @@ country_event = {
 			custom_effect_tooltip = BOT_BNF_joins_UDC
 			set_variable = { BNF_old_popularity = party_pop_array^3 }
 			subtract_from_variable = { western_change = party_pop_array^3 }
-			set_temp_variable = { party_index = 18 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^3 }
-			add_relative_party_popularity = yes
+			add_to_variable = { party_pop_array^18 = party_pop_array^3 }
 			set_variable = { party_pop_array^3 = 0 }
 		}
 		if = {
@@ -171,9 +169,7 @@ country_event = {
 			custom_effect_tooltip = BOT_MELS_joins_UDC
 			set_variable = { MELS_old_popularity = party_pop_array^4 }
 			subtract_from_variable = { emerging_change = party_pop_array^4 }
-			set_temp_variable = { party_index = 18 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^4 }
-			add_relative_party_popularity = yes
+			add_to_variable = { party_pop_array^18 = party_pop_array^4 }
 			set_variable = { party_pop_array^4 = 0 }
 		}
 		if = {
@@ -183,9 +179,7 @@ country_event = {
 			custom_effect_tooltip = BOT_BPP_joins_UDC
 			set_variable = { BPP_old_popularity = party_pop_array^5 }
 			subtract_from_variable = { emerging_change = party_pop_array^5 }
-			set_temp_variable = { party_index = 18 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^5 }
-			add_relative_party_popularity = yes
+			add_to_variable = { party_pop_array^18 = party_pop_array^5 }
 			set_variable = { party_pop_array^5 = 0 }
 		}
 		if = {
@@ -194,9 +188,7 @@ country_event = {
 			}
 			custom_effect_tooltip = BOT_BMD_joins_UDC
 			set_variable = { BMD_old_popularity = party_pop_array^16 }
-			set_temp_variable = { party_index = 18 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^16 }
-			add_relative_party_popularity = yes
+			add_to_variable = { party_pop_array^18 = party_pop_array^16 }
 			set_variable = { party_pop_array^16 = 0 }
 		}
 		if = {
@@ -205,9 +197,7 @@ country_event = {
 			}
 			custom_effect_tooltip = BOT_ISBO_joins_UDC
 			set_variable = { ISBO_old_popularity = party_pop_array^19 }
-			set_temp_variable = { party_index = 18 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^19 }
-			add_relative_party_popularity = yes
+			add_to_variable = { party_pop_array^18 = party_pop_array^19 }
 			set_variable = { party_pop_array^19 = 0 }
 		}
 		if = {
@@ -217,9 +207,7 @@ country_event = {
 			custom_effect_tooltip = BOT_BWF_joins_UDC
 			set_variable = { BWF_old_popularity = party_pop_array^20 }
 			subtract_from_variable = { nationalist_change = party_pop_array^20 }
-			set_temp_variable = { party_index = 18 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^20 }
-			add_relative_party_popularity = yes
+			add_to_variable = { party_pop_array^18 = party_pop_array^20 }
 			set_variable = { party_pop_array^20 = 0 }
 		}
 		set_variable = { UDC_forming_popularity = party_pop_array^18 }

--- a/events/Brazilian.txt
+++ b/events/Brazilian.txt
@@ -791,9 +791,12 @@ country_event = {
 			set_temp_variable = { col_two = 2 }
 			change_ruling_party_effect = yes
 			add_popularity = { ideology = democratic popularity = 0.1 }
-			add_to_variable = { party_pop_array^1 = 0.1 } #DEM
-			add_to_variable = { party_pop_array^2 = 0.1 } #PSDB
-			recalculate_party = yes
+			set_temp_variable = { party_index = 1 } #DEM
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 2 } #PSDB
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
 			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
@@ -806,7 +809,9 @@ country_event = {
 			set_temp_variable = { rul_party_temp = 20 }
 			set_temp_variable = { col_one = 1 }
 			change_ruling_party_effect = yes
-			add_to_variable = { party_pop_array^1 = 0.1 } #DEM
+			set_temp_variable = { party_index = 1 } #DEM
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
 			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
@@ -829,7 +834,9 @@ country_event = {
 			set_temp_variable = { rul_party_temp = 20 }
 			set_temp_variable = { col_one = 6 }
 			change_ruling_party_effect = yes
-			add_to_variable = { party_pop_array^6 = 0.1 } #PRTB
+			set_temp_variable = { party_index = 6 } #PRTB
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
 			add_popularity = { ideology = communism popularity = 0.05 }
 		}
 	}
@@ -1022,7 +1029,9 @@ country_event = {
 			set_temp_variable = { rul_party_temp = 2 }
 			set_temp_variable = { col_one = 1 }
 			change_ruling_party_effect = yes
-			add_to_variable = { party_pop_array^1 = 0.1 } #DEM
+			set_temp_variable = { party_index = 1 } #DEM
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
 			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
@@ -1047,7 +1056,9 @@ country_event = {
 			set_temp_variable = { rul_party_temp = 2 }
 			set_temp_variable = { col_one = 1 }
 			change_ruling_party_effect = yes
-			add_to_variable = { party_pop_array^1 = 0.1 } #DEM
+			set_temp_variable = { party_index = 1 } #DEM
+			set_temp_variable = { party_popularity_increase = 0.1 }
+			add_relative_party_popularity = yes
 			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}

--- a/events/Brazilian.txt
+++ b/events/Brazilian.txt
@@ -790,14 +790,14 @@ country_event = {
 			set_temp_variable = { col_one = 1 }
 			set_temp_variable = { col_two = 2 }
 			change_ruling_party_effect = yes
-			add_popularity = { ideology = democratic popularity = 0.1 }
 			set_temp_variable = { party_index = 1 } #DEM
 			set_temp_variable = { party_popularity_increase = 0.1 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { party_index = 2 } #PSDB
 			set_temp_variable = { party_popularity_increase = 0.1 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
 	option = {
@@ -811,8 +811,8 @@ country_event = {
 			change_ruling_party_effect = yes
 			set_temp_variable = { party_index = 1 } #DEM
 			set_temp_variable = { party_popularity_increase = 0.1 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
 	option = {
@@ -836,8 +836,8 @@ country_event = {
 			change_ruling_party_effect = yes
 			set_temp_variable = { party_index = 6 } #PRTB
 			set_temp_variable = { party_popularity_increase = 0.1 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = communism popularity = 0.05 }
 		}
 	}
 }
@@ -1031,8 +1031,8 @@ country_event = {
 			change_ruling_party_effect = yes
 			set_temp_variable = { party_index = 1 } #DEM
 			set_temp_variable = { party_popularity_increase = 0.1 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
 
@@ -1058,8 +1058,8 @@ country_event = {
 			change_ruling_party_effect = yes
 			set_temp_variable = { party_index = 1 } #DEM
 			set_temp_variable = { party_popularity_increase = 0.1 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = democratic popularity = 0.1 }
 		}
 	}
 }

--- a/events/Georgia.txt
+++ b/events/Georgia.txt
@@ -404,12 +404,17 @@ country_event = {
 			set_temp_variable = { current_cons_popularity = party_pop_array^0 }
 			multiply_temp_variable = { current_cons_popularity = 9.5 }
 			# Remove most of support, retrack it to emerg communist party
-			subtract_from_variable = { party_pop_array^7 = current_cons_popularity }
-			add_to_variable = { party_pop_array^0 = current_cons_popularity }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 7 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			multiply_temp_variable = { party_popularity_increase = -1 }
+			add_relative_party_popularity = yes
+			set_temp_variable = { party_index = 0 }
+			set_temp_variable = { party_popularity_increase = current_cons_popularity }
+			add_relative_party_popularity = yes
 		}
-		add_to_variable = { party_pop_array^0 = 0.30 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 0 }
+		set_temp_variable = { party_popularity_increase = 0.30 }
+		add_relative_party_popularity = yes
 		create_country_leader = {
 			name = "Nino Burjanadze - Interim Government"
 			picture = "nino_burjanadze.dds"

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -11126,12 +11126,9 @@ country_event = {
 			multiply_temp_variable = { current_cons_popularity = 0.5 }
 			recalculate_party = yes
 		}
-		add_popularity = {
-			ideology = democratic
-			popularity = 0.3
-		}
 		set_temp_variable = { party_index = 0 }
 		set_temp_variable = { party_popularity_increase = 0.3 }
+		set_temp_variable = { temp_outlook_increase = 0.3 }
 		add_relative_party_popularity = yes
 		create_country_leader = {
 			name = "Dmitriy Medvedev"

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -8441,10 +8441,10 @@ country_event = {
 				multiply_temp_variable = {
 					current_cons_popularity = 0.5
 				}
-				subtract_from_variable = {
-					party_pop_array^2 = current_cons_popularity
-				}
-				recalculate_party = yes
+				set_temp_variable = { party_index = 2 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
 				retire_country_leader = yes
 				retire_country_leader = yes
 				POL = {
@@ -8502,10 +8502,10 @@ country_event = {
 				multiply_temp_variable = {
 					current_cons_popularity = 0.5
 				}
-				subtract_from_variable = {
-					party_pop_array^2 = current_cons_popularity
-				}
-				recalculate_party = yes
+				set_temp_variable = { party_index = 2 }
+				set_temp_variable = { party_popularity_increase = current_cons_popularity }
+				multiply_temp_variable = { party_popularity_increase = -1 }
+				add_relative_party_popularity = yes
 				retire_country_leader = yes
 				retire_country_leader = yes
 				CZE = {
@@ -11122,8 +11122,6 @@ country_event = {
 			set_temp_variable = { rul_party_temp = 0 }
 			set_temp_variable = { col_one = 1 }
 			change_ruling_party_effect = yes
-			set_temp_variable = { current_cons_popularity = party_pop_array^2 }
-			multiply_temp_variable = { current_cons_popularity = 0.5 }
 			recalculate_party = yes
 		}
 		set_temp_variable = { party_index = 0 }

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -5497,14 +5497,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: rusboloto.1.b executed"
 		ai_chance = { base = 10 }
 		hidden_effect = {
-			add_to_variable = { party_pop_array^20 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = SOV
 	}
@@ -5536,14 +5538,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: rusboloto.2.b executed"
 		ai_chance = { base = 10 }
 		hidden_effect = {
-			add_to_variable = { party_pop_array^20 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = SOV
 	}
@@ -6647,8 +6651,9 @@ country_event = {
 		name = sov_communists.5.a
 		log = "[GetDateText]: [This.GetName]: sov_communists.5.a"
 		add_stability = 0.02
-		add_to_variable = { party_pop_array^4 = 0.07 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 4 }
+		set_temp_variable = { party_popularity_increase = 0.07 }
+		add_relative_party_popularity = yes
 		ai_chance = {
 			base = 25
 		}
@@ -6658,8 +6663,9 @@ country_event = {
 		name = sov_communists.5.b
 		log = "[GetDateText]: [This.GetName]: sov_communists.5.b"
 		add_war_support = 0.04
-		add_to_variable = { party_pop_array^4 = 0.03 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 4 }
+		set_temp_variable = { party_popularity_increase = 0.03 }
+		add_relative_party_popularity = yes
 		ai_chance = {
 			base = 25
 		}
@@ -6774,8 +6780,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.1.a"
 		add_stability = 0.02
 		increase_centralization = yes
-		add_to_variable = { party_pop_array^20 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 20 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		hidden_effect = {
 			country_event = sov_nationalists.20
 			set_cosmetic_tag = SOV_AUTH_S_nationalist
@@ -6795,8 +6802,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.1.b"
 		add_war_support = 0.05
 		increase_military_spending = yes
-		add_to_variable = { party_pop_array^20 = 0.02 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 20 }
+		set_temp_variable = { party_popularity_increase = 0.02 }
+		add_relative_party_popularity = yes
 		hidden_effect = {
 			country_event = sov_nationalists.20
 			set_cosmetic_tag = SOV_AUTH_S_nationalist
@@ -9442,8 +9450,9 @@ country_event = {
 	option = {
 		name = sov_final_strike.1.a
 		log = "[GetDateText]: [This.GetName]: sov_final_strike.1.a"
-		add_to_variable = { party_pop_array^6 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 6 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		for_each_scope_loop = {
 			array = global.nato_members
 			add_opinion_modifier = {
@@ -9537,8 +9546,9 @@ country_event = {
 		name = sov_final_strike.2.a
 		log = "[GetDateText]: [This.GetName]: sov_final_strike.2.a"
 		add_stability = -0.06
-		add_to_variable = { party_pop_array^6 = -0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 6 }
+		set_temp_variable = { party_popularity_increase = -0.05 }
+		add_relative_party_popularity = yes
 		add_timed_idea = { idea = SOV_slow_advance_idea days = 720 }
 		ai_chance = {
 			base = 25
@@ -9564,8 +9574,9 @@ country_event = {
 		name = sov_final_strike.3.a
 		log = "[GetDateText]: [This.GetName]: sov_final_strike.3.a"
 		add_war_support = 0.05
-		add_to_variable = { party_pop_array^6 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 6 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		ai_chance = {
 			base = 25
 		}
@@ -9705,8 +9716,9 @@ country_event = {
 	option = {
 		name = sov_final_strike.8.a
 		log = "[GetDateText]: [This.GetName]: sov_final_strike.8.a"
-		add_to_variable = { party_pop_array^6 = 0.05 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 6 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
+		add_relative_party_popularity = yes
 		for_each_scope_loop = {
 			array = global.nato_members
 			add_opinion_modifier = {
@@ -11118,8 +11130,9 @@ country_event = {
 			ideology = democratic
 			popularity = 0.3
 		}
-		add_to_variable = { party_pop_array^0 = 0.3 }
-		recalculate_party = yes
+		set_temp_variable = { party_index = 0 }
+		set_temp_variable = { party_popularity_increase = 0.3 }
+		add_relative_party_popularity = yes
 		create_country_leader = {
 			name = "Dmitriy Medvedev"
 			picture = "Dimitry_Medvedev.dds"

--- a/events/Turkey.txt
+++ b/events/Turkey.txt
@@ -2171,11 +2171,9 @@ country_event = {
 		#Half of the lost MPs go to CHP
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = chp_boost }
+		set_temp_variable = { temp_outlook_increase = outlook_change }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = TUR_CHP_BOOST_TT
-		#Adjust Outlook popularity
-		add_popularity = { ideology = democratic popularity = outlook_change }
-		recalculate_party = yes
 	}
 	option = {
 		name = Turkey.1.b	#Backroom deals

--- a/events/Turkey.txt
+++ b/events/Turkey.txt
@@ -2163,10 +2163,15 @@ country_event = {
 		set_temp_variable = { outlook_change = chp_boost }
 		multiply_temp_variable = { outlook_change = -1 }
 		#DSP loses half its MPs
-		subtract_from_variable = { party_pop_array^3 = party_change }
+		set_temp_variable = { party_index = 3 }
+		set_temp_variable = { party_popularity_increase = party_change }
+		multiply_temp_variable = { party_popularity_increase = -1 }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = TUR_DSP_LOSS_TT
 		#Half of the lost MPs go to CHP
-		add_to_variable = { party_pop_array^1 = chp_boost }
+		set_temp_variable = { party_index = 1 }
+		set_temp_variable = { party_popularity_increase = chp_boost }
+		add_relative_party_popularity = yes
 		custom_effect_tooltip = TUR_CHP_BOOST_TT
 		#Adjust Outlook popularity
 		add_popularity = { ideology = democratic popularity = outlook_change }
@@ -2682,8 +2687,9 @@ country_event = {
 				set_temp_variable = { rul_party_temp = 22 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-				add_to_variable = { party_pop_array^22 = 0.20 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 22 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 				meta_effect = {
 					text = {
 						set_country_flag = [META_SET_RULING_PARTY]
@@ -2710,8 +2716,9 @@ country_event = {
 				set_temp_variable = { rul_party_temp = 22 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-				add_to_variable = { party_pop_array^22 = 0.20 }
-				recalculate_party = yes
+				set_temp_variable = { party_index = 22 }
+				set_temp_variable = { party_popularity_increase = 0.20 }
+				add_relative_party_popularity = yes
 				meta_effect = {
 					text = {
 						set_country_flag = [META_SET_RULING_PARTY]

--- a/events/centralasia_events.txt
+++ b/events/centralasia_events.txt
@@ -1032,14 +1032,16 @@ country_event = { #Historical 2022
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
-					add_to_variable = { party_pop_array^21 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 21 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 					add_popularity = {
 						ideology = democratic
 						popularity = 0.05
 					}
-					add_to_variable = { party_pop_array^4 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 4 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 				hold_election = KAZ
 			}
@@ -1054,14 +1056,16 @@ country_event = { #Historical 2022
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
-					add_to_variable = { party_pop_array^21 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 21 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 					add_popularity = {
 						ideology = nationalist
 						popularity = 0.05
 					}
-					add_to_variable = { party_pop_array^4 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 4 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 				hold_election = KAZ
 			}
@@ -1121,14 +1125,16 @@ country_event = {
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
-					add_to_variable = { party_pop_array^21 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 21 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 					add_popularity = {
 						ideology = democratic
 						popularity = 0.05
 					}
-					add_to_variable = { party_pop_array^4 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 4 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 				hold_election = KAZ
 			}
@@ -1143,14 +1149,16 @@ country_event = {
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
-					add_to_variable = { party_pop_array^21 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 21 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 					add_popularity = {
 						ideology = nationalist
 						popularity = 0.05
 					}
-					add_to_variable = { party_pop_array^4 = 0.05 }
-					recalculate_party = yes
+					set_temp_variable = { party_index = 4 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					add_relative_party_popularity = yes
 				}
 				hold_election = KAZ
 			}
@@ -1380,14 +1388,16 @@ country_event = { #Historical 2005
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
-			add_to_variable = { party_pop_array^21 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = UZB
 
@@ -1440,14 +1450,16 @@ country_event = { #Historical 2005
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
-			add_to_variable = { party_pop_array^21 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = UZB
 
@@ -1730,14 +1742,16 @@ country_event = { #Historical 2005
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
-			add_to_variable = { party_pop_array^21 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = KYR
 
@@ -1973,14 +1987,16 @@ country_event = { #Historical 2010
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
-			add_to_variable = { party_pop_array^21 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = KYR
 
@@ -2300,14 +2316,16 @@ country_event = { #Historical 2020
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
-			add_to_variable = { party_pop_array^21 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 			add_popularity = {
 				ideology = democratic
 				popularity = 0.05
 			}
-			add_to_variable = { party_pop_array^4 = 0.05 }
-			recalculate_party = yes
+			set_temp_variable = { party_index = 4 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			add_relative_party_popularity = yes
 		}
 		hold_election = KYR
 

--- a/events/centralasia_events.txt
+++ b/events/centralasia_events.txt
@@ -1032,6 +1032,7 @@ country_event = { #Historical 2022
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
+					set_temp_variable = { temp_outlook_increase = 0 }
 					set_temp_variable = { party_index = 21 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					add_relative_party_popularity = yes
@@ -1056,6 +1057,7 @@ country_event = { #Historical 2022
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
+					set_temp_variable = { temp_outlook_increase = 0 }
 					set_temp_variable = { party_index = 21 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					add_relative_party_popularity = yes
@@ -1125,6 +1127,7 @@ country_event = {
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
+					set_temp_variable = { temp_outlook_increase = 0 }
 					set_temp_variable = { party_index = 21 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					add_relative_party_popularity = yes
@@ -1149,6 +1152,7 @@ country_event = {
 				add_relative_party_popularity = yes
 
 				hidden_effect = {
+					set_temp_variable = { temp_outlook_increase = 0 }
 					set_temp_variable = { party_index = 21 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					add_relative_party_popularity = yes
@@ -1388,6 +1392,7 @@ country_event = { #Historical 2005
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
+			set_temp_variable = { temp_outlook_increase = 0 }
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1450,6 +1455,7 @@ country_event = { #Historical 2005
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
+			set_temp_variable = { temp_outlook_increase = 0 }
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1742,6 +1748,7 @@ country_event = { #Historical 2005
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
+			set_temp_variable = { temp_outlook_increase = 0 }
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1987,6 +1994,7 @@ country_event = { #Historical 2010
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
+			set_temp_variable = { temp_outlook_increase = 0 }
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2316,6 +2324,7 @@ country_event = { #Historical 2020
 		add_relative_party_popularity = yes
 
 		hidden_effect = {
+			set_temp_variable = { temp_outlook_increase = 0 }
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes


### PR DESCRIPTION
## Summary

Migrates the deprecated party-popularity pattern to the current API across non-India focus trees, decisions, and events. Split out of the India RAJ PR (#1192) so the cross-country change can be reviewed on its own.

Replaces:

```
add_to_variable = { party_pop_array^N = X }
recalculate_party = yes
```

with:

```
set_temp_variable = { party_index = N }
set_temp_variable = { party_popularity_increase = X }
add_relative_party_popularity = yes
```

`add_relative_party_popularity` already exists in `00_subideology_scripted_effects.txt`; the old API still works, so this is a non-breaking cleanup.

## Files (24)

Russia and EU focus trees / decisions, plus Belarus, Chechnya, South Ossetia, Turkey, Egypt, Georgia, Bulgaria, Transnistria, Brazil, Poland, Syria, Afghanistan, Armenia, Botswana, and central Asia events.

## Notes

- India's own files (`05_india.txt`, `India.txt`, `events/Indian.txt`) still contain matching migration sites; those ride along with #1192 since they are interleaved with India content.
- Dozens of other countries still use the old API. This PR does not attempt a full repo-wide migration, only the sites that were already converted on the India branch.

## Testing

- [ ] Spot-check a migrated focus/event/decision per country: complete it and confirm the subideology popularity shifts as before.
