### PR TITLE
Validation for Influence Percentage

### DIFF
--- a/common/decisions/05_ENG_decisions.txt
+++ b/common/decisions/05_ENG_decisions.txt
@@ -1678,18 +1678,10 @@ ENG_monarchy_decision_category = {
 				}
 				country_event = ENG_inner_circle_charles.03
 				effect_tooltip = {
-					THIS = {
-						add_opinion_modifier = {
-							target = ENG
-							modifier = ENG_charles_harmony
-						}
-						reverse_add_opinion_modifier = {
-							target = THIS
-							modifier = ENG_charles_harmony
-						}
-						set_temp_variable = { percent_change = 5 }
-						change_influence_percentage = yes
-					}
+					add_opinion_modifier = { target = ENG modifier = ENG_charles_harmony }
+					reverse_add_opinion_modifier = { target = ENG modifier = ENG_charles_harmony }
+					set_temp_variable = { percent_change = 5 }
+					change_influence_percentage = yes
 				}
 			}
 		}

--- a/common/defines/MD_defines.lua
+++ b/common/defines/MD_defines.lua
@@ -1140,10 +1140,9 @@
 		200, -- NAVAL INVASION SUPPORT
 	}
 
-	-- NDefines.NAI.MIN_UNITS_FACTOR_FRONT_ORDER = 10.0
-	NDefines.NIndustrialOrganisation.ASSIGN_DESIGN_TEAM_PP_COST_PER_DAY = 0.1					-- 0.1
-	NDefines.NIndustrialOrganisation.ASSIGN_INDUSTRIAL_MANUFACTURER_PP_COST_PER_DAY = 0.1		-- 0
-	NDefines.NIndustrialOrganisation.FUNDS_FOR_SIZE_UP = 800					-- 700
+	NDefines.NIndustrialOrganisation.ASSIGN_DESIGN_TEAM_PP_COST_PER_DAY = 0.05					-- 0.1
+	NDefines.NIndustrialOrganisation.ASSIGN_INDUSTRIAL_MANUFACTURER_PP_COST_PER_DAY = 0.05		-- 0
+	NDefines.NIndustrialOrganisation.FUNDS_FOR_SIZE_UP = 1000					-- 700
 	NDefines.NIndustrialOrganisation.FUNDS_FOR_SIZE_UP_LEVEL_FACTOR = 75 			-- 100
 	NDefines.NIndustrialOrganisation.FUNDS_FOR_SIZE_UP_LEVEL_POW = 1.8			-- 1.8
 	NDefines.NIndustrialOrganisation.UNLOCKED_TRAITS_PER_SIZE_UP = 1			-- 1

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -18954,7 +18954,7 @@ focus_tree = {
 		set_temp_variable = { influence_target = FRA.id }
 		change_influence_percentage = yes
 		set_temp_variable = { percent_change = 6 }
-		set_temp_variable = { influence_target = GBR.id }
+		set_temp_variable = { influence_target = ENG.id }
 		change_influence_percentage = yes
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
@@ -24000,7 +24000,7 @@ focus_tree = {
 			SOV = {
 				set_temp_variable = { percent_change = 1 }
 				change_influence_percentage = yes
-				set_temp_variable = { tag_index = SHI.id }
+				set_temp_variable = { tag_index = CHI.id }
 				change_influence_percentage = yes
 			}
 			set_temp_variable = { percent_change = 1 }

--- a/common/national_focus/05_bolivia.txt
+++ b/common/national_focus/05_bolivia.txt
@@ -8943,42 +8943,51 @@ focus_tree = {
 		relative_position_id = BOL_foreign_policy
 		prerequisite = { focus = BOL_chilean_gas_exports }
 
-		search_filters = { FOCUS_FILTER_POLITICAL }
-
-
+		search_filters = { FOCUS_FILTER_INFLUENCE }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_a_new_day_in_the_americas"
 			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = BRA }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = PRU }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = ARG }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = PAR }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = ECU }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = COL }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = VEN }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = GUY }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = SUR }
-			change_influence_percentage = yes
-			set_temp_variable = { percent_change = 4 }
-			set_temp_variable = { influence_target = URU }
-			change_influence_percentage = yes
+			if = { limit = { country_exists = BRA }
+				set_temp_variable = { influence_target = BRA }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = PRU }
+				set_temp_variable = { influence_target = PRU }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = ARG }
+				set_temp_variable = { influence_target = ARG }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = PAR }
+				set_temp_variable = { influence_target = PAR }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = ECU }
+				set_temp_variable = { influence_target = ECU }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = COL }
+				set_temp_variable = { influence_target = COL }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = VEN }
+				set_temp_variable = { influence_target = VEN }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = GUY }
+				set_temp_variable = { influence_target = GUY }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = SUR }
+				set_temp_variable = { influence_target = SUR }
+				change_influence_percentage = yes
+			}
+			if = { limit = { country_exists = URG }
+				set_temp_variable = { influence_target = URG }
+				change_influence_percentage = yes
+			}
 		}
 
 		ai_will_do = {

--- a/common/national_focus/05_canada.txt
+++ b/common/national_focus/05_canada.txt
@@ -6507,7 +6507,7 @@ focus_tree = {
 			SOV = {
 				set_temp_variable = { percent_change = 1 }
 				change_influence_percentage = yes
-				set_temp_variable = { tag_index = SHI.id }
+				set_temp_variable = { tag_index = CHI.id }
 				change_influence_percentage = yes
 			}
 			set_temp_variable = { percent_change = 1 }

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -17506,7 +17506,7 @@ focus_tree = {
 						tag_index = ISR
 					}
 					set_temp_variable = {
-						influence_target = TAG
+						influence_target = THIS
 					}
 					change_influence_percentage = yes
 					custom_effect_tooltip = decreses_boyc_tt

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -21318,6 +21318,7 @@ focus_tree = {
 				}
 			}
 			set_temp_variable = { percent_change = -1 }
+			set_temp_variable = { tag_index = SOV.id }
 			set_temp_variable = { influence_target = KOR.id }
 			change_influence_percentage = yes
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_expand_business_with_south"
@@ -21559,6 +21560,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = SOV }
 			change_influence_percentage = yes
 			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = SOV }
 			set_temp_variable = { influence_target = TAI }
 			change_influence_percentage = yes
 			TAI = {
@@ -31384,6 +31386,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = SOV }
 			change_influence_percentage = yes
 			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = SOV }
 			set_temp_variable = { influence_target = TAI }
 			change_influence_percentage = yes
 			custom_effect_tooltip = SOV_taiwan_coop_check_tt

