### PR TITLE
Validator Checks Expansion

### DIFF
--- a/.claude/rules/general-rules.md
+++ b/.claude/rules/general-rules.md
@@ -34,7 +34,7 @@ Default to no comments. Add one only when the WHY is non-obvious: a hidden const
 
 ## NOT blocks and "NOR"
 
-`NOT = { A B }` means NOT(A AND B) — "not both at once", almost never intended. For "neither" write separate `NOT` blocks or `NOT = { OR = { A B } }`. `NOR` is not a HOI4 trigger keyword.
+`NOT = { A B }` means NOT(A AND B) — "not both at once", almost never intended. For "neither" write separate `NOT` blocks or `NOT = { OR = { A B } }`. `NOR` is not a HOI4 trigger keyword. Bare multi-child NOTs are flagged (warning) by `validate_simplifications.py`.
 
 ## random over two-bucket random_list
 
@@ -128,4 +128,4 @@ When a reward/option fires an event at another country: follow the fire with `cu
 
 ## Log message option IDs
 
-`log =` strings inside an event option must cite the option's own ID (`foo.1.b` in option `.b` — not a copy-pasted `.a`).
+`log =` strings inside an event option must cite the option's own ID (`foo.1.b` in option `.b` — not a copy-pasted `.a`). Log-ID mismatches in focuses, decisions, and event options are caught by `check_common_mistakes.py`; `tools/linting/fix_log_ids.py` auto-fixes them.

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -407,6 +407,8 @@ v2.0.0
   - Reduced political power cost for Korwin's balance of power decisions from 55 to 35, after he wins with Wałęsa
 
  Bugfix:
+  - Fixed 41 always-true NOT government checks in French chaos-path decisions and Central Asian focuses that never filtered anything
+  - [INS] Fixed an Indonesian event option (indonesia.888.a) referencing the wrong localisation key
   - [BRA] Fixed the Pro-Workers and Support the Unions communist focuses showing "This focus currently has no effect"; Pro-Workers now switches the industrial conglomerates faction back to labour unions so its opinion boost applies, and Support the Unions grants the Pro-Unions national spirit (Issue #2240)
   - [HEZ] Fixed the "Hezbollah has attacked our bases!" event (international_hezbollah.5) showing an "Influencer and Influencee are the same" error toast; the influence penalty now reads the attacked country off the sender scope, and both target-routing branches in international_hezbollah.4 use the correct attack-mission variable (Issue #2297)
   - [SPR] Fixed the helicopter procurement focuses (A Deal for the Apaches, Eurocopter Tigre, Eurocopter Cougar, A Deal for the Chinooks) granting production licenses that never appeared in inventory; each focus now requires the granting nation to hold the relevant helicopter technology (Issue #2290)
@@ -1032,6 +1034,7 @@ v2.0.0
   - [SOV] Consolidated three Gazprom/Rosneft capitalisation_*_calculate clusters into single init-add-apply units (5 gas-stream blocks, 7 Gazprom oil-province blocks, 8 Rosneft oil-province blocks): drops ~120 lines from 99_SOV_scripted_effects.txt and 20 redundant _support helper calls per monthly tick (Issue #1452)
 
  Quality of Life:
+  - [LIC] The Path of Conquest and Claim the HRE focuses now list the nations they will lead to war with
   - [GER] BFV GUI now updates immediately on button clicks instead of waiting for the next daily tick
   - Widened technology name text fields in the research screen to prevent text clipping
   - You can now push your Election Threshold to 0% instead of the minimum 1% in the Subideology screen

--- a/common/decisions/!_energy_decisions.txt
+++ b/common/decisions/!_energy_decisions.txt
@@ -40,7 +40,7 @@ decision_category_energy = {
 		is_good = yes
 
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision energy_building_battery_parks"
+			log = "[GetDateText]: [Root.GetName]: Decision energy_automatic_fuel_purchase"
 			buy_fuel_from_the_market_effect = yes
 			activate_mission = energy_automatic_fuel_purchase
 			set_country_flag = { flag = recently_bought_fuel value = 1 days = 28 }

--- a/common/decisions/05_LAT_decisions.txt
+++ b/common/decisions/05_LAT_decisions.txt
@@ -19,13 +19,13 @@ generic_coalition_politics_decisions = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision POR_expand_the_neves_corvo_mine"
+			log = "[GetDateText]: [Root.GetName]: Decision LAT_reopen_the_vef_microchip_plant"
 			set_temp_variable = { treasury_change = -5.00 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove POR_expand_the_neves_corvo_mine"
+			log = "[GetDateText]: [Root.GetName]: Decision remove LAT_reopen_the_vef_microchip_plant"
 			107 = {
 				add_building_construction = {
 					type = microchip_plant

--- a/common/decisions/05_SWE_decision.txt
+++ b/common/decisions/05_SWE_decision.txt
@@ -128,7 +128,7 @@ SWE_decision_Forsvarsmarkten_category = {
 
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision GER_recruitment_campaigns"
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_fortifications"
 			442 = {
 				add_building_construction = {
 					type = bunker
@@ -210,7 +210,7 @@ SWE_decision_Forsvarsmarkten_category = {
 
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision GER_recruitment_campaigns"
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_open_weapons_depots"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_3
 				amount = 12500
@@ -333,7 +333,7 @@ SWE_decision_Forsvarsmarkten_category = {
 		fire_only_once = no
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision GER_Launch_big_Trainings_exercise"
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_Home_defence_Trainings_exercise"
 			SWE = {
 				random_country_division = { add_divisional_commander_xp = 110 }
 				random_country_division = { add_divisional_commander_xp = 110 }
@@ -829,7 +829,7 @@ SWE_decision_Royal_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SWE_send_to_UN"
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_visit_asia"
 			if = {
 				limit = {
 					country_exists = JAP
@@ -925,7 +925,7 @@ SWE_decision_Royal_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SWE_send_to_UN"
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_visit_EU"
 			if = {
 				limit = {
 					country_exists = GER
@@ -1002,7 +1002,7 @@ SWE_decision_Royal_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SWE_charity"
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_governmental_office"
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes

--- a/common/decisions/05_north_korea.txt
+++ b/common/decisions/05_north_korea.txt
@@ -14,7 +14,7 @@ NKO_united_front_department = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove closed_kaesong "
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_close_kaesong_industrial_park "
 			set_country_flag = closed_kaesong
 			set_temp_variable = { temp_opinion = 5 }
 			change_communist_cadres_opinion = yes
@@ -55,7 +55,7 @@ NKO_united_front_department = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove closed_kaesong "
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_reopen_kaesong_industrial_park "
 			clr_country_flag = closed_kaesong
 			set_temp_variable = { temp_opinion = -5 }
 			change_communist_cadres_opinion = yes
@@ -122,7 +122,7 @@ NKO_united_front_department = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_reunification_talks_failed "
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_restart_peace_talks "
 			clr_country_flag = NKO_peace_talks_failed
 		}
 		remove_effect = {
@@ -174,7 +174,7 @@ NKO_united_front_department = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_reunification_talks_failed ,  add NKO_proposed_unity_reunification"
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_propose_north_led_reunification_decision ,  add NKO_proposed_unity_reunification"
 			set_country_flag = NKO_proposed_north_reunification
 		}
 
@@ -684,14 +684,14 @@ NKO_arduous_march = {
 			NOT = { has_country_flag = NKO_accept_money_active }
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision add NKO_medicine_relief_active"
+			log = "[GetDateText]: [Root.GetName]: Decision add NKO_medicine_relief"
 			random_owned_state = {
 				add_manpower = 2000
 			}
 			set_country_flag = NKO_medicine_relief_active
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_medicine_relief_active"
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_medicine_relief"
 			clr_country_flag = NKO_medicine_relief_active
 		}
 		modifier = {
@@ -817,11 +817,11 @@ NKO_arduous_march = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision add NKO_international_assistance_active"
+			log = "[GetDateText]: [Root.GetName]: Decision add NKO_international_assistance"
 			set_country_flag = NKO_international_assistance_active
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_international_assistance_active"
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_international_assistance"
 
 			clr_country_flag = NKO_international_assistance_active
 		}
@@ -844,7 +844,7 @@ NKO_arduous_march = {
 			emerging_communist_state_are_in_power = yes
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove BNKO_resource_extraction"
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_resource_extraction"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 			random_owned_state = {
@@ -2541,7 +2541,7 @@ NKO_rus_friend_category = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_coop_russian_gas_pipeline"
+			log = "[GetDateText]: [Root.GetName]: Decision remove NKO_coop_russian_gas_pipeline_start"
 			add_ideas = SOV_korean_stream_idea
 			hidden_effect = {
 				SOV = {

--- a/common/decisions/99_mp_decisions.txt
+++ b/common/decisions/99_mp_decisions.txt
@@ -788,7 +788,7 @@ mp_resource_decision_category = {
 				}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision add_aluminium_resource"
+			log = "[GetDateText]: [Root.GetName]: Decision add_aluminum_resource"
 			country_event = resource.3
 		}
 	}
@@ -1033,7 +1033,7 @@ mp_resource_decision_category = {
 		}
 		fire_only_once = yes
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision add_workforce_idea"
+			log = "[GetDateText]: [Root.GetName]: Decision add_research_idea"
 			add_ideas = MP_research_idea
 			set_country_flag = research_idea
 			set_temp_variable = { treasury_change = -30 }

--- a/common/decisions/Afghanistan.txt
+++ b/common/decisions/Afghanistan.txt
@@ -948,9 +948,6 @@ AFG_agriculture_mech = {
 		days_remove = 30
 		days_re_enable = 90
 
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision AFG_Pomegranate_invesment1"
-		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision AFG_Pomegranate_invesment1"
 			hidden_effect = {
@@ -1614,10 +1611,6 @@ Taliban_insurgency_category = {
 
 		available = {
 			no_jihadist_government = yes
-		}
-
-		complete_effect = {
-			log = "[GetDateText]: [This.GetName]: decision afghan_unity_propaganda executed"
 		}
 
 		days_remove = 30
@@ -2474,7 +2467,7 @@ AFG_tal_insurgency_new = {
 		days_remove = 25
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TAL_move_into_tribal_areas"
+			log = "[GetDateText]: [Root.GetName]: Decision TAL_construct_the_safed_koh_system"
 			1207 = {
 				add_building_construction = {
 					type = supply_node

--- a/common/decisions/AfricanUnion.txt
+++ b/common/decisions/AfricanUnion.txt
@@ -37,7 +37,7 @@ african_union_decisions_category = {
 			has_idea = AU_member
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision African_Union_join_the_union"
+			log = "[GetDateText]: [Root.GetName]: Decision African_Union_leave_the_union"
 			remove_ideas = AU_member
 		}
 

--- a/common/decisions/Arab Spring.txt
+++ b/common/decisions/Arab Spring.txt
@@ -159,7 +159,7 @@ arab_spring_category = {
 		fire_only_once = yes
 
 		remove_effect = {
-			log = "[GetDateText]: [This.GetName]: decision arab_spring_deploy_the_military executed"
+			log = "[GetDateText]: [This.GetName]: decision arab_spring_return_to_barracks executed"
 			set_temp_variable = { temp_strength = 15 }
 			change_arab_spring_strength = yes
 			clr_country_flag = arab_spring_military_deployed
@@ -182,7 +182,7 @@ arab_spring_category = {
 		fixed_random_seed = no
 
 		remove_effect = {
-			log = "[GetDateText]: [This.GetName]: decision arab_spring_deploy_the_military executed"
+			log = "[GetDateText]: [This.GetName]: decision arab_spring_reshuffle_government executed"
 			set_temp_variable = { temp_strength = -50 }
 			change_arab_spring_strength = yes
 			if = {

--- a/common/decisions/Armenia.txt
+++ b/common/decisions/Armenia.txt
@@ -296,7 +296,7 @@ ARM_soc_pac_bop_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision ARM_prioritize_invest_green_energy"
+			log = "[GetDateText]: [Root.GetName]: Decision ARM_prioritize_invest_energy"
 			add_power_balance_value = {
 				id = ARM_soc_pac_bop
 				value = -0.10
@@ -1545,7 +1545,7 @@ ARM_special_services_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove ARM_promotion_of_interest_armenia"
+			log = "[GetDateText]: [Root.GetName]: Decision remove ARM_promotion_of_interest_armenia_in_poland"
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = ARM }
 			set_temp_variable = { influence_target = POL }
@@ -1887,7 +1887,7 @@ ARM_special_services_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove ARM_promotion_of_interest_greece"
+			log = "[GetDateText]: [Root.GetName]: Decision remove ARM_promotion_of_interest_armenia_in_greece"
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { tag_index = ARM }
 			set_temp_variable = { influence_target = GRE }

--- a/common/decisions/Brazil.txt
+++ b/common/decisions/Brazil.txt
@@ -52,7 +52,7 @@ BRA_amazon_conservation_system_decision_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove BRA_decision_plant_additional_trees"
+			log = "[GetDateText]: [Root.GetName]: Decision remove BRA_decision_declare_new_conservation_lands"
 			set_temp_variable = { temp_change = 15 }
 			BRA_conserv_acreage_effect = yes
 			set_temp_variable = { temp_change = -15 }

--- a/common/decisions/Cartel Decisions.txt
+++ b/common/decisions/Cartel Decisions.txt
@@ -571,7 +571,7 @@ cartels_decision_category = {
 		days_re_enable = 90
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision target_cartel_money_laundering_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision target_cartel_drug_running_decision"
 			custom_effect_tooltip = while_cartel_drug_attacking_active_tt
 			unlock_decision_tooltip = raid_drug_convoys_decision
 			unlock_decision_tooltip = raid_cartel_hideouts_decision
@@ -1008,7 +1008,7 @@ cartels_decision_category = {
 		days_re_enable = 30
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision Remove raid_distribution_centres_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision Remove raid_refinement_centres_decision"
 			random_list = {
 				40 = {
 					modifier = {
@@ -1382,7 +1382,7 @@ cartels_decision_category = {
 
 		# Select the Button
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout_effect narcos_crisis"
+			log = "[GetDateText]: [Root.GetName]: Decision narcos_crisis narcos_crisis"
 			set_temp_variable = { strength_of_cartels_strength = strength_of_cartels }
 			multiply_temp_variable = { strength_of_cartels_strength = 0.01 }
 			clamp_variable = {
@@ -1448,7 +1448,7 @@ cartels_decision_category = {
 		}
 
 		complete_effect = { #if chosen the narcos take over
-			log = "[GetDateText]: [Root.GetName]: Decision complete_effect narcos_crisis"
+			log = "[GetDateText]: [Root.GetName]: Decision narcos_crisis narcos_crisis"
 			# Peaceful Takeover if you concede to the cartels
 			if = { limit = { check_variable = { cartel_political_influence < 98 } }
 				start_civil_war = {
@@ -1571,7 +1571,7 @@ cartels_decision_category = {
 		days_mission_timeout = 180
 
 		timeout_effect = { # Momento of truth
-			log = "[GetDateText]: [Root.GetName]: Decision timeout_effect mexican_cartel_war"
+			log = "[GetDateText]: [Root.GetName]: Decision mexican_cartel_war mexican_cartel_war"
 			country_event = cartel_event.1
 			set_country_flag = CARTEL_narco_wars_triggered
 		}

--- a/common/decisions/Cheat Decisions.txt
+++ b/common/decisions/Cheat Decisions.txt
@@ -1171,7 +1171,7 @@ cheat_decision_categories = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision cheat_decisions_add_5_operative"
+			log = "[GetDateText]: [Root.GetName]: Decision cheat_decisions_add_10_operative"
 			add_ideas = operatives10
 		}
 	}

--- a/common/decisions/China.txt
+++ b/common/decisions/China.txt
@@ -3940,7 +3940,7 @@ one_china_category = {
 		complete_effect = {
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [This.GetName]: decision anti_DPP_media_campaign executed"
+			log = "[GetDateText]: [This.GetName]: decision anti_DPP_media_campaign_2 executed"
 		}
 
 		remove_effect = {
@@ -5140,7 +5140,7 @@ southwest_hydroelectricity_dev_category = {
 		complete_effect = {
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [This.GetName]: decision construction_jialing_dam executed"
+			log = "[GetDateText]: [This.GetName]: decision construction_jialingjiang_dam executed"
 		}
 
 		days_remove = 360
@@ -5187,7 +5187,7 @@ xinjiang_category = {
 
 		complete_effect = {
 			add_command_power = -40
-			log = "[GetDateText]: [This.GetName]: decision raid_TIP_hideouts executed"
+			log = "[GetDateText]: [This.GetName]: decision raid_militant_hideouts executed"
 		}
 
 		days_remove = 15
@@ -5656,7 +5656,7 @@ taiwan_coup_category = {
 		cost = 50
 
 		remove_effect = {
-			log = "[GetDateText]: [This.GetName]: decision send_political_support_taiwan executed"
+			log = "[GetDateText]: [This.GetName]: decision send_civilian_support_taiwan executed"
 			TAI = {
 				add_political_power = 50
 			}
@@ -5689,7 +5689,7 @@ taiwan_coup_category = {
 
 		complete_effect = {
 			add_command_power = -50
-			log = "[GetDateText]: [This.GetName]: decision rally_support_taiwan executed"
+			log = "[GetDateText]: [This.GetName]: decision rally_support_military_taiwan executed"
 		}
 
 		days_remove = 3
@@ -6089,7 +6089,7 @@ hongkong_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [This.GetName]: decision deploy_troops executed"
+			log = "[GetDateText]: [This.GetName]: decision request_troops executed"
 			if = {
 				limit = { CHI = { has_idea = CHI_Hong_Kong_Protests_01 } }
 				HKG = { remove_ideas = Hong_Kong_Protests_01 }
@@ -6940,7 +6940,7 @@ arunachal_war_decisions_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision attack_475_from_589"
+			log = "[GetDateText]: [Root.GetName]: Decision attack_982_from_589"
 			set_country_flag = Attacking_in_Arunachal
 		}
 

--- a/common/decisions/Cuba.txt
+++ b/common/decisions/Cuba.txt
@@ -62,7 +62,7 @@ CUB_ter_defence_category = {
 			has_completed_focus = CUB_create_ter_defense
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove CUB_ter_oboronaup_start"
+			log = "[GetDateText]: [Root.GetName]: Decision remove CUB_ter_oboronaup"
 			add_manpower = -5000
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
@@ -950,7 +950,7 @@ CUB_confederation_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SER_invite_bosnia"
+			log = "[GetDateText]: [Root.GetName]: Decision CUB_invite_haiti"
 			HAI = {	country_event = { id = CubaConf.50 days = 1 } }
 		}
 	}
@@ -981,7 +981,7 @@ CUB_confederation_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SER_invite_bosnia"
+			log = "[GetDateText]: [Root.GetName]: Decision CUB_invite_dominicana"
 			DOM = {	country_event = { id = CubaConf.50 days = 1 } }
 		}
 	}
@@ -1013,7 +1013,7 @@ CUB_confederation_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SER_invite_bosnia"
+			log = "[GetDateText]: [Root.GetName]: Decision CUB_invite_puerto_rico"
 			PTR = {	country_event = { id = CubaConf.50 days = 1 } }
 		}
 	}
@@ -1045,7 +1045,7 @@ CUB_confederation_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SER_invite_bosnia"
+			log = "[GetDateText]: [Root.GetName]: Decision CUB_invite_colombia"
 			COL = {	country_event = { id = CubaConf.50 days = 1 } }
 		}
 	}

--- a/common/decisions/Czech_Republic.txt
+++ b/common/decisions/Czech_Republic.txt
@@ -1977,7 +1977,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_volkswagen_group_civil_war"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_volkswagen_group_civil_war2"
 			if = {
 				limit = {
 					CZE = { has_country_flag = CZE_skoda_overthrown_volkswagen_flag }
@@ -2053,7 +2053,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_call_a_press_conference_skoda"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_call_a_press_conference"
 			if = {
 				limit = {
 					original_tag = CZE
@@ -3627,7 +3627,7 @@ CZE_kscm_strikes_at_eu_category = {
 		}
 
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_pay_bills"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_eu_mission_fail"
 			clr_country_flag = CZE_kscm_eu_problem_flag
 			custom_effect_tooltip = CZE_kscm_eu_problem_failed
 		}
@@ -5832,7 +5832,7 @@ CZE_prague_castle_renovation_decisions = {
 		remove_effect = {
 			clear_variable = third_renovation_completed
 
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_first_renovation"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_last_renovation"
 
 			country_event = CZE_monarchy_event.17
 		}
@@ -6403,7 +6403,7 @@ CZE_the_prague_conference_category = {
 
 		complete_effect = {
 			CZE_prague_conference_decision_ongoing = yes
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_foreing_embassies"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_foreign_treaties"
 
 		}
 
@@ -6442,7 +6442,7 @@ CZE_the_prague_conference_category = {
 
 		complete_effect = {
 			CZE_prague_conference_decision_ongoing = yes
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_foreing_embassies"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_create_a_plan_for_monarchies"
 		}
 
 		remove_effect = {
@@ -6880,7 +6880,7 @@ CZE_the_prague_conference_category = {
 		complete_effect = {
 			CZE_prague_conference_decision_ongoing = yes
 			custom_effect_tooltip = CZE_debt_unification
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_foreing_embassies"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_debt"
 		}
 
 		modifier = {
@@ -6926,7 +6926,7 @@ CZE_the_prague_conference_category = {
 			modify_treasury_effect = yes
 
 			CZE_prague_conference_decision_ongoing = yes
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_foreing_embassies"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_civilian_investment_in_rural_areas"
 		}
 
 		modifier = {
@@ -7056,7 +7056,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_infrastCZE_skoda_learnings"
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_skoda_learnings"
 			set_temp_variable = { treasury_change = 0 }
 			if = { limit = { country_exists = AUS }
 				add_to_temp_variable = { treasury_change = -10 }

--- a/common/decisions/Denmark.txt
+++ b/common/decisions/Denmark.txt
@@ -352,7 +352,7 @@ DEN_urban_development_fund_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [This.GetName]: decision influence_for_autonomy_decision executed"
+			log = "[GetDateText]: [This.GetName]: decision DEN_local_construction_initiatives_decision executed"
 			set_temp_variable = { temp_change = -5 }
 			modify_urban_development_fund_effect = yes
 			FROM = {
@@ -397,7 +397,7 @@ DEN_urban_development_fund_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [This.GetName]: decision influence_for_autonomy_decision executed"
+			log = "[GetDateText]: [This.GetName]: decision DEN_local_renewable_investment_decision executed"
 			set_temp_variable = { temp_change = -5 }
 			modify_urban_development_fund_effect = yes
 			FROM = {
@@ -1176,7 +1176,7 @@ DEN_decision_Investments_Global = {
 		days_re_enable = 365
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision DEN_Invest"
+			log = "[GetDateText]: [Root.GetName]: Decision DEN_Maersk_Invest"
 			FROM = {
 				set_country_flag = DEN_Investments
 				set_temp_variable = { percent_change = 2.1 }
@@ -1329,7 +1329,7 @@ DEN_decision_Investments_Global_II = {
 		fixed_random_seed = yes
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision DEN_Invest"
+			log = "[GetDateText]: [Root.GetName]: Decision DEN_DSV_Invest"
 			FROM = {
 				set_country_flag = DEN_Investments
 				set_temp_variable = { percent_change = 1.9 }

--- a/common/decisions/France.txt
+++ b/common/decisions/France.txt
@@ -208,8 +208,10 @@ FRA_invest_LEB_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -237,8 +239,10 @@ FRA_invest_LEB_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -265,8 +269,10 @@ FRA_invest_LEB_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -297,8 +303,10 @@ FRA_invest_LEB_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -330,7 +338,7 @@ FRA_french_africa_decision_category = {
 		fire_only_once = yes
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision FRA_invest_in_french_africa_education_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision FRA_invest_in_NEPAD_education_decision"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = AFRICA_idea_nepad_modifier
@@ -348,8 +356,10 @@ FRA_french_africa_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -397,8 +407,10 @@ FRA_french_africa_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -446,8 +458,10 @@ FRA_french_africa_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}
@@ -494,8 +508,10 @@ FRA_french_africa_decision_category = {
 				factor = 0
 				NOT = {
 					has_global_flag = FRA_CHAOS_PATH
-					has_government = communism
-					has_government = nationalist
+					OR = {
+						has_government = communism
+						has_government = nationalist
+					}
 				}
 			}
 		}

--- a/common/decisions/Germany.txt
+++ b/common/decisions/Germany.txt
@@ -1453,9 +1453,6 @@ GER_civil_war_mission = {
 		}
 		days_mission_timeout = 100
 		is_good = no
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision GER_incoming_collapse"
-		}
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision GER_incoming_collapse"
 			custom_effect_tooltip = GER_civil_war_TT
@@ -1956,9 +1953,6 @@ GER_V_fall_Decision = {
 	GER_Territorial_Defense = {
 		fire_only_once = yes
 		days_remove = 45
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_country_flag = GER_V_fall
@@ -2026,9 +2020,6 @@ GER_V_fall_Decision = {
 	GER_call_reservists = {
 		fire_only_once = yes
 		days_remove = 45
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_country_flag = GER_V_fall
@@ -2096,9 +2087,6 @@ GER_V_fall_Decision = {
 	GER_fortifications_I = {
 		days_remove = 30
 		days_re_enable = 365
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_country_flag = GER_V_fall
@@ -2145,9 +2133,6 @@ GER_V_fall_Decision = {
 
 		days_remove = 30
 		days_re_enable = 365
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_country_flag = GER_V_fall
@@ -2191,9 +2176,6 @@ GER_V_fall_Decision = {
 
 		days_remove = 30
 		days_re_enable = 365
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_country_flag = GER_V_fall
@@ -2253,10 +2235,6 @@ GER_V_fall_Decision = {
 		}
 	}
 	GER_end_V_Fall = {
-
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_country_flag = GER_V_fall
@@ -2329,9 +2307,6 @@ GER_Officer_Training_Decisions = {
 		fixed_random_seed = no
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2380,9 +2355,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2431,9 +2403,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2483,9 +2452,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2535,9 +2501,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2587,9 +2550,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2640,9 +2600,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2692,9 +2649,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 90
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2747,9 +2701,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 365
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member
@@ -2774,9 +2725,6 @@ GER_Officer_Training_Decisions = {
 
 		days_remove = 365
 		cost = 70
-		available = {
-			original_tag = GER
-		}
 
 		visible = {
 			has_idea = NATO_member

--- a/common/decisions/Hezbollah.txt
+++ b/common/decisions/Hezbollah.txt
@@ -2012,9 +2012,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 				influence_higher_10 = yes
 				custom_trigger_tooltip = {
 					tooltip = HEZ_the_might_of_muqawimat_TT
-					hidden_trigger = {
-						 check_variable = { party_pop_array^9 > 0.29 }
-					}
+					check_variable = { party_pop_array^9 > 0.29 }
 				}
 			}
 		}

--- a/common/decisions/India.txt
+++ b/common/decisions/India.txt
@@ -151,10 +151,6 @@ RAJ_religious_groups = {
 
 		fire_only_once = no
 
-		visible = {
-			original_tag = RAJ
-		}
-
 		available = {
 			NOT = { has_civil_war = yes }
 		}

--- a/common/decisions/Influence Decisions.txt
+++ b/common/decisions/Influence Decisions.txt
@@ -206,7 +206,7 @@ influence_decisions = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision disable_auto_influence_notification_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision enable_auto_influence_notification_decision"
 			clr_country_flag = disable_auto_influence_notification
 		}
 	}

--- a/common/decisions/Internal Factions.txt
+++ b/common/decisions/Internal Factions.txt
@@ -344,7 +344,7 @@ decision_category_internal_factions = {
 		cost = 75
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: decision remove impose_taxes_on_religious_institutions_decision"
+			log = "[GetDateText]: [Root.GetName]: decision remove encourage_further_party_propaganda"
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = -0.002 }
 			modify_treasury_effect = yes
@@ -378,7 +378,7 @@ decision_category_internal_factions = {
 		fixed_random_seed = no
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: decision remove impose_taxes_on_religious_institutions_decision"
+			log = "[GetDateText]: [Root.GetName]: decision remove sell_political_positions_to_the_highest_bidder"
 			if = {
 				limit = {
 					NOT = { has_idea = corruption_level_10 }

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -263,7 +263,7 @@ PER_Iranian_elections_decision_category = {
 	PER_street_ads_for_principalists = {
 		days_re_enable = 30
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_tv_ads_for_principalists"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_street_ads_for_principalists"
 			country_event = PER_election_events.24
 		}
 		cost = 100
@@ -676,7 +676,7 @@ PER_Iranian_president_info = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_support_the_reform_plans_in_the_parliament"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_send_diplomats_to_the_west"
 			USA = {
 				add_opinion_modifier = {
 					target = PER
@@ -778,7 +778,7 @@ PER_Iranian_president_info = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_support_the_reform_plans_in_the_parliament"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_start_the_new_phase_of_liberalization"
 			add_stability = 0.005
 			set_temp_variable = { party_index = 8 }
 			set_temp_variable = { party_popularity_increase = 0.01 }
@@ -818,7 +818,7 @@ PER_Iranian_president_info = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_support_the_reform_plans_in_the_parliament"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_develop_the_economy"
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = 0.008 }
 			modify_treasury_effect = yes
@@ -1547,7 +1547,7 @@ PER_resitance_axis = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_aid_hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_give_arms_to_hezbollah"
 			clr_country_flag = PER_give_arms_to_hezbollah_d
 			HEZ = {
 				country_event = message_from_iran.1
@@ -1652,7 +1652,7 @@ PER_resitance_axis = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_aid_hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_financial_aid_to_hezbollah"
 			clr_country_flag = PER_financial_aid_to_hezbollah_d
 			HEZ = {
 				country_event = message_from_iran.2
@@ -1869,7 +1869,7 @@ PER_resitance_axis = {
 
 		remove_effect = {
 			clr_country_flag = PER_iraq_military_industry_increase_d
-			log = "[GetDateText]: [Root.GetName]: Decision PER_aid_hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_iraq_military_industry_increase"
 			IRQ = {
 				country_event = message_from_iran.3
 				add_offsite_building = { type = arms_factory level = 1 }
@@ -2083,7 +2083,7 @@ PER_resitance_axis = {
 
 		remove_effect = {
 			clr_country_flag = PER_syria_military_industry_increase_d
-			log = "[GetDateText]: [Root.GetName]: Decision PER_aid_hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_syria_military_industry_increase"
 			SYR = {
 				country_event = message_from_iran.3
 				add_offsite_building = { type = arms_factory level = 1 }
@@ -2297,7 +2297,7 @@ PER_resitance_axis = {
 
 		remove_effect = {
 			clr_country_flag = PER_houthis_military_industry_increase_d
-			log = "[GetDateText]: [Root.GetName]: Decision PER_aid_hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_houthis_military_industry_increase"
 			HOU = {
 				country_event = message_from_iran.3
 				add_offsite_building = { type = arms_factory level = 1 }
@@ -3089,7 +3089,7 @@ PER_domestic_politics = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_liquify_hormuz"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_lift_the_fatwa"
 			clr_country_flag = PER_no_nuclear
 			custom_effect_tooltip = PER_lift_fatwa_TT
 			newline = yes
@@ -3562,7 +3562,7 @@ PER_domestic_politics = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_reintegrate_azerbaijan"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_reintegrate_south_azerbaijan"
 			407 = {
 				add_core_of = PER
 			}
@@ -3594,7 +3594,7 @@ PER_domestic_politics = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_integrate_azerbaijan"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_integrate_basrah_maysan"
 			171 = {
 				set_state_name = "Basiran"
 				add_core_of = PER
@@ -4918,7 +4918,7 @@ PER_Iranian_prime_ministers = {
 		days_remove = 90
 		days_re_enable = 180
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_crack_down_on_crime"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_housing_projects"
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			set_temp_variable = { temp_outlook_increase = 0.025 }
 			add_relative_party_popularity = yes
@@ -5244,7 +5244,7 @@ PER_Iranian_prime_ministers = {
 		days_re_enable = 180
 		fixed_random_seed = no
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_nationalize_industries"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_nationalize_resource_industries"
 			random_list = {
 				10 = {
 					random_core_state = {
@@ -5482,7 +5482,7 @@ PER_Iranian_prime_ministers = {
 		days_remove = 90
 		days_re_enable = 180
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_cut_back_military_spending"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_open_borders"
 			set_temp_variable = { temp_productivity_change = 50 }
 			random_core_state = {
 				state_flat_productivity_change_effect = yes
@@ -5736,7 +5736,7 @@ PER_Iranian_prime_ministers = {
 		days_remove = 90
 		days_re_enable = 180
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_closed_borders"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_deport_illegals"
 			random_core_state = {
 				add_manpower = -450
 			}
@@ -5842,7 +5842,7 @@ PER_new_majlis = {
 		fire_only_once = yes
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_new_majlis"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_move_to_baharestan"
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -6658,7 +6658,7 @@ PER_new_majlis = {
 		days_mission_timeout = 500
 		is_good = no
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_no_mountain_will_stop_us"
+			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_disparity_has_no_place_here"
 			three_random_industrial_complex = yes
 			newline = yes
 			add_stability = 0.05
@@ -6666,7 +6666,7 @@ PER_new_majlis = {
 			set_country_flag = PER_did_lib_8
 		}
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_no_mountain_will_stop_us"
+			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_disparity_has_no_place_here"
 			set_temp_variable = { party_popularity_increase = -0.15 }
 			set_temp_variable = { temp_outlook_increase = -0.15 }
 			add_relative_party_popularity = yes
@@ -8899,7 +8899,7 @@ PER_new_majlis = {
 		days_mission_timeout = 500
 		is_good = no
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_our_old_jewel"
+			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_our_lost_jewel"
 			add_resource = {
 				type = oil
 				amount = 24
@@ -8923,7 +8923,7 @@ PER_new_majlis = {
 			set_country_flag = PER_did_monarch_6
 		}
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_our_old_jewel"
+			log = "[GetDateText]: [Root.GetName]: Decision timeout PER_our_lost_jewel"
 			set_temp_variable = { percent_change = 10 }
 			set_temp_variable = { tag_index = SAU }
 			set_temp_variable = { influence_target = PER }
@@ -11305,7 +11305,7 @@ PER_cento_decisions = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_invite_iraq"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_invite_iraq2"
 			IRQ = {
 				country_event = {
 					id = iranian_focus.54
@@ -11349,7 +11349,7 @@ PER_cento_decisions = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_invite_lebanon"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_invite_lebanon2"
 			LEB = {
 				country_event = {
 					id = iranian_focus.54
@@ -11644,7 +11644,7 @@ PER_war_in_yemem = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision PER_demand_houthi_offensive"
+			log = "[GetDateText]: [Root.GetName]: Decision PER_demand_houthi_perform_offensive"
 			clr_global_flag = HOU_Houthi_offensive
 		}
 

--- a/common/decisions/Iraq.txt
+++ b/common/decisions/Iraq.txt
@@ -27,7 +27,7 @@ IRQ_iraq_war = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout IRQ_war_phase_two"
+			log = "[GetDateText]: [Root.GetName]: Decision timeout IRQ_war_phase_one"
 			if = {
 				limit = {
 					488 = {
@@ -2502,7 +2502,7 @@ IRQ_fao_decisions = {
 			has_country_flag = IRQ_open_invite_menu
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision IRQ_open_invites"
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_close_invites"
 			clr_country_flag = IRQ_open_invite_menu
 		}
 		ai_will_do = {

--- a/common/decisions/Italy.txt
+++ b/common/decisions/Italy.txt
@@ -2702,7 +2702,7 @@ generic_ITA = {
 		}
 		days_re_enable = 180
 		complete_effect = {
-			log = "[GetDateText]: [This.GetName]: decision random_financial_police_surprise_checks executed"
+			log = "[GetDateText]: [This.GetName]: decision provide_local_party_positions_to_business_owners executed"
 			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			set_temp_variable = { provide_local_party_positions_to_business_owners_cost = provide_local_party_positions_to_business_owners_times_taken_var }
@@ -3111,13 +3111,13 @@ integrative_restoration_ITA = {
 			base = 10
 		}
 		complete_effect = {
-			log = "[GetDateText]: [This.GetName]: decision restore_Pompeii executed"
+			log = "[GetDateText]: [This.GetName]: decision restore_the_Temple_Valley executed"
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 		days_remove = 365
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove restore_Pompeii"
+			log = "[GetDateText]: [Root.GetName]: Decision remove restore_the_Temple_Valley"
 			add_to_variable = { ITA_monuments_restored_counter = 1 }
 			if = {
 				limit = {
@@ -4011,14 +4011,14 @@ ITA_italian_space_decision_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision ITA_expand_space_program"
+			log = "[GetDateText]: [Root.GetName]: Decision ITA_shrink_space_program"
 			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 		}
 		cost = 50
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove ITA_expand_space_program"
+			log = "[GetDateText]: [Root.GetName]: Decision remove ITA_shrink_space_program"
 			add_to_variable = { ITA_space_program_level = -1 }
 			add_to_variable = { ITA_peoples_support = 10.0 }
 			custom_effect_tooltip = ITA_increase_people_support_10_TT

--- a/common/decisions/Liechtenstein.txt
+++ b/common/decisions/Liechtenstein.txt
@@ -174,7 +174,7 @@ LIC_holy_roman_empire_category = {
 		}
 		cost = 100
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision LIC_form_hre"
+			log = "[GetDateText]: [Root.GetName]: Decision LIC_form_HRE"
 			set_cosmetic_tag = LIC_AUTH_SS
 			set_variable = { LIC_formed_HRE = 1 }
 			add_ideas = { LIC_idea_HRE_government }

--- a/common/decisions/Nigeria.txt
+++ b/common/decisions/Nigeria.txt
@@ -1029,7 +1029,7 @@ NIG_expand_hydro_decisions_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision NIG_construct_the_mambilla_hydroelectric_power_plant complete"
+			log = "[GetDateText]: [Root.GetName]: Decision NIG_construct_the_gurara_hydroelectric_power_plant complete"
 			set_temp_variable = { treasury_change = -8 }
 			modify_treasury_effect = yes
 		}

--- a/common/decisions/Norway.txt
+++ b/common/decisions/Norway.txt
@@ -209,7 +209,7 @@ NRY_norge_mining_decision_cat = {
 			set_country_flag = NRY_taking_decision
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision NRY_mines_in_vestlandet"
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_mines_in_norde_norge"
 			clr_country_flag = NRY_taking_decision
 			if = {
 				limit = {
@@ -309,7 +309,7 @@ NRY_norge_mining_decision_cat = {
 			set_country_flag = NRY_taking_decision
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision NRY_mines_in_vestlandet"
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_deep_sea_mining_in_trondelag"
 			clr_country_flag = NRY_taking_decision
 			if = {
 				limit = {
@@ -408,7 +408,7 @@ NRY_norge_mining_decision_cat = {
 			set_country_flag = NRY_taking_decision
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision NRY_mines_in_oslo"
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_deep_sea_in_oslo"
 			clr_country_flag = NRY_taking_decision
 			if = {
 				limit = {

--- a/common/decisions/Poland.txt
+++ b/common/decisions/Poland.txt
@@ -4541,9 +4541,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage1_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_1
-				}
+				has_country_flag = POL_polsa_1
 			}
 		}
 
@@ -4582,9 +4580,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage2_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_2
-				}
+				has_country_flag = POL_polsa_2
 			}
 		}
 
@@ -4623,9 +4619,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage3_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_3
-				}
+				has_country_flag = POL_polsa_3
 			}
 		}
 
@@ -4659,9 +4653,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage4_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_4
-				}
+				has_country_flag = POL_polsa_4
 			}
 		}
 
@@ -4690,9 +4682,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage5_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_5
-				}
+				has_country_flag = POL_polsa_5
 			}
 			NOT = {
 				OR = {
@@ -4738,9 +4728,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage5_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_5
-				}
+				has_country_flag = POL_polsa_5
 			}
 			NOT = {
 				OR = {
@@ -4785,9 +4773,7 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage5_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_5
-				}
+				has_country_flag = POL_polsa_5
 			}
 			NOT = {
 				OR = {
@@ -4832,11 +4818,9 @@ POL_polsa_construction_category = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage6_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_6
-					has_country_flag = POL_polsa_7
-					has_country_flag = POL_polsa_8
-				}
+				has_country_flag = POL_polsa_6
+				has_country_flag = POL_polsa_7
+				has_country_flag = POL_polsa_8
 			}
 		}
 
@@ -8276,7 +8260,7 @@ POL_department_of_foreign_influence_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_lithuania"
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_latvia"
 			set_variable = { POL_faction_invite = LAT.id }
 			country_event = poland.105
 		}

--- a/common/decisions/Political Desicions.txt
+++ b/common/decisions/Political Desicions.txt
@@ -592,7 +592,7 @@ generic_coalition_politics_decisions = {
 		fixed_random_seed = no
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision promote_outlook_decision_support_the_salafists"
+			log = "[GetDateText]: [Root.GetName]: Decision promote_reduced_spending_campaigns"
 			custom_effect_tooltip = propaganda_campaign_costs_tt
 			ingame_update_setup = yes
 			random = {
@@ -1292,7 +1292,7 @@ generic_coalition_politics_decisions = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove GLOBAL_arm_delete_abk_resistan"
+			log = "[GetDateText]: [Root.GetName]: Decision remove GLOBAL_arm_delete_aze_resistan"
 			713 = {
 				remove_dynamic_modifier = {
 					modifier = GLOBAL_azer_resistance_modifier

--- a/common/decisions/Romania.txt
+++ b/common/decisions/Romania.txt
@@ -3,7 +3,7 @@ ROM_monarchy_referendum = {
 	ROM_referendum_timer = {
 		icon = GFX_decision_politics
 		allowed = { always = yes }
-		available = { original_tag = ROM  NOT = { has_country_flag = rom_referendum } }
+		available = { NOT = { has_country_flag = rom_referendum } }
 		activation = { original_tag = ROM has_country_flag = rom_referendum }
 		days_mission_timeout = 150
 		is_good = no
@@ -311,7 +311,7 @@ ROM_vadim_struggle = {
 	ROM_vadim_timer = {
 		icon = GFX_decision_decision_eng_blackshirt_march
 		allowed = { always = yes }
-		available = { original_tag = ROM NOT = { has_country_flag = mission_vadim } }
+		available = { NOT = { has_country_flag = mission_vadim } }
 		activation = { original_tag = ROM has_country_flag = mission_vadim }
 		days_mission_timeout = 250
 		is_good = no

--- a/common/decisions/Russia.txt
+++ b/common/decisions/Russia.txt
@@ -19,7 +19,7 @@ SOV_mvd_category = {
 			has_idea = SOV_rosguard_troops_idea
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_rosguard_22"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_rosguard_mobilize"
 			SOV_rosguard_mobilise_effect = yes
 		}
 		ai_will_do = {
@@ -243,7 +243,7 @@ SOV_mvd_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SOV_svr__open"
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_svr_open"
 			set_country_flag = SOV_svr_open
 		}
 		ai_will_do = {
@@ -642,7 +642,7 @@ SOV_mvd_category = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_promotion_of_unite_with_russia_armenia"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_promotion_of_unite_with_russia_bulgaria"
 			if = {
 				limit = {
 					NOT = { has_completed_focus = SOV_coopt_hyper_nationalists }
@@ -1222,7 +1222,7 @@ SOV_mvd_category = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_iraq_bases"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_libya_bases"
 			LBA = { country_event = sov_nationalists.49 }
 			add_command_power = -50
 		}
@@ -2490,7 +2490,7 @@ SOV_mvd_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_referendum_on_the_unification_of_czechoslovakiac"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_referendum_on_the_unification_of_czechoslovakia"
 			set_temp_variable = { percent_change = 4 }
 			set_temp_variable = { tag_index = SOV }
 			set_temp_variable = { influence_target = CZE }
@@ -2936,11 +2936,11 @@ SOV_mvd_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SOV_libya_instructor"
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_libya_instructors"
 			set_country_flag = SOV_gru_active
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_iraq_instructors"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_libya_instructors"
 			LBA = { country_event = sov_gru.1 }
 			add_command_power = -50
 		}
@@ -3616,11 +3616,11 @@ SOV_mvd_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SOV_wagner_drc_instructors"
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_wagner_mali_instructors"
 			set_country_flag = SOV_wagner_active
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_wagner_drc_instructors"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_wagner_mali_instructors"
 			MAL = { country_event = sov_gru.10 }
 			add_command_power = -50
 		}
@@ -3774,7 +3774,7 @@ SOV_democracy_taiwam_category = {
 		}
 		ai_will_do = { base = 355 }
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_invest_taiwan"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_puppet_taiwan"
 			if = {
 				limit = {
 					has_global_flag = GAME_RULE_allow_colored_puppets
@@ -6613,7 +6613,7 @@ SOV_economy_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_npp_anti_sanctions_exports"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_npp_anti_sanctions_construction"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 			add_political_power = -50
@@ -6889,7 +6889,6 @@ SOV_army_category = {
 			URA = {
 				has_completed_focus = URA_monarchy_revive_cossack
 			}
-			original_tag = SOV
 			SOV = {
 				has_idea = SOV_kazachestvo_idea
 				owns_state = 676
@@ -6957,7 +6956,6 @@ SOV_army_category = {
 			URA = {
 				has_completed_focus = URA_monarchy_revive_cossack
 			}
-			original_tag = SOV
 			SOV = {
 				has_idea = SOV_kazachestvo_idea
 				owns_state = 1118
@@ -7024,7 +7022,6 @@ SOV_army_category = {
 			KUB = {
 				has_completed_focus = KUB_revival_cossak_army
 			}
-			original_tag = SOV
 			SOV = {
 				has_idea = SOV_kazachestvo_idea
 				owns_state = 668
@@ -7158,7 +7155,7 @@ SOV_army_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SOV_kazachestvo_volga"
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_kazachestvo_siberia"
 			add_command_power = -50
 		}
 
@@ -7287,7 +7284,7 @@ SOV_army_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SOV_kazachestvo_centr"
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_kazachestvo_crimea"
 			add_command_power = -50
 		}
 
@@ -7992,7 +7989,7 @@ SOV_army_category = {
 			has_completed_focus = SOV_form_bars
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_twenty_nine_bars_start"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_thirty_four_bars_start"
 			add_manpower = -4000
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes

--- a/common/decisions/Serbia.txt
+++ b/common/decisions/Serbia.txt
@@ -399,7 +399,6 @@ SER_The_Montenegro_Confederacy = {
 		icon = GFX_decision_monte_separ_button
 		allowed = { always = yes }
 		available = {
-			original_tag = SER
 			has_country_flag = SER_montenegro_independence_dead
 		}
 		activation = {
@@ -848,7 +847,7 @@ SER_doctrine_category = {
 			is_subject = no
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SER_anti_cro_doctrines"
+			log = "[GetDateText]: [Root.GetName]: Decision SER_de_fence_doctrines"
 			if = {
 				limit = { has_idea = SER_anti_cro_doc }
 				swap_ideas = {
@@ -1530,7 +1529,7 @@ SER_vojvodina_separatism_category = {
 		cost = 40
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision VOJ_more_autonomy"
+			log = "[GetDateText]: [Root.GetName]: Decision VOJ_more_army"
 			SER = {
 				country_event = {
 					id = SerbiaFocus.104
@@ -1589,7 +1588,7 @@ SER_vojvodina_separatism_category = {
 			country_exists = VOJ
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision VOJ_integrate"
+			log = "[GetDateText]: [Root.GetName]: Decision VOJ_integrate_buff"
 			VOJ = {
 				set_temp_variable = { modify_voj_integr = 5 }
 				modify_voj_integr_support = yes
@@ -1699,7 +1698,7 @@ KOS_albania_union = {
 		cost = 25
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision KOS_unity_boost"
+			log = "[GetDateText]: [Root.GetName]: Decision KOS_appease_serbs"
 			custom_effect_tooltip = KOS_SER_opinion_increase_2
 			add_to_variable = { var = KOS_serbs value = 0.02 }
 			clamp_variable = { var = KOS_serbs min = 0 max = 1 }

--- a/common/decisions/Spain.txt
+++ b/common/decisions/Spain.txt
@@ -107,7 +107,7 @@ SPR_the_regions_of_spain = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_basque_targeted_subsidies_decisions"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_basque_targeted_subsidies_decision"
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = 3 }
 			SPR_modify_cultural_opinion = yes
@@ -271,7 +271,7 @@ SPR_the_regions_of_spain = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_basque_targeted_subsidies_decisions"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_catalonian_targeted_subsidies_decision"
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = 3 }
 			SPR_modify_cultural_opinion = yes
@@ -466,7 +466,7 @@ SPR_the_regions_of_spain = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_basque_targeted_subsidies_decisions"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_galician_targeted_subsidies_decision"
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = 3 }
 			SPR_modify_cultural_opinion = yes
@@ -659,7 +659,7 @@ SPR_the_regions_of_spain = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_basque_targeted_subsidies_decisions"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_andalusian_targeted_subsidies_decision"
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = 3 }
 			SPR_modify_cultural_opinion = yes
@@ -689,7 +689,7 @@ SPR_the_regions_of_spain = {
 		days_remove = 100
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_revoke_catalonian_citizenship_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_revoke_andalusian_citizenship_decision"
 			93 = { remove_core_of = SPA }
 			add_stability = -0.05
 			custom_effect_tooltip = SPR_all_culture_decrease_10_tt
@@ -924,7 +924,7 @@ SPR_the_regions_of_spain = {
 		fire_only_once = yes
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_codify_the_ban_into_law"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_codify_the_ban_into_law_decision"
 			remove_mission = SPR_challenge_the_court_ban_bull_mission
 		}
 		ai_will_do = { base = 0 }
@@ -944,7 +944,7 @@ SPR_the_regions_of_spain = {
 		fire_only_once = yes
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_codify_the_ban_into_law"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_codify_the_killing_of_the_bull_decision"
 			remove_mission = SPR_challenge_the_court_killing_bull_mission
 		}
 		ai_will_do = { base = 0 }
@@ -1242,7 +1242,7 @@ SPR_monarchist_spain = {
 		days_remove = 90
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_add_conservatism_into_coalition_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_add_socialism_into_coalition_decision"
 			set_temp_variable = { add_col_one = 3 }
 			add_coalition_members_effect = yes
 		}
@@ -1270,7 +1270,7 @@ SPR_monarchist_spain = {
 		days_remove = 90
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_add_conservatism_into_coalition_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_add_nat_fascism_into_coalition_decision"
 			set_temp_variable = { add_col_one = 21 }
 			add_coalition_members_effect = yes
 			if = { limit = { has_completed_focus = SPR_the_youth_front }
@@ -1449,7 +1449,7 @@ SPR_political_policy_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_file_a_motion_of_no_confidence"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_tap_the_bank_funds_decision"
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { treasury_change = gdp_total }
@@ -2043,7 +2043,7 @@ SPR_political_policy_category = {
 		fire_only_once = no
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_socialism_policy_replacer_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_communist_policy_replacer_decision"
 			if = {
 				limit = {
 					NOT = { has_idea = SPR_the_rights_of_the_worker_idea }
@@ -2162,13 +2162,13 @@ SPR_political_policy_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_expand_the_los_santos_mine"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_expand_the_huelva_copper_mine"
 			set_temp_variable = { treasury_change = -3.75 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SPR_expand_the_los_santos_mine"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SPR_expand_the_huelva_copper_mine"
 			add_resource = {
 				type = tungsten
 				amount = 5
@@ -2296,7 +2296,7 @@ SPR_foreign_recruitment = {
 		cost = 25
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_spawn_foreign_legion_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_spawn_new_foreign_legion_decision"
 			add_to_variable = { SPR.SPR_deployed_legions = 1 }
 			if = {
 				limit = { has_country_flag = SPR_reformed_the_new_foreign_legion }
@@ -2347,7 +2347,7 @@ SPR_foreign_recruitment = {
 		cost = 150
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SPR_spawn_foreign_legion_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision SPR_reform_the_spanish_foreign_legion_decision"
 			set_country_flag = SPR_reformed_the_new_foreign_legion
 			delete_unit_template_and_units = {
 				division_template = "Foreign Legion Tercio"

--- a/common/decisions/SubjectsOfRussia.txt
+++ b/common/decisions/SubjectsOfRussia.txt
@@ -82,7 +82,7 @@ SOV_Sovfed_category = {
 			SUB_subjects_army_integration = yes
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SUB_economic_integrate"
+			log = "[GetDateText]: [Root.GetName]: Decision SUB_army_integrate"
 			custom_effect_tooltip = SUB_sovfed_subject_army_tt
 			hidden_effect = {
 				country_event = subject_rus.132
@@ -190,7 +190,7 @@ SOV_Sovfed_category = {
 			}
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove SOV_rusempire_governorates"
+			log = "[GetDateText]: [Root.GetName]: Decision remove SUB_rusempire_governorates_create"
 			SOV_russian_governorates_created = yes
 		}
 		ai_will_do = { base = 0 }
@@ -498,7 +498,7 @@ SOV_Sovfed_category = {
 		cost = 100
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SOV_transbaikal_unif"
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_cumchatka_unif"
 			custom_effect_tooltip = SOV_subjectsepar_minus_tt
 			custom_effect_tooltip = SOV_subjectsepar_minus_tt
 			hidden_effect = {
@@ -1176,7 +1176,7 @@ SOV_Sovfed_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TA_clear_air"
+			log = "[GetDateText]: [Root.GetName]: Decision TAT_clear_air"
 			SOV = { country_event = { id = subject_rus.60 days = 1 } }
 		}
 		ai_will_do = {
@@ -1243,7 +1243,7 @@ SOV_Sovfed_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision CHE_attack_ukr"
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_attack_geo"
 			SOV = { country_event = chechnya.2 }
 		}
 		ai_will_do = { base = 0 }
@@ -1613,7 +1613,7 @@ SOV_Sovfed_category = {
 			SOV = { owns_state = 1125 }
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision KUB_unite_adyg"
+			log = "[GetDateText]: [Root.GetName]: Decision KUB_unite_karachaevo"
 			SOV = { country_event = { id = kuban.30 days = 1 } }
 		}
 		ai_will_do = { base = 0 }
@@ -2280,7 +2280,7 @@ TAT_tatneft_category = {
 			has_country_flag = TAT_neftehimshina
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TAT_tatneft_start"
+			log = "[GetDateText]: [Root.GetName]: Decision TAT_tatneft_tech"
 			set_country_flag = TAT_tech
 			swap_ideas = {
 				remove_idea = TAT_tatneft_idea
@@ -2514,7 +2514,7 @@ SIL_bund_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SIL_bund_pol"
+			log = "[GetDateText]: [Root.GetName]: Decision SIL_bund_pol_police"
 			POL = {
 				set_temp_variable = { modify_silesiabund = -5 }
 				modify_silesiabund_support = yes
@@ -2842,7 +2842,7 @@ SIL_bund_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SIL_bund_sov_vlianie"
+			log = "[GetDateText]: [Root.GetName]: Decision SIL_bund_sov_wagner"
 			POL = {
 				set_temp_variable = { modify_silesiabund = 11 }
 				modify_silesiabund_support = yes
@@ -2925,7 +2925,7 @@ SIL_bund_category = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision SIL_bund_sov_weapons"
+			log = "[GetDateText]: [Root.GetName]: Decision SIL_bund_sov_warsaw"
 			POL = {
 				set_temp_variable = { modify_silesiabund = 5 }
 				modify_silesiabund_support = yes
@@ -3121,7 +3121,7 @@ Form_Idel_Ural = {
 		days_remove = 180
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BSH_integrate_TAT"
+			log = "[GetDateText]: [Root.GetName]: Decision TAT_integrate_BSH"
 			set_cosmetic_tag = BSH_IDL
 			TAT = {
 				annex_country = { target = BSH transfer_troops = yes }
@@ -3307,7 +3307,7 @@ KHM_reunifcation_category = {
 			is_subject = no
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision KHM_subject_rus"
+			log = "[GetDateText]: [Root.GetName]: Decision KHM_subject_annexion"
 			khanti_subjects_annex = yes
 		}
 

--- a/common/decisions/Syria.txt
+++ b/common/decisions/Syria.txt
@@ -626,7 +626,7 @@ Syria_greater_syria_decisions = {
 		cost = 50
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision sow_discord_between_HEZ_and_PER"
+			log = "[GetDateText]: [Root.GetName]: Decision demand_submission_from_palestine"
 			if = {
 				limit = {
 					country_exists = PAL
@@ -1114,7 +1114,7 @@ Syria_greater_syria_decisions = {
 		fire_only_once = yes
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision syria_iran_recruit_turkmen_militias"
+			log = "[GetDateText]: [Root.GetName]: Decision syria_iran_recruit_tabaristani_militias"
 			custom_effect_tooltip = TT_SYR_TABARISTAN_ARMED
 			set_temp_variable = { treasury_change = -9 }
 			modify_treasury_effect = yes
@@ -1482,7 +1482,7 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 300
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision damascus_private_sector_encouragement"
+			log = "[GetDateText]: [Root.GetName]: Decision aleppan_economy_booming"
 			syrian_industry_effect1 = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 			add_ideas = idea_aleppan_slums1
@@ -1591,7 +1591,7 @@ Syria_economic_investments = {
 		days_remove = 300
 		complete_effect = {
 			add_ideas = idea_damascus_priv_sector1
-			log = "[GetDateText]: [Root.GetName]: Decision damascus_private_sector_encouragement"
+			log = "[GetDateText]: [Root.GetName]: Decision damascus_private_sector_booming"
 			syrian_industry_effect1 = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 		}

--- a/common/decisions/Tajikistan.txt
+++ b/common/decisions/Tajikistan.txt
@@ -69,7 +69,7 @@ TAJ_forbidden_bazaar = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TAJ_negligible_security_flag"
+			log = "[GetDateText]: [Root.GetName]: Decision TAJ_negligible_security"
 			set_country_flag = TAJ_negligible_security_flag
 			clr_country_flag = TAJ_high_security_flag
 			clr_country_flag = TAJ_medium_security_flag
@@ -284,7 +284,7 @@ TAJ_forbidden_bazaar = {
 		is_good = yes
 
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision timeout TAJ_batken_occupation"
+			log = "[GetDateText]: [Root.GetName]: Decision timeout TAJ_russian_demands"
 			SOV = {
 				country_event = tajik_corruption.29
 			}
@@ -1110,7 +1110,7 @@ TAJ_badakhshani_unrest = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TAJ_settle_the_troublemakers"
+			log = "[GetDateText]: [Root.GetName]: Decision TAJ_settle_the_unrest"
 			set_country_flag = TAJ_badakhshani_unrest_solved
 			custom_effect_tooltip = TAJ_ends_unrest_TT
 			722 = {
@@ -2289,7 +2289,7 @@ TAJ_The_Undeclared_Cold_War = {
 			}
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TAJ_Nadyrov_s_Funding_Proposal"
+			log = "[GetDateText]: [Root.GetName]: Decision TAJ_Crisis_hotline_talks"
 			country_event = tajik_lore.11
 			set_country_flag = TAJ_Crisis_hotline
 		}

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -3708,7 +3708,7 @@ TUR_ciw_decisions = {
 			has_idea = CIW_member
 		}
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove TUR_ask_for_airbase"
+			log = "[GetDateText]: [Root.GetName]: Decision remove TUR_leave_ciw"
 			remove_ideas = CIW_member
 			TUR = {
 				country_event = TurkeyFocusEvents.49
@@ -4334,7 +4334,7 @@ TUR_PKK_mechanic = {
 		days_remove = 30
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TUR_clean_out_PKK_in_van"
+			log = "[GetDateText]: [Root.GetName]: Decision TUR_clean_out_PKK_in_euphrates"
 			country_event = TUR_pkk.215
 			set_country_flag = TUR_euphrates_done
 			clr_country_flag = TUR_auto_attacks_euphrates
@@ -4458,11 +4458,11 @@ TUR_rebuilding_kurdistan = {
 		days_mission_timeout = 1500
 		is_good = no
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TUR_the_promise_of_the_century"
+			log = "[GetDateText]: [Root.GetName]: Decision TUR_the_promise_of_no_return"
 			country_event = TUR_pkk.601
 		}
 		timeout_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TUR_the_promise_of_the_century"
+			log = "[GetDateText]: [Root.GetName]: Decision TUR_the_promise_of_no_return"
 			country_event = TUR_pkk.600
 		}
 	}
@@ -4913,7 +4913,7 @@ TUR_rebuilding_kurdistan = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TUR_jobs_and_careers"
+			log = "[GetDateText]: [Root.GetName]: Decision TUR_power_infrastructure"
 			add_days_mission_timeout = {
 				mission = TUR_the_promise_of_no_return
 				days = 550
@@ -4921,7 +4921,7 @@ TUR_rebuilding_kurdistan = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision TUR_jobs_and_careers"
+			log = "[GetDateText]: [Root.GetName]: Decision TUR_power_infrastructure"
 			add_to_variable = {
 				var = TUR_pkk_reconcile_var value = 1
 			}

--- a/common/decisions/Ukraine.txt
+++ b/common/decisions/Ukraine.txt
@@ -850,7 +850,7 @@ UKR_tro_brigades_ukraine_decision_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_zapad"
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_zapad_close"
 			clr_country_flag = TRO_Zapad
 			set_country_flag = TRO_Zapad_close
 		}
@@ -1165,7 +1165,7 @@ UKR_tro_brigades_ukraine_decision_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_south"
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_south_close"
 			clr_country_flag = TRO_South
 			set_country_flag = TRO_South_close
 		}
@@ -1391,7 +1391,7 @@ UKR_tro_brigades_ukraine_decision_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_north"
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_north_close"
 			clr_country_flag = TRO_North
 			set_country_flag = TRO_North_close
 		}
@@ -1676,7 +1676,7 @@ UKR_tro_brigades_ukraine_decision_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_east"
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_territorial_defense_east_close"
 			clr_country_flag = TRO_East
 			set_country_flag = TRO_East_close
 		}
@@ -2515,7 +2515,7 @@ UKR_hur_decision_category = {
 		cost = 45
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_hire_red_bashkiria"
+			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_hire_red_cossaks"
 			set_country_flag = HUR_red_cossaks
 		}
 		ai_will_do = {
@@ -2537,7 +2537,7 @@ UKR_hur_decision_category = {
 		cost = 45
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_hire_red_bashkiria"
+			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_hire_red_karelia"
 			set_country_flag = HUR_red_karelia
 		}
 		ai_will_do = {
@@ -2713,7 +2713,7 @@ UKR_hur_decision_category = {
 		cost = 120
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_attack_crimea"
+			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_attack_kuban"
 			SOV = { UKR_HUR_attack_kuban = yes }
 		}
 		ai_will_do = {
@@ -2857,7 +2857,7 @@ UKR_hur_decision_category = {
 		cost = 120
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_attack_dagestan"
+			log = "[GetDateText]: [Root.GetName]: Decision remove UKR_attack_vladivostok"
 			SOV = { UKR_HUR_attack_vladivostok = yes }
 		}
 		ai_will_do = {

--- a/common/decisions/Union State.txt
+++ b/common/decisions/Union State.txt
@@ -108,7 +108,7 @@ USR_Union_state_category = {
 			has_autonomy_state = autonomy_union_state
 		}
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision USR_economic_integrate_yes"
+			log = "[GetDateText]: [Root.GetName]: Decision USR_leave_union_state"
 			SOV = { country_event = union_state.21 }
 			hidden_effect = {
 				USR_leave_union_state_script = yes
@@ -2966,7 +2966,7 @@ USR_Union_state_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision USR_pro_union_state_revout_blr"
+			log = "[GetDateText]: [Root.GetName]: Decision USR_pro_union_state_revout_arm"
 			SOV = { country_event = union_state_belarus.1 }
 		}
 

--- a/common/decisions/kasmir_war_decisions.txt
+++ b/common/decisions/kasmir_war_decisions.txt
@@ -1914,7 +1914,7 @@ kasmir_war_china_decisions_category = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision attack_591_from_993"
+			log = "[GetDateText]: [Root.GetName]: Decision attack_589_from_993"
 			set_country_flag = Attacking_in_Kasmir_China
 		}
 

--- a/common/decisions/libya.txt
+++ b/common/decisions/libya.txt
@@ -1652,7 +1652,7 @@ libya_gaddafi_family = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision complete libya_gaddafi_family_recall_muhammad_muammar"
+			log = "[GetDateText]: [Root.GetName]: Decision complete libya_gaddafi_family_father_to_son_talk_muhammad_muammar"
 			random_list = {
 				25 = {
 					effect_tooltip = {
@@ -2545,7 +2545,7 @@ libya_gaddafi_family = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision complete libya_gaddafi_family_send_to_rehab_al_saadi"
+			log = "[GetDateText]: [Root.GetName]: Decision complete libya_gaddafi_family_additional_equipment_mutassim"
 			random_list = {
 				25 = {
 					effect_tooltip = {
@@ -4306,10 +4306,6 @@ libya_gaddafi_family = {
 			country_event = LibyaCivilWar.15
 		}
 
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision complete libya_gaddafi_family_anti_government_protests"
-		}
-
 	}
 
 	libya_gaddafi_family_deploy_military = {
@@ -5461,13 +5457,13 @@ libya_libyan_foreign_policy = {
 		}
 
 		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision complete libya_core_northern_mali"
+			log = "[GetDateText]: [Root.GetName]: Decision complete libya_core_mauritanian_sahara"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove libya_core_northern_mali"
+			log = "[GetDateText]: [Root.GetName]: Decision remove libya_core_mauritanian_sahara"
 			add_state_core = 370
 			add_state_core = 413
 		}
@@ -6914,7 +6910,7 @@ libya_libyan_foreign_policy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove libya_demand_tuareg_territory"
+			log = "[GetDateText]: [Root.GetName]: Decision remove libya_demand_toubou_territory"
 			FROM = { country_event = { id = LibyaFocus.112 hours = 6 } }
 			custom_effect_tooltip = libya_liberate_minorities_tt
 			FROM = {

--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -1181,7 +1181,7 @@ MER_request_mercosur_associate_membership = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision MER_request_mercosur_associate_membership"
+			log = "[GetDateText]: [Root.GetName]: Decision remove_effect"
 			country_event = mercosur.104
 			custom_effect_tooltip = MER_request_mercosur_associate_membership_tt
 		}
@@ -1264,7 +1264,7 @@ MER_request_mercosur_full_membership = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision MER_request_mercosur_full_membership"
+			log = "[GetDateText]: [Root.GetName]: Decision remove_effect"
 			country_event = mercosur.92
 			country_event = mercosur.94
 			custom_effect_tooltip = MER_request_mercosur_full_membership_tt
@@ -1346,7 +1346,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision MER_request_unasul_membership"
+			log = "[GetDateText]: [Root.GetName]: Decision remove_effect"
 			country_event = mercosur.106
 			custom_effect_tooltip = MER_request_unasul_membership_tt
 		}

--- a/common/decisions/netherlands.txt
+++ b/common/decisions/netherlands.txt
@@ -390,7 +390,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_ING_Group_Strategies_Expansion2 Italy"
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA Italy"
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = HOL_economy
@@ -4084,7 +4084,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies"
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_promote_urban_investments"
 			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 1
 			}
@@ -4198,7 +4198,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies"
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_promote_rural_investments"
 			random_owned_controlled_state = {
 				add_building_construction = {
 					type = agriculture_district
@@ -5907,7 +5907,7 @@ HOL_grey_society_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy2"
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu2"
 			swap_ideas = {
 				remove_idea = HOL_grey_society2
 				add_idea = HOL_grey_society3

--- a/common/decisions/subparty_policies_decisions.txt
+++ b/common/decisions/subparty_policies_decisions.txt
@@ -521,7 +521,7 @@ subparty_policies_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision combat_biggest_influencer_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision generic_nationalise_biggest_influencer_industries"
 			set_temp_variable = { percent_change = -5 }
 			set_temp_variable = { influencer_index = 0 }
 			change_current_influencer_index_percentage = yes
@@ -634,7 +634,7 @@ subparty_policies_category = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision combat_biggest_influencer_decision"
+			log = "[GetDateText]: [Root.GetName]: Decision generic_nationalise_second_biggest_influencer_industries"
 			set_temp_variable = { percent_change = -5 }
 			set_temp_variable = { influencer_index = 1 }
 			change_current_influencer_index_percentage = yes

--- a/common/national_focus/01_EU_USoE_shared.txt
+++ b/common/national_focus/01_EU_USoE_shared.txt
@@ -2798,7 +2798,7 @@ shared_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus USoE632"
+		log = "[GetDateText]: [Root.GetName]: Focus USoE633"
 		custom_effect_tooltip = tooltip_USoE632_effect
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
@@ -3277,7 +3277,7 @@ shared_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus USoE642"
+		log = "[GetDateText]: [Root.GetName]: Focus USoE643"
 		set_country_flag = USoE_capital_moved
 		set_capital = { state = 51 }
 		51 = {

--- a/common/national_focus/02_EU_POTEF_shared.txt
+++ b/common/national_focus/02_EU_POTEF_shared.txt
@@ -7142,7 +7142,7 @@ shared_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus POTEF700"
+		log = "[GetDateText]: [Root.GetName]: Focus POTEF750"
 		if = {
 			limit = {
 				has_idea = EU_member
@@ -7222,7 +7222,7 @@ shared_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus POTEF751"
+		log = "[GetDateText]: [Root.GetName]: Focus POTEF752"
 		if = {
 			limit = {
 				POTEF_is_eastern = yes

--- a/common/national_focus/05_abkhazia.txt
+++ b/common/national_focus/05_abkhazia.txt
@@ -60,7 +60,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_tourism1"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_our_place"
 			set_temp_variable = { percent_change = 8 }
 			change_domestic_influence_percentage = yes
 			add_stability = 0.04
@@ -121,7 +121,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_internet"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_internet_akvafon"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			random_owned_controlled_state = {
@@ -881,7 +881,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_our_red_path"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_one_party"
 			add_ideas = GRE_one_party
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			add_relative_party_popularity = yes
@@ -912,7 +912,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_china_help_jd"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_china_invest_tech"
 			CHI = {
 				set_temp_variable = { treasury_change = -6.5 }
 				modify_treasury_effect = yes
@@ -1020,7 +1020,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_korea_workers"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_korea_trade"
 			NKO = {
 				add_opinion_modifier = {
 					target = ROOT
@@ -1126,7 +1126,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_mil_prop"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_sup_work"
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -1164,7 +1164,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_mil_prop"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_people_militia"
 			division_template = {
 				name = "Abkhazian militia"
 				regiments = {
@@ -1216,7 +1216,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_atheism"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_empower_sgb"
 			set_temp_variable = { temp_opinion = 15 }
 			change_intelligence_community_opinion = yes
 			add_stability = 0.05
@@ -1248,7 +1248,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_atheism"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_rel_quest"
 			add_stability = 0.01
 			add_popularity = {
 				ideology = democratic
@@ -1336,7 +1336,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_atheism"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_rel_commu"
 			if = {
 				limit = {
 					has_idea = orthodox_christian
@@ -1408,7 +1408,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_farmer_collab"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_nep"
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 			set_temp_variable = { treasury_change = -9.5 }
@@ -1441,7 +1441,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_farmer_collab"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_fiveka"
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -1509,7 +1509,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_farmer_collab"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_free_education"
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_stability = 0.08
@@ -1619,7 +1619,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_defend_our_home2"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_mobilise_masses"
 			add_ideas = militarism
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes
@@ -1773,7 +1773,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_invest_from_eng"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_monarchy_eng"
 			set_temp_variable = { debt_change = -5 }
 			modify_debt_effect = yes
 			add_opinion_modifier = { modifier = supports_us target = ENG }
@@ -1806,7 +1806,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_invest_from_eng"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_invest_from_tur"
 			set_temp_variable = { treasury_change = 10 }
 			modify_treasury_effect = yes
 			set_temp_variable = { party_popularity_increase = 0.04 }
@@ -1926,7 +1926,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_bul_bondex"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_sov_heast"
 			add_opinion_modifier = { modifier = declaration_of_friendship target = SOV }
 			reverse_add_opinion_modifier = { modifier = declaration_of_friendship target = SOV }
 			add_war_support = 0.05
@@ -2065,7 +2065,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_nati_ideas"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_parli_dead"
 			add_popularity = {
 				ideology = democratic
 				popularity = -0.05
@@ -2100,7 +2100,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_start_prepare_for_war"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_dictatorship"
 			set_country_flag = do_not_retire
 			set_politics = {
 				ruling_party = nationalist
@@ -2842,7 +2842,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_jd_abk_russia"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_jd_abk_russia_arms"
 			SOV = {
 				set_temp_variable = { treasury_change = -3.5 }
 				modify_treasury_effect = yes
@@ -2984,7 +2984,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_artshakh_friend"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_cus_create"
 			add_political_power = 75
 		}
 
@@ -3077,7 +3077,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_artshakh_friend"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_soo_friend"
 			add_opinion_modifier = { target = SOO modifier = diplomatic_support }
 			reverse_add_opinion_modifier = { target = SOO modifier = diplomatic_support }
 			GEO = {
@@ -3452,7 +3452,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_increase_medicine"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_increase_education"
 			set_temp_variable = { party_popularity_increase = 0.08 }
 			add_relative_party_popularity = yes
 			add_research_buff = yes
@@ -3670,7 +3670,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_let_wagner_enter"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_we_are_country"
 			remove_ideas = non_state_actor
 		}
 
@@ -3750,7 +3750,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_fleet"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_air"
 			air_experience = 30
 				add_tech_bonus = {
 					name = GENERIC_air_force_reform
@@ -3967,7 +3967,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_Russian_Way"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_China_Way"
 			reverse_add_opinion_modifier = {
 				target = CHI
 				modifier = recent_actions_positive
@@ -4214,7 +4214,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ABK_CSTO_training"
+			log = "[GetDateText]: [Root.GetName]: Focus ABK_China_training"
 			army_experience = 15
 			add_command_power = 10
 			remove_ideas = ABK_outdated_army_idea

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -472,7 +472,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_enlisting_personal"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_updating_equipment"
 			army_experience = 10
 			add_tech_bonus = {
 				name = AFG_enlisting_personal
@@ -1623,7 +1623,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_building_society"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_wounded_veterans"
 			increase_healthcare_budget = yes
 			add_stability = 0.05
 			add_manpower = 2500
@@ -1715,7 +1715,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_un_troops"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_changing_our_economy"
 			increase_economic_growth = yes
 			add_timed_idea = {
 				idea = mass_exports5
@@ -5846,7 +5846,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_Endorse_the_american_candidate"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_Islamic_Democracy"
 			custom_effect_tooltip = AFG_focus_will_auto_complete
 			hidden_effect = {
 				add_dynamic_modifier = { modifier = AFG_National_Assembly }
@@ -5874,7 +5874,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_Endorse_the_american_candidate"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_Naveen"
 			custom_effect_tooltip = AFG_focus_will_auto_complete
 			hidden_effect = {
 				add_dynamic_modifier = { modifier = AFG_National_Assembly }
@@ -6706,7 +6706,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_Agricultural_Modernisation"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_Second_Man_of_the_State"
 			AFG_National_Assembly_Checks = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = AFG_National_Assembly }
 			add_to_variable = { AFG_Assembly_political_power_gain = 0.05 tooltip = political_power_gain_tt }
@@ -7365,7 +7365,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_TRADE FOCUS_FILTER_DIPLOMACY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_Ghanis_coup"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_Ghanis_Plan"
 			add_political_power = 75
 			set_temp_variable = { taliban_strength_increase = 5 }
 			increase_taliban_strength = yes
@@ -7455,7 +7455,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_Knife_to_the_Taliban"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_Knife_to_the_warlords"
 			add_political_power = 75
 			set_temp_variable = { taliban_strength_increase = 5 }
 			decrease_taliban_strength = yes
@@ -8471,7 +8471,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_TRADE FOCUS_FILTER_DIPLOMACY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus AFG_Root_out_the_Old_cabinet"
+			log = "[GetDateText]: [Root.GetName]: Focus AFG_Moderate_Islamism"
 			add_political_power = 100
 			add_timed_idea = {
 			idea = AFG_liberal_society

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -23220,7 +23220,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_NATO FOCUS_FILTER_EXPENDITURE }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_counterterrorism_coordination "
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_counterterrorism_coordination"
 			increase_military_spending = yes
 			set_temp_variable = { temp_opinion = 3 }
 			change_the_military_opinion = yes

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -1019,7 +1019,7 @@ focus_tree = {
 			}
 
 			completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_legacy_revolution"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_no_pres_alliance"
 			add_timed_idea = {
 				idea = ALG_fln_dominance
 				days = 356
@@ -6515,7 +6515,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_abolish_conscription"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_quality_over_quantity"
 			swap_ideas = {
 				remove_idea = ALG_military_quality_initiative
 				add_idea = ALG_military_quality_initiative2
@@ -6542,7 +6542,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_abolish_conscription"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_a_cost_effective_army"
 			swap_ideas = {
 				remove_idea = ALG_army_reform_specops3
 				add_idea = ALG_army_reform_specops4
@@ -8313,7 +8313,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_prepare_the_economy"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_withdrawal_from_npt"
 			add_war_support = 0.10
 			newline = yes
 			set_temp_variable = { percent_change = 15 }
@@ -15859,7 +15859,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ECONOMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_snvi_modernization"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_annaba_steel_complex"
 			two_random_fossil_fuel_powerplant = yes
 			set_temp_variable = { party_popularity_increase = 0.080 }
 			add_relative_party_popularity = yes
@@ -18620,7 +18620,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_enahda_media_network"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_supreme_islamic_council"
 			add_ideas = ALG_supreme_islamic_council_idea
 		}
 
@@ -18650,7 +18650,7 @@ focus_tree = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: focus ARM_monarch executed"
+		log = "[GetDateText]: [Root.GetName]: focus ALG_reclaim_the_crown executed"
 		add_popularity = {
 			ideology = nationalist
 			popularity = 0.1
@@ -19561,7 +19561,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_democratic_vicotry"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_democratic_victory"
 			add_popularity = { ideology = democratic popularity = 0.10 }
 			recalculate_party = yes
 		}
@@ -19620,7 +19620,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_cut_military_spending"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_dismantle_the_military"
 			add_timed_idea = {
 				idea = algerian_military_dismantling
 				days = 180
@@ -23220,7 +23220,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_NATO FOCUS_FILTER_EXPENDITURE }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_exchange_research_with_nato "
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_counterterrorism_coordination "
 			increase_military_spending = yes
 			set_temp_variable = { temp_opinion = 3 }
 			change_the_military_opinion = yes
@@ -23246,7 +23246,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_NATO FOCUS_FILTER_RESEARCH }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_exchange_research_with_nato "
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_get_investements_from_nato "
 			for_each_loop = {
 				array = global.nato_members
 				var:v = {
@@ -23277,7 +23277,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_exchange_research_with_nato"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_strengthen_democratic_norms"
 			set_temp_variable = { party_index = 1 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
@@ -25698,7 +25698,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ALG_approach_hamas"
+			log = "[GetDateText]: [Root.GetName]: Focus ALG_send_fighters_to_hamas"
 			if = {
 				limit = { PAL = { neutrality_neutral_muslim_brotherhood_are_in_power = yes } }
 				set_temp_variable = { influence_target = PAL }

--- a/common/national_focus/05_artsakh.txt
+++ b/common/national_focus/05_artsakh.txt
@@ -604,7 +604,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus NKR_safe_army executed"
+			log = "[GetDateText]: [This.GetName]: focus NKR_planes executed"
 			remove_ideas = ARM_outdated_airforce_idea1
 		}
 
@@ -747,7 +747,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus NKR_safe_mo_ra executed"
+			log = "[GetDateText]: [This.GetName]: focus NKR_safe_anti_air executed"
 			add_ideas = ARM_army_anti_air
 		}
 
@@ -813,7 +813,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus NKR_safe_aspar executed"
+			log = "[GetDateText]: [This.GetName]: focus NKR_safe_davisur executed"
 			add_tech_bonus = {
 				name = ARM_davisur_arm
 				uses = 1
@@ -1002,7 +1002,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus NKR_plant_minefields executed"
+			log = "[GetDateText]: [This.GetName]: focus NKR_final_defense executed"
 			add_timed_idea = {
 				idea = NKR_last_defense
 				days = 44

--- a/common/national_focus/05_bolivia.txt
+++ b/common/national_focus/05_bolivia.txt
@@ -310,7 +310,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_strengthen_mestizo_pride"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_bolivias_gems"
 			swap_ideas = {
 				remove_idea = BOL_strength_of_the_media_luna3
 				add_idea = BOL_strength_of_the_media_luna4
@@ -635,7 +635,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_hand_with_the_catholic_church"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_promote_catholic_missionaries"
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -950,7 +950,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_lower_tax_regime"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_crackdown_on_organized_labour"
 			add_timed_idea = {
 				idea = BOL_trade_union_crackdown
 				days = 350
@@ -988,7 +988,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_lower_tax_regime"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_liberalize_bolivias_trade_regime"
 			increase_exports = yes
 		}
 
@@ -1636,7 +1636,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_ban_indigenous_languages"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_bolivian_corporate_state"
 			swap_ideas = {
 				remove_idea = BOL_the_new_banzerato3
 				add_idea = BOL_the_new_banzerato4
@@ -1883,7 +1883,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_avenge_chaco_war"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_bolivias_place_in_the_sun_restored"
 			add_ideas = BOL_bolivia_grande
 		}
 
@@ -2624,7 +2624,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_ensure_investment_safety"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_lower_sme_taxation"
 			swap_ideas = {
 				remove_idea = BOL_market_reforms2
 				add_idea = BOL_market_reforms3
@@ -2696,7 +2696,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_telecom_investments"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_invest_in_the_tertiary_sector"
 			swap_ideas = {
 				remove_idea = BOL_services_development
 				add_idea = BOL_services_development2
@@ -2925,7 +2925,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_promote_sustainable_development"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_bolivia_for_all"
 			swap_ideas = {
 				remove_idea = BOL_bolivian_unity3
 				add_idea = BOL_a_bolivia_for_all
@@ -3618,7 +3618,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_modernize_coca_production"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_towards_a_mixed_economy"
 			decrease_exports = yes
 		}
 
@@ -4830,7 +4830,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_expand_the_cement_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_towards_a_construction_boom"
 			swap_ideas = {
 				remove_idea = BOL_construction_industry_expansion
 				add_idea = BOL_construction_industry_expansion2
@@ -5923,7 +5923,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_improve_public_transportation"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_urban_policing_initiative"
 			increase_policing_budget = yes
 			decrease_corruption = yes
 		}
@@ -6396,7 +6396,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_abolish_conscription"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_quality_over_quantity"
 			swap_ideas = {
 				remove_idea = BOL_military_quality_initiative
 				add_idea = BOL_military_quality_initiative2
@@ -6425,7 +6425,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOL_abolish_conscription"
+			log = "[GetDateText]: [Root.GetName]: Focus BOL_a_cost_effective_army"
 			swap_ideas = {
 				remove_idea = BOL_army_reform_specops3
 				add_idea = BOL_army_reform_specops4

--- a/common/national_focus/05_botswana.txt
+++ b/common/national_focus/05_botswana.txt
@@ -891,7 +891,7 @@ focus_tree = {
 		cost = 5
 		search_filters = { FOCUS_FILTER_AIRCRAFT }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOT_replace_f4s"
+			log = "[GetDateText]: [Root.GetName]: Focus BOT_replace_f5s"
 			custom_effect_tooltip = BOT_replace_f5s_tt
 			if = {
 				limit = { has_dlc = "By Blood Alone" }
@@ -1233,7 +1233,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOT_empower_the_house_of_chiefs"
+			log = "[GetDateText]: [Root.GetName]: Focus BOT_keep_the_status_quo_of_chiefs"
 			add_stability = 0.05
 			add_political_power = 100
 			BOT_boost_BDP_A = yes
@@ -1980,7 +1980,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_RESEARCH }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOT_kalahari_exploitation"
+			log = "[GetDateText]: [Root.GetName]: Focus BOT_resource_excavation_research"
 			add_tech_bonus = {
 				name = BOT_resource_excavation_research
 				bonus = 0.5
@@ -2124,7 +2124,7 @@ focus_tree = {
 		cost = 10
 		search_filters = { FOCUS_FILTER_ENVIRONMENT FOCUS_FILTER_RESEARCH }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOT_kgalagadi_wind_park"
+			log = "[GetDateText]: [Root.GetName]: Focus BOT_tuli_wind_park"
 			set_temp_variable = { treasury_change = -8.50 }
 			modify_treasury_effect = yes
 			287 = {
@@ -2357,7 +2357,7 @@ focus_tree = {
 		cost = 10
 		search_filters = { FOCUS_FILTER_RESOURCE FOCUS_FILTER_INTERNAL_FACTION }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOT_biofuel_experimentation"
+			log = "[GetDateText]: [Root.GetName]: Focus BOT_biofuel_plants"
 			set_temp_variable = { treasury_change = -8.50 }
 			modify_treasury_effect = yes
 			287 = {
@@ -2795,7 +2795,7 @@ focus_tree = {
 		cost = 10
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BOT_national_space_program"
+			log = "[GetDateText]: [Root.GetName]: Focus BOT_innovation_city"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 			287 = {

--- a/common/national_focus/05_comoros.txt
+++ b/common/national_focus/05_comoros.txt
@@ -1247,7 +1247,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_push_it_to_the_limit"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_absolute_employment"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			increase_economic_growth = yes
@@ -1743,7 +1743,7 @@ focus_tree = {
 		prerequisite = { focus = COM_befriend_the_west }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_befriend_the_west executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_buy_missile_defences executed"
 			if = {
 				limit = { has_dlc = "No Step Back" }
 				add_equipment_to_stockpile = {
@@ -1843,7 +1843,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_befriend_the_west executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_befriend_the_east executed"
 			for_each_scope_loop = {
 				array = global.CSTO_member
 				tooltip = TT_ALL_CSTO_MEMBER_NATIONS_GAIN
@@ -1914,7 +1914,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INFLUENCE FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_tighter_edf_cooperation executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_tighter_chi_cooperation executed"
 			add_political_power = 50
 			add_stability = 0.05
 			one_random_infrastructure = yes
@@ -1949,7 +1949,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_non_nato_ally executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_anti_nato_ally executed"
 			add_opinion_modifier = {
 				target = SOV
 				modifier = diplomatic_support
@@ -2717,7 +2717,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_the_warrior_king executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_the_consolidation_of_power executed"
 			add_political_power = 125
 			if = {
 				limit = { has_idea = COM_unstable_government_idea }
@@ -2753,7 +2753,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_the_warrior_king executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_legitimize_our_rule executed"
 			add_stability = 0.04
 			if = {
 				limit = { has_idea = COM_unstable_government_idea }
@@ -2790,7 +2790,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_the_warrior_king executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_declare_the_state_of_pmcs executed"
 			add_ideas = COM_state_of_the_pmcs_idea
 		}
 
@@ -2819,7 +2819,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_the_warrior_king executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_a_rifle_for_hire executed"
 			custom_effect_tooltip = COM_a_rifle_for_hire_tt
 		}
 
@@ -2848,7 +2848,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_the_warrior_king executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_expanded_regional_operations executed"
 			add_ideas = COM_expanded_regional_operations_idea
 			set_country_flag = COM_expanded_private_military_operations
 		}
@@ -2879,7 +2879,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_the_warrior_king executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_expanded_global_operations executed"
 			swap_ideas = {
 				remove_idea = COM_expanded_regional_operations_idea
 				add_idea = COM_expanded_global_operations_idea
@@ -2915,7 +2915,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_ghost_of_colonialism executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_the_zanzibar_agreement executed"
 			if = {
 				limit = { TNZ = { owns_state = 253 } }
 				TNZ = { country_event = { id = comoros.33 days = 1 } }
@@ -3299,7 +3299,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INFLUENCE FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_loi_des_competences executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_Loi_des_competences executed"
 			add_stability = 0.02
 			MAD = {
 				add_opinion_modifier = {
@@ -3694,7 +3694,7 @@ focus_tree = {
 		prerequisite = { focus = COM_agricultural_developments }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_vanilla_exports executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_comorian_forestry executed"
 			COM_update_agricultural_development_ideas = yes
 		}
 
@@ -3803,7 +3803,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_expand_on_moheli executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_join_the_world_trade_organization executed"
 			add_timed_idea = {
 				idea = recently_acceded_to_wto
 				days = 365
@@ -3932,7 +3932,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_india executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_madagascar executed"
 			set_temp_variable = { treasury_change = 2.45 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 2 }
@@ -4006,7 +4006,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_singapore executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_tanzania executed"
 			set_temp_variable = { treasury_change = 2.45 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 2 }
@@ -4081,7 +4081,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GENERIC_attract_foreign_investors"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_debt_refactoring"
 			set_temp_variable = { debt_change = debt }
 			multiply_temp_variable = { debt_change = 0.05 }
 			clamp_temp_variable = { var = debt_change min = 0 max = 100 }
@@ -4124,7 +4124,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_india executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_trading_with_west executed"
 			add_opinion_modifier = { target = FRA modifier = improve_trade }
 			reverse_add_opinion_modifier = { target = FRA modifier = improve_trade }
 			set_temp_variable = { receiver_nation = FRA.id }
@@ -4157,7 +4157,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_india executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_french_investments executed"
 			FRA = {
 				country_event = { id = comoros.16 days = 1 }
 			}
@@ -4246,7 +4246,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_india executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_cooperation_with_east_africa executed"
 			add_political_power = 75
 			every_other_country = {
 				limit = {
@@ -4278,7 +4278,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus COM_trade_deals_with_india executed"
+			log = "[GetDateText]: [Root.GetName]: Focus COM_trading_with_east_africa executed"
 			every_other_country = {
 				limit = {
 					has_country_flag = east_african_nation_flag

--- a/common/national_focus/05_cuba.txt
+++ b/common/national_focus/05_cuba.txt
@@ -272,7 +272,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_coop_china"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_coop_usa"
 			USA = {
 				add_opinion_modifier = {
 					target = CUB
@@ -795,7 +795,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_cbaf_115"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_btr_100"
 			add_tech_bonus = {
 				name = CUB_btr_100
 				bonus = 0.3
@@ -829,7 +829,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_cbi_73"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_CBI_73M"
 			add_tech_bonus = {
 				name = CUB_CBI_73M
 				uses = 1
@@ -870,7 +870,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_jupiter"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_Jupiter_III"
 			add_tech_bonus = {
 				name = CUB_Jupiter_III
 				bonus = 0.3
@@ -1529,7 +1529,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_upgrade_airbase"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_buy_drones"
 			add_equipment_to_stockpile = {
 				type = medium_plane_suicide_airframe
 				amount = 500
@@ -1840,7 +1840,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_air_doc"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_ground_doc"
 			add_doctrine_cost_reduction = {
 				name = CUB_air_doc
 				category = CAT_battlefield_support_tree
@@ -2234,7 +2234,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_own_projects"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_exp_bases"
 			one_random_dockyard = yes
 		}
 
@@ -5626,7 +5626,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_the_new_castro"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_start_reformism"
 			add_ideas = CUB_reformism_idea1
 			add_political_power = 70
 		}
@@ -6150,7 +6150,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_new_cuban_constituation"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_recognize_taiwan_as_china"
 			CHI = {
 				add_opinion_modifier = {
 					target = CUB
@@ -7660,7 +7660,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_usa_presense"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_israel"
 			add_political_power = 150
 			ISR = {
 				add_opinion_modifier = {
@@ -7940,7 +7940,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_new_cuban_constituation"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_venesuella_defence"
 			add_timed_idea = {
 				idea = CUB_prepare_for_worst_idea
 				days = 1000
@@ -9432,7 +9432,7 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_tesak_in_power"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_loyal_military"
 			army_experience = 20
 			add_stability = 0.05
 			set_temp_variable = { party_index = 22 }
@@ -9486,7 +9486,7 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_new_justice_constitution"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_fight_with_lgbt"
 			add_ideas = CUB_anti_lgbtqa_idea
 		}
 
@@ -9537,7 +9537,7 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_revolution_support"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_welfare_funds"
 			one_random_industrial_complex = yes
 		}
 
@@ -9560,7 +9560,7 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_revolution_support"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_internet_propoganda"
 			set_temp_variable = { percent_change = 2.5 }
 			set_temp_variable = { influence_target = SOV }
 			change_influence_percentage = yes
@@ -9743,7 +9743,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_root_out_coruption"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_intervention_for_best"
 			increase_intervention_law_effect = yes
 			add_trait = {
 				trait = interventionist
@@ -9772,7 +9772,7 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_root_out_coruption"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_save_venezuella"
 
 			set_temp_variable = { wargoal_on = VEN }
 			set_temp_variable = { wargoal_type = 1 }
@@ -9805,7 +9805,7 @@ icon = CUB_fidelcastro
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INFLUENCE }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_root_out_coruption"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_save_cis"
 			SOV = {
 				decrease_corruption = yes
 			}
@@ -9840,7 +9840,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_root_out_coruption"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_spain"
 			SPR = {
 				start_civil_war = {
 					ideology = nationalist
@@ -9877,7 +9877,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_root_out_coruption"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_ukraine"
 			UKR = {
 				start_civil_war = {
 					ideology = nationalist
@@ -9914,7 +9914,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_root_out_coruption"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_kazahstan"
 			KAZ = {
 				start_civil_war = {
 					ideology = nationalist
@@ -9954,7 +9954,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_nationalist"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_nationalists"
 			if = {
 				limit = { NOT = { is_in_array = { ruling_party = 21 } } }
 				set_temp_variable = { rul_party_temp = 21 }
@@ -10233,7 +10233,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_the_new_education_system"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_the_new_education_system_nati"
 			increase_education_budget = yes
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.025 }
@@ -12657,7 +12657,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_destroy_revanshists_memoriess"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_destroy_revanshists_memories"
 			swap_ideas = {
 				remove_idea = CUB_idea_memory
 				add_idea = CUB_idea_republic_memory
@@ -12882,7 +12882,7 @@ icon = CUB_fidelcastro
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CUB_prepare_federations"
+			log = "[GetDateText]: [Root.GetName]: Focus CUB_prepare_federation"
 			add_timed_idea = { idea = CUB_idea_conf_one days = 390 }
 		}
 

--- a/common/national_focus/05_donetsk.txt
+++ b/common/national_focus/05_donetsk.txt
@@ -309,7 +309,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_nov_zavods"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_nov_politic"
 			set_temp_variable = { percent_change = 15 }
 			set_temp_variable = { tag_index = DPR }
 			set_temp_variable = { influence_target = LPR }
@@ -413,7 +413,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_nov_annex_hpr"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_nov_annex_opr"
 			annex_country = { target = OPR transfer_troops = yes }
 			OPR = { every_core_state = { add_core_of = DPR } }
 			DPR = {
@@ -565,7 +565,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_propaganda"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_donetsk_build"
 			add_stability = 0.1
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
@@ -902,7 +902,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_reform_army"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_reforms_army"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_ideas = DPR_proffesional_army
@@ -1389,7 +1389,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_sparta"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_oplot"
 			693 = {
 				create_unit = {
 					division = "name = \"Brigada Oplot\" division_template = \"Mekhanizirovannaya Brigada\" start_experience_factor = 0.1"
@@ -1420,7 +1420,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_ter_oborona"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_territorial_defence"
 			hidden_effect = {
 				division_template = {
 					name = "Territorial Defense Brigade"
@@ -1465,7 +1465,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_sparta"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_dizel"
 			693 = {
 				create_unit = {
 					division = "name = \"Brigada Dizel\" division_template = \"Tankovyi Batalyon\" start_experience_factor = 0.1"
@@ -1533,7 +1533,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_sparta"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_guard"
 			693 = {
 				create_unit = {
 					division = "name = \"Respublikanskaya Gvardiya DNR\" division_template = \"Mekhanizirovannaya Brigada\" start_experience_factor = 0.1"
@@ -2295,7 +2295,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_more_powers"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_moneys"
 			set_temp_variable = { treasury_change = 2.5 }
 			modify_treasury_effect = yes
 			add_stability = 0.05
@@ -2532,7 +2532,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_speeches"
+			log = "[GetDateText]: [Root.GetName]: Focus DPR_donbass_details"
 			remove_ideas = DPR_sad_oborud_idea
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes

--- a/common/national_focus/05_estonia.txt
+++ b/common/national_focus/05_estonia.txt
@@ -399,7 +399,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_family_traidions_con executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_family_traditions_con executed"
 			add_timed_idea = { idea = EST_homosexuality_oppress days = 1095 }
 			add_political_power = 250
 			add_stability = 0.1
@@ -628,7 +628,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_invest_in_ports executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_invest_in_trade_ports executed"
 			add_ideas = EST_trade_port_investing
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
@@ -1299,7 +1299,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_home_problems executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_expand_welfare executed"
 			increase_social_spending = yes
 			remove_ideas = EST_population_decline
 			add_ideas = EST_pop_stagnation
@@ -1330,7 +1330,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_socdem_best executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_invite_investors executed"
 			add_timed_idea = {
 				idea = idea_focus_generic_public_service_investment
 				days = 730
@@ -1877,7 +1877,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_stabilization_economy executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_stabilizing_the_nation executed"
 			add_timed_idea = { idea = EST_stabilizing_the_nation days = 180 }
 			add_political_power = 125
 			add_war_support = -0.015
@@ -2342,7 +2342,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_a_free_nation executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_green_ideas executed"
 			set_temp_variable = { temp_opinion = -10 }
 			change_fossil_fuel_industry_opinion = yes
 			for_each_scope_loop = {
@@ -3118,7 +3118,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_infrastructure_expansion executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_focus_on_consumer_goods executed"
 			set_temp_variable = { temp_opinion = 5 }
 			change_industrial_conglomerates_opinion = yes
 			decrease_exports = yes
@@ -3257,7 +3257,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_playing_both_sides executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_playing_seesaw executed"
 			country_event = estonia.8
 		}
 
@@ -4254,7 +4254,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION }
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus EST_socdem_best executed"
+			log = "[GetDateText]: [This.GetName]: focus EST_sollar_pannels executed"
 			if = { limit = { has_idea = EST_renewing_energy }
 				modify_timed_idea = {
 					idea = EST_renewing_energy

--- a/common/national_focus/05_ethiopia.txt
+++ b/common/national_focus/05_ethiopia.txt
@@ -775,7 +775,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ETH_african_economic_relationships"
+			log = "[GetDateText]: [Root.GetName]: Focus ETH_refactor_our_debt"
 			set_temp_variable = { debt_change = debt }
 			multiply_temp_variable = { debt_change = -0.20 }
 			clamp_variable = { var = debt_change min = 0 max = 15 }
@@ -3002,7 +3002,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ETH_detain_rabble_rousers"
+			log = "[GetDateText]: [Root.GetName]: Focus ETH_maintain_a_watchful_eye"
 			unlock_decision_tooltip = ETH_utilise_informants
 			add_timed_idea = { idea = ETH_1984_mode days = 365 }
 		}
@@ -3313,7 +3313,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ETH_eritrea_constitution"
+			log = "[GetDateText]: [Root.GetName]: Focus ETH_eritrea_lawbooks"
 			ERI = {
 				add_ideas = ERI_ethiopian_lawbooks
 			}

--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -3044,7 +3044,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_streamlining_tax_code_expansions }
 		search_filters = { FOCUS_FILTER_STABILITY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_streamlining_tax_code_expansions"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_building_tall"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
 				remove_dynamic_modifier = {
@@ -3338,7 +3338,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_education_budget_expansion }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_education_budget_expansion"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_balancing_budgets"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
 			add_to_variable = { fijian_econ_political_power_gain = 0.02 tooltip = political_power_factor_tt }
@@ -5027,7 +5027,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_expanding_education_funding }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_expanding_education_funding"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_creating_the_research_institute_of_fiji"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
 				remove_dynamic_modifier = {
@@ -5524,7 +5524,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_creating_the_research_institute_of_fiji }
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_phase_two_business_development"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_pacific_economics_exchange_commission"
 			add_ideas = fiji_pacific_economics_exchange_commission
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
@@ -5653,7 +5653,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_royal_military_contracts }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_royal_military_contracts"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_royal_fijian_dream"
 			add_ideas = fiji_titles_by_election
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
@@ -5958,7 +5958,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_funding_our_future }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_growing_our_manufacturing_base"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_building_the_institute_of_automation"
 			add_ideas = fiji_institute_of_automation
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
@@ -6263,7 +6263,7 @@ focus = {
 		prerequisite = { focus = fiji_focus_labour_prison_program }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_labour_corps"
+			log = "[GetDateText]: [Root.GetName]: Focus fiji_focus_increasing_domestic_steel"
 			set_temp_variable = { treasury_change = -3.00 }
 			modify_treasury_effect = yes
 			535 = {

--- a/common/national_focus/05_georgia.txt
+++ b/common/national_focus/05_georgia.txt
@@ -241,7 +241,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_rustavitwo"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_crush_opposition_dreams"
 			custom_effect_tooltip = geo_non_demo_path_TT
 			swap_ideas = {
 				remove_idea = GEO_political_opposition_mod_idea
@@ -827,7 +827,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus haha_com_classic"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_haha_com_classic"
 			hidden_effect = {
 				set_temp_variable = { rul_party_temp = 19 }
 				set_temp_variable = { col_one = 4 }
@@ -999,7 +999,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_intervene_in_azerbaijan"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_armenian_proposal_com"
 			ARM = {
 				country_event = geo_misc.8
 			}
@@ -4605,7 +4605,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_befriend_nat_armenia"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_befriend_nat_azeris"
 			add_opinion_modifier = {
 				target = AZE
 				modifier = diplomatic_support
@@ -5745,7 +5745,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_russian_mil_in_geo"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_agreements_with_turks"
 			give_guarantee = TUR
 			TUR = {
 				give_guarantee = GEO
@@ -8668,7 +8668,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		completion_reward = { log = "[GetDateText]: [Root.GetName]: Focus GEO_mineral_waters"
+		completion_reward = { log = "[GetDateText]: [Root.GetName]: Focus GEO_rebrand_borjomi"
 			swap_ideas = {
 				remove_idea = GEO_georgian_water_1
 				add_idea = GEO_georgian_water_2
@@ -10886,7 +10886,7 @@ focus_tree = {
 		available = { eu_trade_above_50 = yes }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_gazprom_rus"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_ITERA"
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			GEO_update_energy_problems_idea = yes
@@ -12064,7 +12064,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_EQUIPMENT }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_train_again"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_american_train_again"
 			add_tech_bonus = {
 				name = GEO_american_train_again
 				bonus = 0.3
@@ -12352,7 +12352,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_EQUIPMENT }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_afgan_train"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_afghan_train"
 			army_experience = 5
 			add_opinion_modifier = {
 				target = AFG
@@ -12867,7 +12867,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_EQUIPMENT }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_ikr_kolchuga"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_ukr_kolchuga"
 			custom_effect_tooltip = GEO_ukr_kolchuga_TT
 			add_equipment_to_stockpile = {
 				type = SP_Anti_Air_1
@@ -13260,7 +13260,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GEO_us_helis"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_su27"
 			set_temp_variable = {
 				treasury_change = -4.5
 			}
@@ -13878,7 +13878,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_EQUIPMENT }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ukraine_verf"
+			log = "[GetDateText]: [Root.GetName]: Focus GEO_ukraine_verf"
 			UKR = {
 				diplomatic_relation = {
 					country = GEO

--- a/common/national_focus/05_germany.txt
+++ b/common/national_focus/05_germany.txt
@@ -4168,9 +4168,7 @@ focus_tree = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = GER_had_civilwar_TT
-				hidden_trigger = {
-					has_country_flag = GER_constitutional_government
-				}
+				has_country_flag = GER_constitutional_government
 			}
 		}
 
@@ -4560,9 +4558,7 @@ focus_tree = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = GER_had_civilwar_TT
-				hidden_trigger = {
-					has_country_flag = GER_constitutional_government
-				}
+				has_country_flag = GER_constitutional_government
 			}
 		}
 
@@ -6092,7 +6088,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS FOCUS_FILTER_ARMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_KRK_army"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Rapid_deployment_doctrine"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = GER_Bundeswehr_modifier
@@ -7972,7 +7968,7 @@ focus_tree = {
 		 search_filters = { FOCUS_FILTER_MILITARY_LAWS FOCUS_FILTER_NAVY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_littoral_warfare_training"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Balanced_interventions"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = GER_Deutsche_Marine_modifier
@@ -8940,7 +8936,7 @@ focus_tree = {
 		prerequisite = { focus = GER_HDW }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_HDW"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_GNY"
 			add_tech_bonus = {
 				name = GER_GNY
 				bonus = 0.5
@@ -9227,7 +9223,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Rheinmetall_"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Cooperation_possible"
 			one_random_arms_factory = yes
 			if = {
 				limit = {
@@ -12916,7 +12912,7 @@ focus_tree = {
 			has_completed_focus = GER_will_of_the_people
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_german_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_stray_from_the_republic"
 			country_event = germany.236
 			hidden_effect = {
 				every_country = {
@@ -13263,7 +13259,7 @@ focus_tree = {
 			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_social_cuts"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_psas"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = GER_generic_spending_laws
@@ -13373,7 +13369,7 @@ focus_tree = {
 			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_condemn_american_aggression"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_condemn_american_aggro"
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -14873,7 +14869,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_idea_sustainable_development"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_sustainable_development"
 			add_ideas = GER_idea_sustainable_development
 		}
 		ai_will_do = {
@@ -16051,7 +16047,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_the_alternative"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_the_left"
 			set_temp_variable = { party_index = 5 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -17501,7 +17497,7 @@ focus_tree = {
 			nationalist_fascist_are_in_power = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_youth_wing_militarism"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_the_new_world_police"
 			if = {
 				limit = {
 					has_idea = intervention_isolation
@@ -17684,7 +17680,7 @@ focus_tree = {
 			nationalist_monarchists_are_in_power = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_the_alternative"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_the_bundestag_address"
 			decrease_corruption = yes
 		}
 		ai_will_do = {
@@ -18027,7 +18023,7 @@ focus_tree = {
 			nationalist_monarchists_are_in_power = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_the_alternative"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_extended_work_quotas"
 			swap_ideas = {
 				remove_idea = GER_idea_extended_work_hours
 				add_idea = GER_idea_extended_work_hours2
@@ -18084,7 +18080,7 @@ focus_tree = {
 			nationalist_monarchists_are_in_power = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_the_alternative"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_revenge_for_versailles"
 			add_ideas = GER_idea_fuck_versailles
 		}
 		ai_will_do = {
@@ -18896,7 +18892,7 @@ focus_tree = {
 			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_pension_cuts"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_companies_are_lazy"
 			custom_effect_tooltip = GER_increase_leftist_status_by_5
 			add_to_variable = { GER_leftwing_department_status = 5 }
 			add_popularity = {
@@ -19427,7 +19423,7 @@ focus_tree = {
 		prerequisite = { focus = GER_choose_C4ISR }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Military_companies"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_additional_Constructeur"
 			one_random_arms_factory = yes
 		}
 		ai_will_do = {
@@ -19451,7 +19447,7 @@ focus_tree = {
 			}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Military_companies"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Flensburger_Fahrzeugbau_I"
 			custom_effect_tooltip = GER_Flensburger_Fahrzeugbau_I_TT
 		}
 
@@ -19475,7 +19471,7 @@ focus_tree = {
 			}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Military_companies"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Armored_Car_Systems_I"
 			custom_effect_tooltip = GER_Armored_Car_Systems_I_TT
 		}
 
@@ -19499,7 +19495,7 @@ focus_tree = {
 			}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Military_companies"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_MAN_again"
 			custom_effect_tooltip = GER_MAN_again_TT
 			mio:GER_rheinmetall_man = {
 			add_mio_size_up_requirement_factor = -0.15
@@ -19531,7 +19527,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Update_Leopard_Tank"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Start_APC_Programms"
 			country_event = germany_foci.11
 		}
 		ai_will_do = {
@@ -19556,7 +19552,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Update_Leopard_Tank"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Start_IFV_Programms"
 			country_event = germany_foci.12
 		}
 		ai_will_do = {
@@ -19660,7 +19656,7 @@ focus_tree = {
 		cost = 4.3
 		prerequisite = { focus = GER_Startup_Investments }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Startup_Investments"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Neuer_Markt"
 			if = {
 				limit = { has_idea = GER_neuer_markt_idea }
 				swap_ideas = {
@@ -19728,7 +19724,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Startup_Investments"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Tech_DAX"
 			random_owned_state = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -19870,7 +19866,7 @@ focus_tree = {
 		prerequisite = { focus = GER_Restructure_Infrastructure }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Deutsche_Bahn_AG"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Deutsche_Bahn"
 			add_tech_bonus = {
 					name = GER_resource_excavation_research
 					bonus = 0.30
@@ -19951,7 +19947,7 @@ focus_tree = {
 		prerequisite = { focus = GER_Deutsche_Bahn }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GER_Deutsche_Bahn"
+			log = "[GetDateText]: [Root.GetName]: Focus GER_Deutsche_Bahn_AG"
 			add_timed_idea = {
 				idea = GER_idea_duetch_reichsban
 				days = 500

--- a/common/national_focus/05_italy.txt
+++ b/common/national_focus/05_italy.txt
@@ -308,7 +308,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ITA_draw_closer_to_far_east"
+			log = "[GetDateText]: [Root.GetName]: Focus ITA_industrial_cooperation_with_japan"
 			615 = {
 				owner = {
 					country_event = italy_md.17
@@ -3142,7 +3142,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ITA_dismantle_parliament"
+			log = "[GetDateText]: [Root.GetName]: Focus ITA_seize_power"
 			ITA_calculate_civil_war_size = yes
 			set_country_flag = ITA_undemocratic_coup
 			remove_dynamic_modifier = { modifier = ITA_party_popularity_drift_modifier }
@@ -5568,7 +5568,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ITA_reclaim_colonies"
+			log = "[GetDateText]: [Root.GetName]: Focus ITA_fourth_shore"
 			set_temp_variable = { treasury_change = -200 }
 			modify_treasury_effect = yes
 			every_state = {
@@ -9107,7 +9107,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ITA_economic_policies"
+			log = "[GetDateText]: [Root.GetName]: Focus ITA_social_policies"
 		}
 		ai_will_do = {
 			base = 80
@@ -22195,7 +22195,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ITA_repeal_former_government_measures_7"
+			log = "[GetDateText]: [Root.GetName]: Focus ITA_repeal_former_government_measures_8"
 			enable_elections_with_no_leader_change = yes
 			add_political_power = -500
 			set_country_flag = dynamic_flag

--- a/common/national_focus/05_kosovo.txt
+++ b/common/national_focus/05_kosovo.txt
@@ -63,7 +63,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_patch_the_scars"
 			add_political_power = 150
 		}
 
@@ -92,7 +92,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_for_freedom"
 			add_autonomy_ratio = {
 				value = 0.05
 				localization = influence_for_autonomy_decision_autonomy
@@ -128,7 +128,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_break_away"
 			add_autonomy_ratio = {
 				value = 0.05
 				localization = influence_for_autonomy_decision_autonomy
@@ -161,7 +161,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_ties_albania"
 			custom_effect_tooltip = KOS_boost_unity_5
 			add_to_variable = { var = KOS_albania value = 0.05 }
 			clamp_variable = { var = KOS_albania min = 0 max = 1 }
@@ -195,7 +195,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_offer_support"
 			remove_ideas = KOS_Ruined_Nations
 		}
 
@@ -225,7 +225,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_Referendum"
 			SER = {
 				country_event = ser_kos.1
 				end_puppet = KOS
@@ -300,7 +300,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus kos_mine_problem"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_mine_problem"
 			remove_ideas = KOS_Land_Mines
 		}
 
@@ -323,7 +323,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus kos_Mining_Potential"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_Mining_Potential"
 			add_tech_bonus = {
 				name = KOS_the_energy_debate
 				bonus = 0.5
@@ -352,7 +352,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus kos_coal_production_rump_up"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_coal_production_rump_up"
 			add_ideas = kos_new_coal_mines
 			random_list = {
 				25 = {
@@ -481,7 +481,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus kos_transportation"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_radars"
 			133 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -853,7 +853,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_maintain_un"
 			add_ideas = KOS_un_mission
 		}
 
@@ -878,7 +878,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_un_economists"
 			increase_economic_growth = yes
 			KOS = {
 				country_event = kosovo_un.1
@@ -906,7 +906,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_un_government_assistance"
 			increase_centralization = yes
 			block_bureau_decrease = yes
 		}
@@ -935,7 +935,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_un_build_network"
 			133 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -976,7 +976,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_un_hospitals"
 			swap_ideas = {
 				remove_idea = KOS_un_mission
 				add_idea = KOS_un_mission2
@@ -1007,7 +1007,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_repairing_damages"
 			set_temp_variable = { treasury_change = -2.00 }
 			modify_treasury_effect = yes
 			133 = {
@@ -1041,7 +1041,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_un_troop_bases"
 			KOS = {
 				division_template = {
 					name = "UN troops"
@@ -1085,7 +1085,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_bandage_on_forever_war"
 			swap_ideas = {
 				remove_idea = KOS_Yugoslav_war_state
 				add_idea = KOS_Yugoslav_war_state2
@@ -1113,7 +1113,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_aligning_security"
 			increase_policing_budget = yes
 			block_police_decrease = yes
 		}
@@ -1139,7 +1139,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_trauma_care"
 			swap_ideas = {
 				remove_idea = KOS_Yugoslav_war_state2
 				add_idea = KOS_Yugoslav_war_state3
@@ -1170,7 +1170,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_never_again"
 			remove_ideas = KOS_Yugoslav_war_state3
 		}
 
@@ -1499,7 +1499,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_security_troubles"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_kpc"
 			one_random_arms_factory = yes
 			swap_ideas = {
 				remove_idea = KOS_kla_legacy
@@ -1962,7 +1962,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_job_opportunities"
 			increase_economic_growth = yes
 		}
 
@@ -1991,7 +1991,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_fund_start_ups"
 			one_office_construction = yes
 		}
 
@@ -2020,7 +2020,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_commit_to_rule_of_law"
 			increase_centralization = yes
 			block_bureau_decrease = yes
 			decrease_corruption = yes
@@ -2051,7 +2051,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_attack_left"
 			add_ideas = KOS_attacking_left
 			add_popularity = {
 				ideology = communism
@@ -2096,7 +2096,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_democratic_campaigns"
 			set_temp_variable = { party_popularity_increase = 0.15 }
 			set_temp_variable = { temp_outlook_increase = 0.15 }
 			add_relative_party_popularity = yes
@@ -2133,7 +2133,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_values_of_freedom"
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			add_relative_party_popularity = yes
 			add_ideas = KOS_idea_rights
@@ -2160,7 +2160,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_national_movement"
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -2191,7 +2191,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_distancing_from_west"
 			add_opinion_modifier = {
 				modifier = major_breach_of_trust
 				target = USA
@@ -2229,7 +2229,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_welfare_programs"
 			add_timed_idea = {
 				idea = KOS_social_focus_idea
 				days = 700
@@ -2261,7 +2261,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_kosvan_identity"
 			add_stability = 0.05
 			add_war_support = 0.1
 			set_temp_variable = { percent_change = 10 }
@@ -2293,7 +2293,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_fighting_serb_influence"
 			set_temp_variable = { percent_change = -5.12 }
 			set_temp_variable = { tag_index = SER }
 			set_temp_variable = { influence_target = KOS }
@@ -2325,7 +2325,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_chinese_friendship"
 			add_opinion_modifier = {
 				target = CHI
 				modifier = improve_trade
@@ -2371,7 +2371,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_teachings_of_marx"
 			add_ideas = KOS_teachings_marx
 		}
 
@@ -2400,7 +2400,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_distance_from_islam"
 			swap_ideas = {
 				remove_idea = sunni
 				add_idea = DEN_idea_state_atheism
@@ -2432,7 +2432,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KOS_the_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_crushing_the_liberals"
 			add_stability = 0.09
 			add_popularity = {
 				ideology = neutrality
@@ -2869,7 +2869,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus attacking_the_right"
+			log = "[GetDateText]: [Root.GetName]: Focus KOS_attacking_the_right"
 			add_popularity = {
 				ideology = nationalist
 				popularity = -0.15

--- a/common/national_focus/05_liechtenstein.txt
+++ b/common/national_focus/05_liechtenstein.txt
@@ -49,7 +49,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LIC_politics"
+			log = "[GetDateText]: [Root.GetName]: Focus LIC_prince_regnant"
 			add_political_power = 50
 			add_ideas = LIC_idea_prince_regnant
 			add_popularity = {
@@ -360,7 +360,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LIC_changing_succession_laws"
+			log = "[GetDateText]: [Root.GetName]: Focus LIC_changing_succesion_laws"
 			add_political_power = 200
 			swap_ideas = {
 				remove_idea = LIC_idea_modern_monarch
@@ -523,7 +523,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LIC_the_military"
+			log = "[GetDateText]: [Root.GetName]: Focus LIC_the_military_question"
 			add_stability = 0.05
 			increase_military_spending = yes
 		}
@@ -1945,7 +1945,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LIC_finnish_haven"
+			log = "[GetDateText]: [Root.GetName]: Focus LIC_huge_tax_haven"
 			add_political_power = 50
 			add_stability = -0.01
 			set_variable = { haven_swap = 1 }
@@ -3318,6 +3318,20 @@ focus_tree = {
 			focus = LIC_Prince_Alois
 		}
 
+		will_lead_to_war_with = FRA
+		will_lead_to_war_with = CZE
+		will_lead_to_war_with = HOL
+		will_lead_to_war_with = BEL
+		will_lead_to_war_with = ITA
+		will_lead_to_war_with = SLV
+		will_lead_to_war_with = SWI
+		will_lead_to_war_with = LUX
+		will_lead_to_war_with = POL
+		will_lead_to_war_with = GER
+		will_lead_to_war_with = AUS
+		will_lead_to_war_with = HLS
+		will_lead_to_war_with = SMA
+
 		search_filters = { FOCUS_FILTER_DIPLOMACY }
 
 		completion_reward = {
@@ -3583,6 +3597,34 @@ focus_tree = {
 		mutually_exclusive = {
 			focus = LIC_path_of_peace
 		}
+
+		will_lead_to_war_with = CRO
+		will_lead_to_war_with = BOS
+		will_lead_to_war_with = SER
+		will_lead_to_war_with = ENG
+		will_lead_to_war_with = SPR
+		will_lead_to_war_with = HUN
+		will_lead_to_war_with = BUL
+		will_lead_to_war_with = ROM
+		will_lead_to_war_with = TUR
+		will_lead_to_war_with = POR
+		will_lead_to_war_with = MOR
+		will_lead_to_war_with = MNC
+		will_lead_to_war_with = GRE
+		will_lead_to_war_with = FYR
+		will_lead_to_war_with = ALB
+		will_lead_to_war_with = TUN
+		will_lead_to_war_with = ALG
+		will_lead_to_war_with = LBA
+		will_lead_to_war_with = EGY
+		will_lead_to_war_with = ISR
+		will_lead_to_war_with = SYR
+		will_lead_to_war_with = LEB
+		will_lead_to_war_with = PAL
+		will_lead_to_war_with = HEZ
+		will_lead_to_war_with = CYP
+		will_lead_to_war_with = NCY
+		will_lead_to_war_with = SLO
 
 		search_filters = { FOCUS_FILTER_DIPLOMACY }
 

--- a/common/national_focus/05_montenegro.txt
+++ b/common/national_focus/05_montenegro.txt
@@ -734,7 +734,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus MNT_buy_frigates"
+			log = "[GetDateText]: [Root.GetName]: Focus MNT_buy_transport"
 			country_event = Montenegro.18
 		}
 

--- a/common/national_focus/05_myanmar.txt
+++ b/common/national_focus/05_myanmar.txt
@@ -55,7 +55,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BRM_imprison_opposition_figures"
+			log = "[GetDateText]: [Root.GetName]: Focus BRM_the_new_economic_boom"
 			increase_economic_growth = yes
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = 0.05 }
@@ -90,7 +90,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BRM_imprison_opposition_figures"
+			log = "[GetDateText]: [Root.GetName]: Focus BRM_loan_refactoring"
 			set_temp_variable = { debt_change = debt }
 			multiply_temp_variable = { debt_change = -0.20 }
 			clamp_temp_variable = { var = debt_change max = 0 min = -100 }

--- a/common/national_focus/05_south_ossetia.txt
+++ b/common/national_focus/05_south_ossetia.txt
@@ -1762,7 +1762,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: focus SOO_unite_knowlege_economy"
+			log = "[GetDateText]: [THIS.GetName]: focus SOO_revive_alan_spirit"
 			country_event = Ossetia.12
 			if = {
 				limit = { has_idea = non_state_actor }
@@ -2483,7 +2483,7 @@ focus_tree = {
 		available = { emerging_communist_state_are_in_power = yes }
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: focus SOO_fight_narcota"
+			log = "[GetDateText]: [THIS.GetName]: focus SOO_mnogo_parti"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOO_commie_modifier }
 			add_to_variable = { SOO_commie_stability_factor = 0.09 tooltip = stability_factor_tt }
 			add_to_variable = { SOO_commie_drift_defence_factor = -0.15 tooltip = drift_defence_factor_tt }
@@ -2786,7 +2786,7 @@ focus_tree = {
 		available = { emerging_communist_state_are_in_power = yes }
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: focus SOO_osetian_language"
+			log = "[GetDateText]: [THIS.GetName]: focus SOO_marxism"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOO_commie_modifier }
 			add_to_variable = { SOO_commie_communism_drift = 0.05 tooltip = communism_drift_tt }
 			add_to_variable = { SOO_commie_education_cost_multiplier_modifier = 0.10 tooltip = education_cost_multiplier_modifier_tt }
@@ -2819,7 +2819,7 @@ focus_tree = {
 		bypass = { NOT = { SOV = { owns_state = 673 } } }
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: focus SOO_unite_with_northosset_as_rus_pup"
+			log = "[GetDateText]: [THIS.GetName]: focus SOO_five_year_plan"
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			add_relative_party_popularity = yes
 			add_political_power = 150
@@ -3153,7 +3153,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: focus SOO_podchistit_polit_pole"
+			log = "[GetDateText]: [THIS.GetName]: focus SOO_military_arms"
 			one_random_arms_factory = yes
 		}
 
@@ -4277,7 +4277,7 @@ focus_tree = {
 		available = { country_exists = SHA }
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: focus SOO_syria_relations"
+			log = "[GetDateText]: [THIS.GetName]: focus SOO_shara_relat"
 			SHA = {
 				add_opinion_modifier = {
 					target = ROOT

--- a/common/national_focus/05_transnistria.txt
+++ b/common/national_focus/05_transnistria.txt
@@ -583,7 +583,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_ger_invest"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_ge_invest"
 			set_temp_variable = { percent_change = 6.5 }
 			set_temp_variable = { tag_index = GER }
 			set_temp_variable = { influence_target = PMR }
@@ -1591,7 +1591,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_pro_ukraine"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_propaganda"
 			add_political_power = 100
 			set_temp_variable = { percent_change = 7 }
 			set_temp_variable = { tag_index = UKR }
@@ -2811,7 +2811,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_expel_russian"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_expel_russians"
 			remove_ideas = PMR_14_army
 			SOV = {
 				country_event = transnistria.39
@@ -3277,7 +3277,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_workers"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_commi_promka"
 			set_temp_variable = { temp_opinion = 5 }
 			change_communist_cadres_opinion = yes
 			add_political_power = 50
@@ -3310,7 +3310,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_workers"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_commi_ideology"
 			set_temp_variable = { temp_opinion = 5 }
 			change_communist_cadres_opinion = yes
 			add_political_power = 50
@@ -4008,7 +4008,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_clean_government"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_clean_governments"
 			add_timed_idea = { idea = PMR_corruption_dead_in_govern_idea days = 760 }
 			add_political_power = -50
 		}
@@ -4070,7 +4070,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_ded_sheriff"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_ded_sheriffs"
 			remove_ideas = PMR_sheriff7
 			set_country_flag = PMR_sheriff_finish
 			add_political_power = -100
@@ -4559,7 +4559,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_democracy"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_infra"
 			one_random_infrastructure = yes
 		}
 
@@ -4686,7 +4686,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_corruptable"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_selhoz"
 			one_random_agriculture_district = yes
 		}
 
@@ -5779,7 +5779,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_TRANSNISTRIA_ARMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_suvorov_academy"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_lebed_academy"
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
@@ -6547,7 +6547,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_vpk"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_kazaki_more"
 			add_manpower = -499
 			capital_scope = {
 				create_unit = {
@@ -6756,7 +6756,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus PMR_vpk"
+			log = "[GetDateText]: [Root.GetName]: Focus PMR_defenced"
 			add_stability = 0.1
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes

--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -234,7 +234,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ENG_Maintain_Nuclear_Deterrent"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_trident_nuclear_program"
 			add_tech_bonus = {
 				name = ENG_trident_nuclear_program
 				uses = 1
@@ -565,7 +565,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ENG_future_soldier_armed_forces"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_aircraft_ai_integration"
 			add_timed_idea = {
 				idea = ENG_aircraft_ai_idea
 				days = 720
@@ -708,7 +708,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus EENG_strategic_aircraft_strategy"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_strategic_aircraft_strategy"
 			add_ideas = ENG_strategic_aircraft_strategy_idea
 			add_doctrine_cost_reduction = {
 				name = ENG_strategic_aircraft_strategy
@@ -745,7 +745,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus Field_Army_Expansion"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_field_army_expansion"
 			swap_ideas = {
 				remove_idea = ENG_worldwide_command2
 				add_idea = ENG_worldwide_command3
@@ -2056,7 +2056,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ENG_British_Armed_Forces_Programs"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_royal_army"
 			army_experience = 50
 			add_ideas = ENG_royal_army1
 			newline = yes
@@ -4049,7 +4049,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus Revive_P125_Project"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_revive_p125_project"
 			swap_ideas = {
 				remove_idea = ENG_royal_airforce2
 				add_idea = ENG_royal_airforce4
@@ -4989,7 +4989,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_SPACE }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ENG_space_red_coats"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_1st_space_force_division"
 			swap_ideas = {
 				remove_idea = ENG_Space_Command2
 				add_idea = ENG_Space_Command3
@@ -7779,7 +7779,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ECONOMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ENG_expand_scottish_steel"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_refine_natural_bauxite"
 			9 = {
 				add_resource = {
 					type = aluminium
@@ -8143,7 +8143,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ECONOMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus ENG_marine_power_systems"
+			log = "[GetDateText]: [Root.GetName]: Focus ENG_develop_edinburgh_west_end"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_economy_modifier
@@ -10540,7 +10540,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_prioritize_the_teachers"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_strengthening_our_grids"
 			set_temp_variable = { temp_opinion = 10 }
 			change_fossil_fuel_industry_opinion = yes
 			newline = yes
@@ -10643,7 +10643,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_competition_planning_and_regulation"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_codify_key_of_convetions"
 			# custom_effect_tooltip = ENG_codification_tt
 			# newline = yes
 			custom_effect_tooltip = {
@@ -11252,7 +11252,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_scraping_the_skies"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_party_of_pensior_poverty"
 			hidden_effect = {
 				set_temp_variable = { party_index = 1 }
 				set_temp_variable = { party_popularity_increase = -0.05 }
@@ -12483,7 +12483,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_fighting_the_power_of_brussels"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_no_army_outside_of_europe"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_political_modifier
@@ -13254,7 +13254,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_across_the_board_tax_slashes"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_tax_slashes_only_for_some"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_economy_modifier
@@ -13330,7 +13330,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_keeping_hospitals_clean"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_corporate_invitations"
 			12 = {
 				add_building_construction = {
 					type = microchip_plant
@@ -13618,7 +13618,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_cutting_wait_times"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_keeping_up_our_guard"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_political_modifier
@@ -13754,7 +13754,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_cleanup_westminster"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_big_society_not_big_government"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_economy_modifier
@@ -13826,7 +13826,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_the_most_family_friendly_country"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_protecting_childhood"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_economy_modifier
@@ -13901,7 +13901,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_bigger_place_for_educators"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_knowledge_for_industry"
 			set_temp_variable = { temp_opinion = 5 }
 			change_defense_industry_opinion = yes
 			newline = yes
@@ -13986,7 +13986,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_bigger_place_for_educators"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_more_balanced_economy"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_economy_modifier
@@ -14257,7 +14257,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_more_transparent_government"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_public_reading_stage"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_political_modifier
@@ -14292,7 +14292,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_more_transparent_government"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_petitions_for_debate"
 			remove_ideas = ENG_two_party_system_idea
 			newline = yes
 			custom_effect_tooltip = ENG_shatter_two_party_system_TT
@@ -14348,7 +14348,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_more_transparent_government"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_for_the_common_man"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_economy_modifier
@@ -14420,7 +14420,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_more_transparent_government"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_for_the_wealthy_man"
 			set_temp_variable = { temp_opinion = 10 }
 			change_fossil_fuel_industry_opinion = yes
 			newline = yes
@@ -14684,7 +14684,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_rule_sword_sceptre"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_bid_soft_power"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_monarchy
@@ -14729,7 +14729,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_rule_sword_sceptre"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_commonwealth_summit"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_monarchy
@@ -14789,7 +14789,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_rule_sword_sceptre"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_crown_procurement_program"
 			add_ideas = ENG_crown_procurement_program_idea
 		}
 
@@ -14841,7 +14841,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_rule_sword_sceptre"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_modernize_royal_navy"
 			if = {
 				limit = { has_idea = ENG_crown_procurement_program_idea }
 				swap_ideas = {
@@ -14908,7 +14908,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_rule_sword_sceptre"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_raf_army_overhaul"
 			if = {
 				limit = { has_idea = ENG_crown_procurement_program_idea }
 				swap_ideas = {
@@ -15201,7 +15201,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_secure_succession"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_convene_foreign_secretary_cabinet"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_monarchy
@@ -15271,7 +15271,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_secure_succession"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_european_outreach"
 			for_each_scope_loop = {
 				array = global.EU_member
 				tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
@@ -15372,7 +15372,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_secure_succession"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_close_proximity_nato"
 			USA = { country_event = ENG_military.045 }
 		}
 
@@ -15400,7 +15400,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_secure_succession"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_joint_operational_command"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_monarchy
@@ -15435,7 +15435,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_secure_succession"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_reaffirm_special_relationship"
 			USA = {
 				add_opinion_modifier = { target = ENG modifier = ENG_monarch_outreach }
 				reverse_add_opinion_modifier = { target = ENG modifier = ENG_monarch_outreach }
@@ -15493,7 +15493,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_royal_prerogative_activation"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_royal_charitable_initiative"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_monarchy
@@ -19749,7 +19749,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_australian_outreach"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_new_zealands_offer"
 			NZL = {
 				country_event = {
 					id = britain_md.35
@@ -19819,7 +19819,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus ENG_australian_outreach"
+			log = "[GetDateText]: [THIS.GetName]: Focus ENG_declare_the_commonwealth"
 			#TODO: Global event here
 			custom_effect_tooltip = ENG_declares_commonwealth_federation_TT
 			hidden_effect = {

--- a/common/national_focus/06_Commonwealth_Shared.txt
+++ b/common/national_focus/06_Commonwealth_Shared.txt
@@ -448,7 +448,7 @@ joint_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CMW_Health_Section"
+		log = "[GetDateText]: [Root.GetName]: Focus CMW_Body_And_Sports"
 		custom_effect_tooltip = {
 			localization_key = modifies_dynamic_modifier_tt
 			MODIFIER = Commonwealth_member_modifier

--- a/common/national_focus/Cascadia.txt
+++ b/common/national_focus/Cascadia.txt
@@ -3087,7 +3087,7 @@ focus_tree = {
 		available = { emerging_anarchist_communism_are_in_power = yes }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_the_peoples_mountain_state"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_the_peoples_pacific_gem_state"
 			set_temp_variable = { treasury_change = -13.75 }
 			modify_treasury_effect = yes
 			809 = {
@@ -10560,7 +10560,7 @@ focus_tree = {
 		prerequisite = { focus = CAS_focus_bringing_oregon_online }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_bringing_oregon_online"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_stabilizing_the_national_grid"
 			set_temp_variable = { treasury_change = -17.00 }
 			modify_treasury_effect = yes
 			809 = {
@@ -11461,7 +11461,7 @@ focus_tree = {
 		prerequisite = { focus = CAS_focus_mountaineering_army }
 		search_filters = { FOCUS_FILTER_ARMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_streamlining_personnel_placement"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_expanding_training_camps"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = cascadia_federal_budgets }
 			add_to_variable = { CAS_budget_personnel_cost = 0.02 tooltip = personnel_cost_multiplier_modifier_tt }
@@ -11576,7 +11576,7 @@ focus_tree = {
 		mutually_exclusive = { focus = CAS_focus_aggression_strategy }
 		search_filters = { FOCUS_FILTER_ARMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_general_refinement_programs"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_army_defensive_strategy"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = cascadia_federal_budgets }
 			add_to_variable = { CAS_budget_personnel_cost = 0.02 tooltip = personnel_cost_multiplier_modifier_tt }
@@ -12305,7 +12305,7 @@ focus_tree = {
 		prerequisite = { focus = CAS_focus_fighter_priority_strategy }
 		search_filters = { FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_fighter_priority_strategy"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_improved_weapons_testing"
 			add_ideas = CAS_ideas_weapons_testing_facilities
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = cascadia_federal_budgets }
 			add_to_variable = { CAS_budget_education_cost = 0.06 tooltip = education_cost_multiplier_modifier_tt }
@@ -12497,7 +12497,7 @@ focus_tree = {
 		prerequisite = { focus = CAS_focus_general_infrastructure_investments }
 		search_filters = { FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_general_infrastructure_investments"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_air_force_assistance_department"
 			add_ideas = CAS_ideas_assistance_department
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = cascadia_federal_budgets }
 			add_to_variable = { CAS_budget_bureaucracy_cost = 0.05 tooltip = bureaucracy_cost_multiplier_modifier_tt }
@@ -12557,7 +12557,7 @@ focus_tree = {
 		prerequisite = { focus = CAS_focus_clear_skies_ahead }
 		search_filters = { FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_clear_skies_ahead"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_a_refined_fighting_force"
 			swap_ideas = {
 				remove_idea = CAS_ideas_cascadian_armed_services_infancy
 				add_idea = CAS_ideas_cascadian_armed_services_refined
@@ -14755,7 +14755,7 @@ focus_tree = {
 		prerequisite = { focus = CAS_focus_war_plan_marathon }
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_capital_clean_up"
+			log = "[GetDateText]: [Root.GetName]: Focus CAS_focus_liberty_shines_once_more"
 
 			transfer_state = 769
 			transfer_state = 768

--- a/common/national_focus/Crimea.txt
+++ b/common/national_focus/Crimea.txt
@@ -162,7 +162,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CRM_monarchy"
+			log = "[GetDateText]: [Root.GetName]: Focus CRM_natbols"
 			set_temp_variable = { party_index = 0 }
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
@@ -684,7 +684,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INTERNAL_AFFAIRS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CRM_monarchy"
+			log = "[GetDateText]: [Root.GetName]: Focus CRM_monarchy_rule"
 			add_ideas = CRM_rule_romanov
 		}
 
@@ -771,7 +771,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_SOCIAL_CONSERVATISM }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CRM_monarchy_antidemocracy"
+			log = "[GetDateText]: [Root.GetName]: Focus CRM_monarchy_church"
 			set_temp_variable = { temp_opinion = 15 }
 			change_the_clergy_opinion = yes
 			change_oligarchs_opinion = yes

--- a/common/national_focus/Hezbollah.txt
+++ b/common/national_focus/Hezbollah.txt
@@ -366,7 +366,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Backers"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_banks_in_beirut"
 			set_temp_variable = { percent_change = 1.0 }
 			set_temp_variable = { tag_index = GER }
 			set_temp_variable = { influence_target = HEZ }
@@ -406,7 +406,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Backers"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_negotiations_in_the_south"
 			set_temp_variable = { treasury_change = 10.00 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1.2 }
@@ -440,7 +440,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Backers"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_a_new_economy"
 			set_temp_variable = { treasury_change = -20.00 }
 			modify_treasury_effect = yes
 			increase_economic_growth = yes
@@ -463,7 +463,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Backers"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_a_free_market"
 			add_ideas = HEZ_liberization
 		}
 
@@ -484,7 +484,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Backers"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_a_free_industry"
 			add_ideas = HEZ_industrial_investments
 		}
 
@@ -506,7 +506,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Backers"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_new_dubai"
 			add_stability = 0.05
 			capital_scope = {
 				add_extra_state_shared_building_slots = 3
@@ -934,7 +934,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_last_effects_of_the_drugs"
 			USA = { add_stability = -0.05 }
 			add_political_power = -150
 		}
@@ -964,7 +964,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_propaganda_for_north_america"
 			add_manpower = -500
 			add_political_power = -100
 			set_temp_variable = { treasury_change = -10.00 }
@@ -999,7 +999,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_an_american_muslim_spring"
 			add_timed_idea = {
 				idea = HEZ_preparing_for_new_plans
 				days = 180
@@ -1031,7 +1031,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_fund_muslim_institutes"
 			set_temp_variable = { treasury_change = -2.50 }
 			modify_treasury_effect = yes
 			add_political_power = -50
@@ -1070,7 +1070,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_first_wave_of_protests"
 			set_temp_variable = { treasury_change = -5.00 }
 			modify_treasury_effect = yes
 			add_political_power = -50
@@ -1108,7 +1108,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE FOCUS_FILTER_INSURGENCY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_muslim_militias"
 			swap_ideas = {
 				remove_idea = HEZ_strange_activities_1
 				add_idea = HEZ_strange_activities_2
@@ -1141,7 +1141,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INFLUENCE FOCUS_FILTER_INSURGENCY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_North_American_Hezbollah"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_the_muslim_spring"
 			army_experience = -10
 			set_temp_variable = { treasury_change = -15.00 }
 			modify_treasury_effect = yes
@@ -2961,7 +2961,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollahs_independent_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_friends_in_lebanon"
 			set_temp_variable = { percent_change = -2.5 }
 			set_temp_variable = { influence_target = LEB }
 			change_influence_percentage = yes
@@ -2987,7 +2987,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollahs_independent_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_friends_in_outside"
 			add_ideas = HEZ_foreign_economical_funds
 		}
 
@@ -3010,7 +3010,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollahs_independent_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_ready_for_construction"
 			capital_scope = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -3042,7 +3042,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollahs_independent_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_collaboration_in_the_civilian_industry"
 			capital_scope = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -3074,7 +3074,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollahs_independent_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_collaboration_in_the_military_industry"
 			capital_scope = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -3105,7 +3105,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ECONOMY FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollahs_independent_industry"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_al_bina"
 			capital_scope = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -3650,7 +3650,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Lobbying_Public_Support"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Lebanese_Support"
 			custom_effect_tooltip = HEZ_lebanese_aid_income_based_on_influence_TT
 		}
 
@@ -3787,7 +3787,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Shias_Lebanon"
+			log = "[GetDateText]: [Root.GetName]: Focus HEZ_maintain_status_quo"
 			add_political_power = 100
 			set_temp_variable = { treasury_change = 100.00 }
 			modify_treasury_effect = yes

--- a/common/national_focus/Khanti-mansi.txt
+++ b/common/national_focus/Khanti-mansi.txt
@@ -290,7 +290,7 @@ focus_tree = {
 		# cancel = { }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_a_pragmatic_approach"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_democratic_idealism"
 			add_ideas = SUB_idea_democratic_idealism
 		}
 
@@ -676,7 +676,7 @@ focus_tree = {
 		prerequisite = { focus = KHM_zir_ideas }
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_grip"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_gripers"
 			increase_policing_budget = yes
 			swap_ideas = {
 				remove_idea = KHM_zhir
@@ -1041,7 +1041,7 @@ focus_tree = {
 		mutually_exclusive = { focus = KHM_multi }
 		search_filters = { FOCUS_FILTER_OSSETIA_COMMI }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_salary"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_one_party"
 			add_popularity = {
 				ideology = nationalist
 				popularity = -0.15
@@ -1069,7 +1069,7 @@ focus_tree = {
 		mutually_exclusive = { focus = KHM_one_party }
 		search_filters = { FOCUS_FILTER_OSSETIA_COMMI }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_salary"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_multi"
 			add_stability = 0.03
 			add_popularity = {
 				ideology = nationalist
@@ -1161,7 +1161,7 @@ focus_tree = {
 		prerequisite = { focus = KHM_power_to_the_workers }
 		search_filters = { FOCUS_FILTER_OSSETIA_COMMI }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_salary"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_zavods"
 			two_random_industrial_complex = yes
 			two_random_fossil_fuel_powerplant = yes
 			KHM_ecology_sad_script = yes
@@ -1373,7 +1373,7 @@ focus_tree = {
 		prerequisite = { focus = KHM_oligarch }
 		prerequisite = { focus = KHM_oil }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus BSH_five_year_plan"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_five_year_plan"
 			add_political_power = 150
 			set_temp_variable = { temp_opinion = 5 }
 			change_communist_cadres_opinion = yes
@@ -1761,7 +1761,7 @@ focus_tree = {
 		prerequisite = { focus = KHM_filipenko }
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_corporations"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_agri"
 			add_ideas = KHM_agri_idea
 		}
 		ai_will_do = { base = 100 }
@@ -1997,7 +1997,7 @@ focus_tree = {
 		prerequisite = { focus = KHM_new_road focus = KHM_future }
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_yugra"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_machine"
 			add_ideas = KHM_edro_super
 		}
 		ai_will_do = { base = 100 }
@@ -2466,7 +2466,7 @@ focus_tree = {
 		prerequisite = { focus = KHM_bridges }
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KHM_surgut_airport"
+			log = "[GetDateText]: [Root.GetName]: Focus KHM_ecology"
 			KHM_ecology_good_script = yes
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes

--- a/common/national_focus/Kuban.txt
+++ b/common/national_focus/Kuban.txt
@@ -560,7 +560,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_RUSSIA_ECONOMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_aomz"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_abinsk"
 			two_random_fossil_fuel_powerplant = yes
 			set_temp_variable = { party_popularity_increase = 0.080 }
 			add_relative_party_popularity = yes
@@ -1771,7 +1771,7 @@ focus_tree = {
 
 		available = { emerging_reactionaries_are_in_power = yes }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_russian_mobile"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_revive_factories_agro"
 			one_random_agriculture_district = yes
 			set_temp_variable = { temp_opinion = 10 }
 			change_farmers_opinion = yes
@@ -3271,7 +3271,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_olighars_commie"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_corruption_fight"
 			decrease_corruption = yes
 			add_popularity = {
 				ideology = communism
@@ -3559,7 +3559,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_multy_party_system"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_soviet_contst"
 			add_political_power = 100
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = 0.050 }
@@ -4294,7 +4294,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_multy_party_system"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_revive_our_kgb"
 			add_ideas = KUB_kgb_idea
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = 0.050 }
@@ -4993,7 +4993,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_purge_commies"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_support_domestic_production"
 			one_random_industrial_complex = yes
 			one_random_fossil_fuel_powerplant = yes
 			if = {
@@ -5192,7 +5192,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_repair_roads"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_greatness_of_kuban_people"
 			swap_ideas = {
 				remove_idea = KUB_nationalists_four
 				add_idea = KUB_nationalists_five
@@ -5959,7 +5959,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_russian_mobile_operators"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_rzd_coop"
 			one_random_infrastructure = yes
 			if = {
 				limit = {
@@ -7269,7 +7269,7 @@ focus_tree = {
 			EU_european_union_currently_exists = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_eu_integration"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_eu_integration_dems"
 			if = {
 				limit = {
 					KUB = { is_subject_of = SOV }
@@ -7692,7 +7692,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_rus_academies"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_military_exercises_with_russia_dems"
 			army_experience = 25
 			navy_experience = 25
 			air_experience = 25
@@ -7749,7 +7749,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_rus_academies"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_adygea"
 			custom_effect_tooltip = KUB_adygea_russia_tt
 		}
 
@@ -7910,7 +7910,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_nato_integration"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_nato_membership_dems"
 			USA = { country_event = { id = kuban.48 days = 1 } }
 		}
 
@@ -8898,7 +8898,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_new_doctrinea"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_new_doctrine"
 			add_command_power = 150
 			add_political_power = 50
 			add_doctrine_cost_reduction = {
@@ -9121,7 +9121,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_russian_weapons"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_russian_weapons_cossaks"
 			SOV = { country_event = { id = kuban.27 days = 1 } }
 			newline = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -9200,7 +9200,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus A Just Russia/Rodina"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_rodina_start Just Russia/Rodina"
 			add_ideas = KUB_rodina
 			set_temp_variable = { party_index = 7 }
 			set_temp_variable = { party_popularity_increase = 0.050 }
@@ -9436,7 +9436,7 @@ focus_tree = {
 
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_oligharsn_fight_rodina"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_police_funding_rodina"
 			increase_policing_budget = yes
 		}
 		ai_will_do = {
@@ -9529,7 +9529,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus KUB_locals_support_just"
+			log = "[GetDateText]: [Root.GetName]: Focus KUB_fight_coruuption_just"
 			decrease_corruption = yes
 			set_temp_variable = { party_index = 7 }
 			set_temp_variable = { party_popularity_increase = 0.050 }

--- a/common/national_focus/LPR.txt
+++ b/common/national_focus/LPR.txt
@@ -292,7 +292,7 @@ focus_tree = {
 		cost = 1
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_zarya"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_leshiy"
 			1075 = {
 				create_unit = {
 					division = "name = \"Batalyon Leshiy\" division_template = \"Batalyon Spetsnaza\" start_experience_factor = 0.1"
@@ -365,7 +365,7 @@ focus_tree = {
 		cost = 1
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_august"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_4thguard"
 			1075 = {
 				create_unit = {
 					division = "name = \"4th Guards Motorized Rifle Brigade\" division_template = \"Motorizovannaya Brigada\" start_experience_factor = 0.1"
@@ -400,7 +400,7 @@ focus_tree = {
 		cost = 1
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_august"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_interbrigade"
 			1075 = {
 				create_unit = {
 					division = "name = \"Interbrigade Lugansk\" division_template = \"Batalyon Dobrovolchev\" start_experience_factor = 0.1"
@@ -488,7 +488,7 @@ focus_tree = {
 		cost = 3
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_territorial_defence"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_more_kossaks"
 			1075 = {
 				create_unit = {
 					division = "name = \"Cossacks Motorized Brigade\" division_template = \"Kazachya Brigada\" start_experience_factor = 0.1"
@@ -592,7 +592,7 @@ focus_tree = {
 		cost = 7
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_rzso_cheburashka"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_rifles"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
@@ -653,7 +653,7 @@ focus_tree = {
 		cost = 5
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_reform_army"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_reforms_army"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_ideas = LPR_proffesional_army
@@ -772,7 +772,7 @@ focus_tree = {
 		cost = 5
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_mgb"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_mgb"
 			add_ideas = LPR_mgb
 		}
 		ai_will_do = { base = 20 }
@@ -913,7 +913,7 @@ focus_tree = {
 		cost = 7
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_bivaluta"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_internet"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			random_owned_controlled_state = {
@@ -948,7 +948,7 @@ focus_tree = {
 		cost = 1
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_nationalise"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_defence"
 			add_stability = 0.1
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
@@ -1129,7 +1129,7 @@ focus_tree = {
 		cost = 7
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DPR_nov_zavods"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_nov_politic"
 			set_temp_variable = { percent_change = 15 }
 			set_temp_variable = { tag_index = LPR }
 			set_temp_variable = { influence_target = DPR }
@@ -1206,7 +1206,7 @@ focus_tree = {
 		cost = 7
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_nov_annex_hpr"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_nov_annex_opr"
 			annex_country = { target = OPR transfer_troops = yes }
 			OPR = { every_core_state = { add_core_of = LPR } }
 			LPR = {
@@ -1270,7 +1270,7 @@ focus_tree = {
 		cost = 7
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LPR_nationalise"
+			log = "[GetDateText]: [Root.GetName]: Focus LPR_npz"
 			set_temp_variable = { temp_opinion = 3 }
 			change_fossil_fuel_industry_opinion = yes
 			1075 = {

--- a/common/national_focus/New England.txt
+++ b/common/national_focus/New England.txt
@@ -314,7 +314,7 @@ focus_tree = {
 		prerequisite = { focus = NEN_focus_vermont_violence }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus NEN_focus_boston_beauty"
+			log = "[GetDateText]: [Root.GetName]: Focus NEN_focus_virtuous_vermont"
 			add_state_core = 766
 			766 = {
 				add_building_construction = {
@@ -384,7 +384,7 @@ focus_tree = {
 		prerequisite = { focus = NEN_focus_connecticut_crutch }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus NEN_focus_boston_beauty"
+			log = "[GetDateText]: [Root.GetName]: Focus NEN_focus_middletown_miracle"
 			add_state_core = 768
 			768 = {
 				add_building_construction = {

--- a/common/national_focus/Odessa.txt
+++ b/common/national_focus/Odessa.txt
@@ -72,7 +72,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus OPR_odessa_defence"
+			log = "[GetDateText]: [Root.GetName]: Focus OPR_odessa_defences"
 			add_stability = 0.1
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
@@ -135,7 +135,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus OPR_trans_suplly"
+			log = "[GetDateText]: [Root.GetName]: Focus OPR_more_marines"
 			695 = {
 				create_unit = {
 					division = "name = \"2nd Odessa Brigade\" division_template = \"Bryhada Morskoyi Pikhoty\" start_experience_factor = 0.1"
@@ -168,7 +168,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus OPR_teroborona"
+			log = "[GetDateText]: [Root.GetName]: Focus OPR_teroboronas"
 			hidden_effect = {
 				division_template = {
 					name = "Territorial Defense Brigade"
@@ -211,7 +211,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus OPR_weapon_suplly"
+			log = "[GetDateText]: [Root.GetName]: Focus OPR_weapon_supllys"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_3
 				amount = 1500

--- a/common/national_focus/Republic of Lakota.txt
+++ b/common/national_focus/Republic of Lakota.txt
@@ -3702,7 +3702,7 @@ focus_tree = {
 		available = { emerging_anarchist_communism_are_in_power = yes }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_improving_farming_methods"
+			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_mechanized_agriculture_union"
 			set_temp_variable = { treasury_change = -22.50 }
 			modify_treasury_effect = yes
 
@@ -4633,7 +4633,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_the_common_folk_progress_parties"
+			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_new_lakotan_nationals_parties"
 			add_political_power = 50
 			add_stability = 0.05
 			add_war_support = 0.05
@@ -7907,7 +7907,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_RESOURCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_need_by_need_investment_strategy"
+			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_iron_ore_revival"
 			set_temp_variable = { treasury_change = -18.00 }
 			modify_treasury_effect = yes
 			786 = {
@@ -9049,7 +9049,7 @@ focus_tree = {
 		available = { any_owned_state = { is_coastal = yes } }
 		search_filters = { FOCUS_FILTER_NAVY_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_formalizing_naval_training_programs"
+			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_our_naval_priority"
 			navy_experience = 25
 
 			add_ideas = LKT_ideas_strategically_cheap
@@ -10725,7 +10725,7 @@ focus_tree = {
 		prerequisite = { focus = LKT_focus_southern_sunrise }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_southern_sunrise"
+			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_the_western_identity"
 
 			country_event = {
 				id = LKT_nation_name_event.5
@@ -11510,7 +11510,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_dividing_up_the_west"
+			log = "[GetDateText]: [Root.GetName]: Focus LKT_focus_the_northern_concessions"
 
 			758 = {
 				transfer_state_to = LKT

--- a/common/national_focus/Southern_Republic_of_America.txt
+++ b/common/national_focus/Southern_Republic_of_America.txt
@@ -1827,7 +1827,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_investments_across_dixie }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_investments_across_dixie"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_civilian_industrial_expansions"
 			set_temp_variable = { treasury_change = -60.00 }
 			modify_treasury_effect = yes
 			791 = {
@@ -3926,7 +3926,7 @@ focus_tree = {
 		available = { neutrality_neutral_autocracy_are_in_power = yes }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_revitalizing_the_interstate_system"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_electrical_grid_advancements"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = southern_republic_federal_budgets }
 			add_to_variable = { SRA_budget_bureaucracy_cost = 0.12 tooltip = bureaucracy_cost_multiplier_modifier_tt }
@@ -7116,7 +7116,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_southern_cultural_society }
 		search_filters = { FOCUS_FILTER_STABILITY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_southern_cultural_society"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_the_southern_dream"
 			add_political_power = 100
 			swap_ideas = {
 				remove_idea = SRA_idea_historical_tensions
@@ -8123,7 +8123,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_fasp_victory"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_dpl_victory"
 			add_stability = 0.04
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = southern_republic_domestic_policies }
@@ -8240,7 +8240,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_DFP_programs }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_voluntary_emigration_programs"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_electrical_prioritization_programs"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = southern_republic_domestic_policies }
 			add_to_variable = { SRA_domestic_political_power_factor = 0.05 tooltip = political_power_factor_tt }
@@ -8284,7 +8284,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_voluntary_emigration_programs }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_voluntary_emigration_programs"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_robust_economics"
 			set_temp_variable = { treasury_change = -46.50 }
 			modify_treasury_effect = yes
 			790 = {
@@ -8605,7 +8605,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_organized_deportations }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_organized_deportations"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_a_hard_border_is_a_real_border"
 			set_temp_variable = { treasury_change = -4.00 }
 			modify_treasury_effect = yes
 			790 = {
@@ -8710,7 +8710,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_the_basic_needs_program }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_the_basic_needs_program"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_fueling_the_nation"
 			set_temp_variable = { treasury_change = -22.50 }
 			modify_treasury_effect = yes
 			every_owned_state = {
@@ -10110,7 +10110,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_imperial_minerals_security_act }
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_imperial_minerals_security_act"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_royal_nation_proclaimed"
 			custom_effect_tooltip = CSA_Southern_Kingdom_desc
 
 			newline = yes
@@ -10633,7 +10633,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_southern_militarism }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_southern_militarism"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_from_past_pains_to_future_honors"
 			swap_ideas = {
 				remove_idea = SRA_idea_historical_tensions
 				add_idea = SRA_idea_from_past_scars_to_future_honors
@@ -11000,7 +11000,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_renewable_diversity }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_renewable_diversity"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_real_green_energy"
 			set_temp_variable = { temp_change = 1 }
 			random_owned_state = { add_building_construction = { type = enrichment_facility level = 1 } }
 			set_temp_variable = { treasury_change = -27.00 }
@@ -11065,7 +11065,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_real_green_energy }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_renewable_diversity"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_brighter_tomorrow"
 			add_ideas = SRA_idea_formalized_department_of_energy
 
 			newline = yes
@@ -11106,7 +11106,7 @@ focus_tree = {
 		mutually_exclusive = { focus = CSA_focus_modernized_dixinomics_program }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_department_of_energy"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_modern_agrinomics_plan"
 			set_temp_variable = { treasury_change = -15.00 }
 			modify_treasury_effect = yes
 			794 = {
@@ -11670,7 +11670,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_agrinomics_expansion }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_agrinomics_expansion"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_dixie_agrinomics_practice"
 			set_temp_variable = { temp_opinion = 10 }
 			change_landowners_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -11865,7 +11865,7 @@ focus_tree = {
 		prerequisite = { focus = CSA_focus_dixie_lithium_belt }
 		search_filters = { FOCUS_FILTER_RESOURCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_dixie_lithium_belt"
+			log = "[GetDateText]: [Root.GetName]: Focus CSA_focus_a_devils_deal_with_georgia"
 			set_temp_variable = { treasury_change = -16.00 }
 			modify_treasury_effect = yes
 			792 = {

--- a/common/national_focus/Subject_of_russia.txt
+++ b/common/national_focus/Subject_of_russia.txt
@@ -1084,7 +1084,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SSUB_smi_not_free"
+			log = "[GetDateText]: [Root.GetName]: Focus SUB_smi_not_free"
 			add_political_power = 50
 			add_stability = -0.09
 		}
@@ -1131,7 +1131,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SUB_no_lgbt"
+			log = "[GetDateText]: [Root.GetName]: Focus SUB_zavods"
 			two_random_industrial_complex = yes
 		}
 

--- a/common/national_focus/Vitebsk.txt
+++ b/common/national_focus/Vitebsk.txt
@@ -347,7 +347,7 @@ focus_tree = {
 		cost = 7
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VBT_centralization"
+			log = "[GetDateText]: [Root.GetName]: Focus VBT_strengthen_government"
 			add_ideas = political_power_bonus
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/Vojvodina.txt
+++ b/common/national_focus/Vojvodina.txt
@@ -233,7 +233,7 @@ focus_tree = {
 			nationalist_fascist_are_in_power = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VOJ_guard"
+			log = "[GetDateText]: [Root.GetName]: Focus VOJ_path"
 			add_political_power = 100
 		}
 	}

--- a/common/national_focus/Volhynia Democratic Republic.txt
+++ b/common/national_focus/Volhynia Democratic Republic.txt
@@ -145,7 +145,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VRP_odessa_defence"
+			log = "[GetDateText]: [Root.GetName]: Focus VRP_lviv_defence"
 			add_stability = 0.1
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes

--- a/common/national_focus/armenia.txt
+++ b/common/national_focus/armenia.txt
@@ -701,7 +701,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ARM_suppressing_opposition executed"
+			log = "[GetDateText]: [This.GetName]: focus ARM_suppress_opposition executed"
 			add_political_power = 50
 			add_timed_idea = {
 				idea = ARM_suppressed_oppos
@@ -3000,7 +3000,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ARM_support_patriotic_movement executed"
+			log = "[GetDateText]: [This.GetName]: focus ARM_sov_legacy_cond_dec executed"
 			news_event = {
 				hours = 12
 				id = arm_demirchyan_news.1
@@ -6106,7 +6106,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ARM_buying_out executed"
+			log = "[GetDateText]: [This.GetName]: focus ARM_buy_small_business executed"
 			ARM_multigroup_script = yes
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
@@ -7409,7 +7409,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ARM_armeno_ari_union executed"
+			log = "[GetDateText]: [This.GetName]: focus ARM_bagratuni executed"
 			country_event = arme.221
 			set_country_flag = ARM_roland_obmanul
 			hidden_effect = {
@@ -11999,7 +11999,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ARMENIA_ECONOMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ARM_economy_agro_support executed"
+			log = "[GetDateText]: [This.GetName]: focus ARM_economy_daily_products executed"
 			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = ARM_add_idea_to_economy_idea_tt
@@ -12082,7 +12082,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ARMENIA_ECONOMY }
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ARM_economy_wto executed"
+			log = "[GetDateText]: [This.GetName]: focus ARM_government_subsid_it_sphere executed"
 			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 			ARM_it_sector_positive_script = yes
@@ -15752,7 +15752,7 @@ focus_tree = {
 			}
 
 			completion_reward = {
-				log = "[GetDateText]: [This.GetName]: focus ARM_capture_iranian_agents executed"
+				log = "[GetDateText]: [This.GetName]: focus ARM_hez_are_terrorists executed"
 				add_opinion_modifier = { target = HEZ modifier = terrorism_is_no_no }
 				reverse_add_opinion_modifier = { target = HEZ modifier = terrorism_is_no_no }
 				set_temp_variable = { percent_change = -10 }
@@ -16347,7 +16347,7 @@ focus_tree = {
 			search_filters = { FOCUS_FILTER_ARMENIA_DIPLOMACY }
 
 			completion_reward = {
-				log = "[GetDateText]: [This.GetName]: focus ARM_post_ussr_partnershs"
+				log = "[GetDateText]: [This.GetName]: focus ARM_post_ussr_partnersh"
 				add_political_power = 100
 				every_country = {
 					limit = { has_idea = CIS_member_state_idea }
@@ -17598,7 +17598,7 @@ focus_tree = {
 			}
 
 			completion_reward = {
-				log = "[GetDateText]: [This.GetName]: focus ARM_our_land_their_freedom executed"
+				log = "[GetDateText]: [This.GetName]: focus ARM_support_barzani_ambitions executed"
 				KUR = {
 					country_event = md4.4
 				}
@@ -18505,7 +18505,7 @@ focus_tree = {
 			}
 
 			completion_reward = {
-				log = "[GetDateText]: [This.GetName]: focus ARM_negotiate_kurds executed"
+				log = "[GetDateText]: [This.GetName]: focus ARM_negotiate_syria executed"
 				SYR = {
 					country_event = arm_expansion.2
 				}

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -283,7 +283,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus BRA_the_true_moderate_path"
+			log = "[GetDateText]: [THIS.GetName]: Focus BRA_a_promise_to_keep"
 			set_temp_variable = { temp_change = 5 }
 			BRA_worker_party_alignment_effect = yes
 			set_temp_variable = { party_index = 5 }
@@ -3234,7 +3234,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION }
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus BRA_help_business_owners"
+			log = "[GetDateText]: [THIS.GetName]: Focus BRA_support_international_bankers"
 			set_temp_variable = { int_investment_change = gdp_total }
 			multiply_temp_variable = { int_investment_change = 0.03 }
 			modify_international_investment_effect = yes
@@ -5991,7 +5991,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus BRA_brazilian_space_force"
+			log = "[GetDateText]: [THIS.GetName]: Focus BRA_brazilian_space"
 			add_ideas = BRA_idea_brazilian_space_force
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = -0.02 }
@@ -7780,7 +7780,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus BRA_left_wing_propaganda_effort"
+			log = "[GetDateText]: [THIS.GetName]: Focus BRA_foro_de_sp"
 			add_popularity = { ideology = communism popularity = 0.075 }
 			set_rule = {
 				can_create_factions = yes
@@ -10670,7 +10670,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [THIS.GetName]: Focus BRA_mobilize_working_class"
+			log = "[GetDateText]: [THIS.GetName]: Focus BRA_agrarian_reform"
 			add_ideas = BRA_idea_agrarian_reform
 		}
 

--- a/common/national_focus/centralasia.txt
+++ b/common/national_focus/centralasia.txt
@@ -1448,8 +1448,10 @@ focus_tree = {
 		y = 1
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		prerequisite = { focus = CES_our_state_kaz }
@@ -1485,8 +1487,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1529,8 +1533,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1565,8 +1571,10 @@ focus_tree = {
 		cost = 6
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1604,8 +1612,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1634,8 +1644,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1667,8 +1679,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1697,8 +1711,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1756,8 +1772,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1797,8 +1815,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1830,8 +1850,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1863,8 +1885,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1894,8 +1918,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1933,8 +1959,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1964,8 +1992,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -1999,8 +2029,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -2046,8 +2078,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -2081,8 +2115,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -2501,8 +2537,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -2531,8 +2569,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -2564,8 +2604,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_raise_from_ash
@@ -2596,8 +2638,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_personal_guard
@@ -2633,8 +2677,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_put_diss_in_jail
@@ -2668,8 +2714,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_governmental_propaganda
@@ -2704,8 +2752,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_pensions_increase
@@ -2734,8 +2784,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_healthcare_reform
@@ -2770,8 +2822,10 @@ focus_tree = {
 		cost = 7
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_constitutional_reform
@@ -2804,8 +2858,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_put_diss_in_jail
@@ -2834,8 +2890,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_put_diss_in_jail
@@ -2864,8 +2922,10 @@ focus_tree = {
 		cost = 5
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_put_diss_in_jail
@@ -2898,8 +2958,10 @@ focus_tree = {
 		cost = 6
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_peaceful_prowestern
@@ -2973,8 +3035,10 @@ focus_tree = {
 		cost = 6
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_changing_the_course
@@ -3035,8 +3099,10 @@ focus_tree = {
 		cost = 6
 		available = {
 			NOT = {
-				has_government = fascism
-				has_government = nationalist
+				OR = {
+					has_government = fascism
+					has_government = nationalist
+				}
 			}
 		}
 		relative_position_id = CES_peaceful_eastern
@@ -3191,7 +3257,7 @@ focus_tree = {
 		prerequisite = { focus = CES_economic_affairs }
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus GENERIC_attract_foreign_investors"
+			log = "[GetDateText]: [Root.GetName]: Focus CES_debt_reafctoring"
 			set_temp_variable = { debt_change = debt }
 			multiply_temp_variable = { debt_change = 0.05 }
 			clamp_temp_variable = { var = debt_change min = 0 max = 100 }
@@ -8916,7 +8982,7 @@ focus_tree = {
 		prerequisite = { focus = CES_airforce_trainings }
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus CES_buying_planes executed"
+			log = "[GetDateText]: [This.GetName]: focus CES_new_air_doctrine executed"
 			air_experience = 75
 			add_war_support = 0.02
 
@@ -9529,7 +9595,7 @@ focus_tree = {
 		prerequisite = { focus = CES_infantr_guns }
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus CES_chinese_guns executed"
+			log = "[GetDateText]: [This.GetName]: focus CES_us_guns executed"
 			add_timed_idea = {
 				idea = rifle_production_bonus2
 				days = 365
@@ -10892,7 +10958,7 @@ focus_tree = {
 		relative_position_id = CES_kaz_reform_vs
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus ter_oborna executed"
+			log = "[GetDateText]: [This.GetName]: focus CES_kaz_ter_oborna executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CES_kaz_modifier }
 			add_to_variable = { CES_kaz_army_core_defence_factor = 0.10 tooltip = army_core_defence_factor_tt }
 			custom_effect_tooltip = CES_ter_oborona_tt

--- a/common/national_focus/china.txt
+++ b/common/national_focus/china.txt
@@ -5610,7 +5610,7 @@ focus_tree = {
 			}
 			set_temp_variable = { modify_chinese_aggression = 1 }
 			CHI_modify_chinese_aggression = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_One_System executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Combat_the_Traitors executed"
 		}
 
 		ai_will_do = {
@@ -6824,7 +6824,7 @@ focus_tree = {
 
 		completion_reward = {
 			add_political_power = 150
-			log = "[GetDateText]: [This.GetName]: focus CHI_Socialism_with_Maoist_Characteristics executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Socialist_Reconstruction executed"
 		}
 
 		ai_will_do = {
@@ -7713,7 +7713,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = KAZ }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Begin_CCWAEC executed"
 		}
 
 		ai_will_do = {
@@ -7792,7 +7792,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = UZB }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_Uzbek_Link executed"
 		}
 
 		ai_will_do = {
@@ -7861,7 +7861,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = KYR }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_Kyrgyz_Link executed"
 		}
 
 		ai_will_do = {
@@ -7930,7 +7930,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = TRK }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_Turkmen_Link executed"
 		}
 
 		ai_will_do = {
@@ -7999,7 +7999,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = TAJ }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_Tajik_Link executed"
 		}
 
 		ai_will_do = {
@@ -8088,7 +8088,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_Persian_Link executed"
 		}
 
 		ai_will_do = {
@@ -8167,7 +8167,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = TUR }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_African_Railway_Projects executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_Turkish_Link executed"
 		}
 
 		ai_will_do = {
@@ -8642,7 +8642,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = PAK }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_Gwadar_Port_Expansion executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_The_China_Pakistan_Economic_Corridor executed"
 		}
 
 		ai_will_do = {
@@ -9030,7 +9030,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = LAO }
 			change_influence_percentage = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_Central_Route executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Central_Route_Laos executed"
 		}
 
 		ai_will_do = {
@@ -9582,7 +9582,7 @@ focus_tree = {
 				set_temp_variable = { percent_change = 1 }
 				change_influence_percentage = yes
 			}
-			log = "[GetDateText]: [This.GetName]: focus CHI_Global_South_Photovoltaic_Aid executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Export_Photovoltaic_Systems executed"
 		}
 
 		ai_will_do = {
@@ -9639,7 +9639,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_stability = 0.05
-			log = "[GetDateText]: [This.GetName]: focus CHI_Radiation_Translation executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Construct_Nuclear_Waste_Repository executed"
 		}
 
 		ai_will_do = {
@@ -11614,7 +11614,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus CHI_Volkswagen executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Hyundai executed"
 			if = {
 				limit = { has_completed_focus = CHI_Korean_Joint_Ventures }
 				set_temp_variable = { treasury_change = -3 }
@@ -12244,7 +12244,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_air_eqp
 			}
-			log = "[GetDateText]: [This.GetName]: focus CHI_Expand_CSIC executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Aerospace_Industry executed"
 		}
 
 		ai_will_do = {
@@ -15369,7 +15369,7 @@ focus_tree = {
 			RAJ = { country_event = sino_indian.11 }
 			set_temp_variable = { modify_chinese_aggression = -2 }
 			CHI_modify_chinese_aggression = yes
-			log = "[GetDateText]: [This.GetName]: focus CHI_Strategic_Realignment executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Sino_Indian_Treaty_of_Friendship executed"
 		}
 
 		ai_will_do = {
@@ -16418,7 +16418,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus CHI_China_Mongol_Friendship_Treaty executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Sino_Mongol_Friendship_Treaty executed"
 			SOV = {
 				add_opinion_modifier = { target = CHI modifier = political_outreach }
 			}
@@ -17223,7 +17223,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_STABILITY }
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus CHI_Development_Assistance executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_Tackle_Drug_Trafficking executed"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			every_country = {
@@ -18537,7 +18537,7 @@ focus_tree = {
 		prerequisite = { focus = CHI_weaponized_space }
 
 		completion_reward = {
-			log = "[GetDateText]: [This.GetName]: focus CHI_space_marines_idea executed"
+			log = "[GetDateText]: [This.GetName]: focus CHI_space_marines executed"
 			swap_ideas = {
 				remove_idea = space_combat_support_force_2
 				add_idea = space_combat_support_force_3

--- a/common/national_focus/czechoslovakia_shared.txt
+++ b/common/national_focus/czechoslovakia_shared.txt
@@ -1,4 +1,4 @@
-﻿### CZECHOSLOVAKIA (in case you haven't read the file name) ~By XCezor ###
+### CZECHOSLOVAKIA (in case you haven't read the file name) ~By XCezor ###
 # Localization in Czech Republic loc file (MD_focus_CZE_l_english.yml)
 joint_focus = {
 	id = CZE_SLO_open_political_court
@@ -80,7 +80,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_start_looking_into_the_future"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_start_looking_into_the_future"
 		add_stability = 0.02
 	}
 	completion_reward_joint_originator = {
@@ -130,7 +130,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_question_divide"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_question_divide"
 		if = {
 			limit = {
 				original_tag = CZE
@@ -177,7 +177,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_close_up_of_the_governments"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_close_up_of_the_governments"
 		add_timed_idea = { idea = CZE_SLO_government_cooperation_idea days = 1095 }
 		add_stability = 0.01
 	}
@@ -216,7 +216,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_economical_aid"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_economic_aid"
 		one_random_industrial_complex = yes
 		custom_effect_tooltip = CZE_SLO_other_country_gets_factory
 	}
@@ -258,7 +258,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_upgrade_industrial_sector"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_upgrade_industrial_sector"
 		add_timed_idea = { idea = CZE_SLO_industrial_innovations_idea days = 720 }
 	}
 	completion_reward_joint_originator = {
@@ -305,7 +305,7 @@ joint_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_stop_border_controls"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_stop_border_controls"
 		add_popularity = {
 			ideology = democratic
 			popularity = 0.03
@@ -354,7 +354,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_d1_highway_construction"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_d1_highway_construction"
 		two_random_infrastructure = yes
 		custom_effect_tooltip = CZE_SLO_other_country_gets_factory
 	}
@@ -421,7 +421,7 @@ joint_focus = {
 	joint_trigger = { is_czechoslovakian_country = yes }
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_discuss_about_european_union"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_discuss_about_european_union"
 		set_temp_variable = { modify_europeanism = 0.05 }
 		set_temp_variable = { modify_europeanism_target = THIS }
 		europeanism_change = yes
@@ -478,7 +478,7 @@ joint_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_protect_democratic_values"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_protect_democratic_values"
 		add_popularity = {
 			ideology = democratic
 			popularity = 0.05
@@ -2844,7 +2844,7 @@ shared_focus = {
 	}
 
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_media_prCZE_SLO_ensure_loyalty_in_the_armyopaganda"
+		log = "[GetDateText]: [Root.GetName]: Focus CZE_SLO_ensure_loyalty_in_the_army"
 		set_temp_variable = { CZE_SLO_military_support_temp = 10 }
 		CZE_SLO_add_military_support_points = yes
 		add_command_power = 20

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -3178,7 +3178,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DEN_F35_Programme"
+			log = "[GetDateText]: [Root.GetName]: Focus DEN_Future_Combat_Air_System"
 			mark_focus_tree_layout_dirty = yes
 			if = {
 				limit = { has_dlc = "By Blood Alone" }
@@ -3497,7 +3497,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DEN_the_corruption_problem"
+			log = "[GetDateText]: [Root.GetName]: Focus DEN_found_Visitdenmark"
 			add_ideas = DEN_idea_Visitdenmark
 		}
 
@@ -4744,7 +4744,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DEN_centraliezd_government_empowerment"
+			log = "[GetDateText]: [Root.GetName]: Focus DEN_centralized_government_empowerment"
 			if = { limit = { has_idea = DEN_last_bastions_of_corruption }
 				swap_ideas = {
 					remove_idea = DEN_last_bastions_of_corruption
@@ -11040,7 +11040,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus DEN_danish_military"
+			log = "[GetDateText]: [Root.GetName]: Focus DEN_danish_militarism"
 			add_manpower = 10000
 			add_ideas = DEN_for_faedre_landet
 			increase_military_spending = yes

--- a/common/national_focus/free_states_of_america.txt
+++ b/common/national_focus/free_states_of_america.txt
@@ -257,7 +257,7 @@ focus_tree = {
 		prerequisite = { focus = free_america_focus_backyard_battleground }
 		search_filters = { FOCUS_FILTER_STABILITY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_backyard_battleground"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_from_backyard_to_frontyard"
 			add_stability = 0.06
 			add_war_support = 0.03
 			add_state_core = 772
@@ -389,7 +389,7 @@ focus_tree = {
 		prerequisite = { focus = free_america_focus_the_old_dominion_state }
 		search_filters = { FOCUS_FILTER_STABILITY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_the_old_dominion_state"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_norfolk_novelty"
 			add_stability = 0.06
 			add_war_support = 0.03
 			add_state_core = 773
@@ -1480,7 +1480,7 @@ focus_tree = {
 		available = { has_country_flag = FS_continued_election_ban }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_federal_remechanization_act"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_federal_scraping_up_defense_industries"
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
 			772 = {
@@ -3054,7 +3054,7 @@ focus_tree = {
 		available = { has_country_flag = FS_continued_election_ban }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_mid_atlantic_energy_advancements_act"
+			log = "[GetDateText]: [Root.GetName]: Focus free_mid_atlantic_the_true_green_way"
 			set_temp_variable = { treasury_change = -9.00 }
 			modify_treasury_effect = yes
 			773 = {
@@ -3577,7 +3577,7 @@ focus_tree = {
 		available = { has_country_flag = FS_continued_election_ban }
 		search_filters = { FOCUS_FILTER_RESOURCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_nsp_national_high_command"
+			log = "[GetDateText]: [Root.GetName]: Focus free_nsp_mini_steel_belt"
 			set_temp_variable = { treasury_change = -20.00 }
 			modify_treasury_effect = yes
 			771 = {
@@ -4356,7 +4356,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_CORRUPTION }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_states_focus_fed_left_the_true_deal"
+			log = "[GetDateText]: [Root.GetName]: Focus free_states_focus_fed_left_department_of_internal_investigation"
 			add_stability = 0.07
 			decrease_corruption2 = yes
 
@@ -5154,7 +5154,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_RESEARCH }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_civil_affairs_administration"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_red_ducation_act"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = free_states_federal_budgets }
 			add_to_variable = { FS_budget_education_cost = 0.07 tooltip = education_cost_multiplier_modifier_tt }
@@ -5195,7 +5195,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_civil_affairs_administration"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_foreign_relations_act"
 			add_ideas = free_states_idea_foreign_relations_act
 
 			newline = yes
@@ -5291,7 +5291,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_mineral_expansion_act"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_the_interstate_renewal_act"
 			set_temp_variable = { treasury_change = -13.50 }
 			modify_treasury_effect = yes
 			770 = {
@@ -5367,7 +5367,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_mineral_expansion_act"
+			log = "[GetDateText]: [Root.GetName]: Focus free_america_focus_anarchists_consumer_industry_advancements"
 			set_temp_variable = { treasury_change = -17.00 }
 			modify_treasury_effect = yes
 			770 = {
@@ -6683,7 +6683,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_nsp_monarchist_the_modern_merchants_act"
+			log = "[GetDateText]: [Root.GetName]: Focus free_nsp_monarchist_the_great_connections_act"
 			add_stability = 0.07
 			add_war_support = 0.07
 			set_temp_variable = { treasury_change = -39.00 }
@@ -6840,7 +6840,7 @@ focus_tree = {
 		available = { has_country_flag = FS_established_elections }
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus free_nsp_monarchist_domestic_first_policy"
+			log = "[GetDateText]: [Root.GetName]: Focus free_nsp_monarchist_the_grand_tour"
 			add_ideas = free_states_idea_diplomatic_corps
 
 			newline = yes
@@ -7522,7 +7522,7 @@ focus_tree = {
 		mutually_exclusive = { focus = USB_america_targeted_resource_extraction }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_department_for_strategic_resource_collection"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_aggressive_extraction_methods"
 			add_political_power = -200
 			add_stability = 0.04
 			add_war_support = 0.01
@@ -7603,7 +7603,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_aggressive_extraction_methods }
 		search_filters = { FOCUS_FILTER_RESOURCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_department_for_strategic_resource_collection"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_rusting_sheets_to_polished_metals"
 			add_political_power = -100
 			set_temp_variable = { treasury_change = -30.00 }
 			modify_treasury_effect = yes
@@ -7833,7 +7833,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_strategic_metallurgic_expansions }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_strategic_metallurgic_expansions"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_from_coal_to_petrochemicals"
 			set_temp_variable = { treasury_change = -39.50 }
 			modify_treasury_effect = yes
 			772 = {
@@ -7918,7 +7918,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_the_capital_gemstones }
 		search_filters = { FOCUS_FILTER_RESOURCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_the_capital_gemstones"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_the_dynamic_ming_duo"
 			add_political_power = -100
 			set_temp_variable = { treasury_change = -30.00 }
 			modify_treasury_effect = yes
@@ -8212,7 +8212,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_industrial_development_planning_board }
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_industrial_development_planning_board"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_civilian_development_administration"
 			add_stability = 0.04
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = free_states_domestic_policies }
@@ -8997,7 +8997,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_altoona_automatics_contract }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_altoona_automatics_contract"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_the_consumer_complex_initiative"
 			add_ideas = free_states_idea_consumer_complex_initiative
 
 			newline = yes
@@ -10061,7 +10061,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_maryland_munitions }
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_maryland_munitions"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_appalachian_arms"
 			set_temp_variable = { treasury_change = -15.00 }
 			modify_treasury_effect = yes
 			773 = {
@@ -10830,7 +10830,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_power_hubs }
 		search_filters = { FOCUS_FILTER_RESEARCH }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_power_hubs"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_department_for_synthetic_development"
 			add_ideas = free_states_idea_department_for_synthetic_development
 
 			newline = yes
@@ -11480,7 +11480,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_sky_defenders_program }
 		search_filters = { FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_sky_defenders_program"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_fighter_defense_doctrine"
 			add_ideas = free_states_idea_the_fighter_defense_doctrine
 
 			newline = yes
@@ -11561,7 +11561,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_agility_training_measures }
 		search_filters = { FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_agility_training_measures"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_aircraft_refinement_programs"
 			add_ideas = free_states_idea_the_increasing_defensive_capabilites
 
 			newline = yes
@@ -12134,7 +12134,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_the_spearhead_doctrine }
 		search_filters = { FOCUS_FILTER_NAVY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_rapid_response_protocols"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_streamlining_port_facilities"
 
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = free_states_federal_budgets }
 			add_to_variable = { FS_budget_personnel_cost = 0.10 tooltip = personnel_cost_multiplier_modifier_tt }
@@ -12789,7 +12789,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_uniting_the_arcadians"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_midwestern_unity"
 			add_political_power = -100
 			annex_country = { target = GLC transfer_troops = yes }
 			776 = { add_core_of = USB }
@@ -13521,7 +13521,7 @@ focus_tree = {
 		prerequisite = { focus = USB_america_mandatory_service_period }
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USB_america_mandatory_service_period"
+			log = "[GetDateText]: [Root.GetName]: Focus USB_america_ground_defense_is_air_defense"
 			add_stability = 0.05
 			add_war_support = 0.05
 			add_ideas = free_states_idea_ground_to_air_dominance

--- a/common/national_focus/greenland.txt
+++ b/common/national_focus/greenland.txt
@@ -1787,7 +1787,7 @@ focus_tree = {
 		prerequisite = { focus = GRN_focus_Narrow_Gauge_Standard }
 		search_filters = { FOCUS_FILTER_INFRASTRUCTURE }
 		completion_reward = {
-			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Narrow_Gauge_Standard"
+			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Nuuk_Western_Railway"
 			add_autonomy_score = { value = 25 }
 
 			set_temp_variable = { treasury_change = -0.90 }
@@ -10338,7 +10338,7 @@ focus_tree = {
 		prerequisite = { focus = GRN_focus_Submersival_Fleet_Doctrine }
 		search_filters = { FOCUS_FILTER_NAVY_XP }
 		completion_reward = {
-			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Submersival_Fleet_Doctrine"
+			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Attack_Submarine_Pillar"
 			navy_experience = 15
 
 			add_ideas = GRN_idea_attack_submarine_programs
@@ -15836,7 +15836,7 @@ focus_tree = {
 		mutually_exclusive = { focus = GRN_focus_Solidifying_Nordic_Unity }
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Solidifying_Nordic_Unity"
+			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Continental_Ambitions"
 
 			add_ideas = GRN_ideas_domesticating_foreign_policy
 
@@ -16018,7 +16018,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		will_lead_to_war_with = EST
 		completion_reward = {
-			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Eastern_Continental_Interests"
+			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Operation_Nordic_Adjacent"
 
 			create_wargoal = {
 				target = EST

--- a/common/national_focus/norway.txt
+++ b/common/national_focus/norway.txt
@@ -2056,7 +2056,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus add_building_construction"
+			log = "[GetDateText]: [Root.GetName]: Focus NRY_forest_conservation_plans"
 			set_temp_variable = { party_popularity_increase = 0.045 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			add_relative_party_popularity = yes

--- a/common/national_focus/poland.txt
+++ b/common/national_focus/poland.txt
@@ -523,14 +523,49 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_close_west_border"
+			for_each_scope_loop = {
+				array = global.EU_member
+				tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
+				if = {
+					limit = {
+						NOT = { tag = ROOT }
+						capital_scope = { is_on_continent = europe }
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_poland_closes_border
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_trade_poland_closes_border
+					}
+				}
+			}
+			for_each_scope_loop = {
+				array = global.nato_members
+				tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
+				if = {
+					limit = {
+						NOT = { tag = ROOT }
+						NOT = { has_idea = EU_member }
+						capital_scope = { is_on_continent = europe }
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_poland_closes_border
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_trade_poland_closes_border
+					}
+				}
+			}
 			every_other_country = {
 				limit = {
+					has_government = neutrality
+					NOT = { has_idea = EU_member }
+					NOT = { has_idea = NATO_member }
 					capital_scope = { is_on_continent = europe }
-					OR = {
-						has_idea = NATO_member
-						has_idea = EU_member
-						has_government = neutrality
-					}
 				}
 				add_opinion_modifier = {
 					target = POL
@@ -599,17 +634,19 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_close_east_border_communist"
-			every_other_country = {
-				limit = {
-					has_idea = CSTO_member
-				}
-				add_opinion_modifier = {
-					target = POL
-					modifier = POL_poland_closes_border
-				}
-				add_opinion_modifier = {
-					target = POL
-					modifier = POL_trade_poland_closes_border
+			for_each_scope_loop = {
+				array = global.CSTO_member
+				tooltip = TT_ALL_CSTO_MEMBER_NATIONS_GAIN
+				if = {
+					limit = { NOT = { tag = ROOT } }
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_poland_closes_border
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_trade_poland_closes_border
+					}
 				}
 			}
 			decrease_economic_growth = yes
@@ -3839,13 +3876,22 @@ focus_tree = {
 					add_opinion_modifier = { target = POL modifier = POL_trade_poland_cuts_the_trade }
 				}
 			}
-			every_other_country = {
-				limit = {
-					OR = {
-						has_idea = CSTO_member
-						tag = UKR
+			for_each_scope_loop = {
+				array = global.CSTO_member
+				tooltip = TT_ALL_CSTO_MEMBER_NATIONS_GAIN
+				if = {
+					limit = { NOT = { tag = ROOT } }
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_poland_opens_the_trade
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_trade_poland_opens_the_trade
 					}
 				}
+			}
+			UKR = {
 				add_opinion_modifier = {
 					target = POL
 					modifier = POL_poland_opens_the_trade
@@ -3896,13 +3942,22 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_antagonize_east"
-			every_other_country = {
-				limit = {
-					OR = {
-						has_idea = CSTO_member
-						tag = UKR
+			for_each_scope_loop = {
+				array = global.CSTO_member
+				tooltip = TT_ALL_CSTO_MEMBER_NATIONS_GAIN
+				if = {
+					limit = { NOT = { tag = ROOT } }
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_poland_cuts_the_trade
+					}
+					add_opinion_modifier = {
+						target = POL
+						modifier = POL_trade_poland_cuts_the_trade
 					}
 				}
+			}
+			UKR = {
 				add_opinion_modifier = {
 					target = POL
 					modifier = POL_poland_cuts_the_trade
@@ -9941,9 +9996,7 @@ focus_tree = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = POL_polsa_construction_first_stage7_TT
-				hidden_trigger = {
-					has_country_flag = POL_polsa_9
-				}
+				has_country_flag = POL_polsa_9
 			}
 		}
 

--- a/common/national_focus/serbia.txt
+++ b/common/national_focus/serbia.txt
@@ -584,7 +584,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_anti_corruption_measures"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_crush_the_opposition"
 			add_popularity = { ideology = democratic popularity = -0.10 }
 			recalculate_party = yes
 			add_timed_idea = {
@@ -654,7 +654,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_empower_kleptocratic"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_criminal_government"
 			add_stability = -0.03
 			set_temp_variable = { treasury_change = 2.50 }
 			modify_treasury_effect = yes
@@ -690,7 +690,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_empower_kleptocratic"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_criminal_oligarchs"
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_clergy_opinion = yes
 			set_temp_variable = { treasury_change = 7.50 }
@@ -1533,7 +1533,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_confederation_gre"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_a_newer_identity"
 			add_ideas = SER_new_identity
 		}
 
@@ -1618,7 +1618,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_confederation_bul"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_confederation_romania"
 			custom_effect_tooltip = SER_federation_romania_tt
 			hidden_effect = {
 				ROM = { set_country_flag = balkan_subject_agree }
@@ -1904,7 +1904,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_authoritarian_control_over_government"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_new_const"
 			add_timed_idea = { idea = SER_new_constitution_idea days = 140 }
 		}
 
@@ -1937,7 +1937,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_authoritarian_control_over_government"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_atheism"
 			swap_ideas = {
 				remove_idea = orthodox_christian
 				add_idea = DEN_idea_state_atheism
@@ -2092,7 +2092,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_four_year_plan_prepare"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_four_year_plan_start"
 			add_timed_idea = { idea = SER_new_four_year_plan2_idea days = 1460 }
 			one_random_fossil_fuel_powerplant = yes
 		}
@@ -2168,7 +2168,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_four_year_plan_prepare"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_worker_rights"
 			swap_ideas = {
 				remove_idea = SER_new_workplace
 				add_idea = SER_new_workplace1
@@ -2967,7 +2967,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_rise_nation"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_military_nation"
 			swap_ideas = {
 				remove_idea = SER_rise_serbian_idea
 				add_idea = SER_rise_serbian_idea1
@@ -5748,7 +5748,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_remove_previous_kleptocrats"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_crush_the_old_system"
 			add_political_power = 100
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -6332,7 +6332,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_free_elections"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_free_elections_again"
 		}
 
 		ai_will_do = {
@@ -6794,7 +6794,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_balkan_defender"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_miracle_of_european_system"
 			swap_ideas = {
 				remove_idea = SER_radical_liberalism_idea
 				add_idea = SER_model_democracy_idea
@@ -8139,7 +8139,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_kosovo_is_serbia"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_recognize_kosovo"
 			news_event = serbia_news.2
 			add_opinion_modifier = {
 				modifier = declaration_of_friendship
@@ -9265,7 +9265,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_cultural_reawakening"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_ter_down_communist_narratives"
 			add_ideas = SER_inner_policy
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = -0.05 }
@@ -9950,7 +9950,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_reinstate_the_church_in_macedonia"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_reinstate_church_bulgaria"
 			SER = {
 				set_temp_variable = { wargoal_on = BUL }
 				set_temp_variable = { wargoal_type = 2 }
@@ -10669,7 +10669,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SER_loosened_union"
+			log = "[GetDateText]: [Root.GetName]: Focus SER_economic_autonomy"
 			134 = {
 				add_building_construction = {
 					type = industrial_complex

--- a/common/national_focus/syria.txt
+++ b/common/national_focus/syria.txt
@@ -1812,7 +1812,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SYR_religious_economic_charity"
+			log = "[GetDateText]: [Root.GetName]: Focus SYR_qatari_support"
 			random_owned_state = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -2026,7 +2026,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SYR_maintain_ban_on_ethnic_parties"
+			log = "[GetDateText]: [Root.GetName]: Focus SYR_statist_rise"
 			add_popularity = { ideology = neutrality popularity = -0.10 }
 			add_popularity = { ideology = nationalist popularity = 0.20 }
 			increase_centralization = yes
@@ -2507,7 +2507,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SYR_towards_total_secularism"
+			log = "[GetDateText]: [Root.GetName]: Focus SYR_pan_syrian_nationalism"
 			set_temp_variable = { temp_modify_social_con_government = -10 }
 			modify_social_conservatism_government = yes
 		}
@@ -2915,7 +2915,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SYR_cut_military_spending"
+			log = "[GetDateText]: [Root.GetName]: Focus SYR_dismantle_the_military"
 			add_timed_idea = {
 				idea = syrian_military_dismantling
 				days = 180
@@ -5389,7 +5389,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SYR_invest_in_the_sector"
+			log = "[GetDateText]: [Root.GetName]: Focus SYR_expand_the_sector"
 			189 = {
 				add_dynamic_modifier = {
 					modifier = SYR_latakian_service_expansion
@@ -15312,7 +15312,7 @@ shared_focus = {
 
 	search_filters = { FOCUS_FILTER_MANPOWER }
 	completion_reward = {
-		log = "[GetDateText]: [Root.GetName]: Focus SYR_supply_al_shabaab"
+		log = "[GetDateText]: [Root.GetName]: Focus SYR_safehaven_for_islamists"
 		if = {
 			limit = {
 				NOT = { has_idea = global_salafist_recruitment }

--- a/common/national_focus/tibesti.txt
+++ b/common/national_focus/tibesti.txt
@@ -453,7 +453,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TIE_seek_help_from_boko_haram"
+			log = "[GetDateText]: [Root.GetName]: Focus TIE_make_money_of_refugees"
 			add_ideas = TIE_money_from_refugees
 		}
 
@@ -1098,7 +1098,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TIE_mine_natron"
+			log = "[GetDateText]: [Root.GetName]: Focus TIE_survey_for_gold"
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			random_owned_state = {
@@ -1283,7 +1283,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TIE_trans_saharan_trade_niger"
+			log = "[GetDateText]: [Root.GetName]: Focus TIE_trans_saharan_trade_libya"
 			if = {
 				limit = {
 					has_idea = TIE_trans_saharan_trade_1
@@ -1357,7 +1357,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TIE_trans_saharan_trade_niger"
+			log = "[GetDateText]: [Root.GetName]: Focus TIE_trans_saharan_trade_chad"
 			if = {
 				limit = {
 					has_idea = TIE_trans_saharan_trade_1

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -142,7 +142,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_small_imf_loans"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_large_imf_loans"
 			add_stability = 0.1
 			set_temp_variable = { debt_change = -50 }
 			modify_debt_effect = yes
@@ -195,7 +195,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_EXPENDITURE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_reduce_foreign_investors"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_more_foreign_investors"
 			set_temp_variable = { percent_change = -5 }
 			change_domestic_influence_percentage = yes
 			set_temp_variable = { treasury_change = 20 }
@@ -4616,7 +4616,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_FOREIGN_POLICY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_commit_to_divided_cyprus"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_appease_conglomerate"
 			add_political_power = 100
 			set_temp_variable = { temp_opinion = 5 }
 			change_industrial_conglomerates_opinion = yes
@@ -5493,7 +5493,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_NAVY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_reform_village_institutes"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_expand_shipping_industry"
 			one_random_dockyard = yes
 		}
 	}
@@ -5768,7 +5768,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION FOCUS_FILTER_SOCIAL_CONSERVATISM }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_increase_education_spending"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_increase_social_security_spending"
 			block_social_decrease = yes
 			increase_social_spending = yes
 		}
@@ -6846,7 +6846,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INTERNAL_FACTION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_destroy_totalitarian_education"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_new_supply"
 			159 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -7194,7 +7194,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_state_owned_economy"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_rent_to_production_economy"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
 			random_owned_state = {
@@ -9100,7 +9100,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_greatest_productive_force"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_committees_of_production"
 			add_ideas = TUR_committees_of_production_for_factories
 		}
 
@@ -9760,7 +9760,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_improve_relations_with_iran"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_improve_relations_with_egypt"
 			add_opinion_modifier = {
 				modifier = declaration_of_friendship
 				target = EGY
@@ -11612,7 +11612,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_ally_fp"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_clean_energy_shift"
 			two_random_renewable_energy_infra = yes
 		}
 	}
@@ -16042,7 +16042,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_great_east"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_enforce_dress_code"
 			add_political_power = 100
 			custom_effect_tooltip = conservatism_government_increase_15_tt
 			add_to_variable = { social_conservatism_government = 15 }
@@ -16119,7 +16119,7 @@ focus_tree = {
 		will_lead_to_war_with = SOO
 		will_lead_to_war_with = AZE
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus TUR_great_east"
+			log = "[GetDateText]: [Root.GetName]: Focus TUR_eastward"
 			set_temp_variable = { wargoal_on = ARM }
 			set_temp_variable = { wargoal_type = 2 }
 			add_threat_from_wargoal_effect = yes

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -1683,7 +1683,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_ending_2004_democrats"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_2004_republicans"
 		}
 
 		ai_will_do = {
@@ -2079,7 +2079,7 @@ focus_tree = {
 		available = { date > 2006.12.31 }
 		search_filters = { FOCUS_FILTER_ECONOMY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_2004_budget_balancing"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_2007_tax_cuts"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = USA_american_tax_code
@@ -4577,7 +4577,7 @@ focus_tree = {
 		prerequisite = { focus = USA_focus_the_pentagon_wars }
 		search_filters = { FOCUS_FILTER_WAR_SUPPORT }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_the_pentagon_wars"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_united_states_army"
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = USA_federal_budgets
@@ -7475,7 +7475,7 @@ focus_tree = {
 		mutually_exclusive = { focus = USA_focus_every_soldier_a_trooper }
 		search_filters = { FOCUS_FILTER_AIR_XP }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_paratrooper_corps"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_focus_jump_wings_forever"
 			add_ideas = USA_idea_paratrooper_corps
 
 			custom_effect_tooltip = {
@@ -14258,7 +14258,7 @@ focus_tree = {
 		prerequisite = { focus = USA_asteroid_mining }
 		search_filters = { FOCUS_FILTER_RESOURCE }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_asteroid_mining"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_high_cost_for_high_rewards"
 			add_ideas = USA_idea_high_price_for_high_rewards
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -15090,7 +15090,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_there_are_more_options"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_breaking_the_mold"
 			remove_ideas = us_mass_media_problems_five_a
 
 			newline = yes
@@ -15258,7 +15258,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_scars_from_the_forever_war"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_pulling_back_from_the_war"
 			add_stability = 0.10
 			add_war_support = -0.10
 			swap_ideas = {
@@ -15487,7 +15487,7 @@ focus_tree = {
 			prerequisite = { focus = USA_going_on_the_offensive focus = USA_holding_our_ground focus = USA_pulling_back_from_the_war }
 			search_filters = { FOCUS_FILTER_POLITICAL }
 			completion_reward = {
-				log = "[GetDateText]: [Root.GetName]: Focus USA_going_on_the_offensive"
+				log = "[GetDateText]: [Root.GetName]: Focus USA_healing_the_wounds"
 				if = { limit = { has_idea = us_war_on_drugs_five_c }
 					remove_ideas = us_war_on_drugs_five_c
 				}
@@ -16219,7 +16219,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_electoral_rainbow"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_green_victory"
 			add_political_power = -200
 			add_stability = 0.1
 			add_war_support = 0.1
@@ -21014,7 +21014,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_USA_ECONOMIC_REGULATION }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_increased_labor_reforms"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_reforming_the_corporate_tax"
 
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -21656,7 +21656,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_appeasing_the_anarchist_society"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_left_wing_unity"
 
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -27201,7 +27201,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus SA_backyard_act"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_backyard_act"
 
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -31308,7 +31308,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_militarist_securing_atlantic_interests"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_militarist_operation_paradise"
 
 			USA = {
 				add_state_core = 854
@@ -31340,7 +31340,7 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_militarist_securing_atlantic_interests"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_militarist_policing_and_cultural_programs"
 
 			add_ideas = USA_idea_military_junta_cultural_programs
 		}
@@ -38447,7 +38447,7 @@ focus_tree = {
 		will_lead_to_war_with = SLO
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_black_sea"
+			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_vistula"
 			if = {
 				limit = {
 					country_exists = GER

--- a/common/national_focus/venezuela.txt
+++ b/common/national_focus/venezuela.txt
@@ -642,7 +642,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_fundación_villa_del_cine"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_fundacion_villa_del_cine"
 			874 = {
 				add_building_construction = {
 					type = radar_station
@@ -1886,7 +1886,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_EXPENDITURE }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_plan_bolivar_2000"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_plan_bolivar"
 			swap_ideas = {
 				remove_idea = VEN_plan_bolivar_1
 				add_idea = VEN_plan_bolivar_2
@@ -2272,7 +2272,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_STABILITY FOCUS_FILTER_INDUSTRY }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_agrarian_reform"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_land_development"
 			add_stability = 0.15
 			add_timed_idea = {
 				idea = recent_agrarian_reform
@@ -3568,7 +3568,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_settle_the_republic"
 			add_stability = 0.05
 		}
 
@@ -3591,7 +3591,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_separation_of_church_and_state"
 			swap_ideas = {
 				remove_idea = christian
 				add_idea = DEN_idea_state_atheism
@@ -3617,7 +3617,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_new_economic_model"
 			if = {
 				limit = {
 					874 = {
@@ -3673,7 +3673,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_socialism_with_venezuelan_characteristics"
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			add_relative_party_popularity = yes
@@ -3700,7 +3700,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_denounce_south_american_capitalism"
 			set_temp_variable = { percent_change = -3 }
 			set_temp_variable = { tag_index = USA }
 			set_temp_variable = { influence_target = COL }
@@ -3739,7 +3739,7 @@ focus_tree = {
 			emerging_anarchist_communism_in_power_or_coalition = yes
 		}
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_good_of_the_americas"
 			every_country = {
 				limit = {
 					is_in_south_america = yes
@@ -3771,7 +3771,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_secure_the_basics"
 			increase_healthcare_budget = yes
 		}
 
@@ -3795,7 +3795,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_agrarian_communes"
 			swap_ideas = {
 				remove_idea = oligarchs
 				add_idea = farmers
@@ -3822,7 +3822,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_economic_restructuring"
 			decrease_corruption = yes
 		}
 
@@ -3845,7 +3845,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_secure_our_place"
 			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 		}
@@ -3869,7 +3869,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_world_stage"
 			decrease_exports = yes
 		}
 
@@ -3892,7 +3892,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_venezuelan_communism"
 			two_random_industrial_complex = yes
 			two_random_dockyards = yes
 		}
@@ -3913,7 +3913,7 @@ focus_tree = {
 		prerequisite = { focus = VEN_secure_our_place }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_support_our_people"
 			increase_centralization = yes
 			add_ideas = VEN_the_people
 		}
@@ -3937,7 +3937,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_arm_the_proletariat"
 			add_ideas = VEN_armed_proletariat
 		}
 
@@ -3960,7 +3960,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_military_communes"
 			876 = {
 				add_building_construction = {
 					type = bunker
@@ -4019,7 +4019,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_motto_of_self_sacrifice"
 			add_ideas = VEN_self_sacrifice
 		}
 
@@ -4042,7 +4042,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_equality_in_the_eyes_of_state"
 			if = {
 				limit = {
 					has_idea = no_women_in_military
@@ -4089,7 +4089,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_proletarian_internationalism"
 			every_neighbor_country = {
 				set_temp_variable = { percent_change = 2 }
 				change_influence_percentage = yes
@@ -4120,7 +4120,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_propaganda"
 			set_temp_variable = { party_index = 5 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
@@ -4148,7 +4148,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_red_rising"
 			every_neighbor_country = {
 				set_temp_variable = { party_index = 5 }
 				set_temp_variable = { party_popularity_increase = 0.10 }
@@ -4180,7 +4180,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_setting_the_stage"
 			add_ideas = red_rising
 			add_named_threat = {
 				threat = 2.5
@@ -4207,7 +4207,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_assist_our_brothers"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_1
 				amount = -1000
@@ -4260,7 +4260,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_quito_revolution"
 			set_temp_variable = { wargoal_on = ECU }
 			add_threat_from_wargoal_effect = yes
 			create_wargoal = { type = puppet_wargoal_focus target = ECU }
@@ -4317,7 +4317,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_eastern_revolutions"
 			if = {
 				limit = {
 					country_exists = GUY
@@ -4397,7 +4397,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_reclaim_the_home_of_bolivar"
 			if = { limit = { country_exists = COL }
 				if = { limit = { COL = { is_subject_of = VEN } }
 					set_temp_variable = { treasury_change = -7.5 }
@@ -4508,7 +4508,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_lima_insurrection"
 			puppet = PRU
 			PRU = {
 				set_temp_variable = { party_index = 5 }
@@ -4549,7 +4549,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_venezuelan_dawn"
 			add_ideas = VEN_venezuelan_dawn
 		}
 
@@ -4576,7 +4576,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_brasilia_will_burn"
 			set_temp_variable = { wargoal_on = BRA }
 			add_threat_from_wargoal_effect = yes
 			create_wargoal = { type = puppet_wargoal_focus target = BRA }
@@ -4604,7 +4604,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_democratic_socialism"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_santiago_assault"
 			set_temp_variable = { wargoal_on = CHL }
 			add_threat_from_wargoal_effect = yes
 			create_wargoal = { type = puppet_wargoal_focus target = CHL }
@@ -4663,7 +4663,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_brazilian_alliance"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_bolivarian_missions"
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = 0.10 }
 			clamp_temp_variable = {
@@ -4718,7 +4718,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_robinson"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_mercal"
 			add_tech_bonus = {
 				name = VEN_mission_robinson
 				bonus = 1
@@ -4752,7 +4752,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_robinson"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_habitat"
 			random_owned_state = {
 				limit = { infrastructure < 5 }
 				prioritize = { 876 }
@@ -4890,7 +4890,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_florentino"
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
 			add_relative_party_popularity = yes
@@ -4952,7 +4952,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_ciencia"
 			add_tech_bonus = {
 				name = VEN_welfare_state
 				bonus = 0.5
@@ -4984,7 +4984,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_corazon_adentro"
 			increase_healthcare_budget = yes
 		}
 
@@ -5008,7 +5008,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_guaicaipuro"
 			increase_centralization = yes
 		}
 
@@ -5032,7 +5032,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_zamora"
 			917 = {
 				add_extra_state_shared_building_slots = 1
 			}
@@ -5072,7 +5072,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_vuelta_al_campo"
 			add_stability = -0.05
 
 			875 = { add_manpower = -100000 }
@@ -5113,7 +5113,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_arbol"
 			add_ideas = VEN_rainforest_protectors
 		}
 
@@ -5138,7 +5138,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_welfare_state"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_mission_vuelvan_caras"
 			increase_economic_growth = yes
 		}
 
@@ -5308,7 +5308,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_nationalist_recovery"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_spread_right_wing_propaganda"
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
@@ -8953,7 +8953,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_cleaning_our_records"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_purging_corrupt_officials"
 			decrease_corruption = yes
 		}
 
@@ -10520,7 +10520,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_cooperation_with_cuba"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_anti_cuban_stance"
 			add_ideas = VEN_against_cuba
 			add_war_support = 0.15
 		}
@@ -10953,7 +10953,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_increase_the_size_of_the_cartel"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_coup_in_colombia"
 			puppet = COL
 			COL = {
 				set_cosmetic_tag = COL_farc_tag
@@ -11121,7 +11121,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_fight_the_farc"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_arresting_high_profile_individuals"
 			set_temp_variable = { cart_strength_change = -10 }
 			set_temp_variable = { cart_influence_change = -5 }
 			modify_cartel_variables_effect = yes
@@ -11206,7 +11206,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_submarine_construction"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_diesel_submarines"
 
 			add_tech_bonus = {
 				name = CAT_atk_sub
@@ -11228,7 +11228,7 @@ focus_tree = {
 		prerequisite = { focus = VEN_the_navy }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_modern_frigates"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_armed_corvettes"
 
 			add_tech_bonus = {
 				name = CAT_corvette
@@ -11255,7 +11255,7 @@ focus_tree = {
 		prerequisite = { focus = VEN_diesel_submarines }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_submarine_construction"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_death_from_underneath"
 			add_tech_bonus = {
 				name = VEN_death_from_underneath
 				bonus = 0.5
@@ -11471,7 +11471,7 @@ focus_tree = {
 		prerequisite = { focus = VEN_military_reforms }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_modern_equipment"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_venezuela_national_militia"
 			add_ideas = VEN_cost_effectiveness
 			add_command_power = 35
 			army_experience = 20
@@ -11494,7 +11494,7 @@ focus_tree = {
 		prerequisite = { focus = VEN_increase_of_arms_production }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_modern_equipment"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_improved_officer_training"
 			add_ideas = VEN_better_generals
 		}
 
@@ -11725,7 +11725,7 @@ focus_tree = {
 		prerequisite = { focus = VEN_boliviarian_national_guard }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_modern_equipment"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_reorganize_the_colectivos"
 			set_temp_variable = { treasury_change = -5.00 }
 			modify_treasury_effect = yes
 			swap_ideas = {
@@ -11755,7 +11755,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_airforce"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_boliviarian_national_guard"
 			division_template = {
 				name = "Guardia Nacional"
 				division_names_group = VEN_bolivarian_national_guard
@@ -11797,7 +11797,7 @@ focus_tree = {
 		mutually_exclusive = { focus = VEN_end_of_mandatory_service }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_airforce"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_maintain_mandatory_service"
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -11825,7 +11825,7 @@ focus_tree = {
 		mutually_exclusive = { focus = VEN_maintain_mandatory_service }
 
 		completion_reward = {
-			log = "[GetDateText]: [Root.GetName]: Focus VEN_the_airforce"
+			log = "[GetDateText]: [Root.GetName]: Focus VEN_end_of_mandatory_service"
 			if = {
 				limit = { has_idea = draft_army }
 				swap_ideas = {

--- a/common/scripted_triggers/99_GCC_scripted_triggers.txt
+++ b/common/scripted_triggers/99_GCC_scripted_triggers.txt
@@ -1,11 +1,9 @@
 jihadist_government = {
 	custom_trigger_tooltip = {
 		tooltip = GCC_jihadist_government_tt
-		hidden_trigger = {
-			OR = {
-				salafist_caliphate_are_in_power = yes
-				salafist_caliphate_are_in_coalition = yes
-			}
+		OR = {
+			salafist_caliphate_are_in_power = yes
+			salafist_caliphate_are_in_coalition = yes
 		}
 	}
 }
@@ -13,10 +11,8 @@ jihadist_government = {
 no_jihadist_government = {
 	custom_trigger_tooltip = {
 		tooltip = GCC_jihadist_government_tt_NOT
-		hidden_trigger = {
-			NOT = { salafist_caliphate_are_in_power = yes }
-			NOT = { salafist_caliphate_are_in_coalition = yes }
-		}
+		NOT = { salafist_caliphate_are_in_power = yes }
+		NOT = { salafist_caliphate_are_in_coalition = yes }
 	}
 }
 

--- a/events/Afghanistan.txt
+++ b/events/Afghanistan.txt
@@ -5977,7 +5977,7 @@ country_event = {
 	}
 	option = {
 		name = AfghanistanPolicalEvents.4.d
-		log = "[GetLogInfo]: event AfghanistanPolicalEvents.5.b"
+		log = "[GetLogInfo]: event AfghanistanPolicalEvents.4.d"
 		set_temp_variable = { rul_party_temp = 2 }
 		change_ruling_party_effect = yes
 		clr_country_flag = AFG_Endorse_the_american_candidate

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -1797,7 +1797,7 @@ country_event = {
 	# Too Big to Fail
 	option = {
 		name = econvent.11.a
-		log = "[GetDateText]: [Root.GetName]: event econvent.10.a"
+		log = "[GetDateText]: [Root.GetName]: event econvent.11.a"
 
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.05 }
@@ -1888,7 +1888,7 @@ country_event = {
 	# Let it fail..
 	option = {
 		name = econvent.11.b
-		log = "[GetDateText]: [Root.GetName]: event econvent.10.b"
+		log = "[GetDateText]: [Root.GetName]: event econvent.11.b"
 
 		set_temp_variable = { temp_opinion = -15 }
 		change_international_bankers_opinion = yes

--- a/events/Estonia.txt
+++ b/events/Estonia.txt
@@ -134,7 +134,7 @@ country_event = {
 
 	option = {
 		name = estonia.8.o3
-		log = "[GetDateText]: [This.GetName]: event estonia.8.o2 executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.8.o3 executed"
 		set_temp_variable = { party_index = 15 }
 		multiply_temp_variable = { party_popularity_increase = 0.02 }
 		add_relative_party_popularity = yes
@@ -177,14 +177,14 @@ country_event = {
 	}
 	option = {
 		name = estonia.7.o2
-		log = "[GetDateText]: [This.GetName]: event estonia.7.o1 executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.7.o2 executed"
 		add_political_power = -100
 		set_temp_variable = { treasury_change = -1.5 }
 		modify_treasury_effect = yes
 	}
 	option = {
 		name = estonia.7.o3
-		log = "[GetDateText]: [This.GetName]: event estonia.7.o1 executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.7.o3 executed"
 		add_political_power = 10
 		add_stability = -0.01
 		set_temp_variable = { treasury_change = -5.5 }
@@ -358,7 +358,7 @@ country_event = {
 	# Blame the Russians!
 	option = {
 		name = estonia.10.o1
-		log = "[GetDateText]: [This.GetName]: event estonia.10.o2 executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.10.o1 executed"
 		SOV = {
 			add_opinion_modifier = { target = ROOT modifier = EST_attack_on_cyber_infrastructure }
 		}
@@ -682,7 +682,7 @@ country_event = {
 
 	option = {
 		name = estonia.102.b
-		log = "[GetDateText]: [This.GetName]: event estonia.102.a executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.102.b executed"
 
 		add_political_power = 50
 		ai_chance = {
@@ -722,12 +722,12 @@ country_event = {
 
 	option = {
 		name = estonia.104.a
-		log = "[GetDateText]: [This.GetName]: event estonia.103.a executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.104.a executed"
 	}
 
 	option = {
 		name = estonia.104.b
-		log = "[GetDateText]: [This.GetName]: event estonia.103.a executed"
+		log = "[GetDateText]: [This.GetName]: event estonia.104.b executed"
 	}
 }
 

--- a/events/Indonesia.txt
+++ b/events/Indonesia.txt
@@ -1429,7 +1429,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = indonesia.988.a
+		name = indonesia.888.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.888.a"
 		complete_national_focus = IND_our_policies
 		ai_chance = {

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -2774,7 +2774,7 @@ country_event = {
 
 	option = {
 		name = usa_economic_events.3.b
-		log = "[GetDateText]: [Root.GetName]: event usa_economic_events.3.a"
+		log = "[GetDateText]: [Root.GetName]: event usa_economic_events.3.b"
 		set_temp_variable = { treasury_change = -30 }
 		modify_treasury_effect = yes
 		custom_effect_tooltip = usa_economic_bailout_tt
@@ -2846,7 +2846,7 @@ country_event = {
 
 	option = {
 		name = usa_economic_events.4.b
-		log = "[GetDateText]: [Root.GetName]: event usa_economic_events.4.a"
+		log = "[GetDateText]: [Root.GetName]: event usa_economic_events.4.b"
 		set_temp_variable = { treasury_change = -100 }
 		modify_treasury_effect = yes
 		custom_effect_tooltip = usa_economic_bailout_tt

--- a/history/countries/SWE - Sweden.txt
+++ b/history/countries/SWE - Sweden.txt
@@ -12,6 +12,7 @@ capital = 34
 	complete_special_project = sp:sp_space_program
 	complete_special_project = sp:sp_composite_production
 	complete_special_project = sp:sp_nuclear_energy
+	complete_special_project = sp:sp_microchip_production
 
 	complete_special_project = sp:sp_armoured_vehicle_project
 	if = {

--- a/tools/linting/check_common_mistakes.py
+++ b/tools/linting/check_common_mistakes.py
@@ -32,6 +32,9 @@ Detects mechanically-checkable rule violations from CLAUDE.md:
     a check_variable-style leftover; block form or a bare scalar are both valid
   - every_owned_controlled_state (does not exist; use every_controlled_state)
   - random_select_amount set to a variable/decimal instead of an integer literal
+  - log = "...Focus X" / "...Decision X" / "...Event X" where X doesn't match the
+    enclosing focus/decision/event id (copy-paste bug from duplicating a neighbor)
+  - hidden_trigger = { } directly inside custom_trigger_tooltip (redundant nesting)
 """
 
 import os
@@ -96,6 +99,44 @@ _RE_FOCUS_ID_IN_BLOCK = re.compile(r"\bid\s*=\s*(\w+)")
 _RE_COMPLETE_FOCUS = re.compile(r"\bcomplete_national_focus\s*=\s*(\w+)")
 _RE_UNLOCK_FOCUS = re.compile(r"\bunlock_national_focus\s*=\s*(\w+)")
 _RE_ACTIVATE_DECISION = re.compile(r"\bactivate_decision\s*=\s*(\w+)")
+_RE_FOCUS_ANY_BLOCK_OPEN = re.compile(
+    r"^\s*(?:focus|shared_focus|joint_focus)\s*=\s*\{"
+)
+_RE_LOG_FOCUS_TOKEN = re.compile(r'log\s*=\s*"[^"]*\bFocus\s+(\w+)', re.IGNORECASE)
+# "Decision <keyword...> <id>" tolerates a chain of filler words before the real
+# id: the block-name keywords (remove/complete/completed/timeout/cancel/add,
+# describing which effect block logged the line) and, in a couple of legacy
+# logs, a spelled-out "effect" after the keyword ("Decision cancel effect X"
+# for a cancel_effect block). Strip all leading filler tokens, then compare
+# whatever's left to the decision's own id.
+_DECISION_LOG_FILLER_WORDS = {
+    "remove",
+    "complete",
+    "completed",
+    "timeout",
+    "cancel",
+    "add",
+    "effect",
+}
+_RE_LOG_DECISION_MARKER = re.compile(r'log\s*=\s*"[^"]*\bDecision\b', re.IGNORECASE)
+_RE_NEXT_WORD = re.compile(r"\s+(\w+)")
+# Event ids are namespace.number (dots), unlike focus/decision ids -- \w+ alone
+# would truncate at the dot.
+_RE_EVENT_DEF_OPEN = re.compile(
+    r"^(?:country_event|news_event|operative_leader_event|unit_leader_event)\s*=\s*\{"
+)
+_RE_EVENT_ID_IN_BLOCK = re.compile(r"^\s*id\s*=\s*([\w.]+)")
+_RE_OPTION_NAME_IN_BLOCK = re.compile(r"^\s*name\s*=\s*([\w.]+)")
+# Two log conventions coexist: the bare event id followed by a separate
+# "Option <letter>" phrase ("Event HKG_contract.1 Option a"), and the option's
+# own full dotted name standing in for the id ("event satellites.2.a" ==
+# namespace.number.letter). [\w.]+ is greedy, so on the second style it
+# swallows the trailing ".<letter>" into the token -- checked against both
+# forms below rather than assuming the bare id alone.
+_RE_LOG_EVENT_TOKEN = re.compile(r'log\s*=\s*"[^"]*\bEvent\s+([\w.]+)', re.IGNORECASE)
+_RE_LOG_EVENT_OPTION_SUFFIX = re.compile(r"\s+Option\s+([a-zA-Z])\b", re.IGNORECASE)
+_RE_CUSTOM_TRIGGER_TOOLTIP_OPEN = re.compile(r"\bcustom_trigger_tooltip\s*=\s*\{")
+_RE_HIDDEN_TRIGGER_OPEN = re.compile(r"\bhidden_trigger\s*=\s*\{")
 _RE_OR_BLOCK_OPEN = re.compile(r"^\s*OR\s*=\s*\{")
 _RE_NOT_BLOCK_OPEN = re.compile(r"^\s*NOT\s*=\s*\{")
 _RE_TRIGGER_ASSIGN = re.compile(r"^(\w+)\s*=\s*([\w.]+)$")
@@ -282,6 +323,15 @@ def _get_block(lines, start):
         depth += code.count("{") - code.count("}")
         j += 1
     return lines[start:j], j
+
+
+def _code_for_depth(line):
+    """Like strip_inline_comment, but also blanks quoted strings before brace
+    counting. A log string can contain a stray brace (e.g. a formatted-loc
+    placeholder); left unblanked it would drift the depth count for whatever
+    manual brace-tracking scans past it.
+    """
+    return _RE_QUOTED_STRING.sub('""', strip_inline_comment(line))
 
 
 def _check_focus_available_always_no(lines):
@@ -1525,6 +1575,280 @@ def _check_tautological_or(lines):
     return issues
 
 
+def _find_focus_log_mismatches(lines):
+    """Return (line_idx, tok_start, tok_end, focus_id, bad_token) for each
+    log = "...Focus <token>" line inside a focus/shared_focus/joint_focus block
+    where token doesn't match the block's own id.
+
+    Suppressed when the mismatched token is completed/unlocked elsewhere in the
+    same block via complete_national_focus / unlock_national_focus -- that's a
+    focus intentionally completing or unlocking a sibling and logging the
+    sibling's id, not a copy-paste bug. Shared by _check_focus_log_id and
+    fix_log_ids.py so both use the same detection.
+    """
+    results = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if _RE_FOCUS_ANY_BLOCK_OPEN.match(lines[i]):
+            start = i
+            block, i = _get_block(lines, start)
+            code_lines = [strip_inline_comment(bl) for bl in block]
+            text = "".join(code_lines)
+            id_match = _RE_FOCUS_ID_IN_BLOCK.search(text)
+            if not id_match:
+                continue
+            focus_id = id_match.group(1)
+            suppressed = set(_RE_COMPLETE_FOCUS.findall(text)) | set(
+                _RE_UNLOCK_FOCUS.findall(text)
+            )
+            for k, cl in enumerate(code_lines):
+                m = _RE_LOG_FOCUS_TOKEN.search(cl)
+                if m:
+                    token = m.group(1)
+                    if token != focus_id and token not in suppressed:
+                        results.append(
+                            (start + k, m.start(1), m.end(1), focus_id, token)
+                        )
+        else:
+            i += 1
+    return results
+
+
+def _check_focus_log_id(lines):
+    """Flag log = "...Focus <token>" lines whose token doesn't match the
+    enclosing focus/shared_focus/joint_focus block's own id -- almost always a
+    copy-paste leftover from duplicating a neighboring focus.
+    """
+    issues = []
+    for line_idx, _s, _e, focus_id, token in _find_focus_log_mismatches(lines):
+        issues.append(
+            (
+                line_idx + 1,
+                f"log references Focus {token}, but the enclosing focus is "
+                f"{focus_id} -- likely copy-paste; fix the log id",
+            )
+        )
+    return issues
+
+
+def _decision_log_token_span(line):
+    """Return (token, start, end) for the id referenced by a
+    `log = "...Decision ..."` line, skipping leading filler words
+    (_DECISION_LOG_FILLER_WORDS), or None if the line has no such log
+    statement (or nothing substantive follows the filler words).
+    """
+    marker = _RE_LOG_DECISION_MARKER.search(line)
+    if not marker:
+        return None
+    pos = marker.end()
+    while True:
+        m = _RE_NEXT_WORD.match(line, pos)
+        if not m:
+            return None
+        token = m.group(1)
+        if token.lower() in _DECISION_LOG_FILLER_WORDS:
+            pos = m.end()
+            continue
+        return token, m.start(1), m.end(1)
+
+
+def _find_decision_log_mismatches(lines):
+    """Return (line_idx, tok_start, tok_end, decision_id, bad_token) for each
+    log = "...Decision ..." line inside a decision block whose referenced id
+    doesn't match the enclosing decision's own key.
+
+    Enclosing decision = the block key at depth 1 (the category is depth 0),
+    same category/decision traversal as _check_decision_allowed_dynamic.
+    Shared by _check_decision_log_id and fix_log_ids.py.
+    """
+    results = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        code = strip_inline_comment(lines[i])
+        if (
+            _RE_TOPLEVEL_WORD.match(lines[i])
+            and "{" in code
+            and not lines[i].lstrip().startswith("#")
+        ):
+            cat_start = i
+            cat_block, i = _get_block(lines, cat_start)
+            k = 1
+            while k < len(cat_block) - 1:
+                bl = cat_block[k]
+                bl_code = strip_inline_comment(bl)
+                if _RE_INDENTED_WORD.match(bl) and "{" in bl_code:
+                    dec_block, next_k = _get_block(cat_block, k)
+                    dec_id_match = _RE_BLOCK_ID.match(cat_block[k])
+                    dec_id = dec_id_match.group(1) if dec_id_match else None
+                    if dec_id:
+                        for p, dbl in enumerate(dec_block):
+                            dbl_code = strip_inline_comment(dbl)
+                            token_span = _decision_log_token_span(dbl_code)
+                            if token_span:
+                                token, tstart, tend = token_span
+                                if token != dec_id:
+                                    results.append(
+                                        (
+                                            cat_start + k + p,
+                                            tstart,
+                                            tend,
+                                            dec_id,
+                                            token,
+                                        )
+                                    )
+                    k = next_k
+                else:
+                    k += 1
+        else:
+            i += 1
+    return results
+
+
+def _check_decision_log_id(lines):
+    """Flag log = "...Decision ..." lines whose referenced id doesn't match
+    the enclosing decision (tolerating remove/complete/completed/timeout/
+    cancel/effect filler words: "Decision remove X", "Decision cancel effect
+    X") -- almost always a copy-paste leftover from duplicating a neighboring
+    decision.
+    """
+    issues = []
+    for line_idx, _s, _e, dec_id, token in _find_decision_log_mismatches(lines):
+        issues.append(
+            (
+                line_idx + 1,
+                f"log references Decision {token}, but the enclosing decision "
+                f"is {dec_id} -- likely copy-paste; fix the log id",
+            )
+        )
+    return issues
+
+
+def _check_event_log_id(lines):
+    """Flag log = "...Event <token>..." lines inside a country_event /
+    news_event / operative_leader_event / unit_leader_event block where token
+    matches neither the block's own id nor the enclosing option's own declared
+    `name = ` (its real identity), or -- for the bare-id form -- where a
+    separate "Option <x>" phrase names a letter that doesn't match the suffix
+    of that same `name = `.
+
+    Ground-truthed against the option's own `name = ` line rather than a
+    computed sequential letter: option lettering isn't always contiguous
+    (e.g. singapore.101 skips from .c straight to .e), so a position-based
+    a/b/c/... expectation would false-positive on those.
+
+    Only top-level event definitions count (column 0); a nested
+    `country_event = { id = X days = N }` is a scheduling effect call, not a
+    definition, and is skipped since it never starts at column 0.
+    """
+    issues = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if _RE_EVENT_DEF_OPEN.match(lines[i]):
+            start = i
+            block, i = _get_block(lines, start)
+            event_id = None
+            for bl in block:
+                m = _RE_EVENT_ID_IN_BLOCK.match(strip_inline_comment(bl))
+                if m:
+                    event_id = m.group(1)
+                    break
+            if not event_id:
+                continue
+            j = 1
+            block_n = len(block)
+            while j < block_n - 1:
+                bl_code = strip_inline_comment(block[j])
+                if _RE_OPTION_BLOCK_OPEN.search(bl_code):
+                    opt_block, next_j = _get_block(block, j)
+                    own_name = None
+                    for obl in opt_block:
+                        nm = _RE_OPTION_NAME_IN_BLOCK.match(strip_inline_comment(obl))
+                        if nm:
+                            own_name = nm.group(1)
+                            break
+                    own_suffix = None
+                    if own_name and own_name.startswith(event_id + "."):
+                        own_suffix = own_name[len(event_id) + 1 :]
+                    for p, obl in enumerate(opt_block):
+                        obl_code = strip_inline_comment(obl)
+                        m = _RE_LOG_EVENT_TOKEN.search(obl_code)
+                        if not m:
+                            continue
+                        token = m.group(1)
+                        if own_name and token == own_name:
+                            continue
+                        if token == event_id:
+                            om = _RE_LOG_EVENT_OPTION_SUFFIX.match(obl_code, m.end())
+                            if (
+                                om
+                                and own_suffix
+                                and om.group(1).lower() != own_suffix.lower()
+                            ):
+                                issues.append(
+                                    (
+                                        start + j + p + 1,
+                                        f"log says Option {om.group(1)} but "
+                                        f"this option's own name is "
+                                        f"{own_name} -- fix the option "
+                                        f"letter",
+                                    )
+                                )
+                            continue
+                        if own_name:
+                            issues.append(
+                                (
+                                    start + j + p + 1,
+                                    f"log references Event {token}, but this "
+                                    f"option's own name is {own_name} -- "
+                                    f"likely copy-paste; fix the log id",
+                                )
+                            )
+                    j = next_j
+                else:
+                    j += 1
+        else:
+            i += 1
+    return issues
+
+
+def _check_hidden_trigger_in_ctt(lines):
+    """Flag hidden_trigger = { } at relative depth 1 inside
+    custom_trigger_tooltip.
+
+    Everything inside custom_trigger_tooltip besides the tooltip line is
+    already the hidden trigger the tooltip describes -- wrapping it in
+    hidden_trigger adds a redundant nesting level with no effect.
+    """
+    issues = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        code = _code_for_depth(lines[i])
+        if _RE_CUSTOM_TRIGGER_TOOLTIP_OPEN.search(code):
+            depth = code.count("{") - code.count("}")
+            j = i + 1
+            while depth > 0 and j < n:
+                c2 = _code_for_depth(lines[j])
+                if depth == 1 and _RE_HIDDEN_TRIGGER_OPEN.search(c2):
+                    issues.append(
+                        (
+                            j + 1,
+                            "hidden_trigger = { } directly inside "
+                            "custom_trigger_tooltip is redundant -- unwrap its "
+                            "children to the tooltip's own depth",
+                        )
+                    )
+                depth += c2.count("{") - c2.count("}")
+                j += 1
+            i = j
+        else:
+            i += 1
+    return issues
+
+
 def check_file(filepath):
     """Check a single file for common mistakes. Returns list of (filepath, line_num, message) tuples."""
     issues = []
@@ -1547,6 +1871,7 @@ def check_file(filepath):
     is_common_or_events_file = (
         "common/" in normalized_filepath or "events/" in normalized_filepath
     )
+    is_event_file = "events/" in normalized_filepath
 
     # Only track idea categories for idea files (non-selectable vs selectable)
     # Dynamically parsed from common/idea_tags/*.txt
@@ -1719,10 +2044,15 @@ def check_file(filepath):
     if is_focus_file:
         issues.extend(_check_focus_available_always_no(lines))
         issues.extend(_check_focus_missing_war_hint(lines))
+        issues.extend(_check_focus_log_id(lines))
     if is_decision_file:
         issues.extend(_check_decision_available_always_no(lines))
         issues.extend(_check_decision_allowed_dynamic(lines))
+        issues.extend(_check_decision_log_id(lines))
+    if is_event_file:
+        issues.extend(_check_event_log_id(lines))
 
+    issues.extend(_check_hidden_trigger_in_ctt(lines))
     issues.extend(_check_consecutive_scope_blocks(lines))
     issues.extend(_check_embargo_dlc_guard(lines))
     issues.extend(_check_divide_variable_zero_guard(lines))

--- a/tools/linting/fix_log_ids.py
+++ b/tools/linting/fix_log_ids.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Rewrite mismatched log IDs in focus/decision log strings (Check C sweep).
+
+Shares detection with check_common_mistakes.py's _find_focus_log_mismatches /
+_find_decision_log_mismatches (Check C) -- same core, so a clean run of the
+checker implies a clean run here and vice versa. Only the mismatched ID token
+inside the quoted log string is rewritten; complete/timeout/remove/cancel
+phrasing around it is left untouched. Scope: common/national_focus/ and
+common/decisions/ (fix_common_mistakes.py's event-log check has no fixer --
+its ~13 legacy sites were hand-verified and hand-fixed instead).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from check_common_mistakes import (
+    _find_decision_log_mismatches,
+    _find_focus_log_mismatches,
+)
+from shared_utils import (
+    Timer,
+    clean_filepath,
+    collect_files_by_mode,
+    create_linting_parser,
+    get_root_dir,
+    print_timing_summary,
+    run_with_pool,
+)
+
+__version__ = 1.0
+
+
+def _finder_for(filepath):
+    normalized = filepath.replace("\\", "/")
+    if "common/national_focus" in normalized:
+        return _find_focus_log_mismatches
+    if "common/decisions" in normalized:
+        return _find_decision_log_mismatches
+    return None
+
+
+def _rewrite_line(line, spans):
+    """Apply (start, end, replacement) *spans* to *line*, rightmost first so
+    earlier spans stay valid after the length changes."""
+    for start, end, replacement in sorted(spans, reverse=True):
+        line = line[:start] + replacement + line[end:]
+    return line
+
+
+def _apply(filepath, dry_run):
+    """Rewrite mismatched log-id tokens in a single file.
+
+    Returns (filepath, fix_count).
+    """
+    finder = _finder_for(filepath)
+    if finder is None:
+        return (filepath, 0)
+
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except Exception:
+        return (filepath, 0)
+
+    mismatches = finder(lines)
+    if not mismatches:
+        return (filepath, 0)
+
+    by_line = {}
+    for line_idx, start, end, correct_id, _bad_token in mismatches:
+        by_line.setdefault(line_idx, []).append((start, end, correct_id))
+
+    for line_idx, spans in by_line.items():
+        lines[line_idx] = _rewrite_line(lines[line_idx], spans)
+
+    if not dry_run:
+        with open(filepath, "w", encoding="utf-8", newline="") as f:
+            f.writelines(lines)
+
+    return (filepath, len(mismatches))
+
+
+def fix_file(filepath):
+    return _apply(filepath, dry_run=False)
+
+
+def fix_file_dry_run(filepath):
+    return _apply(filepath, dry_run=True)
+
+
+def main():
+    def _extra(parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be fixed without writing changes",
+        )
+
+    parser = create_linting_parser(
+        "Rewrite mismatched log IDs in focus/decision log strings (Check C sweep)",
+        extra_args_fn=_extra,
+    )
+    args = parser.parse_args()
+
+    timings = []
+    root_dir = get_root_dir()
+    print(f"Fix Log IDs v{__version__} (Mode: {args.mode}, Dry run: {args.dry_run})")
+
+    with Timer("file collection") as t:
+        all_files = collect_files_by_mode(args, root_dir)
+    timings.append(("file collection", t.elapsed))
+
+    existing_files = [f for f in all_files if _finder_for(f) is not None]
+
+    if not existing_files:
+        print("No focus/decision files to process")
+        return 0
+
+    print(f"Processing {len(existing_files)} files...")
+
+    process_fn = fix_file_dry_run if args.dry_run else fix_file
+    with Timer("processing") as t:
+        results = run_with_pool(process_fn, existing_files, args.workers)
+    timings.append(("processing", t.elapsed))
+
+    action = "Would fix" if args.dry_run else "Fixed"
+    files_fixed = [(f, c) for f, c in results if c > 0]
+    total_fixes = sum(c for _, c in results)
+
+    for f, c in sorted(files_fixed):
+        print(f"  {clean_filepath(f)}: {action.lower()} {c} log id(s)")
+
+    print("\n------")
+    print(f"Processed {len(existing_files)} files")
+    print(f"{action} {total_fixes} log id(s) in {len(files_fixed)} file(s)")
+
+    elapsed_total = sum(t for _, t in timings)
+    print(f"\nCompleted in {elapsed_total:.1f}s")
+    print_timing_summary(timings)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/linting/tests/check_common_mistakes_test.py
+++ b/tools/linting/tests/check_common_mistakes_test.py
@@ -15,6 +15,8 @@ Unit tests for the checks added to check_common_mistakes.py:
   12. random_select_amount set to a non-integer-literal
   13. any_country/any_other_country with has_idea = X_member when array exists
   14. on_add adds to a global array the sibling on_remove never removes from
+  15. focus/decision/event log = "..." referencing the wrong id (Check C)
+  16. hidden_trigger = { } directly inside custom_trigger_tooltip (Check E1)
 """
 
 import os
@@ -27,13 +29,17 @@ from check_common_mistakes import (
     _check_check_var_ge_le,
     _check_consecutive_scope_blocks,
     _check_decision_allowed_dynamic,
+    _check_decision_log_id,
     _check_divide_variable_zero_guard,
     _check_duplicate_add_to_variable,
     _check_embargo_dlc_guard,
+    _check_event_log_id,
     _check_every_country_member_array,
     _check_every_owned_controlled_state,
+    _check_focus_log_id,
     _check_focus_missing_war_hint,
     _check_has_idea_mutex_in_not_block,
+    _check_hidden_trigger_in_ctt,
     _check_influence_setter_scope,
     _check_on_add_array_symmetry,
     _check_random_select_amount_literal,
@@ -1568,6 +1574,436 @@ assert_finds(
     ],
     0,
     "random_select_amount with integer literal not flagged",
+)
+
+
+# 15a. Focus log-id mismatch (Check C)
+
+print("\n── Focus log-id mismatch ──")
+
+# Basic copy-paste bug: log names a sibling focus's id -> flag
+assert_finds(
+    _check_focus_log_id,
+    [
+        "\tfocus = {\n",
+        "\t\tid = ABK_our_place\n",
+        "\t\tcompletion_reward = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Focus ABK_tourism1"\n',
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    1,
+    "focus log referencing a different focus id flagged",
+)
+
+# Log matches the enclosing focus's own id -> no flag
+assert_finds(
+    _check_focus_log_id,
+    [
+        "\tfocus = {\n",
+        "\t\tid = ABK_our_place\n",
+        "\t\tcompletion_reward = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Focus ABK_our_place"\n',
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    0,
+    "focus log matching its own id not flagged",
+)
+
+# Mismatch suppressed by complete_national_focus targeting the logged id in the
+# same block -- this focus intentionally completes a sibling and logs it
+assert_finds(
+    _check_focus_log_id,
+    [
+        "\tfocus = {\n",
+        "\t\tid = ABK_our_place\n",
+        "\t\tcompletion_reward = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Focus ABK_tourism1"\n',
+        "\t\t\tcomplete_national_focus = ABK_tourism1\n",
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    0,
+    "mismatch suppressed by complete_national_focus in same block",
+)
+
+# Mismatch suppressed by unlock_national_focus targeting the logged id
+assert_finds(
+    _check_focus_log_id,
+    [
+        "\tfocus = {\n",
+        "\t\tid = ABK_our_place\n",
+        "\t\tcompletion_reward = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Focus ABK_tourism1"\n',
+        "\t\t\tunlock_national_focus = ABK_tourism1\n",
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    0,
+    "mismatch suppressed by unlock_national_focus in same block",
+)
+
+# shared_focus block also checked, lowercase "focus" + "executed" suffix style
+assert_finds(
+    _check_focus_log_id,
+    [
+        "shared_focus = {\n",
+        "\tid = GCC_the_gcc\n",
+        "\tcompletion_reward = {\n",
+        '\t\tlog = "[GetDateText]: [This.GetName]: focus GCC_economic_union executed"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "shared_focus block with lowercase 'focus' log flagged",
+)
+
+# joint_focus block, log matches its own id -> no flag
+assert_finds(
+    _check_focus_log_id,
+    [
+        "\tjoint_focus = {\n",
+        "\t\tid = NKR_economy_start\n",
+        "\t\tcompletion_reward = {\n",
+        '\t\t\tlog = "[GetDateText]: [This.GetName]: focus NKR_economy_start executed"\n',
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    0,
+    "joint_focus block matching its own id not flagged",
+)
+
+
+# 15b. Decision log-id mismatch (Check C)
+
+print("\n── Decision log-id mismatch ──")
+
+# Basic copy-paste bug: complete_effect log names a different decision's id
+assert_finds(
+    _check_decision_log_id,
+    [
+        "LAT_decisions_category = {\n",
+        "\tLAT_reopen_the_vef_microchip_plant = {\n",
+        "\t\tcomplete_effect = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision POR_expand_the_neves_corvo_mine"\n',
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "decision log referencing a different decision id flagged",
+)
+
+# "Decision remove <id>" keyword tolerance -- id matches -> no flag
+assert_finds(
+    _check_decision_log_id,
+    [
+        "UAR_decisions_category = {\n",
+        "\tUAR_integrate_MAU = {\n",
+        "\t\tremove_effect = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision remove UAR_integrate_MAU"\n',
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "'Decision remove <own id>' keyword tolerance not flagged",
+)
+
+# "Decision remove <id>" keyword tolerance -- id mismatched -> flag
+assert_finds(
+    _check_decision_log_id,
+    [
+        "NKO_decisions_category = {\n",
+        "\tNKO_resource_extraction = {\n",
+        "\t\tremove_effect = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision remove BNKO_resource_extraction"\n',
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "'Decision remove <wrong id>' (typo) still flagged",
+)
+
+# "Decision cancel effect <id>" double filler-word tolerance -- id matches
+assert_finds(
+    _check_decision_log_id,
+    [
+        "NATO_decisions_category = {\n",
+        "\tNATO_CSTO_breach_mission = {\n",
+        "\t\tcancel_effect = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision cancel effect NATO_CSTO_breach_mission"\n',
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "'Decision cancel effect <own id>' double-filler tolerance not flagged",
+)
+
+# Keyword-only log (nothing substantive follows) -- not flagged, no token to compare
+assert_finds(
+    _check_decision_log_id,
+    [
+        "SOME_decisions_category = {\n",
+        "\tSOME_decision = {\n",
+        "\t\tcomplete_effect = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision"\n',
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "keyword-only log with no id token not flagged",
+)
+
+# Log buried several if/limit levels deep still attributed to the correct
+# enclosing decision, not a sibling in the same category
+assert_finds(
+    _check_decision_log_id,
+    [
+        "MIX_decisions_category = {\n",
+        "\tMIX_first_decision = {\n",
+        "\t\tcomplete_effect = {\n",
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision MIX_first_decision"\n',
+        "\t\t}\n",
+        "\t}\n",
+        "\tMIX_second_decision = {\n",
+        "\t\tcomplete_effect = {\n",
+        "\t\t\tif = {\n",
+        "\t\t\t\tlimit = { always = yes }\n",
+        "\t\t\t\tif = {\n",
+        "\t\t\t\t\tlimit = { always = yes }\n",
+        '\t\t\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision MIX_first_decision"\n',
+        "\t\t\t\t}\n",
+        "\t\t\t}\n",
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "nested-if log correctly attributed to its own enclosing decision",
+)
+
+
+# 15c. Event log-id / option-letter mismatch (Check C)
+
+print("\n── Event log-id / option-letter mismatch ──")
+
+# Bare id + separate "Option <letter>" matching position -> no flag
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = HKG_contract.1\n",
+        "\toption = {\n",
+        "\t\tname = HKG_contract.1.a\n",
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Event HKG_contract.1 Option a"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "bare id + matching Option letter not flagged",
+)
+
+# Bare id + Option letter that doesn't match this option's own name -> flag
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = HKG_contract.1\n",
+        "\toption = {\n",
+        "\t\tname = HKG_contract.1.b\n",
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Event HKG_contract.1 Option a"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "Option letter not matching own name flagged",
+)
+
+# Event id itself mismatched -> flag
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = estonia.104\n",
+        "\toption = {\n",
+        "\t\tname = estonia.104.a\n",
+        '\t\tlog = "[GetDateText]: [This.GetName]: event estonia.103.a executed"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "log referencing the wrong event id flagged",
+)
+
+# Full dotted name matching the option's own name (a/b/c style) -> no flag
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = satellites.2\n",
+        "\toption = {\n",
+        "\t\tname = satellites.2.a\n",
+        '\t\tlog = "[GetDateText]: [Root.GetName]: event satellites.2.a"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "full dotted name matching own name not flagged",
+)
+
+# Numeric 'oN' suffix convention matching own name -> no flag
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = estonia.7\n",
+        "\toption = {\n",
+        "\t\tname = estonia.7.o2\n",
+        '\t\tlog = "[GetDateText]: [This.GetName]: event estonia.7.o2 executed"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "numeric oN suffix matching own name not flagged",
+)
+
+# Numeric 'oN' suffix copy-pasted from a sibling option -> flag
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = estonia.7\n",
+        "\toption = {\n",
+        "\t\tname = estonia.7.o1\n",
+        '\t\tlog = "[GetDateText]: [This.GetName]: event estonia.7.o1 executed"\n',
+        "\t}\n",
+        "\toption = {\n",
+        "\t\tname = estonia.7.o2\n",
+        '\t\tlog = "[GetDateText]: [This.GetName]: event estonia.7.o1 executed"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "oN suffix copy-pasted from a sibling option flagged",
+)
+
+# Non-sequential option lettering (skips a letter): log matches the option's
+# own name -> not flagged even though the position-based letter would differ
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = singapore.101\n",
+        "\toption = {\n",
+        "\t\tname = singapore.101.c\n",
+        '\t\tlog = "[GetDateText]: [THIS.GetName]: event singapore.101.c"\n',
+        "\t}\n",
+        "\toption = {\n",
+        "\t\tname = singapore.101.e\n",
+        '\t\tlog = "[GetDateText]: [THIS.GetName]: event singapore.101.e"\n',
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "non-sequential option lettering (c then e) not flagged",
+)
+
+# Nested country_event effect call (id + days, indented) is a scheduling call,
+# not a definition -- must not be scanned as its own event block
+assert_finds(
+    _check_event_log_id,
+    [
+        "country_event = {\n",
+        "\tid = china.68\n",
+        "\toption = {\n",
+        "\t\tname = china.68.a\n",
+        '\t\tlog = "[GetDateText]: [Root.GetName]: event china.68.a"\n',
+        "\t\thidden_effect = {\n",
+        "\t\t\tcountry_event = {\n",
+        "\t\t\t\tid = china.69\n",
+        "\t\t\t\tdays = 35\n",
+        "\t\t\t}\n",
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "nested country_event scheduling call not treated as a definition",
+)
+
+
+# 15d. hidden_trigger inside custom_trigger_tooltip (Check E1)
+
+print("\n── hidden_trigger inside custom_trigger_tooltip ──")
+
+# hidden_trigger at relative depth 1 -> flag
+assert_finds(
+    _check_hidden_trigger_in_ctt,
+    [
+        "\t\t\tcustom_trigger_tooltip = {\n",
+        "\t\t\t\ttooltip = GER_had_civilwar_TT\n",
+        "\t\t\t\thidden_trigger = {\n",
+        "\t\t\t\t\thas_country_flag = GER_constitutional_government\n",
+        "\t\t\t\t}\n",
+        "\t\t\t}\n",
+    ],
+    1,
+    "hidden_trigger at depth 1 inside custom_trigger_tooltip flagged",
+)
+
+# hidden_trigger nested under OR (relative depth 2) -> not flagged
+assert_finds(
+    _check_hidden_trigger_in_ctt,
+    [
+        "\tcustom_trigger_tooltip = {\n",
+        "\t\ttooltip = GCC_jihadist_government_tt\n",
+        "\t\tOR = {\n",
+        "\t\t\thidden_trigger = {\n",
+        "\t\t\t\thas_country_flag = test_flag\n",
+        "\t\t\t}\n",
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    0,
+    "hidden_trigger nested under OR (depth 2) not flagged",
+)
+
+# hidden_trigger as a sibling AFTER custom_trigger_tooltip closes -> not flagged
+assert_finds(
+    _check_hidden_trigger_in_ctt,
+    [
+        "\t\t\tcustom_trigger_tooltip = {\n",
+        "\t\t\t\ttooltip = ISR_judicial_pres_TT\n",
+        "\t\t\t}\n",
+        "\t\t\thidden_trigger = {\n",
+        "\t\t\t\thas_country_flag = ISR_judicial\n",
+        "\t\t\t}\n",
+    ],
+    0,
+    "hidden_trigger as a sibling outside custom_trigger_tooltip not flagged",
+)
+
+# Quote-blanking regression: a log string containing a literal '{' inside the
+# custom_trigger_tooltip block must not drift the depth count and mask the
+# hidden_trigger that follows
+assert_finds(
+    _check_hidden_trigger_in_ctt,
+    [
+        "\tcustom_trigger_tooltip = {\n",
+        "\t\ttooltip = TEST_TT\n",
+        '\t\tlog = "test { brace"\n',
+        "\t\thidden_trigger = {\n",
+        "\t\t\thas_country_flag = test_flag\n",
+        "\t\t}\n",
+        "\t}\n",
+    ],
+    1,
+    "stray brace inside a quoted log string doesn't mask the hidden_trigger",
 )
 
 

--- a/tools/validation/tests/focus_pp_malus_test.py
+++ b/tools/validation/tests/focus_pp_malus_test.py
@@ -1,0 +1,77 @@
+"""Tests for the PP malus check in validate_focus_tree.
+
+A literal add_political_power = -N inside a focus's completion_reward is
+flagged; occurrences inside an effect_tooltip subtree (previewing a PP
+change applied elsewhere) and outside completion_reward (select_effect,
+bypass) are not.
+"""
+
+from validate_focus_tree import Validator, _extract_pp_malus
+
+
+def _write_focus_file(tmp_path, content):
+    nf_dir = tmp_path / "common" / "national_focus"
+    nf_dir.mkdir(parents=True, exist_ok=True)
+    fpath = nf_dir / "test.txt"
+    fpath.write_text(content, encoding="utf-8")
+    return fpath
+
+
+FOCUS_TEMPLATE = """focus_tree = {{
+	id = test_tree
+	focus = {{
+		id = TAG_focus_a
+		x = 0
+		y = 0
+		cost = 1
+		{extra}
+		completion_reward = {{
+			{reward}
+		}}
+	}}
+}}
+"""
+
+
+def _ids(tmp_path, reward, extra=""):
+    fpath = _write_focus_file(
+        tmp_path, FOCUS_TEMPLATE.format(reward=reward, extra=extra)
+    )
+    return {d[0] for d in _extract_pp_malus((str(fpath), str(tmp_path)))}
+
+
+def test_negative_pp_in_completion_reward_is_flagged(tmp_path):
+    assert _ids(tmp_path, "add_political_power = -50") == {"TAG_focus_a"}
+
+
+def test_positive_pp_is_clean(tmp_path):
+    assert _ids(tmp_path, "add_political_power = 50") == set()
+
+
+def test_negative_pp_inside_effect_tooltip_is_clean(tmp_path):
+    reward = "effect_tooltip = {\n\t\t\t\tadd_political_power = -50\n\t\t\t}"
+    assert _ids(tmp_path, reward) == set()
+
+
+def test_negative_pp_in_select_effect_is_clean(tmp_path):
+    extra = "select_effect = {\n\t\t\tadd_political_power = -50\n\t\t}"
+    assert _ids(tmp_path, "newline = yes", extra=extra) == set()
+
+
+def test_negative_pp_in_bypass_is_clean(tmp_path):
+    extra = "bypass = {\n\t\t\tadd_political_power = -50\n\t\t}"
+    assert _ids(tmp_path, "newline = yes", extra=extra) == set()
+
+
+def test_variable_form_is_clean(tmp_path):
+    assert _ids(tmp_path, "add_political_power = some_var") == set()
+
+
+def test_validator_reports_pp_malus_as_warning_not_error(tmp_path):
+    _write_focus_file(
+        tmp_path, FOCUS_TEMPLATE.format(reward="add_political_power = -50", extra="")
+    )
+    v = Validator(mod_path=str(tmp_path), use_colors=False, workers=1)
+    v.validate_pp_malus_in_rewards()
+    assert v.warnings_found == 1
+    assert v.errors_found == 0

--- a/tools/validation/tests/validate_decisions_category_redundant_test.py
+++ b/tools/validation/tests/validate_decisions_category_redundant_test.py
@@ -1,0 +1,143 @@
+"""Tests for the category-lock tag/original_tag redundancy check (Check D).
+
+_find_category_redundant_rows fills the gap between validate_redundant_tag_checks
+(decision's own allowed pin vs its own visible/available) and
+validate_allowed_redundant_with_category (sole-content allowed duplicating the
+category pin): neither compares the *category*'s single-tag lock against a
+decision's visible/available, or against a partial (multi-condition) allowed
+block.
+"""
+
+from validate_decisions import DecisionFactory, _find_category_redundant_rows
+
+
+def _make_factory(
+    token, allowed=None, available=None, visible=None, basename="test.txt"
+):
+    """Build a DecisionFactory for a single decision block with the given
+    (inner, brace-free) allowed/available/visible content."""
+    lines = [f"\t{token} = {{"]
+    for field, content in (
+        ("allowed", allowed),
+        ("available", available),
+        ("visible", visible),
+    ):
+        if content is None:
+            continue
+        lines.append(f"\t\t{field} = {{")
+        for line in content.strip("\n").split("\n"):
+            lines.append(f"\t\t\t{line}")
+        lines.append("\t\t}")
+    lines.append("\t}")
+    raw = "\n".join(lines) + "\n"
+    return DecisionFactory(dec=raw, source_basename=basename)
+
+
+CAT = "some_category"
+
+
+def test_original_tag_lock_flags_original_tag_recheck():
+    factories = [_make_factory("dec1", available="original_tag = GER")]
+    cat_pins = {CAT: {("original_tag", "GER")}}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    rows = _find_category_redundant_rows(factories, cat_pins, cats_with_decs)
+
+    assert len(rows) == 1
+    assert "dec1" in rows[0]
+    assert "available" in rows[0]
+
+
+def test_original_tag_lock_does_not_flag_tag_recheck():
+    # original_tag lock admits civil-war split-offs; a runtime `tag` check is
+    # a real restriction, not a redundant re-check.
+    factories = [_make_factory("dec1", available="tag = GER")]
+    cat_pins = {CAT: {("original_tag", "GER")}}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    assert _find_category_redundant_rows(factories, cat_pins, cats_with_decs) == []
+
+
+def test_tag_lock_flags_both_tag_and_original_tag_recheck():
+    factories = [
+        _make_factory("dec_tag_recheck", available="tag = GER"),
+        _make_factory("dec_origtag_recheck", visible="original_tag = GER"),
+    ]
+    cat_pins = {CAT: {("tag", "GER")}}
+    cats_with_decs = {CAT: ["dec_tag_recheck", "dec_origtag_recheck"]}
+
+    rows = _find_category_redundant_rows(factories, cat_pins, cats_with_decs)
+
+    assert len(rows) == 2
+    joined = "\n".join(rows)
+    assert "dec_tag_recheck" in joined
+    assert "dec_origtag_recheck" in joined
+
+
+def test_not_wrapped_recheck_skipped():
+    factories = [_make_factory("dec1", available="NOT = {\n\toriginal_tag = GER\n}")]
+    cat_pins = {CAT: {("original_tag", "GER")}}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    assert _find_category_redundant_rows(factories, cat_pins, cats_with_decs) == []
+
+
+def test_from_wrapped_recheck_skipped():
+    factories = [_make_factory("dec1", available="FROM = {\n\toriginal_tag = GER\n}")]
+    cat_pins = {CAT: {("original_tag", "GER")}}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    assert _find_category_redundant_rows(factories, cat_pins, cats_with_decs) == []
+
+
+def test_multi_tag_lock_skipped():
+    # Category pins two different tag values at depth 0 - not a single-tag
+    # lock, so a decision's own single-tag check is narrowing, not redundant.
+    factories = [_make_factory("dec1", available="original_tag = GER")]
+    cat_pins = {CAT: {("original_tag", "GER"), ("original_tag", "ITA")}}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    assert _find_category_redundant_rows(factories, cat_pins, cats_with_decs) == []
+
+
+def test_scripted_trigger_category_no_lock_skipped():
+    # A scripted-trigger allowed (e.g. has_country_flag = x) has no flat tag
+    # pin, so _category_allowed_pins maps it to an empty set - no lock.
+    factories = [_make_factory("dec1", available="original_tag = GER")]
+    cat_pins = {CAT: set()}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    assert _find_category_redundant_rows(factories, cat_pins, cats_with_decs) == []
+
+
+def test_sole_pin_allowed_skipped():
+    # allowed's only content is the pin itself - already owned by
+    # validate_allowed_redundant_with_category; must not be double-reported.
+    factories = [_make_factory("dec1", allowed="original_tag = GER")]
+    cat_pins = {CAT: {("original_tag", "GER")}}
+    cats_with_decs = {CAT: ["dec1"]}
+
+    assert _find_category_redundant_rows(factories, cat_pins, cats_with_decs) == []
+
+
+def test_ger_territorial_defense_shape_flagged():
+    # Mirrors common/decisions/Germany.txt:1956-1965: category
+    # GER_V_fall_Decision is locked to `original_tag = GER`
+    # (common/decisions/categories/99_GER_decision_categories.txt:96-100), and
+    # GER_Territorial_Defense re-checks it in `available` with no `allowed`
+    # at all, so the sole-pin-allowed exemption doesn't apply.
+    factories = [
+        _make_factory(
+            "GER_Territorial_Defense",
+            available="original_tag = GER",
+            visible="has_country_flag = GER_V_fall",
+        )
+    ]
+    cat_pins = {"GER_V_fall_Decision": {("original_tag", "GER")}}
+    cats_with_decs = {"GER_V_fall_Decision": ["GER_Territorial_Defense"]}
+
+    rows = _find_category_redundant_rows(factories, cat_pins, cats_with_decs)
+
+    assert len(rows) == 1
+    assert "GER_Territorial_Defense" in rows[0]
+    assert "available" in rows[0]

--- a/tools/validation/tests/validate_history_buildings_test.py
+++ b/tools/validation/tests/validate_history_buildings_test.py
@@ -1,0 +1,257 @@
+"""Tests for the nuclear-reactor/nuclear_status check and the
+project-granted-building check in validate_history.
+
+A state that starts with `nuclear_reactor >= 1` implies its owner's country
+file grants one of the nuclear_status idea group's non-default members. A
+state that starts with a building a special project's reward grants (e.g.
+`microchip_plant` via sp_microchip_production) implies its owner's country
+file completes a granting project. Both checks share one pass over
+history/states/*.txt via `parse_state_building_owners`.
+"""
+
+import validate_history as V
+
+
+def _write_ideas(tmp_path, body):
+    ideas_dir = tmp_path / "common" / "ideas"
+    ideas_dir.mkdir(parents=True, exist_ok=True)
+    (ideas_dir / "test.txt").write_text(body)
+
+
+def _write_state(tmp_path, name, body):
+    states_dir = tmp_path / "history" / "states"
+    states_dir.mkdir(parents=True, exist_ok=True)
+    (states_dir / name).write_text(body)
+
+
+def _write_projects(tmp_path, body):
+    projects_dir = tmp_path / "common" / "special_projects" / "projects"
+    projects_dir.mkdir(parents=True, exist_ok=True)
+    (projects_dir / "test.txt").write_text(body)
+
+
+def _write_country(tmp_path, name, body):
+    cdir = tmp_path / "history" / "countries"
+    cdir.mkdir(parents=True, exist_ok=True)
+    (cdir / name).write_text(body)
+
+
+_NUCLEAR_STATUS_IDEAS = (
+    "ideas = {\n"
+    "\tnuclear_status = {\n"
+    "\t\tuse_list_view = yes\n"
+    "\t\tnon_nuclear_power = {\n"
+    "\t\t\tdefault = yes\n"
+    "\t\t\tcost = 300\n"
+    "\t\t}\n"
+    "\t\tnuclear_energy = {\n"
+    "\t\t\tcost = 300\n"
+    "\t\t\tavailable = { has_tech = reactor1 }\n"
+    "\t\t}\n"
+    "\t\tnuclear_power_def = {\n"
+    "\t\t\tcost = 300\n"
+    "\t\t}\n"
+    "\t\tnuclear_power_off = {\n"
+    "\t\t\tcost = 300\n"
+    "\t\t}\n"
+    "\t}\n"
+    "}\n"
+)
+
+
+def test_parse_nuclear_status_ideas_excludes_default(tmp_path):
+    _write_ideas(tmp_path, _NUCLEAR_STATUS_IDEAS)
+    ideas = V.parse_nuclear_status_ideas(str(tmp_path))
+    assert ideas == {"nuclear_energy", "nuclear_power_def", "nuclear_power_off"}
+
+
+def test_parse_nuclear_status_ideas_empty_when_group_absent(tmp_path):
+    _write_ideas(tmp_path, "ideas = {\n\tnuclear_stance = {\n\t\tfoo = {}\n\t}\n}\n")
+    assert V.parse_nuclear_status_ideas(str(tmp_path)) == set()
+
+
+def test_parse_state_building_owners_scalar_only(tmp_path):
+    # nuclear_reactor at the top level counts; a province-keyed sub-block must
+    # not be read into, and commented-out / zero-level entries must not count.
+    _write_state(
+        tmp_path,
+        "1-Test.txt",
+        "state = {\n"
+        "\thistory = {\n"
+        "\t\towner = TST\n"
+        "\t\tbuildings = {\n"
+        "\t\t\tnuclear_reactor = 1\n"
+        "\t\t\t# nuclear_reactor = 5\n"
+        "\t\t\tmicrochip_plant = 0\n"
+        "\t\t\t1234 = {\n"
+        "\t\t\t\tnuclear_reactor = 9\n"
+        "\t\t\t}\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n",
+    )
+    owners = V.parse_state_building_owners(
+        str(tmp_path), {"nuclear_reactor", "microchip_plant"}
+    )
+    assert owners == {"nuclear_reactor": {"TST"}}
+
+
+def test_parse_state_building_owners_missing_owner_not_attributed(tmp_path):
+    _write_state(
+        tmp_path,
+        "1-Test.txt",
+        "state = {\n"
+        "\thistory = {\n"
+        "\t\tbuildings = {\n"
+        "\t\t\tnuclear_reactor = 1\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n",
+    )
+    assert V.parse_state_building_owners(str(tmp_path), {"nuclear_reactor"}) == {}
+
+
+def test_parse_project_granted_buildings(tmp_path):
+    _write_projects(
+        tmp_path,
+        "sp_microchip_production = {\n"
+        "\tproject_output = {\n"
+        "\t\tfacility_state_effects = {\n"
+        "\t\t\tset_building_level = {\n"
+        "\t\t\t\ttype = microchip_plant\n"
+        "\t\t\t\tlevel = 1\n"
+        "\t\t\t}\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n"
+        "sp_composite_production = {\n"
+        "\tproject_output = {\n"
+        "\t\tfacility_state_effects = {\n"
+        "\t\t\tset_building_level = {\n"
+        "\t\t\t\ttype = composite_plant\n"
+        "\t\t\t}\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n",
+    )
+    granted = V.parse_project_granted_buildings(str(tmp_path))
+    assert granted == {
+        "microchip_plant": {"sp_microchip_production"},
+        "composite_plant": {"sp_composite_production"},
+    }
+
+
+def test_parse_project_granted_buildings_multi_project_same_building(tmp_path):
+    _write_projects(
+        tmp_path,
+        "sp_a = {\n\tproject_output = {\n\t\tfacility_state_effects = {\n"
+        "\t\t\tset_building_level = { type = shared_plant }\n\t\t}\n\t}\n}\n"
+        "sp_b = {\n\tproject_output = {\n\t\tfacility_state_effects = {\n"
+        "\t\t\tset_building_level = { type = shared_plant }\n\t\t}\n\t}\n}\n",
+    )
+    granted = V.parse_project_granted_buildings(str(tmp_path))
+    assert granted == {"shared_plant": {"sp_a", "sp_b"}}
+
+
+def test_find_reactor_owners_flags_missing_idea():
+    errors = V._find_reactor_owners_without_nuclear_status(
+        {"TST"}, {"nuclear_energy", "nuclear_power_def"}, {"TST": "capital = 1"}
+    )
+    assert len(errors) == 1
+    assert "TST" in errors[0]
+
+
+def test_find_reactor_owners_clean_when_idea_present():
+    errors = V._find_reactor_owners_without_nuclear_status(
+        {"TST"},
+        {"nuclear_energy", "nuclear_power_def"},
+        {"TST": "add_ideas = { nuclear_energy }"},
+    )
+    assert errors == []
+
+
+def test_find_reactor_owners_idea_only_in_comment_still_flagged():
+    # Callers pass comment-stripped content (via _load_country_contents);
+    # simulate that pipeline so a commented-out grant does not satisfy the check.
+    raw = "# add_ideas = { nuclear_energy }\nadd_ideas = { non_nuclear_power }\n"
+    stripped = V.strip_comments(raw)
+    errors = V._find_reactor_owners_without_nuclear_status(
+        {"TST"}, {"nuclear_energy", "nuclear_power_def"}, {"TST": stripped}
+    )
+    assert len(errors) == 1
+    assert "TST" in errors[0]
+
+
+def test_find_reactor_owners_missing_country_file():
+    errors = V._find_reactor_owners_without_nuclear_status(
+        {"TST"}, {"nuclear_energy"}, {}
+    )
+    assert len(errors) == 1
+    assert "TST" in errors[0]
+    assert "no history/countries/" in errors[0]
+
+
+def test_find_buildings_without_granting_project_flags_gap():
+    errors = V._find_buildings_without_granting_project(
+        {"microchip_plant": {"SWE"}},
+        {"microchip_plant": {"sp_microchip_production"}},
+        {"SWE": "complete_special_project = sp:sp_composite_production"},
+    )
+    assert len(errors) == 1
+    assert "SWE" in errors[0]
+    assert "microchip_plant" in errors[0]
+    assert "sp:sp_microchip_production" in errors[0]
+
+
+def test_find_buildings_without_granting_project_clean_when_completed():
+    errors = V._find_buildings_without_granting_project(
+        {"microchip_plant": {"SWE"}},
+        {"microchip_plant": {"sp_microchip_production"}},
+        {"SWE": "complete_special_project = sp:sp_microchip_production"},
+    )
+    assert errors == []
+
+
+def test_find_buildings_multi_project_satisfied_by_either():
+    # A building granted by two different projects is satisfied by completing
+    # any one of them.
+    errors = V._find_buildings_without_granting_project(
+        {"shared_plant": {"TST"}},
+        {"shared_plant": {"sp_a", "sp_b"}},
+        {"TST": "complete_special_project = sp:sp_b"},
+    )
+    assert errors == []
+
+
+def test_find_buildings_without_granting_project_missing_country_file():
+    errors = V._find_buildings_without_granting_project(
+        {"microchip_plant": {"TST"}},
+        {"microchip_plant": {"sp_microchip_production"}},
+        {},
+    )
+    assert len(errors) == 1
+    assert "no history/countries/" in errors[0]
+
+
+def test_tag_country_file_map(tmp_path):
+    _write_country(tmp_path, "SWE - Sweden.txt", "capital = 34\n")
+    mapping = V._tag_country_file_map(str(tmp_path))
+    assert "SWE" in mapping
+    assert mapping["SWE"].endswith("SWE - Sweden.txt")
+
+
+def test_load_country_contents_strips_comments(tmp_path):
+    _write_country(
+        tmp_path,
+        "TST - Test.txt",
+        "# complete_special_project = sp:sp_x\ncapital = 1\n",
+    )
+    tag_files = V._tag_country_file_map(str(tmp_path))
+    contents = V._load_country_contents(tag_files, {"TST"})
+    assert "sp_x" not in contents["TST"]
+    assert "capital" in contents["TST"]
+
+
+def test_load_country_contents_skips_unknown_tag(tmp_path):
+    tag_files = V._tag_country_file_map(str(tmp_path))
+    assert V._load_country_contents(tag_files, {"ZZZ"}) == {}

--- a/tools/validation/tests/validate_simplifications_test.py
+++ b/tools/validation/tests/validate_simplifications_test.py
@@ -7,6 +7,7 @@ under OR / random_list / count_triggers, and never for non-deterministic
 """
 
 from validate_simplifications import (
+    _find_bare_not,
     _find_count_collapsible,
     _find_empty_trigger_blocks,
     _find_government_match,
@@ -39,6 +40,10 @@ def _empty(text):
 
 def _gov(text):
     return [rep for _, rep in _find_government_match(strip_comments(text))]
+
+
+def _not(text):
+    return [(line, n) for line, n in _find_bare_not(strip_comments(text))]
 
 
 def _all_five(target, scoped_tmpl):
@@ -453,3 +458,37 @@ def test_mixed_sense_not_flagged():
         "}\n"
     )
     assert _gov(text) == []
+
+
+# --- bare multi-child NOT ----------------------------------------------------
+
+
+def test_two_child_not_flagged():
+    assert _not("NOT = { tag = USA tag = CHI }\n") == [(1, 2)]
+
+
+def test_not_or_wrapper_clean():
+    assert _not("NOT = { OR = { tag = USA tag = CHI } }\n") == []
+
+
+def test_not_and_wrapper_clean():
+    assert _not("NOT = { AND = { tag = USA has_war = yes } }\n") == []
+
+
+def test_single_trigger_not_clean():
+    assert _not("NOT = { has_capitulated = yes }\n") == []
+
+
+def test_nested_not_inside_or_still_detected():
+    text = "OR = {\n  tag = USA\n  NOT = { tag = GER tag = ITA }\n}\n"
+    assert _not(text) == [(3, 2)]
+
+
+def test_single_child_multiline_clean():
+    text = "NOT = {\n\thas_country_flag = some_flag\n}\n"
+    assert _not(text) == []
+
+
+def test_block_child_beside_scalar_flagged():
+    # An OR wrapper plus a trailing bare trigger is still two children.
+    assert _not("NOT = { OR = { tag = USA tag = CHI } has_war = yes }\n") == [(1, 2)]

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -128,12 +128,15 @@ _BARE_TRIGGER_RE = re.compile(
 )
 
 
-def _flat_tag_pins(block: str) -> set:
-    """Return the set of tags pinned by flat (non-nested) tag/original_tag tokens.
+def _flat_tag_pins_with_kind(block: str) -> set:
+    """Return {(keyword, tag), ...} for flat (non-nested), depth-0 tag/original_tag tokens.
 
-    Tokens nested inside OR/NOT/AND/if subblocks are skipped because they are
-    conditional, not hard pins. Handles both multi-line and single-line block
-    formats.
+    Dim-aware sibling of ``_flat_tag_pins``: keeps the keyword ('tag' or
+    'original_tag') alongside each pinned tag so callers can tell a
+    ``tag = X`` lock (excludes civil-war split-offs) apart from
+    ``original_tag = X`` (admits them). Tokens nested inside OR/NOT/AND/if/
+    FROM/any_country/TAG={} subblocks are skipped because they are
+    conditional or scoped, not flat hard pins.
     """
     if not block:
         return set()
@@ -142,7 +145,7 @@ def _flat_tag_pins(block: str) -> set:
         inner = inner[1:]
     if inner.endswith("}"):
         inner = inner[:-1]
-    tags = set()
+    pins = set()
     depth = 0
     i = 0
     n = len(inner)
@@ -163,11 +166,220 @@ def _flat_tag_pins(block: str) -> set:
         if depth == 0:
             m = _TAG_TOKEN_PATTERN.match(inner, i)
             if m:
-                tags.add(m.group(2))
+                pins.add((m.group(1), m.group(2)))
                 i = m.end()
                 continue
         i += 1
-    return tags
+    return pins
+
+
+def _flat_tag_pins(block: str) -> set:
+    """Return the set of tags pinned by flat (non-nested) tag/original_tag tokens.
+
+    Tokens nested inside OR/NOT/AND/if subblocks are skipped because they are
+    conditional, not hard pins. Handles both multi-line and single-line block
+    formats.
+    """
+    return {tag for _, tag in _flat_tag_pins_with_kind(block)}
+
+
+def _is_sole_flat_pin(block: str, tag: str) -> bool:
+    """True if ``block``'s only content (after comment-stripping) is a single
+    flat ``tag = X`` / ``original_tag = X`` pin equal to ``tag``.
+
+    Mirrors the sole-pin shape validate_allowed_redundant_with_category
+    already reports, so callers can skip re-flagging it.
+    """
+    if not block:
+        return False
+    inner = block.strip()
+    if inner.startswith("{"):
+        inner = inner[1:]
+    if inner.endswith("}"):
+        inner = inner[:-1]
+    cleaned = re.sub(r"#[^\n]*", "", inner).strip()
+    pat = re.compile(r"^\s*(?:original_tag|tag)\s*=\s*" + re.escape(tag) + r"\s*$")
+    return bool(pat.match(cleaned))
+
+
+def _category_allowed_pins(categories: Dict[str, str]) -> Dict[str, set]:
+    """Return category name -> {(keyword, tag), ...} pinned by its flat,
+    depth-0 ``allowed`` block.
+
+    Categories with no ``allowed`` block are omitted; categories whose
+    ``allowed`` has no flat tag pin at all (e.g. a scripted trigger) map to
+    an empty set — both read as "no lock" to callers.
+    """
+    cat_pins: Dict[str, set] = {}
+    for cat_name, cat_code in categories.items():
+        am = re.search(r"\ballowed\s*=\s*\{", cat_code)
+        if not am:
+            continue
+        a_start = cat_code.find("{", am.start())
+        depth = 1
+        i = a_start + 1
+        while i < len(cat_code) and depth > 0:
+            if cat_code[i] == "{":
+                depth += 1
+            elif cat_code[i] == "}":
+                depth -= 1
+            i += 1
+        cat_pins[cat_name] = _flat_tag_pins_with_kind(cat_code[a_start:i])
+    return cat_pins
+
+
+def _scan_top_level(block: str):
+    """Iterate top-level tokens inside a block.
+
+    Yields (kind, payload) pairs where kind is 'tag' or 'scope' and payload
+    is the tag string. Tokens nested inside subblocks (OR/AND/NOT/if/
+    custom_trigger_tooltip/etc.) are skipped — those are conditional
+    context, not unconditional pins.
+    """
+    if not block:
+        return
+    inner = block.strip()
+    if inner.startswith("{"):
+        inner = inner[1:]
+    if inner.endswith("}"):
+        inner = inner[:-1]
+
+    depth = 0
+    i = 0
+    n = len(inner)
+    while i < n:
+        ch = inner[i]
+        if ch == "{":
+            depth += 1
+            i += 1
+            continue
+        if ch == "}":
+            depth -= 1
+            i += 1
+            continue
+        if ch == "#":
+            while i < n and inner[i] != "\n":
+                i += 1
+            continue
+        if depth == 0:
+            # An identifier-start char only counts if it begins on a
+            # word boundary (preceded by start-of-block or whitespace),
+            # otherwise we'd misread `has_cosmetic_tag = MAU` as a
+            # `tag = MAU` token.
+            if ch.isalpha() or ch == "_":
+                prev = inner[i - 1] if i > 0 else "\n"
+                if prev.isalnum() or prev == "_":
+                    i += 1
+                    continue
+                m = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*", inner[i:])
+                if m:
+                    ident = m.group(1)
+                    after = i + m.end()
+                    # `tag = X` / `original_tag = X` token
+                    if ident in ("tag", "original_tag"):
+                        tm = re.match(r"([A-Z][A-Z0-9_]{1,7})\b", inner[after:])
+                        if tm:
+                            yield ("tag", tm.group(1))
+                            i = after + tm.end()
+                            continue
+                    # `TAG = { ... }` self-scope (3-letter caps tag)
+                    if (
+                        re.match(r"^[A-Z][A-Z0-9_]{1,7}$", ident)
+                        and after < n
+                        and inner[after] == "{"
+                    ):
+                        yield ("scope", ident)
+                        # Don't consume the brace, let the outer loop dive in
+                        i = after
+                        continue
+                    # Skip past the entire identifier so we don't
+                    # re-scan its tail and falsely match nested tokens.
+                    i = after
+                    continue
+        i += 1
+
+
+def _find_category_redundant_rows(
+    factories: List["DecisionFactory"],
+    cat_pins: Dict[str, set],
+    cats_with_decs: Dict[str, List[str]],
+) -> List[str]:
+    """Pure detection: decision-level tag/original_tag re-checks already
+    covered by the parent category's single-tag lock.
+
+    Fills the gap between ``validate_redundant_tag_checks`` (decision's own
+    ``allowed`` pin vs its own ``visible``/``available``) and
+    ``validate_allowed_redundant_with_category`` (sole-content ``allowed``
+    duplicating the category pin): neither compares the *category* lock
+    against a decision's ``visible``/``available``, or against a partial
+    (multi-condition) ``allowed`` block.
+
+    Rules:
+    - Only single-tag category locks count: the category's ``allowed`` must
+      pin exactly one tag value at depth 0. A scripted-trigger ``allowed``
+      (no flat tag/original_tag token) or one pinning several different tags
+      yields no lock and is skipped.
+    - A category locked via ``original_tag = X`` only flags decision-level
+      ``original_tag = X`` re-checks. ``tag = X`` is a real narrowing (it
+      excludes civil-war split-offs the ``original_tag`` lock admits), so
+      it's left alone.
+    - A category locked via ``tag = X`` (with or without an accompanying
+      ``original_tag = X`` for the same tag) flags both ``tag = X`` and
+      ``original_tag = X`` re-checks — the category is already at least as
+      restrictive as either.
+    - ``allowed`` is skipped when its only content is the pin itself; that
+      exact shape is already reported by
+      ``validate_allowed_redundant_with_category``.
+    - Depth-0 only, via ``_flat_tag_pins_with_kind``: negations
+      (``NOT = {...}``), ``FROM``/``any_country``/``TAG = {}`` scopes are
+      auto-excluded. ``target_trigger``/``target_root_trigger`` are separate
+      factory fields and are not scanned.
+    """
+    token_to_cat: Dict[str, str] = {}
+    for cat, dec_tokens in cats_with_decs.items():
+        for tok in dec_tokens:
+            token_to_cat.setdefault(tok, cat)
+
+    results: List[str] = []
+    for d in factories:
+        cat_name = token_to_cat.get(d.token)
+        if cat_name is None:
+            continue
+        pins = cat_pins.get(cat_name)
+        if not pins:
+            continue
+        tag_values = {tg for _, tg in pins}
+        if len(tag_values) != 1:
+            continue
+        lock_tag = next(iter(tag_values))
+        keywords_used = {kw for kw, tg in pins if tg == lock_tag}
+        lock_kind = "tag" if "tag" in keywords_used else "original_tag"
+        flagged_kinds = (
+            {"tag", "original_tag"} if lock_kind == "tag" else {"original_tag"}
+        )
+
+        issues = []
+        for field_name, block in (
+            ("allowed", d.allowed),
+            ("available", d.available),
+            ("visible", d.visible),
+        ):
+            if not block:
+                continue
+            if field_name == "allowed" and _is_sole_flat_pin(block, lock_tag):
+                continue
+            hits = _flat_tag_pins_with_kind(block)
+            for kw in ("original_tag", "tag"):
+                if kw in flagged_kinds and (kw, lock_tag) in hits:
+                    issues.append(f"{field_name} re-checks {kw}")
+
+        if issues:
+            results.append(
+                f"{d.token:<55}{d.source_basename} "
+                f"(category locked to {lock_kind} = {lock_tag}: {', '.join(issues)})"
+            )
+
+    return results
 
 
 def extract_value_single_line(obj: str, s: str) -> str:
@@ -952,76 +1164,6 @@ class Validator(BaseValidator):
         factories = parse_all_decision_factories(self.mod_path)
         results = []
 
-        def _scan_top_level(block: str):
-            """Iterate top-level tokens inside a block.
-
-            Yields (kind, payload) pairs where kind is 'tag' or 'scope' and
-            payload is the tag string. Tokens nested inside subblocks
-            (OR/AND/NOT/if/custom_trigger_tooltip/etc.) are skipped — those are
-            conditional context, not unconditional pins.
-            """
-            if not block:
-                return
-            inner = block.strip()
-            if inner.startswith("{"):
-                inner = inner[1:]
-            if inner.endswith("}"):
-                inner = inner[:-1]
-
-            depth = 0
-            i = 0
-            n = len(inner)
-            while i < n:
-                ch = inner[i]
-                if ch == "{":
-                    depth += 1
-                    i += 1
-                    continue
-                if ch == "}":
-                    depth -= 1
-                    i += 1
-                    continue
-                if ch == "#":
-                    while i < n and inner[i] != "\n":
-                        i += 1
-                    continue
-                if depth == 0:
-                    # An identifier-start char only counts if it begins on a
-                    # word boundary (preceded by start-of-block or whitespace),
-                    # otherwise we'd misread `has_cosmetic_tag = MAU` as a
-                    # `tag = MAU` token.
-                    if ch.isalpha() or ch == "_":
-                        prev = inner[i - 1] if i > 0 else "\n"
-                        if prev.isalnum() or prev == "_":
-                            i += 1
-                            continue
-                        m = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*", inner[i:])
-                        if m:
-                            ident = m.group(1)
-                            after = i + m.end()
-                            # `tag = X` / `original_tag = X` token
-                            if ident in ("tag", "original_tag"):
-                                tm = re.match(r"([A-Z][A-Z0-9_]{1,7})\b", inner[after:])
-                                if tm:
-                                    yield ("tag", tm.group(1))
-                                    i = after + tm.end()
-                                    continue
-                            # `TAG = { ... }` self-scope (3-letter caps tag)
-                            if (
-                                re.match(r"^[A-Z][A-Z0-9_]{1,7}$", ident)
-                                and after < n
-                                and inner[after] == "{"
-                            ):
-                                yield ("scope", ident)
-                                # Don't consume the brace, let the outer loop dive in
-                                i = after
-                                continue
-                            # Skip past the entire identifier so we don't
-                            # re-scan its tail and falsely match nested tokens.
-                            i = after
-                            continue
-                i += 1
-
         def _has_top_level_tag_check(block: str, tag: str) -> bool:
             for kind, payload in _scan_top_level(block):
                 if kind == "tag" and payload == tag:
@@ -1109,23 +1251,7 @@ class Validator(BaseValidator):
         factories = parse_all_decision_factories(self.mod_path)
         categories = parse_decision_categories(self.mod_path)
         cats_with_decs = parse_categories_with_decisions(self.mod_path)
-
-        # Build category -> pinned tags
-        cat_pins = {}
-        for cat_name, cat_code in categories.items():
-            am = re.search(r"\ballowed\s*=\s*\{", cat_code)
-            if not am:
-                continue
-            a_start = cat_code.find("{", am.start())
-            depth = 1
-            i = a_start + 1
-            while i < len(cat_code) and depth > 0:
-                if cat_code[i] == "{":
-                    depth += 1
-                elif cat_code[i] == "}":
-                    depth -= 1
-                i += 1
-            cat_pins[cat_name] = _flat_tag_pins(cat_code[a_start:i])
+        cat_pins = _category_allowed_pins(categories)
 
         results = []
         for d in factories:
@@ -1136,16 +1262,7 @@ class Validator(BaseValidator):
                 continue
             pinned = next(iter(dec_pinned))
             # Verify allowed has ONLY this pin (no extra conditions)
-            inner = d.allowed.strip()
-            if inner.startswith("{"):
-                inner = inner[1:]
-            if inner.endswith("}"):
-                inner = inner[:-1]
-            cleaned = re.sub(r"#[^\n]*", "", inner).strip()
-            single_pin_pat = re.compile(
-                r"^\s*(?:original_tag|tag)\s*=\s*" + re.escape(pinned) + r"\s*$"
-            )
-            if not single_pin_pat.match(cleaned):
+            if not _is_sole_flat_pin(d.allowed, pinned):
                 continue
 
             # Find parent category
@@ -1156,13 +1273,37 @@ class Validator(BaseValidator):
                     break
             if cat_name not in cat_pins:
                 continue
-            if pinned in cat_pins[cat_name]:
+            cat_tag_values = {tg for _, tg in cat_pins[cat_name]}
+            if pinned in cat_tag_values:
                 results.append(f"{d.token:<55}{d.source_basename} ({pinned})")
 
         self._report(
             results,
             "✓ No decisions with allowed redundant with parent category",
             "Decisions with `allowed` redundant with parent category (remove the decision's allowed):",
+        )
+
+    def validate_tag_redundant_with_category(self):
+        """Flag decision-level tag/original_tag re-checks already covered by
+        the parent category's single-tag lock.
+
+        See ``_find_category_redundant_rows`` for the full rule set.
+        """
+        self._log_section(
+            "Checking decisions for tag re-checks redundant with category lock..."
+        )
+
+        factories = parse_all_decision_factories(self.mod_path)
+        categories = parse_decision_categories(self.mod_path)
+        cats_with_decs = parse_categories_with_decisions(self.mod_path)
+        cat_pins = _category_allowed_pins(categories)
+
+        results = _find_category_redundant_rows(factories, cat_pins, cats_with_decs)
+
+        self._report(
+            results,
+            "✓ No decisions with tag checks redundant with category lock",
+            "Decisions with tag/original_tag re-checks redundant with the parent category's lock (remove the re-check):",
         )
 
     def validate_pp_charge_in_effect(self):
@@ -1800,6 +1941,7 @@ class Validator(BaseValidator):
         self.validate_random_list_seed()
         self.validate_redundant_tag_checks()
         self.validate_allowed_redundant_with_category()
+        self.validate_tag_redundant_with_category()
         self.validate_pp_charge_in_effect()
         self.validate_visible_equals_available()
         self.validate_bare_trigger_names()

--- a/tools/validation/validate_focus_tree.py
+++ b/tools/validation/validate_focus_tree.py
@@ -54,6 +54,13 @@ _REWARD_BLOCK_RE = re.compile(
 _TECH_BONUS_START = re.compile(r"\badd_tech_bonus\s*=\s*\{")
 _NAME_LINE_RE = re.compile(r"\bname\s*=\s*(\S+)")
 
+# PP malus in completion_reward (focus time is the cost — AGENTS.md).
+# Occurrences inside an effect_tooltip = { } subtree preview a PP change
+# applied elsewhere (e.g. a select_effect) rather than executing it, so
+# they are not flagged.
+_EFFECT_TOOLTIP_START = re.compile(r"\beffect_tooltip\s*=\s*\{")
+_PP_MALUS_RE = re.compile(r"\badd_political_power\s*=\s*(-\d+(?:\.\d+)?)\b")
+
 # ai_will_do staffing/bankruptcy guards (issue #2233 + the AGENTS.md
 # convention). Building type -> the scripted trigger
 # (common/scripted_triggers/00_economic_triggers.txt) that an ai_will_do
@@ -587,6 +594,73 @@ def _extract_cross_country_fires(args: Tuple[str, str]) -> List[Dict]:
 
     return disk_cache.per_file_cached_by_content(
         mod_path, "focus_tree.cross_country_tt.v1", filepath, text, _compute
+    )
+
+
+def _extract_pp_malus(args: Tuple[str, str]) -> List[Tuple[str, str, int]]:
+    """Pool worker: return (focus_id, filepath, line) for each negative,
+    literal add_political_power inside a focus's completion_reward.
+
+    Occurrences inside an effect_tooltip = { } subtree are skipped — those
+    preview a PP change applied elsewhere (e.g. a select_effect) rather
+    than executing the malus.
+    """
+    filepath, mod_path = args
+    try:
+        with open(filepath, "r", encoding="utf-8-sig", errors="replace") as fh:
+            raw = fh.read()
+    except Exception:
+        return []
+    text = strip_comments(raw)
+
+    def _compute() -> List[Tuple[str, str, int]]:
+        out: List[Tuple[str, str, int]] = []
+        pos = 0
+        while True:
+            fm = _FOCUS_BLOCK_START.search(text, pos)
+            if not fm:
+                break
+            fbody, fend = _extract_block(text, fm.start())
+            if not fbody:
+                pos = fm.end()
+                continue
+            idm = _ID_LINE_RE.search(fbody)
+            focus_id = idm.group(1) if idm else "?"
+
+            rpos = fm.start()
+            while True:
+                rm = _REWARD_BLOCK_RE.search(text, rpos, fend)
+                if not rm:
+                    break
+                rbody, rend = _extract_block(text, rm.start())
+                if not rbody or rend > fend:
+                    rpos = rm.end()
+                    continue
+
+                tooltip_spans: List[Tuple[int, int]] = []
+                tpos = rm.start()
+                while True:
+                    tm = _EFFECT_TOOLTIP_START.search(text, tpos, rend)
+                    if not tm:
+                        break
+                    tbody, tend = _extract_block(text, tm.start())
+                    if not tbody or tend > rend:
+                        tpos = tm.end()
+                        continue
+                    tooltip_spans.append((tm.start(), tend))
+                    tpos = tend
+
+                for pm in _PP_MALUS_RE.finditer(text, rm.start(), rend):
+                    if any(s <= pm.start() < e for s, e in tooltip_spans):
+                        continue
+                    out.append((focus_id, filepath, _line_of(text, pm.start())))
+
+                rpos = rend
+            pos = fend
+        return out
+
+    return disk_cache.per_file_cached_by_content(
+        mod_path, "focus_tree.pp_malus", filepath, text, _compute
     )
 
 
@@ -1272,6 +1346,47 @@ class Validator(BaseValidator):
             category="missing-cross-country-tooltip",
         )
 
+    def validate_pp_malus_in_rewards(self):
+        """Flag a literal PP loss (add_political_power = -N) inside a focus's
+        completion_reward.
+
+        Focus time is the cost (AGENTS.md) — a PP malus on completion is a
+        balance choice needing per-site judgment, so this reports at WARNING
+        only. Scope is the literal-negative-number pattern: variable forms
+        and timed lose-PP ideas are not detected. effect_tooltip previews of
+        a PP change applied elsewhere (e.g. via select_effect) are skipped.
+        """
+        self._log_section("Checking for PP malus in focus completion_reward...")
+
+        files = self._collect_files(["common/national_focus/*.txt"], ignore_staged=True)
+        data_lists = self._pool_map(
+            _extract_pp_malus, [(f, self.mod_path) for f in files], chunksize=10
+        )
+
+        results = []
+        for sub in data_lists:
+            for focus_id, fp, line in sub:
+                if not self._is_reportable(fp):
+                    continue
+                rel = os.path.relpath(fp, self.mod_path)
+                results.append(
+                    (
+                        f"Focus '{focus_id}' completion_reward applies a PP"
+                        " malus (negative add_political_power) — focus time"
+                        " is the cost; verify this is intended",
+                        rel,
+                        line,
+                    )
+                )
+
+        self._report(
+            results,
+            "No PP malus found in focus completion_reward blocks",
+            "Focuses applying a PP malus in completion_reward (balance-sensitive — verify intent):",
+            Severity.WARNING,
+            category="pp-malus-completion-reward",
+        )
+
     # -----------------------------------------------------------------------
     # Check 6: Dependency cycles
     # -----------------------------------------------------------------------
@@ -1407,6 +1522,7 @@ class Validator(BaseValidator):
         self.validate_tech_bonus_names()
         self.validate_ai_will_do_guards()
         self.validate_cross_country_event_tooltips()
+        self.validate_pp_malus_in_rewards()
 
         if self.missing_icons:
             self.validate_focus_icons()

--- a/tools/validation/validate_history.py
+++ b/tools/validation/validate_history.py
@@ -54,6 +54,16 @@ _SP_REQUIRED_RE = re.compile(r"is_special_project_completed\s*=\s*sp:([a-zA-Z0-9
 _CUSTOM_TOOLTIP_RE = re.compile(r"\bcustom_effect_tooltip\s*=\s*\{")
 _SP_UNLOCK_TECH_KEY_RE = re.compile(r"localization_key\s*=\s*SP_UNLOCK_TECH\b")
 _TECH_PARAM_RE = re.compile(r"\bTECH\s*=\s*([a-zA-Z0-9_]+)")
+# Direct scalar building entries inside a state's `buildings = { ... }` block
+# (e.g. `nuclear_reactor = 2`). Province-keyed sub-blocks like
+# `6050 = { naval_base = 5 }` are excluded by brace depth in the caller.
+_BUILDINGS_BLOCK_RE = re.compile(r"^buildings\s*=\s*\{")
+_BUILDING_LEVEL_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(\d+)\s*$")
+# `nuclear_status = { ... }` idea-group wrapper (nested under `ideas = { }`),
+# and a project's `set_building_level = { type = X ... }` reward grant.
+_NUCLEAR_STATUS_GROUP_RE = re.compile(r"(?m)^\s*nuclear_status\s*=\s*\{")
+_SET_BUILDING_LEVEL_RE = re.compile(r"set_building_level\s*=\s*\{")
+_BUILDING_TYPE_RE = re.compile(r"\btype\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)")
 
 
 def parse_tech_dependencies(mod_path: str) -> Tuple[Dict, Set, Dict, Dict]:
@@ -347,6 +357,266 @@ def parse_sp_output_claims(mod_path: str) -> Dict[str, List[str]]:
                     claims[name].append(tp.group(1))
 
     return dict(claims)
+
+
+def parse_nuclear_status_ideas(mod_path: str) -> Set[str]:
+    """Derive the non-default member ideas of the `nuclear_status` idea group
+    from common/ideas/*.txt.
+
+    Finds the `nuclear_status = { ... }` group (nested under the outer
+    `ideas = { ... }` wrapper) and brace-matches its body, walking it one
+    nesting level at a time (mirrors the tech-block walk in
+    `parse_tech_sp_requirements`) so only direct-child ideas are collected,
+    not nested `available`/`modifier` sub-blocks. Ideas marked `default = yes`
+    are excluded — the default state is granted to every country and is never
+    a signal that one has gone nuclear. Returns an empty set when the group is
+    not found; callers must skip the check then, not treat every country as
+    non-compliant.
+    """
+    ideas_dir = os.path.join(mod_path, "common", "ideas")
+    for filepath in glob.iglob(os.path.join(ideas_dir, "*.txt")):
+        try:
+            with open(filepath, "r", encoding="utf-8-sig") as f:
+                content = f.read()
+        except Exception:
+            continue
+        content = strip_comments(content)
+
+        m = _NUCLEAR_STATUS_GROUP_RE.search(content)
+        if not m:
+            continue
+        end = _match_brace_end(content, m.end())
+        body = content[m.end() : end - 1]
+
+        members: Set[str] = set()
+        i, n = 0, len(body)
+        depth = 0
+        while i < n:
+            ch = body[i]
+            if ch == "{":
+                depth += 1
+                i += 1
+                continue
+            if ch == "}":
+                depth -= 1
+                i += 1
+                continue
+            if ch in " \t\n":
+                i += 1
+                continue
+            line_end = body.find("\n", i)
+            if line_end < 0:
+                line_end = n
+            line = body[i:line_end].strip()
+            member_m = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*\{", line)
+            if member_m and depth == 0:
+                name = member_m.group(1)
+                block_start = i + member_m.end()
+                block_end = _match_brace_end(body, block_start)
+                block_body = body[block_start : block_end - 1]
+                if not re.search(r"\bdefault\s*=\s*yes\b", block_body):
+                    members.add(name)
+                i = block_end
+                continue
+            i = line_end + 1 if line_end < n else n
+        return members
+
+    return set()
+
+
+def parse_state_building_owners(
+    mod_path: str, buildings: Set[str]
+) -> Dict[str, Set[str]]:
+    """One pass over history/states/*.txt mapping each building in *buildings*
+    to the set of tags that start a state with it at level >= 1.
+
+    Owner is the first `owner = TAG` line in the file. Buildings are only
+    recognized in scalar form (`nuclear_reactor = 2`) at the top level of the
+    `buildings = { ... }` block; province-keyed sub-blocks (`6050 = {
+    naval_base = 5 }`) are skipped by brace depth so a same-named building
+    nested under a province is never attributed to the state's owner. Shared
+    by the reactor/nuclear_status check and the project-granted-building
+    check — the state-file tree is parsed once, not once per check.
+    """
+    owners: Dict[str, Set[str]] = defaultdict(set)
+    states_dir = os.path.join(mod_path, "history", "states")
+
+    for filepath in glob.iglob(os.path.join(states_dir, "*.txt")):
+        try:
+            with open(filepath, "r", encoding="utf-8-sig") as f:
+                content = f.read()
+        except Exception:
+            continue
+        content = strip_comments(content)
+
+        owner: Optional[str] = None
+        in_buildings = False
+        depth = 0
+        found: Set[str] = set()
+
+        for line in content.split("\n"):
+            stripped = line.strip()
+            if owner is None:
+                om = _STATE_OWNER_RE.match(line)
+                if om:
+                    owner = om.group(1)
+
+            if not in_buildings:
+                if _BUILDINGS_BLOCK_RE.match(stripped):
+                    in_buildings = True
+                    depth = 1
+                continue
+
+            if depth == 1:
+                bm = _BUILDING_LEVEL_RE.match(stripped)
+                if bm and bm.group(1) in buildings and int(bm.group(2)) >= 1:
+                    found.add(bm.group(1))
+
+            depth += stripped.count("{") - stripped.count("}")
+            if depth <= 0:
+                in_buildings = False
+
+        if owner:
+            for b in found:
+                owners[b].add(owner)
+
+    return dict(owners)
+
+
+def parse_project_granted_buildings(mod_path: str) -> Dict[str, Set[str]]:
+    """Map each building type to the special project(s) whose reward grants it.
+
+    Scans common/special_projects/projects/*.txt for top-level project
+    definitions containing `set_building_level = { type = X ... }` anywhere in
+    the body (typically inside `project_output.facility_state_effects`).
+    Returned map is building -> {granting project name, ...}; a building can
+    be granted by more than one project, and completing any one satisfies the
+    history check.
+    """
+    projects_dir = os.path.join(mod_path, "common", "special_projects", "projects")
+    granted: Dict[str, Set[str]] = defaultdict(set)
+
+    for filepath in glob.iglob(os.path.join(projects_dir, "*.txt")):
+        try:
+            with open(filepath, "r", encoding="utf-8-sig") as f:
+                content = f.read()
+        except Exception:
+            continue
+        content = strip_comments(content)
+
+        for m in re.finditer(r"(?m)^([a-zA-Z0-9_]+)\s*=\s*\{", content):
+            name = m.group(1)
+            end = _match_brace_end(content, m.end())
+            block = content[m.end() : end]
+            for sbl in _SET_BUILDING_LEVEL_RE.finditer(block):
+                sbl_end = _match_brace_end(block, sbl.end())
+                body = block[sbl.end() : sbl_end - 1]
+                tm = _BUILDING_TYPE_RE.search(body)
+                if tm:
+                    granted[tm.group(1)].add(name)
+
+    return dict(granted)
+
+
+def _tag_country_file_map(mod_path: str) -> Dict[str, str]:
+    """Map each country tag to its history/countries/ file path, derived from
+    the `TAG - Name.txt` filename convention (same convention used inline in
+    `validate_oob_references`)."""
+    countries_dir = os.path.join(mod_path, "history", "countries")
+    mapping: Dict[str, str] = {}
+    for filepath in glob.iglob(os.path.join(countries_dir, "*.txt")):
+        filename = os.path.basename(filepath)
+        tag = (
+            filename.split(" - ")[0]
+            if " - " in filename
+            else os.path.splitext(filename)[0]
+        )
+        mapping[tag] = filepath
+    return mapping
+
+
+def _load_country_contents(tag_files: Dict[str, str], tags: Set[str]) -> Dict[str, str]:
+    """Read and comment-strip each tag's history/countries/ file, for exactly
+    the tags that need checking. Shared by both building-ownership checks so a
+    tag relevant to both is only read once."""
+    content: Dict[str, str] = {}
+    for tag in tags:
+        filepath = tag_files.get(tag)
+        if not filepath:
+            continue
+        try:
+            with open(filepath, "r", encoding="utf-8-sig") as f:
+                content[tag] = strip_comments(f.read())
+        except Exception:
+            continue
+    return content
+
+
+def _find_reactor_owners_without_nuclear_status(
+    reactor_owners: Set[str],
+    nuclear_status_ideas: Set[str],
+    tag_country_content: Dict[str, str],
+) -> List[str]:
+    """Validate that each tag owning a state with `nuclear_reactor >= 1` at
+    game start grants at least one non-default nuclear_status idea in its
+    country file (word-boundary token match on comment-stripped content).
+    Returns error strings. A tag absent from `tag_country_content` has no
+    country file.
+    """
+    results = []
+    for tag in sorted(reactor_owners):
+        content = tag_country_content.get(tag)
+        if content is None:
+            results.append(
+                f"{tag}: owns a state with a nuclear_reactor at game start "
+                f"but has no history/countries/ file"
+            )
+            continue
+        if not any(
+            re.search(rf"\b{re.escape(idea)}\b", content)
+            for idea in nuclear_status_ideas
+        ):
+            ideas_str = ", ".join(sorted(nuclear_status_ideas))
+            results.append(
+                f"{tag}: owns a state with a nuclear_reactor at game start "
+                f"but grants no nuclear_status idea ({ideas_str})"
+            )
+    return results
+
+
+def _find_buildings_without_granting_project(
+    building_owners: Dict[str, Set[str]],
+    project_granted_buildings: Dict[str, Set[str]],
+    tag_country_content: Dict[str, str],
+) -> List[str]:
+    """Validate that each tag owning a project-granted building at game start
+    completes at least one granting project in its country file. Returns error
+    strings. A tag absent from `tag_country_content` has no country file.
+    """
+    results = []
+    for building in sorted(project_granted_buildings):
+        owners = building_owners.get(building, set())
+        granting_projects = project_granted_buildings[building]
+        for tag in sorted(owners):
+            content = tag_country_content.get(tag)
+            if content is None:
+                results.append(
+                    f"{tag}: owns a state starting with {building} but has "
+                    f"no history/countries/ file"
+                )
+                continue
+            if not any(
+                re.search(
+                    rf"complete_special_project\s*=\s*sp:{re.escape(p)}\b", content
+                )
+                for p in granting_projects
+            ):
+                projects_str = ", ".join(f"sp:{p}" for p in sorted(granting_projects))
+                results.append(
+                    f"{tag}: owns a state starting with {building} but never "
+                    f"completes the granting special project ({projects_str})"
+                )
+    return results
 
 
 def validate_sp_output_consistency(
@@ -1140,6 +1410,10 @@ class Validator(BaseValidator):
         self.sp_allowed_dlc = {}
         self.sp_always_yes = set()
         self.sp_output_claims = {}
+        self.project_granted_buildings = {}
+        self.nuclear_status_ideas = set()
+        self.building_owners = {}
+        self.tag_country_contents = {}
 
     def _build_tech_graph(self):
         """Build the technology dependency graph from tech definition files."""
@@ -1173,6 +1447,38 @@ class Validator(BaseValidator):
         self.log(
             f"  Found {len(self.tech_sp_reqs)} technologies requiring special projects"
         )
+
+    def _build_building_ownership(self):
+        """Parse the special-project building-grant map and the nuclear_status
+        idea group, then do the single state-file building-ownership pass
+        shared by the two building checks."""
+        self._log_section("Building state building-ownership maps...")
+
+        self.project_granted_buildings = parse_project_granted_buildings(self.mod_path)
+        self.nuclear_status_ideas = parse_nuclear_status_ideas(self.mod_path)
+        tag_country_files = _tag_country_file_map(self.mod_path)
+
+        buildings_of_interest = {"nuclear_reactor"} | set(
+            self.project_granted_buildings
+        )
+        self.building_owners = parse_state_building_owners(
+            self.mod_path, buildings_of_interest
+        )
+
+        owner_tags: Set[str] = set()
+        for building in buildings_of_interest:
+            owner_tags |= self.building_owners.get(building, set())
+        self.tag_country_contents = _load_country_contents(
+            tag_country_files, owner_tags
+        )
+
+        self.log(
+            f"  Found {len(self.project_granted_buildings)} project-granted building types"
+        )
+        self.log(
+            f"  Found {len(self.nuclear_status_ideas)} non-default nuclear_status ideas"
+        )
+        self.log(f"  Found {len(owner_tags)} tags owning a tracked building")
 
     def _get_history_files(self) -> List[str]:
         """Get list of history country files to validate."""
@@ -1333,6 +1639,53 @@ class Validator(BaseValidator):
             "History files missing a capital definition:",
         )
 
+    def validate_reactor_nuclear_status(self):
+        """Validate that every tag owning a nuclear_reactor at game start
+        grants a non-default nuclear_status idea in its country file."""
+        self._log_section(
+            "Checking nuclear-reactor owners for a nuclear_status idea..."
+        )
+        if not self.nuclear_status_ideas:
+            self.log(
+                "  Note: no non-default nuclear_status idea found in "
+                "common/ideas/*.txt; skipping check"
+            )
+            return
+
+        reactor_owners = self.building_owners.get("nuclear_reactor", set())
+        results = _find_reactor_owners_without_nuclear_status(
+            reactor_owners, self.nuclear_status_ideas, self.tag_country_contents
+        )
+        self._report(
+            results,
+            "✓ All nuclear-reactor owners grant a nuclear_status idea",
+            "Nuclear-reactor owners missing a nuclear_status idea:",
+        )
+
+    def validate_project_granted_buildings(self):
+        """Validate that every tag owning a project-granted building at game
+        start completes the granting special project in its country file."""
+        self._log_section(
+            "Checking project-granted buildings for the granting special project..."
+        )
+        if not self.project_granted_buildings:
+            self.log(
+                "  Note: no set_building_level grants found in "
+                "common/special_projects/projects/*.txt; skipping check"
+            )
+            return
+
+        results = _find_buildings_without_granting_project(
+            self.building_owners,
+            self.project_granted_buildings,
+            self.tag_country_contents,
+        )
+        self._report(
+            results,
+            "✓ All project-granted buildings are paired with the granting special project",
+            "States starting with a project-granted building whose owner never completes the project:",
+        )
+
     def run_validations(self):
         self._build_tech_graph()
         self.validate_tech_dependencies()
@@ -1343,6 +1696,9 @@ class Validator(BaseValidator):
         self.validate_sp_output_consistency()
         self.validate_oob_references()
         self.validate_capital_defined()
+        self._build_building_ownership()
+        self.validate_reactor_nuclear_status()
+        self.validate_project_granted_buildings()
 
 
 if __name__ == "__main__":

--- a/tools/validation/validate_simplifications.py
+++ b/tools/validation/validate_simplifications.py
@@ -51,6 +51,13 @@ _SCAN_PATTERNS = [
     "events/**/*.txt",
 ]
 
+# The bare multi-child NOT check scans every trigger-bearing script file, not
+# just the effect-heavy dirs above (history/ carries no bare multi-child NOTs).
+_NOT_SCAN_PATTERNS = [
+    "common/**/*.txt",
+    "events/**/*.txt",
+]
+
 # Matches `HEADER = {`. The header charset covers tags, state ids, magic scopes,
 # and variable/target scopes (var:x, event_target:y, global.event_target:z^0).
 _OPEN_RE = re.compile(r"([\w.:^@\[\]-]+)\s*=\s*\{")
@@ -398,6 +405,67 @@ def _find_government_match(text: str):
     return results
 
 
+# Bare multi-child NOT is ambiguous: the project doc reads it as NAND, cwtools
+# as NOR (see AGENTS.md "NOT blocks and NOR"). A single child — one trigger or
+# one explicit AND/OR wrapper — is unambiguous and never flagged.
+_NOT_RE = re.compile(r"\bNOT\s*=\s*\{")
+_CHILD_KEY_RE = re.compile(r"[\w.:^@\[\]-]+\s*(?:>=|<=|=|>|<)\s*")
+_VALUE_RE = re.compile(r"\S+")
+
+
+def _count_children(body: str) -> int:
+    """Count direct depth-1 constructs in a block body: a `key = { ... }`
+    block (however large) and a bare `key = value` scalar each count as one
+    child. Stops counting on anything unparseable, so malformed input
+    undercounts rather than false-flagging."""
+    count = 0
+    pos = 0
+    n = len(body)
+    while pos < n:
+        while pos < n and body[pos].isspace():
+            pos += 1
+        if pos >= n:
+            break
+        m = _CHILD_KEY_RE.match(body, pos)
+        if not m:
+            break
+        count += 1
+        pos = m.end()
+        if pos < n and body[pos] == "{":
+            _, end = extract_block_from_text(body, pos)
+            if end == -1:
+                break
+            pos = end
+        elif pos < n and body[pos] == '"':
+            close = body.find('"', pos + 1)
+            if close == -1:
+                break
+            pos = close + 1
+        else:
+            vm = _VALUE_RE.match(body, pos)
+            if not vm:
+                break
+            pos = vm.end()
+    return count
+
+
+def _find_bare_not(text: str):
+    """Return (line, child_count) for each `NOT = { ... }` with 2+ direct
+    children. A single child — a lone trigger or an explicit AND/OR wrapper —
+    is unambiguous and not flagged. finditer walks the whole file, so a NOT
+    nested inside another block (OR, if, a second NOT) is found independently
+    of its container."""
+    results = []
+    for m in _NOT_RE.finditer(text):
+        body, end = extract_block_from_text(text, m.end() - 1)
+        if end == -1:
+            continue
+        count = _count_children(body)
+        if count >= 2:
+            results.append((text.count("\n", 0, m.start()) + 1, count))
+    return results
+
+
 def _is_magic_chain(header: str) -> bool:
     return all(part in _MAGIC for part in header.split("."))
 
@@ -503,6 +571,24 @@ def _scan_file(text: str, path: str):
     return findings
 
 
+def _scan_bare_not(text: str, path: str):
+    """Return [(message, line)] for the bare multi-child NOT check. Separate
+    from _scan_file: NOT lives in trigger contexts across all of common/ (the
+    founding bug was in an ai_strategy allowed block), so this check scans
+    wider than the effect-bearing files the other detectors target."""
+    findings = []
+    for line, count in _find_bare_not(text):
+        findings.append(
+            (
+                f"NOT with {count} children is ambiguous (semantics disputed "
+                "NAND vs NOR); write `NOT = { OR = { ... } }` or one NOT "
+                "per trigger",
+                line,
+            )
+        )
+    return findings
+
+
 class Validator(BaseValidator):
     TITLE = "SIMPLIFICATION SUGGESTIONS"
     STAGED_EXTENSIONS = [".txt"]
@@ -516,13 +602,18 @@ class Validator(BaseValidator):
             _SCAN_PATTERNS, "simplifications.scan", _scan_file
         )
         self.log(f"Scanned {len(parsed)} files for simplification opportunities")
+        parsed_not = self.parse_files_cached(
+            _NOT_SCAN_PATTERNS, "simplifications.bare_not", _scan_bare_not
+        )
+        self.log(f"Scanned {len(parsed_not)} files for bare multi-child NOT")
 
         self._log_section("Collecting and reporting results...")
         results = []
-        for path, findings in parsed.items():
-            rel = os.path.relpath(path, self.mod_path)
-            for message, line in findings:
-                results.append((message, rel, line))
+        for parsed_map in (parsed, parsed_not):
+            for path, findings in parsed_map.items():
+                rel = os.path.relpath(path, self.mod_path)
+                for message, line in findings:
+                    results.append((message, rel, line))
 
         self._report(
             results,


### PR DESCRIPTION
### Summary

#### Validation

- **Nuclear status check.** Nations starting with nuclear reactors must hold a non-default `nuclear_status` idea; the idea set is derived from the idea group so future tiers are covered automatically.
- **Special project check.** States starting with a project-granted building (`enrichment_facility`, `microchip_plant`, `composite_plant`) require the owner to complete the granting special project; the building-to-project map is read from `common/special_projects/projects/`.
- **Log-ID check.** `log` strings in focuses, decisions, and event options must cite the enclosing ID, with suppression when a reward completes the logged focus. New `tools/linting/fix_log_ids.py` rewrites mismatched IDs in place.
- **Redundant tag check.** Decisions inside a tag-locked category no longer re-check the category's `original_tag`; `tag = X` re-checks under an `original_tag` lock are kept since they still exclude civil-war split-offs.
- **hidden_trigger check.** `hidden_trigger` directly inside `custom_trigger_tooltip` is redundant and now errors.
- **Warning-level checks.** Bare multi-child `NOT` blocks (validate_simplifications) and negative political power in focus completion rewards (validate_focus_tree). Both non-gating; the legacy backlogs surface in reports only.

#### Bug Fixes

- **Always-true NOT blocks.** 41 `NOT` blocks with multiple `has_government` values in French chaos-path decisions and Central Asian focuses never filtered anything; wrapped in `OR` so they exclude the listed governments as intended.
- **Sweden microchip plant.** SWE starts with a `microchip_plant` but never completed `sp_microchip_production`; the project is now completed at start.
- **Event copy-paste bugs.** Fixed 13 event options logging the wrong event or option; `indonesia.888.a` had the typo in the option `name` field itself, which pointed the button at the wrong localisation key.
- **Log-ID sweep.** Rewrote roughly 1030 wrong focus and decision log IDs across 97 files (debug strings only, no behavior change) and removed 4 log-only `complete_effect` blocks.
- **Liechtenstein war hints.** `LIC_path_of_conquest` and `LIC_claim_the_HRE` declare war without `will_lead_to_war_with`; added the full target lists.
- **Cleanup.** Removed 23 redundant category tag re-checks (GER, SOV, RAJ, SER, ROM) and unwrapped all 14 legacy `hidden_trigger` sites.

#### Performance

- **Poland bloc loops.** Converted 4 `every_other_country` loops in poland.txt to `for_each_scope_loop` over the EU, NATO, and CSTO membership arrays.