### PR TITLE
Default party_index to ruling party in add_relative_party_popularity

### DIFF
--- a/common/decisions/05_ENG_decisions.txt
+++ b/common/decisions/05_ENG_decisions.txt
@@ -1251,7 +1251,6 @@ decisions_ENG = {
 		is_good = no
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_build_london"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.025 }
 			add_relative_party_popularity = yes
 		}
@@ -1283,7 +1282,6 @@ decisions_ENG = {
 		is_good = no
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_promise_labour"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			add_relative_party_popularity = yes
 		}
@@ -1316,7 +1314,6 @@ decisions_ENG = {
 		is_good = no
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_promise_military"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			add_relative_party_popularity = yes
 		}
@@ -1352,7 +1349,6 @@ decisions_ENG = {
 		is_good = no
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_promise_fossil_fuel"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			add_relative_party_popularity = yes
 		}

--- a/common/decisions/05_SWE_decision.txt
+++ b/common/decisions/05_SWE_decision.txt
@@ -1003,7 +1003,6 @@ SWE_decision_Royal_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SWE_charity"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes

--- a/common/decisions/05_comoros_decisions.txt
+++ b/common/decisions/05_comoros_decisions.txt
@@ -184,7 +184,6 @@ COM_mayotte_referendum_decisions = {
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect COM_mayotte_referendum_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 

--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -608,7 +608,6 @@ EGY_coptic_decision = {
 			modify_coptic_opinion_effect = yes
 			set_temp_variable = { coptic_pol_influence_change = 5 }
 			modify_coptic_pol_influence_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -902,7 +901,6 @@ EGY_aswan_tribal_clashes_category = {
 		complete_effect = {
 			effect_tooltip = {
 				add_stability = 0.03
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.05 }
 				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes

--- a/common/decisions/05_japan.txt
+++ b/common/decisions/05_japan.txt
@@ -561,7 +561,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_increasing_childbirth_allowance_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -640,7 +639,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_free_early_childhood_education_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -725,7 +723,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_child_allowances_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -806,7 +803,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_fertility_treatment_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -885,7 +881,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_expanding_social_insurance_coverage_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -968,7 +963,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_digital_reskilling_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -1049,7 +1043,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_converting_regular_employment_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -1132,7 +1125,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_job_change_market_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -1213,7 +1205,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_rent_housing_support_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -1296,7 +1287,6 @@ JAP_domestic_policy_decision = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove JAP_support_marriage_and_starting_a_new_remove_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes

--- a/common/decisions/Cartel Decisions.txt
+++ b/common/decisions/Cartel Decisions.txt
@@ -270,7 +270,6 @@ cartels_decision_category = {
 					set_country_flag = failed_investigation_casino
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -402,7 +401,6 @@ cartels_decision_category = {
 					set_country_flag = failed_investigation_banks
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -530,7 +528,6 @@ cartels_decision_category = {
 					set_country_flag = failed_investigation_shell_companies
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -688,7 +685,6 @@ cartels_decision_category = {
 					set_country_flag = failed_raid_drug_convoys
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -838,7 +834,6 @@ cartels_decision_category = {
 					set_country_flag = failed_raid_cartel_hideouts
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -964,7 +959,6 @@ cartels_decision_category = {
 					set_country_flag = failed_raid_distribution_centres
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -1086,7 +1080,6 @@ cartels_decision_category = {
 					set_country_flag = failed_raid_refinement_centres
 					custom_effect_tooltip = investigate_bad_results_tt
 					effect_tooltip = {
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						set_temp_variable = { temp_outlook_increase = -0.04 }
 						add_relative_party_popularity = yes
@@ -1140,7 +1133,6 @@ cartels_decision_category = {
 						}
 						factor = 2.0
 					}
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = 0.03 }
 					set_temp_variable = { temp_outlook_increase = 0.03 }
 					add_relative_party_popularity = yes
@@ -1193,7 +1185,6 @@ cartels_decision_category = {
 						factor = 1.10
 						difficulty > 1
 					}
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = -0.04 }
 					set_temp_variable = { temp_outlook_increase = -0.04 }
 					add_relative_party_popularity = yes
@@ -1244,7 +1235,6 @@ cartels_decision_category = {
 						}
 						factor = 2.0
 					}
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = 0.03 }
 					set_temp_variable = { temp_outlook_increase = 0.03 }
 					add_relative_party_popularity = yes
@@ -1297,7 +1287,6 @@ cartels_decision_category = {
 						factor = 1.10
 						difficulty > 1
 					}
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = -0.03 }
 					set_temp_variable = { temp_outlook_increase = -0.03 }
 					add_relative_party_popularity = yes

--- a/common/decisions/Cuba.txt
+++ b/common/decisions/Cuba.txt
@@ -461,7 +461,6 @@ CUB_blockade_fight_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: CUB_propoganda_of_time_inv"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.003 }
 			add_relative_party_popularity = yes
 			add_stability = 0.05
@@ -486,7 +485,6 @@ CUB_blockade_fight_category = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: CUB_ask_for_chinese_money"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			add_relative_party_popularity = yes
 			add_stability = 0.05

--- a/common/decisions/Czech_Republic.txt
+++ b/common/decisions/Czech_Republic.txt
@@ -7469,7 +7469,6 @@ CZE_fidesz_problem = {
 					val = CZE_intel_strength
 				}
 
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = CZE_intel_strength }
 				add_relative_party_popularity = yes
 			}
@@ -7519,7 +7518,6 @@ CZE_fidesz_problem = {
 					var = party_pop_array^14
 					val = CZE_intel_strength
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = CZE_intel_strength }
 				add_relative_party_popularity = yes
 			}
@@ -7562,7 +7560,6 @@ CZE_fidesz_problem = {
 			CZE_intel_bonus_effect = yes
 
 			HUN = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = CZE_intel_strength }
 				add_relative_party_popularity = yes
 			}
@@ -7604,7 +7601,6 @@ CZE_fidesz_problem = {
 			CZE_intel_bonus_effect = yes
 
 			HUN = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = CZE_intel_strength }
 				add_relative_party_popularity = yes
 

--- a/common/decisions/Germany.txt
+++ b/common/decisions/Germany.txt
@@ -2948,7 +2948,6 @@ GER_balance_of_power_category = {
 				id = GER_power_balance
 				value = -0.125
 			}
-			set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.01 }
 				set_temp_variable = { temp_outlook_increase = 0.002 }
 				add_relative_party_popularity = yes
@@ -2991,7 +2990,6 @@ GER_balance_of_power_category = {
 				id = GER_power_balance
 				value = -0.15
 			}
-			set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				set_temp_variable = { temp_outlook_increase = 0.002 }
 				add_relative_party_popularity = yes
@@ -3038,7 +3036,6 @@ GER_balance_of_power_category = {
 				id = GER_power_balance
 				value = 0.05
 			}
-			set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				set_temp_variable = { temp_outlook_increase = 0.02 }
 				add_relative_party_popularity = yes
@@ -3082,7 +3079,6 @@ GER_balance_of_power_category = {
 				id = GER_power_balance
 				value = 0.075
 			}
-			set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				set_temp_variable = { temp_outlook_increase = 0.02 }
 				add_relative_party_popularity = yes

--- a/common/decisions/Hezbollah.txt
+++ b/common/decisions/Hezbollah.txt
@@ -1354,7 +1354,6 @@ HEZ_our_boots_on_africa_decisions = {
 		}
 		remove_effect = {
 			LBA = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.03 }
 				add_relative_party_popularity = yes
 				add_political_power = -20

--- a/common/decisions/Indonesia.txt
+++ b/common/decisions/Indonesia.txt
@@ -1289,7 +1289,6 @@ IND_back_noone = {
 		cost = 50
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove IND_neutral"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1580,7 +1579,6 @@ IND_help_aceh = {
 		days_remove = 45
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove IND_aceh5"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -2.75 }

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -3263,7 +3263,6 @@ PER_domestic_politics = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_distribute_leader_photos"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -3897,7 +3896,6 @@ PER_domestic_politics = {
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_political_backup"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.15 }
 			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
@@ -4886,7 +4884,6 @@ PER_Iranian_prime_ministers = {
 		days_re_enable = 180
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_crack_down_on_crime"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -5714,7 +5711,6 @@ PER_Iranian_prime_ministers = {
 				}
 			}
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -5812,7 +5808,6 @@ PER_new_majlis = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_new_majlis"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6288,7 +6283,6 @@ PER_new_majlis = {
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_purging_the_remnants"
 			clr_country_flag = PER_doing_proposal
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -6319,7 +6313,6 @@ PER_new_majlis = {
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_turning_the_clock_forward"
 			clr_country_flag = PER_doing_proposal
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -6466,7 +6459,6 @@ PER_new_majlis = {
 		is_good = no
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_clean_records"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -6574,7 +6566,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_is_this_thing_on"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.15 }
 			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
@@ -6641,7 +6632,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_no_mountain_will_stop_us"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.15 }
 			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
@@ -6681,7 +6671,6 @@ PER_new_majlis = {
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_iran_is_full"
 			clr_country_flag = PER_doing_proposal
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -6894,7 +6883,6 @@ PER_new_majlis = {
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_the_socialist_threat"
 			clr_country_flag = PER_doing_proposal
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -7315,7 +7303,6 @@ PER_new_majlis = {
 		is_good = no
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_no_place_for_fascists"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.15 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -7324,7 +7311,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_no_place_for_fascists"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.15 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -7803,7 +7789,6 @@ PER_new_majlis = {
 	# 	is_good = no
 	# 	complete_effect = {
 	# 		log = "[GetDateText]: [Root.GetName]: Decision timeout PER_a_return_to_the_past"
-	# 		set_party_index_to_ruling_party = yes
 	# 		set_temp_variable = { party_popularity_increase = 0.1 }
 	# 		set_temp_variable = { temp_outlook_increase = 0.1 }
 	# 		add_relative_party_popularity = yes
@@ -7815,7 +7800,6 @@ PER_new_majlis = {
 	# 	}
 	# 	timeout_effect = {
 	# 		log = "[GetDateText]: [Root.GetName]: Decision timeout PER_a_return_to_the_past"
-	# 		set_party_index_to_ruling_party = yes
 	# 		set_temp_variable = { party_popularity_increase = -0.1 }
 	# 		set_temp_variable = { temp_outlook_increase = -0.1 }
 	# 		add_relative_party_popularity = yes
@@ -7950,7 +7934,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_demand_our_payments"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -8210,7 +8193,6 @@ PER_new_majlis = {
 		is_good = no
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_right_to_bear_arms"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -8222,7 +8204,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_right_to_bear_arms"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -8364,7 +8345,6 @@ PER_new_majlis = {
 				category = CAT_nuclear_reactors
 				category = CAT_nuclear_weapons
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -8451,7 +8431,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_the_electric_grid"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -8727,7 +8706,6 @@ PER_new_majlis = {
 		is_good = no
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_air_facilities"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
@@ -8737,7 +8715,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_air_facilities"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -9444,7 +9421,6 @@ PER_new_majlis = {
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_brothers_to_the_east"
 			add_political_power = -500
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -9722,7 +9698,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_industrialization_of_rural_areas"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -9790,7 +9765,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_passive_aggressive_competition"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -10095,7 +10069,6 @@ PER_new_majlis = {
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_our_rightful_money"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -14572,7 +14545,6 @@ PER_clergy_balance_of_power_category = {
 				value = 0.05
 			}
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.025 }
 			set_temp_variable = { temp_outlook_increase = 0.015 }
 			add_relative_party_popularity = yes

--- a/common/decisions/Iraq.txt
+++ b/common/decisions/Iraq.txt
@@ -842,13 +842,11 @@ IRQ_political_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision IRQ_the_blood_quran"
 			random_list = {
 				50 = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = 0.10 }
 					set_temp_variable = { temp_outlook_increase = 0.10 }
 					add_relative_party_popularity = yes
 				}
 				50 = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = -0.075 }
 					set_temp_variable = { temp_outlook_increase = -0.055 }
 					add_relative_party_popularity = yes

--- a/common/decisions/Israel.txt
+++ b/common/decisions/Israel.txt
@@ -1445,7 +1445,6 @@ israel_palestine_category = {
 			block_operations = yes
 			add_command_power = 15
 			add_war_support = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/decisions/Italy.txt
+++ b/common/decisions/Italy.txt
@@ -1892,7 +1892,6 @@ mafia_ITA = {
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			add_war_support = 0.2
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2404,7 +2403,6 @@ generic_ITA = {
 			set_temp_variable = { decision_gdp_cost = gdp_total }
 			multiply_temp_variable = { decision_gdp_cost = -0.002 }
 			multiply_temp_variable = { one_time_paycheck_bonus_cost = decision_gdp_cost }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			set_temp_variable = { temp_outlook_increase = 0.04 }
 			add_relative_party_popularity = yes
@@ -2803,7 +2801,6 @@ generic_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision discredit_political_opponents_in_talk_shows executed"
 			set_variable = { discredit_political_opponents_in_talk_shows_cost = discredit_political_opponents_in_talk_shows_times_taken_var }
 			multiply_variable = { discredit_political_opponents_in_talk_shows_cost = 10 }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -2916,7 +2913,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2977,7 +2973,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3038,7 +3033,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3099,7 +3093,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3160,7 +3153,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3221,7 +3213,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3282,7 +3273,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3343,7 +3333,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3404,7 +3393,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3465,7 +3453,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3526,7 +3513,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3587,7 +3573,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3648,7 +3633,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3709,7 +3693,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3770,7 +3753,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3831,7 +3813,6 @@ integrative_restoration_ITA = {
 				clear_variable = ITA_monuments_restored_counter
 			}
 			add_political_power = 250
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -4729,7 +4710,6 @@ policies_ITA = {
 			}
 			set_temp_variable = { drift_switch_change = 0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -4769,7 +4749,6 @@ policies_ITA = {
 			}
 			set_temp_variable = { drift_switch_change = -0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -4886,7 +4865,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_let_companies_fail_decision executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -4918,7 +4896,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_let_companies_fail_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -4980,7 +4957,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_modify_article_18_decision executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -5012,7 +4988,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_modify_article_18_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -5082,7 +5057,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = -0.05 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -5117,7 +5091,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = 0.04 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -5168,7 +5141,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_citizenship_income_decision executed"
 			set_temp_variable = { drift_switch_change = 0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -5201,7 +5173,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_citizenship_income_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.03 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -5276,7 +5247,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = 0.05 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -5313,7 +5283,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = -0.06 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5395,7 +5364,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = 0.03 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -5428,7 +5396,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = -0.04 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5490,7 +5457,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = 0.03 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -5523,7 +5489,6 @@ policies_ITA = {
 			multiply_temp_variable = { money_amount = -0.04 }
 			set_temp_variable = { treasury_change = money_amount }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5665,7 +5630,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_protect_prisoners_rights_decision executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -5689,7 +5653,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_protect_prisoners_rights_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -5736,7 +5699,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_allow_euthanasia_decision executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -5760,7 +5722,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_allow_euthanasia_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -5808,7 +5769,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_allow_same_sex_marriage_decision executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -5832,7 +5792,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_allow_same_sex_marriage_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -5878,7 +5837,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_outlaw_lgbt_behaviour_decision executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -5902,7 +5860,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_outlaw_lgbt_behaviour_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -5968,7 +5925,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_repeal_law_194_decision executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -6062,7 +6018,6 @@ policies_ITA = {
 			}
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -6096,7 +6051,6 @@ policies_ITA = {
 			}
 			set_temp_variable = { drift_switch_change = -0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -6154,7 +6108,6 @@ policies_ITA = {
 			modify_reform_expectance_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -6185,7 +6138,6 @@ policies_ITA = {
 			modify_reform_expectance_effect = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_labour_unions_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -6276,7 +6228,6 @@ policies_ITA = {
 				add_idea = ITA_migration_tolerated
 				remove_idea = ITA_migrants_from_africa
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -6311,7 +6262,6 @@ policies_ITA = {
 				add_idea = ITA_migrants_from_africa
 				remove_idea = ITA_migration_tolerated
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -6371,7 +6321,6 @@ policies_ITA = {
 				add_idea = ITA_migrants_from_africa_encouraged
 				remove_idea = ITA_migration_tolerated
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -6408,7 +6357,6 @@ policies_ITA = {
 				add_idea = ITA_migration_tolerated
 				remove_idea = ITA_migrants_from_africa_encouraged
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -6471,7 +6419,6 @@ policies_ITA = {
 			set_temp_variable = { drift_switch_change = -0.02 }
 			modify_reform_expectance_effect = yes
 			add_ideas = ITA_ius_soli_spirit
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -6495,7 +6442,6 @@ policies_ITA = {
 			set_temp_variable = { drift_switch_change = 0.015 }
 			modify_reform_expectance_effect = yes
 			remove_ideas = ITA_ius_soli_spirit
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			set_temp_variable = { temp_outlook_increase = 0.04 }
 			add_relative_party_popularity = yes
@@ -6542,7 +6488,6 @@ policies_ITA = {
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
 			add_ideas = ITA_ius_scholae_spirit
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -6566,7 +6511,6 @@ policies_ITA = {
 			set_temp_variable = { drift_switch_change = 0.005 }
 			modify_reform_expectance_effect = yes
 			remove_ideas = ITA_ius_scholae_spirit
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -6619,7 +6563,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_encourage_births_decision executed"
 			set_temp_variable = { drift_switch_change = 0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6669,7 +6612,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_normalize_extraordinary_bonuses_decision executed"
 			set_temp_variable = { drift_switch_change = 0.05 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6697,7 +6639,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_normalize_extraordinary_bonuses_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.06 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -6753,7 +6694,6 @@ policies_ITA = {
 			modify_reform_expectance_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -6784,7 +6724,6 @@ policies_ITA = {
 			modify_reform_expectance_effect = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_labour_unions_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -6857,7 +6796,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_tax_the_rich_decision executed"
 			set_temp_variable = { drift_switch_change = 0.03 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6885,7 +6823,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_tax_the_rich_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.04 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -6952,7 +6889,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_flat_tax_decision executed"
 			set_temp_variable = { drift_switch_change = 0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -6980,7 +6916,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_flat_tax_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.03 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -7108,7 +7043,6 @@ policies_ITA = {
 			change_labour_unions_opinion = yes
 			set_temp_variable = { drift_switch_change = 0.03 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -7138,7 +7072,6 @@ policies_ITA = {
 			change_labour_unions_opinion = yes
 			set_temp_variable = { drift_switch_change = -0.04 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -7195,7 +7128,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_ban_gmos_decision executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7223,7 +7155,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_ban_gmos_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -7308,7 +7239,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_ban_nuclear_power_decision executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -7343,7 +7273,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_ban_nuclear_power_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -7389,7 +7318,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_encourage_renewables_decision executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7417,7 +7345,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_encourage_renewables_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -7453,7 +7380,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_happy_degrowth_decision executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -7479,7 +7405,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_happy_degrowth_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -7643,7 +7568,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_building_amnesty_decision executed"
 			set_temp_variable = { drift_switch_change = 0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7737,7 +7661,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_widespread_expropriation_decision executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7763,7 +7686,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_widespread_expropriation_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -7808,7 +7730,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_redistribution_decision executed"
 			set_temp_variable = { drift_switch_change = 0.03 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -7955,7 +7876,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_silence_defeatists_decision executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7977,7 +7897,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_silence_defeatists_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -8104,7 +8023,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_Quota_100_decision executed"
 			set_temp_variable = { drift_switch_change = 0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -8148,7 +8066,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_Quota_100_decision_repeal executed"
 			set_temp_variable = { drift_switch_change = -0.03 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -8197,7 +8114,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_increase_pension_age_requirements_decision executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -8237,7 +8153,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_increase_pension_age_requirements_decision executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -8286,7 +8201,6 @@ policies_ITA = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_recalculate_baby_pensions_decision executed"
 			set_temp_variable = { drift_switch_change = -0.01 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -8326,7 +8240,6 @@ policies_ITA = {
 		days_re_enable = 365
 		complete_effect = {
 			log = "[GetDateText]: [This.GetName]: decision ITA_recalculate_baby_pensions_decision_repeal executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -8371,7 +8284,6 @@ policies_ITA = {
 			modify_reform_expectance_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -8415,7 +8327,6 @@ policies_ITA = {
 			modify_reform_expectance_effect = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_labour_unions_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes

--- a/common/decisions/Korea.txt
+++ b/common/decisions/Korea.txt
@@ -362,7 +362,6 @@ KOR_38th_parallel = {
 				}
 			}
 			custom_effect_tooltip = KOR_popularity_decrease_tt
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			add_relative_party_popularity = yes
 

--- a/common/decisions/Spain.txt
+++ b/common/decisions/Spain.txt
@@ -31,14 +31,12 @@ SPR_the_regions_of_spain = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect SPR_basque_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_political_power = 25
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect SPR_basque_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.075 }
 			add_relative_party_popularity = yes
 			set_country_flag = NAV_revolted_against_spain
@@ -187,14 +185,12 @@ SPR_the_regions_of_spain = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect SPR_basque_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_political_power = 25
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect SPR_basque_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.075 }
 			add_relative_party_popularity = yes
 			set_country_flag = CAT_revolted_against_spain
@@ -378,14 +374,12 @@ SPR_the_regions_of_spain = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect SPR_galician_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_political_power = 25
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect SPR_galician_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.075 }
 			add_relative_party_popularity = yes
 			set_country_flag = GAL_revolted_against_spain
@@ -556,14 +550,12 @@ SPR_the_regions_of_spain = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect SPR_andalusia_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_political_power = 25
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect SPR_andalusia_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.075 }
 			add_relative_party_popularity = yes
 			set_country_flag = SPA_revolted_against_spain
@@ -741,14 +733,12 @@ SPR_the_regions_of_spain = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect SPR_canarios_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_political_power = 25
 		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect SPR_canarios_revolt_against_spain_mission"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.075 }
 			add_relative_party_popularity = yes
 			set_country_flag = CNR_revolted_against_spain
@@ -1356,7 +1346,6 @@ SPR_political_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SPR_file_a_motion_of_no_confidence"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			add_relative_party_popularity = yes
 			set_country_flag = { flag = SPR_filed_a_motion_of_no_confidence value = 1 days = 365 }
@@ -1387,7 +1376,6 @@ SPR_political_policy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SPR_political_support_decision"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -1457,7 +1445,6 @@ SPR_political_policy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SPR_file_a_motion_of_no_confidence"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = gdp_total }

--- a/common/decisions/Syria.txt
+++ b/common/decisions/Syria.txt
@@ -171,7 +171,6 @@ Syria_decisions = {
 			set_country_flag = Golan_Negotiations
 			ISR = {	country_event = { id = SyriaDecisions.0 days = 3 } }
 
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -220,7 +219,6 @@ Syria_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision renounce_claims_on_hatay"
 			set_country_flag = Hatay_Negotiations
 			TUR = {	country_event = { id = SyriaDecisions.3 days = 3 } }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -265,7 +263,6 @@ Syria_decisions = {
 			set_country_flag = Rojava_Negotiations
 			ROJ = {	country_event = { id = SyriaDecisions.6 days = 3 } }
 
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.20 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			add_relative_party_popularity = yes

--- a/common/decisions/Tajikistan.txt
+++ b/common/decisions/Tajikistan.txt
@@ -496,7 +496,6 @@ TAJ_radicalism_system = {
 			add_to_variable = { var = TAJ_radical_influence value = -100 }
 			clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -1237,7 +1236,6 @@ TAJ_badakhshani_unrest = {
 			add_to_variable = { var = TAJ_badakhshan_unrest_var value = 3 }
 			clamp_variable = { var = TAJ_badakhshan_unrest_var min = 0 }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -199,7 +199,6 @@ TUR_domestic_politics_category = {
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove TUR_religious_directorate"
 			add_ideas = TUR_religious_directorate
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -682,7 +681,6 @@ TUR_domestic_politics_category = {
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = -0.01 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -3350,7 +3350,6 @@ USA_f35_program_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove USA_put_forward_frame_tech"
 			custom_effect_tooltip = USA_increase_funding_by_10
 			air_experience = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3402,7 +3401,6 @@ USA_f35_program_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove USA_put_forward_counter_measure_tech"
 			custom_effect_tooltip = USA_increase_funding_by_10
 			air_experience = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3454,7 +3452,6 @@ USA_f35_program_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove USA_put_forward_radar_tech"
 			custom_effect_tooltip = USA_increase_funding_by_10
 			air_experience = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/decisions/bankruptcy_decisions.txt
+++ b/common/decisions/bankruptcy_decisions.txt
@@ -894,7 +894,6 @@ bankruptcy_decisions = {
 		days_mission_timeout = 360
 
 		timeout_effect = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			add_relative_party_popularity = yes
@@ -995,7 +994,6 @@ bankruptcy_decisions = {
 		days_mission_timeout = 365
 
 		timeout_effect = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -1078,7 +1076,6 @@ bankruptcy_decisions = {
 
 		complete_effect = {
 			add_political_power = 150
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/decisions/subparty_policies_decisions.txt
+++ b/common/decisions/subparty_policies_decisions.txt
@@ -477,7 +477,6 @@ subparty_policies_category = {
 				remove_decision = generic_initiate_energy_5_year_plan
 			}
 			add_stability = -0.10
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/00_generic.txt
+++ b/common/national_focus/00_generic.txt
@@ -1377,7 +1377,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GENERIC_alignment_debate"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3666,7 +3665,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GENERIC_emphasize_separation_of_church_and_state"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_abkhazia.txt
+++ b/common/national_focus/05_abkhazia.txt
@@ -696,7 +696,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_returm_marxism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_timed_idea = {
@@ -762,7 +761,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_increase_cencorship"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_stability = 0.05
@@ -885,7 +883,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_our_red_path"
 			add_ideas = GRE_one_party
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			add_political_power = 25
@@ -1130,7 +1127,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_mil_prop"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -1383,7 +1379,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_collectivism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_ideas = TAT_control_economic_idea
@@ -1447,7 +1442,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_farmer_collab"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -1482,7 +1476,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_farmer_collab"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 3 }
@@ -1517,7 +1510,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_farmer_collab"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_stability = 0.08
@@ -1629,7 +1621,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_defend_our_home2"
 			add_ideas = militarism
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -1700,7 +1691,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_abkhazvozvrashenstroy"
 			set_temp_variable = { treasury_change = 12 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 5 }
@@ -1819,7 +1809,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_invest_from_eng"
 			set_temp_variable = { treasury_change = 10 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 6 }
@@ -1860,7 +1849,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_invest_from_chi"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 5 }
@@ -2185,7 +2173,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_abkhazian_kingdom"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			add_opinion_modifier = {
@@ -2291,7 +2278,6 @@ focus_tree = {
 			add_ideas = militarism
 			set_temp_variable = { temp_opinion = 15 }
 			change_the_military_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			swap_ideas = {
@@ -2330,7 +2316,6 @@ focus_tree = {
 			one_random_arms_factory = yes
 			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -2362,7 +2347,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_cis_2_military"
 			add_ideas = political_power_bonus
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			create_faction_from_template = faction_template_cis2_abk
@@ -2441,7 +2425,6 @@ focus_tree = {
 			}
 			change_the_priesthood_opinion = yes
 			add_ideas = ABK_orthodox_church_support
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -2929,7 +2912,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_decrease_cencorship"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			add_relative_party_popularity = yes
 			add_stability = -0.05
@@ -3331,7 +3313,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_crypto"
 			add_ideas = ABK_crypto_idea
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			if = {
@@ -3380,7 +3361,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_against_corruption"
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = -7 }
@@ -3443,7 +3423,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_increase_medicine"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			increase_healthcare_budget = yes
@@ -3474,7 +3453,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_increase_medicine"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			add_research_buff = yes
@@ -3607,7 +3585,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_mvd_sgb"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 15 }

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -4713,11 +4713,8 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: AFG_afghan_independents"
 			set_temp_variable = { party_index = 8 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = communism
-				popularity = 0.10
-			}
 			swap_ideas = {
 				remove_idea = international_bankers
 				add_idea = iranian_quds_force

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -386,7 +386,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_FLN_preserve_system"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -7502,7 +7501,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_return_to_the_sea"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -8320,7 +8318,6 @@ focus_tree = {
 			set_temp_variable = { percent_change = 15 }
 			change_domestic_influence_percentage = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -15668,7 +15665,6 @@ focus_tree = {
 			increase_education_budget = yes
 			set_temp_variable = { treasury_change = 7 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.100 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -15701,7 +15697,6 @@ focus_tree = {
 				uses = 2
 				category = CAT_internet_tech
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -15732,7 +15727,6 @@ focus_tree = {
 				add_idea = ALG_science_idea_two
 			}
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 		}
@@ -15788,7 +15782,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_constantine_hub"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -15820,7 +15813,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_tlemcen_agro_industry"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.100 }
 			add_relative_party_popularity = yes
 		}
@@ -15855,7 +15847,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_snvi_modernization"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -15888,7 +15879,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_snvi_modernization"
 			two_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.080 }
 			add_relative_party_popularity = yes
 		}
@@ -15916,7 +15906,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_arzew_refinery"
 			two_fuel_reserve = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -15952,7 +15941,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_pipeline_modernization"
 			one_fuel_reserve = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -16141,7 +16129,6 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -16231,7 +16218,6 @@ focus_tree = {
 			one_random_agriculture_district = yes
 			one_random_fossil_fuel_powerplant = yes
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -16309,7 +16295,6 @@ focus_tree = {
 			one_random_agriculture_district = yes
 			one_random_fossil_fuel_powerplant = yes
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -16416,7 +16401,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_restore_hotel_resorts"
 			two_office_construction = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -16442,7 +16426,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_blida_airbase_modernization"
 			one_air_base = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -16469,7 +16452,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_algiers_oran_highway"
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -16538,7 +16520,6 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -17363,7 +17344,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_al_jazair_al_djadida"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 			add_stability = 0.03

--- a/common/national_focus/05_azerbaijan.txt
+++ b/common/national_focus/05_azerbaijan.txt
@@ -160,7 +160,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_enemies_of_state"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -316,7 +315,6 @@ focus_tree = {
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = -0.02 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -1594,7 +1592,6 @@ focus_tree = {
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = -0.01 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -3782,7 +3779,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_control_crowd"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_bashkiriya.txt
+++ b/common/national_focus/05_bashkiriya.txt
@@ -478,7 +478,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_bashkiria_free_nationalist_polit_nation"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_stability = 0.1
@@ -542,7 +541,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_bashkiria_free_nationalist_reform_delenie"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -849,7 +847,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_bashkiria_free_eu_friendship"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			if = {
@@ -2149,7 +2146,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_medicine"
 			increase_healthcare_budget = yes
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			if = { limit = { SUB_is_a_non_rebelling_russian_national_republic = yes }
@@ -3265,7 +3261,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_single_party"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_partyall_banned = yes
@@ -3300,7 +3295,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_free_education"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BSH_tatar_kommi_modifier }
@@ -4502,7 +4496,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_National_science"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -10 }

--- a/common/national_focus/05_belarus.txt
+++ b/common/national_focus/05_belarus.txt
@@ -103,7 +103,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BLR_speed_up_land_reformation"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -350,7 +349,6 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -11.34 }
 			modify_treasury_effect = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.075 }
 			add_relative_party_popularity = yes
 		}
@@ -1275,7 +1273,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_constitution_from_1994"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_stability = 0.1
@@ -1314,7 +1311,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Dismiss_soviet_officers"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_popularity = {
@@ -1369,7 +1365,6 @@ focus_tree = {
 			decrease_corruption = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_nati_modifier }
 			add_to_variable = { BLR_belarus_nati_nationalist_drift = 0.03 tooltip = nationalist_drift_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -1410,7 +1405,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Belarusisation"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 10 }
@@ -1457,7 +1451,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_National_science"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -10 }
@@ -1506,7 +1499,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Delete_KGB"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_stability = -0.05
@@ -1611,7 +1603,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_We_not_energy_slave"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = -10.12 }
@@ -1716,7 +1707,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_debur"
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -1863,7 +1853,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Anti_corruption_law"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.06 }
 			add_relative_party_popularity = yes
@@ -1907,7 +1896,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Taler_ruble"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_nati_modifier }
@@ -1945,7 +1933,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Sovereign_Internet"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 5 }
@@ -2022,7 +2009,6 @@ focus_tree = {
 				}
 				remove_ideas = BLR_unstable_national_currency
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 15 }
@@ -2265,7 +2251,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_anti_immigration_policies"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_nati_modifier }
@@ -2310,7 +2295,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_church_reforms"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -2352,7 +2336,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_church_separate"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_separate_rel
@@ -2388,7 +2371,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_church_state"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_state_rel
@@ -2423,7 +2405,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Influence_nationalists"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			POL = {
@@ -2480,7 +2461,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Reform_Police"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			decrease_corruption = yes
@@ -2516,7 +2496,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_territorial_reform"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -2556,7 +2535,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_anti_lgbt"
 			add_stability = -0.02
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			add_relative_party_popularity = yes
@@ -2600,7 +2578,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_litvins_past"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_nati_modifier }
@@ -2648,7 +2625,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Young_Front"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_nati_modifier }
@@ -2722,7 +2698,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_white_legion"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_white_legion
@@ -3961,7 +3936,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_revoult_debur"
 			decrease_corruption = yes
 			decrease_centralization_2 = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -5011,7 +4985,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_GDL"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			unlock_decision_category_tooltip = BLR_Litva_belarusizations_category
@@ -5058,7 +5031,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_legacy_kurland"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_state_claim = 869
@@ -5261,7 +5233,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_belavia"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.010 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -2.5 }
@@ -5339,7 +5310,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Development_domestic_tourism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_tourism
@@ -5636,7 +5606,6 @@ focus_tree = {
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -5681,7 +5650,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -5762,7 +5730,6 @@ focus_tree = {
 					modifier = recent_actions_positive
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 		}
@@ -5799,7 +5766,6 @@ focus_tree = {
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
 			two_random_industrial_complex = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -5844,7 +5810,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 		}
@@ -5917,7 +5882,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 		}
@@ -6000,7 +5964,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 		}
@@ -6082,7 +6045,6 @@ focus_tree = {
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.11 }
 			add_relative_party_popularity = yes
 		}
@@ -6119,7 +6081,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -6147,7 +6108,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Impact_kgb"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -6238,7 +6198,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_concept_national_security_Belarus"
 			set_temp_variable = { modify_batka = 5 }
 			modify_batka_support = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			add_stability = 0.03
@@ -6276,7 +6235,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Economic_development_2001_2005"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 3 }
@@ -6321,7 +6279,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_BRSM"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 2 }
@@ -6400,7 +6357,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Hi_Tech_Park"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 3 }
@@ -6458,7 +6414,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Milk_war"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = -3 }
@@ -6535,7 +6490,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_New_concept_security"
 			set_temp_variable = { modify_batka = 2 }
 			modify_batka_support = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			swap_ideas = {
@@ -6616,7 +6570,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_CJSC_Turkcell"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			add_relative_party_popularity = yes
 			reverse_add_opinion_modifier = {
@@ -6802,7 +6755,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Increased_censorship"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = -5 }
@@ -6888,7 +6840,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Anti_Corruption"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 5 }
@@ -6932,7 +6883,6 @@ focus_tree = {
 			add_political_power = -50
 			set_temp_variable = { temp_opinion = -15 }
 			change_oligarchs_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			decrease_corruption = yes
@@ -7082,7 +7032,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Promote_new_officers"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 3 }
@@ -7224,7 +7173,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Energy_conflict"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.08 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = -7 }
@@ -7310,7 +7258,6 @@ focus_tree = {
 					add_idea = BLR_oil_russian_positive
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 6 }
@@ -7351,7 +7298,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Changes_Customs_policy"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 4 }
@@ -7440,7 +7386,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_reform_kolhoz"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 5 }
@@ -7484,7 +7429,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_New_Land_code"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 2 }
@@ -7525,7 +7469,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_promise_first_nuclear"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 5 }
@@ -7658,7 +7601,6 @@ focus_tree = {
 				remove_idea = BLR_BRSM
 				add_idea = BLR_BRSM1
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 1 }
@@ -7731,7 +7673,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_National_Library"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 1 }
@@ -7825,7 +7766,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Eastern_Partnership"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 3 }
@@ -7904,7 +7844,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Factory_Kommunarka"
 			unlock_decision_category_tooltip = BLR_Kommunarka_category
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -1.50 }
@@ -7945,7 +7884,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Investing_Agro_industry"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 4 }
@@ -7988,7 +7926,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Internet_cencorship"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.06 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = -5 }
@@ -8033,7 +7970,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_launch_own_satellite"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 2 }
@@ -8078,7 +8014,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_gasification_country"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.09 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 5 }
@@ -8136,7 +8071,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Potato_Empire"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_potato_empire_idea
@@ -8271,7 +8205,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_100dney"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 2 }
@@ -8353,7 +8286,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Pension_reform"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = -8 }
@@ -8629,7 +8561,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Migrant_crisis"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			add_relative_party_popularity = yes
 			add_opinion_modifier = {
@@ -8853,7 +8784,6 @@ focus_tree = {
 					}
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.08 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = -10 }
@@ -9011,7 +8941,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Amendment_to_Constitution"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_batka = 5 }
@@ -9515,7 +9444,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_release_political_prisoners"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_political_power = 100
@@ -9597,7 +9525,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_decommunize_belarus_society"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			add_relative_party_popularity = yes
 			if = {
@@ -9837,7 +9764,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_new_democratic_constitution"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_stability = 0.1
@@ -9877,7 +9803,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_American_Protection"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			give_military_access = USA
@@ -10337,7 +10262,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_people_rights"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_idea_rights
@@ -10399,7 +10323,6 @@ focus_tree = {
 				limit = {
 					western_liberals_are_in_power = yes
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				add_relative_party_popularity = yes
 				change_intelligence_community_opinion = yes
@@ -10409,7 +10332,6 @@ focus_tree = {
 				limit = {
 					western_conservatism_are_in_power = yes
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				add_relative_party_popularity = yes
 				change_intelligence_community_opinion = yes
@@ -10420,7 +10342,6 @@ focus_tree = {
 					western_autocrats_are_in_power = yes
 				}
 				custom_effect_tooltip = BLR_kgb_west_TT
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.09 }
 				add_relative_party_popularity = yes
 				add_stability = 0.04
@@ -10459,7 +10380,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Freedom_Meetings"
 			add_ideas = BLR_Freedom_Meeting
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -10494,7 +10414,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_dont_torture"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.09 }
 			add_relative_party_popularity = yes
 			increase_healthcare_budget = yes
@@ -10542,7 +10461,6 @@ focus_tree = {
 					add_idea = BLR_unstable_national_currency2
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			if = {
@@ -10593,7 +10511,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_fight_the_oligarchs"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			add_relative_party_popularity = yes
 			decrease_corruption = yes
@@ -10632,7 +10549,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Attract_European_investments"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			add_relative_party_popularity = yes
 			one_office_construction = yes
@@ -10734,7 +10650,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Encourage_Exchange_Students"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			add_ideas = BLR_Encourage_Exchange_Students
@@ -10769,7 +10684,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_European_university_connections"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.025 }
 			add_relative_party_popularity = yes
 			increase_education_budget = yes
@@ -10809,7 +10723,6 @@ focus_tree = {
 				limit = {
 					western_liberals_are_in_power = yes
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.07 }
 				add_relative_party_popularity = yes
 				add_ideas = SPR_pro_lgbtqa_stance_idea
@@ -10818,7 +10731,6 @@ focus_tree = {
 					limit = {
 						western_conservatism_are_in_power = yes
 					}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.09 }
 				add_relative_party_popularity = yes
 				add_ideas = SPR_anti_lgbtqa_stance_idea
@@ -10827,7 +10739,6 @@ focus_tree = {
 					limit = {
 						western_autocrats_are_in_power = yes
 					}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.09 }
 				add_relative_party_popularity = yes
 				add_ideas = SPR_anti_lgbtqa_stance_idea
@@ -10944,7 +10855,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_political_platforms"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			increase_corruption = yes
@@ -10984,7 +10894,6 @@ focus_tree = {
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_landowners_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.075 }
 			add_relative_party_popularity = yes
 			703 = {
@@ -11889,7 +11798,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_collectivism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_to_variable = { BLR_belarus_kommi_local_resources_factor = 0.05 tooltip = local_resources_factor_tt }
@@ -11926,7 +11834,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_constitution_BSSR"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_kommi_modifier }
 			add_to_variable = { BLR_belarus_kommi_political_power_gain = 0.02 tooltip = political_power_gain_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = -5 }
@@ -11971,7 +11878,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_single_party"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_partyall_banned = yes
@@ -12010,7 +11916,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_free_education"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_kommi_modifier }
@@ -12049,7 +11954,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_pioneria"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -12090,7 +11994,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Marks_school"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_kommi_modifier }
@@ -12132,7 +12035,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_state_atheism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			add_relative_party_popularity = yes
 			if = {
@@ -12178,7 +12080,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_dissolve_monasteries"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = gdp_total }
@@ -12221,7 +12122,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_the_culture_of_proletarianism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_kommi_modifier }
@@ -12262,7 +12162,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_arest_silovic"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = -5 }
@@ -12352,7 +12251,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_antigay_propaganda_laws"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_nati_modifier }
@@ -12388,7 +12286,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_clean_soc_net"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 			add_timed_idea = { idea = BLR_clean_soc_net days = 320 }
@@ -12423,7 +12320,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_fight_international_capitalists"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 3 }
@@ -12463,7 +12359,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_support_of_the_worker"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -12503,7 +12398,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_weaken_the_banks"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -12540,7 +12434,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_nationalize_foreign_business"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 5 }
@@ -12581,7 +12474,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_five_year_plan"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -12667,7 +12559,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_better_roads"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			two_random_infrastructure = yes
@@ -12702,7 +12593,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_soviet_academy_of_sciences"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -5 }
@@ -12740,7 +12630,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_progress_cult"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			add_tech_bonus = {
@@ -12887,7 +12776,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_mobilize_the_masses"
 			add_manpower = 5000
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = BLR_belarus_kommi_modifier }
@@ -12927,7 +12815,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_reestablish_the_military_industrial_complex"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			one_random_arms_factory = yes
@@ -13403,7 +13290,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Hardline_EuroScepticism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_eurosceptic = 0.01 }
@@ -13443,7 +13329,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Belarusian_nation_law"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 4 }
@@ -13781,7 +13666,6 @@ focus_tree = {
 					add_idea = orthodox_christian
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }

--- a/common/national_focus/05_bolivia.txt
+++ b/common/national_focus/05_bolivia.txt
@@ -64,7 +64,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_bolivian_right"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -270,7 +269,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_expand_political_support"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -638,7 +636,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_hand_with_the_catholic_church"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1071,7 +1068,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_morally_correct_bolivia"
 			add_ideas = BOL_moral_bolivia
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1920,7 +1916,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_bolivian_reformists"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2385,7 +2380,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_pragmatic_economic_approach"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2934,7 +2928,6 @@ focus_tree = {
 				remove_idea = BOL_bolivian_unity3
 				add_idea = BOL_a_bolivia_for_all
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7219,7 +7212,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_return_to_the_sea"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -8897,7 +8889,6 @@ focus_tree = {
 			set_temp_variable = { influence_target = CHL }
 			change_influence_percentage = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_bulgaria.txt
+++ b/common/national_focus/05_bulgaria.txt
@@ -1499,7 +1499,6 @@ focus_tree = {
 				remove_idea = oligarchs
 				add_idea = intelligence_community
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -3871,7 +3870,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BUL_yugoslavian_question"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.09 }
 			add_relative_party_popularity = yes
 			add_war_support = 0.05
@@ -4416,7 +4414,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus BUL_political_correctness"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			set_temp_variable = { temp_opinion = 10 }

--- a/common/national_focus/05_canada.txt
+++ b/common/national_focus/05_canada.txt
@@ -2418,7 +2418,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CAN_renewable_energy_projects"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -3906,7 +3905,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CAN_crush_anti_quebecois_movements"
 			add_popularity = { ideology = nationalist popularity = -0.10 }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -3995,7 +3993,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CAN_Autonomie_Quebecois e"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -4212,7 +4209,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CAN_federal_reorganization"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_chechnya.txt
+++ b/common/national_focus/05_chechnya.txt
@@ -1382,7 +1382,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHE_islam_univer"
 			add_ideas = CHE_russian_islamic_university
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			if = { limit = { SUB_is_a_non_rebelling_russian_national_republic = yes }
@@ -3213,7 +3212,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHE_start_investing_medicine"
 			increase_healthcare_budget = yes
 			add_manpower = 1000
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -3249,7 +3247,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHE_revive_education"
 			increase_education_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -3364,7 +3361,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHE_grozni_city"
 			one_office_construction = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			if = { limit = { SUB_is_a_non_rebelling_russian_national_republic = yes }
@@ -3403,7 +3399,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHE_establish_islamic_university"
 			add_ideas = CHE_russian_islamic_university
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			if = { limit = { SUB_is_a_non_rebelling_russian_national_republic = yes }

--- a/common/national_focus/05_cuba.txt
+++ b/common/national_focus/05_cuba.txt
@@ -141,7 +141,6 @@ focus_tree = {
 			air_experience = 25
 			navy_experience = 25
 			add_war_support = 0.03
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_command_power = 150
@@ -512,7 +511,6 @@ focus_tree = {
 			add_manpower = 5000
 			add_stability = -0.05
 			add_command_power = 150
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			swap_ideas = {
@@ -2755,7 +2753,6 @@ focus_tree = {
 			add_political_power = 150
 			set_temp_variable = { percent_change = 10 }
 			change_domestic_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -2908,7 +2905,6 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = 7.5 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			newline = yes
@@ -3246,7 +3242,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_invest_in_infrastructure"
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 		}
@@ -3339,7 +3334,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus  CUB_oil"
 			add_political_power = 30
 			add_stability = 0.02
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_timed_idea = { idea = CUB_oil_repair_idea1 days = 365 }
@@ -3927,7 +3921,6 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 		}
@@ -4396,7 +4389,6 @@ focus_tree = {
 			change_influence_percentage = yes
 			set_temp_variable = { treasury_change = 6 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -4451,7 +4443,6 @@ focus_tree = {
 			change_influence_percentage = yes
 			set_temp_variable = { treasury_change = 7 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			one_random_infrastructure = yes
@@ -5144,7 +5135,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_revive_metallurgy"
 			add_political_power = 50
 			add_stability = 0.03
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			one_random_industrial_complex = yes
@@ -5180,7 +5170,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_upgrade_old_factories"
 			one_random_industrial_complex = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 		}
@@ -5291,7 +5280,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_update_old_factory"
 			one_random_industrial_complex = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 		}
@@ -8177,7 +8165,6 @@ icon = CUB_fidelcastro
 				ideology = communism
 				popularity = 0.05
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			add_political_power = 120
@@ -10374,7 +10361,6 @@ icon = CUB_fidelcastro
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_new_standarts_of_edcuation_mil"
 			  increase_officer_training_level = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/05_donetsk.txt
+++ b/common/national_focus/05_donetsk.txt
@@ -1914,7 +1914,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -1968,7 +1967,6 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -1995,7 +1993,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_go"
 			increase_economic_growth = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2134,7 +2131,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_terobor_bandits"
 			remove_ideas = DPR_bandits_idea
 			set_temp_variable = { party_popularity_increase = 0.04 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2245,7 +2241,6 @@ focus_tree = {
 				add_idea = DPR_corrupt_chinusha_idea1
 			}
 			set_temp_variable = { party_popularity_increase = 0.04 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2325,7 +2320,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_raids"
 			decrease_corruption = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2353,7 +2347,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_jail"
 			remove_ideas = DPR_corrupt_chinusha_idea1
 			set_temp_variable = { party_popularity_increase = 0.06 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2409,7 +2402,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2488,7 +2480,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2514,7 +2505,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_speeches"
 			add_political_power = 150
 			set_temp_variable = { party_popularity_increase = 0.03 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -2572,7 +2562,6 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 

--- a/common/national_focus/05_egypt.txt
+++ b/common/national_focus/05_egypt.txt
@@ -82,7 +82,6 @@ focus_tree = {
 				elections_allowed = yes
 			}
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 10 }
@@ -118,7 +117,6 @@ focus_tree = {
 					}
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -223,7 +221,6 @@ focus_tree = {
 				ideology = fascism
 				popularity = -0.05
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -254,7 +251,6 @@ focus_tree = {
 				ideology = fascism
 				popularity = -0.5
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -374,7 +370,6 @@ focus_tree = {
 		relative_position_id = EGY_egyptian_politics
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_secur_the_throne"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -397,7 +392,6 @@ focus_tree = {
 		relative_position_id = EGY_egyptian_politics
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_ally_military_mub"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -646,7 +640,6 @@ focus_tree = {
 					modifier = diplomatic_proximity
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -789,7 +782,6 @@ focus_tree = {
 			set_temp_variable = { percent_change = 4 }
 			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -1025,7 +1017,6 @@ focus_tree = {
 				modifier = supports_us
 				target = QAT
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1088,7 +1079,6 @@ focus_tree = {
 		relative_position_id = EGY_morsi
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_islam_dom_parl"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1116,7 +1106,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_revok_mub_laws"
 			clr_country_flag = party13_banned
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1616,7 +1605,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_sahwat_hegazi"
 			add_political_power = -50
 			add_manpower = 1500
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1958,7 +1946,6 @@ focus_tree = {
 		relative_position_id = EGY_natfront_all
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_ally_commies"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2057,7 +2044,6 @@ focus_tree = {
 		relative_position_id = EGY_natfront_all
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_naguit_obs"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2342,7 +2328,6 @@ focus_tree = {
 		relative_position_id = EGY_natfront_all
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_egyp_rev_com_con"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2674,7 +2659,6 @@ focus_tree = {
 				ideology = fascism
 				popularity = -0.05
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3758,7 +3742,6 @@ focus_tree = {
 					modifier = diplomatic_proximity
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3991,7 +3974,6 @@ focus_tree = {
 				ideology = fascism
 				popularity = -0.05
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5640,7 +5622,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_ibrahim_sinai_militia"
 			add_stability = 0.02
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_estonia.txt
+++ b/common/national_focus/05_estonia.txt
@@ -951,7 +951,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus EST_ngo_support executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1170,7 +1169,6 @@ focus_tree = {
 			}
 			add_stability = 0.01
 			add_political_power = -100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_georgia.txt
+++ b/common/national_focus/05_georgia.txt
@@ -9923,7 +9923,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = -7 }
 			change_fossil_fuel_industry_opinion = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.04 }
 			add_relative_party_popularity = yes
@@ -11326,7 +11325,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus GEO_geopolice_game"
 			add_stability = 0.04
 			add_political_power = 125
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_germany.txt
+++ b/common/national_focus/05_germany.txt
@@ -389,7 +389,6 @@ focus_tree = {
 		select_effect = {
 			add_political_power = -100
 			set_temp_variable = { party_popularity_increase = -0.05 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 		}
 
@@ -1435,7 +1434,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_increase_mining_funds"
 			set_temp_variable = { party_popularity_increase = 0.02 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 			if = {
 				limit = { has_idea = fossil_fuel_industry }
@@ -1899,7 +1897,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_expand_west"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_stability = 0.02
@@ -2906,7 +2903,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_a_greener_germany"
 			add_stability = 0.05
 			set_temp_variable = { party_popularity_increase = 0.02 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 			newline = yes
 			custom_effect_tooltip = GER_non_nuclear_path_TT
@@ -3190,7 +3186,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_committed_to_green_power"
 			add_stability = 0.05
 			set_temp_variable = { party_popularity_increase = 0.02 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 			newline = yes
 			custom_effect_tooltip = GER_non_nuclear_path_TT
@@ -3438,7 +3433,6 @@ focus_tree = {
 				add_idea = GER_idea_carbon_neutral
 			}
 			set_temp_variable = { party_popularity_increase = 0.05 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 10 }
 			change_industrial_conglomerates_opinion = yes
@@ -3736,7 +3730,6 @@ focus_tree = {
 			}
 			newline = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
-			set_party_index_to_ruling_party = yes
 			add_relative_party_popularity = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -4.00 }
@@ -13400,7 +13393,6 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_condemn_american_aggression"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -19874,7 +19866,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_Military_trainings_area"
 			army_experience = 15
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_india.txt
+++ b/common/national_focus/05_india.txt
@@ -592,7 +592,6 @@ focus_tree = {
 		relative_position_id = RAJ_indias_politics
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_foreign_education_partner_ship"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.025 }
 			add_relative_party_popularity = yes
 			increase_education_budget = yes
@@ -1039,7 +1038,6 @@ focus_tree = {
 				}
 			}
 			add_stability = 0.03
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = {
@@ -2327,7 +2325,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_unslumization_of_cities"
 			add_political_power = 75
 			add_stability = 0.02
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2425,7 +2422,6 @@ focus_tree = {
 			change_influence_percentage = yes
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2456,7 +2452,6 @@ focus_tree = {
 			change_influence_percentage = yes
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2476,7 +2471,6 @@ focus_tree = {
 		prerequisite = { focus = RAJ_israeli_water_spec focus = RAJ_spanish_water_spec }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_minjur_water_plant"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5045,7 +5039,6 @@ focus_tree = {
 		prerequisite = { focus = RAJ_trishul }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_agni_tech"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.025 }
 			add_relative_party_popularity = yes
 			increase_officer_training_level = yes
@@ -7337,7 +7330,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_27_perc_project_medic"
 			one_office_construction = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.09 }
 			add_relative_party_popularity = yes
 		}
@@ -7664,7 +7656,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_ujjwala_scheme"
 			add_political_power = 150
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -9244,7 +9235,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_triumph_of_communism"
 			add_political_power = 150
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -11321,7 +11311,6 @@ focus_tree = {
 				}
 			}
 			add_political_power = 150
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -13653,7 +13642,6 @@ focus_tree = {
 			add_political_power = 100
 			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -13676,7 +13664,6 @@ focus_tree = {
 				remove_idea = RAJ_neutrality_idea
 				add_idea = RAJ_neutrality_idea1
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_stability = 0.09

--- a/common/national_focus/05_iran.txt
+++ b/common/national_focus/05_iran.txt
@@ -1184,7 +1184,6 @@ focus_tree = {
 			set_temp_variable = { percent_change = 15 }
 			change_domestic_influence_percentage = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -2816,7 +2815,6 @@ focus_tree = {
 			add_to_variable = { PER_self_sufficiency = 1 }
 			add_political_power = 150
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5363,7 +5361,6 @@ focus_tree = {
 				add_to_variable = { PER_intel_network_gain_factor = 0.15 tooltip = intel_network_gain_factor_tt }
 				newline = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -5764,7 +5761,6 @@ focus_tree = {
 			newline = yes
 			add_to_variable = { PER_political_power_factor = 0.05 tooltip = political_power_factor_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -7842,7 +7838,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_way_of_the_imam"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -9569,7 +9564,6 @@ focus_tree = {
 			newline = yes
 			add_to_variable = { PER_resistance_growth = -0.10 tooltip = resistance_growth_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -9912,7 +9906,6 @@ focus_tree = {
 			newline = yes
 			add_to_variable = { PER_expected_police_modifier = -1.00 tooltip = expected_police_modifier_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -10522,7 +10515,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_strengthen_guardian_council"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -10755,7 +10747,6 @@ focus_tree = {
 			change_the_ulema_opinion = yes
 			change_intelligence_community_opinion = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -14180,7 +14171,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: focus = PER_eastern_initiative"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.15 }
 			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
@@ -14259,7 +14249,6 @@ focus_tree = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_solidarity_through_strength"
 			add_political_power = 200
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -16270,7 +16259,6 @@ focus_tree = {
 			newline = yes
 			army_experience = 50
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -1057,7 +1057,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shura_council executed"
 			country_event = israel.148
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -1113,7 +1112,6 @@ focus_tree = {
 			206 = {
 				one_state_industrial_complex = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -1212,7 +1210,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_family_values executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -2283,7 +2280,6 @@ focus_tree = {
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
-			set_party_index_to_ruling_party = yes
 		}
 
 		ai_will_do = {
@@ -2394,7 +2390,6 @@ focus_tree = {
 			set_temp_variable = {
 				party_popularity_increase = 0.02
 			}
-			set_party_index_to_ruling_party = yes
 		}
 
 		ai_will_do = {
@@ -3206,7 +3201,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_raise_tax_on_wealthy executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -3525,7 +3519,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_holocaust_survivors executed"
 			add_ideas = ISR_yesh_pey_atid_localhost
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -4169,7 +4162,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_accept_kotel_protocols executed"
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -4701,7 +4693,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_above_all executed"
 			add_ideas = ISR_israel_above_all
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -5215,7 +5206,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_limit_terms executed"
 			add_political_power = 50
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -5442,7 +5432,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_soviet_voters executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -8180,7 +8169,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_adinas_donations executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.04
 			}
@@ -8241,7 +8229,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_strong_aryeh executed"
 			add_war_support = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -8347,7 +8334,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_crown_to_its_former_glory executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -10171,7 +10157,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_legalize_cannabis executed"
 			add_ideas = ISR_legalize_cannabis
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -11242,7 +11227,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_pension_reform executed"
 			add_ideas = ISR_lower_pension
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = -0.04
 			}
@@ -11418,7 +11402,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reform_bituach_leumi executed"
 			add_ideas = ISR_no_insurance
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = -0.04
 			}
@@ -12991,7 +12974,6 @@ focus_tree = {
 			}
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13167,7 +13149,6 @@ focus_tree = {
 			}
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13262,7 +13243,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_police_racism executed"
 			add_stability = 0.05
 			increase_policing_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13312,7 +13292,6 @@ focus_tree = {
 			}
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13363,7 +13342,6 @@ focus_tree = {
 			}
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13414,7 +13392,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shabac_intervention_yes executed"
 			add_political_power = -150
 			arab_mafia_decr = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13538,7 +13515,6 @@ focus_tree = {
 			}
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -13752,7 +13728,6 @@ focus_tree = {
 				influence_target = ISR
 			}
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = -0.05
 			}
@@ -13983,7 +13958,6 @@ focus_tree = {
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = 0.05
 				}
@@ -14864,7 +14838,6 @@ focus_tree = {
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = 100
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = 0.05
 				}
@@ -15435,7 +15408,6 @@ focus_tree = {
 
 				give_guarantee = JOR
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -15481,7 +15453,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_war_with_isis executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -20288,7 +20259,6 @@ focus_tree = {
 			news_event = israel_news.11
 			PER = {
 				add_stability = -0.02
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = -0.05
 				}
@@ -20813,7 +20783,6 @@ focus_tree = {
 			effect_tooltip = {
 				PER = {
 					add_stability = -0.05
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = {
 						party_popularity_increase = -0.05
 					}
@@ -22952,7 +22921,6 @@ focus_tree = {
 			modify_treasury_effect = yes
 			PER = {
 				add_stability = 0.02
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = 0.05
 				}
@@ -25534,7 +25502,6 @@ focus_tree = {
 				mission = south_lebanon_occupation_ticker_mission
 				days = 20
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.02
 			}
@@ -25947,7 +25914,6 @@ focus_tree = {
 						treasury_change = 4
 					}
 					modify_treasury_effect = yes
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = {
 						party_popularity_increase = -0.05
 					}
@@ -35861,7 +35827,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_yohalam executed"
 			add_stability = 0.02
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -36083,7 +36048,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_army_builds_society executed"
 			add_war_support = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}

--- a/common/national_focus/05_italy.txt
+++ b/common/national_focus/05_italy.txt
@@ -3996,7 +3996,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_secure_the_succession"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -17128,7 +17127,6 @@ focus_tree = {
 			custom_effect_tooltip = eradicating_mafia_focus_TT
 			add_to_variable = { police_effectivness_base = 0.05 }
 			update_police_effectiveness = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -17171,7 +17169,6 @@ focus_tree = {
 			add_to_variable = { police_effectivness_base = 0.1 }
 			update_police_effectiveness = yes
 			custom_effect_tooltip = eradicating_mafia_focus_TT
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -18009,7 +18006,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_fire_excessive_government_employees"
 			add_political_power = -50
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.025 }
 			add_relative_party_popularity = yes
@@ -18072,7 +18068,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_let_salaries_decrease"
 			add_political_power = -50
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -18529,7 +18524,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_classical_education"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -18592,7 +18586,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_modern_education"
 			set_temp_variable = { drift_switch_change = -0.005 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -18662,7 +18655,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_safeguard_teachers_privileges"
 			set_temp_variable = { drift_switch_change = 0.005 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -18768,7 +18760,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_introduce_meritocracy"
 			set_temp_variable = { drift_switch_change = -0.005 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			add_relative_party_popularity = yes
@@ -19054,7 +19045,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_defund_school_laboratories"
 			set_temp_variable = { drift_switch_change = -0.005 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -19121,7 +19111,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_school_mass_hiring"
 			set_temp_variable = { drift_switch_change = 0.02 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -19187,7 +19176,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_cash_bonus_to_18_year_olds"
 			set_temp_variable = { drift_switch_change = 0.005 }
 			modify_reform_expectance_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -20699,7 +20687,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_limit_8xmille"
 			set_temp_variable = { temp_opinion = -5 }
 			change_the_clergy_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -20807,7 +20794,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_abolish_school_religion_teaching"
 			set_temp_variable = { temp_opinion = -5 }
 			change_the_clergy_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_japan.txt
+++ b/common/national_focus/05_japan.txt
@@ -403,7 +403,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_protecting_human_rights"
 			add_dynamic_modifier = { modifier = JAP_protecting_human_rights_modifier }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -1971,7 +1970,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_prioritizing_order"
 			add_dynamic_modifier = { modifier = JAP_prioritizing_order_modifier }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/05_kosovo.txt
+++ b/common/national_focus/05_kosovo.txt
@@ -1859,7 +1859,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_democratic_agenda"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2097,7 +2096,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.15 }
 			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
@@ -2135,7 +2133,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_ideas = KOS_idea_rights
@@ -2163,7 +2160,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2780,7 +2776,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_pdk"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -10110,6 +10110,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_global_vision"
 			add_political_power = 50
 			set_temp_variable = { party_index = 2 }
+			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -10110,7 +10110,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_global_vision"
 			add_political_power = 50
 			set_temp_variable = { party_index = 2 }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -7017,11 +7017,8 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_embrace_monarchists"
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
+			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = nationalist
-				popularity = 0.1
-			}
 			hidden_effect = {
 				if = {
 					limit = { SOV = { is_ai = yes } }

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -4499,7 +4499,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_unite_as_one"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.20 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 15 }
@@ -17460,7 +17459,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_true_federalism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -18062,7 +18060,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_our_own_section_230"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_navalny_inner_modifier }
 			add_to_variable = { SOV_navalny_inner_drift_defence_factor = -0.15 tooltip = drift_defence_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -31609,7 +31606,6 @@ focus_tree = {
 				decrease_corruption = yes
 				set_temp_variable = { temp_opinion = -40 }
 				change_oligarchs_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.15 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { treasury_change = 110 }

--- a/common/national_focus/05_san_marino.txt
+++ b/common/national_focus/05_san_marino.txt
@@ -88,11 +88,8 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus SMA_break_power_of_church executed"
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = -0.15 }
+			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = nationalist
-				popularity = -0.15
-			}
 		}
 
 		ai_will_do = {
@@ -129,11 +126,8 @@ focus_tree = {
 			add_relative_party_popularity = yes
 			set_temp_variable = { party_index = 18 }
 			set_temp_variable = { party_popularity_increase = -0.15 }
+			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = neutrality
-				popularity = -0.15
-			}
 		}
 
 		ai_will_do = {
@@ -214,11 +208,8 @@ focus_tree = {
 			add_relative_party_popularity = yes
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = -0.15 }
+			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
-			add_popularity = {
-				ideology = nationalist
-				popularity = -0.15
-			}
 		}
 
 		ai_will_do = {

--- a/common/national_focus/05_south_ossetia.txt
+++ b/common/national_focus/05_south_ossetia.txt
@@ -245,7 +245,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_OSSETIA_MAIN }
 
 		completion_reward = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -278,7 +277,6 @@ focus_tree = {
 			add_political_power = 100
 			set_temp_variable = { percent_change = 8.5 }
 			change_domestic_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -1593,7 +1591,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOO_natpop_modifier }
 			add_to_variable = { SOO_natpop_stability_factor = 0.05 tooltip = stability_factor_tt }
 			add_to_variable = { SOO_natpop_bureaucracy_cost_multiplier_modifier = -0.15 tooltip = bureaucracy_cost_multiplier_modifier_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 		}
@@ -1629,7 +1626,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes
 			one_office_construction = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -2185,7 +2181,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOO_nyhaz_modifier }
 			add_to_variable = { SOO_nyhaz_stability_factor = 0.09 tooltip = stability_factor_tt }
 			add_to_variable = { SOO_nyhaz_drift_defence_factor = -0.15 tooltip = drift_defence_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			add_relative_party_popularity = yes
 		}
@@ -2648,7 +2643,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOO_commie_modifier }
 			add_to_variable = { SOO_commie_political_power_gain = 0.03 tooltip = political_power_gain_tt }
 			add_to_variable = { SOO_commie_drift_defence_factor = -0.12 tooltip = drift_defence_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -2682,7 +2676,6 @@ focus_tree = {
 			add_to_variable = { SOO_commie_production_speed_buildings_factor = 0.09 tooltip = production_speed_buildings_factor_tt }
 			add_to_variable = { SOO_commie_health_cost_multiplier_modifier = 0.05 tooltip = health_cost_multiplier_modifier_tt }
 			add_to_variable = { SOO_commie_social_cost_multiplier_modifier = 0.05 tooltip = social_cost_multiplier_modifier_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			add_relative_party_popularity = yes
 		}
@@ -2827,7 +2820,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: focus SOO_unite_with_northosset_as_rus_pup"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -3578,7 +3570,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: focus SOO_end_fight"
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 			add_stability = 0.09

--- a/common/national_focus/05_tatarstan.txt
+++ b/common/national_focus/05_tatarstan.txt
@@ -116,7 +116,6 @@ focus_tree = {
 				}
 			}
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			if = { limit = { SUB_is_a_non_rebelling_russian_national_republic = yes }
@@ -1002,7 +1001,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_National_science"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -10 }
@@ -1772,7 +1770,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_single_party"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_partyall_banned = yes
@@ -1805,7 +1802,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_free_education"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = TAT_tatar_kommi_modifier }
@@ -3037,7 +3033,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_western_welfare"
 			increase_healthcare_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			if = { limit = { SUB_is_a_non_rebelling_russian_national_republic = yes }
@@ -3426,7 +3421,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_western_liberal_heaven"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = TAT_liberals_modifier }
 			add_to_variable = { TAT_liberals_democratic_support = 0.04 tooltip = democratic_drift_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { modify_subjectinped = 10 }

--- a/common/national_focus/05_transnistria.txt
+++ b/common/national_focus/05_transnistria.txt
@@ -4386,7 +4386,6 @@ focus_tree = {
 			add_political_power = 100
 			set_temp_variable = { percent_change = 8.5 }
 			change_domestic_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -10597,7 +10597,6 @@ focus_tree = {
 			add_to_variable = { ENG_welfare_cost = 0.025 tooltip = social_cost_multiplier_modifier_tt }
 			add_to_variable = { ENG_consumer_goods_factor = -0.05 tooltip = consumer_goods_factor_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -10695,7 +10694,6 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.025 }
 			set_temp_variable = { temp_outlook_increase = 0.015 }
 			add_relative_party_popularity = yes
@@ -11203,7 +11201,6 @@ focus_tree = {
 			add_to_variable = { ENG_welfare_cost = 0.01 tooltip = social_cost_multiplier_modifier_tt }
 			add_to_variable = { ENG_global_building_slots_factor = 0.15 tooltip = global_building_slots_factor_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -11454,7 +11451,6 @@ focus_tree = {
 			add_to_variable = { ENG_internal_investments_money_cost_modifier = -0.15 tooltip = internal_investments_money_cost_modifier_tt }
 			add_to_variable = { ENG_receiving_investment_cost_modifier = -0.15 tooltip = receiving_investment_cost_modifier_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -12013,7 +12009,6 @@ focus_tree = {
 			add_to_variable = { ENG_political_power_factor = 0.02 tooltip = political_power_factor_tt }
 			add_to_variable = { ENG_mobilization_speed = 0.10 tooltip = mobilization_speed_tt }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -12310,7 +12305,6 @@ focus_tree = {
 			add_to_variable = { ENG_production_speed_internet_station_factor = 0.10 tooltip = production_speed_internet_station_factor_tt }
 			add_stability = 0.03
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -14270,7 +14264,6 @@ focus_tree = {
 			newline = yes
 			add_stability = 0.03
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -20107,7 +20100,6 @@ focus_tree = {
 			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.055 }
 			set_temp_variable = { temp_outlook_increase = 0.075 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/05_ural.txt
+++ b/common/national_focus/05_ural.txt
@@ -145,7 +145,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_new_business_centers"
 			one_office_construction = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -5672,7 +5671,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_democratic_subsidies_regions"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -7402,7 +7400,6 @@ focus_tree = {
 				set_temp_variable = { treasury_change = -0.5 }
 				modify_treasury_effect = yes
 				add_political_power = -100
-				set_party_index_to_ruling_party = yes
 				annex_country = { target = KHM transfer_troops = yes }
 				KHM = { every_core_state = { add_core_of = URA } }
 				hidden_effect = {
@@ -7424,7 +7421,6 @@ focus_tree = {
 				set_temp_variable = { treasury_change = -0.5 }
 				modify_treasury_effect = yes
 				add_political_power = -100
-				set_party_index_to_ruling_party = yes
 				annex_country = { target = KHM transfer_troops = yes }
 				YAM = { every_core_state = { add_core_of = URA } }
 				hidden_effect = {

--- a/common/national_focus/Kuban.txt
+++ b/common/national_focus/Kuban.txt
@@ -386,7 +386,6 @@ focus_tree = {
 			increase_education_budget = yes
 			set_temp_variable = { treasury_change = 7 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.100 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -417,7 +416,6 @@ focus_tree = {
 				uses = 2
 				category = CAT_internet_tech
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -446,7 +444,6 @@ focus_tree = {
 				add_idea = KUB_science_idea_two
 			}
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.100 }
 			add_relative_party_popularity = yes
 		}
@@ -492,7 +489,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_tihoretsk"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -517,7 +513,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_durso"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.100 }
 			add_relative_party_popularity = yes
 		}
@@ -542,7 +537,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_aomz"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -568,7 +562,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_aomz"
 			two_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.080 }
 			add_relative_party_popularity = yes
 		}
@@ -594,7 +587,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_slavaynsk_npz"
 			two_fuel_reserve = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -619,7 +611,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_update_oil_infr"
 			one_fuel_reserve = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -790,7 +781,6 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -870,7 +860,6 @@ focus_tree = {
 			one_random_agriculture_district = yes
 			one_random_fossil_fuel_powerplant = yes
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 
@@ -976,7 +965,6 @@ focus_tree = {
 			one_random_agriculture_district = yes
 			one_random_fossil_fuel_powerplant = yes
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 
@@ -1054,7 +1042,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_restore_hotel_resorts"
 			two_office_construction = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -1078,7 +1065,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_krasnodar_airbase"
 			one_air_base = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -1103,7 +1089,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_dzhubga_sochi_highway"
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -1168,7 +1153,6 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -3098,7 +3082,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_one_party_system"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
@@ -5082,7 +5065,6 @@ focus_tree = {
 			add_manpower = -4000
 			add_stability = 0.05
 			add_war_support = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 		}
@@ -5145,7 +5127,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_social_spending"
 			increase_social_spending = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			add_relative_party_popularity = yes
 		}
@@ -5179,7 +5160,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_repair_roads"
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 			add_political_power = 50
@@ -5342,7 +5322,6 @@ focus_tree = {
 					modifier = supports_us
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 		}
@@ -5508,7 +5487,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = UKR }
 			set_temp_variable = { influence_target = KUB }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.070 }
 			add_relative_party_popularity = yes
 		}
@@ -5560,7 +5538,6 @@ focus_tree = {
 					}
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			add_relative_party_popularity = yes
 		}
@@ -7149,7 +7126,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_decentalisation"
 			decrease_centralization = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -7996,7 +7972,6 @@ focus_tree = {
 			modify_corporate_tax_rate_effect = yes
 			set_temp_variable = { pop_change = 6 }
 			modify_population_tax_rate_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.030 }
 			add_relative_party_popularity = yes
 		}
@@ -8025,7 +8000,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_free_markets"
 			increase_economic_growth = yes
 			increase_exports = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.100 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/Subject_of_russia.txt
+++ b/common/national_focus/Subject_of_russia.txt
@@ -1,4 +1,4 @@
-﻿## SUBJECTS OF RUSSIA FOCUS TREE
+## SUBJECTS OF RUSSIA FOCUS TREE
 ## Author: LordBogdanoff
 focus_tree = {
 
@@ -593,7 +593,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_fight_bad_cops"
 			decrease_corruption = yes
 			remove_ideas = SUB_corrupt_police_idea
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -617,7 +616,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_fight_bandits"
 			remove_ideas = SUB_banditism_idea
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -663,7 +661,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_cooperate_rjd"
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 3.5 }
@@ -691,7 +688,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_airport"
 			one_air_base = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -740,7 +736,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_free_zone"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 		}
@@ -819,7 +814,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_social_invest"
 			increase_social_spending = yes
 			add_ideas = SUB_min_obr
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -919,7 +913,6 @@ focus_tree = {
 				remove_idea = SUB_min_selhoz1
 				add_idea = SUB_min_selhoz2
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 		}
@@ -943,7 +936,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_medicina"
 			increase_healthcare_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -967,7 +959,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_fight_narcos"
 			remove_ideas = SUB_narcos_idea
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -992,7 +983,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_sport"
 			add_stability = 0.015
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = -1 }
@@ -1069,7 +1059,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_lgbt"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 			add_ideas = SUB_anti_lgbtqa_stance_idea
@@ -1119,7 +1108,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SUB_no_lgbt"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.09 }
 			add_relative_party_popularity = yes
 			add_ideas = SPR_anti_lgbtqa_stance_idea

--- a/common/national_focus/Vitebsk.txt
+++ b/common/national_focus/Vitebsk.txt
@@ -305,7 +305,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VBT_svet"
 			one_random_industrial_complex = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 		}
@@ -328,7 +327,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VBT_roads"
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -351,7 +349,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VBT_centralization"
 			add_ideas = political_power_bonus
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -437,7 +434,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VBT_education"
 			generic_research_buff = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 		}
@@ -459,7 +455,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VBT_medicine"
 			increase_healthcare_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -481,7 +476,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VBT_social"
 			increase_social_spending = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/armenia.txt
+++ b/common/national_focus/armenia.txt
@@ -97,7 +97,6 @@ focus_tree = {
 				mission = arm_opposition_backlash_ticker_mission
 				days = 40
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.1
 			}
@@ -519,7 +518,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_silence_hun executed"
 			add_political_power = -100
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -1075,7 +1073,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_Sargsyan executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.1
 			}
@@ -3452,7 +3449,6 @@ focus_tree = {
 				ideology = neutrality
 				popularity = 0.1
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.1
 			}
@@ -3783,7 +3779,6 @@ focus_tree = {
 			}
 			add_stability = 0.06
 			add_war_support = -0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.04
 			}
@@ -10379,7 +10374,6 @@ focus_tree = {
 				}
 				set_temp_variable = { treasury_change = -1.875 }
 				modify_treasury_effect = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.03 }
 				add_relative_party_popularity = yes
 				add_power_balance_value = {
@@ -10440,7 +10434,6 @@ focus_tree = {
 				set_temp_variable = { tag_index = FRA }
 				set_temp_variable = { influence_target = ARM }
 				change_influence_percentage = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.03 }
 				add_relative_party_popularity = yes
 				add_power_balance_value = {
@@ -10476,7 +10469,6 @@ focus_tree = {
 			effect_tooltip = {
 				set_temp_variable = { treasury_change = -7.00 }
 				modify_treasury_effect = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.03 }
 				add_relative_party_popularity = yes
 				custom_effect_tooltip = ARM_add_idea_to_economy_idea_tt
@@ -10589,7 +10581,6 @@ focus_tree = {
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				one_random_agriculture_district = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.03 }
 				add_relative_party_popularity = yes
 				add_power_balance_value = {
@@ -11192,7 +11183,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_economy_longest executed"
 			set_temp_variable = { treasury_change = -0.8 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = ARM_tourism_expand_TT
@@ -11219,7 +11209,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_economy_historic executed"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			custom_effect_tooltip = ARM_tourism_expand_TT
@@ -14216,7 +14205,6 @@ focus_tree = {
 					target = SOV
 				}
 				add_political_power = -100
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.10 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_index = 7 }
@@ -15842,7 +15830,6 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_mithridates_legacy executed"
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = 0.02
 				}
@@ -17278,7 +17265,6 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_friendship_syria executed"
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = 0.02
 				}
@@ -17550,7 +17536,6 @@ focus_tree = {
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_yazidis_are_kurds executed"
 				add_war_support = -0.05
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = -0.05
 				}
@@ -17736,7 +17721,6 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_levons_legacy executed"
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = {
 					party_popularity_increase = 0.02
 				}

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -6470,7 +6470,6 @@ focus_tree = {
 				remove_idea = BRA_idea_crippled_currency_one
 				add_idea = BRA_idea_crippled_currency_two
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/centralasia.txt
+++ b/common/national_focus/centralasia.txt
@@ -104,7 +104,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_DIPLOMACY }
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_populistic_sentiment executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1539,7 +1538,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_our_beloved_autocrat_kaz executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1577,7 +1575,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_purge_unloyal_polit executed"
 			increase_centralization = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1647,7 +1644,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_promote_nostalgia executed"
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			set_temp_variable = { temp_outlook_increase = 0.06 }
 			add_relative_party_popularity = yes
@@ -1714,7 +1710,6 @@ focus_tree = {
 				limit = {
 					has_government = democratic
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.05 }
 				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
@@ -2648,7 +2643,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_social_network_control_kaz executed"
 			increase_policing_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -2787,7 +2781,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus CES_strongman_dream_kaz executed"
 			add_political_power = 100
 			add_stability = 0.04
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			set_temp_variable = { temp_outlook_increase = 0.08 }
 			add_relative_party_popularity = yes
@@ -2958,7 +2951,6 @@ focus_tree = {
 				limit = {
 					has_government = democratic
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.1 }
 				set_temp_variable = { temp_outlook_increase = 0.1 }
 				add_relative_party_popularity = yes
@@ -3020,7 +3012,6 @@ focus_tree = {
 				limit = {
 					has_government = neutrality
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.1 }
 				set_temp_variable = { temp_outlook_increase = 0.1 }
 				add_relative_party_popularity = yes
@@ -3094,7 +3085,6 @@ focus_tree = {
 				limit = {
 					has_government = communism
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.1 }
 				set_temp_variable = { temp_outlook_increase = 0.1 }
 				add_relative_party_popularity = yes
@@ -10476,7 +10466,6 @@ focus_tree = {
 			add_to_variable = { CES_liberals_democratic_support = 0.03 tooltip = democratic_drift_tt }
 			add_to_variable = { CES_liberals_stability_factor = 0.05 tooltip = stability_factor_tt }
 			add_to_variable = { CES_liberals_drift_defence_factor = -0.05 tooltip = drift_defence_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -10505,7 +10494,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_western_anti_corruption executed"
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 		}
@@ -10536,7 +10524,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CES_liberals_modifier }
 			add_to_variable = { CES_liberals_social_cost_multiplier_modifier = 0.20 tooltip = social_cost_multiplier_modifier_tt }
 			add_to_variable = { CES_liberals_local_resources_factor = 0.10 tooltip = local_resources_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -10596,7 +10583,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_western_welfare executed"
 			increase_healthcare_budget = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -10764,7 +10750,6 @@ focus_tree = {
 			add_to_variable = { CES_liberals_stability_factor = 0.02 tooltip = stability_factor_tt }
 			add_to_variable = { CES_liberals_monthly_population = 0.05 tooltip = monthly_population_tt }
 			add_to_variable = { CES_liberals_social_cost_multiplier_modifier = 0.05 tooltip = social_cost_multiplier_modifier_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			add_relative_party_popularity = yes
 		}
@@ -10797,7 +10782,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CES_liberals_modifier }
 			add_to_variable = { CES_liberals_research_speed_factor = 0.15 tooltip = research_speed_factor_tt }
 			add_to_variable = { CES_liberals_stability_factor = 0.08 tooltip = stability_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			increase_economic_growth = yes
@@ -10854,7 +10838,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus CES_western_liberal_heaven executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CES_liberals_modifier }
 			add_to_variable = { CES_liberals_democratic_support = 0.04 tooltip = democratic_drift_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 		}
@@ -11186,7 +11169,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_bring_soviet executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			add_stability = -0.08
@@ -11220,7 +11202,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus CES_free_the_people executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CES_red_zaraza }
 			add_to_variable = { CES_red_zaraza_modifier_communism_drift = 0.01 tooltip = communism_drift_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 3 }
@@ -11256,7 +11237,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_central_plan executed"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_timed_idea = {

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -14663,8 +14663,8 @@ focus_tree = {
 			set_country_flag = DEN_alternatived_name_switch
 			set_temp_variable = { party_index = 17 }
 			set_temp_variable = { party_popularity_increase = 0.005 }
+			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = neutrality popularity = 0.02 }
 			recalculate_party = yes
 			update_party_name = yes
 			}
@@ -14781,8 +14781,8 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_cooperate_with_the_People"
 			set_temp_variable = { party_index = 17 }
 			set_temp_variable = { party_popularity_increase = 0.003 }
+			set_temp_variable = { temp_outlook_increase = 0.01 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = neutrality popularity = 0.01 }
 			recalculate_party = yes
 			newline = yes
 			add_ideas = DEN_a_green_leap_forward

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -4121,7 +4121,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_release_the_holdings"
 			mark_focus_tree_layout_dirty = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/greece.txt
+++ b/common/national_focus/greece.txt
@@ -3114,7 +3114,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: GRE_dictatorship"
 			add_stability = -0.03
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/indonesia.txt
+++ b/common/national_focus/indonesia.txt
@@ -1107,7 +1107,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_bribe_media"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1709,7 +1708,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_fight_rising_prices"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1739,7 +1737,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_keep_high_prices"
 			add_ideas = IND_high_prices
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			add_relative_party_popularity = yes
@@ -2931,7 +2928,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_bolster_party_pop"
 			set_temp_variable = { treasury_change = -6.25 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -2989,7 +2985,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_bolster_nationalism"
 			set_temp_variable = { treasury_change = -6.25 }
 			modify_treasury_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -4640,7 +4635,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_naw_reps_village"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 			add_political_power = 75
@@ -5229,7 +5223,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_address_issues"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -5569,7 +5562,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_und_national_dev"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -6326,7 +6318,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_strug_purge_sus_members"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}
@@ -6939,7 +6930,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_dem_small_business_support"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/iraq2.txt
+++ b/common/national_focus/iraq2.txt
@@ -2700,7 +2700,6 @@ focus_tree = {
 		prerequisite = { focus = IRQ_blood_fuels_innovation }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_saddamism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -2806,7 +2805,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_the_baathist_party"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -3192,7 +3190,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_the_cult_of_saddam"
 			add_ideas = IRQ_cult_of_saddam
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6004,7 +6001,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_rebuilding_iraq_together"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6145,7 +6141,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_free_and_fair_judicial_system"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6222,7 +6217,6 @@ focus_tree = {
 			add_stability = 0.05
 			newline = yes
 			increase_economic_growth = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -6384,7 +6378,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_reaffirm_democratic_institutions"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -10106,7 +10099,6 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_national_rallies"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.045 }
 			set_temp_variable = { temp_outlook_increase = 0.055 }
 			add_relative_party_popularity = yes
@@ -12094,7 +12086,6 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_the_duty_of_voting"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -12208,7 +12199,6 @@ focus_tree = {
 			PER = {
 				add_stability = -0.03
 				newline = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.05 }
 				set_temp_variable = { temp_outlook_increase = -0.045 }
 				add_relative_party_popularity = yes

--- a/common/national_focus/korea_unified.txt
+++ b/common/national_focus/korea_unified.txt
@@ -488,7 +488,6 @@ shared_focus = {
 	completion_reward = {
 		add_stability = 0.1
 		add_political_power = 100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes

--- a/common/national_focus/libya.txt
+++ b/common/national_focus/libya.txt
@@ -18164,7 +18164,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_give_power_to_central_committee"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/norway.txt
+++ b/common/national_focus/norway.txt
@@ -400,7 +400,6 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_production_twenty_fifty"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
 			add_relative_party_popularity = yes
@@ -1918,7 +1917,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_party_of_labour"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -2059,7 +2057,6 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus add_building_construction"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.045 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -2150,7 +2147,6 @@ focus_tree = {
 		relative_position_id = NRY_modernization_of_the_welfare_state
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_transatlantic_cooperation"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2353,7 +2349,6 @@ focus_tree = {
 		relative_position_id = NRY_party_of_labour
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_the_political_earthquake"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.075 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2379,7 +2374,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_christan_peoples_party"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -2526,7 +2520,6 @@ focus_tree = {
 		relative_position_id = NRY_christan_peoples_party
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_for_minorities"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.075 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2768,7 +2761,6 @@ focus_tree = {
 			set_temp_variable = { modify_eurosceptic_target = ROOT }
 			eurosceptic_change = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
 			add_relative_party_popularity = yes
@@ -2793,7 +2785,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_party_of_progress"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -3115,7 +3106,6 @@ focus_tree = {
 		relative_position_id = NRY_party_of_progress
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus NRY_state_of_norway"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.055 }
 			set_temp_variable = { temp_outlook_increase = 0.3 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -3862,7 +3862,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ROM_reinforce_republicanism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/sahrawi.txt
+++ b/common/national_focus/sahrawi.txt
@@ -47,7 +47,6 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SHA_the_fifth_column"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		add_relative_party_popularity = yes
 		add_political_power = 100
@@ -158,7 +157,6 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SHA_quash_the_bandits"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		add_relative_party_popularity = yes
 		if = {

--- a/common/national_focus/serbia.txt
+++ b/common/national_focus/serbia.txt
@@ -9268,8 +9268,8 @@ focus_tree = {
 			add_ideas = SER_inner_policy
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = -0.05 }
+			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
-			add_popularity = { ideology = communism popularity = -0.05 }
 			recalculate_party = yes
 		}
 

--- a/common/national_focus/serbia.txt
+++ b/common/national_focus/serbia.txt
@@ -422,7 +422,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_milosevic_authority"
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -553,7 +552,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_anti_corruption_measures"
 			add_political_power = -50
 			decrease_corruption = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			add_relative_party_popularity = yes
@@ -5409,7 +5407,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = SER }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -5542,7 +5539,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_independent_judiciary"
 			add_political_power = -100
 			add_stability = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { percent_change = 10 }
@@ -5754,7 +5750,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_remove_previous_kleptocrats"
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6033,7 +6028,6 @@ focus_tree = {
 				limit = { NOT = { has_done_agency_upgrade = upgrade_passive_defense } }
 				upgrade_intelligence_agency = upgrade_passive_defense
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6080,7 +6074,6 @@ focus_tree = {
 			}
 			set_temp_variable = { debt_change = -0.5 }
 			modify_debt_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -7764,7 +7757,6 @@ focus_tree = {
 					modifier = diplomatic_proximity
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -8048,7 +8040,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_de_escalation"
 			add_stability = 0.05
 			add_threat = -3
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -10165,7 +10156,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_the_sick_woman_of_the_coalition"
 			add_stability = -0.05
 			add_political_power = -50
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			add_relative_party_popularity = yes
 		}

--- a/common/national_focus/spain.txt
+++ b/common/national_focus/spain.txt
@@ -4657,6 +4657,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
 			add_relative_party_popularity = yes
+			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/spain.txt
+++ b/common/national_focus/spain.txt
@@ -97,7 +97,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_faith_in_the_constitution"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			add_relative_party_popularity = yes
 			add_political_power = 100
@@ -4658,7 +4657,6 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
 			add_relative_party_popularity = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
@@ -5242,7 +5240,6 @@ focus_tree = {
 			eurosceptic_change = yes
 			set_temp_variable = { modify_eurosceptic = 0.03 }
 			EU_eurosceptic_change = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -5307,7 +5304,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_western_alignment"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -11432,7 +11428,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_farmers_opinion = yes
 
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -14816,7 +14811,6 @@ focus_tree = {
 			add_stability = -0.05
 			add_political_power = 150
 
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/sweden.txt
+++ b/common/national_focus/sweden.txt
@@ -14674,7 +14674,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_non_aligned_trade_network"
 			add_ideas = SWE_trading_net
 			increase_exports = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}

--- a/common/national_focus/tajikistan.txt
+++ b/common/national_focus/tajikistan.txt
@@ -326,7 +326,6 @@ focus_tree = {
 			custom_effect_tooltip = TAJ_integrate_agrarians_TT
 			add_to_array = { gov_coalition_array = 18 }
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1342,7 +1341,6 @@ focus_tree = {
 			set_country_flag = party23_banned
 			set_country_flag = party24_banned
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1625,7 +1623,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_revolutionary_nationalism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -1866,7 +1863,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_the_partys_legacy"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -2129,7 +2125,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_oligarchs_opinion = yes
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2444,7 +2439,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_a_new_era"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.045 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -4993,7 +4987,6 @@ focus_tree = {
 				remove_claim_by = TAJ
 			}
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -5159,7 +5152,6 @@ focus_tree = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_cleansing_the_badge"
 			add_political_power = 100
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -5454,7 +5446,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_compromise_with_shadows"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6300,7 +6291,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_rahmons_men"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -7113,7 +7103,6 @@ focus_tree = {
 				}
 			}
 			else = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.1 }
 				set_temp_variable = { temp_outlook_increase = 0.1 }
 				add_relative_party_popularity = yes
@@ -7257,7 +7246,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_clearing_the_way"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -7556,7 +7544,6 @@ focus_tree = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_electoral_reform"
 			country_event = tajik_focus.61
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.045 }
 			set_temp_variable = { temp_outlook_increase = 0.35 }
 			add_relative_party_popularity = yes
@@ -7755,7 +7742,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_dostievs_endorsement"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -8056,7 +8042,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_foreign_legitimacy"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -10809,7 +10794,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_rural_hunger"
 			add_ideas = TAJ_rural_nurishment
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.045 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -91,7 +91,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_increase_unemployment_insurance"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.025 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -1692,7 +1691,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_mission_to_moon"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -4901,7 +4899,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_improve_workers_rights"
 			add_stability = 0.05
 			newline = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -9426,7 +9423,6 @@ focus_tree = {
 				limit = {
 					has_idea = sunni
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.05 }
 				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
@@ -10408,7 +10404,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_purge_judges"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -11302,7 +11297,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_service_to_the_community"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -11592,7 +11586,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_modern_islam"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -12310,7 +12303,6 @@ focus_tree = {
 				limit = {
 					has_idea = sunni
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.05 }
 				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
@@ -12979,7 +12971,6 @@ focus_tree = {
 				limit = {
 					has_idea = sunni
 				}
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.05 }
 				set_temp_variable = { temp_outlook_increase = 0.05 }
 				add_relative_party_popularity = yes
@@ -14052,7 +14043,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_awareness_campaigns"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/ukraine.txt
+++ b/common/national_focus/ukraine.txt
@@ -301,7 +301,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_aid_from_minign_companies"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = 1.5 }
@@ -2125,7 +2124,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_block_land_trading"
 			UKR_idea_lands_reforms_minus = yes
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			if = {
@@ -2505,7 +2503,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_spu_start"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 			add_political_power = 100
@@ -4283,7 +4280,6 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = UKR }
 			change_influence_percentage = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			add_relative_party_popularity = yes
 		}
@@ -4425,7 +4421,6 @@ focus_tree = {
 			set_temp_variable = { influence_target = UKR }
 			change_influence_percentage = yes
 			one_random_infrastructure = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 		}
@@ -13534,7 +13529,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_opfl_rural_land"
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_stability = 0.03
@@ -13728,7 +13722,6 @@ focus_tree = {
 			add_to_variable = { UKR_liberals_democratic_support = 0.02 tooltip = neutrality_drift_tt }
 			add_political_power = 100
 			add_stability = 0.03
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -14224,7 +14217,6 @@ focus_tree = {
 			add_to_variable = { UKR_liberals_democratic_support = 0.02 tooltip = neutrality_drift_tt }
 			add_to_variable = { UKR_liberals_stability_factor = 0.05 tooltip = stability_factor_tt }
 			add_to_variable = { UKR_liberals_corruption_cost_factor = -0.1 tooltip = corruption_cost_factor_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -14416,7 +14408,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = -10 }
 			change_oligarchs_opinion = yes
 			add_stability = 0.02
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -15032,7 +15023,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = UKR_liberals_modifier }
 			add_to_variable = { UKR_liberals_communism_drift = -0.05 tooltip = communism_drift_tt }
 			add_to_variable = { UKR_liberals_emerging_outlook_campaign_cost_modifier = 0.1 tooltip = emerging_outlook_campaign_cost_modifier_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -15091,7 +15081,6 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = UKR_liberals_modifier }
 			add_to_variable = { UKR_liberals_communism_drift = -0.05 tooltip = communism_drift_tt }
 			add_to_variable = { UKR_liberals_emerging_outlook_campaign_cost_modifier = 0.15 tooltip = emerging_outlook_campaign_cost_modifier_tt }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/venezuela.txt
+++ b/common/national_focus/venezuela.txt
@@ -1665,7 +1665,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_fight_poverty"
 			increase_social_spending = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.050 }
 			set_temp_variable = { temp_outlook_increase = 0.050 }
 			add_relative_party_popularity = yes
@@ -3671,7 +3670,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -4365,7 +4363,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_world_revolution"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -4890,7 +4887,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -5278,7 +5274,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_purge_the_opponents"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.075 }
 			add_relative_party_popularity = yes
@@ -6228,7 +6223,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_give_a_little_freedom"
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			add_relative_party_popularity = yes
 			add_popularity = {
@@ -7313,7 +7307,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_pacify_the_plebs"
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes

--- a/common/on_actions/99_USA_on_actions.txt
+++ b/common/on_actions/99_USA_on_actions.txt
@@ -144,7 +144,6 @@ on_actions = {
 							modify_treasury_effect = yes
 						}
 						10 = {
-							set_party_index_to_ruling_party = yes
 							set_temp_variable = { party_popularity_increase = -0.02 }
 							add_relative_party_popularity = yes
 						}

--- a/common/scripted_effects/00_expected_spending_effects.txt
+++ b/common/scripted_effects/00_expected_spending_effects.txt
@@ -629,7 +629,6 @@ give_in_to_protestors_effect = {
 		block_defence_decrease = yes
 	}
 
-	set_party_index_to_ruling_party = yes
 	set_temp_variable = { party_popularity_increase = -0.05 }
 	set_temp_variable = { temp_outlook_increase = -0.05 }
 	add_relative_party_popularity = yes

--- a/common/scripted_effects/00_subideology_scripted_effects.txt
+++ b/common/scripted_effects/00_subideology_scripted_effects.txt
@@ -245,13 +245,17 @@ set_party_index_to_ruling_party = {
 #
 # 2022/04/30 - Added a additional parameter Z to allow you to increase the outlook within the script
 #
-# set_temp_variable = { party_index = X } #Index of party to be changed 0-23
+# set_temp_variable = { party_index = X } #OPTIONAL -- Index of party to be changed 0-23. Defaults to ruling party if not set.
 # set_temp_variable = { party_popularity_increase = Y } #How much party popularity is changed, must be in decimals so 2% is 0.02
 # set_temp_variable = { temp_outlook_increase = Z } #OPTIONAL PARAMETER -- Must be in decimals so 2% is 0.02
 # add_relative_party_popularity = yes
 #
 #NOTE! The temp variable names must be the same as above!
 add_relative_party_popularity = {
+	if = {
+		limit = { NOT = { has_variable = party_index } }
+		set_party_index_to_ruling_party = yes
+	}
 	custom_effect_tooltip = TT_ADD_RELATIVE_PARTY_POPULARITY
 	if = {
 		limit = { check_variable = { party_index < 4 } }

--- a/common/scripted_effects/00_subideology_scripted_effects.txt
+++ b/common/scripted_effects/00_subideology_scripted_effects.txt
@@ -262,7 +262,7 @@ add_relative_party_popularity = {
 
 		# If you have the optional parameter. First ADD the new outlook percentage.
 		if = { limit = { has_variable = temp_outlook_increase }
-			add_popularity = { ideology = democratic popularity = temp_outlook_increase }
+			hidden_effect = { add_popularity = { ideology = democratic popularity = temp_outlook_increase } }
 			add_to_variable = { party_pop_array^party_index = party_popularity_increase }
 		}
 		else = {
@@ -289,7 +289,7 @@ add_relative_party_popularity = {
 				}
 			}
 			else = {
-				add_popularity = { ideology = democratic popularity = party_popularity_increase }
+				hidden_effect = { add_popularity = { ideology = democratic popularity = party_popularity_increase } }
 			}
 		}
 	}
@@ -298,7 +298,7 @@ add_relative_party_popularity = {
 
 		# If you have the optional parameter. First ADD the new outlook percentage.
 		if = { limit = { has_variable = temp_outlook_increase }
-			add_popularity = { ideology = communism popularity = temp_outlook_increase }
+			hidden_effect = { add_popularity = { ideology = communism popularity = temp_outlook_increase } }
 			add_to_variable = { party_pop_array^party_index = party_popularity_increase }
 		}
 		else = {
@@ -325,7 +325,7 @@ add_relative_party_popularity = {
 				}
 			}
 			else = {
-				add_popularity = { ideology = communism popularity = party_popularity_increase }
+				hidden_effect = { add_popularity = { ideology = communism popularity = party_popularity_increase } }
 			}
 		}
 	}
@@ -334,7 +334,7 @@ add_relative_party_popularity = {
 
 		# If you have the optional parameter. First ADD the new outlook percentage.
 		if = { limit = { has_variable = temp_outlook_increase }
-			add_popularity = { ideology = fascism popularity = temp_outlook_increase }
+			hidden_effect = { add_popularity = { ideology = fascism popularity = temp_outlook_increase } }
 			add_to_variable = { party_pop_array^party_index = party_popularity_increase }
 		}
 		else = {
@@ -361,7 +361,7 @@ add_relative_party_popularity = {
 				}
 			}
 			else = {
-				add_popularity = { ideology = fascism popularity = party_popularity_increase }
+				hidden_effect = { add_popularity = { ideology = fascism popularity = party_popularity_increase } }
 			}
 		}
 	}
@@ -370,7 +370,7 @@ add_relative_party_popularity = {
 
 		# If you have the optional parameter. First ADD the new outlook percentage.
 		if = { limit = { has_variable = temp_outlook_increase }
-			add_popularity = { ideology = neutrality popularity = temp_outlook_increase }
+			hidden_effect = { add_popularity = { ideology = neutrality popularity = temp_outlook_increase } }
 			add_to_variable = { party_pop_array^party_index = party_popularity_increase }
 		}
 		else = {
@@ -397,14 +397,14 @@ add_relative_party_popularity = {
 				}
 			}
 			else = {
-				add_popularity = { ideology = neutrality popularity = party_popularity_increase }
+				hidden_effect = { add_popularity = { ideology = neutrality popularity = party_popularity_increase } }
 			}
 		}
 	}
 	else = {
 		# If you have the optional parameter. First ADD the new outlook percentage.
 		if = { limit = { has_variable = temp_outlook_increase }
-			add_popularity = { ideology = nationalist popularity = temp_outlook_increase }
+			hidden_effect = { add_popularity = { ideology = nationalist popularity = temp_outlook_increase } }
 			add_to_variable = { party_pop_array^party_index = party_popularity_increase }
 		}
 		else = {
@@ -431,7 +431,7 @@ add_relative_party_popularity = {
 				}
 			}
 			else = {
-				add_popularity = { ideology = nationalist popularity = party_popularity_increase }
+				hidden_effect = { add_popularity = { ideology = nationalist popularity = party_popularity_increase } }
 			}
 		}
 	}

--- a/common/scripted_effects/99_ARM_scripted_effects.txt
+++ b/common/scripted_effects/99_ARM_scripted_effects.txt
@@ -2225,7 +2225,6 @@ armenian_state_annex_effect = {
 		add_political_power = pp_cost
 		set_temp_variable = { treasury_change = treasury_cost }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = popularity_change }
 		set_temp_variable = { temp_outlook_increase = popularity_change }
 		add_relative_party_popularity = yes

--- a/common/scripted_effects/99_CES_scripted_effects.txt
+++ b/common/scripted_effects/99_CES_scripted_effects.txt
@@ -74,7 +74,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = UZB }
 		change_influence_percentage = yes
 		UZB = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -84,7 +83,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = TRK }
 		change_influence_percentage = yes
 		TRK = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -94,7 +92,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = TAJ }
 		change_influence_percentage = yes
 		TAJ = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -104,7 +101,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = KYR }
 		change_influence_percentage = yes
 		KAZ = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -120,7 +116,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = KAZ }
 		change_influence_percentage = yes
 		KAZ = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -130,7 +125,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = TRK }
 		change_influence_percentage = yes
 		TRK = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -140,7 +134,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = TAJ }
 		change_influence_percentage = yes
 		TAJ = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -150,7 +143,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = KYR }
 		change_influence_percentage = yes
 		KYR = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -166,7 +158,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = KAZ }
 		change_influence_percentage = yes
 		KAZ = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -176,7 +167,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = TRK }
 		change_influence_percentage = yes
 		TRK = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -186,7 +176,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = TAJ }
 		change_influence_percentage = yes
 		TAJ = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes
@@ -196,7 +185,6 @@ CES_peace_reunification = {
 		set_temp_variable = { influence_target = UZB }
 		change_influence_percentage = yes
 		UZB = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.12 }
 			set_temp_variable = { temp_outlook_increase = 0.12 }
 			add_relative_party_popularity = yes

--- a/common/scripted_effects/99_KHM_scripted_effects.txt
+++ b/common/scripted_effects/99_KHM_scripted_effects.txt
@@ -71,7 +71,6 @@ KHM_subject_annex_effect = {
 		add_political_power = -90
 		set_temp_variable = { treasury_change = -4 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes

--- a/common/scripted_effects/99_KOR_scripted_effects.txt
+++ b/common/scripted_effects/99_KOR_scripted_effects.txt
@@ -14,13 +14,11 @@ liberal_policy_effect = {
 			check_variable = { temp_pop > 0.5 }
 		}
 		custom_effect_tooltip = good_liberal_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 	else = {
 		custom_effect_tooltip = bad_liberal_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
@@ -41,13 +39,11 @@ liberal_policy_effect_small = {
 			check_variable = { temp_pop > 0.5 }
 		}
 		custom_effect_tooltip = good_liberal_policy_effect_small_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 	}
 	else = {
 		custom_effect_tooltip = bad_liberal_policy_effect_small_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 	}
@@ -75,13 +71,11 @@ conservative_policy_effect = {
 			check_variable = { temp_pop > 0.5 }
 		}
 		custom_effect_tooltip = good_conservative_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 	else = {
 		custom_effect_tooltip = bad_conservative_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
@@ -114,13 +108,11 @@ social_conservative_policy_effect = {
 			check_variable = { temp_pop > 0.5 }
 		}
 		custom_effect_tooltip = good_social_conservative_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 	else = {
 		custom_effect_tooltip = bad_social_conservative_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
@@ -139,13 +131,11 @@ progressive_policy_effect = {
 			check_variable = { temp_pop > 0.5 }
 		}
 		custom_effect_tooltip = good_progressive_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 	}
 	else = {
 		custom_effect_tooltip = bad_progressive_policy_effect_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}

--- a/common/scripted_effects/99_SOV_scripted_effects.txt
+++ b/common/scripted_effects/99_SOV_scripted_effects.txt
@@ -3140,7 +3140,6 @@ russian_tatarstan_annex = {
 		}
 		add_political_power = -150
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -3216,7 +3215,6 @@ russian_bashkortostan_annex = {
 		}
 		add_political_power = -150
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -3292,7 +3290,6 @@ russian_chechnya_annex = {
 		}
 		add_political_power = -120
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -3367,7 +3364,6 @@ russian_dagestan_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -3442,7 +3438,6 @@ russian_adygea_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -3517,7 +3512,6 @@ russian_karachaevo_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -3593,7 +3587,6 @@ russian_yakutia_annex = {
 		}
 		add_political_power = -120
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -3669,7 +3662,6 @@ russian_tuva_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -3745,7 +3737,6 @@ russian_buryatia_annex = {
 		}
 		add_political_power = -150
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -3821,7 +3812,6 @@ russian_karelia_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -3896,7 +3886,6 @@ russian_komi_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -3972,7 +3961,6 @@ russian_kalmikiya_annex = {
 		}
 		add_political_power = -110
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4047,7 +4035,6 @@ russian_altai_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -4122,7 +4109,6 @@ russian_yamal_annex = {
 		}
 		add_political_power = -110
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4197,7 +4183,6 @@ russian_nenets_annex = {
 		}
 		add_political_power = -120
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4272,7 +4257,6 @@ russian_chukotka_annex = {
 		}
 		add_political_power = -35
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -4347,7 +4331,6 @@ russian_khakassia_annex = {
 		}
 		add_political_power = -35
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4422,7 +4405,6 @@ russian_yugra_annex = {
 		}
 		add_political_power = -100
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4497,7 +4479,6 @@ russian_ingushetia_annex = {
 		}
 		add_political_power = -35
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4572,7 +4553,6 @@ russian_kabardino_annex = {
 		}
 		add_political_power = -35
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -4647,7 +4627,6 @@ russian_chuvashia_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4723,7 +4702,6 @@ russian_mari_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4798,7 +4776,6 @@ russian_mordovia_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4873,7 +4850,6 @@ russian_udmurtia_annex = {
 		}
 		add_political_power = -90
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -4951,7 +4927,6 @@ russian_kuban_annex = {
 		}
 		add_political_power = -150
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes

--- a/common/scripted_effects/99_SubjectRussia_scripted_effects.txt
+++ b/common/scripted_effects/99_SubjectRussia_scripted_effects.txt
@@ -679,7 +679,6 @@ URA_ural_monarchy_empire = {
 		set_temp_variable = { treasury_change = -1 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		annex_country = { target = MNT transfer_troops = yes }
 		MNT = { every_core_state = { add_core_of = URA } }
 		hidden_effect = {
@@ -699,7 +698,6 @@ URA_ural_monarchy_empire = {
 		set_temp_variable = { treasury_change = -1 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		annex_country = { target = ALB transfer_troops = yes }
 		ALB = { every_core_state = { add_core_of = URA } }
 		hidden_effect = {
@@ -719,7 +717,6 @@ URA_ural_monarchy_empire = {
 		set_temp_variable = { treasury_change = -1 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		annex_country = { target = FYR transfer_troops = yes }
 		FYR = { every_core_state = { add_core_of = URA } }
 		hidden_effect = {
@@ -739,7 +736,6 @@ URA_ural_monarchy_empire = {
 		set_temp_variable = { treasury_change = -1 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		annex_country = { target = GAM transfer_troops = yes }
 		GAM = { every_core_state = { add_core_of = URA } }
 		hidden_effect = {
@@ -759,7 +755,6 @@ URA_ural_monarchy_empire = {
 		set_temp_variable = { treasury_change = -1 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		annex_country = { target = TRI transfer_troops = yes }
 		TRI = { every_core_state = { add_core_of = URA } }
 		hidden_effect = {
@@ -1455,7 +1450,6 @@ SUB_apply_annex_transfer = {
 	add_political_power = pp_cost
 	set_temp_variable = { treasury_change = treasury_cost }
 	modify_treasury_effect = yes
-	set_party_index_to_ruling_party = yes
 	set_temp_variable = { party_popularity_increase = popularity_change }
 	set_temp_variable = { temp_outlook_increase = popularity_change }
 	add_relative_party_popularity = yes

--- a/common/scripted_effects/99_UKR_scripted_effects.txt
+++ b/common/scripted_effects/99_UKR_scripted_effects.txt
@@ -147,7 +147,6 @@ ukraine_subjects_annex = {
 		add_political_power = -300
 		set_temp_variable = { treasury_change = -12 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.13 }
 		set_temp_variable = { temp_outlook_increase = -0.13 }
 		add_relative_party_popularity = yes
@@ -172,7 +171,6 @@ ukraine_subjects_annex = {
 		add_political_power = -300
 		set_temp_variable = { treasury_change = -12 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.13 }
 		set_temp_variable = { temp_outlook_increase = -0.13 }
 		add_relative_party_popularity = yes
@@ -197,7 +195,6 @@ ukraine_subjects_annex = {
 		add_political_power = -300
 		set_temp_variable = { treasury_change = -12 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.13 }
 		set_temp_variable = { temp_outlook_increase = -0.13 }
 		add_relative_party_popularity = yes
@@ -222,7 +219,6 @@ ukraine_subjects_annex = {
 		add_political_power = -300
 		set_temp_variable = { treasury_change = -12 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.13 }
 		set_temp_variable = { temp_outlook_increase = -0.13 }
 		add_relative_party_popularity = yes
@@ -247,7 +243,6 @@ ukraine_subjects_annex = {
 		add_political_power = -300
 		set_temp_variable = { treasury_change = -12 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.13 }
 		set_temp_variable = { temp_outlook_increase = -0.13 }
 		add_relative_party_popularity = yes

--- a/common/scripted_guis/00_missiles_scripted_guis.txt
+++ b/common/scripted_guis/00_missiles_scripted_guis.txt
@@ -2931,7 +2931,6 @@ scripted_gui = {
 			}
 			domestic_survellience_button_click = {
 				add_political_power = -100
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.02 }
 				add_relative_party_popularity = yes
 
@@ -2954,7 +2953,6 @@ scripted_gui = {
 			}
 			domestic_survellience_button_right_click = {
 				add_political_power = -100
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				add_relative_party_popularity = yes
 
@@ -4944,7 +4942,6 @@ scripted_gui = {
 				effect_tooltip = {
 					var:current_cyber_nation_target = {
 						add_timed_idea = { idea = cyber_propaganda_ops_malus days = 120 }
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.03 }
 						add_relative_party_popularity = yes
 						add_stability = -0.02
@@ -5025,7 +5022,6 @@ scripted_gui = {
 				effect_tooltip = {
 					var:current_cyber_nation_target = {
 						add_timed_idea = { idea = cyber_election_interference_malus days = 180 }
-						set_party_index_to_ruling_party = yes
 						set_temp_variable = { party_popularity_increase = -0.04 }
 						add_relative_party_popularity = yes
 						add_stability = -0.02

--- a/docs/src/content/resources/code-resource.md
+++ b/docs/src/content/resources/code-resource.md
@@ -539,13 +539,14 @@ change_current_influencer_index_percentage = yes
 ### Party Popularity
 
 ```hoiscript
-# Set party index (0-23) and change popularity
-set_temp_variable = { party_index = 2 }
+# Add relative popularity to the ruling party (default)
 set_temp_variable = { party_popularity_increase = 0.10 }  # 10% = 0.10
 add_relative_party_popularity = yes
 
-# Or set to ruling party automatically
-set_party_index_to_ruling_party = yes
+# Or target a specific party by index (0-23)
+set_temp_variable = { party_index = 2 }
+set_temp_variable = { party_popularity_increase = 0.10 }
+add_relative_party_popularity = yes
 ```
 
 ### Ruling Party Changes

--- a/docs/src/content/resources/code-stylization-guide.md
+++ b/docs/src/content/resources/code-stylization-guide.md
@@ -183,7 +183,6 @@ country_event = {
     option = {
         name = france_md.504.a
         log = "[GetDateText]: [This.GetName]: france_md.504.a executed"
-        set_party_index_to_ruling_party = yes
         set_temp_variable = { party_popularity_increase = -0.01 }
         add_relative_party_popularity = yes
 

--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -1618,7 +1618,6 @@ country_event = {
 			increase_corruption = yes
 		}
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -6054,7 +6053,6 @@ country_event = {
 	option = {
 		name = british_flavor.4.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.4.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes

--- a/events/Afghanistan.txt
+++ b/events/Afghanistan.txt
@@ -1628,7 +1628,6 @@ news_event = {
 		name = TalibanInsurgency.24.a
 		log = "[GetDateText]: [This.GetName]: TalibanInsurgency.24.a executed"
 		add_political_power = -25
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes

--- a/events/African.txt
+++ b/events/African.txt
@@ -102,7 +102,6 @@ country_event = {
 		name = african.2.a
 		log = "[GetDateText]: [This.GetName]: african.2.a executed"
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -122,7 +121,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_farmers_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes

--- a/events/Algeria.txt
+++ b/events/Algeria.txt
@@ -1849,25 +1849,25 @@ news_event = {
 	}
 }
 news_event = {
-    id = alg_cabinet_news.1
-    title = alg_cabinet_news.1.t
-    desc = alg_cabinet_news.1.d
-    picture = GFX_election_rally
-    is_triggered_only = yes
-    major = no
+	id = alg_cabinet_news.1
+	title = alg_cabinet_news.1.t
+	desc = alg_cabinet_news.1.d
+	picture = GFX_election_rally
+	is_triggered_only = yes
+	major = no
 
-    trigger = {
-        OR = {
-            has_country_flag = ALG_mod_hardliner
-            has_country_flag = ALG_drs_reformist
-            has_country_flag = ALG_cabinet_crisis_brewing
-        }
-    }
+	trigger = {
+		OR = {
+			has_country_flag = ALG_mod_hardliner
+			has_country_flag = ALG_drs_reformist
+			has_country_flag = ALG_cabinet_crisis_brewing
+		}
+	}
 
-    option = {
-        name = alg_cabinet_news.1.a
-        log = "[GetDateText]: [This.GetName]: alg_cabinet_news.1.a executed"
-    }
+	option = {
+		name = alg_cabinet_news.1.a
+		log = "[GetDateText]: [This.GetName]: alg_cabinet_news.1.a executed"
+	}
 }
 
 country_event = {
@@ -2356,7 +2356,7 @@ country_event = {
 		}
 		every_country = {
 			limit = {
-				is_asian_nation = yes
+				has_country_flag = asian_nation_flag
 				has_idea = sunni
 			}
 			ALG = { add_to_faction = PREV }
@@ -2368,7 +2368,7 @@ country_event = {
 
 		every_country = {
 			limit = {
-				is_asian_nation = yes
+				has_country_flag = asian_nation_flag
 				has_idea = sunni
 			}
 			add_opinion_modifier = {
@@ -2484,7 +2484,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.40 }
 		set_temp_variable = { temp_outlook_increase = 0.40 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = neutrality popularity = 0.40 }
 		swap_ideas = {
 			remove_idea = the_military
 			add_idea = labour_unions
@@ -2531,7 +2530,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.40 }
 		set_temp_variable = { temp_outlook_increase = 0.40 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = democratic popularity = 0.40 }
 		swap_ideas = {
 			remove_idea = the_military
 			add_idea = international_bankers
@@ -2566,7 +2564,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.40 }
 		set_temp_variable = { temp_outlook_increase = 0.40 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = neutrality popularity = 0.40 }
 		swap_ideas = {
 			remove_idea = industrial_conglomerates
 			add_idea = the_ulema
@@ -2601,7 +2598,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.40 }
 		set_temp_variable = { temp_outlook_increase = 0.40 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = neutrality popularity = 0.40 }
 		swap_ideas = {
 			remove_idea = the_military
 			add_idea = labour_unions
@@ -7275,21 +7271,21 @@ country_event = {
 	}
 }
 country_event = {
-    id = alg.450
-    title = alg.450.t
-    desc = alg.450.d
-    picture = GFX_election_rally
-    is_triggered_only = yes
-    fire_only_once = yes
+	id = alg.450
+	title = alg.450.t
+	desc = alg.450.d
+	picture = GFX_election_rally
+	is_triggered_only = yes
+	fire_only_once = yes
 
-    trigger = {
-        has_country_flag = ALG_civil_war_triggered
-    }
+	trigger = {
+		has_country_flag = ALG_civil_war_triggered
+	}
 
-    option = {
-        name = alg.450.a
-        log = "[GetDateText]: [This.GetName]: alg.450.a executed"
-    }
+	option = {
+		name = alg.450.a
+		log = "[GetDateText]: [This.GetName]: alg.450.a executed"
+	}
 }
 # country_event = {
 # 	id = algeria_news.100
@@ -8506,21 +8502,23 @@ country_event = {
 					original_tag = UAE
 					original_tag = KUW
 					NOT = {
-						original_tag = RAJ
-						original_tag = SWI
-						original_tag = AUS
-						original_tag = TAJ
-						original_tag = AFG
-						original_tag = CHI
-						original_tag = SOV
-						original_tag = KOR
-						original_tag = PAL
-						original_tag = SYR
-						original_tag = HUN
-						original_tag = TRK
-						original_tag = UZB
-						original_tag = ARM
-						is_in_africa = yes
+						OR = {
+							original_tag = RAJ
+							original_tag = SWI
+							original_tag = AUS
+							original_tag = TAJ
+							original_tag = AFG
+							original_tag = CHI
+							original_tag = SOV
+							original_tag = KOR
+							original_tag = PAL
+							original_tag = SYR
+							original_tag = HUN
+							original_tag = TRK
+							original_tag = UZB
+							original_tag = ARM
+							is_in_africa = yes
+						}
 					}
 				}
 			}

--- a/events/Algeria.txt
+++ b/events/Algeria.txt
@@ -3200,7 +3200,6 @@ country_event = {
 				ideology = democratic
 				popularity = 0.035
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.095 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -3282,7 +3281,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: algerian_event.51.a executed"
 		add_political_power = 120
 		add_war_support = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -6573,7 +6571,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: algeria.48.a"
 		add_stability = 0.02
 		increase_centralization = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -6584,7 +6581,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: algeria.48.b"
 		add_war_support = 0.05
 		increase_military_spending = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes

--- a/events/Arab Spring.txt
+++ b/events/Arab Spring.txt
@@ -317,7 +317,6 @@ country_event = {
 		add_popularity = { ideology = neutrality popularity = 0.10 }
 		recalculate_party = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		add_relative_party_popularity = yes
@@ -760,7 +759,6 @@ country_event = {
 	option = {
 		name = arab_spring.18.a
 		log = "[GetDateText]: [This.GetName]: arab_spring.18.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		add_relative_party_popularity = yes

--- a/events/Armenia.txt
+++ b/events/Armenia.txt
@@ -7407,7 +7407,6 @@ country_event = {
 	option = {
 		name = arme.176.b
 		log = "[GetDateText]: [This.GetName]: arme.176.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.1
 		}
@@ -7539,7 +7538,6 @@ country_event = {
 		}
 		add_political_power = 150
 		add_stability = -0.25
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.15
 		}
@@ -7622,7 +7620,6 @@ country_event = {
 		}
 		add_political_power = 150
 		add_war_support = -0.1
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.1
 		}
@@ -7678,7 +7675,6 @@ country_event = {
 			target = ARM
 		}
 		add_political_power = 150
-		set_party_index_to_ruling_party = yes
 		remove_opinion_modifier = {
 			target = ARM
 			modifier = refuse_to_apologize_for_warcrimes2
@@ -7962,7 +7958,6 @@ country_event = {
 	option = {
 		name = arme.191.a
 		log = "[GetDateText]: [This.GetName]: arme.191.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.15
 		}
@@ -8120,7 +8115,6 @@ country_event = {
 		name = arme.196.a
 		log = "[GetDateText]: [This.GetName]: arme.196.a executed"
 		add_political_power = 50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.02
 		}
@@ -8146,7 +8140,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: arme.197.a executed"
 		set_temp_variable = { temp_opinion = 10 }
 		change_the_clergy_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.02
 		}
@@ -8203,7 +8196,6 @@ country_event = {
 	option = {
 		name = arme.199.b
 		log = "[GetDateText]: [This.GetName]: arme.199.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.15
 		}
@@ -8267,7 +8259,6 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -8302,7 +8293,6 @@ country_event = {
 		name = arme.203.b
 		log = "[GetDateText]: [This.GetName]: arme.203.b executed"
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -8339,7 +8329,6 @@ country_event = {
 	option = {
 		name = arme.204.b
 		log = "[GetDateText]: [This.GetName]: arme.204.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.15
 		}
@@ -8365,7 +8354,6 @@ country_event = {
 		name = arme.205.a
 		log = "[GetDateText]: [This.GetName]: arme.205.a executed"
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -8489,7 +8477,6 @@ country_event = {
 		name = arme.209.a
 		log = "[GetDateText]: [This.GetName]: arme.209.a executed"
 		add_political_power = 50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -8617,7 +8604,6 @@ country_event = {
 		name = arme.214.a
 		log = "[GetDateText]: [This.GetName]: arme.214.a executed"
 		add_political_power = 50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -9079,7 +9065,6 @@ country_event = {
 	option = {
 		name = arm_pashinyan.5.a
 		log = "[GetDateText]: [This.GetName]: arm_pashinyan.5.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.1
 		}
@@ -9104,7 +9089,6 @@ country_event = {
 	option = {
 		name = arm_pashinyan.6.a
 		log = "[GetDateText]: [This.GetName]: arm_pashinyan.6.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -9133,7 +9117,6 @@ country_event = {
 			ideology = nationalist
 			popularity = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.07
 		}
@@ -10299,7 +10282,6 @@ country_event = {
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.09 }
 		set_temp_variable = { temp_outlook_increase = 0.09 }
 		add_relative_party_popularity = yes
@@ -10539,7 +10521,6 @@ country_event = {
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.09 }
 		set_temp_variable = { temp_outlook_increase = 0.09 }
 		add_relative_party_popularity = yes
@@ -12509,7 +12490,6 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -9.00 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		add_power_balance_value = {
@@ -12561,7 +12541,6 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -1.875 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		add_power_balance_value = {
@@ -12618,7 +12597,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: arm_economic.10.a executed"
 		set_temp_variable = { treasury_change = -7.00 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		custom_effect_tooltip = ARM_add_idea_to_economy_idea_tt
@@ -12675,7 +12653,6 @@ country_event = {
 		name = arm_economic.11.a
 		log = "[GetDateText]: [This.GetName]: arm_economic.11.a executed"
 		one_random_agriculture_district = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		add_power_balance_value = {
@@ -12730,7 +12707,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: arm_economic.12.a executed"
 		one_random_industrial_complex = yes
 		one_random_fossil_fuel_powerplant = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		add_power_balance_value = {
@@ -12795,7 +12771,6 @@ country_event = {
 		set_temp_variable = { tag_index = FRA }
 		set_temp_variable = { influence_target = ARM }
 		change_influence_percentage = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		add_power_balance_value = {

--- a/events/Bolivia.txt
+++ b/events/Bolivia.txt
@@ -52,7 +52,6 @@ country_event = {
 			value = 25
 		}
 		custom_effect_tooltip = BOL_increase_mestizo_opinion_25_tt
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		add_relative_party_popularity = yes

--- a/events/Botswana.txt
+++ b/events/Botswana.txt
@@ -564,7 +564,6 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: Botswana_pulse.14.a executed"
 		name = Botswana_pulse.14.a
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.025 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes

--- a/events/Brazilian.txt
+++ b/events/Brazilian.txt
@@ -2281,7 +2281,6 @@ country_event = {
 		name = brazil_amazon.3.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.3.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -2363,7 +2362,6 @@ country_event = {
 		name = brazil_amazon.4.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.4.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -3218,7 +3216,6 @@ country_event = {
 
 		set_temp_variable = { temp_change = -30 }
 		BRA_wild_acreage_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -3273,7 +3270,6 @@ country_event = {
 		set_temp_variable = { temp_change = -20 }
 		BRA_wild_acreage_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3338,7 +3334,6 @@ country_event = {
 		set_temp_variable = { temp_change = -10 }
 		BRA_wild_acreage_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes

--- a/events/Canada.txt
+++ b/events/Canada.txt
@@ -441,7 +441,6 @@ country_event = { #Peaceful Protests
 		log = "[GetDateText]: [Root.GetName]: event canada.701.a"
 		set_temp_variable = { modify_que_happy = -5 }
 		CAN_modify_french_happiness = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/Central African Republic.txt
+++ b/events/Central African Republic.txt
@@ -130,7 +130,6 @@ country_event = {
 	option = {
 		name = central_africa.5.a
 		log = "[GetDateText]: [This.GetName]: central_africa.5.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.06 }
 		set_temp_variable = { temp_outlook_increase = 0.06 }
 		add_relative_party_popularity = yes
@@ -408,7 +407,6 @@ country_event = {
 		name = central_africa.10.b
 		log = "[GetDateText]: [This.GetName]: central_africa.10.b executed"
 		set_country_flag = CAR_bars_patasse_from_election
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -440,7 +438,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: central_africa.12.a executed"
 		if = { limit = { has_country_leader = { name = "François Bozizé Yangouvonda" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -462,7 +459,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: central_africa.12.b executed"
 		if = { limit = { has_country_leader = { name = "Martin Ziguélé" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -486,7 +482,6 @@ country_event = {
 
 		if = { limit = { has_country_leader = { name = "Ange-Félix Patassé" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -1256,7 +1251,6 @@ country_event = {
 		if = {
 			limit = { has_country_leader = { name = "Michel Djotodia" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -1293,7 +1287,6 @@ country_event = {
 		news_event = { id = central_africa.1004 days = 3 }
 		add_stability = 0.05
 		add_political_power = 100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes

--- a/events/CyberWarfare.txt
+++ b/events/CyberWarfare.txt
@@ -119,7 +119,6 @@ country_event = {
 		else = {
 			add_timed_idea = { idea = cyber_propaganda_ops_malus days = 120 }
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 	}
@@ -236,7 +235,6 @@ country_event = {
 		else = {
 			add_timed_idea = { idea = cyber_election_interference_malus days = 180 }
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 	}

--- a/events/Czech Republic.txt
+++ b/events/Czech Republic.txt
@@ -12784,11 +12784,11 @@ country_event = {
 
 		CZE = { country_event = CZE_HUN_monarchy_event.8 }
 
-		set_temp_variable = { party_index = 23 }
-		set_temp_variable = { party_popularity_increase = -0.05 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
-		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
 		log = "[GetDateText]: [This.GetName]: CZE_HUN_monarchy_event.7.a executed"
@@ -12819,11 +12819,11 @@ country_event = {
 
 		CZE = { country_event = CZE_HUN_monarchy_event.10 }
 
-		set_temp_variable = { party_index = 23 }
-		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
-		set_temp_variable = { party_popularity_increase = -0.05 }
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
 		log = "[GetDateText]: [This.GetName]: CZE_HUN_monarchy_event.7.c executed"
@@ -12934,11 +12934,11 @@ country_event = {
 
 		CZE = { country_event = CZE_HUN_monarchy_event.13 }
 
-		set_temp_variable = { party_index = 23 }
-		set_temp_variable = { party_popularity_increase = -0.05 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
-		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
 		log = "[GetDateText]: [This.GetName]: CZE_HUN_monarchy_event.11.b executed"
@@ -13129,12 +13129,13 @@ country_event = {
 
 		increase_corruption = yes
 
-		set_temp_variable = { party_index = 23 }
-		set_temp_variable = { party_popularity_increase = 0.1 }
-		add_relative_party_popularity = yes
-
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
+		add_relative_party_popularity = yes
+
+		clear_variable = temp_outlook_increase
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.1 }
 		add_relative_party_popularity = yes
 
 		CZE = { country_event = CZE_HUN_monarchy_event.20 }
@@ -13163,11 +13164,11 @@ country_event = {
 
 		increase_corruption = yes
 
-		set_temp_variable = { party_index = 23 }
-		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
-		set_temp_variable = { party_popularity_increase = -0.05 }
+		set_temp_variable = { party_index = 23 }
+		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
 		CZE = { country_event = CZE_HUN_monarchy_event.21 }

--- a/events/Czech Republic.txt
+++ b/events/Czech Republic.txt
@@ -12788,7 +12788,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
@@ -12824,7 +12823,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
@@ -12940,7 +12938,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
@@ -13093,7 +13090,6 @@ country_event = {
 			base = 50
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
@@ -13137,7 +13133,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.1 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -13172,7 +13167,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 
@@ -13840,7 +13834,6 @@ country_event = {
 
 		add_stability = -0.1
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		add_relative_party_popularity = yes
 

--- a/events/Denmark.txt
+++ b/events/Denmark.txt
@@ -1361,7 +1361,6 @@ country_event = {
 		add_political_power = -100
 		add_stability = -0.02
 		remove_ideas = DEN_euro_question_idea
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { modify_eurosceptic = 0.05 }
@@ -1390,7 +1389,6 @@ country_event = {
 		add_political_power = -50
 		add_stability = -0.01
 		remove_ideas = DEN_euro_question_idea
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 
@@ -1405,7 +1403,6 @@ country_event = {
 		add_political_power = -100
 		add_stability = -0.02
 		remove_ideas = DEN_euro_question_idea
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { modify_eurosceptic = -0.05 }
@@ -1431,7 +1428,6 @@ country_event = {
 		name = denmark.100.a
 		log = "[GetDateText]: [THIS.GetName]: denmark.100.a executed"
 		add_stability = 0.04
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -1817,7 +1817,6 @@ country_event = {
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -1905,7 +1904,6 @@ country_event = {
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1995,7 +1993,6 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -2023,7 +2020,6 @@ country_event = {
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -2221,7 +2217,6 @@ country_event = {
 	option = {
 		name = econvent.14.a
 		log = "[GetDateText]: [This.GetName]: econvent.14.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -2315,7 +2310,6 @@ country_event = {
 	option = {
 		name = econvent.15.a
 		log = "[GetDateText]: [This.GetName]: econvent.15.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -3794,7 +3788,6 @@ country_event = {
 			modify_corporate_tax_rate_effect = yes
 			set_temp_variable = { pop_change = 10 }
 			modify_population_tax_rate_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			add_relative_party_popularity = yes
@@ -3804,7 +3797,6 @@ country_event = {
 			modify_corporate_tax_rate_effect = yes
 			set_temp_variable = { pop_change = 5 }
 			modify_population_tax_rate_effect = yes
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes

--- a/events/Egypt.txt
+++ b/events/Egypt.txt
@@ -1490,7 +1490,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Egypt.48.a"
 		add_stability = 0.02
 		increase_centralization = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -1501,7 +1500,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Egypt.48.b"
 		add_war_support = 0.05
 		increase_military_spending = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1835,7 +1833,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = 5 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 12 }
@@ -1861,7 +1858,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = -3 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
@@ -1893,7 +1889,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = 2 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 12 }
@@ -1919,7 +1914,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = -2 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
@@ -1951,7 +1945,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = 5 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 12 }
@@ -1977,7 +1970,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = -3 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
@@ -2009,7 +2001,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = 2 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 12 }
@@ -2035,7 +2026,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = -2 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
@@ -2067,7 +2057,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = 3 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 12 }
@@ -2093,7 +2082,6 @@ country_event = {
 		modify_coptic_pol_influence_effect = yes
 		set_temp_variable = { temp_modify_social_con_government = -2 }
 		modify_social_conservatism_government = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
@@ -3968,7 +3956,6 @@ country_event = {
 		set_country_flag = EGY_aswan_tribal_conflict_resolved
 
 		add_stability = 0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -4016,7 +4003,6 @@ country_event = {
 		set_country_flag = EGY_aswan_historical_choice
 
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes

--- a/events/Estonia.txt
+++ b/events/Estonia.txt
@@ -499,11 +499,8 @@ country_event = { # Constitutional reform focus
 		add_command_power = 10
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
-		add_popularity = {
-			ideology = democratic
-			popularity = 0.05
-		}
 		add_popularity = {
 			ideology = nationalist
 			popularity = -0.1
@@ -518,11 +515,8 @@ country_event = { # Constitutional reform focus
 		add_command_power = 10
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = -0.01 }
+		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
-		add_popularity = {
-			ideology = democratic
-			popularity = -0.05
-		}
 		add_popularity = {
 			ideology = nationalist
 			popularity = 0.05

--- a/events/Estonia.txt
+++ b/events/Estonia.txt
@@ -449,7 +449,6 @@ country_event = {
 		name = estonia.16.o1
 		log = "[GetDateText]: [This.GetName]: event estonia.16.o1 executed"
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -771,7 +770,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: event estonia.106.a executed"
 
 		add_political_power = 100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes

--- a/events/Ethiopia.txt
+++ b/events/Ethiopia.txt
@@ -636,7 +636,6 @@ country_event = {
 		}
 		add_stability = -0.05
 		add_war_support = -0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		add_relative_party_popularity = yes
@@ -676,7 +675,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ethiopia.22.a executed"
 		add_stability = 0.05
 		add_war_support = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes

--- a/events/France.txt
+++ b/events/France.txt
@@ -1390,7 +1390,6 @@ country_event = {
 	option = {
 		name = france_md.504.a
 		log = "[GetDateText]: [This.GetName]: france_md.504.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes

--- a/events/Germany.txt
+++ b/events/Germany.txt
@@ -695,7 +695,6 @@ country_event = {
 		country_event = { id = germany.11 days = 20 }
 		add_political_power = -100
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.055 }
 		set_temp_variable = { temp_outlook_increase = 0.055 }
 		add_relative_party_popularity = yes
@@ -708,7 +707,6 @@ country_event = {
 		name = germany.10.b
 		log = "[GetDateText]: [This.GetName]: germany.10.a executed"
 		country_event = { id = germany.11 days = 20 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		add_relative_party_popularity = yes
@@ -790,7 +788,6 @@ country_event = {
 	option = {
 		name = germany.12.a
 		log = "[GetDateText]: [This.GetName]: germany.12.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.035 }
 		add_relative_party_popularity = yes
@@ -882,7 +879,6 @@ country_event = {
 	option = {
 		name = germany.15.b
 		log = "[GetDateText]: [This.GetName]: germany.15.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -1610,7 +1606,6 @@ country_event = {
 		name = germany.39.a
 		log = "[GetDateText]: [This.GetName]: germany.39.a executed"
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -1977,7 +1972,6 @@ country_event = {
 		name = germany.52.a
 		add_political_power = -10
 		add_stability = 0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -2014,7 +2008,6 @@ country_event = {
 		name = germany.53.a
 		add_political_power = -50
 		add_stability = 0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -2024,7 +2017,6 @@ country_event = {
 		name = germany.53.b
 		add_political_power = 10
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		add_relative_party_popularity = yes
@@ -2163,7 +2155,6 @@ country_event = {
 		name = germany.58.a
 		add_political_power = -20
 		add_stability = 0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		add_relative_party_popularity = yes
@@ -2177,7 +2168,6 @@ country_event = {
 		name = germany.58.b
 		add_political_power = 20
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		add_relative_party_popularity = yes
@@ -2439,7 +2429,6 @@ country_event = {
 				id = GER_power_balance
 				value = 0.05
 			}
-			set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -2449,7 +2438,6 @@ country_event = {
 		name = germany_nsu.1.b
 		log = "[GetDateText]: [This.GetName]: germany_nsu.1.b executed"
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		add_relative_party_popularity = yes
@@ -2474,7 +2462,6 @@ country_event = {
 		name = germany_nsu.2.a
 		log = "[GetDateText]: [This.GetName]: germany_nsu.2.a executed"
 		add_stability = 0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.005 }
 		set_temp_variable = { temp_outlook_increase = 0.005 }
 		add_relative_party_popularity = yes
@@ -2523,7 +2510,6 @@ country_event = {
 		name = germany_nsu.3.b
 		log = "[GetDateText]: [This.GetName]: germany_nsu.3.b executed"
 		add_stability = 0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.005 }
 		set_temp_variable = { temp_outlook_increase = 0.005 }
 		add_relative_party_popularity = yes
@@ -2858,7 +2844,6 @@ country_event = { #Die Linke questions our administration
 	option = {
 		name = germany_divide.5.a
 		log = "[GetDateText]: [This.GetName]:germany_divide.5.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3093,7 +3078,6 @@ country_event = {
 	option = { # Lets bite our tongues
 		name = germany_divide.13.a
 		log = "[GetDateText]: [This.GetName]:germany_divide.13.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3107,7 +3091,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:germany_divide.13.b executed"
 		custom_effect_tooltip = GER_east_decrease_opinion
 		add_to_variable = { GER_east_opinion = -1 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -3537,7 +3520,6 @@ country_event = {
 			type = puppet_wargoal_focus
 		}
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.15 }
 		set_temp_variable = { temp_outlook_increase = -0.15 }
 		add_relative_party_popularity = yes
@@ -5507,7 +5489,6 @@ country_event = {
 				ideology = democratic
 				popularity = 0.035
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.095 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -6040,7 +6021,6 @@ country_event = {
 		name = germany_yearly.4.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.4.a executed"
 		add_political_power = -150
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.025 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		add_relative_party_popularity = yes
@@ -6052,7 +6032,6 @@ country_event = {
 	option = {
 		name = germany_yearly.4.b
 		log = "[GetDateText]: [This.GetName]: germany_yearly.4.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -6066,7 +6045,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany_yearly.4.c executed"
 		army_experience = -30
 		add_command_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		add_relative_party_popularity = yes
@@ -6706,7 +6684,6 @@ country_event = {
 		}
 		newline = yes
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -8446,7 +8423,6 @@ country_event = { # "Damage to Vineyards Following Bundeswehr Exercise"
 		name = Germany_Mech.6.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.6.a executed"
 		add_political_power = 10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.020 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		add_relative_party_popularity = yes
@@ -8459,7 +8435,6 @@ country_event = { # "Damage to Vineyards Following Bundeswehr Exercise"
 		name = Germany_Mech.6.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.6.b executed"
 		add_political_power = -10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -8483,7 +8458,6 @@ country_event = { # "Public Park Damaged by Armored Vehicles"
 		name = Germany_Mech.7.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.7.a executed"
 		add_political_power = 10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.020 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		add_relative_party_popularity = yes
@@ -8495,7 +8469,6 @@ country_event = { # "Public Park Damaged by Armored Vehicles"
 	option = {
 		name = Germany_Mech.7.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.7.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -8532,7 +8505,6 @@ country_event = { # "Misfired Training Missile Cuts Off Town’s Communication"
 	option = {
 		name = Germany_Mech.8.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.8.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -8932,7 +8904,6 @@ country_event = { #Phillip Holzmann AG insolvenz 2002.03
 		name = Germany_Mech.28.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.28.a executed"
 		add_stability = 0.03
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.095 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -8942,7 +8913,6 @@ country_event = { #Phillip Holzmann AG insolvenz 2002.03
 		name = Germany_Mech.28.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.28.b executed"
 		add_stability = -0.04
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.095 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -9128,7 +9098,6 @@ country_event = { #Dotcom Bubble collapse
 		set_temp_variable = { treasury_change = GER.gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.19 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.005 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -9147,7 +9116,6 @@ country_event = { #Dotcom Bubble collapse
 		set_temp_variable = { treasury_change = GER.gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.04 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.025 }
 		set_temp_variable = { temp_outlook_increase = -0.035 }
 		add_relative_party_popularity = yes
@@ -9227,7 +9195,6 @@ country_event = { #Rechtsrock #Schulhof CD
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.40.b executed"
 		custom_effect_tooltip = Germany_Mech.40_b
 		add_stability = -0.04
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.005 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -9293,7 +9260,6 @@ country_event = { #NPD Schulhof CD
 			id = GER_power_balance
 			value = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.002 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -9331,7 +9297,6 @@ country_event = { # Landser verbotsverfahren
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.42.a executed"
 		custom_effect_tooltip = Germany_Mech.42_a
 		add_stability = 0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.002 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -9345,7 +9310,6 @@ country_event = { # Landser verbotsverfahren
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.42.b executed"
 		custom_effect_tooltip = Germany_Mech.42_b
 		add_stability = -0.04
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.005 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -9383,7 +9347,6 @@ country_event = { #landser court
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.43.a executed"
 		custom_effect_tooltip = Germany_Mech.43_a
 		add_stability = 0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.003 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -9406,7 +9369,6 @@ country_event = { #landser court
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.43.b executed"
 		custom_effect_tooltip = Germany_Mech.43_b
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.001 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -9429,7 +9391,6 @@ country_event = { #landser court
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.43.c executed"
 		custom_effect_tooltip = Germany_Mech.43_c
 		add_stability = -0.04
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.005 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -9469,7 +9430,6 @@ country_event = { #Lunikoff return
 		name = Germany_Mech.44.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.44.a executed"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.001 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -11533,7 +11493,6 @@ country_event = { #Rec
 #				}
 #			}
 #		}
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.015 }
 #		set_temp_variable = { temp_outlook_increase = 0.025 }
 #		add_relative_party_popularity = yes
@@ -11559,7 +11518,6 @@ country_event = { #Rec
 #				}
 #			}
 #		}
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.005 }
 #		set_temp_variable = { temp_outlook_increase = 0.025 }
 #		add_relative_party_popularity = yes
@@ -11573,7 +11531,6 @@ country_event = { #Rec
 #		name = GER_Cold_War.21.c
 #		log = "[GetDateText]: [This.GetName]: GER_Cold_War.21.c executed"
 #		custom_effect_tooltip = GER_Keep_TT
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.005 }
 #		set_temp_variable = { temp_outlook_increase = 0.005 }
 #		add_relative_party_popularity = yes
@@ -12172,7 +12129,6 @@ country_event = { #Heerestruppenkommando
 #				}
 #			}
 #		}
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.015 }
 #		set_temp_variable = { temp_outlook_increase = 0.025 }
 #		add_relative_party_popularity = yes
@@ -12201,7 +12157,6 @@ country_event = { #Heerestruppenkommando
 #				}
 #			}
 #		}
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.005 }
 #		set_temp_variable = { temp_outlook_increase = 0.025 }
 #		add_relative_party_popularity = yes
@@ -12214,7 +12169,6 @@ country_event = { #Heerestruppenkommando
 #	option = {
 #		name = GER_Cold_War.26.c
 #		log = "[GetDateText]: [This.GetName]: GER_Cold_War.26.c executed"
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.005 }
 #		set_temp_variable = { temp_outlook_increase = 0.005 }
 #		add_relative_party_popularity = yes
@@ -16784,7 +16738,6 @@ news_event = {
 	option = {
 		name = GER_news.13.a
 		log = "[GetDateText]: [This.GetName]: GER_news.13.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -16809,7 +16762,6 @@ country_event = {
 	option = {
 		name = GER_news.14.a
 		log = "[GetDateText]: [This.GetName]: GER_news.14.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -16839,7 +16791,6 @@ country_event = {
 	option = {
 		name = GER_news.14.b
 		log = "[GetDateText]: [This.GetName]: GER_news.14.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -16860,7 +16811,6 @@ country_event = {
 	option = {
 		name = GER_news.14.c
 		log = "[GetDateText]: [This.GetName]: GER_news.14.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -16972,7 +16922,6 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: GER_news.17.a executed"
 		set_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -17103,7 +17052,6 @@ news_event = {
 	option = {
 		name = GER_news.22.a
 		log = "[GetDateText]: [This.GetName]: GER_news.22.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -17122,7 +17070,6 @@ news_event = {
 	option = {
 		name = GER_news.23.a
 		log = "[GetDateText]: [This.GetName]: GER_news.23.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -17141,7 +17088,6 @@ news_event = {
 	option = {
 		name = GER_news.24.a
 		log = "[GetDateText]: [This.GetName]: GER_news.24.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -18032,7 +17978,6 @@ country_event = {
 			decrease_corruption = yes
 		}
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -18053,7 +17998,6 @@ country_event = {
 		custom_effect_tooltip = GER_Corruption.01.b_desc
 		add_stability = 0.01
 		add_political_power = -10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -18069,7 +18013,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = 0.24 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.055 }
 		set_temp_variable = { temp_outlook_increase = -0.055 }
 		add_relative_party_popularity = yes
@@ -18096,7 +18039,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18141,7 +18083,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18177,7 +18118,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18221,7 +18161,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18257,7 +18196,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18302,7 +18240,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18338,7 +18275,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18383,7 +18319,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18440,7 +18375,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18484,7 +18418,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18517,7 +18450,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18561,7 +18493,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18594,7 +18525,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18639,7 +18569,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -18672,7 +18601,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.20 }
 		modify_treasury_effect = yes
 		add_political_power = -20
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		add_relative_party_popularity = yes
@@ -18717,7 +18645,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
 		add_political_power = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -20930,7 +20857,6 @@ country_event = { #Key ressources
 #			add_opinion_modifier = { target = GER modifier = drama }
 #		}
 #		add_political_power = -10
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = 0.020 }
 #		set_temp_variable = { temp_outlook_increase = 0.016 }
 #
@@ -20947,7 +20873,6 @@ country_event = { #Key ressources
 #
 #		add_political_power = 10
 #
-#		set_party_index_to_ruling_party = yes
 #		set_temp_variable = { party_popularity_increase = -0.020 }
 #		set_temp_variable = { temp_outlook_increase = -0.016 }
 #

--- a/events/Haiti.txt
+++ b/events/Haiti.txt
@@ -48,7 +48,6 @@ country_event = {
 		name = haiti.2.a
 		log = "[GetDateText]: [This.GetName]: haiti.2.a executed"
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.06 }
 		set_temp_variable = { temp_outlook_increase = 0.06 }
 		add_relative_party_popularity = yes
@@ -915,7 +914,6 @@ country_event = {
 		name = haiti.21.a
 		log = "[GetDateText]: [This.GetName]: haiti.21.a executed"
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes

--- a/events/Indian.txt
+++ b/events/Indian.txt
@@ -529,7 +529,6 @@ country_event = {
 		name = indian_event.13.b
 		log = "[GetDateText]: [This.GetName]: indian_event.13.b executed"
 		ai_chance = { base = 1 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2187,7 +2186,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.51.a executed"
 		add_political_power = 120
 		add_war_support = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/Indonesia.txt
+++ b/events/Indonesia.txt
@@ -1252,7 +1252,6 @@ country_event = {
 		name = indonesia.37.b
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.37.b"
 		add_stability = -0.10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		add_relative_party_popularity = yes
 	}

--- a/events/Influence.txt
+++ b/events/Influence.txt
@@ -2124,7 +2124,6 @@ country_event = {
 		set_temp_variable = { tag_index = event_target:coup_contest_sender.id }
 		set_temp_variable = { influence_target = event_target:coup_contest_victim.id }
 		change_influence_percentage = yes
-		set_party_index_to_ruling_party = yes
 		event_target:coup_contest_victim = {
 			set_temp_variable = { contester_influence = 0 }
 			for_each_loop = {
@@ -2192,7 +2191,6 @@ country_event = {
 				modifier = attacked_our_influence
 			}
 		}
-		set_party_index_to_ruling_party = yes
 		event_target:coup_contest_victim = {
 			set_temp_variable = { contester_influence = 0 }
 			for_each_loop = {

--- a/events/Internal Faction Events.txt
+++ b/events/Internal Faction Events.txt
@@ -35,7 +35,6 @@ country_event = {
 					has_communist_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -66,7 +65,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -125,7 +123,6 @@ country_event = {
 					has_reactionary_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -144,7 +141,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -164,7 +160,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -228,7 +223,6 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { arg_popularity = 0.02 }
 		add_ruling_outlook_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 	}
@@ -257,7 +251,6 @@ country_event = {
 					has_communist_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -274,7 +267,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -326,7 +318,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -348,7 +339,6 @@ country_event = {
 					has_communist_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -366,7 +356,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -415,7 +404,6 @@ country_event = {
 				has_environmentalist_government = yes
 			}
 
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -425,7 +413,6 @@ country_event = {
 		name = internal_factions_events.5.o3
 		log = "[GetDateText]: [This.GetName]: internal_factions_events.5.o3 executed"	#Just ignore it
 		ai_chance = { base = 1 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -465,7 +452,6 @@ country_event = {
 					has_communist_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -485,7 +471,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -539,7 +524,6 @@ country_event = {
 					has_communist_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -562,7 +546,6 @@ country_event = {
 			limit = {
 				has_economically_liberal_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -621,7 +604,6 @@ country_event = {
 					has_liberal_government = yes
 				}
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -650,7 +632,6 @@ country_event = {
 			limit = {
 				has_conservative_government = yes
 			}
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -1617,7 +1598,6 @@ country_event = {
 	option = { # Ignore Complaints
 		name = internal_factions_events.22.o1
 		log = "[GetDateText]: [This.GetName]: internal_factions_events.22.o1 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 
@@ -1654,7 +1634,6 @@ country_event = {
 		change_intelligence_community_opinion = yes
 		add_stability = -0.05
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 		ai_chance = {
@@ -1991,7 +1970,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_defense_industry_opinion = yes
 		add_political_power = -125
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		add_relative_party_popularity = yes
@@ -2782,7 +2760,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -15 }
 		change_labour_unions_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -2800,7 +2777,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_labour_unions_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -3807,7 +3783,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: internal_factions_events.46.a executed"
 		set_temp_variable = { temp_opinion = 10 }
 		change_the_ulema_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -3830,7 +3805,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: internal_factions_events.46.b executed"
 		set_temp_variable = { temp_opinion = -5 }
 		change_the_ulema_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		add_relative_party_popularity = yes
@@ -4153,7 +4127,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: internal_factions_events.52.a executed"
 		set_temp_variable = { temp_opinion = 10 }
 		change_saudi_royal_family_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -4172,7 +4145,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: internal_factions_events.52.b executed"
 		set_temp_variable = { temp_opinion = -10 }
 		change_saudi_royal_family_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -4513,7 +4485,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -10 }
 		change_intelligence_community_opinion = yes
 		add_timed_idea = { idea = internal_factions_transparency_costs days = 180 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 		ai_chance = { base = 1 }

--- a/events/Iran.txt
+++ b/events/Iran.txt
@@ -6688,7 +6688,6 @@ country_event = {
 			days = 14
 			value = 1
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -6966,7 +6965,6 @@ country_event = {
 			days = 14
 			value = 1
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -7244,7 +7242,6 @@ country_event = {
 			days = 14
 			value = 1
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -7619,7 +7616,6 @@ country_event = {
 			days = 14
 			value = 1
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -7994,7 +7990,6 @@ country_event = {
 			days = 14
 			value = 1
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -12825,7 +12820,6 @@ country_event = {
 			}
 			add_to_faction = HAZ
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -20339,7 +20333,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:iranian_events.239.b executed"
 		custom_effect_tooltip = PER_ban_khatami_TT
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.045 }
 		set_temp_variable = { temp_outlook_increase = 0.035 }
 		add_relative_party_popularity = yes
@@ -20504,7 +20497,6 @@ country_event = {
 	option = {
 		name = iranian_events.245.a
 		log = "[GetDateText]: [This.GetName]:iranian_events.245.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -20572,7 +20564,6 @@ country_event = {
 			}
 		}
 		else = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -20676,7 +20667,6 @@ country_event = {
 		set_temp_variable = { percent_change = 3 }
 		change_domestic_influence_percentage = yes
 		newline = yes
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			set_temp_variable = { temp_outlook_increase = 0.01 }
 			add_relative_party_popularity = yes

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -881,7 +881,6 @@ country_event = {
 		clamp_variable = { var = IRQ_american_weariness min = 0 max = 100 }
 		newline = yes
 		ISR = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			add_relative_party_popularity = yes
@@ -920,7 +919,6 @@ country_event = {
 		newline = yes
 		add_political_power = -150
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -946,7 +944,6 @@ country_event = {
 			days = 360
 		}
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -959,7 +956,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraqi_events.25.b executed"
 		add_country_leader_trait = zealous
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -2074,7 +2070,6 @@ country_event = {
 		newline = yes
 		add_war_support = 0.15
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -2794,7 +2789,6 @@ country_event = { # De-Ba'athification of Iraqi Society
 		add_to_variable = { var = IRQ_sunni_political_influence value = 10 }
 		clamp_variable = { var = IRQ_sunni_political_influence min = 0 max = 100 }
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.055 }
 		set_temp_variable = { temp_outlook_increase = -0.045 }
 		add_relative_party_popularity = yes
@@ -4273,7 +4267,6 @@ country_event = { # Small Anti-Government Gathering
 		add_to_variable = { var = IRQ_sunni_political_influence value = 1 }
 		clamp_variable = { var = IRQ_sunni_political_influence min = 0 max = 100 }
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -4323,7 +4316,6 @@ country_event = { # Large Anti-Government Gathering
 		add_to_variable = { var = IRQ_sunni_political_influence value = 2 }
 		clamp_variable = { var = IRQ_sunni_political_influence min = 0 max = 100 }
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.045 }
 		set_temp_variable = { temp_outlook_increase = -0.035 }
 		add_relative_party_popularity = yes
@@ -4416,7 +4408,6 @@ country_event = { # Nationwide Protests
 		clamp_variable = { var = IRQ_sunni_political_influence min = 0 max = 100 }
 		IRQ_update_dynamic_modifier = yes
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.055 }
 		set_temp_variable = { temp_outlook_increase = -0.045 }
 		add_relative_party_popularity = yes
@@ -5149,7 +5140,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.2.a executed"
 		custom_effect_tooltip = IRQ_add_to_coalition_TT
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -5167,7 +5157,6 @@ country_event = {
 	option = {
 		name = iraq_md.2.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.2.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5263,7 +5252,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.5.a executed"
 		add_stability = 0.05
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -6731,7 +6719,6 @@ country_event = {
 	option = {
 		name = iraq_md.41.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.41.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -9321,7 +9308,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.89.a executed"
 		add_political_power = -75
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -9746,7 +9732,6 @@ country_event = {
 	option = {
 		name = iraq_md.305.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.305.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes

--- a/events/Israel_events.txt
+++ b/events/Israel_events.txt
@@ -23,7 +23,6 @@ country_event = {
 	option = {
 		name = israel.coalition.0.a
 		log = "[GetDateText]: [This.GetName]: israel.coalition.0.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		add_relative_party_popularity = yes
 		add_political_power = 200
@@ -391,7 +390,6 @@ country_event = {
 	option = {
 		name = israel.coalition.13.a
 		log = "[GetDateText]: [This.GetName]: israel.coalition.13.a"
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.2 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
@@ -470,7 +468,6 @@ country_event = {
 		name = israel.knesset.1.a
 		log = "[GetDateText]: [This.GetName]: israel.knesset.1.a"
 		custom_effect_tooltip = ISR_knesset_lose_TT
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -493,7 +490,6 @@ country_event = {
 		name = israel.knesset.2.a
 		log = "[GetDateText]: [This.GetName]: israel.knesset.2.a"
 		custom_effect_tooltip = ISR_knesset_gain_TT
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -516,7 +512,6 @@ country_event = {
 		name = israel.knesset.3.a
 		log = "[GetDateText]: [This.GetName]: israel.knesset.3.a"
 		custom_effect_tooltip = ISR_knesset_gain_TT
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.04
 		}
@@ -558,7 +553,6 @@ country_event = {
 		name = israel.knesset.4.b
 		log = "[GetDateText]: [This.GetName]: israel.knesset.4.b"
 		add_stability = -0.04
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.01
 		}
@@ -575,7 +569,6 @@ country_event = {
 	option = {
 		name = israel.knesset.5.a
 		log = "[GetDateText]: [This.GetName]: israel.knesset.5.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.03
 		}
@@ -593,7 +586,6 @@ country_event = {
 	option = {
 		name = israel.knesset.6.a
 		log = "[GetDateText]: [This.GetName]: israel.knesset.6.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -1292,7 +1284,6 @@ country_event = {
 			army_experience = 10
 			add_command_power = 10
 			add_war_support = 0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -1307,7 +1298,6 @@ country_event = {
 			}
 			add_political_power = -100
 			add_war_support = -0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = -0.05
 			}
@@ -1326,7 +1316,6 @@ country_event = {
 			}
 			add_political_power = -100
 			add_war_support = -0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = -0.05
 			}
@@ -1366,7 +1355,6 @@ country_event = {
 				original_tag = ISR
 			}
 			add_political_power = -100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = -0.05
 			}
@@ -1381,7 +1369,6 @@ country_event = {
 			}
 			add_war_support = 0.05
 			add_political_power = 50
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -1396,7 +1383,6 @@ country_event = {
 			}
 			add_war_support = 0.05
 			add_political_power = 50
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -1422,7 +1408,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: israel_mechanic.24.a executed"
 		add_political_power = -150
 		add_stability = -0.1
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.1
 		}
@@ -1448,7 +1433,6 @@ country_event = {
 		add_political_power = 100
 		add_war_support = 0.05
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -1473,7 +1457,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: israel_mechanic.25.a executed"
 		add_political_power = -150
 		add_stability = -0.1
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.15
 		}
@@ -2650,7 +2633,6 @@ country_event = {
 			}
 			modify_treasury_effect = yes
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -5559,7 +5541,6 @@ country_event = {
 			base = 1
 		}
 		add_stability = -0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -7846,7 +7827,6 @@ country_event = {
 		name = israel_economy.123.a
 		log = "[GetDateText]: [This.GetName]: israel_economy.123.a"
 		effect_tooltip = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = {
 				party_popularity_increase = 0.05
 			}
@@ -11299,7 +11279,6 @@ country_event = {
 		name = israel_economy.182.a
 		log = "[GetDateText]: [This.GetName]: israel_economy.182.a"
 		add_political_power = 100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -11406,7 +11385,6 @@ country_event = {
 		name = israel_economy.183.a
 		log = "[GetDateText]: [This.GetName]: israel_economy.183.a"
 		add_political_power = 100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -14817,7 +14795,6 @@ country_event = {
 			}
 			complete_national_focus = ISR_intifada_darkest_hour
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.1
 		}
@@ -15151,7 +15128,6 @@ country_event = {
 		}
 		add_war_support = 0.05
 		army_experience = 10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -15171,7 +15147,6 @@ country_event = {
 		}
 		add_war_support = -0.05
 		army_experience = 5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -15200,7 +15175,6 @@ country_event = {
 		}
 		add_war_support = 0.05
 		army_experience = 10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -15220,7 +15194,6 @@ country_event = {
 		}
 		add_war_support = -0.05
 		army_experience = 5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -15248,7 +15221,6 @@ country_event = {
 			tag = HEZ
 		}
 		army_experience = 5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -15267,7 +15239,6 @@ country_event = {
 			tag = ISR
 		}
 		army_experience = 5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -15297,7 +15268,6 @@ country_event = {
 		add_manpower = -20
 		add_command_power = -15
 		army_experience = -25
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -15347,7 +15317,6 @@ country_event = {
 		}
 		add_command_power = 15
 		army_experience = 10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.03
 		}
@@ -15374,7 +15343,6 @@ country_event = {
 		trigger = {
 			tag = HEZ
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.02
 		}
@@ -15392,7 +15360,6 @@ country_event = {
 		trigger = {
 			tag = ISR
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -18469,7 +18436,6 @@ country_event = {
 			influence_target = PAL
 		}
 		change_influence_percentage = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -18495,7 +18461,6 @@ country_event = {
 		}
 		add_war_support = 0.05
 		change_influence_percentage = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -18535,7 +18500,6 @@ country_event = {
 			}
 			change_influence_percentage = yes
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.07
 		}
@@ -18583,7 +18547,6 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: israel.97.a executed"
 		add_political_power = 25
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.02
 		}
@@ -19325,7 +19288,6 @@ country_event = {
 			tag = ISR
 		}
 		log = "[GetDateText]: [This.GetName]: israel.117.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
@@ -19388,7 +19350,6 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: israel.119.a executed"
 		add_war_support = -0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.03
 		}
@@ -21726,7 +21687,6 @@ country_event = {
 		name = israel_likud.0.a
 		log = "[GetDateText]: [This.GetName]: israel_likud.0.a"
 		increase_corruption = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
@@ -21747,7 +21707,6 @@ country_event = {
 	option = {
 		name = israel_likud.1.a
 		log = "[GetDateText]: [This.GetName]: israel_likud.1.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = -0.03
 		}
@@ -21768,7 +21727,6 @@ country_event = {
 	option = {
 		name = israel_likud.2.a
 		log = "[GetDateText]: [This.GetName]: israel_likud.2.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.02
 		}
@@ -21808,7 +21766,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = 0.02
 		}
-		set_party_index_to_ruling_party = yes
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
@@ -21982,7 +21939,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.1
 		}
-		set_party_index_to_ruling_party = yes
 		add_to_variable = {
 			var = bill_support
 			value = -5
@@ -22046,7 +22002,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 		add_to_variable = {
 			var = bill_support
 			value = -15
@@ -22078,7 +22033,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.01
 		}
-		set_party_index_to_ruling_party = yes
 	}
 }
 
@@ -22096,7 +22050,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.04
 		}
-		set_party_index_to_ruling_party = yes
 	}
 }
 
@@ -22114,7 +22067,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 	}
 }
 
@@ -22132,7 +22084,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 		country_event = {
 			id = israel_likud.17
 			days = 10
@@ -22153,7 +22104,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 		country_event = {
 			id = israel_likud.18
 			days = 10
@@ -22184,7 +22134,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 		country_event = {
 			id = israel_likud.19
 			days = 10
@@ -22214,7 +22163,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = -0.05
 		}
-		set_party_index_to_ruling_party = yes
 		country_event = {
 			id = israel_likud.20
 			days = 10
@@ -22255,7 +22203,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		add_political_power = 150
 		hidden_effect = {
 			set_temp_variable = { add_col_one = 1 }
@@ -23916,7 +23863,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		add_political_power = 150
 		ai_chance = {
 			base = 10
@@ -23939,7 +23885,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		add_stability = 0.04
 		ai_chance = {
 			base = 5
@@ -23961,7 +23906,6 @@ country_event = {
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		add_stability = 0.04
 		ai_chance = {
 			base = 10
@@ -23993,7 +23937,6 @@ country_event = {
 				union_man
 			}
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = {
 			party_popularity_increase = 0.05
 		}

--- a/events/Italy.txt
+++ b/events/Italy.txt
@@ -1054,7 +1054,6 @@ country_event = {
 			target = ITA
 			modifier = ITA_oil_investments_africa
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		add_relative_party_popularity = yes
@@ -2418,7 +2417,6 @@ country_event = {
 		}
 		name = italy_md.38.o2
 		log = "[GetDateText]: [This.GetName]: italy_md.38.o2 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -2579,7 +2577,6 @@ country_event = {
 	option = {
 		name = italy_md.42.o1
 		log = "[GetDateText]: [This.GetName]: italy_md.42.o1 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2594,7 +2591,6 @@ country_event = {
 	option = {
 		name = italy_md.42.o2
 		log = "[GetDateText]: [This.GetName]: italy_md.42.o2 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -2624,7 +2620,6 @@ country_event = {
 	option = {
 		name = italy_md.43.o1
 		log = "[GetDateText]: [This.GetName]: italy_md.43.o1 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2639,7 +2634,6 @@ country_event = {
 	option = {
 		name = italy_md.43.o2
 		log = "[GetDateText]: [This.GetName]: italy_md.43.o2 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -3435,7 +3429,6 @@ country_event = {
 	option = {
 		name = italy_md.60.o1
 		log = "[GetDateText]: [This.GetName]: italy_md.60.o1 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -4159,7 +4152,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mafia.3.a executed"
 		custom_effect_tooltip = mafia_strength_decrease_tt
 		add_political_power = 50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/Ivory_Coast.txt
+++ b/events/Ivory_Coast.txt
@@ -1,4 +1,4 @@
-﻿add_namespace = ivory_coast_md
+add_namespace = ivory_coast_md
 
 # 2000 Election events
 country_event = {
@@ -791,7 +791,6 @@ country_event = {
 		name = ivory_coast_md.10.o1
 		log = "[GetDateText]: [This.GetName]: ivory_coast_md.10.o1 executed"
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -977,7 +976,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ivory_coast_md.13.a executed"
 
 		add_political_power = -75
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_stability = -0.03
@@ -992,7 +990,6 @@ country_event = {
 		name = ivory_coast_md.13.b
 		log = "[GetDateText]: [This.GetName]: ivory_coast_md.13.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_stability = -0.05
@@ -1160,7 +1157,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ivory_coast_md.15.a executed"
 		set_global_flag = CDI_second_ivory_coast_civil_war_cleanedup
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes

--- a/events/Japan.txt
+++ b/events/Japan.txt
@@ -5373,6 +5373,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.28.b executed"
 
 		set_temp_variable = { party_index = 2 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5402,6 +5403,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.29.b executed"
 
 		set_temp_variable = { party_index = 2 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5465,6 +5467,7 @@ country_event = {
 			add_to_variable = { JAP_strategic_bomb_visibility_airforce = 0.15 tooltip = strategic_bomb_visibility_tt }
 		}
 		set_temp_variable = { party_index = 2 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/Japan.txt
+++ b/events/Japan.txt
@@ -418,7 +418,6 @@ country_event = {
 	option = {
 		name = japan_classic.16.o1
 		log = "[GetDateText]: [This.GetName]: japan_classic.16.o1 executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 		create_country_leader = {
@@ -454,7 +453,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: japan_classic.18.o1 executed"
 		add_stability = -0.01
 		add_political_power = -10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 		ai_chance = { base = 90 }
@@ -576,7 +574,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.121006001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -620,7 +617,6 @@ country_event = {
 		name = JAP_historical.130210001.oB
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.130210001.oB"
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 		if = {
@@ -689,7 +685,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.130324001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -729,7 +724,6 @@ country_event = {
 			}
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		add_relative_party_popularity = yes
 		set_country_flag = JAP_KOIZUMI_HISTRICAL_APPEARANCE
@@ -814,7 +808,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.150526001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -877,7 +870,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.150726001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -938,7 +930,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.150926001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1000,7 +991,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.161023001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1057,7 +1047,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.170320001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1182,7 +1171,6 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.190216001.oA"
 		add_political_power = -400
 		add_stability = -0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1219,7 +1207,6 @@ country_event = {
 	option = {
 		name = JAP_historical.20070307.oB
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070307.oB executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 		set_country_flag = JAP_MATSUOKA_SCANDAL
@@ -1273,7 +1260,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.190325001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1300,7 +1286,6 @@ country_event = {
 	option = {
 		name = JAP_historical.20070528.oA
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070528.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 
@@ -1324,7 +1309,6 @@ country_event = {
 	option = {
 		name = JAP_historical.20070704.oA
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070704.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 
@@ -1373,7 +1357,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.190716001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1400,7 +1383,6 @@ country_event = {
 	option = {
 		name = JAP_historical.20070801.oA
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070801.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 
@@ -1497,7 +1479,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.200614001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1871,7 +1852,6 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.210811001 - disaster_leave"
 		add_stability = -0.01
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -2522,7 +2502,6 @@ country_event = {
 	option = {
 		name = Japan_Demographic.003.a
 		log = "[GetDateText]: [Root.GetName]: Japan_Demographic.003.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2540,7 +2519,6 @@ country_event = {
 	option = {
 		name = Japan_Demographic.004.a
 		log = "[GetDateText]: [Root.GetName]: Japan_Demographic.004.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -2557,7 +2535,6 @@ country_event = {
 	option = {
 		name = Japan_Demographic.005.a
 		log = "[GetDateText]: [Root.GetName]: Japan_Demographic.005.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -2575,7 +2552,6 @@ country_event = {
 	option = {
 		name = Japan_Demographic.006.a
 		log = "[GetDateText]: [Root.GetName]: Japan_Demographic.006.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -2612,7 +2588,6 @@ country_event = {
 	option = {
 		name = Japan.101.b
 		log = "[GetDateText]: [This.GetName]: Japan.101.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -3101,7 +3076,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.03.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.03.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -3149,7 +3123,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.04.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.04.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3302,7 +3275,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.07.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.07.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -3350,7 +3322,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.08.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.08.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3503,7 +3474,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.11.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.11.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -3551,7 +3521,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.12.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.12.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3701,7 +3670,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.15.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.15.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -3749,7 +3717,6 @@ country_event = {
 	option = {
 		name = JAP_territorial.16.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.16.oA executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -3916,7 +3883,6 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.03.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.03.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -3942,7 +3908,6 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.04.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.04.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5408,7 +5373,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.28.b executed"
 
 		set_temp_variable = { party_index = 2 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5438,7 +5402,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.29.b executed"
 
 		set_temp_variable = { party_index = 2 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5502,7 +5465,6 @@ country_event = {
 			add_to_variable = { JAP_strategic_bomb_visibility_airforce = 0.15 tooltip = strategic_bomb_visibility_tt }
 		}
 		set_temp_variable = { party_index = 2 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/Mali.txt
+++ b/events/Mali.txt
@@ -18,7 +18,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.1.a executed"
 		if = { limit = { has_country_leader = { name = "Amadou Toumani Touré" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -44,7 +43,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.1.b executed"
 		if = { limit = { has_country_leader = { name = "Soumaïla Cissé" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -70,7 +68,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.1.c executed"
 		if = { limit = { has_country_leader = { name = "Ibrahim Boubacar Keita" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -111,7 +108,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.01 }
 		modify_treasury_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -126,7 +122,6 @@ country_event = {
 		name = mali.2.b
 		log = "[GetDateText]: [This.GetName]: mali.2.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -161,7 +156,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -180,7 +174,6 @@ country_event = {
 		name = mali.3.b
 		log = "[GetDateText]: [This.GetName]: mali.3.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -260,7 +253,6 @@ country_event = {
 		name = mali.5.b
 		log = "[GetDateText]: [This.GetName]: mali.5.b executed"
 		add_manpower = -6
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -360,7 +352,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.7.a executed"
 		set_country_flag = MAL_accepted_the_algerian_peace_accords
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -388,7 +379,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.7.b executed"
 		set_global_flag = MAL_tuareg_rebellion_2007_escalated
 		news_event = { id = mali.1000 days = 3 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes
@@ -486,7 +476,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.9.a executed"
 		if = { limit = { has_country_leader = { name = "Amadou Toumani Touré" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -516,7 +505,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.9.b executed"
 		if = { limit = { has_country_leader = { name = "Ibrahim Boubacar Keita" ruling_only = yes } }
 			add_political_power = 100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -707,7 +695,6 @@ country_event = {
 		name = mali.13.a
 		log = "[GetDateText]: [This.GetName]: mali.13.a executed"
 		trigger = { has_country_flag = MAL_pay_the_ransom }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -720,7 +707,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.13.b executed"
 		trigger = { NOT = { has_country_flag = MAL_failed_to_rescue } }
 		add_manpower = -7
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -732,7 +718,6 @@ country_event = {
 		name = mali.13.c
 		log = "[GetDateText]: [This.GetName]: mali.13.c executed"
 		trigger = { has_country_flag = MAL_failed_to_rescue }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -744,7 +729,6 @@ country_event = {
 		name = mali.13.d
 		log = "[GetDateText]: [This.GetName]: mali.13.d executed"
 		trigger = { has_country_flag = MAL_does_nothing }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -880,7 +864,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.03 }
 		modify_treasury_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -899,7 +882,6 @@ country_event = {
 		name = mali.17.b
 		log = "[GetDateText]: [This.GetName]: mali.17.b executed"
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -983,7 +965,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.21.a executed"
 		add_manpower = -65
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -1007,7 +988,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.21.b executed"
 		add_political_power = -75
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -1238,14 +1218,12 @@ country_event = {
 		# Unpopular with a nationalist government
 		if = {
 			limit = { has_government = nationalist }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_relative_party_popularity = yes
 		}
 		else_if = {
 			limit = { has_government = fascism }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.06 }
 			set_temp_variable = { temp_outlook_increase = -0.06 }
 			add_relative_party_popularity = yes
@@ -1271,14 +1249,12 @@ country_event = {
 		add_command_power = -50
 		if = {
 			limit = { has_government = nationalist }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
 		else_if = {
 			limit = { has_government = fascism }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -1594,7 +1570,6 @@ country_event = {
 		news_event = { id = mali.1004 days = 3 }
 		add_stability = 0.05
 		add_political_power = 150
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -1692,7 +1667,6 @@ country_event = {
 		news_event = { id = mali.1003 days = 3 }
 		add_stability = 0.05
 		add_political_power = 150
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes

--- a/events/Middle East Peace Plan.txt
+++ b/events/Middle East Peace Plan.txt
@@ -1512,7 +1512,6 @@ country_event = {
 		newline = yes
 		add_stability = -0.10
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		add_relative_party_popularity = yes

--- a/events/Migration Events.txt
+++ b/events/Migration Events.txt
@@ -74,7 +74,6 @@ country_event = {
 		log = "[GetDateText]: [ROOT.GetName]: event migrant_event.1.b executed"
 		add_political_power = -75
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -104,7 +103,6 @@ country_event = {
 		name = migrant_event.1.c
 		log = "[GetDateText]: [ROOT.GetName]: event migrant_event.1.c executed"
 		add_political_power = -75
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -226,7 +224,6 @@ country_event = {
 		add_political_power = -50
 		add_stability = -0.015
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes

--- a/events/Morocco.txt
+++ b/events/Morocco.txt
@@ -14,7 +14,6 @@ country_event = {
 	option = {
 		name = morocco.400.a
 		log = "[GetDateText]: [This.GetName]: event morocco.400.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -35,7 +34,6 @@ country_event = {
 	option = {
 		name = morocco.400.b
 		log = "[GetDateText]: [This.GetName]: event morocco.400.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes

--- a/events/Nigeria.txt
+++ b/events/Nigeria.txt
@@ -1590,7 +1590,6 @@ country_event = {
 		name = nigeria_md.106.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.106.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1710,7 +1709,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1750,7 +1748,6 @@ country_event = {
 		name = nigeria_md.110.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.110.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1783,7 +1780,6 @@ country_event = {
 		name = nigeria_md.111.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.111.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1806,7 +1802,6 @@ country_event = {
 		name = nigeria_md.112.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.112.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1854,7 +1849,6 @@ country_event = {
 		name = nigeria_md.113.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.113.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1888,7 +1882,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: nigeria_md.114.a executed"
 		add_political_power = 150
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1910,7 +1903,6 @@ country_event = {
 		name = nigeria_md.115.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.115.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -1921,7 +1913,6 @@ country_event = {
 		name = nigeria_md.115.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.115.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -1934,7 +1925,6 @@ country_event = {
 		name = nigeria_md.115.c
 		log = "[GetDateText]: [This.GetName]: nigeria_md.115.c executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -1961,7 +1951,6 @@ country_event = {
 		name = nigeria_md.116.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.116.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -1997,7 +1986,6 @@ country_event = {
 		name = nigeria_md.117.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.117.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes

--- a/events/Norway.txt
+++ b/events/Norway.txt
@@ -913,7 +913,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: norway.14.b executed"
 		add_stability = 0.03
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -2075,7 +2075,6 @@ country_event = {
 	option = {
 		name = russia.611.a
 		log = "[GetDateText]: [This.GetName]: russia.611.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.35 }
 		add_relative_party_popularity = yes
 		news_event = russia_news.10000
@@ -3619,7 +3618,6 @@ country_event = {
 		name = russia.119.b
 		log = "[GetDateText]: [This.GetName]: russia.119.b executed"
 		add_stability = 0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -8353,7 +8351,6 @@ country_event = {
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_political_power = -100
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.09 }
 			set_temp_variable = { temp_outlook_increase = 0.09 }
 			add_relative_party_popularity = yes
@@ -11805,7 +11802,6 @@ country_event = {
 		name = russia.301.b
 		log = "[GetDateText]: [This.GetName]: russia.301.b executed"
 		add_political_power = 150
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.055 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		add_relative_party_popularity = yes
@@ -12002,7 +11998,6 @@ country_event = {
 		change_intelligence_community_opinion = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_oligarchs_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		add_relative_party_popularity = yes
 		ai_chance = {
@@ -12022,7 +12017,6 @@ country_event = {
 			ideology = democratic
 			popularity = 0.05
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { temp_opinion = 3 }
@@ -13448,7 +13442,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: sov_economic.41.o2 executed"
 		add_political_power = -200
 		add_stability = -0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.15 }
 		add_relative_party_popularity = yes
 	}
@@ -13466,7 +13459,6 @@ country_event = {
 		name = sov_economic.42.o1
 		log = "[GetDateText]: [This.GetName]: sov_economic.42.o1 executed"
 		add_political_power = 200
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		add_relative_party_popularity = yes
 	}
@@ -13578,7 +13570,6 @@ country_event = {
 		name = sov_liberals.1.o1
 		log = "[GetDateText]: [This.GetName]: sov_liberals.1.o1 executed"
 		add_political_power = 100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.12 }
 		add_relative_party_popularity = yes
 		set_country_flag = SOV_reforms_done

--- a/events/Sao_Tome_e_Principe.txt
+++ b/events/Sao_Tome_e_Principe.txt
@@ -1,4 +1,4 @@
-﻿add_namespace = Sao_Tome_e_Principe
+add_namespace = Sao_Tome_e_Principe
 add_namespace = Sao_Tome_e_PrincipeNews
 
 #2001 São Toméan presidential election
@@ -196,7 +196,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sao_Tome_e_Principe.2.b executed"
 
 		add_political_power = -75
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		add_relative_party_popularity = yes
 

--- a/events/Senegal.txt
+++ b/events/Senegal.txt
@@ -1,4 +1,4 @@
-﻿add_namespace = senegal_md
+add_namespace = senegal_md
 
 #2000 Election events
 country_event = {
@@ -271,7 +271,6 @@ country_event = {
 			clear_variable = opposition_strength
 		}
 		else = {
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -633,7 +632,6 @@ country_event = {
 		name = senegal_md.11.o1
 		log = "[GetDateText]: [This.GetName]: senegal_md.11.o1 executed"
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes

--- a/events/Serbia.txt
+++ b/events/Serbia.txt
@@ -244,7 +244,6 @@ country_event = { #2004
 		add_stability = 0.05
 		if = {
 			limit = { has_nationalist_government = yes }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
 		}
@@ -440,7 +439,6 @@ country_event = { #Cyanide Spills in Danube
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.8.b executed"
 		name = Serbia.8.b
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/Serbia.txt
+++ b/events/Serbia.txt
@@ -2220,11 +2220,8 @@ country_event = {
 		ai_chance = { base = 1 }
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
-		add_popularity = {
-			ideology = nationalist
-			popularity = 0.05
-		}
 
 	}
 }

--- a/events/Singapore.txt
+++ b/events/Singapore.txt
@@ -137,7 +137,6 @@ country_event = {
 	option = {
 		name = singapore.5.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.5.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -362,7 +361,6 @@ country_event = {
 	option = {
 		name = singapore.101.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.101.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -417,7 +415,6 @@ country_event = {
 	option = {
 		name = singapore.102.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.102.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -447,7 +444,6 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: event singapore.103.a"
 		add_political_power = 75
 		add_stability = 0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -698,7 +694,6 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.03 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -800,7 +795,6 @@ country_event = {
 	option = {
 		name = singapore.113.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.113.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -835,7 +829,6 @@ country_event = {
 	option = {
 		name = singapore.115.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.115.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -927,7 +920,6 @@ country_event = {
 	option = {
 		name = singapore.117.c
 		log = "[GetDateText]: [THIS.GetName]: event singapore.117.c"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -950,7 +942,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -961,7 +952,6 @@ country_event = {
 	option = {
 		name = singapore.118.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.118.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -972,7 +962,6 @@ country_event = {
 	option = {
 		name = singapore.118.c
 		log = "[GetDateText]: [THIS.GetName]: event singapore.118.c"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.07 }
 		set_temp_variable = { temp_outlook_increase = -0.07 }
 		add_relative_party_popularity = yes
@@ -1018,7 +1007,6 @@ country_event = {
 				}
 			}
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		add_relative_party_popularity = yes
@@ -1029,7 +1017,6 @@ country_event = {
 		name = singapore.119.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.119.b"
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -1060,7 +1047,6 @@ country_event = {
 	option = {
 		name = singapore.120.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.120.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -1104,7 +1090,6 @@ country_event = {
 	option = {
 		name = singapore.121.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.121.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -1131,7 +1116,6 @@ country_event = {
 	option = {
 		name = singapore.122.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.122.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -1170,7 +1154,6 @@ country_event = {
 	option = {
 		name = singapore.124.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.124.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -1183,7 +1166,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1202,7 +1184,6 @@ country_event = {
 	option = {
 		name = singapore.125.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.125.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1256,7 +1237,6 @@ country_event = {
 	option = {
 		name = singapore.127.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.127.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -1265,7 +1245,6 @@ country_event = {
 	option = {
 		name = singapore.127.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.127.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes

--- a/events/Singapore.txt
+++ b/events/Singapore.txt
@@ -942,6 +942,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1166,6 +1167,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes

--- a/events/Somalia.txt
+++ b/events/Somalia.txt
@@ -1185,7 +1185,6 @@ country_event = {
 		name = somalia.11.a
 		log = "[GetDateText]: [This.GetName]: somalia.11.a executed"
 		add_stability = 0.05
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		add_relative_party_popularity = yes

--- a/events/Spain.txt
+++ b/events/Spain.txt
@@ -29,7 +29,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -15 }
 		SPR_modify_cultural_opinion = yes
 		if = { limit = { NOT = { is_in_array = { ruling_party = 20 } } }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			add_relative_party_popularity = yes
 		}
@@ -59,7 +58,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
 		if = { limit = { NOT = { is_in_array = { ruling_party = 20 } } }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -85,7 +83,6 @@ country_event = {
 		custom_effect_tooltip = SPR_spain_1_c_tt
 
 		if = { limit = { NOT = { is_in_array = { ruling_party = 20 } } }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
 		}
@@ -603,7 +600,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		add_relative_party_popularity = yes
 		ai_chance = {
@@ -683,7 +679,6 @@ country_event = {
 
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 
@@ -760,7 +755,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		add_relative_party_popularity = yes
 
@@ -1050,7 +1044,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		add_relative_party_popularity = yes
 
@@ -1131,7 +1124,6 @@ country_event = {
 
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 
@@ -1207,7 +1199,6 @@ country_event = {
 				modify_treasury_effect = yes
 			}
 
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.035 }
 			add_relative_party_popularity = yes
 
@@ -1497,7 +1488,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		add_relative_party_popularity = yes
 
@@ -1577,7 +1567,6 @@ country_event = {
 
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 
@@ -1653,7 +1642,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		add_relative_party_popularity = yes
 
@@ -1942,7 +1930,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		add_relative_party_popularity = yes
 
@@ -2023,7 +2010,6 @@ country_event = {
 
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 
@@ -2100,7 +2086,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		add_relative_party_popularity = yes
 
@@ -2391,7 +2376,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		add_relative_party_popularity = yes
 
@@ -2468,7 +2452,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 
@@ -2542,7 +2525,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		add_relative_party_popularity = yes
 
@@ -2871,7 +2853,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 20 }
@@ -2916,7 +2897,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { party_index = 20 }
@@ -2980,7 +2960,6 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: spain.53.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		add_relative_party_popularity = yes
 		add_political_power = 50
@@ -3002,7 +2981,6 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: spain.53.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		add_relative_party_popularity = yes
 		add_political_power = -50
@@ -3074,7 +3052,6 @@ country_event = {
 				set_temp_variable = { culture_index = 0 }
 				set_temp_variable = { cultural_opinion = 2 }
 				SPR_modify_cultural_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				add_relative_party_popularity = yes
 				add_political_power = 100
@@ -3086,7 +3063,6 @@ country_event = {
 				set_temp_variable = { culture_index = 0 }
 				set_temp_variable = { cultural_opinion = -3 }
 				SPR_modify_cultural_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.03 }
 				add_relative_party_popularity = yes
 				set_temp_variable = { party_index = 20 }
@@ -3132,7 +3108,6 @@ country_event = {
 				set_temp_variable = { culture_index = 0 }
 				set_temp_variable = { cultural_opinion = 2 }
 				SPR_modify_cultural_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				add_relative_party_popularity = yes
 				add_political_power = 100
@@ -3482,7 +3457,6 @@ country_event = {
 	option = {
 		name = spain.63.a
 		log = "[GetDateText]: [Root.GetName]: event spain.63.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		annex_country = {
@@ -3516,7 +3490,6 @@ country_event = {
 	option = {
 		name = spain.63.b
 		log = "[GetDateText]: [Root.GetName]: event spain.63.b"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		if = { limit = { POR = { is_subject = yes } }
@@ -3565,7 +3538,6 @@ country_event = {
 	option = {
 		name = spain.64.a
 		log = "[GetDateText]: [Root.GetName]: event spain.64.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 		add_war_support = -0.05
@@ -3693,7 +3665,6 @@ country_event = {
 	option = {
 		name = spain.66.a
 		log = "[GetDateText]: [Root.GetName]: event spain.66.a"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		add_relative_party_popularity = yes
 		if = {
@@ -3755,7 +3726,6 @@ country_event = {
 	option = {
 		name = spain.67.a
 		log = "[GetDateText]: [This.GetName]: spain.67.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 		add_war_support = -0.05
@@ -4593,7 +4563,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -3 }
 		SPR_modify_cultural_opinion = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.07 }
 		add_relative_party_popularity = yes
 
@@ -5306,7 +5275,6 @@ country_event = {
 		name = spain.212.a
 		log = "[GetDateText]: [This.GetName]: spain.212.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { culture_index = 1 }
@@ -5330,7 +5298,6 @@ country_event = {
 		name = spain.213.a
 		log = "[GetDateText]: [This.GetName]: spain.212.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		add_relative_party_popularity = yes
 		set_temp_variable = { culture_index = 2 }
@@ -5750,7 +5717,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5760,7 +5726,6 @@ country_event = {
 	option = {
 		name = spain.232.c
 		log = "[GetDateText]: [This.GetName]: spain.232.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -5795,7 +5760,6 @@ country_event = {
 			transfer_state = 86
 			inherit_technology = FROM
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5810,7 +5774,6 @@ country_event = {
 	option = {
 		name = spain.233.b
 		log = "[GetDateText]: [This.GetName]: spain.233.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -5850,7 +5813,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5860,7 +5822,6 @@ country_event = {
 	option = {
 		name = spain.234.c
 		log = "[GetDateText]: [This.GetName]: spain.234.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -5901,7 +5862,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -5911,7 +5871,6 @@ country_event = {
 	option = {
 		name = spain.235.c
 		log = "[GetDateText]: [This.GetName]: spain.235.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -5952,7 +5911,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -5962,7 +5920,6 @@ country_event = {
 	option = {
 		name = spain.236.c
 		log = "[GetDateText]: [This.GetName]: spain.236.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.06 }
 		set_temp_variable = { temp_outlook_increase = -0.06 }
 		add_relative_party_popularity = yes
@@ -6002,7 +5959,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -6012,7 +5968,6 @@ country_event = {
 	option = {
 		name = spain.237.c
 		log = "[GetDateText]: [This.GetName]: spain.237.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -6047,7 +6002,6 @@ country_event = {
 			transfer_state = 86
 			inherit_technology = SPR
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -6062,7 +6016,6 @@ country_event = {
 	option = {
 		name = spain.238.b
 		log = "[GetDateText]: [This.GetName]: spain.238.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -6160,7 +6113,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -6170,7 +6122,6 @@ country_event = {
 	option = {
 		name = spain.241.c
 		log = "[GetDateText]: [This.GetName]: spain.241.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		add_relative_party_popularity = yes
@@ -6424,7 +6375,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: spain.247.b executed"
 		add_stability = 0.05
 		add_political_power = 150
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -6563,7 +6513,6 @@ country_event = {
 			# Heavy Penalty to popularity and stability
 			50 = {
 				effect_tooltip = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = -0.08 }
 					set_temp_variable = { temp_outlook_increase = -0.08 }
 					add_relative_party_popularity = yes
@@ -6578,7 +6527,6 @@ country_event = {
 			# Populartity Gain and some stability
 			30 = {
 				effect_tooltip = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = 0.03 }
 					set_temp_variable = { temp_outlook_increase = 0.03 }
 					add_relative_party_popularity = yes
@@ -6616,7 +6564,6 @@ country_event = {
 			# Medium Penalty to Popluation and Stability
 			30 = {
 				effect_tooltip = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = -0.08 }
 					set_temp_variable = { temp_outlook_increase = -0.08 }
 					add_relative_party_popularity = yes
@@ -6628,7 +6575,6 @@ country_event = {
 			# Small Popularity gain no stability
 			50 = {
 				effect_tooltip = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = 0.03 }
 					set_temp_variable = { temp_outlook_increase = 0.03 }
 					add_relative_party_popularity = yes
@@ -6659,7 +6605,6 @@ country_event = {
 			# Medium Popularity loss
 			50 = {
 				effect_tooltip = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = -0.05 }
 					set_temp_variable = { temp_outlook_increase = -0.05 }
 					add_relative_party_popularity = yes
@@ -6670,7 +6615,6 @@ country_event = {
 			# Medium Popularity
 			50 = {
 				effect_tooltip = {
-					set_party_index_to_ruling_party = yes
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					set_temp_variable = { temp_outlook_increase = 0.05 }
 					add_relative_party_popularity = yes
@@ -6713,14 +6657,12 @@ country_event = {
 		name = spain.256.a
 		log = "[GetDateText]: [This.GetName]: spain.256.a executed"
 		if = { limit = { has_country_flag = SPR_mdbombings_weak_government_case }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			add_relative_party_popularity = yes
 			add_stability = -0.05
 		}
 		else_if = { limit = { has_country_flag = SPR_mdbombings_supportive_government_case }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6810,7 +6752,6 @@ country_event = {
 		name = spain.257.a
 		log = "[GetDateText]: [This.GetName]: spain.257.a executed"
 		if = { limit = { has_country_flag = SPR_mdbombings_eta_worst_case }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.08 }
 			set_temp_variable = { temp_outlook_increase = -0.08 }
 			add_relative_party_popularity = yes
@@ -6820,7 +6761,6 @@ country_event = {
 			add_stability = -0.075
 		}
 		else_if = { limit = { has_country_flag = SPR_mdbombings_eta_best_case }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -6833,14 +6773,12 @@ country_event = {
 			add_political_power = -100
 		}
 		else_if = { limit = { has_country_flag = SPR_mdbombings_islamists_worst_case }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.08 }
 			set_temp_variable = { temp_outlook_increase = -0.08 }
 			add_relative_party_popularity = yes
 			add_stability = -0.075
 		}
 		else_if = { limit = { has_country_flag = SPR_mdbombings_islamists_best_case }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -6870,7 +6808,6 @@ country_event = {
 	option = {
 		name = spain.258.a
 		log = "[GetDateText]: [This.GetName]: spain.258.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -6949,7 +6886,6 @@ country_event = {
 		name = spain.261.a
 		log = "[GetDateText]: [This.GetName]: spain.261.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -7007,7 +6943,6 @@ country_event = {
 		name = spain.262.a
 		log = "[GetDateText]: [This.GetName]: spain.262.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -7242,7 +7177,6 @@ country_event = {
 	option = {
 		name = spain.266.a
 		log = "[GetDateText]: [This.GetName]: spain.266.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -7301,7 +7235,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -7320,7 +7253,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes

--- a/events/Spain.txt
+++ b/events/Spain.txt
@@ -7235,6 +7235,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
 
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -7253,6 +7254,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
 
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes

--- a/events/Sweden.txt
+++ b/events/Sweden.txt
@@ -4941,7 +4941,6 @@ country_event = {
 	option = { #shine in royal glory
 		name = Sweden_news.32.a
 		log = "[GetDateText]: [This.GetName]: Sweden_news.32.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -5004,7 +5003,6 @@ country_event = {
 	option = {
 		name = Sweden_news.33.a
 		log = "[GetDateText]: [This.GetName]: Sweden_news.33.a executed"
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes
@@ -5032,7 +5030,6 @@ country_event = {
 		set_temp_variable = { int_investment_change = FROM.gdp_per_capita }
 			multiply_temp_variable = { int_investment_change = 0.09 }
 			modify_international_investment_effect = yes
-		set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			set_temp_variable = { temp_outlook_increase = 0.01 }
 			add_relative_party_popularity = yes
@@ -5545,7 +5542,6 @@ country_event = {
 		decrease_military_spending = yes
 		add_political_power = -25
 		set_temp_variable = { party_popularity_increase = 0.02 }
-		set_party_index_to_ruling_party = yes
 		add_relative_party_popularity = yes
 		country_lock_all_division_template = yes
 		SWE = { country_event = { id = Sweden_Forsvarsbeslutet.11 days = 5 } }
@@ -5564,7 +5560,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_Forsvarsbeslutet.10.b executed"
 		add_political_power = 25
 		set_temp_variable = { party_popularity_increase = -0.02 }
-		set_party_index_to_ruling_party = yes
 		add_relative_party_popularity = yes
 		SWE = { country_event = { id = Sweden_news.11 days = 7 } }
 		block_defence_change = yes

--- a/events/Syria.txt
+++ b/events/Syria.txt
@@ -1150,10 +1150,12 @@ country_event = {
 		random_country = {
 			limit = {
 				NOT = {
-					tag = USA
-					tag = ENG
-					tag = FRA
-					tag = GER
+					OR = {
+						tag = USA
+						tag = ENG
+						tag = FRA
+						tag = GER
+					}
 				}
 				has_government = democratic
 			}
@@ -4383,7 +4385,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.40 }
 		set_temp_variable = { temp_outlook_increase = 0.40 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = neutrality popularity = 0.40 }
 		add_ideas = syrian_promises_of_change_neutral
 		swap_ideas = {
 			remove_idea = oligarchs

--- a/events/Syria.txt
+++ b/events/Syria.txt
@@ -1054,7 +1054,6 @@ country_event = {
 		}
 		add_popularity = { ideology = communism popularity = 0.1 }
 		# Reduction of 20% for the ruling party
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.20 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		add_relative_party_popularity = yes
@@ -1083,7 +1082,6 @@ country_event = {
 				num_divisions < 15
 			}
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -1103,7 +1101,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.20.a executed"				#Let them join
 		ai_chance = { base = 30 }
 		add_popularity = { ideology = communism popularity = 0.05 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1135,7 +1132,6 @@ country_event = {
 		ai_chance = { base = 10 }
 		add_popularity = { ideology = fascism popularity = 0.05 }
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -1191,7 +1187,6 @@ country_event = {
 		name = SyriaFocus.21.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.21.b executed"		#Allow them
 		ai_chance = { base = 20 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1225,7 +1220,6 @@ country_event = {
 		name = SyriaFocus.22.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.22.b executed"		#Allow them
 		ai_chance = { base = 30 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1260,7 +1254,6 @@ country_event = {
 		name = SyriaFocus.23.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.23.b executed"		#Allow them
 		ai_chance = { base = 30 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes

--- a/events/Tajikistan.txt
+++ b/events/Tajikistan.txt
@@ -464,7 +464,6 @@ country_event = {
 				}
 			}
 			add_stability = -0.05
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			add_relative_party_popularity = yes
@@ -3767,7 +3766,6 @@ country_event = {
 	option = { # Crackdown on them!
 		name = tajik_radicalism.3.a
 		log = "[GetDateText]: [This.GetName]: tajik_radicalism.3.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -3808,7 +3806,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: tajik_radicalism.4.a executed"
 		set_temp_variable = { treasury_change = 15.00 }
 		modify_treasury_effect = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -6053,7 +6050,6 @@ country_event = { # Anti-Government Pamphlets Spread
 	option = {
 		name = tajik_corruption.4.a
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.4.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes

--- a/events/Turkey.txt
+++ b/events/Turkey.txt
@@ -606,13 +606,11 @@ country_event = {
 		random_list = {
 			80 = {
 				add_stability = -0.05
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.035 }
 				set_temp_variable = { temp_outlook_increase = -0.025 }
 				add_relative_party_popularity = yes
 			}
 			10 = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.05 }
 				set_temp_variable = { temp_outlook_increase = -0.05 }
 				add_relative_party_popularity = yes
@@ -943,7 +941,6 @@ country_event = {
 				}
 			}
 		}
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.025 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		add_relative_party_popularity = yes
@@ -1080,7 +1077,6 @@ country_event = {
 	option = {
 		name = TUR_pkk.204.b
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.204.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.1 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		add_relative_party_popularity = yes
@@ -2229,7 +2225,6 @@ country_event = {
 	option = {
 		name = Turkey.3.a
 		log = "[GetDateText]: [This.GetName]: Turkey.3.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2400,7 +2395,6 @@ country_event = {
 		custom_effect_tooltip = conservatism_government_decrease_2_tt
 		subtract_from_variable = { social_conservatism_government = 2 }
 		add_stability = 0.025
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		add_relative_party_popularity = yes
@@ -5235,7 +5229,6 @@ country_event = { #2003 Kurdish laws for EU
 	option = { # No, keep them!
 		name = TUR_flavor_event.17.a
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.17.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -5244,7 +5237,6 @@ country_event = { #2003 Kurdish laws for EU
 	option = { # Ease restrictions
 		name = TUR_flavor_event.17.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.17.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -6794,7 +6786,6 @@ country_event = { #assassination attempt by the Mafia
 		name = Turkish_mafia.5.a
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.5.a executed"
 		add_stability = -0.02
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes

--- a/events/Ukraine.txt
+++ b/events/Ukraine.txt
@@ -35,7 +35,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.1.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.1.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		add_relative_party_popularity = yes
 		add_stability = -0.01
@@ -57,7 +56,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.2.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.2.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 		add_stability = -0.03
@@ -118,7 +116,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.4.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.4.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -139,7 +136,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.5.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.5.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		add_relative_party_popularity = yes
 		add_stability = -0.01
@@ -161,7 +157,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.6.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.6.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 		add_stability = -0.02
@@ -183,7 +178,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.7.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.7.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.06 }
 		add_relative_party_popularity = yes
 		add_stability = -0.07
@@ -501,7 +495,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.13.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.13.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -522,7 +515,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.14.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.14.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -543,7 +535,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.15.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.15.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -609,7 +600,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.17.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.17.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.09 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -707,7 +697,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.20.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.20.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.09 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -728,7 +717,6 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.21.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.21.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.07 }
 		add_relative_party_popularity = yes
 		hidden_effect = {
@@ -1856,7 +1844,6 @@ country_event = {
 		name = ukraine_maidan_east.22.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.22.a executed"
 		add_stability = -0.10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.15 }
 		set_temp_variable = { temp_outlook_increase = -0.15 }
 		add_relative_party_popularity = yes
@@ -3662,7 +3649,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ukraine_our_ukraine.3.a executed"
 		add_political_power = 200
 		add_stability = 0.1
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.1 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		add_relative_party_popularity = yes
@@ -6792,7 +6778,6 @@ country_event = { # Parliament opposition questions our administration
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.33.a executed"
 		custom_effect_tooltip = UKR_lose_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = -3 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -6806,7 +6791,6 @@ country_event = { # Parliament opposition questions our administration
 		add_political_power = -150
 		custom_effect_tooltip = UKR_gain_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = 2 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
@@ -6840,7 +6824,6 @@ country_event = { # Parliament demands higher healthcare
 		custom_effect_tooltip = UKR_gain_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = 5 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6851,7 +6834,6 @@ country_event = { # Parliament demands higher healthcare
 		custom_effect_tooltip = UKR_lose_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = -10 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6882,7 +6864,6 @@ country_event = { # Parliament demands higher pensions
 		custom_effect_tooltip = UKR_gain_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = 5 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6893,7 +6874,6 @@ country_event = { # Parliament demands higher pensions
 		custom_effect_tooltip = UKR_lose_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = -10 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6924,7 +6904,6 @@ country_event = { # Parliament demands higher security funding
 		custom_effect_tooltip = UKR_gain_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = 5 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6935,7 +6914,6 @@ country_event = { # Parliament demands higher security funding
 		custom_effect_tooltip = UKR_lose_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = -10 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6966,7 +6944,6 @@ country_event = { # Parliament demands higher education funding
 		custom_effect_tooltip = UKR_gain_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = 5 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -6977,7 +6954,6 @@ country_event = { # Parliament demands higher education funding
 		custom_effect_tooltip = UKR_lose_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = -10 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -7007,7 +6983,6 @@ country_event = { # Parliament demands higher military funding
 		custom_effect_tooltip = UKR_gain_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = 5 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}
@@ -7018,7 +6993,6 @@ country_event = { # Parliament demands higher military funding
 		custom_effect_tooltip = UKR_lose_some_seats_TT
 		add_to_variable = { UKR_verkhovna_support = -10 }
 		clamp_variable = { var = UKR_verkhovna_support min = 0 max = 450 }
-		set_party_index_to_ruling_party = yes
 		ai_chance = {
 			base = 3
 		}

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -727,7 +727,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: usa.11.o1 executed"
 		add_political_power = -150
 		add_stability = -0.03
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
 	}
@@ -24277,7 +24276,6 @@ country_event = {
 		set_temp_variable = { treasury_change = -15.00 }
 		modify_treasury_effect = yes
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		add_relative_party_popularity = yes
 		ai_chance = {
@@ -27711,7 +27709,6 @@ country_event = {
 	option = { # Okay
 		name = department_of_state.69.a
 		log = "[GetDateText]: [This.GetName]: department_of_state.69.a executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.2 }
 		set_temp_variable = { temp_outlook_increase = 0.2 }
 		add_relative_party_popularity = yes
@@ -29383,7 +29380,6 @@ country_event = {
 				modify_treasury_effect = yes
 			}
 			10 = {
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.01 }
 				add_relative_party_popularity = yes
 			}

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -14740,13 +14740,13 @@ country_event = {
 			days = 61
 		}
 		add_ideas = USA_migrant_crisis_one
-		add_popularity = { ideology = democratic popularity = -0.05 }
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
+		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = democratic popularity = -0.05 }
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
+		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
 	}
 
@@ -14891,13 +14891,13 @@ country_event = {
 		add_to_variable = { domestic_nationalist_drift = -0.01 tooltip = nationalist_drift_tt }
 		add_to_variable = { domestic_democratic_drift = -0.01 tooltip = democratic_drift_tt }
 		newline = yes
-		add_popularity = { ideology = democratic popularity = 0.03 }
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
+		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
-		add_popularity = { ideology = democratic popularity = 0.03 }
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.07 }
+		set_temp_variable = { temp_outlook_increase = 0.03 }
 		add_relative_party_popularity = yes
 		ai_chance = {
 			base = 1

--- a/events/agricultural_events.txt
+++ b/events/agricultural_events.txt
@@ -1945,7 +1945,6 @@ add_namespace = AGRI_famine
 				trigger = { has_country_flag = AGRI_sided_with_farmer_one }
 				set_temp_variable = { temp_opinion = 4 }
 				change_farmers_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.04 }
 				set_temp_variable = { temp_outlook_increase = -0.04 }
 				add_relative_party_popularity = yes
@@ -1958,7 +1957,6 @@ add_namespace = AGRI_famine
 				trigger = { has_country_flag = AGRI_sided_with_farmer_two }
 				set_temp_variable = { temp_opinion = -2 }
 				change_farmers_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.04 }
 				set_temp_variable = { temp_outlook_increase = 0.04 }
 				add_relative_party_popularity = yes
@@ -1971,7 +1969,6 @@ add_namespace = AGRI_famine
 				trigger = { has_country_flag = AGRI_sided_with_no_one }
 				set_temp_variable = { temp_opinion = 2 }
 				change_farmers_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				set_temp_variable = { temp_outlook_increase = 0.02 }
 				add_relative_party_popularity = yes
@@ -1984,7 +1981,6 @@ add_namespace = AGRI_famine
 				trigger = { has_country_flag = AGRI_shootouts_on_the_farm }
 				set_temp_variable = { temp_opinion = -3 }
 				change_farmers_opinion = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.03 }
 				set_temp_variable = { temp_outlook_increase = -0.03 }
 				add_relative_party_popularity = yes

--- a/events/belarus.txt
+++ b/events/belarus.txt
@@ -70,7 +70,6 @@ country_event = {
 		set_temp_variable = { int_investment_change = 85.00 }
 		modify_international_investment_effect = yes
 		newline = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/cartel_events.txt
+++ b/events/cartel_events.txt
@@ -1452,7 +1452,6 @@ country_event = { # Foreign Celebrity Death tied to Criminal Activity
 		multiply_temp_variable = { treasury_change = -0.006 }
 		modify_treasury_effect = yes
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1573,7 +1572,6 @@ country_event = { # Local Gang Clashes
 		name = cartel_event.22.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.22.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1909,7 +1907,6 @@ country_event = { # Neighbour Accedes to Demands
 		name = cartel_event.31.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.31.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -1935,7 +1932,6 @@ country_event = { # Neighbour Says NO to Demands
 		name = cartel_event.32.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.32.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -2049,7 +2045,6 @@ country_event = { # Cartel Tank Destroyed in Successful Raid
 		name = cartel_event.35.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.35.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -2080,7 +2075,6 @@ country_event = { # Cartel Tank Used in Retaliatory Strike
 		log = "[GetDateText]: [This.GetName]: cartel_event.36.a executed"
 
 		add_manpower = -25
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -2160,7 +2154,6 @@ country_event = { # Arrested Lackey Turns Out to Be Important Cartel Leader
 		name = cartel_event.38.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.38.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		add_relative_party_popularity = yes
@@ -2354,7 +2347,6 @@ country_event = { # Industrial Conglomerates Safehousing Contraband
 	option = {
 		name = cartel_event.42.c
 		log = "[GetDateText]: [This.GetName]: cartel_event.42.c executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -2513,7 +2505,6 @@ country_event = { # Shipping Container of Contraband
 		name = cartel_event.44.c
 		log = "[GetDateText]: [This.GetName]: cartel_event.44.c executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		add_relative_party_popularity = yes
@@ -2577,7 +2568,6 @@ country_event = { # Bankers Turning a Blind Eye
 		name = cartel_event.45.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.45.b executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -2807,7 +2797,6 @@ country_event = { # Youth Losing Hope
 	option = {
 		name = cartel_event.49.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.49.b executed"
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		add_relative_party_popularity = yes
@@ -2834,7 +2823,6 @@ country_event = { # Cartel Retaliatory Strike
 		log = "[GetDateText]: [This.GetName]: cartel_event.53.a executed"
 
 		add_manpower = -10
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		add_relative_party_popularity = yes
@@ -2858,7 +2846,6 @@ country_event = { # Failed Cartel Retaliatory Strike
 		log = "[GetDateText]: [This.GetName]: cartel_event.54.a executed"
 
 		add_manpower = -5
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		add_relative_party_popularity = yes
@@ -3010,7 +2997,6 @@ country_event = {
 			modify_cartel_variables_effect = yes
 		}
 		else_if = { limit = { has_country_flag = failed_investigation_casino }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes
@@ -3038,7 +3024,6 @@ country_event = {
 			}
 		}
 		else_if = { limit = { has_country_flag = failed_investigation_banks }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes
@@ -3066,7 +3051,6 @@ country_event = {
 			modify_cartel_variables_effect = yes
 		}
 		else_if = { limit = { has_country_flag = failed_investigation_shell_companies }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes
@@ -3207,7 +3191,6 @@ country_event = {
 			modify_cartel_variables_effect = yes
 		}
 		else_if = { limit = { has_country_flag = failed_raid_drug_convoys }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes
@@ -3243,7 +3226,6 @@ country_event = {
 			}
 		}
 		else_if = { limit = { has_country_flag = failed_raid_cartel_hideouts }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes
@@ -3266,7 +3248,6 @@ country_event = {
 			modify_cartel_variables_effect = yes
 		}
 		else_if = { limit = { has_country_flag = failed_raid_distribution_centres }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes
@@ -3288,7 +3269,6 @@ country_event = {
 			modify_cartel_variables_effect = yes
 		}
 		else_if = { limit = { has_country_flag = failed_raid_refinement_centres }
-			set_party_index_to_ruling_party = yes
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			add_relative_party_popularity = yes

--- a/events/centralasia_events.txt
+++ b/events/centralasia_events.txt
@@ -1025,6 +1025,7 @@ country_event = { #Historical 2022
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
+				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1046,6 +1047,7 @@ country_event = { #Historical 2022
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
+				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1111,6 +1113,7 @@ country_event = {
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
+				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1132,6 +1135,7 @@ country_event = {
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
+				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1367,6 +1371,7 @@ country_event = { #Historical 2005
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1425,6 +1430,7 @@ country_event = { #Historical 2005
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1709,6 +1715,7 @@ country_event = { #Historical 2005
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1944,6 +1951,7 @@ country_event = { #Historical 2010
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -2263,6 +2271,7 @@ country_event = { #Historical 2020
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes

--- a/events/centralasia_events.txt
+++ b/events/centralasia_events.txt
@@ -1004,7 +1004,6 @@ country_event = { #Historical 2022
 		country_event = { id = centralkaz.7 days = 1 }
 
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1026,7 +1025,6 @@ country_event = { #Historical 2022
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1048,7 +1046,6 @@ country_event = { #Historical 2022
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1097,7 +1094,6 @@ country_event = {
 		}
 
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1115,7 +1111,6 @@ country_event = {
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1137,7 +1132,6 @@ country_event = {
 				set_temp_variable = { party_popularity_increase = 0.4 }
 				set_temp_variable = { temp_outlook_increase = 0.4 }
 				add_relative_party_popularity = yes
-				set_party_index_to_ruling_party = yes
 				set_temp_variable = { party_popularity_increase = -0.1 }
 				set_temp_variable = { temp_outlook_increase = -0.1 }
 				add_relative_party_popularity = yes
@@ -1358,7 +1352,6 @@ country_event = { #Historical 2005
 			add_manpower = -102
 		}
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1374,7 +1367,6 @@ country_event = { #Historical 2005
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1418,7 +1410,6 @@ country_event = { #Historical 2005
 			add_manpower = -85
 		}
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1434,7 +1425,6 @@ country_event = { #Historical 2005
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1597,7 +1587,6 @@ country_event = { #Historical 2002
 
 		add_political_power = 50
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1611,7 +1600,6 @@ country_event = { #Historical 2002
 
 		add_stability = 0.05
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -1660,7 +1648,6 @@ country_event = { #Historical 2005
 		country_event = { id = centralkyr.9 days = 3 }
 
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1676,7 +1663,6 @@ country_event = { #Historical 2005
 		country_event = { id = centralkyr.26 days = 3 }
 
 		add_political_power = -300
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1701,7 +1687,6 @@ country_event = { #Historical 2005
 			add_manpower = -11
 		}
 		add_political_power = -500
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.2 }
 		set_temp_variable = { temp_outlook_increase = -0.2 }
 		add_relative_party_popularity = yes
@@ -1724,7 +1709,6 @@ country_event = { #Historical 2005
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1765,7 +1749,6 @@ country_event = { #Historical 2005
 		country_event = { id = centralkyr.10 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1789,7 +1772,6 @@ country_event = { #Historical 2005
 		country_event = { id = centralkyr.11 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1813,7 +1795,6 @@ country_event = { #Historical 2005
 		country_event = { id = centralkyr.12 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1837,7 +1818,6 @@ country_event = { #Historical 2005
 		country_event = { id = centralkyr.13 days = 30 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1903,7 +1883,6 @@ country_event = { #Historical 2010
 			add_manpower = -29
 		}
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -1919,7 +1898,6 @@ country_event = { #Historical 2010
 		country_event = { id = centralkyr.26 days = 3 }
 
 		add_political_power = -300
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -1944,7 +1922,6 @@ country_event = { #Historical 2010
 			add_manpower = -321
 		}
 		add_political_power = -500
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.2 }
 		set_temp_variable = { temp_outlook_increase = -0.2 }
 		add_relative_party_popularity = yes
@@ -1967,7 +1944,6 @@ country_event = { #Historical 2010
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -2011,7 +1987,6 @@ country_event = { #Historical 2010
 			add_manpower = -29
 		}
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2038,7 +2013,6 @@ country_event = { #Historical 2010
 			add_manpower = -29
 		}
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2062,7 +2036,6 @@ country_event = { #Historical 2010
 		country_event = { id = centralkyr.18 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2086,7 +2059,6 @@ country_event = { #Historical 2010
 		country_event = { id = centralkyr.19 days = 30 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2230,7 +2202,6 @@ country_event = { #Historical 2020
 			add_manpower = -1
 		}
 		add_political_power = -100
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2246,7 +2217,6 @@ country_event = { #Historical 2020
 		country_event = { id = centralkyr.26 days = 3 }
 
 		add_political_power = -300
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -2271,7 +2241,6 @@ country_event = { #Historical 2020
 			add_manpower = -23
 		}
 		add_political_power = -500
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.2 }
 		set_temp_variable = { temp_outlook_increase = -0.2 }
 		add_relative_party_popularity = yes
@@ -2294,7 +2263,6 @@ country_event = { #Historical 2020
 		set_temp_variable = { party_popularity_increase = 0.4 }
 		set_temp_variable = { temp_outlook_increase = 0.4 }
 		add_relative_party_popularity = yes
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		set_temp_variable = { temp_outlook_increase = -0.1 }
 		add_relative_party_popularity = yes
@@ -2335,7 +2303,6 @@ country_event = { #Historical 2020
 		country_event = { id = centralkyr.23 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2359,7 +2326,6 @@ country_event = { #Historical 2020
 		country_event = { id = centralkyr.24 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes
@@ -2383,7 +2349,6 @@ country_event = { #Historical 2020
 		country_event = { id = centralkyr.25 days = 3 }
 
 		add_political_power = -50
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes

--- a/events/corruption.txt
+++ b/events/corruption.txt
@@ -580,7 +580,6 @@ country_event = {
 		name = corruption.7.a
 		log = "[GetDateText]: [This.GetName]: corruption.7.a executed"
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/netherlands.txt
+++ b/events/netherlands.txt
@@ -13174,6 +13174,7 @@ country_event = {
 			}
 		}
 		set_temp_variable = { party_index = 0 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -13202,6 +13203,7 @@ country_event = {
 			}
 		}
 		set_temp_variable = { party_index = 0 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.15 }
 		set_temp_variable = { temp_outlook_increase = -0.15 }
 		add_relative_party_popularity = yes
@@ -13227,6 +13229,7 @@ country_event = {
 			target = SOV
 		}
 		set_temp_variable = { party_index = 0 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.08 }
 		set_temp_variable = { temp_outlook_increase = 0.08 }
 		add_relative_party_popularity = yes
@@ -13259,6 +13262,7 @@ country_event = {
 		add_political_power = -60
 		USA = { country_event = HOL_common_event.7 }
 		set_temp_variable = { party_index = 0 }
+		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/netherlands.txt
+++ b/events/netherlands.txt
@@ -13174,7 +13174,6 @@ country_event = {
 			}
 		}
 		set_temp_variable = { party_index = 0 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
@@ -13203,7 +13202,6 @@ country_event = {
 			}
 		}
 		set_temp_variable = { party_index = 0 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.15 }
 		set_temp_variable = { temp_outlook_increase = -0.15 }
 		add_relative_party_popularity = yes
@@ -13229,7 +13227,6 @@ country_event = {
 			target = SOV
 		}
 		set_temp_variable = { party_index = 0 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.08 }
 		set_temp_variable = { temp_outlook_increase = 0.08 }
 		add_relative_party_popularity = yes
@@ -13262,7 +13259,6 @@ country_event = {
 		add_political_power = -60
 		USA = { country_event = HOL_common_event.7 }
 		set_temp_variable = { party_index = 0 }
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes

--- a/events/waronterror.txt
+++ b/events/waronterror.txt
@@ -944,7 +944,6 @@ country_event = {
 		ai_chance = { factor = 100 }
 		add_stability = -0.05
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		add_relative_party_popularity = yes
@@ -1180,7 +1179,6 @@ country_event = {
 		add_political_power = -100
 		add_stability = -0.05
 
-		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		add_relative_party_popularity = yes


### PR DESCRIPTION
Move the set_party_index_to_ruling_party logic into add_relative_party_popularity as a default when party_index is not already set. Remove the now-redundant explicit calls across 143 files. The set_party_index_to_ruling_party definition is preserved for backward compatibility.

Closes #1808 