--- a/common/national_focus/05_singapore.txt
+++ b/common/national_focus/05_singapore.txt
@@ -3436,6 +3436,7 @@ focus_tree = {
 					}
 					NOT = { original_tag = SIN }
 				}
+				set_temp_variable = { percent_change = 2 }
 				change_influence_percentage = yes
 				add_opinion_modifier = { target = ROOT modifier = declaration_of_friendship }
 			}

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -6192,7 +6192,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = FIN }
 			change_influence_percentage = yes
 			set_temp_variable = { percent_change = 2 }
-			set_temp_variable = { influence_target = ISL }
+			set_temp_variable = { influence_target = ICE }
 			change_influence_percentage = yes
 		}
 

--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -5979,7 +5979,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: british_flavor.2.a executed"
 		set_temp_variable = { percent_change = 1 }
 		set_temp_variable = { tag_index = ENG }
-		set_temp_variable = { influence_target = CHl }
+		set_temp_variable = { influence_target = CHI }
 		change_influence_percentage = yes
 		ai_chance = {
 			base = 1

--- a/events/Libya.txt
+++ b/events/Libya.txt
@@ -5876,6 +5876,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: LibyaRandomEvents.17.c executed"
 		ai_chance = { base = 50 }
 		large_expenditure = yes
+		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = FRA }
 		set_temp_variable = { percent_change = 5 }
 		change_influence_percentage = yes
