### PR TITLE
Surface Decision Unlocks in Focus Tooltips

### DIFF
--- a/common/decisions/05_CHI_decisions.txt
+++ b/common/decisions/05_CHI_decisions.txt
@@ -5683,6 +5683,7 @@ CHI_south_china_sea_category = {
 			add_resource = { type = oil amount = 4 state = 526 }
 			add_resource = { type = oil amount = 4 state = 943 }
 			set_country_flag = CHI_scs_jdz_signed_PHI
+			unlock_decision_tooltip = CHI_scs_infrastructure_loan_PHI
 			if = {
 				limit = { NOT = { has_country_flag = CHI_scs_first_jdz_signed } }
 				set_country_flag = CHI_scs_first_jdz_signed

--- a/common/decisions/05_comoros_decisions.txt
+++ b/common/decisions/05_comoros_decisions.txt
@@ -32,7 +32,6 @@ COM_comorian_political_decisions = {
 			has_completed_focus = COM_african_mercenaries
 		}
 		available = {
-			has_completed_focus = COM_african_mercenaries
 			NOT = { has_country_flag = COM_disbanded_presidential_guard }
 		}
 
@@ -58,7 +57,6 @@ COM_comorian_political_decisions = {
 			has_completed_focus = COM_african_mercenaries
 		}
 		available = {
-			has_completed_focus = COM_african_mercenaries
 			NOT = { has_country_flag = COM_disbanded_presidential_guard }
 		}
 
@@ -85,7 +83,6 @@ COM_comorian_political_decisions = {
 			has_completed_focus = COM_african_mercenaries
 		}
 		available = {
-			has_completed_focus = COM_african_mercenaries
 			NOT = { has_country_flag = COM_disbanded_presidential_guard }
 		}
 
@@ -112,7 +109,6 @@ COM_comorian_political_decisions = {
 			has_completed_focus = COM_african_mercenaries
 		}
 		available = {
-			has_completed_focus = COM_african_mercenaries
 			NOT = { has_country_flag = COM_disbanded_presidential_guard }
 		}
 
@@ -142,7 +138,6 @@ COM_comorian_political_decisions = {
 			has_country_leader = { name = "Robert Denard" ruling_only = yes }
 		}
 		available = {
-			has_completed_focus = COM_african_mercenaries
 			NOT = { has_country_flag = COM_disbanded_presidential_guard }
 			NOT = { has_country_flag = COM_reformed_7_independent }
 		}

--- a/common/national_focus/05_abkhazia.txt
+++ b/common/national_focus/05_abkhazia.txt
@@ -29,6 +29,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_Corruption_economic"
+			unlock_decision_category_tooltip = ABK_political_decisions
 			add_ideas = political_power_bonus
 			increase_corruption = yes
 			set_temp_variable = { percent_change = 15 }
@@ -597,6 +598,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_president_illness2"
+			unlock_decision_tooltip = ABK_fight_narco
 			create_country_leader = {
 				name = "Lew Shamba"
 				picture = "Lew_shamba.dds"
@@ -1649,6 +1651,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_president_illness3"
+			unlock_decision_tooltip = ABK_fight_narco
 			hidden_effect = {
 				set_cosmetic_tag = ABK_AUTH
 				clr_country_flag = dynamic_flag
@@ -2654,6 +2657,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ABK_president_illness"
+			unlock_decision_tooltip = ABK_fight_narco
 			create_country_leader = {
 				name = "Sergei Bagapsh"
 				picture = "Sergei_Bagapsh.dds"

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -6675,6 +6675,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AFG_Second_Man_of_the_State"
+			unlock_decision_tooltip = AFG_atta_installs_leadership
 			AFG_National_Assembly_Checks = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = AFG_National_Assembly }
 			add_to_variable = { AFG_Assembly_political_power_gain = 0.05 tooltip = political_power_gain_tt }

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -1740,6 +1740,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_national_reconciliation"
+			unlock_decision_category_tooltip = ALG_reconciliation_path_category
 			add_political_power = 250
 			add_stability = 0.01
 			add_ideas = ALG_black_decade_lesson_idea
@@ -2482,6 +2483,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_resist_le_pouvoir"
+			unlock_decision_category_tooltip = ALG_resistance_power_struggle
 			set_variable = {
 				var = ALG_people_grievance
 				value = 1

--- a/common/national_focus/05_armenia.txt
+++ b/common/national_focus/05_armenia.txt
@@ -2803,6 +2803,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_reindustr_country executed"
+			unlock_decision_tooltip = ARM_develop_infrusture
+			unlock_decision_tooltip = ARM_build_house
+			unlock_decision_tooltip = ARM_build_factory
 			custom_effect_tooltip = ARM_forced_industrialisation_unlock_tt
 			add_power_balance_value = {
 				id = ARM_soc_pac_bop
@@ -4631,6 +4634,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_lebanon_coup executed"
+			unlock_decision_tooltip = ARM_foreign_legion_help_lebanon
+			unlock_decision_tooltip = ARM_promotion_of_interest_armenia_in_lebanon
+			unlock_decision_tooltip = ARM_lebanon_reclamation
 			custom_effect_tooltip = {
 				localization_key = UNLOCK_DECISION_IN_CATEGORY
 				DECISION = ARM_lebanon_reclamation
@@ -5103,6 +5109,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_pkk_negotiat executed"
+			unlock_decision_tooltip = ARM_pkk_revoult
 			if = {
 				limit = {
 					country_exists = PKK
@@ -7921,6 +7928,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_supporting_chechens executed"
+			unlock_decision_tooltip = ARM_chechnya_weapons
+			unlock_decision_tooltip = ARM_chechnya_revoult_sub
 			custom_effect_tooltip = {
 				localization_key = UNLOCK_DECISION_IN_CATEGORY
 				DECISION = ARM_chechnya_revoult_sub
@@ -8080,6 +8089,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_polish_hung_dilem executed"
+			unlock_decision_tooltip = USR_arm_ask_help_poland
+			unlock_decision_tooltip = ARM_foreign_legion_help_poland
+			unlock_decision_tooltip = ARM_promotion_of_interest_armenia_in_poland
+			unlock_decision_tooltip = ARM_polish_reclamation
 			custom_effect_tooltip = {
 				localization_key = UNLOCK_DECISION_IN_CATEGORY
 				DECISION = ARM_polish_reclamation
@@ -8123,6 +8136,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_fate_of_italy executed"
+			unlock_decision_tooltip = USR_arm_ask_help_italy
+			unlock_decision_tooltip = ARM_foreign_legion_help_italy
+			unlock_decision_tooltip = ARM_italy_reclamation
 			custom_effect_tooltip = ARM_italy_armenian_union
 			custom_effect_tooltip = {
 				localization_key = UNLOCK_DECISION_IN_CATEGORY
@@ -8230,6 +8246,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_support_ossetia executed"
+			unlock_decision_tooltip = ARM_ossetia_revoult
+			unlock_decision_tooltip = ARM_ossetia_weapons
 			custom_effect_tooltip = {
 				localization_key = UNLOCK_DECISION_IN_CATEGORY
 				DECISION = ARM_ossetia_revoult
@@ -8349,6 +8367,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_liberating_levant executed"
+			unlock_decision_tooltip = ARM_new_crusade_israel
+			unlock_decision_tooltip = ARM_new_crusade_hazbik
+			unlock_decision_tooltip = ARM_new_crusade_palestine
 			hidden_effect = {
 				203 = { add_claim_by = ARM }
 				553 = { add_claim_by = ARM }
@@ -8992,6 +9013,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ARM_intern_cooperat"
+			unlock_decision_tooltip = ARM_coop_west
+			unlock_decision_tooltip = ARM_coop_east
 			custom_effect_tooltip = coop_shit_unlock_tt
 		}
 
@@ -11108,6 +11131,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_economy_shady executed"
+			unlock_decision_tooltip = ARM_economy_shadow_economy_destroy
 			custom_effect_tooltip = ARM_new_decision_economic_unlock_tt
 		}
 
@@ -11552,6 +11576,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ARM_economy_hotels executed"
+			unlock_decision_tooltip = ARM_economy_russian_tourists
+			unlock_decision_tooltip = ARM_economy_tourism_integrate_abkhazia
+			unlock_decision_tooltip = ARM_economy_tourism_integrate_azer
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = ARM_tourism_expand_TT
@@ -14375,6 +14402,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_expand_russian_base_time executed"
+				unlock_decision_tooltip = ARM_exercises_with_russia
 				SOV = {
 					country_event = md4.4
 				}
@@ -15920,6 +15948,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_support_pjaks executed"
+				unlock_decision_tooltip = ARM_foreign_legion_help_kurdistan
 				PER = {
 					country_event = arme.103
 				}
@@ -16029,6 +16058,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_covert_defense_agreement executed"
+				unlock_decision_tooltip = ARM_exercises_with_iran
 				PER = {
 					country_event = arme.100
 				}
@@ -16227,6 +16257,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_mithridates_legacy executed"
+				unlock_decision_tooltip = ARM_promotion_of_interest_armenia_in_greece
 				set_temp_variable = {
 					party_popularity_increase = 0.02
 				}
@@ -16321,6 +16352,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_military_coop_greece executed"
+				unlock_decision_tooltip = ARM_exercises_with_greece
 				GRE = {
 					country_event = arme.70
 				}
@@ -16433,6 +16465,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_anti_turk_diplo executed"
+				unlock_decision_tooltip = ARM_foreign_legion_help_greece
 				GRE = {
 					country_event = arme.83
 				}
@@ -17871,6 +17904,8 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_intervene_in_syria executed"
+				unlock_decision_tooltip = ARM_foreign_legion_help_syria
+				unlock_decision_tooltip = ARM_foreign_legion_help_kurdistan
 				SYR = {
 					country_event = arme.156
 				}
@@ -17915,6 +17950,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_relat_in_kurdistan executed"
+				unlock_decision_tooltip = ARM_foreign_legion_help_kurdistan
 				add_opinion_modifier = {
 					target = KUR
 					modifier = declaration_of_friendship
@@ -18304,6 +18340,7 @@ focus_tree = {
 
 			completion_reward = {
 				log = "[GetDateText]: [This.GetName]: focus ARM_military_coop_fra executed"
+				unlock_decision_tooltip = ARM_exercises_with_france
 				FRA = {
 					country_event = arme.112
 				}

--- a/common/national_focus/05_bashkiriya.txt
+++ b/common/national_focus/05_bashkiriya.txt
@@ -5219,6 +5219,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_bashkiria_idel_ural_inner"
+			unlock_decision_tooltip = BSH_unite_idel_ural
+			unlock_decision_tooltip = BSH_unite_volga
 			custom_effect_tooltip = BSH_idelural_russia_tt
 		}
 
@@ -5247,6 +5249,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_bashkiria_idel_ural_outer"
+			unlock_decision_tooltip = BSH_integrate_TAT
+			unlock_decision_tooltip = BSH_integrate_TATar
 			custom_effect_tooltip = BSH_idelural_notrussia_tt
 			add_state_claim = 661
 		}

--- a/common/national_focus/05_belarus.txt
+++ b/common/national_focus/05_belarus.txt
@@ -47,6 +47,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BLR_bountiful_fields"
+			unlock_decision_category_tooltip = BLR_agricultural_districts
 			custom_effect_tooltip = BLR_activates_fermer_mission_TT
 			hidden_effect = {
 				activate_mission = BLR_get_to_work
@@ -4009,6 +4010,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_white_legion_battalion"
+			unlock_decision_category_tooltip = BLR_whitelegion_battalion_category
 			custom_effect_tooltip = BLR_white_legion_TT
 			hidden_effect = {
 				division_template = {
@@ -4967,6 +4969,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Lykashenko"
+			unlock_decision_category_tooltip = BLR_Lukashenko_category
 			country_event = { id = belarus_character.1 days = 1 }
 			set_temp_variable = { modify_batka = 20 }
 			modify_batka_support = yes
@@ -8356,6 +8359,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_Zimbabwe"
+			unlock_decision_tooltip = BLR_mission_to_Zimbabwe
 			add_opinion_modifier = {
 				target = ZIM
 				modifier = trade_mission

--- a/common/national_focus/05_bolivia.txt
+++ b/common/national_focus/05_bolivia.txt
@@ -5489,6 +5489,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOL_modernize_bolivian_oil_extraction"
+			unlock_decision_tooltip = BOL_explore_oil_reserves_in_santa_cruz
+			unlock_decision_tooltip = BOL_explore_oil_reserves_in_pando_el_beni
 			unlock_decision_category_tooltip = BOL_oil_reserve_decisions
 			swap_ideas = {
 				remove_idea = BOL_renewed_gas_exports

--- a/common/national_focus/05_bosnia.txt
+++ b/common/national_focus/05_bosnia.txt
@@ -3287,6 +3287,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOS_National_awakening"
+			unlock_decision_category_tooltip = Bosnian_prep_for_civil_war
+			unlock_decision_category_tooltip = bos_Islamic_uprising
 			hidden_effect = {
 				add_ideas = bos_croat_manpower_bad
 				add_ideas = bos_serb_manpower_bad
@@ -3710,6 +3712,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOS_religious_identity"
+			unlock_decision_category_tooltip = bos_Return_of_entitled_lands
 			custom_effect_tooltip = bos_war_goals
 			#custom_effect_tooltip = bos_gain_claim_on_former_kingdom_lands
 			add_state_claim = 131
@@ -4060,6 +4063,7 @@ focus_tree = {
 		completion_reward = {
 			add_ideas = bos_trade_with_nato
 			log = "[GetDateText]: [This.GetName]: Focus BOS_western_Objectives"
+			unlock_decision_category_tooltip = bos_Operation_Althea
 			if = { limit = { has_government = democratic }
 				for_each_scope_loop = {
 					array = global.nato_members

--- a/common/national_focus/05_china.txt
+++ b/common/national_focus/05_china.txt
@@ -3166,6 +3166,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_own_designs"
+			unlock_decision_tooltip = CHI_localise_licensed_system
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_research_speed_factor = 0.05 tooltip = research_speed_factor_tt }
 			newline = yes
@@ -3762,6 +3763,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_the_northeast_tiger"
+			unlock_decision_tooltip = CHI_rein_in_cliques
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_political_power_factor = 0.05 tooltip = political_power_factor_tt }
 			newline = yes
@@ -6623,6 +6625,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_project_921"
+			unlock_decision_category_tooltip = CHI_space_program
 			add_tech_bonus = { name = CHI_project_921 bonus = 0.25 uses = 2 category = CAT_space }
 			add_tech_bonus = { name = CHI_project_921 ahead_reduction = 5 uses = 1 category = CAT_space }
 			newline = yes
@@ -6655,6 +6658,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_shenzhou_program"
+			unlock_decision_tooltip = CHI_launch_payload
 			add_tech_bonus = { name = CHI_shenzhou_program bonus = 0.25 uses = 1 category = CAT_space }
 			newline = yes
 			air_experience = 10
@@ -8076,6 +8080,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_South_China_Sea executed"
+			unlock_decision_category_tooltip = CHI_south_china_sea_category
 			add_ideas = CHI_blue_national_soil
 		}
 
@@ -8102,6 +8107,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_Cabbage_Strategy executed"
+			unlock_decision_tooltip = CHI_scs_deploy_maritime_militia
 			PHI = { country_event = { id = china_scs.10 days = 1 } }
 			VIE = { country_event = { id = china_scs.10 days = 1 } }
 			MAY = { country_event = { id = china_scs.10 days = 1 } }
@@ -8253,6 +8259,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_Cabbage_Tightens executed"
+			unlock_decision_tooltip = CHI_scs_natuna_provocation
+			unlock_decision_tooltip = CHI_scs_natuna_press_claim
 			add_to_variable = { CHI_chinese_aggression = 5 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -3 tooltip = CHI_scs_framework_tt }
@@ -8400,6 +8408,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_Maritime_Silk_Road_Initiative executed"
+			unlock_decision_tooltip = CHI_scs_block_asean_consensus
 			add_to_variable = { CHI_scs_framework = 3 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			newline = yes
@@ -8588,6 +8597,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_Mandate_Of_The_Seas executed"
+			unlock_decision_tooltip = CHI_scs_assertive_patrol_VIE
+			unlock_decision_tooltip = CHI_scs_assertive_patrol_PHI
+			unlock_decision_tooltip = CHI_scs_assertive_patrol_MAY
 			add_to_variable = { CHI_chinese_aggression = 3 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -3 tooltip = CHI_scs_framework_tt }
@@ -8639,6 +8651,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_Liu_Huaqing_Doctrine executed"
+			unlock_decision_tooltip = CHI_scs_first_island_chain_exercise
 			add_to_variable = { CHI_chinese_aggression = 5 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			newline = yes
@@ -8859,6 +8872,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_Sea_Within_The_Sea executed"
+			unlock_decision_tooltip = CHI_scs_reclaim_taiping
 			swap_ideas = {
 				remove_idea = CHI_dragon_king_ascendant
 				add_idea = CHI_sea_within_the_sea
@@ -9757,6 +9771,7 @@ focus_tree = {
 			add_to_variable = { CHI_opinion_gain_monthly_factor_diplomacy = 0.03 tooltip = opinion_gain_monthly_factor_tt }
 			add_to_variable = { CHI_intelligence_agency_defense_diplomacy = 0.02 tooltip = intelligence_agency_defense_tt }
 			log = "[GetDateText]: [This.GetName]: focus CHI_The_Border_Personnel_Meetings executed"
+			unlock_decision_tooltip = CHI_de_escalate_at_LAC
 		}
 
 		ai_will_do = {
@@ -9988,6 +10003,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus CHI_String_of_Pearls executed"
+			unlock_decision_tooltip = CHI_seek_basing_BAN
+			unlock_decision_tooltip = CHI_seek_basing_BRM
+			unlock_decision_tooltip = CHI_seek_basing_CBD
+			unlock_decision_tooltip = CHI_seek_basing_PAK
+			unlock_decision_tooltip = CHI_seek_basing_SRI
 			activate_decision = CHI_seek_basing_BAN
 			activate_decision = CHI_seek_basing_BRM
 			activate_decision = CHI_seek_basing_CBD
@@ -10312,6 +10332,7 @@ focus_tree = {
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			log = "[GetDateText]: [This.GetName]: focus CHI_the_diaoyu_sovereignty_declaration executed"
+			unlock_decision_tooltip = CHI_patrol_diaoyu_fishing_grounds
 		}
 
 		ai_will_do = {
@@ -10346,6 +10367,7 @@ focus_tree = {
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			log = "[GetDateText]: [This.GetName]: focus CHI_the_rare_earth_lever executed"
+			unlock_decision_tooltip = CHI_activate_rare_earth_embargo
 		}
 
 		ai_will_do = { base = 1 }
@@ -10399,6 +10421,7 @@ focus_tree = {
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			log = "[GetDateText]: [This.GetName]: focus CHI_the_maritime_militia_initiative executed"
+			unlock_decision_tooltip = CHI_deploy_paf_maritime_militia
 		}
 
 		ai_will_do = {
@@ -12543,6 +12566,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_Belt_and_Road_Initiative"
+			unlock_decision_tooltip = CHI_BRI_redirect_more_to_investments
+			unlock_decision_tooltip = CHI_BRI_redirect_more_to_bri
+			unlock_decision_category_tooltip = CHI_BRI_recipient_actions
 			add_to_variable = { CHI_bri_treasury = 200 tooltip = CHI_bri_treasury_tt }
 			news_event = chi_bri.1
 			unlock_decision_category_tooltip = CHI_BRI_management
@@ -13137,6 +13163,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_Forum_on_China_African_Cooperation"
+			unlock_decision_tooltip = CHI_FOCAC_Summit
 			add_to_variable = { CHI_bri_treasury = 75 tooltip = CHI_bri_treasury_tt }
 			add_to_variable = { CHI_bri_africa_engagement = 5 tooltip = CHI_bri_africa_engagement_tt }
 			add_to_variable = { CHI_bri_global_presence = 5 tooltip = CHI_bri_global_presence_tt }
@@ -13692,6 +13719,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_Predatory_Lending_Doctrine"
+			unlock_decision_tooltip = CHI_Asset_Seizure
 			add_to_variable = { CHI_bri_returns_multiplier = 0.20 tooltip = CHI_bri_returns_multiplier_tt }
 			every_other_country = {
 				limit = {
@@ -13730,6 +13758,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_Win_Win_Cooperation"
+			unlock_decision_tooltip = CHI_Debt_Restructuring
 			add_to_variable = { CHI_bri_monthly_income = 3 tooltip = CHI_bri_monthly_income_tt }
 			add_to_variable = { CHI_chinese_aggression = -1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
@@ -13760,6 +13789,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_Digital_Silk_Road_Initiative"
+			unlock_decision_tooltip = CHI_Surveillance_Export
 			set_temp_variable = { treasury_change = -150 }
 			modify_treasury_effect = yes
 			add_to_variable = { CHI_bri_telecom_built = 5 tooltip = CHI_bri_telecom_built_tt }
@@ -13895,6 +13925,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_BRI_Forum_Beijing"
+			unlock_decision_tooltip = CHI_BRI_Forum_Triennial
 			add_to_variable = { CHI_bri_global_presence = 10 tooltip = CHI_bri_global_presence_tt }
 			add_timed_idea = { idea = CHI_bri_forum_momentum days = 1095 }
 		}
@@ -16802,6 +16833,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_three_gorges_completion"
+			unlock_decision_tooltip = CHI_three_gorges_dam_decision
 			unlock_decision_tooltip = {
 				decision = CHI_three_gorges_dam_decision
 				show_effect_tooltip = yes
@@ -16885,6 +16917,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_four_trillion_stimulus"
+			unlock_decision_category_tooltip = CHI_megaprojects
 			set_temp_variable = { treasury_change = -85 }
 			modify_treasury_effect = yes
 			586 = {
@@ -18233,6 +18266,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_hua_hong_mature_node"
+			unlock_decision_tooltip = CHI_mature_node_export_drive_decision
 			set_temp_variable = { CHI_semi_progress_amount = 6 }
 			CHI_add_semiconductor_progress = yes
 			540 = {
@@ -18359,6 +18393,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_fabless_design_cluster"
+			unlock_decision_tooltip = CHI_fabless_provincial_subsidy_decision
 			set_temp_variable = { CHI_semi_progress_amount = 8 }
 			CHI_add_semiconductor_progress = yes
 			540 = {
@@ -18642,6 +18677,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_strategic_materials"
+			unlock_decision_tooltip = CHI_critical_minerals_export_license_decision
+			unlock_decision_tooltip = CHI_rare_earth_chip_leverage_decision
 			set_temp_variable = { CHI_semi_progress_amount = 6 }
 			CHI_add_semiconductor_progress = yes
 			random_owned_state = {
@@ -18697,6 +18734,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_smee_lithography"
+			unlock_decision_tooltip = CHI_duv_breakthrough_decision
 			set_temp_variable = { CHI_semi_progress_amount = 10 }
 			CHI_add_semiconductor_progress = yes
 			540 = {
@@ -18766,6 +18804,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_memory_independence"
+			unlock_decision_tooltip = CHI_cxmt_hbm_qualification_decision
 			set_temp_variable = { CHI_semi_progress_amount = 12 }
 			CHI_add_semiconductor_progress = yes
 			570 = {
@@ -22809,6 +22848,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_ETK_education_centres"
+			unlock_decision_tooltip = CHI_establish_education_centres
 			592 = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
@@ -23990,6 +24030,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_fleet_modernization"
+			unlock_decision_tooltip = CHI_TAI_amphibious_exercise
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_TAI_shared_modifier
@@ -24041,6 +24082,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_amphibious_doctrine"
+			unlock_decision_tooltip = CHI_TAI_strait_naval_exercise
 			add_timed_idea = {
 				idea = CHI_TAI_amphibious_mastery
 				days = 730
@@ -24071,6 +24113,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_dongfeng_program"
+			unlock_decision_tooltip = CHI_TAI_rocket_test
+			unlock_decision_tooltip = CHI_TAI_blockade_simulation
 			add_tech_bonus = {
 				name = CAT_missile
 				bonus = 0.50
@@ -24098,6 +24142,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_air_superiority"
+			unlock_decision_tooltip = CHI_TAI_adiz_incursion
+			unlock_decision_tooltip = CHI_TAI_grey_zone_ops
 			add_timed_idea = {
 				idea = CHI_TAI_air_dominance
 				days = 730
@@ -24124,6 +24170,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_cyber_warfare"
+			unlock_decision_tooltip = CHI_TAI_cyberattack
 			add_to_variable = { cyber_offense_investment = 2 }
 			calculate_cyber_capability = yes
 			custom_effect_tooltip = cyber_gui_invest_offense_tt
@@ -24154,6 +24201,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_blockade_capability"
+			unlock_decision_tooltip = CHI_TAI_maritime_zone
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_TAI_shared_modifier
@@ -24185,6 +24233,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_one_china_enforcement"
+			unlock_decision_tooltip = CHI_pressure_derecognize_TAI
 			add_to_variable = { CHI_taiwan_us_support = -3 tooltip = CHI_taiwan_us_support_tt }
 			clamp_variable = { var = CHI_taiwan_us_support min = 0 max = 100 }
 			newline = yes
@@ -24287,6 +24336,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_lobby_network"
+			unlock_decision_tooltip = CHI_TAI_influence_us_election
 			add_to_variable = { CHI_taiwan_us_support = -2 tooltip = CHI_taiwan_us_support_tt }
 			clamp_variable = { var = CHI_taiwan_us_support min = 0 max = 100 }
 			country_event = { id = china_sar.027 days = 7 }
@@ -24311,6 +24361,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_proxy_strategy"
+			unlock_decision_tooltip = CHI_TAI_support_houthis
+			unlock_decision_tooltip = CHI_TAI_scs_provocations
+			unlock_decision_tooltip = CHI_TAI_middleeast_diversion
+			unlock_decision_tooltip = CHI_TAI_arm_iran
+			unlock_decision_tooltip = CHI_TAI_nk_provocations
+			unlock_decision_tooltip = CHI_TAI_support_russia
 			add_to_variable = { CHI_taiwan_us_support = -3 tooltip = CHI_taiwan_us_support_tt }
 			clamp_variable = { var = CHI_taiwan_us_support min = 0 max = 100 }
 			newline = yes
@@ -24347,6 +24403,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TAI_distract_america"
+			unlock_decision_tooltip = CHI_TAI_fund_us_opposition
+			unlock_decision_tooltip = CHI_TAI_exploit_us_commitments
 			if = {
 				limit = { USA = { has_war = yes } }
 				add_to_variable = { CHI_taiwan_us_support = -5 tooltip = CHI_taiwan_us_support_tt }
@@ -24839,6 +24897,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_OMG_han_settlement_program"
+			unlock_decision_tooltip = CHI_han_settlement_small
+			unlock_decision_tooltip = CHI_han_settlement_medium
+			unlock_decision_tooltip = CHI_han_settlement_large
 			unlock_decision_tooltip = {
 				decision = CHI_han_settlement_small
 				show_effect_tooltip = yes

--- a/common/national_focus/05_comoros.txt
+++ b/common/national_focus/05_comoros.txt
@@ -180,6 +180,12 @@ focus_tree = {
 			}
 			clr_country_flag = COM_army_route_3
 			custom_effect_tooltip = COM_african_mercenaries_1_tt
+			newline = yes
+			unlock_decision_tooltip = COM_hire_control_risks_decision
+			unlock_decision_tooltip = COM_hire_executive_outcomes_decision
+			unlock_decision_tooltip = COM_hire_defense_systems_decision
+			unlock_decision_tooltip = COM_hire_watchguard_decision
+			unlock_decision_tooltip = COM_reform_7_independent_company_decision
 		}
 
 		ai_will_do = {
@@ -3240,6 +3246,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus COM_the_constitutional_referendum executed"
+			unlock_decision_category_tooltip = COM_the_constitutional_referendum_decisions
 			country_event = comoros.4
 		}
 

--- a/common/national_focus/05_cuba.txt
+++ b/common/national_focus/05_cuba.txt
@@ -5106,6 +5106,11 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_demand_from_us"
 			custom_effect_tooltip = CUB_blockade_tt
+			newline = yes
+			unlock_decision_tooltip = CUB_normalisation_with_USA
+			unlock_decision_tooltip = CUB_diplomacy_with_USA
+			unlock_decision_tooltip = CUB_open_bank_and_trade_with_USA
+			unlock_decision_tooltip = CUB_negotations_with_USA
 		}
 
 		ai_will_do = {
@@ -12981,6 +12986,7 @@ icon = CUB_fidelcastro
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_first_stage_of_federation"
+			unlock_decision_category_tooltip = CUB_confederation_category
 			custom_effect_tooltip = CUB_conf_tt
 		}
 
@@ -13151,6 +13157,7 @@ icon = CUB_fidelcastro
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_liberate_puerto_rico"
+			unlock_decision_tooltip = CUB_ask_puerto
 			USA = { country_event = { id = cuba.40 days = 1 } }
 			newline = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -13265,6 +13272,8 @@ icon = CUB_fidelcastro
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus  CUB_invite_dominicana"
+			unlock_decision_tooltip = CUB_invite_dominicana
+			unlock_decision_tooltip = CUB_invite_puerto_rico
 			custom_effect_tooltip = CUB_invite_dominicana_tt
 		}
 
@@ -13318,6 +13327,7 @@ icon = CUB_fidelcastro
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_invite_haiti"
+			unlock_decision_tooltip = CUB_invite_haiti
 			custom_effect_tooltip = CUB_invite_haiti_tt
 		}
 
@@ -13375,6 +13385,7 @@ icon = CUB_fidelcastro
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_talks_with_jamaica"
+			unlock_decision_tooltip = CUB_invite_jamaica
 			custom_effect_tooltip = CUB_invite_jamaica_tt
 		}
 
@@ -13432,6 +13443,7 @@ icon = CUB_fidelcastro
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CUB_talks_with_colombia"
+			unlock_decision_tooltip = CUB_invite_colombia
 			custom_effect_tooltip = CUB_invite_colombia_tt
 		}
 

--- a/common/national_focus/05_czech_republic.txt
+++ b/common/national_focus/05_czech_republic.txt
@@ -5923,6 +5923,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_stay_with_the_giant"
+			unlock_decision_tooltip = CZE_take_part_in_new_technology_research
+			unlock_decision_tooltip = CZE_expand_middle_east_trade
 			add_political_power = 25
 			add_stability = 0.03
 			custom_effect_tooltip = CZE_stay_with_the_giant_tooltip
@@ -5978,6 +5980,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_skoda_auto_volkswagen_india"
+			unlock_decision_tooltip = CZE_open_aurangabad_factory
+			unlock_decision_tooltip = CZE_expand_set_up_cooperation_with_india
 			reverse_add_opinion_modifier = {
 				target = RAJ
 				modifier = CZE_skoda_auto_volkswagen_india_modifier
@@ -6013,6 +6017,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_chinese_market"
+			unlock_decision_tooltip = CZE_open_nanjing_factory
+			unlock_decision_tooltip = CZE_expansion_to_china
 			custom_effect_tooltip = CZE_skoda_open_for_china_tooltip
 		}
 
@@ -6201,6 +6207,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_prepare_to_leave_the_volkswagen_group"
+			unlock_decision_category_tooltip = CZE_cesky_motor_energy_holding
 			add_political_power = -75
 			country_event = CZE_czech.4
 			custom_effect_tooltip = CZE_skoda_cesky_motor_energy_holding_beginning
@@ -6243,6 +6250,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_negotiate_the_licenses"
+			unlock_decision_tooltip = CZE_buy_back_full_production_license
 			add_political_power = 20
 			custom_effect_tooltip = CZE_skoda_negotiates_licenses
 			set_temp_variable = { temp_opinion = 5 }
@@ -6387,6 +6395,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_focus_on_homeland_companies"
+			unlock_decision_tooltip = CZE_tatra_trucks_decision
+			unlock_decision_tooltip = CZE_vop_cz_decision
+			unlock_decision_tooltip = CZE_praga_decision
+			unlock_decision_tooltip = CZE_cez_decision
 			custom_effect_tooltip = CZE_skoda_adds_companies
 			set_temp_variable = { temp_opinion = 5 }
 			change_industrial_conglomerates_opinion = yes
@@ -6559,6 +6571,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_strategy_to_take_over_volkswagen"
+			unlock_decision_tooltip = CZE_fundaments_of_the_skoda_group
 			reverse_add_opinion_modifier = {
 				target = GER
 				modifier = CZE_skoda_prepares_to_strike
@@ -6758,6 +6771,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_ask_the_government_for_help"
+			unlock_decision_tooltip = CZE_help_promoting_skoda_actions
 			add_political_power = -50
 			reverse_add_opinion_modifier = {
 				target = GER
@@ -6813,6 +6827,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_bend_the_volkswagen_group_rules"
+			unlock_decision_tooltip = CZE_investment_in_the_future
+			unlock_decision_tooltip = CZE_skoda_is_getting_aggressive
+			unlock_decision_tooltip = CZE_what_happened_to_our_group
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			add_political_power = -25
@@ -6869,6 +6886,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_prepare_for_takeover"
+			unlock_decision_tooltip = CZE_finish_the_preparations
 			custom_effect_tooltip = CZE_skoda_prepares_for_takeover
 		}
 
@@ -7019,6 +7037,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_vop_cz"
+			unlock_decision_category_tooltip = CZE_vop_cz_category
 			if = {
 				limit = {
 					any_controlled_state = {
@@ -7869,6 +7888,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_skoda_superb_i"
+			unlock_decision_category_tooltip = CZE_skoda_laboratories_category
+			unlock_decision_category_tooltip = CZE_skoda_superb_cars_export_category
 			# BASIC REWARDS
 			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
@@ -8052,6 +8073,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_finish_selling_state_companies"
+			unlock_decision_category_tooltip = CZE_start_selling_state_companies_category
 			custom_effect_tooltip = CZE_start_selling_state_companies_tooltip
 			set_temp_variable = { int_investment_change = 5 }
 			modify_international_investment_effect = yes
@@ -8923,6 +8945,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_skoda_superb_iii"
+			unlock_decision_tooltip = CZE_skoda_superb_iii_expansion_of_skoda_laboratories
 			swap_ideas = {
 				remove_idea = CZE_skoda_superb_ii_idea
 				add_idea = CZE_skoda_superb_iii_idea
@@ -9089,6 +9112,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_skoda_superb_iv"
+			unlock_decision_category_tooltip = CZE_electric_highway_category
 			swap_ideas = {
 				remove_idea = CZE_skoda_superb_iii_idea
 				add_idea = CZE_skoda_superb_iv_idea
@@ -10477,6 +10501,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_third_nuclear_power_plant_preparations"
+			unlock_decision_category_tooltip = CZE_new_nuclear_power_plant_category
 			custom_effect_tooltip = CZE_third_nuclear_power_plant_preparations_tooltip
 			add_ideas = CZE_new_contract_idea
 		}
@@ -10546,6 +10571,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_start_construction"
+			unlock_decision_tooltip = CZE_construction_site
+			unlock_decision_tooltip = CZE_additional_laboratory_equipment
+			unlock_decision_tooltip = CZE_start_with_better_fuel
+			unlock_decision_tooltip = CZE_thermonuclear_reactor
+			unlock_decision_tooltip = CZE_finish_construction
 			custom_effect_tooltip = CZE_start_construction_tooltip
 			swap_ideas = {
 				remove_idea = CZE_new_contract_idea
@@ -15920,6 +15950,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_change_in_the_government"
+			unlock_decision_category_tooltip = CZE_spolu_government_formation_category
 			add_ideas = CZE_new_government_formation_idea
 			custom_effect_tooltip = CZE_government_changes_info
 			CZE_increase_spolu_popularity = yes
@@ -18351,6 +18382,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_reduce_flooding_risk"
+			unlock_decision_category_tooltip = CZE_reduce_flooding_risk_category
 			if = {
 				limit = {
 					date < 2017.6.15
@@ -24516,6 +24548,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_further_political_career"
+			unlock_decision_category_tooltip = CZE_petr_pavel_presidenture_category
 			custom_effect_tooltip = CZE_spolu_can_be_created
 			set_temp_variable = { CZE_petr_pavel_support_bonus = 5 }
 			CZE_petr_pavel_support_add = yes
@@ -27415,6 +27448,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_seperation_of_powers"
+			unlock_decision_tooltip = CZE_unify_the_nations
 			news_event = CZE_monarchy_event.24
 			set_country_flag = CZE_prague_conference_separated_powers
 			#custom_effect_tooltip = CZE_seperation_of_powers_TT
@@ -27826,6 +27860,7 @@ focus_tree = {
 		completion_reward = {
 			ROM = { country_event = CZE_HUN_monarchy_event.27 }
 			log = "[GetDateText]: [Root.GetName]: Focus CZE_meeting_with_romania"
+			unlock_decision_category_tooltip = CZE_bucarest_meeting
 		}
 
 		ai_will_do = { base = 50 }

--- a/common/national_focus/05_germany.txt
+++ b/common/national_focus/05_germany.txt
@@ -9977,6 +9977,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_Invest_in_Universitat_der_Bundeswehr_Hamburg"
+			unlock_decision_category_tooltip = GER_Officer_Training_Decisions
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = GER_Bundeswehr_modifier
@@ -17089,6 +17090,7 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_torment_the_false_state"
+			unlock_decision_category_tooltip = GER_the_false_state
 			custom_effect_tooltip = GER_torment_israel_npd_TT
 		}
 		ai_will_do = {
@@ -18801,6 +18803,7 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_the_imperial_bloc"
+			unlock_decision_category_tooltip = GER_imperial_bloc_invites
 			add_ideas = faction_imperial_bloc_alliance
 			if = { limit = { is_faction_leader = yes }
 				dismantle_faction = yes
@@ -19401,6 +19404,11 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_Network_Infrastructure"
+			unlock_decision_tooltip = Expand_Network_North
+			unlock_decision_tooltip = Expand_Network_South
+			unlock_decision_tooltip = Expand_Network_West
+			unlock_decision_tooltip = Expand_Network_North_east
+			unlock_decision_tooltip = Expand_Network_east
 			custom_effect_tooltip = GER_unlock_Network_Infrastructure_decision_TT
 		}
 		ai_will_do = {

--- a/common/national_focus/05_greece.txt
+++ b/common/national_focus/05_greece.txt
@@ -1027,6 +1027,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GRE_sovereign_waters"
+			unlock_decision_tooltip = GRE_aegean_survey
+			unlock_decision_tooltip = GRE_aegean_extraction
+			unlock_decision_tooltip = GRE_aegean_offshore_industry
+			unlock_decision_tooltip = GRE_crete_survey
+			unlock_decision_tooltip = GRE_crete_extraction
+			unlock_decision_tooltip = GRE_crete_offshore_industry
 			if = {
 				limit = { country_exists = TUR }
 				TUR = {

--- a/common/national_focus/05_india.txt
+++ b/common/national_focus/05_india.txt
@@ -18022,6 +18022,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus RAJ_BRICS_integer"
+			unlock_decision_category_tooltip = RAJ_brics_alliance_decisions
 			# Invite the historical founders. In brics_join.6: ROOT = invited founder, FROM = India (the forming leader).
 			BRA = {
 				country_event = brics_join.6

--- a/common/national_focus/05_iran.txt
+++ b/common/national_focus/05_iran.txt
@@ -39,6 +39,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus PER_whispers_of_power"
+			unlock_decision_category_tooltip = PER_nuclear_ambitions
 			custom_effect_tooltip = PER_whispers_of_power_TT
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = PER_political_modifier }
@@ -2542,6 +2543,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_safeguard_eastern_border"
+			unlock_decision_category_tooltip = PER_border_fortification
 			add_to_variable = { PER_self_sufficiency = 1 }
 			add_timed_idea = {
 				idea = PER_defensive_infrastructure_idea
@@ -5531,6 +5533,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_expansion_of_state_bonyads"
+			unlock_decision_category_tooltip = PER_bonyad_resources
 			custom_effect_tooltip = PER_bonyad_resources_TT
 		}
 
@@ -10827,6 +10830,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_veins_of_the_revolution"
+			unlock_decision_category_tooltip = PER_resitance_axis
 			custom_effect_tooltip = PER_axis_decisions_TT
 		}
 
@@ -11431,6 +11435,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_utilize_sadr"
+			unlock_decision_category_tooltip = PER_iraq_war_compensation
 			custom_effect_tooltip = PER_iraq_reparations_TT
 		}
 
@@ -12233,6 +12238,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_topple_gulf_monarchies"
+			unlock_decision_tooltip = PER_overthrow_saudi
+			unlock_decision_tooltip = PER_overthrow_uae
+			unlock_decision_tooltip = PER_overthrow_oman
 			custom_effect_tooltip = PER_gulf_overthrow_TT
 		}
 
@@ -12819,6 +12827,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_arabian_underbelly"
+			unlock_decision_category_tooltip = PER_war_in_yemem
 			set_global_flag = Yemen_Civil_War_trigger_iran_focus
 			set_global_flag = PER_ansar_allah
 			if = {
@@ -14884,6 +14893,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_prospect_of_expansion"
+			unlock_decision_category_tooltip = PER_cento_decisions
 			custom_effect_tooltip = PER_unlock_cento_expand_decision_TT
 		}
 
@@ -15275,6 +15285,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_syrian_brothers"
+			unlock_decision_tooltip = PER_intervene_in_syria
 			# Start a Civil War in Syria if it is Al-Assads or Military in Power
 			custom_effect_tooltip = PER_ignite_syrian_civilwar_TT
 			newline = yes
@@ -15616,6 +15627,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_challenge_saudi_hegemony"
+			unlock_decision_tooltip = PER_invite_jordan
+			unlock_decision_tooltip = PER_invite_egypt
+			unlock_decision_tooltip = PER_invite_morocco
+			unlock_decision_tooltip = PER_invite_yemen
 			custom_effect_tooltip = PER_invite_cento_arabia_TT
 			newline = yes
 			set_temp_variable = { percent_change = 3 }
@@ -16573,6 +16588,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_reunification"
+			unlock_decision_tooltip = PER_integrate_turkmenistan
+			unlock_decision_tooltip = PER_integrate_armenia
+			unlock_decision_tooltip = PER_integrate_azerbaijan
 			custom_effect_tooltip = PER_integrate_azerbaijan_TT
 			newline = yes
 			custom_effect_tooltip = PER_integrate_turkmenistan_TT
@@ -17059,6 +17077,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_break_the_iraqi_hand"
+			unlock_decision_tooltip = PER_integrate_basrah_maysan
 			171 = {
 				add_claim_by = PER
 			}
@@ -17718,6 +17737,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_workers_party_of_iraq"
+			unlock_decision_tooltip = PER_socialist_union_with_iraq
 			custom_effect_tooltip = PER_wpi_iraq_TT
 			newline = yes
 			set_temp_variable = { percent_change = 3 }
@@ -20064,6 +20084,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_loose_cloak_of_democracy"
+			unlock_decision_tooltip = PER_reza_pahlavi
 			custom_effect_tooltip = PER_pahlavi_invite_TT
 		}
 
@@ -21183,6 +21204,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_hekamiyate_mellat"
+			unlock_decision_tooltip = PER_utilize_party_support
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = PER_artesh_modifier }
 			add_to_variable = { PER_experience_gain_army_unit_factor = 0.1 tooltip = experience_gain_army_unit_factor_tt }
 			newline = yes
@@ -30114,6 +30136,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_ministry_of_war_and_armed_forces_logistics"
+			unlock_decision_category_tooltip = PER_ministry_of_war_decisions
 			custom_effect_tooltip = PER_ministry_of_war_TT
 		}
 

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -27726,6 +27726,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_disengagement_plan executed"
+			unlock_decision_tooltip = ISR_raid_beit_leiha
 			country_event = israel.116
 			country_event = israel_likud.61
 			custom_effect_tooltip = wemaypiss_people_but_money_tt
@@ -27915,6 +27916,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_focus_on_the_clusters executed"
+			unlock_decision_tooltip = ISR_jabel_mukaber_judge
 			custom_effect_tooltip = isr_tension_decrease_2_TT
 			subtract_from_variable = {
 				ISR_palestine_situation_additional = 2

--- a/common/national_focus/05_italy.txt
+++ b/common/national_focus/05_italy.txt
@@ -20856,6 +20856,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_technocratic_governments"
+			unlock_decision_tooltip = estabilish_technocratic_government
 			custom_effect_tooltip = technocratic_governments_TT
 		}
 
@@ -21077,6 +21078,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_exploit_talk_shows"
+			unlock_decision_tooltip = discredit_political_opponents_in_talk_shows
 			custom_effect_tooltip = exploit_talk_shows_TT
 		}
 
@@ -21525,6 +21527,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ITA_economic_support_for_the_church"
+			unlock_decision_tooltip = extraordinary_church_donation
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_clergy_opinion = yes
 			add_ideas = ITA_extra_church_support

--- a/common/national_focus/05_japan.txt
+++ b/common/national_focus/05_japan.txt
@@ -2772,6 +2772,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_special_zones"
+			unlock_decision_tooltip = JAP_tokyo_startup_special_zone
+			unlock_decision_tooltip = JAP_kansai_medical_special_zone
+			unlock_decision_tooltip = JAP_kyushu_logistics_special_zone
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_regulatory_reform_modifier
@@ -2844,6 +2847,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_expansion_regulatory_reform_zones"
+			unlock_decision_tooltip = JAP_expand_special_zones_nationwide
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_regulatory_reform_modifier
@@ -4253,6 +4257,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_increasing_childbirth_allowance"
+			unlock_decision_tooltip = JAP_increasing_childbirth_allowance_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_declining_birthrate_modifier
@@ -4288,6 +4293,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_free_early_childhood_education"
+			unlock_decision_tooltip = JAP_free_early_childhood_education_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_declining_birthrate_modifier
@@ -4357,6 +4363,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_child_allowances"
+			unlock_decision_tooltip = JAP_child_allowances_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_declining_birthrate_modifier
@@ -4393,6 +4400,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_fertility_treatment"
+			unlock_decision_tooltip = JAP_fertility_treatment_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_declining_birthrate_modifier
@@ -4514,6 +4522,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_expanding_social_insurance_coverage"
+			unlock_decision_tooltip = JAP_expanding_social_insurance_coverage_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_save_ice_age_generation_modifier
@@ -4579,6 +4588,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_digital_reskilling"
+			unlock_decision_tooltip = JAP_digital_reskilling_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_save_ice_age_generation_modifier
@@ -4617,6 +4627,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_converting_regular_employment"
+			unlock_decision_tooltip = JAP_converting_regular_employment_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_save_ice_age_generation_modifier
@@ -4656,6 +4667,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_job_change_market"
+			unlock_decision_tooltip = JAP_job_change_market_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_save_ice_age_generation_modifier
@@ -4695,6 +4707,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_rent_housing_support"
+			unlock_decision_tooltip = JAP_rent_housing_support_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_save_ice_age_generation_modifier
@@ -4735,6 +4748,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_support_marriage_and_starting_a_new"
+			unlock_decision_tooltip = JAP_support_marriage_and_starting_a_new_add_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_save_ice_age_generation_modifier
@@ -7621,6 +7635,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_power_supply"
+			unlock_decision_tooltip = JAP_focus_renewable_energy_decision
+			unlock_decision_tooltip = JAP_focus_thermal_power_decision
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = JAP_once_millennium_disaster
@@ -10752,6 +10768,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_russian_lost_territories"
+			unlock_decision_tooltip = JAP_peaceout_russia
+			unlock_decision_tooltip = JAP_claiming_south_korea
+			unlock_decision_tooltip = JAP_claiming_north_korea
+			unlock_decision_tooltip = JAP_claiming_taiwan
+			unlock_decision_tooltip = JAP_russia_demands_peace_japan
+			unlock_decision_tooltip = JAP_russia_demands_peace_russia
 			691 = { add_claim_by = JAP }
 			690 = { add_claim_by = JAP }
 			unlock_decision_tooltip = JAP_demand_sakhalin
@@ -10783,6 +10805,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus JAP_reclaim_pacific_rim"
+			unlock_decision_tooltip = JAP_claiming_australia
+			unlock_decision_tooltip = JAP_claiming_myanmar
 			unlock_decision_tooltip = JAP_claiming_phillipines
 			unlock_decision_tooltip = JAP_claiming_malaysia
 			unlock_decision_tooltip = JAP_claiming_indonesia

--- a/common/national_focus/05_kosovo.txt
+++ b/common/national_focus/05_kosovo.txt
@@ -1831,6 +1831,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_struggle_for_recognition"
+			unlock_decision_category_tooltip = KOS_int_recognition
 			country_event = kosovo.3
 			drop_cosmetic_tag = yes
 		}
@@ -1854,6 +1855,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_campaign_south_america"
+			unlock_decision_tooltip = KOS_recognition_from_brazil
+			unlock_decision_tooltip = KOS_recognition_from_argentina
+			unlock_decision_tooltip = KOS_recognition_from_chile
 			custom_effect_tooltip = KOS_unlock_SA_recognize
 		}
 
@@ -1876,6 +1880,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_campaign_east_europe"
+			unlock_decision_tooltip = KOS_recognition_from_belarus
+			unlock_decision_tooltip = KOS_recognition_from_ukraine
+			unlock_decision_tooltip = KOS_recognition_from_russia
 			custom_effect_tooltip = KOS_unlock_EEU_recognize
 		}
 
@@ -1898,6 +1905,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KOS_campaign_asia"
+			unlock_decision_tooltip = KOS_recognition_from_china
+			unlock_decision_tooltip = KOS_recognition_from_india
+			unlock_decision_tooltip = KOS_recognition_from_indonesia
 			custom_effect_tooltip = KOS_unlock_AS_recognize
 		}
 

--- a/common/national_focus/05_kuban.txt
+++ b/common/national_focus/05_kuban.txt
@@ -3389,6 +3389,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_adygea_que"
+			unlock_decision_tooltip = KUB_unite_adyg_united_russia
 			custom_effect_tooltip = KUB_adygea_russia_tt
 		}
 
@@ -4075,6 +4076,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_bring_back_adygea"
+			unlock_decision_tooltip = KUB_unite_adyg
 			custom_effect_tooltip = KUB_adygea_russia_tt
 			if = {
 				limit = {
@@ -4121,6 +4123,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_north_caucas_republics"
+			unlock_decision_tooltip = KUB_terskaya_sr
+			unlock_decision_tooltip = KUB_chechnya_sr
 			custom_effect_tooltip = KUB_north_caucas_russia_tt
 			if = {
 				limit = {
@@ -4159,6 +4163,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_stavropolskaya_sr"
+			unlock_decision_tooltip = KUB_stavropolskaya_sr
 			if = {
 				limit = {
 					KUB = { is_subject_of = SOV }
@@ -4196,6 +4201,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_donskaya_sr"
+			unlock_decision_tooltip = KUB_rostov_sr
 			custom_effect_tooltip = KUB_donskaya_russia_tt
 			if = {
 				limit = {
@@ -6787,6 +6793,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_return_adygea"
+			unlock_decision_tooltip = KUB_unite_adyg
 			custom_effect_tooltip = KUB_adygea_russia_tt
 		}
 
@@ -6821,6 +6828,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_return_karachaevo_cherkesia"
+			unlock_decision_tooltip = KUB_unite_karachaevo
 			custom_effect_tooltip = KUB_cherkesy_russia_tt
 		}
 
@@ -8331,6 +8339,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KUB_adygea"
+			unlock_decision_tooltip = KUB_unite_adyg
 			custom_effect_tooltip = KUB_adygea_russia_tt
 		}
 

--- a/common/national_focus/05_liechtenstein.txt
+++ b/common/national_focus/05_liechtenstein.txt
@@ -3884,6 +3884,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: LIC_new_capital"
+			unlock_decision_tooltip = LIC_capital_vatican
 			unlock_decision_tooltip = LIC_capital_paris
 			unlock_decision_tooltip = LIC_capital_wien
 			unlock_decision_tooltip = LIC_capital_berlin

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -1009,6 +1009,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_postbank_fusion"
+			unlock_decision_tooltip = HOL_ing_group_strategies_expansion_speciality1
+			unlock_decision_tooltip = HOL_ing_group_strategies_expansion_speciality2
+			unlock_decision_tooltip = HOL_ing_group_strategies_expansion_speciality3
+			unlock_decision_tooltip = HOL_ing_group_strategies_expansion_speciality4
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = HOL_economy
@@ -5307,6 +5311,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_mars_one #Rework like the Japanese Space Chains (decisions and events)"
+			unlock_decision_category_tooltip = HOL_space_program_category
 			activate_mission = HOL_mars_colony_mission
 			hidden_effect = { country_event = { id = HOL_military.089 days = 150 random_hours = 720 } }
 			set_temp_variable = { treasury_change = gdp_per_capita }
@@ -6383,6 +6388,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_global_land_reclamation #Add a mission to build IJStad project (https://ijstad.nl/)"
+			unlock_decision_category_tooltip = HOL_megaproject_category
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = HOL_economy
@@ -12779,6 +12785,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_global_vision"
+			unlock_decision_category_tooltip = HOL_foreign_policy_category
 			add_political_power = 50
 			set_temp_variable = { party_index = 2 }
 			set_party_index_to_ruling_party = yes
@@ -22650,6 +22657,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_increase_corporation_vlaanderen"
+			unlock_decision_category_tooltip = HOL_influence_flanders
 			custom_effect_tooltip = HOL_increase_corporation_vlaanderen_tt
 			newline = yes
 			set_temp_variable = { treasury_change = gdp_per_capita }
@@ -28401,6 +28409,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_wic_dutch_aid_program"
+			unlock_decision_tooltip = HOL_add_dutchaid
 			every_other_country = {
 				limit = {
 					OR = {
@@ -29704,6 +29713,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_reclaim_crown_colony"
+			unlock_decision_tooltip = HOL_voc_indonesia_attack_mission
 			if = {
 				limit = {
 					has_dlc = "La Resistance"
@@ -29926,6 +29936,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_reclaim_outer_islands"
+			unlock_decision_tooltip = HOL_deploy_islands_commando
 			unlock_decision_tooltip = HOL_reduce_sumatra_detection
 			unlock_decision_tooltip = HOL_reduce_kalimantan_detection
 			unlock_decision_tooltip = HOL_increase_convoy

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -2940,6 +2940,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_address_niger_delta"
+			unlock_decision_tooltip = NIG_oil_revenue_sharing_agreement
+			unlock_decision_tooltip = NIG_reform_nddc
 			add_political_power = 100
 			add_stability = 0.03
 			set_country_flag = NIG_address_niger_delta_path

--- a/common/national_focus/05_north_korea.txt
+++ b/common/national_focus/05_north_korea.txt
@@ -135,6 +135,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NKO_humanitarian_aid executed"
+			unlock_decision_tooltip = NKO_international_assistance
 			unlock_decision_category_tooltip = NKO_arduous_march
 			activate_decision = NKO_international_assistance
 			newline = yes
@@ -227,6 +228,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NKO_healthcare_reform executed"
+			unlock_decision_tooltip = NKO_medicine_relief
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = arduous_march_modifiers
@@ -265,6 +267,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NKO_punish_corruption"
+			unlock_decision_tooltip = NKO_accept_money
 			add_timed_idea = {
 				idea = NKO_punish_corruption_first_idea
 				days = 365

--- a/common/national_focus/05_poland.txt
+++ b/common/national_focus/05_poland.txt
@@ -1471,6 +1471,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_prl_was_a_failure"
+			unlock_decision_category_tooltip = POL_state_controlled_economy_category
 			if = {
 				limit = {
 					has_completed_focus = POL_military_state
@@ -1804,6 +1805,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_control_everything"
+			unlock_decision_category_tooltip = POL_control_everything_category
 			swap_ideas = {
 				remove_idea = POL_armia_ludowa1_idea
 				add_idea = POL_armia_ludowa2_idea
@@ -2041,6 +2043,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_department_of_foreign_influence"
+			unlock_decision_category_tooltip = POL_department_of_foreign_influence_category
 			add_war_support = 0.1
 			if = {
 				limit = { is_faction_leader = yes }
@@ -3020,6 +3023,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_betray_the_communists"
+			unlock_decision_category_tooltip = POL_communists_vs_social_democrats_category
 			remove_ideas = POL_unstable_coalition3_idea
 			custom_effect_tooltip = POL_zkp_p_goes_mental_TT
 			start_civil_war = {
@@ -3534,6 +3538,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_improve_civilian_and_military_industry"
+			unlock_decision_category_tooltip = POL_civ_mil_category
 			one_random_industrial_complex = yes
 			one_random_arms_factory = yes
 			custom_effect_tooltip = POL_civ_mil_TT
@@ -6220,6 +6225,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_creation_of_the_territorial_defense_forces"
+			unlock_decision_category_tooltip = POL_territorial_defense_forces_category
 			custom_effect_tooltip = POL_territorial_defense_forces_TT
 		}
 
@@ -6769,6 +6775,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_production_and_export_of_the_k2pl_tank"
+			unlock_decision_category_tooltip = POL_k2pl_export
 			swap_ideas = {
 				remove_idea = POL_modernization_of_armored_forces_KOR_3_idea
 				add_idea = POL_modernization_of_armored_forces_KOR_4_idea
@@ -7965,6 +7972,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_air_defense_troops"
+			unlock_decision_category_tooltip = POL_air_defense_category
 			custom_effect_tooltip = POL_air_defense_troops_TT
 		}
 
@@ -10374,6 +10382,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_begin_contruction_of_space_company"
+			unlock_decision_category_tooltip = POL_polsa_construction_category
 			one_random_industrial_complex = yes
 			custom_effect_tooltip = POL_build_polsa_TT
 			set_temp_variable = { treasury_change = -20 }
@@ -11902,6 +11911,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_moon_mission_preparations"
+			unlock_decision_category_tooltip = POL_moon_launch_mission
 			add_tech_bonus = {
 				name = POL_moon_mission_preparations
 				bonus = 0.15
@@ -14016,6 +14026,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_intensified_army_training"
+			unlock_decision_category_tooltip = POL_intensified_army_training_category
 			custom_effect_tooltip = POL_intensified_training_TT
 		}
 
@@ -17253,6 +17264,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_removal_of_communist_monuments"
+			unlock_decision_category_tooltip = POL_monuments_removal_category
 			custom_effect_tooltip = POL_removal_monuments_TT
 		}
 
@@ -17651,6 +17663,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_closeup_of_the_visegrad_group"
+			unlock_decision_tooltip = POL_slovakia_unification
+			unlock_decision_category_tooltip = POL_visegrad_unification_category
 			CZE = {
 				add_opinion_modifier = {
 					target = POL
@@ -17734,6 +17748,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_discussion_of_the_world_situation"
+			unlock_decision_category_tooltip = POL_visegrad_unification2_category
 			add_political_power = 50
 			custom_effect_tooltip = POL_visegrad_integration2_TT
 		}
@@ -17797,6 +17812,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_mission_hungary"
+			unlock_decision_category_tooltip = POL_visegrad_unification3_category
 			add_political_power = 50
 			custom_effect_tooltip = POL_visegrad_integration3_TT
 		}
@@ -21363,6 +21379,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_korwin_is_in_power"
+			unlock_decision_category_tooltip = POL_korwin_walesa_bop_category
 			if = {
 				limit = {
 					has_any_power_balance = no
@@ -21846,6 +21863,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_demand_lwow"
+			unlock_decision_category_tooltip = POL_polish_ukrainian_war_category
 			add_power_balance_value = {
 				id = POL_korwin_win_bop
 				value = -0.15
@@ -22802,6 +22820,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_make_two_nations_one_again"
+			unlock_decision_category_tooltip = POL_kaliningrad_problem
 			1044 = {
 				add_core_of = POL
 			}

--- a/common/national_focus/05_romania.txt
+++ b/common/national_focus/05_romania.txt
@@ -6406,6 +6406,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ROM_greater_romania_party executed"
+			unlock_decision_category_tooltip = ROM_vadim_struggle
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -7431,6 +7432,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ROM_the_reunification_of_all_romanians executed"
+			unlock_decision_category_tooltip = ROM_romanianization_category
 			custom_effect_tooltip = rom_reintegration
 			custom_effect_tooltip = ROM_core_compliance_tt
 			add_timed_idea = {

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -344,6 +344,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_stabilisation_fund"
+			unlock_decision_tooltip = SOV_againg_stabfund
 			add_ideas = SOV_stab_fund_idea
 			set_temp_variable = { treasury_change = -155 }
 			modify_treasury_effect = yes
@@ -8602,6 +8603,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_help_armenia"
+			unlock_decision_tooltip = SOV_promotion_of_unite_with_russia_armenia
+			unlock_decision_tooltip = SOV_perevorot_armenia
 			custom_effect_tooltip = SOV_new_decision_sovfed_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			if = {
@@ -9800,6 +9803,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_save_gaddafi"
+			unlock_decision_tooltip = SOV_libya_weapons
+			unlock_decision_tooltip = SOV_libya_bases
+			unlock_decision_tooltip = SOV_libya_instructors
+			unlock_decision_tooltip = SOV_wagner_libya_instructors
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 		}
@@ -10351,6 +10358,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_governorates"
+			unlock_decision_tooltip = SUB_rusempire_governorates_caucas_destroy
+			unlock_decision_tooltip = SUB_rusempire_governorates_other_destroy
+			unlock_decision_tooltip = SUB_rusempire_governorates_siberia_destroy
+			unlock_decision_tooltip = SUB_rusempire_governorates_povoljie_destroy
 			custom_effect_tooltip = SOV_new_decision_sovfed_unlock_tt
 			increase_centralization = yes
 		}
@@ -10545,6 +10556,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_claim_finland"
+			unlock_decision_tooltip = SOV_promotion_of_unite_with_russia_again
+			unlock_decision_tooltip = SOV_perevorot_finland
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -10646,6 +10659,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_question_of_poland"
+			unlock_decision_tooltip = SOV_promotion_of_unite_with_russia_agains
+			unlock_decision_tooltip = SOV_perevorot_poland
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_sovfed_unlock_tt
 		}
@@ -10767,6 +10782,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_question_of_spain"
+			unlock_decision_tooltip = SOV_start_catalonia
+			unlock_decision_tooltip = SOV_start_andaluces
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			SPR = {
 				set_temp_variable = { culture_index = 0 }
@@ -10811,6 +10828,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_question_of_germany"
+			unlock_decision_tooltip = SOV_start_bavaria
+			unlock_decision_tooltip = SOV_start_east_opinion
+			unlock_decision_tooltip = SOV_bavaria_instructors
+			unlock_decision_tooltip = SOV_wagner_bavaria_instructors
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 			GER = {
@@ -10972,6 +10993,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_bulgarian_ally"
+			unlock_decision_tooltip = SOV_promotion_of_unite_with_russia_bulgaria
 			BUL = {
 				country_event = { id = sov_nationalists.7 days = 1 }
 			}
@@ -11237,6 +11259,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_zheltoros"
+			unlock_decision_tooltip = SOV_promotion_of_unite_with_russia_mongolia
+			unlock_decision_tooltip = SOV_perevorot_mongolia
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_sovfed_unlock_tt
 			hidden_effect = {
@@ -12074,6 +12098,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_nazbols_capital_return"
+			unlock_decision_tooltip = SOV_nazbol_capital_return_division
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -12611,6 +12636,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_nazbols_help_artsakh"
+			unlock_decision_tooltip = SOV_artsakh_instructors
+			unlock_decision_tooltip = SOV_wagner_artsakh_instructors
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 		}
 
@@ -12663,6 +12690,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_nazbols_help_kurdistan"
+			unlock_decision_tooltip = SOV_kurdistan_instructors
+			unlock_decision_tooltip = SOV_wagner_kurdistan_instructors
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 		}
 
@@ -12949,6 +12978,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_nazbols_ekb"
+			unlock_decision_tooltip = SOV_ekb_build
 			decrease_centralization = yes
 			set_capital = { state = 676 }
 			add_political_power = 80
@@ -15743,6 +15773,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_warsaw_finland"
+			unlock_decision_tooltip = SOV_influence_on_finland
+			unlock_decision_tooltip = SOV_warsaw_perevorot_finland
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -15794,6 +15826,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_mongolia_question"
+			unlock_decision_tooltip = SOV_influence_on_mongolia
+			unlock_decision_tooltip = SOV_warsaw_perevorot_mongolia
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -15835,6 +15869,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_vietnam_question"
+			unlock_decision_tooltip = SOV_influence_on_vietnam
+			unlock_decision_tooltip = SOV_warsaw_perevorot_vietnam
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -15875,6 +15911,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_spain_influ"
+			unlock_decision_tooltip = SOV_influence_on_spain
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -15915,6 +15952,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_iraq_influ"
+			unlock_decision_tooltip = SOV_influence_on_iraq
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -16007,6 +16045,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_warsaw_greece"
+			unlock_decision_tooltip = SOV_influence_on_greece
+			unlock_decision_tooltip = SOV_warsaw_perevorot_greece
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 		}
 
@@ -16536,6 +16576,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_capitalism_in_500_days"
+			unlock_decision_category_tooltip = SOV_500_days_category
 			if = {
 				limit = {
 					NOT = {
@@ -21974,6 +22015,7 @@ focus_tree = {
 				}
 			}
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_expand_trade_with_taiwan"
+			unlock_decision_category_tooltip = SOV_democracy_taiwam_category
 		}
 
 		ai_will_do = {
@@ -22040,6 +22082,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_support_taiwan_military_buildup"
+			unlock_decision_tooltip = SOV_more_weapon_taiwan
 		}
 
 		ai_will_do = {
@@ -22981,6 +23024,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_pmc_redut_coprs"
+			unlock_decision_tooltip = SOV_start_volunteer_assault_coprs
 			custom_effect_tooltip = SOV_pmc_redut_coprs_TT
 			hidden_effect = {
 				add_ideas = SOV_volunteer_assault_coprs_idea
@@ -23665,6 +23709,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_storm_z"
+			unlock_decision_tooltip = SOV_storm_z_central_russias
+			unlock_decision_tooltip = SOV_storm_z_ural
+			unlock_decision_tooltip = SOV_storm_z_far_east
+			unlock_decision_tooltip = SOV_storm_z_siberia
 			add_popularity = { ideology = nationalist popularity = 0.03 }
 			recalculate_party = yes
 			hidden_effect = {
@@ -24838,6 +24886,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_storm_v"
+			unlock_decision_tooltip = SOV_storm_z_central_russias
+			unlock_decision_tooltip = SOV_storm_z_ural
+			unlock_decision_tooltip = SOV_storm_z_far_east
+			unlock_decision_tooltip = SOV_storm_z_siberia
 			add_popularity = { ideology = nationalist popularity = 0.03 }
 			recalculate_party = yes
 			hidden_effect = {
@@ -25055,6 +25107,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_wagner_more_operations"
+			unlock_decision_tooltip = SOV_dpr_instructors
+			unlock_decision_tooltip = SOV_wagner_dpr_instructors
+			unlock_decision_tooltip = SOV_wagner_lpr_instructors
+			unlock_decision_tooltip = SOV_wagner_hpr_instructors
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 		}
 
@@ -25083,6 +25139,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_wagner_african"
+			unlock_decision_tooltip = SOV_wagner_sudan_instructors
+			unlock_decision_tooltip = SOV_wagner_niger_instructors
+			unlock_decision_tooltip = SOV_wagner_drc_instructors
+			unlock_decision_tooltip = SOV_wagner_mali_instructors
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 			hidden_effect = {
 				add_ideas = SOV_wagner_africa
@@ -25114,6 +25174,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_wagner_support_gru"
+			unlock_decision_tooltip = SOV_wagner_georgia_instructors
+			unlock_decision_tooltip = SOV_wagner_bavaria_instructors
+			unlock_decision_tooltip = SOV_wagner_iraq_instructors
+			unlock_decision_tooltip = SOV_wagner_libya_instructors
+			unlock_decision_tooltip = SOV_wagner_artsakh_instructors
+			unlock_decision_tooltip = SOV_wagner_kurdistan_instructors
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 		}
 
@@ -31203,6 +31269,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_Make_the_Anti-Corruption_Foundation_a_State_Company"
+			unlock_decision_category_tooltip = SOV_fbk_organization_category
 			custom_effect_tooltip = SOV_FBK_TT
 			set_country_flag = SOV_navalny_branch
 			clr_country_flag = SOV_yavlinsky_branch
@@ -31738,6 +31805,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_Cooperation_with_Taiwan"
+			unlock_decision_tooltip = SOV_boost_opinion_of_rus
 			TAI = {
 				add_political_power = 100
 				add_opinion_modifier = {
@@ -32877,6 +32945,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_iraq_moscow_pact"
+			unlock_decision_tooltip = SOV_iraq_weapons
+			unlock_decision_tooltip = SOV_iraq_bases
+			unlock_decision_tooltip = SOV_iraq_instructors
+			unlock_decision_tooltip = SOV_wagner_iraq_instructors
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_gru_unlock_tt
 		}
@@ -32925,6 +32997,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_czechoslovak_region"
+			unlock_decision_tooltip = SOV_promotion_of_unite_with_russia_agains_chechos
+			unlock_decision_tooltip = SOV_perevorot_czechia_govern
+			unlock_decision_tooltip = SOV_perevorot_slovakia_govern
 			custom_effect_tooltip = SOV_new_decision_svr_unlock_tt
 			custom_effect_tooltip = SOV_new_decision_sovfed_unlock_tt
 		}
@@ -32952,6 +33027,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_russian"
+			unlock_decision_tooltip = SOV_first_broken_destroy
+			unlock_decision_tooltip = SOV_second_broken_destroy
+			unlock_decision_tooltip = SOV_third_broken_destroy
 			one_random_industrial_complex = yes
 		}
 
@@ -32984,6 +33062,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_outer_space_initiative"
+			unlock_decision_tooltip = SOV_roskosmos_open
+			unlock_decision_tooltip = SOV_roskosmos_close
 			add_ideas = SOV_idea_outer_space_development
 			hidden_effect = {
 				if = {
@@ -33076,6 +33156,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_outer_space_asteroids_mining"
+			unlock_decision_tooltip = SOV_asteroid_mining_continue
 			add_ideas = SOV_asteroids_idea
 			set_temp_variable = { treasury_change = -9 }
 			modify_treasury_effect = yes
@@ -33767,6 +33848,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_rusagro"
+			unlock_decision_tooltip = SOV_economic_rusagro_expanded
 			add_ideas = SOV_rusagro_idea
 			set_temp_variable = { modify_economic = 1 }
 			modify_economic_support = yes
@@ -33836,6 +33918,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_miratorg"
+			unlock_decision_tooltip = SOV_economic_miratorg_expanded
 			642 = {
 				add_building_construction = {
 					type = agriculture_district
@@ -33881,6 +33964,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_efko"
+			unlock_decision_tooltip = SOV_economic_efko_expanded
 			1172 = {
 				add_building_construction = {
 					type = agriculture_district
@@ -33967,6 +34051,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_belarus_integrate"
+			unlock_decision_tooltip = SOV_belarus_open
+			unlock_decision_tooltip = SOV_belarus_close
 			add_political_power = 100
 		}
 
@@ -34027,6 +34113,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_140_annex"
+			unlock_decision_tooltip = SOV_added_140z1
 			add_ideas = BLR_140_zavod_union_state1
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
@@ -34056,6 +34143,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_mzkt_annex"
+			unlock_decision_tooltip = SOV_added_mzktz1
 			add_ideas = BLR_mzkt_union_state1
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
@@ -34082,6 +34170,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_peleng_annex"
+			unlock_decision_tooltip = SOV_added_pelengz1
 			add_ideas = BLR_peleng_union_state1
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
@@ -34136,6 +34225,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_interrao"
+			unlock_decision_tooltip = SOV_economic_interrao_expand
+			unlock_decision_tooltip = SOV_interrao_open
+			unlock_decision_tooltip = SOV_interrao_close
+			unlock_decision_tooltip = SOV_interrao_buy_pmr_gres
 			two_random_fossil_fuel_powerplant = yes
 			set_temp_variable = { modify_economic = 1 }
 			modify_economic_support = yes
@@ -34175,6 +34268,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_rus_hydro"
+			unlock_decision_tooltip = SOV_economic_rus_hydro_expanded
 			671 = {
 				add_building_construction = {
 					type = fossil_powerplant
@@ -34491,6 +34585,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_severstal"
+			unlock_decision_tooltip = SOV_economic_severstal_expanded
 			1128 = {
 				add_resource = {
 					type = steel
@@ -34549,6 +34644,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_mechel"
+			unlock_decision_tooltip = SOV_economic_yakut_ugol
 			1133 = {
 				add_resource = {
 					type = steel
@@ -34599,6 +34695,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_evraz"
+			unlock_decision_tooltip = SOV_economic_evraz_asset
 			1066 = {
 				add_resource = {
 					type = steel
@@ -35456,6 +35553,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_sber_reorg"
+			unlock_decision_tooltip = SOV_economic_sber_ipo
 			add_ideas = SOV_sberbank_idea
 			set_temp_variable = { modify_economic = 1 }
 			modify_economic_support = yes
@@ -35481,6 +35579,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_vtb"
+			unlock_decision_tooltip = SOV_economic_vtb_ipo
 			add_ideas = SOV_vtbbank_idea
 		}
 
@@ -35503,6 +35602,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_alpha"
+			unlock_decision_tooltip = SOV_economic_alpha_lab
 			add_ideas = SOV_alphabank_idea
 		}
 
@@ -35824,6 +35924,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_mts"
+			unlock_decision_tooltip = SOV_economic_mts_expanding
 			add_ideas = SOV_mts_idea
 			add_tech_bonus = {
 				name = GENERIC_network_infrastructure
@@ -35921,6 +36022,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_poebda"
+			unlock_decision_tooltip = SOV_economic_new_airports
 			swap_ideas = {
 				remove_idea = SOV_aeroflot_idea
 				add_idea = SOV_aeroflot_idea1
@@ -35946,6 +36048,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_rjd"
+			unlock_decision_tooltip = SOV_economic_rjd_sakhalin
+			unlock_decision_tooltip = SOV_economic_rjd_mcd
 			add_ideas = SOV_rjd_idea
 			set_temp_variable = { modify_economic = 1 }
 			modify_economic_support = yes
@@ -36286,6 +36390,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_rusal"
+			unlock_decision_tooltip = SOV_economic_buy_sual
 			1065 = {
 				add_resource = {
 					type = aluminium
@@ -37264,6 +37369,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_gazprom_stream"
+			unlock_decision_tooltip = SOV_nord_stream_prepare
+			unlock_decision_tooltip = SOV_nord_stream2_prepare
+			unlock_decision_tooltip = SOV_blue_stream_prepare
+			unlock_decision_tooltip = SOV_turkey_stream_prepare
 			add_political_power = 50
 			custom_effect_tooltip = SOV_pipelinise_TT
 			set_temp_variable = { temp_opinion = 5 }
@@ -37736,6 +37845,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_alrosa"
+			unlock_decision_tooltip = SOV_economic_nakynskoe
 			688 = {
 				add_resource = {
 					type = chromium
@@ -37796,6 +37906,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_nornickel"
+			unlock_decision_tooltip = SOV_economic_buy_polus
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -37871,6 +37982,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SOV_economic_reform_gazprom"
+			unlock_decision_tooltip = SOV_gazprom_open
+			unlock_decision_tooltip = SOV_gazprom_close
+			unlock_decision_tooltip = SOV_gazprom_in_pmr
 			add_ideas = SOV_gazprom_idea
 			set_temp_variable = { modify_economic = 2 }
 			modify_economic_support = yes

--- a/common/national_focus/05_san_marino.txt
+++ b/common/national_focus/05_san_marino.txt
@@ -1367,6 +1367,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SMA_change_history_in_textbooks executed"
+			unlock_decision_category_tooltip = SMA_change_textbooks
 			custom_effect_tooltip = change_textbooks_TT
 		}
 
@@ -2963,6 +2964,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SMA_research_center executed"
+			unlock_decision_category_tooltip = SMA_research_center_category
 			set_temp_variable = { treasury_change = -4.00 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = start_build_center_TT

--- a/common/national_focus/05_serbia.txt
+++ b/common/national_focus/05_serbia.txt
@@ -1147,6 +1147,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_bos executed"
+			unlock_decision_tooltip = SER_invite_bosnia
 			custom_effect_tooltip = SER_federation_bosnia_tt
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = BOS }
@@ -1232,6 +1233,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_slv_cro executed"
+			unlock_decision_tooltip = SER_invite_croatia
+			unlock_decision_tooltip = SER_invite_slovenia
 			custom_effect_tooltip = SER_federation_croatia_tt
 			custom_effect_tooltip = SER_federation_slovenia_tt
 			set_temp_variable = { percent_change = 2 }
@@ -1318,6 +1321,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_mac_kos executed"
+			unlock_decision_tooltip = SER_invite_makedonia
 			custom_effect_tooltip = SER_federation_macedonia_tt
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = FYR }
@@ -1403,6 +1407,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_alb executed"
+			unlock_decision_tooltip = SER_invite_albania
 			custom_effect_tooltip = SER_federation_albania_tt
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = ALB }
@@ -1463,6 +1468,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_gre executed"
+			unlock_decision_tooltip = SER_invite_greece
 			custom_effect_tooltip = SER_federation_greece_tt
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = GRE }
@@ -1528,6 +1534,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_bul executed"
+			unlock_decision_tooltip = SER_invite_bulgaria
 			custom_effect_tooltip = SER_federation_bulgaria_tt
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = BUL }
@@ -1569,6 +1576,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_confederation_romania executed"
+			unlock_decision_tooltip = SER_invite_romania
 			custom_effect_tooltip = SER_federation_romania_tt
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { influence_target = ROM }
@@ -4581,6 +4589,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_mvd executed"
+			unlock_decision_tooltip = VOJ_separ_debuff
 			increase_policing_budget = yes
 			newline = yes
 			add_stability = 0.01
@@ -4747,6 +4756,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus SER_anti_terror executed"
+			unlock_decision_tooltip = VOJ_separ_debuff1
 			swap_ideas = {
 				remove_idea = SER_kto_unit
 				add_idea = SER_kto_unit1

--- a/common/national_focus/05_singapore.txt
+++ b/common/national_focus/05_singapore.txt
@@ -6483,6 +6483,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus SIN_encourage_migration"
+			unlock_decision_tooltip = SIN_repeal_the_migrant_worker_policy
 			custom_effect_tooltip = SIN_encourage_migration_tt
 			swap_ideas = {
 				remove_idea = SIN_migrant_workers
@@ -6557,6 +6558,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus SIN_import_cheap_labour"
+			unlock_decision_tooltip = SIN_repeal_the_migrant_worker_policy
 			custom_effect_tooltip = SIN_encourage_migration_worse_tt
 			swap_ideas = {
 				remove_idea = SIN_migrant_workers_encouraged_idea

--- a/common/national_focus/05_spain.txt
+++ b/common/national_focus/05_spain.txt
@@ -2297,6 +2297,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_the_old_ways"
+			unlock_decision_category_tooltip = SPR_monarchist_spain
 			set_temp_variable = { party_index = 0 }
 			set_temp_variable = { party_popularity_increase = 0.035 }
 			set_temp_variable = { temp_outlook_increase = 0.035 }
@@ -2336,6 +2337,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_question_of_thrones"
+			unlock_decision_tooltip = SPR_install_the_carlists_decision
 			country_event = spain.57
 		}
 
@@ -2821,6 +2823,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_the_new_elections"
+			unlock_decision_tooltip = SPR_remove_our_coalition_partner_decision
+			unlock_decision_tooltip = SPR_add_conservatism_into_coalition_decision
+			unlock_decision_tooltip = SPR_add_socialism_into_coalition_decision
+			unlock_decision_tooltip = SPR_add_nat_fascism_into_coalition_decision
+			unlock_decision_tooltip = SPR_add_nat_rwp_into_coalition_decision
+			unlock_decision_tooltip = SPR_exploit_the_union_decision
 			add_political_power = 100
 			custom_effect_tooltip = SPR_the_new_elections_tt
 		}
@@ -4737,6 +4745,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_the_welfare_state"
+			unlock_decision_tooltip = SPR_conservatism_policy_replacer_decision
 			if = { limit = { NOT = { has_idea = social_06 } }
 				increase_social_spending = yes
 				block_social_change = yes
@@ -4950,6 +4959,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_party_of_the_people"
+			unlock_decision_tooltip = SPR_conservatism_policy_replacer_decision
 			add_ideas = SPR_a_party_of_the_people_idea
 			set_temp_variable = { party_index = 1 }
 			set_temp_variable = { party_popularity_increase = 0.03 }
@@ -6431,6 +6441,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_pin_parental_education"
+			unlock_decision_tooltip = SPR_rwp_policy_replacer_decisions
 			country_event = spain.73
 		}
 
@@ -6459,6 +6470,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_rise_of_nativism"
+			unlock_decision_tooltip = SPR_rwp_policy_replacer_decisions
 			country_event = spain.74
 			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
@@ -6489,6 +6501,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_the_natalist_view"
+			unlock_decision_tooltip = SPR_rwp_policy_replacer_decisions
 			add_ideas = SPR_the_natalist_view_idea
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = 0.03 }
@@ -7764,6 +7777,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_the_youth_front"
+			unlock_decision_tooltip = SPR_falangists_policy_replacer_decision
 			add_ideas = SPR_the_falangist_youth_front_idea
 		}
 
@@ -7792,6 +7806,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_return_of_francoism"
+			unlock_decision_tooltip = SPR_falangists_policy_replacer_decision
 			country_event = spain.75
 		}
 
@@ -7820,6 +7835,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_spanish_first"
+			unlock_decision_tooltip = SPR_falangists_policy_replacer_decision
 			add_timed_idea = {
 				idea = SPR_spain_first_idea
 				days = 365
@@ -9615,6 +9631,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_decommodify_the_basics"
+			unlock_decision_tooltip = SPR_socialism_policy_replacer_decision
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = -0.03 }
 			modify_treasury_effect = yes
@@ -10275,6 +10292,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_a_keynesian_take"
+			unlock_decision_tooltip = SPR_socialism_policy_replacer_decision
 			add_ideas = SPR_keynesian_economic_idea
 		}
 
@@ -11037,6 +11055,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_in_support_of_the_worker"
+			unlock_decision_tooltip = SPR_communist_policy_replacer_decision
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			change_labour_unions_opinion = yes
@@ -11223,6 +11242,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_marxist_education"
+			unlock_decision_tooltip = SPR_communist_policy_replacer_decision
 			add_timed_idea = {
 				idea = SPR_marxist_reeducation_idea
 				days = 730

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -3787,6 +3787,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_address_ethnic_divides"
+			unlock_decision_category_tooltip = Syria_centralization_balance_of_power_category
 			remove_ideas = syria_power_vacuum
 			set_power_balance = {
 				id = Syria_centralization_balance_of_power_category
@@ -5057,6 +5058,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_legalise_private_banking"
+			unlock_decision_tooltip = hisiyah_industrial_expansion
+			unlock_decision_tooltip = aleppan_economy_booming
 			add_stability = 0.05
 			set_temp_variable = { temp_opinion = 5 }
 			change_international_bankers_opinion = yes
@@ -5086,6 +5089,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_economic_revitalization"
+			unlock_decision_category_tooltip = Syria_economic_investments
 			add_tech_bonus = {
 				name = SYR_tech_name
 				bonus = 0.5
@@ -5124,6 +5128,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_initiate_industrialization"
+			unlock_decision_tooltip = invigorate_hisiyah
+			unlock_decision_tooltip = clear_aleppan_slums
 			custom_effect_tooltip = TT_SYR_ECONOMIC_DECISIONS_UNLOCKED
 		}
 
@@ -5902,6 +5908,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_tap_into_the_oil_reserves"
+			unlock_decision_tooltip = eastern_oil_excavation_phase1
 			custom_effect_tooltip = TT_SYR_EXCAVATION_DECISIONS_UNLOCKED
 		}
 
@@ -6078,6 +6085,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_invest_in_hasakan_cotton"
+			unlock_decision_tooltip = invest_in_eastern_cotton
 			custom_effect_tooltip = TT_SYR_HASAKAN_DECISIONS_UNLOCKED
 		}
 
@@ -6490,6 +6498,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_digitalisation_campaign"
+			unlock_decision_category_tooltip = Syria_digital_investments_decisions
 			custom_effect_tooltip = TT_SYR_DIGITAL_INVESTMENTS_FOCUS_EFFECT
 		}
 
@@ -8615,6 +8624,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_against_hezbollah"
+			unlock_decision_tooltip = infiltrate_hezbollah
+			unlock_decision_tooltip = sow_discord_between_HEZ_and_PER
 			custom_effect_tooltip = TT_SYR_HEZ_DIPLOMACY
 			set_temp_variable = { temp_opinion = -5 }
 			change_iranian_quds_force_opinion = yes

--- a/common/national_focus/05_tatarstan.txt
+++ b/common/national_focus/05_tatarstan.txt
@@ -3545,6 +3545,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_idel_ural_rus"
+			unlock_decision_tooltip = TAT_unite_idel_ural
 			custom_effect_tooltip = BSH_idelural_russia_tt
 		}
 
@@ -3575,6 +3576,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_idel_ural_free"
+			unlock_decision_tooltip = TAT_integrate_BSH
+			unlock_decision_tooltip = TAT_integrate_BSHkir
 			custom_effect_tooltip = BSH_idelural_notrussia_tt
 			add_state_claim = 664
 		}

--- a/common/national_focus/05_ukraine.txt
+++ b/common/national_focus/05_ukraine.txt
@@ -5797,6 +5797,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_revolution_in_russia"
+			unlock_decision_tooltip = UKR_attack_kuban_commies
+			unlock_decision_tooltip = UKR_attack_tatarstan_commies
 			hidden_effect = {
 				SOV = { revoult_in_russia_from_commi_ukraine = yes }
 			}
@@ -5949,6 +5951,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_central_asia_revolt"
+			unlock_decision_tooltip = UKR_revoult_kyrgiz
 			custom_effect_tooltip = UKR_revoult_in_central_shaurma_tt
 		}
 
@@ -7622,6 +7625,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_hur_reform"
+			unlock_decision_category_tooltip = UKR_hur_decision_category
 			if = {
 				limit = { check_variable = { UKR_hur_level = 1 } }
 				add_to_variable = { UKR_hur_level = 1 }
@@ -8097,6 +8101,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_national_guard"
+			unlock_decision_tooltip = UKR_reorganize_the_national_guard_first_brigade
+			unlock_decision_tooltip = UKR_reorganize_the_national_guard_second_brigade
+			unlock_decision_tooltip = UKR_reorganize_the_national_guard_third_brigade
+			unlock_decision_tooltip = UKR_reorganize_the_national_guard_four_brigade
 			custom_effect_tooltip = UKR_natguard_created_tt
 			if = {
 				limit = {
@@ -8293,6 +8301,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_ter_oborona"
+			unlock_decision_category_tooltip = UKR_tro_brigades_ukraine_decision_category
 			custom_effect_tooltip = UKR_tro_created_tt
 			if = {
 				limit = { check_variable = { UKR_teroborona_level < 1 } }
@@ -8910,6 +8919,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_uda"
+			unlock_decision_category_tooltip = UKR_uda_decision_category
 			add_ideas = UKR_uda_encouraged
 			custom_effect_tooltip = UKR_uda_created_tt
 			hidden_effect = {
@@ -8937,6 +8947,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_found_the_uop"
+			unlock_decision_category_tooltip = UKR_uop_decision_category
 			two_random_arms_factory = yes
 			add_ideas = UKR_oup
 		}
@@ -9275,6 +9286,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_inter_legion"
+			unlock_decision_category_tooltip = UKR_interlegion_decision_category
 			custom_effect_tooltip = UKR_inter_created_tt
 			add_ideas = UKR_inter_legion_idea
 			hidden_effect = {
@@ -9786,6 +9798,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_silesian_rebellion"
+			unlock_decision_tooltip = UKR_attack_silesia_war
+			unlock_decision_tooltip = UKR_attack_kashubia_war
 			custom_effect_tooltip = UKR_hur_operation_silesia_tt
 		}
 
@@ -11879,6 +11893,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_caucasus_volunteers"
+			unlock_decision_tooltip = UKR_hire_caucas_drg
 			custom_effect_tooltip = UKR_hur_operation_caucas_volunteer_tt
 		}
 
@@ -11906,6 +11921,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_dagestan_reb_prepare"
+			unlock_decision_tooltip = UKR_attack_dagestan
 			custom_effect_tooltip = UKR_hur_operation_dagestan_tt
 		}
 
@@ -11933,6 +11949,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_befriend_chechens"
+			unlock_decision_tooltip = UKR_attack_checnya
 			custom_effect_tooltip = UKR_hur_operation_chechnya_tt
 		}
 
@@ -11967,6 +11984,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_dig_up_potatoes"
+			unlock_decision_tooltip = UKR_attack_belarus
 			set_temp_variable = { wargoal_on = BLR }
 			add_threat_from_wargoal_effect = yes
 			create_wargoal = {
@@ -12058,6 +12076,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_to_recall_the_volhynia_massacre"
+			unlock_decision_tooltip = UKR_attack_poland
 			set_temp_variable = { wargoal_on = POL }
 			add_threat_from_wargoal_effect = yes
 			create_wargoal = {
@@ -12145,6 +12164,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_secretly_sending_militants_to_kuban"
+			unlock_decision_tooltip = UKR_attack_crimea
 			custom_effect_tooltip = UKR_hur_operation_crimea_tt
 		}
 
@@ -12180,6 +12200,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_liberate_green_klin"
+			unlock_decision_tooltip = UKR_attack_vladivostok
 			custom_effect_tooltip = UKR_hur_operation_vladivostok_tt
 		}
 
@@ -12209,6 +12230,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_agitation_of_radical_ukrainians_in_kuban"
+			unlock_decision_tooltip = UKR_attack_kuban
+			unlock_decision_tooltip = UKR_attack_kuban_commies
 			custom_effect_tooltip = UKR_hur_operation_kuban_tt
 		}
 
@@ -24855,6 +24878,7 @@ SOV = { country_event = { id = ukraine_our_ukraine.7 days = 1 } }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus UKR_min_economy"
+			unlock_decision_category_tooltip = UKR_economy
 			newline = yes
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }

--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -8516,6 +8516,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_national_productivity_commission"
+			unlock_decision_tooltip = ENG_roysth_naval_port_decision
+			unlock_decision_tooltip = ENG_expand_belfast_decision
+			unlock_decision_tooltip = ENG_highland_main_line_decision
+			unlock_decision_tooltip = ENG_titanic_quarter_decision
+			unlock_decision_tooltip = ENG_elizabeth_line_decision
 			unlock_decision_tooltip = {
 				decision = ENG_roysth_naval_port_decision
 				show_effect_tooltip = yes
@@ -16050,6 +16055,7 @@ focus_tree = {
 					}
 				}
 				log = "Advisor was already there. STOP CHEATING!"
+				unlock_decision_tooltip = ENG_charles_charities_network_decision
 			}
 			else_if = { # ASCENDED ADVISORS FULL - NEED TO REPLACE SOMEONE
 				limit = {
@@ -16164,6 +16170,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_harmony_doctrine"
+			unlock_decision_tooltip = ENG_charles_harmony_tour_decision
+			unlock_decision_tooltip = ENG_charles_environmental_diplomacy_tour_decision
 			add_timed_idea = {
 				idea = ENG_harmony_doctrine_idea
 				years = 2
@@ -16241,6 +16249,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_climate_alarm_bell"
+			unlock_decision_tooltip = ENG_charles_sustainable_urban_planning_decision
+			unlock_decision_tooltip = ENG_charles_rainforest_help_decision
+			unlock_decision_tooltip = ENG_charles_youth_sustainability_decision
 			swap_ideas = {
 				remove_idea = ENG_charles_1_idea
 				add_idea = ENG_charles_2_idea
@@ -16322,6 +16333,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_duchy_originals"
+			unlock_decision_tooltip = ENG_charles_organic_agriculture_decision
 			random_core_state = {
 				limit = {
 					is_controlled_by = ROOT
@@ -16499,6 +16511,7 @@ focus_tree = {
 					}
 				}
 				log = "Advisor was already there. STOP CHEATING!"
+				unlock_decision_tooltip = ENG_andrew_naval_haritage_decision
 			}
 			else_if = { # ASCENDED ADVISORS FULL - NEED TO REPLACE SOMEONE
 				limit = {
@@ -16608,6 +16621,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_appoint_trade_representative"
+			unlock_decision_tooltip = ENG_andrew_trade_representive_decision
 			unlock_decision_tooltip = {
 				decision = ENG_andrew_trade_representive_decision
 				show_effect_tooltip = yes
@@ -16686,6 +16700,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_emerging_markets_circuit"
+			unlock_decision_tooltip = ENG_andrew_emerging_trade_agreement_decision
+			unlock_decision_tooltip = ENG_andrew_emerging_economy_benefits_decision
 			unlock_decision_tooltip = {
 				decision = ENG_andrew_emerging_trade_agreement_decision
 				show_effect_tooltip = yes
@@ -16761,6 +16777,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_digital_enterprise_patronage"
+			unlock_decision_tooltip = ENG_andrew_digital_enterprise_decision
 			unlock_decision_tooltip = {
 				decision = ENG_andrew_digital_enterprise_decision
 				show_effect_tooltip = yes
@@ -16982,6 +16999,7 @@ focus_tree = {
 					}
 				}
 				log = "Advisor was already there. STOP CHEATING!"
+				unlock_decision_tooltip = ENG_anne_national_charity_decision
 			}
 			else_if = { # ASCENDED ADVISORS FULL - NEED TO REPLACE SOMEONE
 				limit = {
@@ -17091,6 +17109,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_carers_recognition_campaign"
+			unlock_decision_tooltip = ENG_anne_carers_promotion_decision
 			add_timed_idea = {
 				idea = ENG_anne_carers_campaign_idea
 				years = 1
@@ -17255,6 +17274,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_princess_admiral_royal_navy"
+			unlock_decision_tooltip = ENG_anne_navy_readiness_decision
 			custom_effect_tooltip = ENG_princess_admiral_royal_navy_tt
 			newline = yes
 			swap_ideas = {
@@ -17343,6 +17363,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_colonel_of_horse_logistics"
+			unlock_decision_tooltip = ENG_anne_military_readiness_decision
 			custom_effect_tooltip = ENG_princess_admiral_royal_navy_tt
 			newline = yes
 			unlock_decision_tooltip = {
@@ -17409,6 +17430,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_quiet_professionalism"
+			unlock_decision_tooltip = ENG_anne_tourism_decision
 			if = {
 				limit = { has_idea = ENG_anne_3a_idea }
 				swap_ideas = {
@@ -17530,6 +17552,7 @@ focus_tree = {
 					}
 				}
 				log = "Advisor was already there. STOP CHEATING!"
+				unlock_decision_tooltip = ENG_edward_beach_youth_decision
 			}
 			else_if = { # ASCENDED ADVISORS FULL - NEED TO REPLACE SOMEONE
 				limit = {
@@ -17713,6 +17736,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_commonwealth_youth_outreach"
+			unlock_decision_tooltip = ENG_edward_global_youth_decision
+			unlock_decision_tooltip = ENG_edward_arts_culture_patronage_decision
 			unlock_decision_tooltip = {
 				decision = ENG_edward_global_youth_decision
 				show_effect_tooltip = yes
@@ -17785,6 +17810,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_production_guild_patronage"
+			unlock_decision_tooltip = ENG_edward_production_guild_decision
 			unlock_decision_tooltip = {
 				decision = ENG_edward_production_guild_decision
 				show_effect_tooltip = yes
@@ -17876,6 +17902,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_steady_hand"
+			unlock_decision_tooltip = ENG_edward_veteran_support_decision
 			unlock_decision_tooltip = {
 				decision = ENG_edward_veteran_support_decision
 				show_effect_tooltip = yes
@@ -18026,6 +18053,7 @@ focus_tree = {
 					}
 				}
 				log = "Advisor was already there. STOP CHEATING!"
+				unlock_decision_tooltip = ENG_philip_trust_funds_grants_decision
 			}
 			else_if = { # ASCENDED ADVISORS FULL - NEED TO REPLACE SOMEONE
 				limit = {
@@ -18204,6 +18232,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_wwf_president_emeritus"
+			unlock_decision_tooltip = ENG_philip_faith_conservation_decision
 			if = {
 				limit = {
 					has_idea = ENG_phillip_2_idea
@@ -18278,6 +18307,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_prince_phillip_medal"
+			unlock_decision_tooltip = ENG_philip_award_medal_decision
+			unlock_decision_tooltip = ENG_philip_award_expansion_decision
 			if = {
 				limit = {
 					has_idea = ENG_phillip_3_idea
@@ -18357,6 +18388,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_strength_and_stay"
+			unlock_decision_tooltip = ENG_philip_innovation_recognition_decision
 			if = {
 				limit = {
 					has_idea = ENG_phillip_4_idea
@@ -18466,6 +18498,7 @@ focus_tree = {
 					}
 				}
 				log = "Advisor was already there. STOP CHEATING!"
+				unlock_decision_tooltip = ENG_william_air_ambulance_decision
 			}
 			else_if = { # ASCENDED ADVISORS FULL - NEED TO REPLACE SOMEONE
 				limit = {
@@ -18575,6 +18608,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_royal_foundation"
+			unlock_decision_tooltip = ENG_william_early_years_forum_decision
 			add_tech_bonus = {
 				name = ENG_royal_foundation
 				category = CAT_industry
@@ -18659,6 +18693,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_heads_together"
+			unlock_decision_tooltip = ENG_william_mental_health_at_work_decision
+			unlock_decision_tooltip = ENG_william_step_into_health_decision
 			unlock_decision_tooltip = {
 				decision = ENG_william_mental_health_at_work_decision
 				show_effect_tooltip = yes
@@ -18809,6 +18845,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ENG_bridge_to_the_future"
+			unlock_decision_tooltip = ENG_william_chogm_youth_decision
 			unlock_decision_tooltip = {
 				decision = ENG_william_chogm_youth_decision
 				show_effect_tooltip = yes
@@ -18944,6 +18981,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus ENG_operation_barras"
+			unlock_decision_tooltip = ENG_seize_sierra_leone_resources
 			add_to_variable = { ENG_fp_count = 1 }
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { influence_target = SIE }
@@ -19419,6 +19457,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus ENG_a_more_united_kingdom"
+			unlock_decision_category_tooltip = ENG_a_more_united_kingdom_decisions
 			drop_cosmetic_tag = yes
 			custom_effect_tooltip = ENG_unlock_uniting_the_realm_decisions_TT
 			# Pulling GDP's
@@ -19923,6 +19962,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus ENG_fractured_kingdom_united_state"
+			unlock_decision_category_tooltip = ENG_fractured_kingdom_united_state_decisions
 			custom_effect_tooltip = ENG_unlock_the_next_era_TT
 			hidden_effect = {
 				955 = {
@@ -20075,6 +20115,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus ENG_uniting_the_isle"
+			unlock_decision_tooltip = ENG_integrate_ireland
 			29 = { add_claim_by = ENG }
 			newline = yes
 			27 = { add_claim_by = ENG }

--- a/common/national_focus/05_ural.txt
+++ b/common/national_focus/05_ural.txt
@@ -1459,6 +1459,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_meet_governors"
+			unlock_decision_tooltip = URA_unite_with_kurgan
+			unlock_decision_tooltip = URA_unite_with_chelyaba
+			unlock_decision_tooltip = URA_unite_with_orenburg
+			unlock_decision_tooltip = URA_unite_with_perm
 			set_temp_variable = { percent_change = 2.03 }
 			set_temp_variable = { influence_target = SOV }
 			change_influence_percentage = yes
@@ -2174,6 +2178,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_germany_more_trade"
+			unlock_decision_tooltip = URA_ger_promka
 			GER = { country_event = { id = ural_event.20 days = 1 } }
 		}
 
@@ -2617,6 +2622,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_chelyaba_concern"
+			unlock_decision_tooltip = URA_returm_chelyaba_promka
 			remove_ideas = URA_zlatoust_idea
 			add_ideas = URA_chelyaba_concern_idea
 			set_temp_variable = { treasury_change = -1.75 }
@@ -2862,6 +2868,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_kurgan_concern"
+			unlock_decision_tooltip = URA_returm_kurgan_promka
 			add_ideas = URA_kurgan_concern_idea
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -3213,6 +3220,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_ugmk_meknabor"
+			unlock_decision_tooltip = URA_returm_ugmk_promka
 			URA_ural_ugmk = yes
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -3487,6 +3495,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_ural_concern"
+			unlock_decision_tooltip = URA_returm_ekb_promka
 			remove_ideas = URA_ugz_idea
 			remove_ideas = URA_avia_idea
 			add_ideas = URA_ekb_concern_idea
@@ -4288,6 +4297,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_rne_russian_dictatorship"
+			unlock_decision_tooltip = URA_unite_with_kurgan
+			unlock_decision_tooltip = URA_unite_with_chelyaba
+			unlock_decision_tooltip = URA_unite_with_orenburg
+			unlock_decision_tooltip = URA_unite_with_perm
 			add_ideas = URA_rne_russian_dictatorship_idea
 		}
 
@@ -4744,6 +4757,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_rne_ekb_all_nazbol"
+			unlock_decision_tooltip = URA_nazbols_ekb
 			SOV = {
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4789,6 +4803,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_rne_nazbol_unite_propaganda"
+			unlock_decision_tooltip = URA_nazbols_unite
 			SOV = {
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4834,6 +4849,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_rne_nazbol_revanshizm_propaganda"
+			unlock_decision_tooltip = URA_nazbols_revanshizm
 			SOV = {
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -6946,6 +6962,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_communism_ural_oblast"
+			unlock_decision_tooltip = URA_unite_with_kurgan
+			unlock_decision_tooltip = URA_unite_with_chelyaba
+			unlock_decision_tooltip = URA_unite_with_orenburg
+			unlock_decision_tooltip = URA_unite_with_perm
 			URA_ural_spirit_plus = yes
 			add_political_power = 100
 		}
@@ -9426,6 +9446,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus URA_monarchy_negotiate_land"
+			unlock_decision_tooltip = URA_romanov_montenegro
+			unlock_decision_tooltip = URA_romanov_albania
+			unlock_decision_tooltip = URA_romanov_macedonia
+			unlock_decision_tooltip = URA_romanov_gambia
+			unlock_decision_tooltip = URA_romanov_trinidad
 			MNT = { country_event = { id = ural_event.39 days = 1 } }
 			ALB = { country_event = { id = ural_event.39 days = 1 } }
 			FYR = { country_event = { id = ural_event.39 days = 1 } }

--- a/common/national_focus/EH_generic.txt
+++ b/common/national_focus/EH_generic.txt
@@ -1222,6 +1222,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EH_find_new_veins"
+			unlock_decision_category_tooltip = EH_find_new_veins_category
 			set_temp_variable = { add_randallite = EH_add_randallite_random }
 			EH_add_randallite_effect = yes
 			custom_effect_tooltip = EH_find_new_veins_TT
@@ -1572,6 +1573,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EH_investigate_strange_structure"
+			unlock_decision_category_tooltip = EH_drone_mission_category
 			set_variable = { EH_selected_drones_var = 100 }
 			custom_effect_tooltip = EH_drone_mission_unlock_TT
 			add_ai_strategy = {

--- a/common/national_focus/Hezbollah.txt
+++ b/common/national_focus/Hezbollah.txt
@@ -886,6 +886,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Latin_American_Hezbollah"
+			unlock_decision_category_tooltip = HEZ_our_step_in_latin_america_decisions
 			custom_effect_tooltip = HEZ_unlock_region_latin_america_TT
 		}
 
@@ -1142,6 +1143,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE FOCUS_FILTER_INSURGENCY }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_the_muslim_spring"
+			unlock_decision_category_tooltip = HEZ_assassination_of_salman_rushdie
 			army_experience = -10
 			set_temp_variable = { treasury_change = -15.00 }
 			modify_treasury_effect = yes
@@ -1175,6 +1177,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Hezbollah_in_the_Middle_east"
+			unlock_decision_category_tooltip = HEZ_missions_in_the_middle_east_decisions
 			custom_effect_tooltip = HEZ_unlock_region_middle_east_TT
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { influence_target = YEM }
@@ -1212,6 +1215,8 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_An_Inevitable_failure"
+			unlock_decision_tooltip = HEZ_send_military_equipments_to_syria
+			unlock_decision_tooltip = HEZ_volunteer_forces_for_syria
 			custom_effect_tooltip = HEZ_An_Inevitable_failure_TT
 		}
 
@@ -1236,6 +1241,10 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Our_Brothers_in_Sanaa_and_Baghdad"
+			unlock_decision_tooltip = HEZ_our_funds_for_the_iraqi_people
+			unlock_decision_tooltip = HEZ_weapons_for_the_resistance
+			unlock_decision_tooltip = HEZ_organize_raidings_in_yemen
+			unlock_decision_tooltip = HEZ_weapons_for_our_brothers
 			if = {
 				limit = { IRQ = { NOT = { has_government = communism } } }
 				custom_effect_tooltip = HEZ_Our_Brothers_in_Sanaa_and_Baghdad_TT
@@ -2776,6 +2785,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Memory_of_AMIA"
+			unlock_decision_tooltip = HEZ_sabotage_the_jewish_sectors_arg
 			unlock_decision_category_tooltip = HEZ_our_step_in_latin_america_decisions
 		}
 
@@ -2798,6 +2808,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Anti_Zionist_Parties"
+			unlock_decision_tooltip = support_anti_zionist_parties_arg
 			custom_effect_tooltip = HEZ_Anti_Zionist_Parties_TT
 			ARG = {
 				add_timed_idea = {
@@ -2859,6 +2870,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_New_Contracts_with_Drug_Cartels"
+			unlock_decision_tooltip = deals_with_drug_cartels_arg
 			 custom_effect_tooltip = HEZ_New_Contracts_with_Drug_Cartels_TT
 			set_temp_variable = { treasury_change = -10.00 }
 			modify_treasury_effect = yes
@@ -3862,6 +3874,8 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_call_to_arms"
+			unlock_decision_tooltip = HEZ_our_advisors_in_damascus
+			unlock_decision_tooltip = HEZ_weapons_from_iran
 			custom_effect_tooltip = HEZ_call_to_arms_TT
 			division_template = {
 					name = "Badr Forces"
@@ -4028,6 +4042,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Houthi_brothers"
+			unlock_decision_tooltip = HEZ_fund_houthi_propaganda
 			if = {
 				limit = { YEM = { NOT = { has_government = communism } } }
 				custom_effect_tooltip = HEZ_fund_houthi_propaganda_TT
@@ -4073,6 +4088,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Badr_in_the_shadows"
+			unlock_decision_tooltip = HEZ_fund_propaganda_for_badr
 			if = {
 				limit = { IRQ = { NOT = { has_government = communism } } }
 				custom_effect_tooltip = HEZ_Badr_in_the_shadows_TT
@@ -4128,6 +4144,8 @@ focus_tree = {
 			}
 			add_manpower = -2000
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Organize_Shii_Forces"
+			unlock_decision_tooltip = HEZ_shia_advisors_for_iraq
+			unlock_decision_tooltip = HEZ_volunteers_for_iraq
 			IRQ = {
 				add_manpower = 2000
 				add_popularity = {
@@ -4161,6 +4179,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Invest_in_Saada"
+			unlock_decision_tooltip = HEZ_infrastructure_in_saadaa
 			if = {
 				limit = { YEM = { NOT = { has_government = communism } } }
 				custom_effect_tooltip = HEZ_infrastructure_in_saadaa_TT
@@ -4217,6 +4236,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_Steal_the_Bastards"
+			unlock_decision_tooltip = HEZ_the_might_of_muqawimat
 			set_temp_variable = { treasury_change = -10.00 }
 			modify_treasury_effect = yes
 			add_war_support = 0.1
@@ -4271,6 +4291,8 @@ focus_tree = {
 				custom_effect_tooltip = HEZ_fund_protests_against_wahabbis_in_sanaa_TT
 			}
 			log = "[GetDateText]: [Root.GetName]: Focus HEZ_and_Steal_the_Heathens"
+			unlock_decision_tooltip = HEZ_sabotage_wahhabi_schools
+			unlock_decision_tooltip = HEZ_fund_protests_against_wahabbis_in_sanaa
 			set_temp_variable = { treasury_change = -5.00 }
 			modify_treasury_effect = yes
 			add_political_power = 100

--- a/common/national_focus/Khanti-mansi.txt
+++ b/common/national_focus/Khanti-mansi.txt
@@ -2299,6 +2299,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KHM_motherland_calls"
+			unlock_decision_tooltip = KHM_subject_rus
 			add_political_power = 100
 		}
 		ai_will_do = { base = 100 }
@@ -2350,6 +2351,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus KHM_annex_subjects"
+			unlock_decision_tooltip = KHM_subject_annexion
 			add_political_power = 100
 		}
 		ai_will_do = { base = 100 }

--- a/common/national_focus/Malorossiya.txt
+++ b/common/national_focus/Malorossiya.txt
@@ -17,6 +17,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus MLR_start"
+			unlock_decision_category_tooltip = MLR_manifest_decisions
 			add_political_power = 100
 		}
 		ai_will_do = { base = 100 }

--- a/common/national_focus/Vojvodina.txt
+++ b/common/national_focus/Vojvodina.txt
@@ -1042,6 +1042,7 @@ focus_tree = {
 		cost = 7
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VOJ_vs"
+			unlock_decision_tooltip = VOJ_more_army
 			SER = {
 				country_event = {
 					id = SerbiaFocus.104
@@ -1064,6 +1065,7 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VOJ_autonomy"
+			unlock_decision_tooltip = VOJ_more_autonomy
 			SER = {
 				country_event = {
 					id = SerbiaFocus.109
@@ -1087,6 +1089,7 @@ focus_tree = {
 		}
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VOJ_true_fed"
+			unlock_decision_tooltip = VOJ_more_federation
 			SER = {
 				country_event = {
 					id = SerbiaFocus.101

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -229,6 +229,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_lula"
+			unlock_decision_category_tooltip = BRA_workers_party_alignment_decision_category
 			hidden_effect = {
 				add_ideas = BRA_idea_well_balanced
 			}
@@ -2672,6 +2673,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_legalize_independent_amazonian_development"
+			unlock_decision_tooltip = BRA_decision_halt_independent_developments
+			unlock_decision_tooltip = BRA_decision_continue_independent_developments
 			set_country_flag = BRA_legalized_independent_development
 			custom_effect_tooltip = BRA_legalize_independent_amazonian_development_tt
 		}
@@ -6161,6 +6164,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_amazonian_development_project"
+			unlock_decision_tooltip = BRA_decision_initial_investment
+			unlock_decision_tooltip = BRA_decision_the_road_to_el_dorado
+			unlock_decision_tooltip = BRA_decision_expand_the_mining_industry
+			unlock_decision_tooltip = BRA_decision_increase_the_oil_production
+			unlock_decision_tooltip = BRA_decision_increase_military_production
+			unlock_decision_tooltip = BRA_decision_tech_metal_industry_in_the_amazon
 			country_event = brazil.3
 		}
 
@@ -7926,6 +7935,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_rise_of_bolsonaro"
+			unlock_decision_category_tooltip = BRA_bolsonaro_alignment_decision_category
 			custom_effect_tooltip = BRA_rise_of_bolsonaro_tt
 			hidden_effect = {
 				country_event = { id = brazil.20 days = 2 }

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -3853,6 +3853,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Agriculture"
+			unlock_decision_category_tooltip = DEN_decision_Agriculture
 			add_ideas = DEN_idea_Agriculture
 		}
 
@@ -10266,6 +10267,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_broken_system"
+			unlock_decision_category_tooltip = DEN_decision_danish_revolutionary_thought
 			add_ideas = DEN_communist_gains
 		}
 
@@ -17172,6 +17174,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Logistic_Global_Investments"
+			unlock_decision_category_tooltip = DEN_decision_Investments_Global
+			unlock_decision_category_tooltip = DEN_decision_Investments_Global_II
 				set_temp_variable = { treasury_change = gdp_total }
 				multiply_temp_variable = { treasury_change = -0.01 }
 				modify_treasury_effect = yes

--- a/common/national_focus/greenland.txt
+++ b/common/national_focus/greenland.txt
@@ -754,6 +754,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 		completion_reward = {
 			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Development_Living_Grants"
+			unlock_decision_tooltip = GRN_decision_development_visa_grants
 			add_autonomy_score = { value = 25 }
 
 			1161 = { add_manpower = 10000 }
@@ -8822,6 +8823,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_LAWS }
 		completion_reward = {
 			log = "[GetDateText]: [ROOT.GetName]: Focus GRN_focus_Armed_Services_Of_Greenland"
+			unlock_decision_tooltip = GRN_decision_global_recruitment_efforts
 			army_experience = 25
 			navy_experience = 25
 			air_experience = 25

--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -1928,6 +1928,8 @@ focus_tree = {
 				subtract_from_variable = { mbs = 1 }
 			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_empower_the_mutaween executed"
+			unlock_decision_tooltip = GCC_discourage_female_representation
+			unlock_decision_tooltip = GCC_limit_female_employment
 		}
 
 		ai_will_do = {
@@ -1976,6 +1978,8 @@ focus_tree = {
 				add_to_variable = { mbs = 1 }
 			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_weaken_the_mutaween executed"
+			unlock_decision_tooltip = GCC_encourage_female_representation
+			unlock_decision_tooltip = GCC_expand_female_employment
 		}
 
 		ai_will_do = {
@@ -2040,6 +2044,8 @@ focus_tree = {
 		completion_reward = {
 			custom_effect_tooltip = GCC_women_economy_tt
 			log = "[GetDateText]: [This.GetName]: focus GCC_women_in_the_economy executed"
+			unlock_decision_tooltip = GCC_expand_female_employment
+			unlock_decision_tooltip = GCC_limit_female_employment
 		}
 
 		ai_will_do = { base = 1 }
@@ -2061,6 +2067,8 @@ focus_tree = {
 		completion_reward = {
 			custom_effect_tooltip = GCC_women_politics_tt
 			log = "[GetDateText]: [This.GetName]: focus GCC_women_in_politics executed"
+			unlock_decision_tooltip = GCC_encourage_female_representation
+			unlock_decision_tooltip = GCC_discourage_female_representation
 		}
 
 		ai_will_do = { base = 1 }
@@ -7452,6 +7460,7 @@ focus_tree = {
 				modify_gcc_unity = yes
 			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_improve_relations_with_iran executed"
+			unlock_decision_tooltip = GCC_blockade
 		}
 
 		ai_will_do = { base = 1 }
@@ -7943,6 +7952,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus GCC_confront_iranian_partners executed"
+			unlock_decision_tooltip = GCC_blockade
 			custom_effect_tooltip = GCC_confront_iranian_partners_tt
 			if = {
 				limit = {
@@ -9445,6 +9455,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_saudi_royal_family_opinion = yes
 			log = "[GetDateText]: [This.GetName]: focus GCC_back_the_strongman executed"
+			unlock_decision_tooltip = send_support_to_hor
 		}
 
 		ai_will_do = { base = 1 }

--- a/common/national_focus/indonesia.txt
+++ b/common/national_focus/indonesia.txt
@@ -8450,6 +8450,11 @@ focus_tree = {
 		prerequisite = { focus = IND_help_aceh }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IND_send_aid_package"
+			unlock_decision_tooltip = IND_aceh
+			unlock_decision_tooltip = IND_aceh2
+			unlock_decision_tooltip = IND_aceh3
+			unlock_decision_tooltip = IND_aceh4
+			unlock_decision_tooltip = IND_aceh5
 			custom_effect_tooltip = IND_helping_aceh
 		}
 

--- a/common/national_focus/libya.txt
+++ b/common/national_focus/libya.txt
@@ -2072,6 +2072,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_islamic_state_of_sahel"
+			unlock_decision_tooltip = libya_core_northern_chad
+			unlock_decision_tooltip = libya_core_northern_niger
+			unlock_decision_tooltip = libya_core_algerian_sahara
+			unlock_decision_tooltip = libya_core_northern_mali
+			unlock_decision_tooltip = libya_core_mauritanian_sahara
 			add_stability = 0.05
 			add_war_support = 0.05
 			effect_tooltip = { set_cosmetic_tag = ISIS_SAHEL_fascism }
@@ -6795,6 +6800,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_connect_sabha"
+			unlock_decision_tooltip = libya_dig_wadi_ash_shati
 			build_railway = {
 				level = 1
 				path = { 4047 7194 12866 11912 6295 }
@@ -6879,6 +6885,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_libyan_rail"
+			unlock_decision_tooltip = libya_build_rail_to_tunisia
+			unlock_decision_tooltip = libya_build_rail_to_egypt
+			unlock_decision_tooltip = libya_build_rail_to_niger
+			unlock_decision_tooltip = libya_build_rail_to_chad
 			swap_ideas = {
 				remove_idea = LBA_state_supported_railways
 				add_idea = LBA_state_supported_railways_functional
@@ -9996,6 +10006,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_casablanca_accords"
+			unlock_decision_tooltip = libya_casablanca_accords_draft_solution
+			unlock_decision_tooltip = libya_casablanca_accords_hold_negotiations
+			unlock_decision_tooltip = libya_casablanca_accords_convince_morocco
+			unlock_decision_tooltip = libya_casablanca_accords_convince_sahrawi
+			unlock_decision_tooltip = libya_casablanca_accords_convince_algeria
+			unlock_decision_tooltip = libya_casablanca_accords_convince_mauritania
 			activate_mission = libya_casablanca_accords
 			custom_effect_tooltip = LBA_casablanca_accords_tt
 			custom_effect_tooltip = {
@@ -10563,6 +10579,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_claim_jerusalem_for_arabs"
+			unlock_decision_tooltip = libya_core_palestine
 			custom_effect_tooltip = LBA_claim_jerusalem_for_arabs_tt
 			PAL = {
 				every_core_state = {
@@ -15279,6 +15296,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_attract_private_oil_companies"
+			unlock_decision_tooltip = libya_develop_oil_fields_with_foreign_aid
 			custom_effect_tooltip = {
 				localization_key = UNLOCK_DECISION_IN_CATEGORY
 				DECISION = libya_develop_oil_fields_with_foreign_aid

--- a/common/national_focus/sweden.txt
+++ b/common/national_focus/sweden.txt
@@ -6497,6 +6497,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_weapons_depots"
+			unlock_decision_tooltip = SWE_open_weapons_depots
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_1
 				amount = -12500

--- a/common/national_focus/tajikistan.txt
+++ b/common/national_focus/tajikistan.txt
@@ -775,6 +775,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_summit_in_tehran"
+			unlock_decision_tooltip = IRN_delegates_to_iran
 			custom_effect_tooltip = TAJ_tehran_summit_TT
 		}
 
@@ -1015,6 +1016,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_greater_iranian_world"
+			unlock_decision_tooltip = IRN_ultimatum_to_pakistan
+			unlock_decision_tooltip = IRN_ultimatum_to_turkey
+			unlock_decision_tooltip = IRN_ultimatum_to_turkmenistan
+			unlock_decision_tooltip = IRN_ultimatum_to_uzbekistan
+			unlock_decision_tooltip = IRN_ultimatum_to_armenia
 			custom_effect_tooltip = TAJ_additional_iranic_TT
 		}
 
@@ -4350,6 +4356,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_workers_of_the_world_unite"
+			unlock_decision_category_tooltip = TAJ_soviet_onion
 			custom_effect_tooltip = TAJ_commie_mechanic_TT
 		}
 
@@ -5360,6 +5367,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_masks_of_gold"
+			unlock_decision_category_tooltip = TAJ_forbidden_bazaar
 			custom_effect_tooltip = TAJ_bazaar_mechanic_TT
 			set_country_flag = TAJ_high_security_flag
 			add_dynamic_modifier = {

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -5468,6 +5468,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_reform_village_institutes"
+			unlock_decision_tooltip = TUR_reestablish_village_institutes
 			add_ideas = TUR_village_institutes
 		}
 	}
@@ -6423,6 +6424,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_agricultural_reform"
+			unlock_decision_tooltip = TUR_incentivise_modern_farming
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -7328,6 +7330,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_land_reform"
+			unlock_decision_tooltip = TUR_land_reforms
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			if = {
@@ -7468,6 +7471,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_heavy_agricultural_subsidies"
+			unlock_decision_tooltip = TUR_heavily_subsidise_agriculture
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 			add_ideas = TUR_heavily_subsidised_agriculture
@@ -7555,6 +7559,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_communal_farming"
+			unlock_decision_tooltip = TUR_encourage_communal_farming
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			random_owned_state = {
@@ -8490,6 +8495,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_revolutionary_education"
+			unlock_decision_tooltip = TUR_implement_revolutionary_education
 			block_edu_decrease = yes
 			increase_education_budget = yes
 			add_ideas = TUR_educating_revolutionaries
@@ -9125,6 +9131,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_islamist_victory"
+			unlock_decision_tooltip = TUR_homeland_defence
 			custom_effect_tooltip = conservatism_government_increase_5_tt
 			add_to_variable = { social_conservatism_government = 5 }
 			clamp_variable = {
@@ -9288,6 +9295,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_subsidise_farming"
+			unlock_decision_tooltip = TUR_incentivise_modern_farming
 			add_ideas = TUR_incentivised_farming
 		}
 
@@ -9356,6 +9364,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_turkish_highways"
+			unlock_decision_tooltip = TUR_highways
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 			934 = {
@@ -11641,6 +11650,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_gulenist_information"
+			unlock_decision_tooltip = TUR_employ_gulenist_informants
 			custom_effect_tooltip = TUR_unlocks_gulen_content
 		}
 	}
@@ -12158,6 +12168,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_imams_in_office"
+			unlock_decision_tooltip = TUR_no_prime_minister
 			custom_effect_tooltip = TUR_AKP_ADD_NEW_DECISIONS_TT
 			custom_effect_tooltip = TUR_increases_akp_support_5
 			add_to_variable = { var = akp_power value = 0.05 }
@@ -12192,6 +12203,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_gulenist_economists"
+			unlock_decision_tooltip = TUR_hire_gulenist_economic_advisors
 			custom_effect_tooltip = TUR_unlocks_gulen_content
 			custom_effect_tooltip = TUR_increases_gulenist_support_5
 			add_to_variable = { var = hizmet_power value = 0.05 }
@@ -12256,6 +12268,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_mobilise_the_faithful"
+			unlock_decision_tooltip = TUR_recall_gulenists
 			custom_effect_tooltip = TUR_unlocks_gulen_content
 			custom_effect_tooltip = TUR_increases_gulenist_support_5
 			add_to_variable = { var = hizmet_power value = 0.05 }
@@ -12333,6 +12346,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_expand_diyanet_role"
+			unlock_decision_tooltip = TUR_religious_directorate
 			custom_effect_tooltip = TUR_AKP_ADD_NEW_DECISIONS_TT
 			custom_effect_tooltip = TUR_increases_akp_support_5
 			add_to_variable = { var = akp_power value = 0.05 }
@@ -12367,6 +12381,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_gulenist_education"
+			unlock_decision_tooltip = TUR_hire_gulenist_educators
 			custom_effect_tooltip = TUR_unlocks_gulen_content
 			custom_effect_tooltip = TUR_increases_gulenist_support_5
 			add_to_variable = { var = hizmet_power value = 0.05 }
@@ -12766,6 +12781,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_osman_alliance"
+			unlock_decision_tooltip = TUR_empower_sultan
 			custom_effect_tooltip = TUR_osman_decisions
 			custom_effect_tooltip = TUR_form_coalition_osman
 			if = {

--- a/common/national_focus/venezuela.txt
+++ b/common/national_focus/venezuela.txt
@@ -11140,6 +11140,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_dismantle_the_farc"
+			unlock_decision_category_tooltip = VEN_destroy_farc
 			custom_effect_tooltip = VEN_farc_decisions
 		}
 


### PR DESCRIPTION
### Summary

Focuses that unlock decisions now say so, right in the focus completion tooltip. Previously a decision or a whole decision category would simply appear once its gating focus finished, with no forward signal to the player. This adds the engine's `unlock_decision_category_tooltip` / `unlock_decision_tooltip` lines across the mod so the unlock flow is visible. All of these are display-only: the real gating still lives on each decision's `visible` block, so behaviour is unchanged. The French tree was left out of scope.

#### Interface / UX

- **Category unlocks.** 96 focuses across 28 trees whose completion reveals a whole decision category now advertise it via `unlock_decision_category_tooltip`. For example `UKR_hur_reform` unlocks `UKR_hur_decision_category` and `CHI_project_921` unlocks `CHI_space_program`. Only categories with a real English localisation title were included, so no raw keys render.
- **Individual decision unlocks.** 558 `unlock_decision_tooltip` lines added to focuses that light up specific decisions inside an otherwise-visible category. For example `CUB_demand_from_us` unlocks the four United States relations decisions, and Russia's company focuses (`SOV_economic_gazprom`, `SOV_economic_nornickel`, and so on) each unlock their matching state-asset decisions.
- **Decision that unlocks a decision.** `CHI_scs_joint_development_PHI` now advertises the `CHI_scs_infrastructure_loan_PHI` decision it opens via its signed-JDZ country flag.

#### Code

- **Comoros PMC decisions.** Removed a redundant `has_completed_focus = COM_african_mercenaries` from each decision's `available` block, since the `visible` block already hides them until that focus completes.

#### Scope and safety

- Cross-country gates were classified by gate scope and excluded where a different player takes the decision, for example subject-tree focuses that gate `SOV_added_*` decisions the overlord actually takes. Every referenced decision and category resolves, and the focus tree and decision validators report 0 errors on the changed files.