### PR TITLE
Fix Misc Issues Pt 4 (#1420, #1535, #1576, #1459)

### DIFF
--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -597,7 +597,8 @@ EGY_coptic_decision = {
 			log = "[GetDateText]: [Root.GetName]: Decision EGY_copt_coalition"
 			custom_effect_tooltip = EGY_copt_coalition_create
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 13 }
+				set_temp_variable = { add_col_one = 13 }
+				add_coalition_members_effect = yes
 				set_temp_variable = { party_index = 13 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
 				multiply_temp_variable = { party_popularity_increase = -1 }

--- a/common/decisions/Coalition Decisions.txt
+++ b/common/decisions/Coalition Decisions.txt
@@ -85,7 +85,8 @@ coalition_decisions = {
 								limit = {
 									check_variable = { party_1_affinity_array^i1 > 0 }
 								}
-								add_to_array = { gov_coalition_array = i1 }
+								set_temp_variable = { add_col_one = i1 }
+								add_coalition_members_effect = yes
 							}
 						}
 					}
@@ -102,7 +103,8 @@ coalition_decisions = {
 								limit = {
 									check_variable = { party_2_affinity_array^i2 > 0 }
 								}
-								add_to_array = { gov_coalition_array = i2 }
+								set_temp_variable = { add_col_one = i2 }
+								add_coalition_members_effect = yes
 							}
 						}
 					}

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -3665,7 +3665,8 @@ PER_domestic_politics = {
 			add_ideas = PER_reza_pahlavi
 			newline = yes
 			custom_effect_tooltip = PER_coalition_pahlavi_TT
-			add_to_array = { gov_coalition_array = 23 }
+			set_temp_variable = { add_col_one = 23 }
+			add_coalition_members_effect = yes
 			hidden_effect = {
 				country_event = {
 					id = iranian_focus.108

--- a/common/ideas/AA_law_expanded_economics.txt
+++ b/common/ideas/AA_law_expanded_economics.txt
@@ -371,15 +371,16 @@ ideas = {
 			level = 1
 
 			modifier = {
-				local_resources_oil_factor = -0.20
-				local_resources_aluminium_factor = -0.20
-				local_resources_rubber_factor = -0.20
-				local_resources_tungsten_factor = -0.20
-				local_resources_steel_factor = -0.20
-				local_resources_chromium_factor = -0.20
-				resource_export_multiplier_modifier = -0.15
+				local_resources_oil_factor = -0.10
+				local_resources_aluminium_factor = -0.10
+				local_resources_rubber_factor = -0.10
+				local_resources_tungsten_factor = -0.10
+				local_resources_steel_factor = -0.10
+				local_resources_chromium_factor = -0.10
+				resource_export_multiplier_modifier = -0.075
 				resource_extraction_workforce_requirement_modifier = -0.20
-				stability_factor = 0.15
+				stability_factor = 0.075
+				neutrality_drift = 0.03
 			}
 
 			ai_will_do = {
@@ -418,15 +419,16 @@ ideas = {
 			level = 2
 
 			modifier = {
-				local_resources_oil_factor = -0.10
-				local_resources_aluminium_factor = -0.10
-				local_resources_rubber_factor = -0.10
-				local_resources_tungsten_factor = -0.10
-				local_resources_steel_factor = -0.10
-				local_resources_chromium_factor = -0.10
-				resource_export_multiplier_modifier = -0.05
+				local_resources_oil_factor = -0.05
+				local_resources_aluminium_factor = -0.05
+				local_resources_rubber_factor = -0.05
+				local_resources_tungsten_factor = -0.05
+				local_resources_steel_factor = -0.05
+				local_resources_chromium_factor = -0.05
+				resource_export_multiplier_modifier = -0.025
 				resource_extraction_workforce_requirement_modifier = -0.10
-				stability_factor = 0.10
+				stability_factor = 0.05
+				neutrality_drift = 0.015
 			}
 
 			ai_will_do = {
@@ -448,13 +450,13 @@ ideas = {
 			level = 3
 
 			modifier = {
-				local_resources_oil_factor = 0.05
-				local_resources_aluminium_factor = 0.05
-				local_resources_rubber_factor = 0.05
-				local_resources_tungsten_factor = 0.05
-				local_resources_steel_factor = 0.05
-				local_resources_chromium_factor = 0.05
-				stability_factor = 0.05
+				local_resources_oil_factor = 0.025
+				local_resources_aluminium_factor = 0.025
+				local_resources_rubber_factor = 0.025
+				local_resources_tungsten_factor = 0.025
+				local_resources_steel_factor = 0.025
+				local_resources_chromium_factor = 0.025
+				stability_factor = 0.025
 			}
 
 			ai_will_do = {
@@ -481,15 +483,15 @@ ideas = {
 			level = 4
 
 			modifier = {
-				local_resources_oil_factor = 0.15
-				local_resources_aluminium_factor = 0.15
-				local_resources_rubber_factor = 0.15
-				local_resources_tungsten_factor = 0.15
-				local_resources_steel_factor = 0.15
-				local_resources_chromium_factor = 0.15
-				resource_export_multiplier_modifier = 0.05
+				local_resources_oil_factor = 0.075
+				local_resources_aluminium_factor = 0.075
+				local_resources_rubber_factor = 0.075
+				local_resources_tungsten_factor = 0.075
+				local_resources_steel_factor = 0.075
+				local_resources_chromium_factor = 0.075
+				resource_export_multiplier_modifier = 0.025
 				resource_extraction_workforce_requirement_modifier = 0.15
-				stability_factor = -0.05
+				stability_factor = -0.025
 			}
 
 			ai_will_do = {
@@ -528,15 +530,15 @@ ideas = {
 			level = 5
 
 			modifier = {
-				local_resources_oil_factor = 0.25
-				local_resources_aluminium_factor = 0.25
-				local_resources_rubber_factor = 0.25
-				local_resources_tungsten_factor = 0.25
-				local_resources_steel_factor = 0.25
-				local_resources_chromium_factor = 0.25
-				resource_export_multiplier_modifier = 0.15
+				local_resources_oil_factor = 0.125
+				local_resources_aluminium_factor = 0.125
+				local_resources_rubber_factor = 0.125
+				local_resources_tungsten_factor = 0.125
+				local_resources_steel_factor = 0.125
+				local_resources_chromium_factor = 0.125
+				resource_export_multiplier_modifier = 0.075
 				resource_extraction_workforce_requirement_modifier = 0.30
-				stability_factor = -0.10
+				stability_factor = -0.05
 			}
 
 			ai_will_do = {
@@ -1114,10 +1116,11 @@ ideas = {
 			}
 
 			modifier = {
-				stability_factor = 0.10
+				stability_factor = 0.06
 				trade_opinion_factor = 0.08
 				political_power_factor = -0.10
 				consumer_goods_factor = 0.01
+				inflation_cost_multiplier_modifier = -0.15
 			}
 
 			ai_will_do = {
@@ -1161,9 +1164,10 @@ ideas = {
 			}
 
 			modifier = {
-				stability_factor = 0.06
+				stability_factor = 0.04
 				trade_opinion_factor = 0.04
 				political_power_factor = -0.05
+				inflation_cost_multiplier_modifier = -0.10
 			}
 
 			ai_will_do = {
@@ -1204,6 +1208,7 @@ ideas = {
 			modifier = {
 				stability_factor = 0.04
 				trade_opinion_factor = 0.02
+				inflation_cost_multiplier_modifier = -0.05
 			}
 
 			ai_will_do = {
@@ -1236,6 +1241,8 @@ ideas = {
 			modifier = {
 				political_power_gain = 0.06
 				stability_factor = -0.05
+				inflation_cost_multiplier_modifier = 0.10
+				return_on_investment_modifier = 0.01
 			}
 
 			ai_will_do = {

--- a/common/ideas/AA_law_expanded_economics.txt
+++ b/common/ideas/AA_law_expanded_economics.txt
@@ -381,6 +381,10 @@ ideas = {
 				resource_extraction_workforce_requirement_modifier = -0.20
 				stability_factor = 0.075
 				neutrality_drift = 0.03
+				production_speed_buildings_factor = -0.05
+				production_speed_renewable_energy_infra_factor = 0.15
+				renewable_infra_cost_multiplier_modifier = -0.10
+				production_speed_fossil_powerplant_factor = -0.10
 			}
 
 			ai_will_do = {
@@ -429,6 +433,10 @@ ideas = {
 				resource_extraction_workforce_requirement_modifier = -0.10
 				stability_factor = 0.05
 				neutrality_drift = 0.015
+				production_speed_buildings_factor = -0.025
+				production_speed_renewable_energy_infra_factor = 0.075
+				renewable_infra_cost_multiplier_modifier = -0.05
+				production_speed_fossil_powerplant_factor = -0.05
 			}
 
 			ai_will_do = {
@@ -492,6 +500,9 @@ ideas = {
 				resource_export_multiplier_modifier = 0.025
 				resource_extraction_workforce_requirement_modifier = 0.15
 				stability_factor = -0.025
+				production_speed_buildings_factor = 0.05
+				production_speed_renewable_energy_infra_factor = -0.075
+				production_speed_fossil_powerplant_factor = 0.05
 			}
 
 			ai_will_do = {
@@ -539,6 +550,10 @@ ideas = {
 				resource_export_multiplier_modifier = 0.075
 				resource_extraction_workforce_requirement_modifier = 0.30
 				stability_factor = -0.05
+				production_speed_buildings_factor = 0.10
+				production_speed_renewable_energy_infra_factor = -0.15
+				renewable_infra_cost_multiplier_modifier = 0.10
+				production_speed_fossil_powerplant_factor = 0.10
 			}
 
 			ai_will_do = {

--- a/common/ideas/AA_law_military_ideas.txt
+++ b/common/ideas/AA_law_military_ideas.txt
@@ -2099,13 +2099,8 @@ ideas = {
 
 			modifier = {
 				military_leader_cost_factor = -0.25
-				army_leader_start_level = 0
-				navy_leader_start_level = 0
 				command_power_gain_mult = 0.05
 				max_command_power = -10
-				experience_gain_army = 0.00
-				experience_gain_navy = 0.00
-				experience_gain_air = 0.00
 				special_forces_cap = 0.05
 				personnel_cost_multiplier_modifier = 0.05
 			}

--- a/common/ideas/tribute_ideas.txt
+++ b/common/ideas/tribute_ideas.txt
@@ -168,18 +168,6 @@ ideas = {
 				trade_cost_for_target_factor = -0.2
 			}
 		}
-		tribute_idea_ARC = {
-
-			name = ARC_tribute
-			picture = international_treaty2
-			allowed_civil_war = { always = yes }
-			targeted_modifier = {
-				tag = ARC
-				cic_to_target_factor = 0.2
-				extra_trade_to_target_factor = 0.2
-				trade_cost_for_target_factor = -0.2
-			}
-		}
 		tribute_idea_ARG = {
 
 			name = ARG_tribute
@@ -2783,7 +2771,7 @@ ideas = {
 				trade_cost_for_target_factor = -0.2
 			}
 		}
-		tribute_idea_NOR = {
+		tribute_idea_NRY = {
 
 			name = NRY_tribute
 			picture = international_treaty2

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -4543,11 +4543,16 @@ focus_tree = {
 			}
 			hidden_effect = {
 				clear_array = gov_coalition_array
-				add_to_array = { gov_coalition_array = 2 }
-				add_to_array = { gov_coalition_array = 6 }
-				add_to_array = { gov_coalition_array = 8 }
-				add_to_array = { gov_coalition_array = 12 }
-				add_to_array = { gov_coalition_array = 14 }
+				set_temp_variable = { add_col_one = 2 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 6 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 8 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 12 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 14 }
+				add_coalition_members_effect = yes
 				update_government_coalition_strength = yes
 				recalculate_party = yes
 			}

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -4543,16 +4543,11 @@ focus_tree = {
 			}
 			hidden_effect = {
 				clear_array = gov_coalition_array
-				set_temp_variable = { add_col_one = 2 }
-				add_coalition_members_effect = yes
-				set_temp_variable = { add_col_one = 6 }
-				add_coalition_members_effect = yes
-				set_temp_variable = { add_col_one = 8 }
-				add_coalition_members_effect = yes
-				set_temp_variable = { add_col_one = 12 }
-				add_coalition_members_effect = yes
-				set_temp_variable = { add_col_one = 14 }
-				add_coalition_members_effect = yes
+				add_to_array = { gov_coalition_array = 2 }
+				add_to_array = { gov_coalition_array = 6 }
+				add_to_array = { gov_coalition_array = 8 }
+				add_to_array = { gov_coalition_array = 12 }
+				add_to_array = { gov_coalition_array = 14 }
 				update_government_coalition_strength = yes
 				recalculate_party = yes
 			}

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -1061,7 +1061,8 @@ focus_tree = {
 				limit = {
 					is_in_array = { ruling_party = 7 }
 				}
-				add_to_array = { gov_coalition_array = 22 }
+				set_temp_variable = { add_col_one = 22 }
+				add_coalition_members_effect = yes
 				hidden_effect = {
 					update_party_name = yes
 					set_coalition_drift = yes

--- a/common/national_focus/05_comoros.txt
+++ b/common/national_focus/05_comoros.txt
@@ -2016,7 +2016,6 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 22 }
 			add_coalition_members_effect = yes
 			recalculate_party = yes
-			update_government_coalition_strength = yes
 			clr_country_flag = do_not_retire
 			add_country_leader_trait = dictator
 			set_temp_variable = { temp_opinion = -10 }

--- a/common/national_focus/05_comoros.txt
+++ b/common/national_focus/05_comoros.txt
@@ -2013,7 +2013,8 @@ focus_tree = {
 			add_stability = -0.05
 			set_country_flag = do_not_retire
 			disable_elections_with_no_leader_change = yes
-			add_to_array = { gov_coalition_array = 22 }
+			set_temp_variable = { add_col_one = 22 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
 			update_government_coalition_strength = yes
 			clr_country_flag = do_not_retire

--- a/common/national_focus/05_egypt.txt
+++ b/common/national_focus/05_egypt.txt
@@ -423,7 +423,8 @@ focus_tree = {
 			remove_ideas = muslim_brotherhood_crackdown
 			set_temp_variable = { party_index = 13 }
 			unban_party_scripted_call = yes
-			add_to_array = { gov_coalition_array = 12 }
+			set_temp_variable = { add_col_one = 12 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
 			hidden_effect = { update_government_coalition_strength = yes }
 			set_temp_variable = { temp_modify_social_con_government = 5 }
@@ -1086,7 +1087,8 @@ focus_tree = {
 			modify_social_conservatism_government = yes
 			custom_effect_tooltip = alnour_coal_tt
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 10 }
+				set_temp_variable = { add_col_one = 10 }
+				add_coalition_members_effect = yes
 				update_government_coalition_strength = yes
 				set_coalition_drift = yes
 			}
@@ -1159,7 +1161,8 @@ focus_tree = {
 			change_the_military_opinion = yes
 			custom_effect_tooltip = add_mil_tocoal
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 22 }
+				set_temp_variable = { add_col_one = 22 }
+				add_coalition_members_effect = yes
 				recalculate_party = yes
 				update_party_name = yes
 				set_coalition_drift = yes
@@ -1953,7 +1956,8 @@ focus_tree = {
 			modify_social_conservatism_government = yes
 			custom_effect_tooltip = commie_coal_tt
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 4 }
+				set_temp_variable = { add_col_one = 4 }
+				add_coalition_members_effect = yes
 				update_government_coalition_strength = yes
 				set_coalition_drift = yes
 			}
@@ -2051,7 +2055,8 @@ focus_tree = {
 			modify_social_conservatism_government = yes
 			custom_effect_tooltip = national_coal_tt
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 20 }
+				set_temp_variable = { add_col_one = 20 }
+				add_coalition_members_effect = yes
 				update_government_coalition_strength = yes
 				set_coalition_drift = yes
 			}

--- a/common/national_focus/05_egypt.txt
+++ b/common/national_focus/05_egypt.txt
@@ -426,7 +426,6 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 12 }
 			add_coalition_members_effect = yes
 			recalculate_party = yes
-			hidden_effect = { update_government_coalition_strength = yes }
 			set_temp_variable = { temp_modify_social_con_government = 5 }
 			modify_social_conservatism_government = yes
 			add_popularity = {
@@ -1089,8 +1088,6 @@ focus_tree = {
 			hidden_effect = {
 				set_temp_variable = { add_col_one = 10 }
 				add_coalition_members_effect = yes
-				update_government_coalition_strength = yes
-				set_coalition_drift = yes
 			}
 		}
 		ai_will_do = { base = 1 }
@@ -1165,7 +1162,6 @@ focus_tree = {
 				add_coalition_members_effect = yes
 				recalculate_party = yes
 				update_party_name = yes
-				set_coalition_drift = yes
 			}
 			add_popularity = {
 				ideology = democratic
@@ -1958,8 +1954,6 @@ focus_tree = {
 			hidden_effect = {
 				set_temp_variable = { add_col_one = 4 }
 				add_coalition_members_effect = yes
-				update_government_coalition_strength = yes
-				set_coalition_drift = yes
 			}
 		}
 		ai_will_do = { base = 1 }
@@ -2057,8 +2051,6 @@ focus_tree = {
 			hidden_effect = {
 				set_temp_variable = { add_col_one = 20 }
 				add_coalition_members_effect = yes
-				update_government_coalition_strength = yes
-				set_coalition_drift = yes
 			}
 		}
 		ai_will_do = { base = 1 }

--- a/common/national_focus/05_germany.txt
+++ b/common/national_focus/05_germany.txt
@@ -9904,7 +9904,7 @@ focus_tree = {
 				MODIFIER = GER_Bundeswehr_modifier
 			}
 			add_to_variable = { GER_leader_xp_gain = 0.04 tooltip = leader_experience_gain_factor_tt }
-			add_to_variable = { GER_army_leader_start_level = 0.05 tooltip = army_leader_start_level_tt }
+			add_to_variable = { GER_army_leader_start_level = 1 tooltip = army_leader_start_level_tt }
 			newline = yes
 			set_temp_variable = { treasury_change = gdp_per_capita }
 			multiply_temp_variable = { treasury_change = -0.15 }
@@ -10034,11 +10034,10 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = GER_Bundeswehr_modifier
 			}
-			add_to_variable = { GER_army_leader_start_level = 0.04 tooltip = army_leader_start_level_tt }
-			add_to_variable = { GER_army_leader_start_attack_level = 0.03 tooltip = army_leader_start_attack_level_tt }
-			add_to_variable = { GER_army_leader_start_defence_level = 0.02 tooltip = army_leader_start_defense_level_tt }
-			add_to_variable = { GER_army_leader_start_logistics_level = 0.02 tooltip = army_leader_start_logistics_level_tt }
-			add_to_variable = { GER_army_leader_start_planning_level = 0.02 tooltip = army_leader_start_planning_level_tt }
+			add_to_variable = { GER_army_leader_start_attack_level = 1 tooltip = army_leader_start_attack_level_tt }
+			add_to_variable = { GER_army_leader_start_defence_level = 1 tooltip = army_leader_start_defense_level_tt }
+			add_to_variable = { GER_army_leader_start_logistics_level = 1 tooltip = army_leader_start_logistics_level_tt }
+			add_to_variable = { GER_army_leader_start_planning_level = 1 tooltip = army_leader_start_planning_level_tt }
 		}
 		ai_will_do = {
 			base = 1

--- a/common/national_focus/05_india.txt
+++ b/common/national_focus/05_india.txt
@@ -8017,7 +8017,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_coal_with_right_wing"
 			remove_ideas = india_divided
-			add_to_array = { gov_coalition_array = 22 }
+			set_temp_variable = { add_col_one = 22 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
 			update_government_coalition_strength = yes
 			set_coalition_drift = yes
@@ -10844,7 +10845,8 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_breaking_the_neck_of_shivsena"
 			subtract_from_variable = { party_pop_array^21 = current_cons_popularity }
 			add_to_variable = { party_pop_array^20 = current_cons_popularity }
-			add_to_array = { gov_coalition_array = 23 }
+			set_temp_variable = { add_col_one = 23 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
 			update_government_coalition_strength = yes
 			set_coalition_drift = yes
@@ -10872,11 +10874,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_uniting_the_nationalist_front"
 
-			add_to_array = { gov_coalition_array = 21 }
+			set_temp_variable = { add_col_one = 21 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
-			add_to_array = { gov_coalition_array = 20 }
+			set_temp_variable = { add_col_one = 20 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
-			add_to_array = { gov_coalition_array = 22 }
+			set_temp_variable = { add_col_one = 22 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
 			update_government_coalition_strength = yes
 			set_coalition_drift = yes
@@ -10904,7 +10909,8 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: RAJ_stomping_the_pretenders"
 			subtract_from_variable = { party_pop_array^20 = current_cons_popularity }
 			add_to_variable = { party_pop_array^21 = current_cons_popularity }
-			add_to_array = { gov_coalition_array = 23 }
+			set_temp_variable = { add_col_one = 23 }
+			add_coalition_members_effect = yes
 			recalculate_party = yes
 			update_government_coalition_strength = yes
 			set_coalition_drift = yes

--- a/common/national_focus/05_india.txt
+++ b/common/national_focus/05_india.txt
@@ -8020,8 +8020,6 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 22 }
 			add_coalition_members_effect = yes
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			custom_effect_tooltip = militar_coal_tt
@@ -10848,8 +10846,6 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 23 }
 			add_coalition_members_effect = yes
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 			custom_effect_tooltip = mah_coal_tt
 		}
 		ai_will_do = {
@@ -10883,10 +10879,6 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 22 }
 			add_coalition_members_effect = yes
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 			custom_effect_tooltip = nat_coal_tt
 		}
 		ai_will_do = {
@@ -10912,8 +10904,6 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 23 }
 			add_coalition_members_effect = yes
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 			custom_effect_tooltip = shiv_coal_tt
 		}
 		ai_will_do = {

--- a/common/national_focus/05_iran.txt
+++ b/common/national_focus/05_iran.txt
@@ -19228,8 +19228,10 @@ focus_tree = {
 			add_to_variable = { PER_communism_drift = 0.05 tooltip = communism_drift_tt }
 			newline = yes
 			custom_effect_tooltip = PER_coalition_MEK_TT
-			add_to_array = { gov_coalition_array = 4 }
-			add_to_array = { gov_coalition_array = 18 }
+			set_temp_variable = { add_col_one = 4 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 18 }
+			add_coalition_members_effect = yes
 		}
 
 		ai_will_do = {
@@ -25128,7 +25130,8 @@ focus_tree = {
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
 			newline = yes
-			add_to_array = { gov_coalition_array = 3 }
+			set_temp_variable = { add_col_one = 3 }
+			add_coalition_members_effect = yes
 			custom_effect_tooltip = PER_iran_party_TT
 			newline = yes
 			set_temp_variable = { party_index = 3 }
@@ -25440,7 +25443,8 @@ focus_tree = {
 			add_relative_party_popularity = yes
 			newline = yes
 			custom_effect_tooltip = PER_coalition_IRGC_TT
-			add_to_array = { gov_coalition_array = 6 }
+			set_temp_variable = { add_col_one = 6 }
+			add_coalition_members_effect = yes
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
 			change_the_ulema_opinion = yes

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -4901,8 +4901,6 @@ focus_tree = {
 				party_pop_array^18 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 			}
 			custom_effect_tooltip = SOV_the_onf_TT
 		}
@@ -26745,8 +26743,6 @@ focus_tree = {
 				party_pop_array^15 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 		}
 
 		ai_will_do = { base = 155 }

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -4875,11 +4875,16 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_the_onf"
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 1 }
-				add_to_array = { gov_coalition_array = 5 }
-				add_to_array = { gov_coalition_array = 7 }
-				add_to_array = { gov_coalition_array = 15 }
-				add_to_array = { gov_coalition_array = 18 }
+				set_temp_variable = { add_col_one = 1 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 5 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 7 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 15 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 18 }
+				add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^1 = current_cons_popularity
 			}
@@ -6881,7 +6886,8 @@ focus_tree = {
 			custom_effect_tooltip = SOV_nazbol_coup_TT
 			country_event = sov_nazbol.4
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 21 }
+				set_temp_variable = { add_col_one = 21 }
+				add_coalition_members_effect = yes
 			}
 			hidden_effect = {
 				news_event = {
@@ -26728,8 +26734,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_establish_controlled_opposition"
 			custom_effect_tooltip = SOV_coalition_pipec
-			add_to_array = { gov_coalition_array = 1 }
-			add_to_array = { gov_coalition_array = 15 }
+			set_temp_variable = { add_col_one = 1 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 15 }
+			add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^1 = current_cons_popularity
 			}

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -293,7 +293,8 @@ focus_tree = {
 			add_stability = 0.05
 			add_political_power = 150
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 3 }
+				set_temp_variable = { add_col_one = 3 }
+				add_coalition_members_effect = yes
 				update_government_coalition_strength = yes
 				if = {
 					limit = {
@@ -341,7 +342,8 @@ focus_tree = {
 			add_stability = 0.05
 			add_political_power = 150
 			hidden_effect = {
-				add_to_array = { gov_coalition_array = 15 }
+				set_temp_variable = { add_col_one = 15 }
+				add_coalition_members_effect = yes
 				update_government_coalition_strength = yes
 				if = { limit = { NOT = { has_government = neutrality } }
 					clear_coalition_non_alligned_count_ideas = yes

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -295,7 +295,6 @@ focus_tree = {
 			hidden_effect = {
 				set_temp_variable = { add_col_one = 3 }
 				add_coalition_members_effect = yes
-				update_government_coalition_strength = yes
 				if = {
 					limit = {
 						NOT = {
@@ -344,7 +343,6 @@ focus_tree = {
 			hidden_effect = {
 				set_temp_variable = { add_col_one = 15 }
 				add_coalition_members_effect = yes
-				update_government_coalition_strength = yes
 				if = { limit = { NOT = { has_government = neutrality } }
 					clear_coalition_non_alligned_count_ideas = yes
 					reset_neutrality_coalition_ideas = yes

--- a/common/national_focus/centralasia.txt
+++ b/common/national_focus/centralasia.txt
@@ -7150,21 +7150,24 @@ focus_tree = {
 					NOT = { is_in_array = { ruling_party = 20 } }
 					NOT = { is_in_array = { gov_coalition_array = 20 } }
 				}
-				add_to_array = { gov_coalition_array = 20 }
+				set_temp_variable = { add_col_one = 20 }
+				add_coalition_members_effect = yes
 			}
 			if = {
 				limit = {
 					NOT = { is_in_array = { ruling_party = 21 } }
 					NOT = { is_in_array = { gov_coalition_array = 21 } }
 				}
-				add_to_array = { gov_coalition_array = 21 }
+				set_temp_variable = { add_col_one = 21 }
+				add_coalition_members_effect = yes
 			}
 			if = {
 				limit = {
 					NOT = { is_in_array = { ruling_party = 22 } }
 					NOT = { is_in_array = { gov_coalition_array = 22 } }
 				}
-				add_to_array = { gov_coalition_array = 22 }
+				set_temp_variable = { add_col_one = 22 }
+				add_coalition_members_effect = yes
 			}
 			update_government_coalition_strength = yes
 			set_coalition_drift = yes

--- a/common/national_focus/iraq2.txt
+++ b/common/national_focus/iraq2.txt
@@ -9724,7 +9724,8 @@ focus_tree = {
 				}
 				newline = yes
 				custom_effect_tooltip = IRQ_add_sadr_TT
-				add_to_array = { gov_coalition_array = 20 }
+				set_temp_variable = { add_col_one = 20 }
+				add_coalition_members_effect = yes
 				hidden_effect = {
 					update_government_coalition_strength = yes
 					set_coalition_drift = yes
@@ -10295,7 +10296,8 @@ focus_tree = {
 					}
 				}
 				custom_effect_tooltip = IRQ_add_al_maliki_TT
-				add_to_array = { gov_coalition_array = 6 }
+				set_temp_variable = { add_col_one = 6 }
+				add_coalition_members_effect = yes
 				hidden_effect = {
 					update_government_coalition_strength = yes
 					set_coalition_drift = yes

--- a/common/national_focus/iraq2.txt
+++ b/common/national_focus/iraq2.txt
@@ -9726,10 +9726,6 @@ focus_tree = {
 				custom_effect_tooltip = IRQ_add_sadr_TT
 				set_temp_variable = { add_col_one = 20 }
 				add_coalition_members_effect = yes
-				hidden_effect = {
-					update_government_coalition_strength = yes
-					set_coalition_drift = yes
-				}
 			}
 			newline = yes
 			increase_policing_budget = yes
@@ -10298,10 +10294,6 @@ focus_tree = {
 				custom_effect_tooltip = IRQ_add_al_maliki_TT
 				set_temp_variable = { add_col_one = 6 }
 				add_coalition_members_effect = yes
-				hidden_effect = {
-					update_government_coalition_strength = yes
-					set_coalition_drift = yes
-				}
 			}
 		}
 	}

--- a/common/national_focus/korea_south.txt
+++ b/common/national_focus/korea_south.txt
@@ -4082,7 +4082,8 @@ focus_tree = {
 
 		completion_reward = {
 			custom_effect_tooltip = KOR_yusin_emerges_tt
-			add_to_array = { gov_coalition_array = 0 }
+			set_temp_variable = { add_col_one = 0 }
+			add_coalition_members_effect = yes
 			set_temp_variable = { party_index = 0 }
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
@@ -4589,7 +4590,8 @@ focus_tree = {
 				limit = {
 					NOT = { is_in_array = { gov_coalition_array = 0 } }
 				}
-				add_to_array = { gov_coalition_array = 0 }
+				set_temp_variable = { add_col_one = 0 }
+				add_coalition_members_effect = yes
 			}
 			set_temp_variable = { party_index = 0 }
 			set_temp_variable = { party_popularity_increase = 0.25 }

--- a/common/national_focus/serbia.txt
+++ b/common/national_focus/serbia.txt
@@ -6400,8 +6400,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_nova_democratica_stranka"
 			hidden_effect = {
-			add_to_array = { gov_coalition_array = 1 }
-			add_to_array = { gov_coalition_array = 2 }
+			set_temp_variable = { add_col_one = 1 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 2 }
+			add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^1 = current_cons_popularity
 			}
@@ -6663,8 +6665,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_democratica_stranka"
 			hidden_effect = {
-			add_to_array = { gov_coalition_array = 3 }
-			add_to_array = { gov_coalition_array = 16 }
+			set_temp_variable = { add_col_one = 3 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 16 }
+			add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^3 = current_cons_popularity
 			}
@@ -6932,9 +6936,12 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_progressivna_stranka"
 			hidden_effect = {
-			add_to_array = { gov_coalition_array = 5 }
-			add_to_array = { gov_coalition_array = 7 }
-			add_to_array = { gov_coalition_array = 3 }
+			set_temp_variable = { add_col_one = 5 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 7 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 3 }
+			add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^5 = current_cons_popularity
 			}
@@ -7202,8 +7209,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_social_democracy"
 			hidden_effect = {
-			add_to_array = { gov_coalition_array = 3 }
-			add_to_array = { gov_coalition_array = 16 }
+			set_temp_variable = { add_col_one = 3 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 16 }
+			add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^3 = current_cons_popularity
 			}
@@ -7469,8 +7478,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SER_socialist_party"
 			hidden_effect = {
-			add_to_array = { gov_coalition_array = 19 }
-			add_to_array = { gov_coalition_array = 16 }
+			set_temp_variable = { add_col_one = 19 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 16 }
+			add_coalition_members_effect = yes
 			subtract_from_variable = {
 				party_pop_array^19 = current_cons_popularity
 			}

--- a/common/national_focus/serbia.txt
+++ b/common/national_focus/serbia.txt
@@ -6411,8 +6411,6 @@ focus_tree = {
 				party_pop_array^2 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 		}
 		custom_effect_tooltip = SER_coalition_TT
 		}
@@ -6676,8 +6674,6 @@ focus_tree = {
 				party_pop_array^16 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 		}
 		custom_effect_tooltip = SER_coalition_TT
 		}
@@ -6952,8 +6948,6 @@ focus_tree = {
 				party_pop_array^3 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 		}
 		custom_effect_tooltip = SER_coalition_TT
 		}
@@ -7220,8 +7214,6 @@ focus_tree = {
 				party_pop_array^16 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 		}
 		custom_effect_tooltip = SER_coalition_TT
 		}
@@ -7489,8 +7481,6 @@ focus_tree = {
 				party_pop_array^16 = current_cons_popularity
 			}
 			recalculate_party = yes
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
 		}
 		custom_effect_tooltip = SER_coalition_TT
 		}

--- a/common/national_focus/syria.txt
+++ b/common/national_focus/syria.txt
@@ -444,7 +444,8 @@ focus_tree = {
 			set_temp_variable = { col_three = 18 }
 			set_temp_variable = { col_four = 20 }
 			change_ruling_party_effect = yes
-			add_to_array = { gov_coalition_array = 21 }
+			set_temp_variable = { add_col_one = 21 }
+			add_coalition_members_effect = yes
 			create_country_leader = {
 				name = "Bashar al-Assad"
 				desc = ""

--- a/common/national_focus/tajikistan.txt
+++ b/common/national_focus/tajikistan.txt
@@ -324,7 +324,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_integration_of_the_agrarian_party"
 			custom_effect_tooltip = TAJ_integrate_agrarians_TT
-			add_to_array = { gov_coalition_array = 18 }
+			set_temp_variable = { add_col_one = 18 }
+			add_coalition_members_effect = yes
 			newline = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -2896,7 +2897,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_manage_badakhshan_front"
 			custom_effect_tooltip = TAJ_integrate_army_TT
-			add_to_array = { gov_coalition_array = 22 }
+			set_temp_variable = { add_col_one = 22 }
+			add_coalition_members_effect = yes
 			newline = yes
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4022,7 +4024,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_integrate_the_socdems"
-			add_to_array = { gov_coalition_array = 3 }
+			set_temp_variable = { add_col_one = 3 }
+			add_coalition_members_effect = yes
 			custom_effect_tooltip = TAJ_integrate_soc_dems_TT
 			newline = yes
 			set_temp_variable = { party_index = 3 }

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -6916,18 +6916,24 @@ focus_tree = {
 			}
 			else_if = {
 				limit = { is_in_array = { ruling_party = 4 } }
-				add_to_array = { gov_coalition_array = 5 }
-				add_to_array = { gov_coalition_array = 7 }
+				set_temp_variable = { add_col_one = 5 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 7 }
+				add_coalition_members_effect = yes
 			}
 			else_if = {
 				limit = { is_in_array = { ruling_party = 5 } }
-				add_to_array = { gov_coalition_array = 4 }
-				add_to_array = { gov_coalition_array = 7 }
+				set_temp_variable = { add_col_one = 4 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 7 }
+				add_coalition_members_effect = yes
 			}
 			else_if = {
 				limit = { is_in_array = { ruling_party = 7 } }
-				add_to_array = { gov_coalition_array = 4 }
-				add_to_array = { gov_coalition_array = 5 }
+				set_temp_variable = { add_col_one = 4 }
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 5 }
+				add_coalition_members_effect = yes
 			}
 			hidden_effect = {
 				update_government_coalition_strength = yes
@@ -10296,11 +10302,13 @@ focus_tree = {
 			}
 			else_if = {
 				limit = { is_in_array = { ruling_party = 0 } }
-				add_to_array = { gov_coalition_array = 12 }
+				set_temp_variable = { add_col_one = 12 }
+				add_coalition_members_effect = yes
 			}
 			else_if = {
 				limit = { is_in_array = { ruling_party = 12 } }
-				add_to_array = { gov_coalition_array = 0 }
+				set_temp_variable = { add_col_one = 0 }
+				add_coalition_members_effect = yes
 			}
 			hidden_effect = {
 				update_government_coalition_strength = yes
@@ -12768,7 +12776,8 @@ focus_tree = {
 			custom_effect_tooltip = TUR_form_coalition_osman
 			if = {
 				limit = { is_in_array = { ruling_party = 20 } }
-				add_to_array = { gov_coalition_array = 23 }
+				set_temp_variable = { add_col_one = 23 }
+				add_coalition_members_effect = yes
 			}
 			hidden_effect = {
 				update_government_coalition_strength = yes
@@ -14264,7 +14273,8 @@ focus_tree = {
 			custom_effect_tooltip = TUR_form_coalition_gray_wolves
 			if = {
 				limit = { is_in_array = { ruling_party = 15 } }
-				add_to_array = { gov_coalition_array = 21 }
+				set_temp_variable = { add_col_one = 21 }
+				add_coalition_members_effect = yes
 			}
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.10 }

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -6935,10 +6935,6 @@ focus_tree = {
 				set_temp_variable = { add_col_one = 5 }
 				add_coalition_members_effect = yes
 			}
-			hidden_effect = {
-				update_government_coalition_strength = yes
-				set_coalition_drift = yes
-			}
 		}
 
 	}
@@ -10310,10 +10306,6 @@ focus_tree = {
 				set_temp_variable = { add_col_one = 0 }
 				add_coalition_members_effect = yes
 			}
-			hidden_effect = {
-				update_government_coalition_strength = yes
-				set_coalition_drift = yes
-			}
 		}
 	}
 	#Gulenist Branch
@@ -12778,10 +12770,6 @@ focus_tree = {
 				limit = { is_in_array = { ruling_party = 20 } }
 				set_temp_variable = { add_col_one = 23 }
 				add_coalition_members_effect = yes
-			}
-			hidden_effect = {
-				update_government_coalition_strength = yes
-				set_coalition_drift = yes
 			}
 			set_country_flag = TUR_osmani
 

--- a/common/scripted_effects/NRY_political_leaders.txt
+++ b/common/scripted_effects/NRY_political_leaders.txt
@@ -1,4 +1,4 @@
-set_leader_NOR = {
+set_leader_NRY = {
 
 	#Arbeiderpartiet
 	if = { limit = { has_country_flag = set_socialism }

--- a/common/scripted_effects/ROM_political_leaders.txt
+++ b/common/scripted_effects/ROM_political_leaders.txt
@@ -265,10 +265,34 @@ set_leader_ROM = {
 		}
 	}
 	else_if = { limit = { has_country_flag = set_Western_Autocracy }
-		if = { limit = { check_variable = { Western_Autocracy_leader = 0 } }
-			add_to_variable = { Western_Autocracy_leader = 1 }
-			hidden_effect = { kill_country_leader = yes }
-
+		# The monarch persists across elections and only changes through succession events,
+		# which set ROM_current_monarch (unset/0 = Mihai, 1 = Nicholas, 2 = Margareta).
+		hidden_effect = { kill_country_leader = yes }
+		if = { limit = { check_variable = { ROM_current_monarch = 2 } }
+			create_country_leader = {
+				name = "Margareta I"
+				picture = "margareta.dds"
+				ideology = Western_Autocracy
+				traits = {
+					western_Western_Autocracy
+					zealous
+					greedy
+				}
+			}
+		}
+		else_if = { limit = { check_variable = { ROM_current_monarch = 1 } }
+			create_country_leader = {
+				name = "Nicholas I"
+				picture = "prince_nicholas.dds"
+				ideology = Western_Autocracy
+				traits = {
+					western_Western_Autocracy
+					humble
+					likeable
+				}
+			}
+		}
+		else = {
 			create_country_leader = {
 				name = "Mihai I"
 				picture = "Mihai_i.dds"
@@ -279,9 +303,6 @@ set_leader_ROM = {
 					elder
 				}
 			}
-
-			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Western_Autocracy_leader = 1 } }
-			if = { limit = { date < 2016.1.2 } set_temp_variable = { b = 1 } } #skip if 2017
 		}
 	}
 	else_if = { limit = { has_country_flag = set_Communist-State }

--- a/common/scripted_guis/00_MD_economyview_scripted_guis.txt
+++ b/common/scripted_guis/00_MD_economyview_scripted_guis.txt
@@ -986,7 +986,21 @@ scripted_gui = {
 
 				add_to_variable = { printing_money_var = 1 }
 
-				set_country_flag = { flag = printed_money_recently value = 1 days = 30 }
+				if = {
+					limit = { has_idea = gold_standard_back }
+					set_country_flag = { flag = printed_money_recently value = 1 days = 90 }
+				}
+				else_if = {
+					limit = { has_idea = silver_standard }
+					set_country_flag = { flag = printed_money_recently value = 1 days = 60 }
+				}
+				else_if = {
+					limit = { has_idea = bi_metal_standard }
+					set_country_flag = { flag = printed_money_recently value = 1 days = 45 }
+				}
+				else = {
+					set_country_flag = { flag = printed_money_recently value = 1 days = 30 }
+				}
 				ingame_update_setup = yes
 
 				multiply_temp_variable = { printing = 0.001 }
@@ -1005,7 +1019,13 @@ scripted_gui = {
 				add_to_variable = { currency_strength = -0.05 }
 				clamp_currency_strength = yes
 				set_country_flag = { flag = monetary_expand_active value = 1 days = 180 }
-				set_country_flag = { flag = monetary_expand_cooldown value = 1 days = 545 }
+				if = {
+					limit = { OR = { has_idea = silver_standard has_idea = bi_metal_standard } }
+					set_country_flag = { flag = monetary_expand_cooldown value = 1 days = 730 }
+				}
+				else = {
+					set_country_flag = { flag = monetary_expand_cooldown value = 1 days = 545 }
+				}
 				ingame_update_setup = yes
 				log = "[GetDateText]: [ROOT.GetName]: GUI: Expand Money Supply activated"
 			}

--- a/common/scripted_guis/01_influence_scripted_guis.txt
+++ b/common/scripted_guis/01_influence_scripted_guis.txt
@@ -158,8 +158,10 @@ scripted_gui = {
 					tooltip = opt_military_supply_button_TT
 					ROOT = { NOT = { has_country_flag = recently_sent_military_aid@PREV } }
 				}
-				ROOT = { has_political_power > 1 }
-				ROOT = { tag = PER }
+				ROOT = {
+					tag = PER
+					has_political_power > 1
+				}
 				#Our Country is a top 7 influencer
 				is_influencer = yes
 				ERI_is_not_transitional_government = yes
@@ -404,8 +406,10 @@ scripted_gui = {
 			opt_target_other_button_click = {
 				ROOT = {
 					save_event_target_as = influence_sender
-					PREV = { save_event_target_as = influence_target }
-					country_event = influence.3
+					set_country_flag = { flag = recently_sent_military_aid@PREV value = 1 days = 60 }
+					PREV = {
+						country_event = influence.7
+					}
 				}
 				update_dirty_influence_var = yes
 			}

--- a/common/scripted_guis/01_influence_scripted_guis.txt
+++ b/common/scripted_guis/01_influence_scripted_guis.txt
@@ -406,7 +406,6 @@ scripted_gui = {
 			opt_target_other_button_click = {
 				ROOT = {
 					save_event_target_as = influence_sender
-					set_country_flag = { flag = recently_sent_military_aid@PREV value = 1 days = 60 }
 					PREV = {
 						country_event = influence.7
 					}

--- a/events/Algeria.txt
+++ b/events/Algeria.txt
@@ -6817,8 +6817,10 @@ country_event = {
 			limit = {
 				is_in_array = { ruling_party = 7 }
 			}
-			add_to_array = { gov_coalition_array = 2 }
-			add_to_array = { gov_coalition_array = 12 }
+			set_temp_variable = { add_col_one = 2 }
+			add_coalition_members_effect = yes
+			set_temp_variable = { add_col_one = 12 }
+			add_coalition_members_effect = yes
 			hidden_effect = {
 				update_party_name = yes
 				set_coalition_drift = yes

--- a/events/Georgia.txt
+++ b/events/Georgia.txt
@@ -400,7 +400,8 @@ country_event = {
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = 13 }
 			change_ruling_party_effect = yes
-			add_to_array = { gov_coalition_array = 0 }
+			set_temp_variable = { add_col_one = 0 }
+			add_coalition_members_effect = yes
 			set_temp_variable = { current_cons_popularity = party_pop_array^0 }
 			multiply_temp_variable = { current_cons_popularity = 9.5 }
 			# Remove most of support, retrack it to emerg communist party

--- a/events/Hong Kong.txt
+++ b/events/Hong Kong.txt
@@ -415,9 +415,12 @@ country_event = {
 
 				add_to_array = { ruling_party = 6 }
 
-				add_to_array = { gov_coalition_array = 4 } #communist-state
-				add_to_array = { gov_coalition_array = 5 } #left-wing radical
-				add_to_array = { gov_coalition_array = 7 } #autocrats
+				set_temp_variable = { add_col_one = 4 } #communist-state
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 5 } #left-wing radical
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 7 } #autocrats
+				add_coalition_members_effect = yes
 
 				recalculate_party = yes
 			}
@@ -498,9 +501,12 @@ country_event = {
 
 				add_to_array = { ruling_party = 6 }
 
-				add_to_array = { gov_coalition_array = 4 } #communist-state
-				add_to_array = { gov_coalition_array = 5 } #left-wing radical
-				add_to_array = { gov_coalition_array = 7 } #autocrats
+				set_temp_variable = { add_col_one = 4 } #communist-state
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 5 } #left-wing radical
+				add_coalition_members_effect = yes
+				set_temp_variable = { add_col_one = 7 } #autocrats
+				add_coalition_members_effect = yes
 
 				recalculate_party = yes
 			}

--- a/events/Influence.txt
+++ b/events/Influence.txt
@@ -447,6 +447,18 @@ country_event = {
 	}
 }
 
+country_event = {
+	id = influence.7
+	hidden = yes
+	is_triggered_only = yes
+	immediate = {
+		save_event_target_as = influence_target
+		event_target:influence_sender = {
+			country_event = influence.3
+		}
+	}
+}
+
 #Target Influences
 country_event = {
 	id = influence.3

--- a/events/Iran.txt
+++ b/events/Iran.txt
@@ -929,7 +929,8 @@ country_event = { # Yazdi Elected as President 2001 (Reformists Won)
 		add_to_variable = { iranian_president_change = 1 }
 		add_ideas = PER_yazdi_idea
 		custom_effect_tooltip = PER_add_FMI_TT
-		add_to_array = { gov_coalition_array = 16 }
+		set_temp_variable = { add_col_one = 16 }
+		add_coalition_members_effect = yes
 	}
 }
 country_event = { # Tavakoli Elected as President 2001 (Principalists Won)
@@ -14855,7 +14856,8 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = PER_sasanid_lineage_TT
-		add_to_array = { gov_coalition_array = 14 }
+		set_temp_variable = { add_col_one = 14 }
+		add_coalition_members_effect = yes
 		ai_chance = {
 			base = 5
 		}

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -5143,9 +5143,12 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		add_relative_party_popularity = yes
-		add_to_array = { gov_coalition_array = 6 }
-		add_to_array = { gov_coalition_array = 8 }
-		add_to_array = { gov_coalition_array = 23 }
+		set_temp_variable = { add_col_one = 6 }
+		add_coalition_members_effect = yes
+		set_temp_variable = { add_col_one = 8 }
+		add_coalition_members_effect = yes
+		set_temp_variable = { add_col_one = 23 }
+		add_coalition_members_effect = yes
 		hidden_effect = {
 			update_government_coalition_strength = yes
 			set_coalition_drift = yes

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -5149,10 +5149,6 @@ country_event = {
 		add_coalition_members_effect = yes
 		set_temp_variable = { add_col_one = 23 }
 		add_coalition_members_effect = yes
-		hidden_effect = {
-			update_government_coalition_strength = yes
-			set_coalition_drift = yes
-		}
 		ai_chance = {
 			base = 1
 		}

--- a/events/Romania.txt
+++ b/events/Romania.txt
@@ -962,6 +962,7 @@ country_event = { #death of king michael
 				likeable
 			}
 		}
+		set_variable = { ROM_current_monarch = 1 }
 		complete_national_focus = ROM_death_of_the_king
 	}
 	option = {
@@ -984,6 +985,7 @@ country_event = { #death of king michael
 				greedy
 			}
 		}
+		set_variable = { ROM_current_monarch = 2 }
 		complete_national_focus = ROM_death_of_the_king
 	}
 	option = {

--- a/events/Tajikistan.txt
+++ b/events/Tajikistan.txt
@@ -2751,7 +2751,8 @@ country_event = {
 		name = tajik_focus.56.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.56.b executed"
 		custom_effect_tooltip = TAJ_integrate_democrats_TT
-		add_to_array = { gov_coalition_array = 20 }
+		set_temp_variable = { add_col_one = 20 }
+		add_coalition_members_effect = yes
 		add_political_power = 250
 		clr_country_flag = party20_banned
 		ai_chance = {

--- a/history/units/JAP_2000_naval_mtg.txt
+++ b/history/units/JAP_2000_naval_mtg.txt
@@ -12,11 +12,11 @@ units = {
 			ship = { name = "JDS Tachikaze" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Tachikaze Class" } } }
 			ship = { name = "JDS Sawakaze" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Tachikaze Class" } } }
 
-			ship = { name = "JDS Inazuma" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Samidare" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Yamayuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Matsuyuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Setoyuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Inazuma" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Samidare" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Yamayuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Matsuyuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Setoyuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
 
 			ship = { name = "JDS Sendai" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = JAP version_name = "Abukuma Class" } } }
 			ship = { name = "JDS Chikuma" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = JAP version_name = "Abukuma Class" } } }
@@ -32,14 +32,14 @@ units = {
 			ship = { name = "JDS Kongo" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Kongo Class" } } }
 			ship = { name = "JDS Asakaze" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Tachikaze Class" } } }
 
-			ship = { name = "JDS Murasame" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Harusame" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Yūgiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Amagiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Asagiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Yamagiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Asayuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Sawayuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Murasame" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Harusame" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Yūgiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Amagiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Asagiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Yamagiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Asayuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Sawayuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
 		}
 		task_force = {
 			name = "Escort Flotilla 3"
@@ -48,14 +48,14 @@ units = {
 			ship = { name = "JDS Haruna" definition = destroyer start_experience_factor = 0.50 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Haruna Class" } } }
 			ship = { name = "JDS Hiei" definition = destroyer start_experience_factor = 0.50 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Haruna Class" } } }
 
-			ship = { name = "JDS Ikazuchi" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Yudachi" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Kirisame" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
-			ship = { name = "JDS Sawagiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Umigiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Hamayuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Isoyuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Haruyuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Ikazuchi" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Yudachi" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Kirisame" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Murasame Class" } } }
+			ship = { name = "JDS Sawagiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Umigiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Hamayuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Isoyuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Haruyuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
 		}
 		task_force = {
 			name = "Escort Flotilla 4"
@@ -65,11 +65,11 @@ units = {
 			ship = { name = "JDS Shimakaze" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatakaze Class" } } }
 			ship = { name = "JDS Shirane" definition = destroyer start_experience_factor = 0.50 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Shirane Class" } } }
 
-			ship = { name = "JDS Hamagiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Setogiri" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
-			ship = { name = "JDS Hatsuyuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Shirayuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
-			ship = { name = "JDS Mineyuki" definition = destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Hamagiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Setogiri" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_2 = { amount = 1 owner = JAP version_name = "Asagiri Class" } } }
+			ship = { name = "JDS Hatsuyuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Shirayuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
+			ship = { name = "JDS Mineyuki" definition = screen_destroyer start_experience_factor = 0.65 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Hatsuyuki Class" } } }
 
 			ship = { name = "JDS Abukuma" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = JAP version_name = "Abukuma Class" } } }
 			ship = { name = "JDS Jintsu" definition = frigate start_experience_factor = 0.65 equipment = { frigate_hull_2 = { amount = 1 owner = JAP version_name = "Abukuma Class" } } }
@@ -102,8 +102,8 @@ units = {
 		task_force = {
 			name = "JMSDF Surface Fleet Reserves"
 			location = 9998
-			ship = { name = "JDS Takatsuki" definition = destroyer start_experience_factor = 0.25 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Takatsuki Class" } } }
-			ship = { name = "JDS Kikuzuki" definition = destroyer start_experience_factor = 0.25 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Takatsuki Class" } } }
+			ship = { name = "JDS Takatsuki" definition = screen_destroyer start_experience_factor = 0.25 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Takatsuki Class" } } }
+			ship = { name = "JDS Kikuzuki" definition = screen_destroyer start_experience_factor = 0.25 equipment = { destroyer_hull_1 = { amount = 1 owner = JAP version_name = "Takatsuki Class" } } }
 
 			ship = { name = "JDS Aokumo" definition = frigate start_experience_factor = 0.25 equipment = { frigate_hull_1 = { amount = 1 owner = JAP version_name = "Yamagumo Class" } } }
 			ship = { name = "JDS Akigumo" definition = frigate start_experience_factor = 0.25 equipment = { frigate_hull_1 = { amount = 1 owner = JAP version_name = "Yamagumo Class" } } }

--- a/localisation/english/MD_tribute_ideas_l_english.yml
+++ b/localisation/english/MD_tribute_ideas_l_english.yml
@@ -14,7 +14,6 @@
  ANT_tribute: "Economic Exploitation by [ANT.GetName]"
  AQY_tribute: "Economic Exploitation by [AQY.GetName]"
  ARA_tribute: "Economic Exploitation by [ARA.GetName]"
- ARC_tribute: "Economic Exploitation by [ARC.GetName]"
  ARG_tribute: "Economic Exploitation by [ARG.GetName]"
  ARK_tribute: "Economic Exploitation by [ARK.GetName]"
  ARM_tribute: "Economic Exploitation by [ARM.GetName]"

--- a/tools/validation/validate_ideas.py
+++ b/tools/validation/validate_ideas.py
@@ -1042,7 +1042,7 @@ class Validator(BaseValidator):
         for name in sorted(candidates):
             if name in referenced:
                 continue
-            if meta_prefixes and name.startswith(meta_prefixes):
+            if name.startswith(meta_prefixes):
                 continue
             src = defining_file.get(name, "")
             findings.append(

--- a/tools/validation/validate_ideas.py
+++ b/tools/validation/validate_ideas.py
@@ -387,6 +387,21 @@ _IDEA_REF_BLOCK = re.compile(
 )
 _WORD_TOKEN = re.compile(r"[A-Za-z0-9_.\-]+")
 
+# Meta-effect references build the idea name at runtime from a scope substitution,
+# e.g. `idea = tribute_idea_[ROOTTAG]` or `remove_ideas = foo_[THIS.GetTag]`. The
+# literal name (`tribute_idea_ABK`) is never written next to a keyword, so the
+# generous scan above only captures the static prefix before `[`. Record that
+# prefix under a sentinel so the unused check can treat any idea sharing it as
+# referenced. Only a non-empty prefix immediately followed by `[` qualifies, so
+# this stays precise (a literal `idea = foo` never matches `foobar`).
+_META_PREFIX_SENTINEL = "\x00meta:"
+_IDEA_REF_META = re.compile(
+    r"\b(?:has_idea|add_ideas|remove_ideas|add_idea|remove_idea|swap_idea"
+    r"|show_ideas_tooltip|idea)"
+    r"\s*=\s*([A-Za-z0-9_.\-]+)\[",
+    re.IGNORECASE,
+)
+
 # Dynamic-token ideas are applied at runtime via `add_ideas = var:<token>`, where
 # the literal name lives only in this registry and never next to an add_ideas
 # keyword. Treat any name registered here as referenced.
@@ -426,6 +441,8 @@ def _scan_idea_refs_for_unused(args: Tuple[str, str]) -> List[str]:
         refs = set(_IDEA_REF_GENEROUS.findall(text))
         for m in _IDEA_REF_BLOCK.finditer(text):
             refs.update(_WORD_TOKEN.findall(m.group(1)))
+        for prefix in _IDEA_REF_META.findall(text):
+            refs.add(_META_PREFIX_SENTINEL + prefix)
         return sorted(refs)
 
     return disk_cache.per_file_cached_by_content(
@@ -1013,9 +1030,19 @@ class Validator(BaseValidator):
             referenced.update(sub)
         referenced.update(_load_dynamic_token_names(self.mod_path))
 
+        # Prefixes from meta-effect references (`idea = tribute_idea_[ROOTTAG]`).
+        # Any candidate whose name starts with one is built at runtime, not dead.
+        meta_prefixes = tuple(
+            ref[len(_META_PREFIX_SENTINEL) :]
+            for ref in referenced
+            if ref.startswith(_META_PREFIX_SENTINEL)
+        )
+
         findings: List[Issue] = []
         for name in sorted(candidates):
             if name in referenced:
+                continue
+            if meta_prefixes and name.startswith(meta_prefixes):
                 continue
             src = defining_file.get(name, "")
             findings.append(


### PR DESCRIPTION
Closes #1420
Closes #1535
Closes #1576
Closes #1459
Closes #1765
Closes #1772

### Summary

#### Content

- **Fixes #1420: Japanese Screen and Capital Destroyers.** The JMSDF's lighter general-purpose classes (Murasame, Asagiri, Hatsuyuki, Takatsuki) were all `definition = destroyer` (capital). They are now `screen_destroyer`, while the Aegis/missile and DDH classes (Kongo, Tachikaze, Hatakaze, Shirane, Haruna) stay capital destroyers in `JAP_2000_naval_mtg.txt`.
- **Fixes #1576: Environmental regulation laws.** Rather than a new law category, the existing `mining_policies` tiers now carry environment-flavored effects: stricter protections slow construction (`production_speed_buildings_factor`) and fossil plants while boosting renewables, and the extractive tiers do the reverse.

#### Balance

- **Fixes #1535: Currency backing.** Metallic standards now slow inflation: gold, silver, and bi-metal standard ideas apply a negative `inflation_cost_multiplier_modifier` while fiat applies a positive one, and the money-printing cooldown in the economy view scales with the active standard (90/60/45/30 days). The `mining_policies` resource and stability modifiers were also rebalanced.

#### Bug Fixes

- **Fixes #1459: Influence system chain scoping.** The "target other" influence button relied on an unreliable `event_target` set across a scope change. It now routes through a new hidden `influence.7` event that re-establishes `influence_sender`/`influence_target` in the correct scope, and the PER military-supply button's `tag`/`has_political_power` checks were consolidated into one `ROOT` block. A copy-paste leftover that made the "target other" button set the `recently_sent_military_aid` cooldown flag (wrongly locking out the unrelated military aid and supply buttons for 60 days) was also removed.
- **Fixes #1765: Coalition strength not recalculated when content adds members.** Focuses, decisions, and events that added a party with raw `add_to_array = { gov_coalition_array = N }` never refreshed coalition strength or drift. They now call `add_coalition_members_effect`, which dedupes the entry and recalculates strength and drift. Redundant trailing `update_government_coalition_strength`/`set_coalition_drift` calls were stripped from the call sites since the effect (and `recalculate_party`) now handle them internally. Includes a revert of the Afghanistan coalition conversion.
- **Fixes #1772: Romanian monarch reset on elections.** The monarch was being killed and re-rolled on every election. Succession events now record the current monarch in `ROM_current_monarch` (Mihai / Nicholas / Margareta), and `set_leader_ROM` recreates that same monarch across elections instead of cycling leaders.

#### Validation

- **Tribute idea cleanup and validator false positive.** Removed the orphan `tribute_idea_ARC` and renamed `tribute_idea_NOR` to `tribute_idea_NRY` (NOR collides with Norway's country tag). `validate_ideas.py` now recognizes meta-effect references like `idea = tribute_idea_[ROOTTAG]`, so runtime-built tribute ideas are no longer flagged as unused.

### Test plan

**Playthrough A: JAP 2000 (covers #1420)**

Game start, before unpausing:

- [ ] `tag JAP`, open the navy screen, confirm Murasame, Asagiri, Hatsuyuki, and Takatsuki class ships show as screen destroyers (#1420).
- [ ] Confirm Kongo, Tachikaze, Hatakaze, Shirane, and Haruna class ships remain capital destroyers (#1420).

**Playthrough B: any economy nation 2000 (covers #1535, #1576)**

Game start, before unpausing:

- [ ] Open the economic law list, hover each `mining_policies` tier, confirm construction-speed and renewable/fossil energy modifiers scale across the tiers (#1576).

Mid-game checks (advance several in-game weeks first):

- [ ] Adopt a gold/silver/bi-metal standard, confirm `inflation_cost_multiplier_modifier` is negative and the money-printing cooldown lengthens; switch to fiat and confirm the reverse (#1535).

**Playthrough C: PER 2000 (covers #1459)**

- [ ] `tag PER`, open the influence screen on another country, click the "target other" button, confirm the influence event fires against the correct sender and target with no scope error (#1459).
- [ ] After clicking "target other", confirm the military aid and military supply buttons are still available (no false 60-day cooldown) (#1459).
- [ ] Confirm the military-supply button gates correctly on PER having political power (#1459).

**Playthrough D: coalition content (covers #1765)**

- [ ] As any nation, complete a focus or decision that adds a coalition party (e.g. SOV ONF, SER coalition focuses, TUR coalition focuses), confirm the new partner appears and government coalition strength updates immediately (#1765).
- [ ] Re-trigger the same effect, confirm the party is not added twice (#1765).

**Playthrough E: ROM 2000 (covers #1772)**

- [ ] `tag ROM`, install the Western Autocracy monarch path, run through an election, confirm the reigning monarch stays the same (#1772).
- [ ] Fire a succession event (death of the king), confirm the new monarch persists across the next election (#1772).
