### PR TITLE
Simplify update_neighbors_effects (#1809)

### DIFF
--- a/common/scripted_effects/99_neigbour_system_effects.txt
+++ b/common/scripted_effects/99_neigbour_system_effects.txt
@@ -1,14 +1,12 @@
 # Author(s): Angriest Bird
 update_neighbors_effects = {
-	# Unstable Neighbour Effects
-	set_temp_variable = { unstable_neighbor_count = 0 }
-
-	# Ideology Neighbour Drifts
-	set_temp_variable = { salafist_neighbor_count = 0 }
-	set_temp_variable = { democratic_neighbor_count = 0 }
-	set_temp_variable = { nationalist_neighbor_count = 0 }
-	set_temp_variable = { neutrality_neighbor_count = 0 }
-	set_temp_variable = { communism_neighbor_count = 0 }
+	# Reset neighbor-effect accumulators (read by neighbor_effect_modifiers)
+	set_variable = { stability_factor_neighbor_var = 0 }
+	set_variable = { democratic_drift_neighbor_var = 0 }
+	set_variable = { neutrality_drift_neighbor_var = 0 }
+	set_variable = { nationalist_drift_neighbor_var = 0 }
+	set_variable = { communism_drift_neighbor_var = 0 }
+	set_variable = { fascism_drift_neighbor_var = 0 }
 
 	for_each_scope_loop = {
 		array = neighbors
@@ -21,7 +19,7 @@ update_neighbors_effects = {
 					has_civil_war = yes
 				}
 			}
-			add_to_temp_variable = { PREV.unstable_neighbor_count = 1 }
+			add_to_variable = { PREV.stability_factor_neighbor_var = 1 }
 		}
 		# Neighbour Ideology Drift (major nations count double)
 		set_temp_variable = { weight = 1 }
@@ -30,47 +28,32 @@ update_neighbors_effects = {
 		}
 
 		if = { limit = { has_government = democratic }
-			add_to_temp_variable = { PREV.democratic_neighbor_count = weight }
+			add_to_variable = { PREV.democratic_drift_neighbor_var = weight }
 		}
 		else_if = { limit = { has_government = neutrality }
-			add_to_temp_variable = { PREV.neutrality_neighbor_count = weight }
+			add_to_variable = { PREV.neutrality_drift_neighbor_var = weight }
 		}
 		else_if = { limit = { has_government = nationalist }
-			add_to_temp_variable = { PREV.nationalist_neighbor_count = weight }
+			add_to_variable = { PREV.nationalist_drift_neighbor_var = weight }
 		}
 		else_if = { limit = { has_government = communism }
-			add_to_temp_variable = { PREV.communism_neighbor_count = weight }
+			add_to_variable = { PREV.communism_drift_neighbor_var = weight }
 		}
 		else_if = { limit = { has_government = fascism }
-			add_to_temp_variable = { PREV.salafist_neighbor_count = weight }
+			add_to_variable = { PREV.fascism_drift_neighbor_var = weight }
 		}
 	}
+
+	# Scale counts into modifier magnitudes and clamp
+	set_variable = { stability_factor_neighbor_var = { value = stability_factor_neighbor_var multiply = -0.01 clamp = { min = -0.15 max = 0 } } }
+	set_variable = { democratic_drift_neighbor_var = { value = democratic_drift_neighbor_var multiply = 0.01 clamp = { min = 0 max = 0.15 } } }
+	set_variable = { neutrality_drift_neighbor_var = { value = neutrality_drift_neighbor_var multiply = 0.01 clamp = { min = 0 max = 0.15 } } }
+	set_variable = { nationalist_drift_neighbor_var = { value = nationalist_drift_neighbor_var multiply = 0.01 clamp = { min = 0 max = 0.15 } } }
+	set_variable = { communism_drift_neighbor_var = { value = communism_drift_neighbor_var multiply = 0.01 clamp = { min = 0 max = 0.15 } } }
+	set_variable = { fascism_drift_neighbor_var = { value = fascism_drift_neighbor_var multiply = 0.01 clamp = { min = 0 max = 0.15 } } }
 
 	# Dynamic Modifier for Neighbor Effects
 	if = { limit = { NOT = { has_dynamic_modifier = { modifier = neighbor_effect_modifiers } } }
 		add_dynamic_modifier = { modifier = neighbor_effect_modifiers }
 	}
-
-	# Calculate Effects
-	multiply_temp_variable = { unstable_neighbor_count = -0.01 }
-	multiply_temp_variable = { democratic_neighbor_count = 0.01 }
-	multiply_temp_variable = { neutrality_neighbor_count = 0.01 }
-	multiply_temp_variable = { nationalist_neighbor_count = 0.01 }
-	multiply_temp_variable = { communism_neighbor_count = 0.01 }
-	multiply_temp_variable = { salafist_neighbor_count = 0.01 }
-
-	clamp_variable = { var = unstable_neighbor_count min = -0.15 max = 0 }
-	clamp_variable = { var = democratic_neighbor_count min = 0 max = 0.15 }
-	clamp_variable = { var = neutrality_neighbor_count min = 0 max = 0.15 }
-	clamp_variable = { var = nationalist_neighbor_count min = 0 max = 0.15 }
-	clamp_variable = { var = communism_neighbor_count min = 0 max = 0.15 }
-	clamp_variable = { var = salafist_neighbor_count min = 0 max = 0.15 }
-
-	# Set Dynamic Modifier Variables
-	set_variable = { stability_factor_neighbor_var = unstable_neighbor_count }
-	set_variable = { nationalist_drift_neighbor_var = nationalist_neighbor_count }
-	set_variable = { fascism_drift_neighbor_var = salafist_neighbor_count }
-	set_variable = { neutrality_drift_neighbor_var = neutrality_neighbor_count }
-	set_variable = { communism_drift_neighbor_var = communism_neighbor_count }
-	set_variable = { democratic_drift_neighbor_var = democratic_neighbor_count }
 }


### PR DESCRIPTION
Closes #1809.

`update_neighbors_effects` ran every neighbor through six temp counters, scaled and clamped them, then copied each one into the persistent variable the dynamic modifier actually reads. The temp layer bought nothing, since those persistent vars have to exist anyway.

Now it accumulates straight into the persistent vars and folds each multiply and clamp into a single `set_variable` math expression. Same results, fewer operations on a monthly hot path that runs for every country.