### PR TITLE
Improved EU  Campaign for EU Candidacy + Introduce Europeanism Floor

### DIFF
--- a/common/national_focus/05_kosovo.txt
+++ b/common/national_focus/05_kosovo.txt
@@ -1897,6 +1897,7 @@ focus_tree = {
 			set_temp_variable = { modify_europeanism = 0.05 }
 			EU_potential_europeanism_change = yes
 			set_country_flag = EU_candidate
+			set_eu_candidate_europeanism_floor = yes
 			custom_effect_tooltip = KOS_europeanization_tt
 		}
 

--- a/common/national_focus/czech_republic.txt
+++ b/common/national_focus/czech_republic.txt
@@ -16898,6 +16898,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_eu_candidate"
 			set_country_flag = EU_candidate
+			set_eu_candidate_europeanism_floor = yes
 			custom_effect_tooltip = CZE_add_eu_candidate
 			add_political_power = 50
 			add_war_support = -0.1
@@ -29863,10 +29864,12 @@ focus_tree = {
 
 			if = {
 				limit = {
-					ENG = { OR = {
-						has_government = communism
-						has_government = fascism
-					} }
+					ENG = {
+						OR = {
+							has_government = communism
+							has_government = fascism
+						}
+					}
 				}
 				CZE = { country_event = { id = CZE_AUS_monarchy_event.17 days = 15 } }
 			}

--- a/common/scripted_effects/99_EU_voting_scripted_effects.txt
+++ b/common/scripted_effects/99_EU_voting_scripted_effects.txt
@@ -820,155 +820,155 @@ focus_EU112_QMV_result = {
 # via the EU_former_member cooldown path instead).
 # EU601 - 2003 EU Enlargement
 focus_EU601_QMV_result = {
-	CYP = { set_country_flag = EU_candidate }
-	CZE = { set_country_flag = EU_candidate }
-	EST = { set_country_flag = EU_candidate }
-	HUN = { set_country_flag = EU_candidate }
-	LAT = { set_country_flag = EU_candidate }
-	LIT = { set_country_flag = EU_candidate }
-	MLT = { set_country_flag = EU_candidate }
-	POL = { set_country_flag = EU_candidate }
-	SLO = { set_country_flag = EU_candidate }
-	SLV = { set_country_flag = EU_candidate }
+	CYP = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	CZE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	EST = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	HUN = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	LAT = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	LIT = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	MLT = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	POL = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SLO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SLV = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU602 - 2007 EU Enlargement
 focus_EU602_QMV_result = {
-	BUL = { set_country_flag = EU_candidate }
-	ROM = { set_country_flag = EU_candidate }
+	BUL = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	ROM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU603 - 2013 EU Enlargement
 focus_EU603_QMV_result = {
-	CRO = { set_country_flag = EU_candidate }
+	CRO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU605 - Western Balkans
 focus_EU605_QMV_result = {
-	ALB = { set_country_flag = EU_candidate }
-	SER = { set_country_flag = EU_candidate }
-	MNT = { set_country_flag = EU_candidate }
-	FYR = { set_country_flag = EU_candidate }
-	BOS = { set_country_flag = EU_candidate }
-	RSK = { set_country_flag = EU_candidate }
-	HZG = { set_country_flag = EU_candidate }
-	KOS = { set_country_flag = EU_candidate }
+	ALB = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SER = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	MNT = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	FYR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	BOS = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	RSK = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	HZG = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	KOS = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU606 - Turkey
 focus_EU606_QMV_result = {
-	TUR = { set_country_flag = EU_candidate }
+	TUR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU607 - Eastern Partnership
 focus_EU607_QMV_result = {
-	MLV = { set_country_flag = EU_candidate }
-	UKR = { set_country_flag = EU_candidate }
+	MLV = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	UKR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU608 - Caucasus
 focus_EU608_QMV_result = {
-	ARM = { set_country_flag = EU_candidate }
-	AZE = { set_country_flag = EU_candidate }
-	GEO = { set_country_flag = EU_candidate }
+	ARM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	AZE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	GEO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU609 - EFTA and Microstates
 focus_EU609_QMV_result = {
-	SWI = { set_country_flag = EU_candidate }
-	NRY = { set_country_flag = EU_candidate }
-	ICE = { set_country_flag = EU_candidate }
-	HLS = { set_country_flag = EU_candidate }
-	SMA = { set_country_flag = EU_candidate }
-	MNC = { set_country_flag = EU_candidate }
-	ADO = { set_country_flag = EU_candidate }
-	LIC = { set_country_flag = EU_candidate }
+	SWI = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	NRY = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	ICE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	HLS = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SMA = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	MNC = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	ADO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	LIC = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU610 - Belarus
 focus_EU610_QMV_result = {
-	BLR = { set_country_flag = EU_candidate }
+	BLR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU611 - Regional Aspirants
 focus_EU611_QMV_result = {
-	CAT = { set_country_flag = EU_candidate }
-	CRE = { set_country_flag = EU_candidate }
-	SCL = { set_country_flag = EU_candidate }
-	SCO = { set_country_flag = EU_candidate }
-	WAS = { set_country_flag = EU_candidate }
-	IOM = { set_country_flag = EU_candidate }
-	GAL = { set_country_flag = EU_candidate }
-	SIL = { set_country_flag = EU_candidate }
-	SPA = { set_country_flag = EU_candidate }
-	CNR = { set_country_flag = EU_candidate }
-	NAV = { set_country_flag = EU_candidate }
-	BAY = { set_country_flag = EU_candidate }
-	GRN = { set_country_flag = EU_candidate }
-	FAO = { set_country_flag = EU_candidate }
-	RUS = { set_country_flag = EU_candidate }
+	CAT = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	CRE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SCL = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SCO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	WAS = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	IOM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	GAL = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SIL = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SPA = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	CNR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	NAV = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	BAY = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	GRN = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	FAO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	RUS = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU653 - EU-Russia Treaty
 focus_EU653_QMV_result = {
-	SOV = { set_country_flag = EU_candidate }
+	SOV = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU654 - Barents Sea Enlargement
 focus_EU654_QMV_result = {
-	KAE = { set_country_flag = EU_candidate }
-	KOM = { set_country_flag = EU_candidate }
-	NEE = { set_country_flag = EU_candidate }
+	KAE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	KOM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	NEE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU655 - Volga Enlargement
 focus_EU655_QMV_result = {
-	BSH = { set_country_flag = EU_candidate }
-	CHU = { set_country_flag = EU_candidate }
-	MEL = { set_country_flag = EU_candidate }
-	MOV = { set_country_flag = EU_candidate }
-	TAT = { set_country_flag = EU_candidate }
-	UDM = { set_country_flag = EU_candidate }
+	BSH = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	CHU = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	MEL = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	MOV = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	TAT = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	UDM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU656 - Don-Kuban Enlargement
 focus_EU656_QMV_result = {
-	ADY = { set_country_flag = EU_candidate }
-	DON = { set_country_flag = EU_candidate }
-	KLM = { set_country_flag = EU_candidate }
-	KUB = { set_country_flag = EU_candidate }
+	ADY = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	DON = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	KLM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	KUB = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU657 - Northern Caucasus Enlargement
 focus_EU657_QMV_result = {
-	ABK = { set_country_flag = EU_candidate }
-	CHE = { set_country_flag = EU_candidate }
-	DAG = { set_country_flag = EU_candidate }
-	ING = { set_country_flag = EU_candidate }
-	KBK = { set_country_flag = EU_candidate }
-	KCC = { set_country_flag = EU_candidate }
-	SOO = { set_country_flag = EU_candidate }
+	ABK = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	CHE = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	DAG = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	ING = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	KBK = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	KCC = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	SOO = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU658 - Ruthenia Enlargement
 focus_EU658_QMV_result = {
-	LRP = { set_country_flag = EU_candidate }
-	OPR = { set_country_flag = EU_candidate }
-	PRP = { set_country_flag = EU_candidate }
-	VRP = { set_country_flag = EU_candidate }
+	LRP = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	OPR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	PRP = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	VRP = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU659 - Donets Enlargement
 focus_EU659_QMV_result = {
-	DPR = { set_country_flag = EU_candidate }
-	HPR = { set_country_flag = EU_candidate }
-	LPR = { set_country_flag = EU_candidate }
+	DPR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	HPR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	LPR = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # EU660 - Dnieper Enlargement
 focus_EU660_QMV_result = {
-	CRM = { set_country_flag = EU_candidate }
-	DRP = { set_country_flag = EU_candidate }
+	CRM = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
+	DRP = { set_country_flag = EU_candidate set_eu_candidate_europeanism_floor = yes }
 }
 
 # Shared finalize for a passed EP agenda (mission complete + timeout-success branch).

--- a/common/scripted_effects/99_eu_scripted_effects.txt
+++ b/common/scripted_effects/99_eu_scripted_effects.txt
@@ -179,6 +179,16 @@ EU_potential_europeanism_change = {
 	}
 }
 
+### Raise THIS country's Europeanism to a floor if below it (never lowers)
+### use in country scope (THIS = candidate tag)
+set_eu_candidate_europeanism_floor = {
+	if = {
+		limit = { check_expr = { value = THIS.europeanism less_than = { value = 0.50 } } }
+		set_variable = { THIS.europeanism = 0.50 }
+		update_eu_dirty_variable = yes
+	}
+}
+
 ### Inventment in the single market
 ### use in country scope
 ### TAG is investee

--- a/common/scripted_guis/01_european_union_guis.txt
+++ b/common/scripted_guis/01_european_union_guis.txt
@@ -1237,24 +1237,23 @@ scripted_gui = {
 			}
 			proeuro_country_button_click_enabled = {
 				NOT = { has_country_flag = proeuro_country_button_click_cooldown }
-				has_idea = EU_member
-				has_political_power > 100
-				#make this cost political power for internal
+				OR = {
+					has_idea = EU_member
+					has_country_flag = EU_candidate
+				}
+				has_political_power > 50
+				#candidates may run this in their own country; members keep access
 			}
 			proeuro_euwide_button_visible = {
 				EU_european_union_euro_info_trigger = yes
 			}
 			proeuro_euwide_button_click_enabled = {
 				NOT = { has_country_flag = proeuro_euwide_button_click_cooldown }
-				set_temp_variable = { the_cost = 200 }
-				if = {
-					limit = {
-						NOT = { has_idea = EU_member }
-					}
-					add_to_temp_variable = { the_cost = 100 }
-				}
+				has_idea = EU_member
+				set_temp_variable = { the_cost = global.EU_15_per_member_cost }
+				multiply_temp_variable = { the_cost = 0.5 }
 				has_political_power > the_cost
-				#foreign nations can ONLY do this one
+				#pan-EU campaign is members-only
 			}
 			approve_IPA_button_visible = {
 				EU_european_union_euro_info_trigger = yes
@@ -2529,9 +2528,9 @@ scripted_gui = {
 			}
 			proeuro_country_button_click = {
 				log = "[GetDateText]: [ROOT.GetName]: EU GUI root_pro_european_campaign"
-				set_temp_variable = { var = treasury_change value = { value = gdp_total multiply = -0.003 } }
+				set_temp_variable = { var = treasury_change value = { value = gdp_total multiply = -0.002 } }
 				modify_treasury_effect = yes
-				add_political_power = -100
+				add_political_power = -50
 				random_list = {
 					70 = {
 						modifier = {
@@ -2567,20 +2566,10 @@ scripted_gui = {
 			proeuro_euwide_button_click = {
 				log = "[GetDateText]: [ROOT.GetName]: EU GUI pro_european_campaign"
 				set_temp_variable = { treasury_change = global.EU_gdp }
-				if = { limit = { NOT = { has_idea = EU_member } }
-					set_temp_variable = { var = treasury_change value = { value = treasury_change add = ROOT.gdp_total multiply = -0.004 } }
-				}
-				else = {
-					multiply_temp_variable = { treasury_change = -0.001 }
-				}
+				multiply_temp_variable = { treasury_change = -0.0005 }
 				modify_treasury_effect = yes
 				set_temp_variable = { the_cost = global.EU_15_per_member_cost }
-				if = {
-					limit = {
-						NOT = { has_idea = EU_member }
-					}
-					multiply_temp_variable = { the_cost = 1.5 }
-				}
+				multiply_temp_variable = { the_cost = 0.5 }
 				multiply_temp_variable = { the_cost = -1 }
 				add_political_power = the_cost
 				random_list = {
@@ -3739,7 +3728,7 @@ scripted_gui = {
 			}
 			proeuro_country_button_click = {
 				ai_will_do = {
-					base = 1
+					base = 5
 					modifier = {
 						add = 1
 						NOT = { gov_is_eurosceptical = yes }
@@ -3748,6 +3737,11 @@ scripted_gui = {
 						add = 1
 						NOT = { gov_is_eurosceptical = yes }
 						slowdown_european_integration = yes
+					}
+					modifier = {
+						add = 20
+						has_country_flag = EU_candidate
+						NOT = { has_idea = EU_member }
 					}
 					modifier = {
 						add = -40
@@ -3765,7 +3759,20 @@ scripted_gui = {
 								NOT = { gov_is_eurosceptical = yes }
 								check_expr = { value = THIS.europeanism greater_than = { value = 0.95 } }
 							}
-							has_political_power < 300
+							has_political_power < 50
+							check_expr = { value = interest_rate greater_than = { value = 8.0 } }
+						}
+					}
+					modifier = {
+						factor = 0
+						has_country_flag = EU_candidate
+						NOT = { has_idea = EU_member }
+						OR = {
+							AND = {
+								NOT = { gov_is_eurosceptical = yes }
+								check_expr = { value = THIS.europeanism greater_than = { value = 0.95 } }
+							}
+							has_political_power < 50
 							check_expr = { value = interest_rate greater_than = { value = 8.0 } }
 						}
 					}
@@ -3773,7 +3780,7 @@ scripted_gui = {
 			}
 			proeuro_euwide_button_click = {
 				ai_will_do = {
-					base = 1
+					base = 5
 					modifier = {
 						add = 1
 						NOT = { gov_is_eurosceptical = yes }
@@ -3792,12 +3799,6 @@ scripted_gui = {
 						stop_pro_european_campaign = yes
 					}
 					modifier = {
-						add = 15
-						original_tag = USA
-						date > 2004.1.1
-						has_political_power > 650
-					}
-					modifier = {
 						factor = 0
 						has_idea = EU_member
 						OR = {
@@ -3805,7 +3806,7 @@ scripted_gui = {
 								NOT = { gov_is_eurosceptical = yes }
 								check_expr = { value = global.var_europeanism greater_than = { value = 0.95 } }
 							}
-							has_political_power < 300
+							has_political_power < 200
 							check_expr = { value = interest_rate greater_than = { value = 8.0 } }
 						}
 					}


### PR DESCRIPTION
- Let candidates run the pro-EU campaign in their own country; restrict the pan-EU campaign to members (reverses the prior gate so aspiring members are not forced into the expensive EU-wide campaign)
- Reduce pro-EU campaign costs: own-country 100->50 PP and -0.3%->-0.2% GDP; pan-EU PP cost halved and treasury hit halved
- Boost AI willingness to run pro-EU campaigns (base 1->5, +20 for candidates) and add a candidate guard so AI stops when capped/low PP
- Floor Europeanism at 50% when candidacy is granted, via a new set_eu_candidate_europeanism_floor effect wired into every EU enlargement QMV result and the CZE/KOS focus grants
- Remove dead non-member branches in the pan-EU click effect (also sidesteps a latent sign bug where non-members gained EU_gdp treasury)