@@ -6907,7 +6908,7 @@ country_event = {
 			random_country = {
 				limit = {
 					OR = {
-						is_arabic_nation = yes
+						has_country_flag = arabic_nation_flag
 						is_middle_eastern_nation = yes
 					}
 					OR = {
@@ -6933,7 +6934,7 @@ country_event = {
 			random_country = {
 				limit = {
 					OR = {
-						is_arabic_nation = yes
+						has_country_flag = arabic_nation_flag
 						is_middle_eastern_nation = yes
 					}
 					OR = {

--- a/events/Union State.txt
+++ b/events/Union State.txt
@@ -742,6 +742,7 @@ country_event = {
 		name = union_state.27.a
 		log = "[GetDateText]: [This.GetName]: union_state.27.a executed"
 		set_temp_variable = { percent_change = -1 }
+		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
 	}

--- a/tools/validation/disk_cache.py
+++ b/tools/validation/disk_cache.py
@@ -32,8 +32,11 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 # Bump to invalidate every entry after a schema change. v5 replaced the
 # one-pickle-per-entry layout with a single SQLite db; prune_old_versions drops
-# the orphaned v4 tree (100k+ files) on the next suite run.
-CACHE_VERSION = 5
+# the orphaned v4 tree (100k+ files) on the next suite run. v6 invalidated the
+# scripted_params token cache after the 3-tuple → 4-tuple token format change
+# (the cache keys on file content, not validator source, so a format change in
+# the token shape requires a version bump to avoid stale 3-tuple entries).
+CACHE_VERSION = 6
 
 _CACHE_DIR_NAME = ".validation_cache"
 # Records when the cache was created / last cleared (one unix timestamp), so the

--- a/tools/validation/tests/validate_scripted_params_test.py
+++ b/tools/validation/tests/validate_scripted_params_test.py
@@ -1,0 +1,517 @@
+"""Unit tests for validate_scripted_params.
+
+Pins these behaviors for change_influence_percentage:
+  1. tag_index and influence_target stay OPTIONAL (the effect's own
+     fallbacks to ROOT / THIS are reliable defaults and are used by the
+     majority of call sites — the `for_each_scope_loop` pattern depends
+     on influence_target defaulting to THIS).
+  2. When a call site does set BOTH params explicitly, the validator
+     catches the self-influence (Code 5001) bug where they are set to
+     the same value. Setting only one is fine; defaults are reliable.
+  3. An explicit tag_index / influence_target that is not a real country
+     tag or tag alias is flagged as an ERROR (a typo such as GBR for ENG
+     or the mis-cased CHl for CHI). Scope keywords, var: / event_target:
+     refs, array subscripts, numerics, and aliases are accepted.
+"""
+
+import pytest
+import validate_scripted_params as vsp
+from validate_scripted_params import _validate_call_sites_in_file
+
+
+@pytest.fixture
+def cip_contract():
+    """The change_influence_percentage contract as the validator builds it.
+
+    Pinning it here means a future refactor of the hardcoded block that
+    promotes tag_index/influence_target to required (or removes them)
+    will fail this test instead of silently regressing.
+    """
+    return {
+        "change_influence_percentage": {
+            "required": ["percent_change"],
+            "optional": ["tag_index", "influence_target"],
+        },
+    }
+
+
+# Tags + aliases the test bodies reference. STC / NTR stand in for real tag
+# aliases; the rest are real country tags used across the fixtures.
+_TEST_VALID_TAGS = frozenset(
+    {
+        "USA",
+        "KOR",
+        "CHI",
+        "ENG",
+        "ICE",
+        "SOV",
+        "GER",
+        "FRA",
+        "TAI",
+        "ISR",
+        "STC",  # alias
+        "NTR",  # alias
+    }
+)
+
+
+def _issues(caller_body, contracts, mod_path, valid_tags=_TEST_VALID_TAGS):
+    """Run the per-file validator against a one-shot focus file."""
+    focus_dir = mod_path / "common" / "national_focus"
+    focus_dir.mkdir(parents=True, exist_ok=True)
+    fpath = focus_dir / "test_focus.txt"
+    fpath.write_text(caller_body, encoding="utf-8-sig")
+    results = _validate_call_sites_in_file(
+        (str(fpath), contracts, str(mod_path), frozenset(valid_tags))
+    )
+    out = []
+    for cat, msg, _line in results:
+        if (
+            cat in ("missing-required-param", "identical-influence-params")
+            and "change_influence_percentage" in msg
+        ):
+            out.append((cat, msg))
+        elif cat == "invalid-influence-tag":
+            out.append((cat, msg))
+    return out
+
+
+def test_change_influence_percentage_with_only_percent_change_passes(
+    tmp_path, cip_contract
+):
+    """Defaults are reliable: a call with only percent_change must not be flagged.
+
+    This is the most common call-site pattern in the corpus — the effect
+    defaults tag_index to ROOT and influence_target to THIS, which is
+    correct when the call runs in the focus owner's scope.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert issues == []
+
+
+def test_change_influence_percentage_with_only_tag_index_passes(tmp_path, cip_contract):
+    """Setting only tag_index is fine: influence_target defaults to THIS."""
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = USA.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert issues == []
+
+
+def test_change_influence_percentage_with_only_influence_target_passes(
+    tmp_path, cip_contract
+):
+    """Setting only influence_target is fine: tag_index defaults to ROOT."""
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { influence_target = KOR.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert issues == []
+
+
+def test_change_influence_percentage_dot_id_syntax_variants_are_flagged(
+    tmp_path, cip_contract
+):
+    """Syntactic variants of the same country (USA vs USA.id) must flag.
+
+    The corpus mixes both forms; at runtime they resolve to the same
+    country ID.  Without normalization, a pair like
+        set_temp_variable = { tag_index = USA }
+        set_temp_variable = { influence_target = USA.id }
+    would slip through the literal-string check even though it produces
+    a self-influence at runtime.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = USA }\n"
+        "        set_temp_variable = { influence_target = USA.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any("identical-influence-params" in c for c, _ in issues)
+    flagged = next(m for c, m in issues if c == "identical-influence-params")
+    # Both original values should appear in the message so a reader can
+    # see the syntactic variant, not just the normalized form.
+    assert "'USA'" in flagged
+    assert "'USA.id'" in flagged
+
+
+def test_change_influence_percentage_var_id_syntax_variants_are_flagged(
+    tmp_path, cip_contract
+):
+    """var:foo vs var:foo.id (same variable, different syntax) must flag.
+
+    Variable references in HOI4 can be written as `var:foo` (a scope)
+    or `var:foo.id` (the scope's ID).  At runtime both pass the same
+    numeric value to the effect; the check needs to treat them as equal.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = var:foo }\n"
+        "        set_temp_variable = { influence_target = var:foo.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any("identical-influence-params" in c for c, _ in issues)
+
+
+def test_change_influence_percentage_scope_keyword_id_variants_are_flagged(
+    tmp_path, cip_contract
+):
+    """THIS vs THIS.id (same scope keyword, different syntax) must flag.
+
+    The same applies to ROOT/PREV/FROM.  All five scope keywords are
+    commonly written with or without the trailing .id; both forms
+    resolve to the same country ID.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = THIS }\n"
+        "        set_temp_variable = { influence_target = THIS.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any("identical-influence-params" in c for c, _ in issues)
+
+
+def test_change_influence_percentage_event_target_id_variants_are_flagged(
+    tmp_path, cip_contract
+):
+    """event_target:foo vs event_target:foo.id (same event target) must flag.
+
+    Events commonly pass country references via event_target; the
+    syntactic variant .id vs no .id is the same pattern as country tags.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = event_target:foo }\n"
+        "        set_temp_variable = { influence_target = event_target:foo.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any("identical-influence-params" in c for c, _ in issues)
+
+
+def test_change_influence_percentage_dot_id_normalization_keeps_distinct_values(
+    tmp_path, cip_contract
+):
+    """USA and GER (different countries) must NOT flag even with .id variants.
+
+    Regression guard for the normalization: stripping .id should not
+    collapse genuinely different countries.  USA / GER.id and
+    USA.id / GER should both stay unflagged.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = USA }\n"
+        "        set_temp_variable = { influence_target = GER.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert not any(c == "identical-influence-params" for c, _ in issues)
+
+
+def test_change_influence_percentage_identical_country_tag_is_flagged(
+    tmp_path, cip_contract
+):
+    """Both set to the same country tag is a guaranteed self-influence (Code 5001)."""
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = USA.id }\n"
+        "        set_temp_variable = { influence_target = USA.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any("identical-influence-params" in c for c, _ in issues)
+    flagged = next(m for c, m in issues if c == "identical-influence-params")
+    assert "'USA.id'" in flagged
+
+
+def test_change_influence_percentage_identical_scope_is_flagged(tmp_path, cip_contract):
+    """Both set to the same scope keyword (e.g. ROOT) is the canonical self-influence.
+
+    This is the most common runtime Code 5001 trigger the corpus sees:
+    a focus or event sets tag_index = ROOT and influence_target = ROOT
+    (or omits one and lets the effect default it to ROOT/THIS), and the
+    influence tries to push influence_target onto ROOT itself.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = ROOT.id }\n"
+        "        set_temp_variable = { influence_target = ROOT.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any("identical-influence-params" in c for c, _ in issues)
+
+
+def test_change_influence_percentage_distinct_values_passes(tmp_path, cip_contract):
+    """Both set but to different values is the correct call site — no flag."""
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = USA.id }\n"
+        "        set_temp_variable = { influence_target = KOR.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert issues == []
+
+
+def test_change_influence_percentage_with_zero_value_treated_as_unset(
+    tmp_path, cip_contract
+):
+    """Explicitly setting tag_index = 0 must not flag against influence_target = USA.id.
+
+    0 is the effect's sentinel for "use the default"; treating 0 as a
+    real value would generate a flood of false positives on call sites
+    that pre-initialise one of the two to 0 to make it explicit.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        "        set_temp_variable = { tag_index = 0 }\n"
+        "        set_temp_variable = { influence_target = USA.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert issues == []
+
+
+def test_change_influence_percentage_still_requires_percent_change(
+    tmp_path, cip_contract
+):
+    """percent_change remains required; the identity check did not displace it."""
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { tag_index = USA.id }\n"
+        "        set_temp_variable = { influence_target = KOR.id }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert any(
+        "missing-required-param" in c and "percent_change" in m for c, m in issues
+    )
+
+
+def test_change_influence_percentage_identical_across_adjacent_calls_is_flagged(
+    tmp_path, cip_contract
+):
+    """The leak-between-calls bug pattern: tag_index from one call is reused by the next.
+
+    Pattern in the corpus (e.g. 05_russia.txt:21561):
+        set_temp_variable = { percent_change = 2 }
+        set_temp_variable = { tag_index = TAI }
+        set_temp_variable = { influence_target = SOV }
+        change_influence_percentage = yes
+        set_temp_variable = { percent_change = 2 }
+        set_temp_variable = { influence_target = TAI }
+        change_influence_percentage = yes    # tag_index = TAI still in scope
+
+    The second call has influence_target = TAI explicitly and tag_index
+    still resolving to TAI from the first call (no scope change between
+    them).  At runtime, both resolve to TAI → Code 5001.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 2 }\n"
+        "        set_temp_variable = { tag_index = TAI }\n"
+        "        set_temp_variable = { influence_target = SOV }\n"
+        "        change_influence_percentage = yes\n"
+        "        set_temp_variable = { percent_change = 2 }\n"
+        "        set_temp_variable = { influence_target = TAI }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    identical = [m for c, m in issues if c == "identical-influence-params"]
+    assert len(identical) == 1
+    assert "'TAI'" in identical[0]
+
+
+def test_change_influence_percentage_identical_with_distant_set_is_filtered(
+    tmp_path, cip_contract
+):
+    """The 20-line proximity window filters out scope-tracking false positives.
+
+    The validator's frame-based scope tracking keeps a temp var from a
+    previous focus's completion_reward visible to the current call, even
+    though it wouldn't be in scope at runtime.  Tagging a stale
+    `tag_index` from 25+ lines back as identical to the current
+    `influence_target` would create noise; the proximity window prevents
+    that.
+    """
+    body = (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        # Stale tag_index, 25+ lines back from the call.  At runtime this
+        # would NOT be in scope (different focus's completion_reward),
+        # but the validator's scope tracking is too coarse to know that.
+        "        set_temp_variable = { tag_index = TAI }\n"
+        + ("        add_political_power = 0.01\n" * 25)
+        + "        set_temp_variable = { percent_change = 2 }\n"
+        "        set_temp_variable = { influence_target = TAI }\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+    issues = _issues(body, cip_contract, tmp_path)
+    assert not any(c == "identical-influence-params" for c, _ in issues)
+
+
+def test_hardcoded_cip_contract_keeps_optional_secondary_params():
+    """Guard rail: HARDCODED_CONTRACTS must keep tag_index/influence_target optional.
+
+    The original "promote to required" interpretation was rejected
+    because it would flag ~870 call sites that rely on the ROOT/THIS
+    defaults (e.g. every `for_each_scope_loop` over an array of
+    influence targets). The identity check is the right way to catch
+    the real bug class.
+    """
+    contract = vsp.HARDCODED_CONTRACTS.get("change_influence_percentage")
+    assert contract is not None
+    assert contract["required"] == ["percent_change"]
+    assert set(contract["optional"]) == {"tag_index", "influence_target"}
+
+
+# --- tag-validity check ---------------------------------------------------
+
+
+def _tag_body(param, value):
+    return (
+        "shared_focus = {\n"
+        "    completion_reward = {\n"
+        "        set_temp_variable = { percent_change = 5 }\n"
+        f"        set_temp_variable = {{ {param} = {value} }}\n"
+        "        change_influence_percentage = yes\n"
+        "    }\n"
+        "}\n"
+    )
+
+
+def _invalid_tags(issues):
+    return [m for c, m in issues if c == "invalid-influence-tag"]
+
+
+@pytest.mark.parametrize("value", ["CHI", "CHI.id", "USA", "USA.ID"])
+def test_valid_country_tag_passes(tmp_path, cip_contract, value):
+    """A real tag, with or without .id (any case), is never flagged."""
+    issues = _issues(_tag_body("tag_index", value), cip_contract, tmp_path)
+    assert _invalid_tags(issues) == []
+
+
+@pytest.mark.parametrize("value", ["STC", "NTR"])
+def test_valid_tag_alias_passes(tmp_path, cip_contract, value):
+    """Tag aliases (e.g. STC / NTR) are valid references, not typos."""
+    issues = _issues(_tag_body("influence_target", value), cip_contract, tmp_path)
+    assert _invalid_tags(issues) == []
+
+
+@pytest.mark.parametrize("value", ["ROOT", "THIS", "FROM", "PREV", "Root", "FROM.ID"])
+def test_scope_keyword_passes(tmp_path, cip_contract, value):
+    """Scope keywords (case-insensitive, with or without .id) are not tags."""
+    issues = _issues(_tag_body("influence_target", value), cip_contract, tmp_path)
+    assert _invalid_tags(issues) == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "var:foo",
+        "var:foo.id",
+        "event_target:bar",
+        "event_target:bar.id",
+        "global.some_tag",
+        "influence_array^0",
+        "0",
+        "some_lowercase_var",
+        "v",
+    ],
+)
+def test_non_tag_forms_pass(tmp_path, cip_contract, value):
+    """var: / event_target: / global. refs, array subscripts, numerics, and
+    bare temp-variable names are all accepted."""
+    issues = _issues(_tag_body("tag_index", value), cip_contract, tmp_path)
+    assert _invalid_tags(issues) == []
+
+
+@pytest.mark.parametrize("value", ["GBR", "GBR.id", "SHI.id", "ISL"])
+def test_invalid_uppercase_tag_is_flagged(tmp_path, cip_contract, value):
+    """An uppercase literal that is neither a tag nor an alias is a typo."""
+    issues = _issues(_tag_body("influence_target", value), cip_contract, tmp_path)
+    flagged = _invalid_tags(issues)
+    assert len(flagged) == 1
+    assert "influence_target" in flagged[0]
+
+
+def test_miscased_tag_is_flagged(tmp_path, cip_contract):
+    """CHl (lowercase l) is a typo for CHI; tags are case-sensitive at runtime."""
+    issues = _issues(_tag_body("influence_target", "CHl"), cip_contract, tmp_path)
+    flagged = _invalid_tags(issues)
+    assert len(flagged) == 1
+    assert "CHl" in flagged[0]
+
+
+def test_invalid_tag_placeholder_TAG_is_flagged(tmp_path, cip_contract):
+    """The literal `TAG` placeholder is not a real tag."""
+    issues = _issues(_tag_body("influence_target", "TAG"), cip_contract, tmp_path)
+    assert len(_invalid_tags(issues)) == 1

--- a/tools/validation/validate_scripted_params.py
+++ b/tools/validation/validate_scripted_params.py
@@ -99,10 +99,120 @@ SCOPE_CHANGING_KEYWORDS: Set[str] = _SCOPE_ITERATORS | {
 }
 
 _SET_TEMP_RE = re.compile(
-    r"\bset_temp_variable\s*=\s*\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=",
+    r"\bset_temp_variable\s*=\s*\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([^}]+?)\s*\}",
 )
 _CALL_RE = re.compile(r"\b([a-z][a-z0-9_]*)\s*=\s*yes\b")
 _KW_OPEN_RE = re.compile(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*\{")
+
+
+def _normalize_influence_value(value: str) -> str:
+    """Normalize a tag_index / influence_target value for identity comparison.
+
+    The corpus mixes two equivalent syntaxes for the same source:
+        USA       (country scope)         vs  USA.id      (country ID)
+        var:foo   (variable scope)        vs  var:foo.id  (variable ID)
+        THIS      (scope keyword)         vs  THIS.id     (scope keyword ID)
+        event_target:foo                  vs  event_target:foo.id
+    All six forms resolve to the same numeric tag at runtime.  Stripping
+    the trailing ".id" so both forms collapse to a canonical form lets the
+    identity check catch the full set of same-source pairs, not just the
+    half where the author happened to use the same syntax on both sides.
+
+    Strips only one trailing ".id" so a value like "PREV.id.id" would
+    collapse to "PREV.id" — that is wrong in practice (PREV.id is a
+    numeric ID, appending .id to it isn't meaningful) but the corpus
+    doesn't use that pattern, so the over-stripping case is theoretical.
+
+    The ".id" match is case-insensitive: the corpus ships "FROM.ID" as
+    well as "FROM.id", and both resolve to the same numeric ID.
+    """
+    if value.lower().endswith(".id"):
+        return value[:-3]
+    return value
+
+
+# Scope keywords that resolve to a country at runtime and are NOT tags.  A value
+# matching one of these (case-insensitively, so "Root" passes) is a valid
+# tag_index / influence_target reference, never a typo.
+_INFLUENCE_SCOPE_KEYWORDS: Set[str] = {
+    "ROOT",
+    "THIS",
+    "PREV",
+    "FROM",
+    "OWNER",
+    "CONTROLLER",
+    "OVERLORD",
+    "CAPITAL",
+    "FROMFROM",
+    "PREVPREV",
+}
+_TAG_LITERAL_RE = re.compile(r"[A-Z][A-Z0-9_]{2}")
+_MISCASED_TAG_RE = re.compile(r"[A-Za-z]{3}")
+_NUMERIC_RE = re.compile(r"-?\d+(\.\d+)?")
+
+
+def _load_valid_country_tags(mod_path: str) -> "frozenset[str]":
+    """Load valid country tags and tag aliases as one accept-set.
+
+    Tags come from common/country_tags/*.txt (`TAG = "path"`); aliases from
+    common/country_tag_aliases/*.txt (`ALIAS = { ... }`).  Aliases are real
+    references at runtime — e.g. STC / NTR are aliases, not typos — so the
+    tag-validity check accepts both.
+    """
+    valid: Set[str] = set()
+    tag_re = re.compile(r'^\s*([A-Z0-9_]{3})\s*=\s*"')
+    for fp in glob.glob(os.path.join(mod_path, "common", "country_tags", "*.txt")):
+        try:
+            with open(fp, "r", encoding="utf-8-sig") as fh:
+                for line in fh:
+                    m = tag_re.match(line)
+                    if m:
+                        valid.add(m.group(1))
+        except Exception:
+            continue
+    alias_re = re.compile(r"^\s*([A-Za-z0-9_]{3})\s*=\s*\{")
+    for fp in glob.glob(
+        os.path.join(mod_path, "common", "country_tag_aliases", "*.txt")
+    ):
+        try:
+            with open(fp, "r", encoding="utf-8-sig") as fh:
+                for line in fh:
+                    m = alias_re.match(line)
+                    if m:
+                        valid.add(m.group(1))
+        except Exception:
+            continue
+    return frozenset(valid)
+
+
+def _is_invalid_influence_tag(value: str, valid_tags: "frozenset[str]") -> bool:
+    """Return True if `value` is a tag_index / influence_target that no tag matches.
+
+    `value` is the RHS of `set_temp_variable = { tag_index/influence_target = ... }`.
+    Accepts real tags, tag aliases, scope keywords, var: / event_target: /
+    global. references, array subscripts, getters, numerics, and bare
+    temp-variable names.  Flags only literals that look like a country tag but
+    are not one — typos such as GBR for ENG, ISL for ICE, or the mis-cased
+    CHl for CHI.
+    """
+    v = value.strip()
+    if v[-3:].lower() == ".id":
+        v = v[:-3]
+    if not v or _NUMERIC_RE.fullmatch(v):
+        return False
+    # var: / event_target: / global. refs, array subscripts (name^i), getters
+    if any(c in v for c in ":^.@"):
+        return False
+    if v.upper() in _INFLUENCE_SCOPE_KEYWORDS:
+        return False
+    if _TAG_LITERAL_RE.fullmatch(v):
+        return v not in valid_tags
+    # 3-letter mixed-case token that isn't a scope keyword: a mis-typed tag
+    # (e.g. CHl) — exact-case must match a real tag, since tags are
+    # case-sensitive at runtime.
+    if _MISCASED_TAG_RE.fullmatch(v) and v != v.lower():
+        return v not in valid_tags
+    return False
 
 
 def _parse_effect_contracts_from_file(
@@ -224,21 +334,24 @@ def _normalize_multiline_set_temp(text: str) -> str:
     return result
 
 
-def _tokenize(text: str) -> List[Tuple[str, int, str]]:
+def _tokenize(text: str) -> List[Tuple[str, int, str, str]]:
     """Tokenize comment-stripped script text into a flat token list.
 
-    Each token is (kind, line_number, value):
-      "set_temp"   — set_temp_variable = { NAME = ... }
-      "call"       — NAME = yes
-      "scope_open" — NAME = {  where NAME is a scope-changing keyword
-      "plain_open" — { (non-scope-changing open, including if/hidden_effect/etc.)
-      "close"      — }
+    Each token is (kind, line_number, value, rhs):
+      "set_temp"   — set_temp_variable = { NAME = RHS }  (value=NAME, rhs=RHS)
+      "call"       — NAME = yes                           (value=NAME, rhs="")
+      "scope_open" — NAME = { (scope-changing)            (value=NAME, rhs="")
+      "plain_open" — NAME = { (non-scope-changing)        (value=NAME, rhs="")
+      "close"      — }                                    (value="",    rhs="")
+    The rhs on a set_temp is the literal RHS string (whitespace stripped).
+    It powers the identical-params check for change_influence_percentage; any
+    other call site only needs the name.
     """
     # Collapse multi-line set_temp_variable = { ... } blocks so the regex can
     # match them on a single line.
     text = _normalize_multiline_set_temp(text)
 
-    tokens: List[Tuple[str, int, str]] = []
+    tokens: List[Tuple[str, int, str, str]] = []
     lines = text.splitlines()
 
     for lineno, raw in enumerate(lines, start=1):
@@ -247,9 +360,9 @@ def _tokenize(text: str) -> List[Tuple[str, int, str]]:
         if ci >= 0:
             raw = raw[:ci]
 
-        # set_temp_variable = { NAME = ... }
+        # set_temp_variable = { NAME = RHS }
         for m in _SET_TEMP_RE.finditer(raw):
-            tokens.append(("set_temp", lineno, m.group(1)))
+            tokens.append(("set_temp", lineno, m.group(1), m.group(2).strip()))
 
         # Keyword = { openers — detect before closing braces so order is right
         for m in _KW_OPEN_RE.finditer(raw):
@@ -259,28 +372,29 @@ def _tokenize(text: str) -> List[Tuple[str, int, str]]:
                     "scope_open" if kw in SCOPE_CHANGING_KEYWORDS else "plain_open",
                     lineno,
                     kw,
+                    "",
                 )
             )
 
         # Closing braces
         for _ in re.finditer(r"\}", raw):
-            tokens.append(("close", lineno, ""))
+            tokens.append(("close", lineno, "", ""))
 
         # Effect calls: NAME = yes
         for m in _CALL_RE.finditer(raw):
-            tokens.append(("call", lineno, m.group(1)))
+            tokens.append(("call", lineno, m.group(1), ""))
 
     return tokens
 
 
 def _validate_call_sites_in_file(
-    args: Tuple[str, Dict[str, Dict[str, List[str]]], str],
+    args: Tuple[str, Dict[str, Dict[str, List[str]]], str, "frozenset[str]"],
 ) -> List[Tuple[str, str, int]]:
     """Validate one file for missing required params and orphaned sets.
 
     Returns a list of (category, message, line_number) tuples.
     """
-    filepath, contracts, mod_path = args
+    filepath, contracts, mod_path, valid_tags = args
 
     try:
         with open(filepath, "r", encoding="utf-8-sig") as fh:
@@ -321,7 +435,7 @@ def _validate_call_sites_in_file(
 
     stack: List[Dict] = [{"scope_changing": False, "temps": {}, "depth": 0}]
 
-    for kind, lineno, value in tokens:
+    for kind, lineno, value, rhs in tokens:
         if kind == "scope_open":
             # Push a new scope frame
             stack.append({"scope_changing": True, "temps": {}, "depth": 0})
@@ -338,8 +452,26 @@ def _validate_call_sites_in_file(
             # else: extra close at root, ignore
 
         elif kind == "set_temp":
-            # Record in the current frame
-            stack[-1]["temps"][value] = lineno
+            # Record in the current frame. Track both the line and the RHS
+            # value: the line is used for the existing missing-param check,
+            # and the RHS powers the identical-params check for
+            # change_influence_percentage.
+            stack[-1]["temps"][value] = {"line": lineno, "value": rhs}
+
+            # Tag-validity check: an influencer/influencee written as a literal
+            # that is neither a real tag nor an alias is a silent typo (resolves
+            # to nothing at runtime, so the influence call no-ops or misfires).
+            if value in ("tag_index", "influence_target") and _is_invalid_influence_tag(
+                rhs, valid_tags
+            ):
+                results.append(
+                    (
+                        "invalid-influence-tag",
+                        f"{rel}:{lineno} - '{value}' set to {rhs!r} which is not a "
+                        f"valid country tag or tag alias",
+                        lineno,
+                    )
+                )
 
         elif kind == "call":
             if value not in contracts:
@@ -357,9 +489,9 @@ def _validate_call_sites_in_file(
             # are NOT visible outside.  Since we track frames, any temp var in
             # any frame on the stack at this point was set in the current or an
             # ancestor scope, so it is visible.
-            visible: Set[str] = set()
+            visible: Dict[str, Dict] = {}
             for frame in stack:
-                visible.update(frame["temps"].keys())
+                visible.update(frame["temps"])
 
             for param in required:
                 if param not in visible:
@@ -371,6 +503,61 @@ def _validate_call_sites_in_file(
                             lineno,
                         )
                     )
+
+            # Identical-params check for change_influence_percentage.
+            # The effect's own defaults (tag_index -> ROOT, influence_target -> THIS)
+            # are deliberately retained because they're reliable in the common
+            # call sites; the actual self-influence (Code 5001) error only fires
+            # when both params resolve to the same country.  Flag any call where
+            # the user has set BOTH to an explicit non-zero value in the same
+            # block as the call and those values are identical — that is the
+            # static-only catch for the self-influence bug.
+            #
+            # "Same block" is approximated by line proximity: both set_temp
+            # calls must fall within 20 lines of the call site.  This filters
+            # out false positives where the validator's scope tracking keeps a
+            # temp var from a previous focus's completion_reward in scope; those
+            # temps wouldn't actually be in scope at runtime.  20 lines is
+            # enough to catch the canonical leak-between-calls bug pattern
+            # (tag_index from call N-1 reused by call N in the same block)
+            # while keeping the false-positive rate low.
+            #
+            # Values are compared after `_normalize_influence_value` to catch
+            # syntactic variants of the same source: "USA" and "USA.id",
+            # "var:foo" and "var:foo.id", "event_target:foo" and
+            # "event_target:foo.id", "THIS" and "THIS.id" all resolve to the
+            # same country at runtime.  Without the normalization, the corpus
+            # ships many pairs that look different but compute the same
+            # influence source — most of which are the same self-influence
+            # bug class the literal-string check catches.
+            if value == "change_influence_percentage":
+                tag_entry = visible.get("tag_index")
+                inf_entry = visible.get("influence_target")
+                if tag_entry and inf_entry:
+                    tag_val = tag_entry["value"]
+                    inf_val = inf_entry["value"]
+                    tag_line = tag_entry["line"]
+                    inf_line = inf_entry["line"]
+                    if (
+                        tag_val
+                        and inf_val
+                        and tag_val != "0"
+                        and inf_val != "0"
+                        and _normalize_influence_value(tag_val)
+                        == _normalize_influence_value(inf_val)
+                        and abs(lineno - tag_line) <= 20
+                        and abs(lineno - inf_line) <= 20
+                    ):
+                        results.append(
+                            (
+                                "identical-influence-params",
+                                f"{rel}:{lineno} - 'change_influence_percentage' called with "
+                                f"tag_index = {tag_val!r} and influence_target = {inf_val!r}; "
+                                f"both resolve to the same country and this is a self-influence "
+                                f"(Code 5001) error",
+                                lineno,
+                            )
+                        )
 
             # Scope-boundary violations (temp set inside a popped scope-changing
             # frame, call outside) are already caught by the missing-param check:
@@ -387,6 +574,12 @@ class Validator(BaseValidator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._contracts: Dict[str, Dict[str, List[str]]] = {}
+        self._valid_tags: "frozenset[str]" = frozenset()
+
+    def _build_tag_set(self):
+        """Load valid country tags + aliases for the tag-validity check."""
+        self._valid_tags = _load_valid_country_tags(self.mod_path)
+        self.log(f"  Valid country tags + aliases:     {len(self._valid_tags)}")
 
     def _build_contracts(self):
         """Build the parameter contract registry from hardcoded + auto-discovered data."""
@@ -433,13 +626,17 @@ class Validator(BaseValidator):
         files = self._collect_files(scan_patterns)
         self.log(f"  Scanning {len(files)} files for effect calls")
 
-        args_list = [(f, self._contracts, self.mod_path) for f in files]
+        args_list = [
+            (f, self._contracts, self.mod_path, self._valid_tags) for f in files
+        ]
         all_results = self._pool_map(
             _validate_call_sites_in_file, args_list, chunksize=20
         )
 
         missing_param_results = []
         scope_violation_results = []
+        identical_param_results = []
+        invalid_tag_results = []
 
         for file_results in all_results:
             for category, message, _line in file_results:
@@ -447,6 +644,10 @@ class Validator(BaseValidator):
                     missing_param_results.append(message)
                 elif category == "scope-boundary-violation":
                     scope_violation_results.append(message)
+                elif category == "identical-influence-params":
+                    identical_param_results.append(message)
+                elif category == "invalid-influence-tag":
+                    invalid_tag_results.append(message)
 
         self._report(
             missing_param_results,
@@ -464,8 +665,25 @@ class Validator(BaseValidator):
             category="scope-boundary-violation",
         )
 
+        self._report(
+            identical_param_results,
+            "No change_influence_percentage calls have identical tag_index and influence_target",
+            "change_influence_percentage calls with tag_index == influence_target (self-influence):",
+            severity=Severity.ERROR,
+            category="identical-influence-params",
+        )
+
+        self._report(
+            invalid_tag_results,
+            "All tag_index / influence_target values are valid country tags or aliases",
+            "tag_index / influence_target set to an unknown country tag (typo or removed tag):",
+            severity=Severity.ERROR,
+            category="invalid-influence-tag",
+        )
+
     def run_validations(self):
         self._build_contracts()
+        self._build_tag_set()
         self._validate_callers()
 
 

--- a/tools/validation/validate_scripted_params.py
+++ b/tools/validation/validate_scripted_params.py
@@ -118,11 +118,6 @@ def _normalize_influence_value(value: str) -> str:
     identity check catch the full set of same-source pairs, not just the
     half where the author happened to use the same syntax on both sides.
 
-    Strips only one trailing ".id" so a value like "PREV.id.id" would
-    collapse to "PREV.id" — that is wrong in practice (PREV.id is a
-    numeric ID, appending .id to it isn't meaningful) but the corpus
-    doesn't use that pattern, so the over-stripping case is theoretical.
-
     The ".id" match is case-insensitive: the corpus ships "FROM.ID" as
     well as "FROM.id", and both resolve to the same numeric ID.
     """
@@ -195,9 +190,7 @@ def _is_invalid_influence_tag(value: str, valid_tags: "frozenset[str]") -> bool:
     are not one — typos such as GBR for ENG, ISL for ICE, or the mis-cased
     CHl for CHI.
     """
-    v = value.strip()
-    if v[-3:].lower() == ".id":
-        v = v[:-3]
+    v = _normalize_influence_value(value.strip())
     if not v or _NUMERIC_RE.fullmatch(v):
         return False
     # var: / event_target: / global. refs, array subscripts (name^i), getters
@@ -205,12 +198,11 @@ def _is_invalid_influence_tag(value: str, valid_tags: "frozenset[str]") -> bool:
         return False
     if v.upper() in _INFLUENCE_SCOPE_KEYWORDS:
         return False
-    if _TAG_LITERAL_RE.fullmatch(v):
-        return v not in valid_tags
-    # 3-letter mixed-case token that isn't a scope keyword: a mis-typed tag
-    # (e.g. CHl) — exact-case must match a real tag, since tags are
-    # case-sensitive at runtime.
-    if _MISCASED_TAG_RE.fullmatch(v) and v != v.lower():
+    # An all-caps tag literal, or a 3-letter mixed-case token (a mis-cased tag
+    # like CHl): must match a real tag exactly, since tags are case-sensitive.
+    if _TAG_LITERAL_RE.fullmatch(v) or (
+        _MISCASED_TAG_RE.fullmatch(v) and v != v.lower()
+    ):
         return v not in valid_tags
     return False
 
@@ -504,32 +496,19 @@ def _validate_call_sites_in_file(
                         )
                     )
 
-            # Identical-params check for change_influence_percentage.
-            # The effect's own defaults (tag_index -> ROOT, influence_target -> THIS)
-            # are deliberately retained because they're reliable in the common
-            # call sites; the actual self-influence (Code 5001) error only fires
-            # when both params resolve to the same country.  Flag any call where
-            # the user has set BOTH to an explicit non-zero value in the same
-            # block as the call and those values are identical — that is the
-            # static-only catch for the self-influence bug.
+            # Identical-params check: a change_influence_percentage call where
+            # tag_index and influence_target resolve to the same country is the
+            # self-influence (Code 5001) bug.  Flag only when BOTH are set to an
+            # explicit non-zero value; the effect's own defaults (tag_index ->
+            # ROOT, influence_target -> THIS) are reliable and left alone.
             #
-            # "Same block" is approximated by line proximity: both set_temp
-            # calls must fall within 20 lines of the call site.  This filters
-            # out false positives where the validator's scope tracking keeps a
-            # temp var from a previous focus's completion_reward in scope; those
-            # temps wouldn't actually be in scope at runtime.  20 lines is
-            # enough to catch the canonical leak-between-calls bug pattern
-            # (tag_index from call N-1 reused by call N in the same block)
-            # while keeping the false-positive rate low.
-            #
-            # Values are compared after `_normalize_influence_value` to catch
-            # syntactic variants of the same source: "USA" and "USA.id",
-            # "var:foo" and "var:foo.id", "event_target:foo" and
-            # "event_target:foo.id", "THIS" and "THIS.id" all resolve to the
-            # same country at runtime.  Without the normalization, the corpus
-            # ships many pairs that look different but compute the same
-            # influence source — most of which are the same self-influence
-            # bug class the literal-string check catches.
+            # "Same block" is approximated by line proximity (<= 20 lines): the
+            # scope tracker can keep a temp var from a previous focus's
+            # completion_reward visible when it wouldn't be in scope at runtime,
+            # so the window suppresses those false positives while still catching
+            # the leak-between-calls pattern (tag_index from call N-1 reused by
+            # call N).  Values are normalized so "USA"/"USA.id" and the other
+            # .id variants compare equal.
             if value == "change_influence_percentage":
                 tag_entry = visible.get("tag_index")
                 inf_entry = visible.get("influence_target")


### PR DESCRIPTION
### Changes
1. Added a scripted parameter validation for change_influence_percentage
2. Decreased political power cost of MIOs but increased task size for upgrading
3. Fixed all known issues where influencer and influencee would be the same or invalid tag or references. 