### PR TITLE
Bug fix sprint (#1954, #1979, #1908, #1945, #1955, #1752)

### DIFF
--- a/.claude/docs/scripted-gui-patterns.md
+++ b/.claude/docs/scripted-gui-patterns.md
@@ -10,7 +10,7 @@ When a catalog has N similar entries (votes, MIO unlocks, member states), replac
 
 ### Backing array
 
-Holds integer entry IDs (1..N), not tokens. EU votes use the vote ID directly; MIO catalog uses 1..23 mapped to a parallel `global.mio_catalog_all_tokens` master array.
+Holds integer entry IDs (1..N), not tokens. EU votes use the vote ID directly; MIO catalog uses 1..23 mapped to a parallel `global.mio_catalog_all_tokens` master array. Because the IDs are 1-based but `add_to_array` is 0-based, the token array reserves a never-read index-0 slot so `array^v` lines up (otherwise every `^v` lookup is shifted by one — the cause of issue #1955).
 
 ```
 add_to_array = { mio_catalog_visible_array = 1 }

--- a/.claude/docs/tokenization-patterns.md
+++ b/.claude/docs/tokenization-patterns.md
@@ -53,6 +53,8 @@ mio_catalog_entry_prereqs_yes = {
 
 `TRIG` resolves to (e.g.) `GENERIC_krepost_state_defense_bureau_unlock_btn_enabled`, a real scripted trigger name. The engine evaluates that per-MIO trigger and its `custom_trigger_tooltip` lines render with green/red icons.
 
+> **Gotcha — `^v` indexing is 0-based, `v` is 1-based.** The dynamic-list/loop `v` runs 1..N, but `add_to_array` builds the array 0-based, so `array^v` returns entry `v+1` (and `array^N` is out of range → empty token → falls into the `_unlock_btn_enabled = { always = no }` fallback). A scripted trigger can't `set_temp_variable` to decrement `v`, so reserve a never-read index-0 slot at array seeding to make the array 1-based. This was the cause of issue #1955 (catalogue criteria shifted by one).
+
 Reference: `common/scripted_triggers/01_international_triggers.txt:11-24` (`has_support_of_p5` uses meta_trigger with `thname = "[?FROM.GetTag]"`).
 
 ### Why this matters for tooltips
@@ -93,8 +95,10 @@ For meta substitution to interpolate cleanly, target trigger/effect names must b
 ## End-to-end example — MIO Unlock Catalog
 
 ```
-# 1. Master array seeded at startup
-add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_krepost_state_defense_bureau }
+# 1. Master array seeded at startup. add_to_array is 0-based, but `v` is 1-based — reserve a
+#    never-read index-0 slot so real entries sit at 1..23 and `^v` lines up. See gotcha below.
+add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_krepost_state_defense_bureau } # index 0 — reserved
+add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_krepost_state_defense_bureau } # index 1
 # ...22 more
 
 # 2. Per-entity trigger named after the token

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -859,6 +859,7 @@ v2.0.0
   - [HOL] Reworked most ideas into a dynamic modifier
   - [HOL] Added hiding of obsolete paths in the Dutch focus tree
   - Standardized corruption idea names to a corruption_level_01 through corruption_level_10
