### PR TITLE
Fix `subjects_autonomy_gain_tt`

### DIFF
--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -15440,7 +15440,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_monarchy
 			}
-			add_to_variable = { ENG_subjects_autonomy_gain_monarchy = 0.05 tooltip = subjects_autonomy_gain_tt }
+			add_to_variable = { ENG_subjects_autonomy_gain_monarchy = -0.05 tooltip = subjects_autonomy_gain_tt }
 			add_to_variable = { ENG_political_power_factor_monarchy = 0.05 tooltip = political_power_factor_tt }
 			update_focus_tree_obsolete_branches = yes
 		}

--- a/localisation/braz_por/MD_dm_modifiers_l_braz_por.yml
+++ b/localisation/braz_por/MD_dm_modifiers_l_braz_por.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/english/MD_dm_modifiers_l_english.yml
+++ b/localisation/english/MD_dm_modifiers_l_english.yml
@@ -45,7 +45,7 @@
  line_change_production_efficiency_factor_tt: "$MODIFIER_LINE_CHANGE_PRODUCTION_EFFICIENCY_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  fossil_fuel_consumption_tt: "$fossil_fuel_consumption$: $RIGHT|-=%1$"

--- a/localisation/french/MD_dm_modifiers_l_french.yml
+++ b/localisation/french/MD_dm_modifiers_l_french.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/german/MD_dm_modifiers_l_german.yml
+++ b/localisation/german/MD_dm_modifiers_l_german.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/japanese/MD_dm_modifiers_l_japanese.yml
+++ b/localisation/japanese/MD_dm_modifiers_l_japanese.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/korean/MD_dm_modifiers_l_korean.yml
+++ b/localisation/korean/MD_dm_modifiers_l_korean.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/polish/MD_dm_modifiers_l_polish.yml
+++ b/localisation/polish/MD_dm_modifiers_l_polish.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/russian/MD_dm_modifiers_l_russian.yml
+++ b/localisation/russian/MD_dm_modifiers_l_russian.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/simp_chinese/MD_dm_modifiers_l_simp_chinese.yml
+++ b/localisation/simp_chinese/MD_dm_modifiers_l_simp_chinese.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"

--- a/localisation/spanish/MD_dm_modifiers_l_spanish.yml
+++ b/localisation/spanish/MD_dm_modifiers_l_spanish.yml
@@ -216,7 +216,7 @@
  production_factory_efficiency_gain_factor_tt: "$MODIFIER_PRODUCTION_FACTORY_EFFICIENCY_GAIN_FACTOR$: $RIGHT|+=%1$"
  license_production_speed_tt: "$MODIFIER_LICENSE_PRODUCTION_SPEED$: $RIGHT|+=%1$"
  justify_war_goal_time_tt: "$MODIFIER_JUSTIFY_WAR_GOAL_TIME$: $RIGHT|-=%1$"
- subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|+=%1$"
+ subjects_autonomy_gain_tt: "$MODIFIER_AUTONOMY_SUBJECT_GAIN$: $RIGHT|-=%1$"
  transport_capacity_tt: "$MODIFIER_TRANSPORT_CAPACITY$: $RIGHT|-=%1$"
  energy_gain_tt: "$energy_gain$: $RIGHT|+=%1$"
  supply_consumption_factor_tt: "$MODIFIER_SUPPLY_CONSUMPTION_FACTOR$: $RIGHT|-=%1$"


### PR DESCRIPTION
A master wants its subjects to have low autonomy.

So it should be green when negative, as this reduces subjects autonomy, which is good for a master.

The base game for some unkown reason has coded it the opposite way, which is wrong and a bug in vanilla.