### PR TITLE
BUG #2090 FIX CZE

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -642,6 +642,7 @@ v2.0.0
   - [POL] Fixed national spirit Polish-Ukrainian War not disappearing after the war ended.
   - [POL] Event "Janusz Korwin-Mikke Thrown Out of Power" will no longer appear if Poland don't have active Janusz Korwin-Mikke balance of power.
   - [HOL] Fixed non-D66 coalition partners' focus-tree progression
+  - [CZE] Fixed unite Czechoslovakia decision disappearing prematurely during peaceful unification
 
  Content:
   - New Content for North korea and South Korea post reuification and unification

--- a/common/decisions/categories/99_CZE_decision_categories.txt
+++ b/common/decisions/categories/99_CZE_decision_categories.txt
@@ -193,9 +193,9 @@ CZE_SLO_czechoslovakia_category = {
 		has_country_flag = CZE_SLO_czechoslovakia_start
 		NOT = {
 			has_completed_focus = CZE_SLO_new_dawn_of_czechoslovakia
-			check_variable = { THIS.CZE_SLO_people_acceptance > 99 }
-			check_variable = { THIS.CZE_SLO_law_similarity > 99 }
-			check_variable = { THIS.CZE_SLO_military_support > 99 }
+			check_variable = { THIS.CZE_SLO_people_acceptance > 100 }
+			check_variable = { THIS.CZE_SLO_law_similarity > 100 }
+			check_variable = { THIS.CZE_SLO_military_support > 100 }
 		}
 	}
 


### PR DESCRIPTION
There is a variable check that hides the category when over 99, but the variable is capped at 100