+  - [ENG] Fixed Royal Navy ship naming lists: removed duplicate HMS prefixes on carrier and frigate names, corrected the Royal Fleet Auxiliary prefix to RFA, fixed the Astute-class pennant numbers (Achilles is now S125), and replaced ahistorical fictional carrier and helicopter-carrier names with historical ones (Issue #1908)
 
  Factions:
   - Added a new faction goal "Establish an Airborne Corps"

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -267,6 +267,7 @@ v2.0.0
   - [HOL] Reworked the Dutch doctrine system to be adaptive, with penalties and rewards
 
  Bugfix:
+  - [KAZ] Fixed the "Trade with United Kingdom" focus firing a UK-domestic event ("Connections Between The Two?") for Kazakhstan; the misplaced event call was removed and the focus keeps its investment and UK-influence rewards (Issue #1752)
   - Fixed automated intelligence-agency upgrades (ON / Queue Only) stalling permanently after a manually started upgrade completes, which also left the player unable to start any further manual upgrades; a weekly safety pulse now resumes the queue once the block clears (Issue #1945)
   - [HOL] Fixed "The Belgium Problem" focus appearing to do nothing: the proposal event to France fired with no delay so AI France auto-resolved it instantly and invisibly. The event now fires with a one-day delay, the focus shows accept/reject outcome tooltips, and France accepting now sends the Dutch player a confirmation event (Issue #1979)
   - [HOL] Fixed the agriculture agreement with Sri Lanka decision never sending its proposal; the event was in a dead remove_effect with no timer, now fires on completion (Issue #1651)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -940,6 +940,7 @@ v2.0.0
   - Added 90 completely missing descriptions for focuses that had no _desc entries
   - Fixed the tooltips for the Bulgarian Energy Companies focuses showing that they are giving a debuff when they're giving a bonus
   - Introduced more flavorful text for the satellite access diplomatic actions
+  - [FRA/HOL/GER] Added the historical year to MIO company merger/takeover tooltips (Arquus, KNDS, Airbus Helicopters, Naval Group, GKN/Fokker, Rheinmetall/Stork, Helsing), and corrected the Nexter merger partner to KMW (Issue #1954)
   - Removed the weird gap in additional income or additional expenses that came from the market contracts
   - Fixed a number of missing additional income and additional expenses that were missing from the tooltips so you can actually see those bonuses
   - Rewrote all Conditional Peace Deal tooltips to match the MD diplomatic-action style with detailed mechanical descriptions for each deal term

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -267,6 +267,7 @@ v2.0.0
   - [HOL] Reworked the Dutch doctrine system to be adaptive, with penalties and rewards
 
  Bugfix:
+  - [HOL] Fixed "The Belgium Problem" focus appearing to do nothing: the proposal event to France fired with no delay so AI France auto-resolved it instantly and invisibly. The event now fires with a one-day delay, the focus shows accept/reject outcome tooltips, and France accepting now sends the Dutch player a confirmation event (Issue #1979)
   - [HOL] Fixed the agriculture agreement with Sri Lanka decision never sending its proposal; the event was in a dead remove_effect with no timer, now fires on completion (Issue #1651)
   - [AFG] Fixed Pashtunistan border-war reports naming Afghanistan as its own enemy; the advance decisions now save the target state's owner as the defender instead of FROM (which resolved to Afghanistan), and fixed the Taliban/Afghan border-raid decisions soft-locking the whole subsystem after one raid because the AFG_doing_border_raid mutex was never cleared. Also removed a leftover debug decision and added the missing border-raid decision names (Issue #1629)
   - [BOT] Fixed two Botswana flags being checked but never set: the death of Gomolemo Motswaledi now sets BOT_Motswaledi_dead so the BMD leader rotation advances to Kedikilwe, and the UDC formation/split events now set and clear BCP_joined_UDC so the BCP popularity boost resolves correctly (Issue #1632)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -267,6 +267,7 @@ v2.0.0
   - [HOL] Reworked the Dutch doctrine system to be adaptive, with penalties and rewards
 
  Bugfix:
+  - Fixed automated intelligence-agency upgrades (ON / Queue Only) stalling permanently after a manually started upgrade completes, which also left the player unable to start any further manual upgrades; a weekly safety pulse now resumes the queue once the block clears (Issue #1945)
   - [HOL] Fixed "The Belgium Problem" focus appearing to do nothing: the proposal event to France fired with no delay so AI France auto-resolved it instantly and invisibly. The event now fires with a one-day delay, the focus shows accept/reject outcome tooltips, and France accepting now sends the Dutch player a confirmation event (Issue #1979)
   - [HOL] Fixed the agriculture agreement with Sri Lanka decision never sending its proposal; the event was in a dead remove_effect with no timer, now fires on completion (Issue #1651)
   - [AFG] Fixed Pashtunistan border-war reports naming Afghanistan as its own enemy; the advance decisions now save the target state's owner as the defender instead of FROM (which resolved to Afghanistan), and fixed the Taliban/Afghan border-raid decisions soft-locking the whole subsystem after one raid because the AFG_doing_border_raid mutex was never cleared. Also removed a leftover debug decision and added the missing border-raid decision names (Issue #1629)

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1100,3 +1100,4 @@ v2.0.0
   - Reduced precision in several menus so you do not see 5 decimal points in areas where it does not matter
   - Fixed the user interface for the politics screen when you are a subject and the faction screen overlaps the menu
   - Fixed the "View Factions" button missing when you were in a faction
+  - Fixed MIO Unlock Catalogue requirements being shifted by one entry, leaving Central Heavy Atomics & Power with no criteria and unlockable only via console (Issue #1955)

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -26592,8 +26592,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_belgium_problem"
-			FRA = {
-				country_event = HOL_politics.22
+			FRA = { country_event = { id = HOL_politics.22 days = 1 } }
+			custom_effect_tooltip = TT_IF_THEY_ACCEPT
+			effect_tooltip = {
+				BEL = { country_event = HOL_politics.23 }
+			}
+			custom_effect_tooltip = TT_IF_THEY_REJECT
+			effect_tooltip = {
+				HOL = { country_event = HOL_politics.24 }
 			}
 		}
 

--- a/common/national_focus/centralasia.txt
+++ b/common/national_focus/centralasia.txt
@@ -5342,9 +5342,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_TRADE FOCUS_FILTER_INFLUENCE FOCUS_FILTER_FOREIGN_POLICY FOCUS_FILTER_FOREIGN_INVESTMENTS }
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CES_trade_with_united_kingdom executed"
-			# ROOT = {
-			# 	country_event = britain_md.8
-			# }
 			set_temp_variable = { int_investment_change = 1 }
 			modify_international_investment_effect = yes
 			set_temp_variable = { percent_change = 1 }

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -113,6 +113,8 @@ on_actions = {
 				}
 			}
 
+			MD_auto_agency_weekly_tick = yes
+
 			# Arab Spring
 			if = { limit = { has_country_flag = arab_spring_active }
 				if = {

--- a/common/scripted_effects/00_MD_auto_agency_scripted_effects.txt
+++ b/common/scripted_effects/00_MD_auto_agency_scripted_effects.txt
@@ -274,3 +274,18 @@ MD_auto_agency_begin_if_possible = {
 		MD_auto_agency_mark_dirty = yes
 	}
 }
+
+# Weekly safety pulse: resume ON / Queue-Only automation after a transient block
+# clears (e.g. a native manual upgrade finishing) since nothing else re-fires the
+# event chain. Player-only and gated on lazy-init so AI nations are never touched.
+MD_auto_agency_weekly_tick = {
+	if = {
+		limit = {
+			is_ai = no
+			has_variable = automate_agency_upgrades_choice
+			check_variable = { automate_agency_upgrades_choice > 1 }
+		}
+		MD_auto_agency_reconcile_state = yes
+		MD_auto_agency_begin_if_possible = yes
+	}
+}

--- a/common/scripted_effects/00_startup_effects.txt
+++ b/common/scripted_effects/00_startup_effects.txt
@@ -809,9 +809,11 @@ setup_global_arrays = {
 	set_variable = { GLOBAL.gdp_c_slot^5 = 50.000 }
 	set_variable = { GLOBAL.gdp_c_slot^6 = 60.000 }
 
-	# MIO Unlock Catalog — master token array, indexed 1..23.
-	# Order is load-bearing: dynamic_lists `v`, scripted_loc dispatchers, and the unlock-cost
-	# cascade all key off this order. Adding a MIO = append a token here + new branches downstream.
+	# MIO Unlock Catalog — master token array. Index 0 is a reserved, never-read slot so the real
+	# entries sit at indices 1..23, matching the 1-based `v` every dispatcher uses (scripted_loc,
+	# unlock cascade, and the `^v` meta substitutions). HOI4 add_to_array is 0-based; do not remove
+	# the reserved slot. Order is load-bearing: adding a MIO = append a token here + new branches downstream.
+	add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_krepost_state_defense_bureau } # index 0 — reserved, unread
 	add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_krepost_state_defense_bureau }
 	add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_north_plains_heavy_industries }
 	add_to_array = { global.mio_catalog_all_tokens = token:GENERIC_sentinel_grid_networks }

--- a/common/units/names_ships/ENG_ship_names.txt
+++ b/common/units/names_ships/ENG_ship_names.txt
@@ -18,8 +18,8 @@ ENG_CV_HISTORICAL = {
 
 		"Queen Elizabeth (R08)" "Prince of Wales (R09)"
 		### Fictional
-		"HMS Duke of Edinburgh (R10)" "HMS Duke of Cambridge (R11)"
-		"Ark Royal" "Illustrious" "Formidable" "Victorious" "Implacable" "Indefatigable" "Audacious" "Eagle" "Europa" "Andromeda" "Centaur" "Albion" "Bulwark" "Elephant" "Leviathan" "Arrogant" "Monmouth" "Polyphemus"
+		"Argus (R10)" "Eagle (R11)"
+		"Ark Royal" "Illustrious" "Formidable" "Victorious" "Implacable" "Indefatigable" "Audacious" "Europa" "Andromeda" "Centaur" "Albion" "Bulwark" "Elephant" "Leviathan" "Arrogant" "Monmouth" "Polyphemus"
 	}
 }
 
@@ -42,9 +42,9 @@ ENG_LHA_HISTORICAL = {
 
 		"Albion (L14)" "Bulwark (L15)"
 		### Fictional
-		"Bastion (L16)" "Rampart (L17)"
+		"Ocean (L16)" "Colossus (L17)"
 		# CVL Names
-		"Unicorn" "Colossus" "Venerable" "Vengeance" "Glory" "Pioneer" "Ocean" "Perseus" "Theseus" "Triumph" "Warrior" "Magnificent" "Powerful" "Terrible" "Majestic" "Hercules" "Leviathan"  "Argus" "Hermes" "Centaur" "Albion" "Bulwark" "Elephant" "Arrogant" "Monmouth" "Polyphemus" "Europa" "Andromeda" "Prince of Wales" "Duke of York" "Anson" "Howe" "Jellicoe" "Beatty" "Lion" "Temeraire" "Conqueror" "Thunderer" "Vanguard" "Agincourt" "Resistance" "Bellerophon" "Superb" "St Vincent" "Collingwood" "Neptune" "Colossus" "Hercules" "Orion" "Monarch" "Centurion" "Audacious" "Ajax" "Erin" "Iron Duke" "Marlborough" "Benbow" "Warspite" "Valiant" "Barham" "Malaya" "Revenge" "Resolution" "Royal Oak" "Royal Sovereign" "Ramillies" "Renown" "Repulse" "Nelson" "Incomparable" "Invincible" "Inflexible" "Indomitable" "Indefatigable" "Princess Royal" "Queen Mary" "Tiger" "Courageous" "Glorious" "Furious" "Hood" "Rodney"
+		"Unicorn" "Venerable" "Vengeance" "Glory" "Pioneer" "Perseus" "Theseus" "Triumph" "Warrior" "Magnificent" "Powerful" "Terrible" "Majestic" "Hercules" "Leviathan"  "Argus" "Hermes" "Centaur" "Albion" "Bulwark" "Elephant" "Arrogant" "Monmouth" "Polyphemus" "Europa" "Andromeda" "Prince of Wales" "Duke of York" "Anson" "Howe" "Jellicoe" "Beatty" "Lion" "Temeraire" "Conqueror" "Thunderer" "Vanguard" "Agincourt" "Resistance" "Bellerophon" "Superb" "St Vincent" "Collingwood" "Neptune" "Hercules" "Orion" "Monarch" "Centurion" "Audacious" "Ajax" "Erin" "Iron Duke" "Marlborough" "Benbow" "Warspite" "Valiant" "Barham" "Malaya" "Revenge" "Resolution" "Royal Oak" "Royal Sovereign" "Ramillies" "Renown" "Repulse" "Nelson" "Incomparable" "Invincible" "Inflexible" "Indomitable" "Indefatigable" "Princess Royal" "Queen Mary" "Tiger" "Courageous" "Glorious" "Furious" "Hood" "Rodney"
 	}
 }
 
@@ -124,7 +124,7 @@ ENG_FRIGATE_HISTORICAL = {
 		# Type 26
 		"Glasgow (F88)" "Cardiff (F89)" "Belfast (F90)" "Birmingham (F91)" "Sheffield (F92)" "Newcastle (F93)" "Edinburgh (F94)" "London (F95)"
 		### Fictional
-		"HMS Manchester (F96)" "HMS Liverpool (F97)" "HMS Leeds (F98)" "HMS Bristol (F99)"
+		"Manchester (F96)" "Liverpool (F97)" "Leeds (F98)" "Bristol (F99)"
 		# Type 31
 		"Venturer (F12)" "Active (F08)" "Formidable (F11)" "Bulldog (F09)" "Campbeltown (F10)"
 		### Fictional
@@ -203,9 +203,9 @@ ENG_SS_HISTORICAL = {
 
 	unique = {
 
-		"Astute (S119)" "Ambush (S120)" "Artful (S121)" "Audacious (S122)" "Anson (S123)" "Agamemnon (S124)" "Agincourt (S125)"
+		"Astute (S119)" "Ambush (S120)" "Artful (S121)" "Audacious (S122)" "Anson (S123)" "Agamemnon (S124)" "Achilles (S125)"
 		### Fictional
-		"Archer (S126)" "Ardent (S127)" "Achilles (S128)"
+		"Agincourt (S126)" "Ardent (S127)" "Archer (S128)"
 		# S-class ships
 		"Swordfish" "Sturgeon" "Seahorse" "Starfish" "Thames" "Severn" "Clyde" "Sealion" "Shark" "Snapper" "Salmon" "Seawolf" "Spearfish" "Sunfish" "Sterlet" "Porpoise" "Grampus" "Narwhal" "Rorqual" "Cachalot" "Seal" "Triton" "Thetis" "Tribune" "Trident" "Triumph" "Undine" "Unity" "Ursula" "Umpire" "Una" "Unbeaten" "Undaunted" "Union" "Unique" "Upholder" "Upright" "Urchin" "Urge" "Usk" "Utmost" "Taku" "Tarpon" "Thistle" "Tigris" "Triad" "Truant" "Tuna" "Talisman" "Tetrarch" "Torbay" "Tempest" "Thorn" "Thrasher" "Traveller" "Trooper" "Trusty" "Turbulent" "Uproar" "Ultimatum" "Umbra" "Unbending" "Safari" "Sahib" "Saracen" "Satyr" "Sceptre" "Seadog" "Sibyl" "Sea Rover" "Seraph" "Shakespeare" "Sea Nymph" "Sickle" "Simoom" "Sirdar" "Spiteful" "Splendid" "Sportsman" "Unbroken" "Unison" "United" "Unrivalled" "Unruffled" "Unruly" "Unseen" "Ultor" "Unshaken" "P311" "Trespasser" "Tactician" "Truculent" "Templar" "Tally-Ho" "Tantalus" "Tantivy" "Stoic" "Stonehenge" "Storm" "Stratagem" "Strongbow" "Spark" "Scythian" "Stubborn" "Surf" "Syrtis" "Shalimar" "Scotsman" "Sea Devil" "Spirit" "Statesman" "Unsparing" "Usurper" "Universal" "Untamed" "Untiring" "Varangian" "Uther" "Unswerving" "Vandal" "Upstart" "Varne" "Vox" "Sturdy" "Stygian" "Subtle" "Supreme" "Sea Scout" "Selene" "Seneschal" "Sentinel" "Sidon" "Sleuth" "Solent" "Spearhead" "Venturer" "Viking" "Vampire" "Vox" "Vigorous" "Virtue" "Visigoth" "Vivid" "Voracious" "Vulpine" "Varne" "Upshot" "Urtica" "Vengeful" "Vortex" "Virulent" "Volatile"
 	}
@@ -373,7 +373,7 @@ ENG_RFA = {
 
 	type = ship
 
-	prefix = "HMS "
+	prefix = "RFA "
 
 	unique = {
 		"Tiderace" "Tidespring" "Tidesurge" "Tideforce" "Wave Ruler" "Wave Knight" "Fort Victoria" "Fort Rosalie" "Fort Austin" "Lyme Bay" "Mounts Bay" "Cardigan Bay"

--- a/events/05_netherlands.txt
+++ b/events/05_netherlands.txt
@@ -5578,6 +5578,7 @@ country_event = {
 		name = HOL_politics.22.a
 		log = "[GetDateText]: [This.GetName]: HOL_politics.22.a executed"
 		BEL = { country_event = HOL_politics.23 }
+		HOL = { country_event = HOL_politics.85 }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -13278,5 +13279,17 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: HOL_politics.84.b executed"
 		add_opinion_modifier = { target = ISR modifier = Dutch_Israelian_Support }
 		ai_chance = { base = 40 }
+	}
+}
+country_event = {
+	id = HOL_politics.85
+	title = HOL_politics.85.t
+	desc = HOL_politics.85.d
+	picture = GFX_hol_french_dutch_flag_event_picture
+	is_triggered_only = yes
+
+	option = {
+		name = HOL_politics.85.a
+		log = "[GetDateText]: [This.GetName]: HOL_politics.85.a executed"
 	}
 }

--- a/localisation/english/MD_focus_FRA_l_english.yml
+++ b/localisation/english/MD_focus_FRA_l_english.yml
@@ -603,14 +603,16 @@
  france_md.506.d: "Volvo Group's defence subsidiaries — Renault Trucks Defense and Panhard General Defense — have completed their merger into a single entity. The new firm, Arquus, unites Renault's wheeled mobility platforms with Panhard's reconnaissance heritage and positions France as a unified contender in the European armoured vehicle market. Combined production knowledge, programmes, and modifiers from both legacy firms transfer into the new organisation."
  france_md.506.a: "A new chapter for French armoured mobility"
  france_md.506_tt: "Renault and Panhard will be merged into Arquus"
- FRA_arguus_established: "Renault and Panhard have been merged into Arquus"
+ FRA_arguus_established: "Renault and Panhard have been merged into Arquus in 2018"
  france_md.507.t: "Eurocopter Becomes Airbus Helicopters"
  france_md.507.d: "Effective today, the Eurocopter Group is rebranded as Airbus Helicopters, consolidating the EADS rotorcraft business under the unified Airbus identity. The Marignane works, Donauwörth plant, and Aérospatiale heritage lines now operate under one banner."
  france_md.507.a: "A new chapter for European rotorcraft."
+ FRA_airbus_change: "Eurocopter has been rebranded as Airbus Helicopters in 2014"
  TT_FRA_airbus_change_carry_traits: "§YAll traits already completed at §Y$FRA_eurocopter_manufacturer$§! will carry over to $FRA_airbus_manufacturer$§!"
  france_md.508.t: "DCNS Becomes Naval Group"
  france_md.508.d: "Effective today, the historic state arsenal Direction des Constructions Navales — long since rebranded DCNS — adopts the new identity Naval Group, marking its transformation into a full private corporation. The Lorient, Cherbourg, and Brest yards now operate under one banner, alongside the Naviris joint venture with Fincantieri and a renewed export drive built around the Suffren-class submarine and the FDI Belharra frigate."
  france_md.508.a: "A new chapter for French shipbuilding."
+ FRA_naval_takeover: "DCNS has been rebranded as Naval Group in 2017"
  TT_FRA_naval_takeover_carry_traits: "§YAll traits already completed at $FRA_dcn_manufacturer$ will carry over to $FRA_naval_group_naval_manufacturer$§!"
 
  # French Decision Categories
@@ -815,7 +817,7 @@
 
  ### MIO
  FRA_nexter_manufacturer: "GIAT Industries"
- FRA_nexter_merge: "Nexter has been Merged with KDW"
+ FRA_nexter_merge: "Nexter has been merged with KMW in 2015"
  FRA_nexter_cold_war_legacy: "Cold War Legacy"
  FRA_nexter_scorpion_programme: "Scorpion Programme"
  FRA_nexter_firepower_ammo: "Firepower & Ammunition"

--- a/localisation/english/MD_focus_GER_l_english.yml
+++ b/localisation/english/MD_focus_GER_l_english.yml
@@ -4665,7 +4665,7 @@
  GER_Rejected_mutual_project: "Reject cooperation"
 
  #Country Flags
- ger_helsing_se_founded: "§YHelsing SE§! has been founded"
+ ger_helsing_se_founded: "§YHelsing SE§! has been founded in 2021"
 
  GER_panavia.1.t: "Reactivating Tornado Production?"
  GER_panavia.1.d: "Though the original Tornado production line was shut down in 1998, the changing strategic landscape has reignited interest in the aircraft. With evolving mission profiles, rising operational demands, and growing doubts about newer platforms' timelines, a proposal has emerged to restart Tornado production.\n\nSupporters argue that a reactivated line could modernize the design with new avionics and weapons, offering an interim solution with known reliability. Critics warn that reviving a decades-old airframe could drain resources from more future-proof systems."

--- a/localisation/english/MD_focus_HOL_l_english.yml
+++ b/localisation/english/MD_focus_HOL_l_english.yml
@@ -4186,3 +4186,6 @@
  HOL_politics.84.d: "A fierce friend of Israel, Wilders urges the government to recognise Jerusalem and move the Dutch embassy there. Washington would applaud, but capitals across the region warn of consequences."
  HOL_politics.84.a: "Move the embassy to Jerusalem"
  HOL_politics.84.b: "Keep the embassy in Tel Aviv"
+ HOL_politics.85.t: "France Joins the Partition"
+ HOL_politics.85.d: "Paris has accepted our proposal and will press Belgium for a referendum on its future. The groundwork for the partition is laid. We can now drive the matter forward through our Belgium decisions."
+ HOL_politics.85.a: "Excellent."

--- a/localisation/english/MD_focus_HOL_l_english.yml
+++ b/localisation/english/MD_focus_HOL_l_english.yml
@@ -3932,8 +3932,8 @@
  HOL_germany_rejected_brotherhood: "§Y[GER.GetNameWithFlag]§! rejected the formation of a Germanic Brotherhood"
  HOL_austria_rejected_brotherhood: "§Y[AUS.GetNameWithFlag]§! rejected the formation of a Germanic Brotherhood"
  hol_stork_independant: "§YStork is a [HOL.GetFlag]§Y[HOL.GetAdjectiveCap]§! company§!"
- Rheinmetall_Takeover_Allowed: "Rheinmetall is active in §Y[HOL.GetNameWithFlag]§!"
- HOL_gkn_aerospace_unlocked: "§YGKN Aerospace§! has taken over Fokker Technologies"
+ Rheinmetall_Takeover_Allowed: "Rheinmetall is active in §Y[HOL.GetNameWithFlag]§! since 2008"
+ HOL_gkn_aerospace_unlocked: "§YGKN Aerospace§! has taken over Fokker Technologies in 2015"
  HOL_antilles_investment_active: "§YActive Development in the Antills§!"
  ######## Opinion modifiers
  Dutch_Israelian_Support: "[HOL.GetAdjectiveCap]-[ISR.GetAdjectiveCap] Support"


### PR DESCRIPTION
Closes #1954
Closes #1979
Closes #1908
Closes #1945
Closes #1955
Closes #1752

### Summary

#### Bug Fixes

- **Fixes #1979: "The Belgium Problem" focus doesn't trigger France event.** The Dutch focus `HOL_belgium_problem` fired `HOL_politics.22` to France with no delay, so AI France auto-resolved the proposal the same tick and the player never saw it. The event now fires with `days = 1`, the focus shows `TT_IF_THEY_ACCEPT`/`TT_IF_THEY_REJECT` outcome tooltips, and France accepting sends the Dutch player a new confirmation event (`HOL_politics.85`).
- **Fixes #1908: Royal Navy naming list errors.** Several `ENG` ship names already carried the `HMS` prefix while every list also sets `prefix = "HMS "`, rendering as `HMS HMS ...`; the Royal Fleet Auxiliary list used `HMS` instead of `RFA`, and the Astute-class pennant numbers were off. Stripped the redundant prefixes on the carrier and frigate names, set the RFA list to `RFA `, corrected `Achilles` to `S125`, and replaced the ahistorical fictional carrier/helicopter-carrier names (`Duke of Edinburgh`/`Duke of Cambridge`, `Bastion`/`Rampart`) with historical ones (`Argus`/`Eagle`, `Ocean`/`Colossus`). The focus-tree redesign suggestions from the original report were split out to #1986.
- **Fixes #1945: Automated intel-agency upgrades stall after a manual upgrade completes.** The auto-agency queue is only advanced by GUI clicks, the `md_auto_agency.1` event, and its own mission completion, so a native manual upgrade finishing never re-fired the chain, leaving ON / Queue-Only automation idle forever and the non-empty queue blocking all manual upgrades. A new player-only weekly pulse (`MD_auto_agency_weekly_tick`) re-runs `MD_auto_agency_reconcile_state` + `MD_auto_agency_begin_if_possible` so the queue resumes within a week once the block clears.
- **Fixes #1955: MIO Catalogue unlock criteria misaligned and unlock button non-functional.** The catalogue keys every per-entry dispatcher off the 1-based list variable `v`, but `global.mio_catalog_all_tokens` is built with `add_to_array` and is therefore 0-based, so the two `^v` meta substitutions read entry `v+1`: every displayed requirement was shifted by one, Central Heavy Atomics & Power had no criteria and was unlockable only via console, and unlocking any entry granted the wrong organisation. Reserved a never-read index-0 slot so the real entries sit at indices 1..23 and `^v` resolves correctly.
- **Fixes #1752: Kazakhstan triggers a UK focus tree event.** The Kazakhstan focus `CES_trade_with_united_kingdom` fired the UK-domestic event `britain_md.8` ("Connections Between The Two?") to ROOT, so a UK migration/crime debate displayed for Kazakhstan and set `ENG_` variables uselessly on its scope. Removed the misplaced (already commented-out) event call; the focus keeps its international-investment and UK-influence rewards.

#### Localisation

- **Fixes #1954: Change MIO country flag tooltips.** The `country_flag` availability tooltips on French, Dutch, and German MIO company mergers/takeovers named the event but never said when it happened. Appended the verified historical year to each so players know the takeover date.

### Test plan

**Playthrough A: FRA 2000 (covers #1954)**

- [ ] `tag FRA`, open the MIO production list at game start, confirm the GIAT/Nexter, DCN, Eurocopter, and Renault-Panhard MIO tooltips read with no year yet (legacy entries visible).
- [ ] Complete the Nexter, Naval Group, Airbus, and Arquus merger focuses/events, confirm the successor MIO tooltips now read "merged with KMW in 2015", "rebranded as Naval Group in 2017", "rebranded as Airbus Helicopters in 2014", and "merged into Arquus in 2018".

**Playthrough B: HOL 2000 (covers #1954)**

- [ ] `tag HOL`, take the Rheinmetall takeover path, confirm the Rheinmetall MIO availability tooltip reads "Rheinmetall is active in the Netherlands since 2008".
- [ ] Trigger the GKN/Fokker takeover, confirm the GKN Aerospace MIO tooltip reads "GKN Aerospace has taken over Fokker Technologies in 2015".

**Playthrough C: GER 2000 (covers #1954)**

- [ ] `tag GER`, found Helsing SE, confirm the Helsing MIO tooltip reads "Helsing SE has been founded in 2021".

**Playthrough D: HOL 2008 (covers #1979)**

- [ ] `tag HOL`, take and complete `HOL_belgium_problem`, confirm the focus tooltip now previews the accept and reject outcomes.
- [ ] Immediately after completion, `tag FRA` and confirm the "A Proposal from the Netherlands" event (`HOL_politics.22`) is queued in France's event list.
- [ ] Let France accept, confirm the Netherlands receives the "France Joins the Partition" confirmation event (`HOL_politics.85`); have France reject, confirm the Netherlands still receives `HOL_politics.24`.

**Playthrough E: ENG 2000 (covers #1908)**

- [ ] `tag ENG`, queue a carrier, confirm the fictional names read `HMS Argus (R10)` / `HMS Eagle (R11)` with a single prefix.
- [ ] Queue a helicopter carrier, confirm fictional names read `HMS Ocean (L16)` / `HMS Colossus (L17)`.
- [ ] Queue a Type 26/31/32 frigate, confirm `HMS Manchester (F96)` etc. show a single prefix.
- [ ] Queue an attack submarine, confirm the seventh boat is `HMS Achilles (S125)` and the fictional boats are `HMS Agincourt (S126)` / `HMS Ardent (S127)` / `HMS Archer (S128)`.
- [ ] Queue an RFA vessel, confirm names read `RFA Tiderace`, `RFA Wave Ruler`, etc.

**Playthrough F: any nation with an intelligence agency (covers #1945)**

- [ ] Open the auto-agency queue tab to lazy-init the system, set automation OFF, then start a native intel-agency upgrade manually.
- [ ] Switch to Queue Only (or ON) and queue several upgrades while the native upgrade is still in progress, confirm nothing starts yet.
- [ ] Let the native upgrade finish, confirm that within one weekly tick the `spy_agency_upgrade_in_progress` mission activates and the queue begins draining.
- [ ] After the queue empties in Queue Only mode, confirm native manual upgrades become available again; with automation OFF, confirm the weekly tick never starts an upgrade.

**Playthrough G: any nation (covers #1955)**

- [ ] `tag` any nation, open Production then the MIO catalogue, confirm each entry's requirement tooltip matches its own name (Halland Civic Engineering Group requires industrial conglomerates/factories, Second Academy Missile Bureau requires GLCM + ICBM/IRBM, Central Heavy Atomics & Power requires a reactor + submarine hull).
- [ ] Toggle "Available Only", confirm every listed entry's unlock button is enabled once 50 PP and its prereqs are met, and clicking it unlocks that same MIO.
- [ ] Confirm Central Heavy Atomics & Power now shows real criteria and unlocks without a console command.

**Playthrough H: KAZ 2000 (covers #1752)**

- [ ] `tag KAZ`, complete `CES_trade_with_united_kingdom`, confirm no "Connections Between The Two?" event fires for Kazakhstan and the international-investment and UK-influence rewards still apply.
