### PR TITLE
Fix air force overview labelling carrier CAS as Attack Helicopters (#2126)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1114,6 +1114,7 @@ v2.0.0
   - Stealth destroyers can now mount heavy gun modules across all available weapon and auxiliary slots
   - Removed duplicate point defense module slot entry from stealth destroyer hull definitions
   - Added an Autonomous Surface Combatant Control module for frigates and destroyers that cuts crew requirements in exchange for higher microchip cost, unlocked via the new Autonomous Surface Combatants naval special project (Issue #1833)
+  - Relabeled the air force overview carrier CAS line from "Attack Helicopters" to "Carrier Combat Air Support" now that attack helicopters are land equipment (Issue #2126)
 
  User Interface:
   - Fixed the Ideological Powers tooltips showing inaccurate values and omitting several party modifiers; they now list every modifier each party receives, with party-specific ones qualified

--- a/localisation/english/replace/replaced_from_vanilla_army_l_english.yml
+++ b/localisation/english/replace/replaced_from_vanilla_army_l_english.yml
@@ -20,7 +20,7 @@
  AIR_OVERVIEW_CATEGORY_REGULAR_4: "$COUNT|H$ are §HStrike Fighter§! aircrafts"
  AIR_OVERVIEW_CATEGORY_REGULAR_5: "$COUNT|H$ are §HStrategic Bomber§! aircrafts"
  AIR_OVERVIEW_CATEGORY_REGULAR_6: "$COUNT|H$ are §HTransport Aircrafts§!"
- AIR_OVERVIEW_CATEGORY_CARRIER_0: "$COUNT|H$ are §HAttack Helicopters§!"
+ AIR_OVERVIEW_CATEGORY_CARRIER_0: "$COUNT|H$ are §HCarrier Combat Air Support§! aircrafts"
  AIR_OVERVIEW_CATEGORY_CARRIER_1: "$COUNT|H$ are §HCarrier Fighter§! aircrafts"
  ARMY_NAVIES_TOOLTIP_DETAILED_MULTIPLE_DESC: "We have $COUNT$ §Y$TYPE$§! in total."
  OFFICER_CORP_SPECIAL_FORCES_DOCTRINE: "Special Forces"


### PR DESCRIPTION
Closes #2126

### Summary

#### Bug Fixes

- **Fixes #2126: Aircraft type localisation out of date.** The air force overview's carrier CAS line (`AIR_OVERVIEW_CATEGORY_CARRIER_0`) still read "Attack Helicopters", a leftover from when attack helicopters were aircraft; they are now `heavy_tank_chassis` land equipment, so the carrier-based CAS bucket was mislabeled. Relabeled it "Carrier Combat Air Support" to match the sibling `CARRIER_1` carrier fighter line.