### PR TITLE
Fix non-focus validation errors

### DIFF
--- a/common/decisions/Algeria.txt
+++ b/common/decisions/Algeria.txt
@@ -4446,7 +4446,7 @@ ALG_tamazgha_cultural_revival_category = {
 			set_temp_variable = { int_investment_change = 0.5 }
 			modify_international_investment_effect = yes
 
-			create_faction = "Tamazgha_Confederation"
+			create_faction_from_template = faction_template_tamazgha_confederation
 
 			every_other_country = {
 				limit = {

--- a/common/factions/templates/99_ALG.txt
+++ b/common/factions/templates/99_ALG.txt
@@ -1,0 +1,55 @@
+faction_template_tamazgha_confederation = {
+	name = Tamazgha_Confederation
+	icon = GFX_faction_icon_arabic1
+	manifest = faction_manifest_african_domination
+	can_leader_join_other_factions = no
+	visible = {
+		always = no
+	}
+
+	default_rules = {
+		war_declaration_rule_independent_countries_only
+	}
+}
+
+faction_template_maghreb_joint_defense = {
+	name = The_Maghreb_Joint_Defense
+	icon = GFX_faction_icon_arab_league
+	manifest = faction_manifest_african_domination
+	can_leader_join_other_factions = no
+	visible = {
+		always = no
+	}
+
+	default_rules = {
+		war_declaration_rule_independent_countries_only
+	}
+}
+
+faction_template_arab_defense_bloc = {
+	name = Arab_Defense_Bloc
+	icon = GFX_faction_icon_arab_league
+	manifest = faction_manifest_unite_islamic_countries
+	can_leader_join_other_factions = no
+	visible = {
+		always = no
+	}
+
+	default_rules = {
+		war_declaration_rule_independent_countries_only
+	}
+}
+
+faction_template_al_aqsa_coalition = {
+	name = FIS_al_aqsa_faction
+	icon = GFX_faction_icon_jerusalem_defense
+	manifest = faction_manifest_middle_east_dominance
+	can_leader_join_other_factions = no
+	visible = {
+		always = no
+	}
+
+	default_rules = {
+		war_declaration_rule_independent_countries_only
+	}
+}

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -20791,7 +20791,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_islamic_nato"
 			custom_effect_tooltip = ALG_more_relation_better
 			add_ideas = faction_mto_alliance
-			create_faction = mto_alliance
+			create_faction_from_template = faction_template_mto_alliance
 			if = {
 				limit = { country_exists = EGY }
 				EGY = {
@@ -24894,7 +24894,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_maghreb_joint_defense_pact"
-			create_faction = The_Maghreb_Joint_Defense
+			create_faction_from_template = faction_template_maghreb_joint_defense
 				custom_effect_tooltip = {
 					localization_key = UNLOCK_DECISION_IN_CATEGORY
 					DECISION = MAGHREB_integrate_start
@@ -25427,7 +25427,7 @@ focus_tree = {
 			set_temp_variable = { target_nation = EGY.id }
 			set_temp_variable = { adding_nation = ALG.id }
 			change_permanent_investment_target = yes
-			create_faction = Arab_Defense_Bloc
+			create_faction_from_template = faction_template_arab_defense_bloc
 			add_timed_idea = {
 				idea = ALG_idea_joint_military_arab
 				days = 365
@@ -29015,7 +29015,7 @@ focus_tree = {
 				limit = { is_in_faction = yes }
 				leave_faction = yes
 			}
-			create_faction = FIS_al_aqsa_faction
+			create_faction_from_template = faction_template_al_aqsa_coalition
 		}
 
 		ai_will_do = {

--- a/common/national_focus/05_india.txt
+++ b/common/national_focus/05_india.txt
@@ -17212,10 +17212,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus RAJ_SCO_join"
 			if = {
-				limit = {
-					NOT = { CHI_sco_is_any = yes }
-					CHI_sco_can_apply_to_join = yes
-				}
+				limit = { CHI_sco_can_apply_to_join = yes }
 				CHI_sco_add_dialogue_partner = yes
 				custom_effect_tooltip = RAJ_sco_join_notify_tt
 			}

--- a/common/national_focus/05_libya.txt
+++ b/common/national_focus/05_libya.txt
@@ -4166,8 +4166,9 @@ focus_tree = {
 				limit = { NOT = { has_idea = LoAS_member } }
 				add_ideas = LoAS_member
 			}
-			every_country = {
-				limit = { has_idea = LoAS_member }
+			for_each_scope_loop = {
+				array = global.arab_league_members
+				tooltip = TT_ALL_ARAB_LEAGUE_MEMBER_NATIONS_GAIN
 				add_opinion_modifier = {
 					target = ROOT
 					modifier = declaration_of_friendship

--- a/common/national_focus/france.txt
+++ b/common/national_focus/france.txt
@@ -10333,7 +10333,7 @@ focus_tree = {
 			}
 		}
 		bypass = {
-			is_french_africa_nation = yes
+			has_country_flag = french_africa_nation_flag
 			NOT = { has_idea = cfa_franc }
 			NOT = { has_idea = cfa_franc_2 }
 			NOT = { has_idea = the_eco }
@@ -10483,7 +10483,7 @@ focus_tree = {
 			}
 		}
 		bypass = {
-			is_french_africa_nation = yes
+			has_country_flag = french_africa_nation_flag
 			NOT = { has_idea = cfa_franc }
 			NOT = { has_idea = cfa_franc_2 }
 			NOT = { has_idea = the_eco }

--- a/events/Gulf.txt
+++ b/events/Gulf.txt
@@ -324,22 +324,49 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: gulf.16.a executed"
 		if = {
 			limit = { tag = USA }
-			every_country = {
-				limit = {
-					OR = {
-						has_idea = NATO_member
-						tag = ISR
-						if = {
-							limit = { NOT = { SYR = { has_idea = LoAS_member } } }
-							has_idea = LoAS_member
-						}
+			for_each_scope_loop = {
+				array = global.nato_members
+				tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
+				if = {
+					limit = {
+						NOT = { tag = ISR }
+						NOT = { tag = SYR }
+						NOT = { tag = FSA }
+						NOT = { has_country_flag = received_assad_coalition_proposal }
+						NOT = { has_country_flag = proposed_coalition_against_assad }
 					}
-					NOT = { tag = SYR }
-					NOT = { tag = FSA }
-					NOT = { has_country_flag = received_assad_coalition_proposal }
-					NOT = { has_country_flag = proposed_coalition_against_assad }
+					country_event = gulf.16
 				}
-				country_event = gulf.16
+			}
+			for_each_scope_loop = {
+				array = global.arab_league_members
+				tooltip = TT_ALL_ARAB_LEAGUE_MEMBER_NATIONS_GAIN
+				if = {
+					limit = {
+						NOT = { has_idea = NATO_member }
+						NOT = { tag = ISR }
+						NOT = { SYR = { has_idea = LoAS_member } }
+						NOT = { tag = SYR }
+						NOT = { tag = FSA }
+						NOT = { has_country_flag = received_assad_coalition_proposal }
+						NOT = { has_country_flag = proposed_coalition_against_assad }
+					}
+					country_event = gulf.16
+				}
+			}
+			if = {
+				limit = {
+					country_exists = ISR
+					ISR = {
+						NOT = { tag = SYR }
+						NOT = { tag = FSA }
+						NOT = { has_country_flag = received_assad_coalition_proposal }
+						NOT = { has_country_flag = proposed_coalition_against_assad }
+					}
+				}
+				ISR = {
+					country_event = gulf.16
+				}
 			}
 			if = {
 				limit = { threat < 0.1 }
@@ -699,8 +726,10 @@ country_event = {
 		text = gulf.22.d3
 		trigger = {
 			NOT = {
-				original_tag = USA
-				original_tag = ISR
+				OR = {
+					original_tag = USA
+					original_tag = ISR
+				}
 			}
 		}
 	}
@@ -827,9 +856,13 @@ country_event = {
 		FROM = {
 			country_event = { days = 1 id = gulf.25 }
 		}
-		every_other_country = {
-			limit = { has_idea = NATO_member }
-			country_event = { days = 1 id = gulf.22 }
+		for_each_scope_loop = {
+			array = global.nato_members
+			tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
+			if = {
+				limit = { NOT = { tag = ROOT } }
+				country_event = { days = 1 id = gulf.22 }
+			}
 		}
 		ai_chance = {
 			factor = 1
@@ -1241,18 +1274,47 @@ country_event = {
 					}
 				}
 			}
+			for_each_scope_loop = {
+				array = global.nato_members
+				tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
+				if = {
+					limit = {
+						NOT = {
+							has_war_with = PER
+							is_subject_of = PER
+						}
+						NOT = { tag = USA }
+						NOT = { original_tag = ISR }
+						NOT = { has_country_flag = proposed_coalition_against_iran }
+					}
+					country_event = gulf.30
+				}
+			}
+			for_each_scope_loop = {
+				array = global.arab_league_members
+				tooltip = TT_ALL_ARAB_LEAGUE_MEMBER_NATIONS_GAIN
+				if = {
+					limit = {
+						NOT = {
+							has_war_with = PER
+							is_subject_of = PER
+						}
+						NOT = { tag = USA }
+						NOT = { has_idea = NATO_member }
+						NOT = { original_tag = ISR }
+						NOT = { has_country_flag = proposed_coalition_against_iran }
+					}
+					country_event = gulf.30
+				}
+			}
 			every_country = {
 				limit = {
+					original_tag = ISR
 					NOT = {
 						has_war_with = PER
 						is_subject_of = PER
 					}
 					NOT = { tag = USA }
-					OR = {
-						has_idea = NATO_member
-						original_tag = ISR
-						has_idea = LoAS_member
-					}
 					NOT = { has_country_flag = proposed_coalition_against_iran }
 				}
 				country_event = gulf.30
@@ -1296,7 +1358,7 @@ country_event = {
 		}
 	}
 	option = {
-		trigger = { NOT = { is_arabic_nation = yes } }
+		trigger = { NOT = { has_country_flag = arabic_nation_flag } }
 		name = gulf.30.b #Middle Eastern politics is none of our business.
 		log = "[GetDateText]: [This.GetName]: gulf.30.b executed"
 		if = {
@@ -1331,7 +1393,7 @@ country_event = {
 		}
 	}
 	option = {
-		trigger = { is_arabic_nation = yes }
+		trigger = { has_country_flag = arabic_nation_flag }
 		name = gulf.30.c #We have nothing to gain from [FROM.GetAdjective] adventurism.
 		log = "[GetDateText]: [This.GetName]: gulf.30.c executed"
 		ai_chance = {
@@ -1446,15 +1508,25 @@ country_event = {
 			type = topple_government
 			target = PER
 		}
-		every_country = {
-			limit = {
-				OR = {
-					tag = ISR
-					has_idea = LoAS_member
+		for_each_scope_loop = {
+			array = global.arab_league_members
+			tooltip = TT_ALL_ARAB_LEAGUE_MEMBER_NATIONS_GAIN
+			if = {
+				limit = {
+					NOT = { tag = ISR }
+					NOT = { has_country_flag = proposed_coalition_against_iran }
 				}
-				NOT = { has_country_flag = proposed_coalition_against_iran }
+				country_event = gulf.30
 			}
-			country_event = gulf.30
+		}
+		if = {
+			limit = {
+				country_exists = ISR
+				ISR = { NOT = { has_country_flag = proposed_coalition_against_iran } }
+			}
+			ISR = {
+				country_event = gulf.30
+			}
 		}
 		news_event = { days = 2 id = gulf.32 }
 	}
@@ -1542,7 +1614,7 @@ country_event = {
 		every_country = {
 			limit = {
 				has_military_access_to = ROOT
-				NOT = { is_arabic_nation = yes }
+				NOT = { has_country_flag = arabic_nation_flag }
 			}
 			diplomatic_relation = {
 				country = ROOT
@@ -1562,8 +1634,10 @@ country_event = {
 			modifier = {
 				add = 1
 				NOT = {
-					has_government = democratic
-					has_government = communism
+					OR = {
+						has_government = democratic
+						has_government = communism
+					}
 				}
 			}
 		}
@@ -2186,10 +2260,12 @@ country_event = {
 
 	option = {
 		name = gcc.11.a
-		every_other_country = {
-			limit = { has_idea = idea_gcc_member_state }
-			PREV = {
-				give_guarantee = PREV
+		for_each_scope_loop = {
+			array = global.gcc_member_state
+			tooltip = TT_ALL_GCC_MEMBER_NATIONS_GAIN
+			if = {
+				limit = { NOT = { tag = ROOT } }
+				ROOT = { give_guarantee = PREV }
 			}
 		}
 		if = {
@@ -2727,12 +2803,16 @@ country_event = {
 	option = {
 		name = gcc.18.b #veto the expulsion
 		log = "[GetDateText]: [This.GetName]: gcc.18.b executed"
-		every_other_country = {
-			limit = {
-				has_idea = idea_gcc_member_state
-				NOT = { has_country_flag = being_expelled }
+		for_each_scope_loop = {
+			array = global.gcc_member_state
+			tooltip = TT_ALL_GCC_MEMBER_NATIONS_GAIN
+			if = {
+				limit = {
+					NOT = { tag = ROOT }
+					NOT = { has_country_flag = being_expelled }
+				}
+				country_event = { days = 1 id = gcc.19 }
 			}
-			country_event = { days = 1 id = gcc.19 }
 		}
 		ai_chance = {
 			factor = 1
@@ -2939,8 +3019,8 @@ news_event = {
 					joint_gcc_ventures
 				}
 				remove_from_faction = THIS
-				every_country = {
-					limit = { has_idea = idea_gcc_member_state }
+				for_each_scope_loop = {
+					array = global.gcc_member_state
 					remove_opinion_modifier = {
 						target = ROOT
 						modifier = Gulf_Cooperation_Council_Relations
@@ -3636,8 +3716,9 @@ country_event = {
 				}
 			}
 		}
-		every_country = {
-			limit = { has_idea = idea_gcc_member_state }
+		for_each_scope_loop = {
+			array = global.gcc_member_state
+			tooltip = TT_ALL_GCC_MEMBER_NATIONS_GAIN
 			news_event = { days = 1 id = gcc.23 }
 		}
 		ai_chance = {
@@ -4502,28 +4583,84 @@ country_event = {
 	option = {
 		name = saudi_royal.5.c #Do nothing.
 		log = "[GetDateText]: [This.GetName]: saudi_royal.5.c executed"
-		every_other_country = {
-			limit = {
-				OR = {
-					has_idea = NATO_member
-					tag = AUS
-					tag = SWE
-				}
-				if = {
-					limit = {
-						USA = {
-							has_country_leader = {
-								name = "Donald Trump"
-								ruling_only = yes
-							}
+		for_each_scope_loop = {
+			array = global.nato_members
+			tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
+			if = {
+				limit = {
+					NOT = { tag = ROOT }
+					NOT = {
+						OR = {
+							tag = AUS
+							tag = SWE
 						}
 					}
-					NOT = { tag = USA }
+					if = {
+						limit = {
+							USA = {
+								has_country_leader = {
+									name = "Donald Trump"
+									ruling_only = yes
+								}
+							}
+						}
+						NOT = { tag = USA }
+					}
+				}
+				add_opinion_modifier = {
+					target = SAU
+					modifier = khashoggi_affair
 				}
 			}
-			add_opinion_modifier = {
-				target = SAU
-				modifier = khashoggi_affair
+		}
+		if = {
+			limit = { country_exists = AUS }
+			AUS = {
+				if = {
+					limit = {
+						NOT = { tag = ROOT }
+						if = {
+							limit = {
+								USA = {
+									has_country_leader = {
+										name = "Donald Trump"
+										ruling_only = yes
+									}
+								}
+							}
+							NOT = { tag = USA }
+						}
+					}
+					add_opinion_modifier = {
+						target = SAU
+						modifier = khashoggi_affair
+					}
+				}
+			}
+		}
+		if = {
+			limit = { country_exists = SWE }
+			SWE = {
+				if = {
+					limit = {
+						NOT = { tag = ROOT }
+						if = {
+							limit = {
+								USA = {
+									has_country_leader = {
+										name = "Donald Trump"
+										ruling_only = yes
+									}
+								}
+							}
+							NOT = { tag = USA }
+						}
+					}
+					add_opinion_modifier = {
+						target = SAU
+						modifier = khashoggi_affair
+					}
+				}
 			}
 		}
 		custom_effect_tooltip = MBS_strengthened_tt

--- a/events/Gulf.txt
+++ b/events/Gulf.txt
@@ -1280,8 +1280,10 @@ country_event = {
 				if = {
 					limit = {
 						NOT = {
-							has_war_with = PER
-							is_subject_of = PER
+							OR = {
+								has_war_with = PER
+								is_subject_of = PER
+							}
 						}
 						NOT = { tag = USA }
 						NOT = { original_tag = ISR }
@@ -1296,8 +1298,10 @@ country_event = {
 				if = {
 					limit = {
 						NOT = {
-							has_war_with = PER
-							is_subject_of = PER
+							OR = {
+								has_war_with = PER
+								is_subject_of = PER
+							}
 						}
 						NOT = { tag = USA }
 						NOT = { has_idea = NATO_member }
@@ -1311,8 +1315,10 @@ country_event = {
 				limit = {
 					original_tag = ISR
 					NOT = {
-						has_war_with = PER
-						is_subject_of = PER
+						OR = {
+							has_war_with = PER
+							is_subject_of = PER
+						}
 					}
 					NOT = { tag = USA }
 					NOT = { has_country_flag = proposed_coalition_against_iran }

--- a/events/Nigeria.txt
+++ b/events/Nigeria.txt
@@ -1101,27 +1101,30 @@ country_event = {
 	option = { #Yeah, Sure
 		name = nigeria_md.8.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.8.a executed"
-		set_temp_variable = { percent_change = 2 }
-		set_temp_variable = { tag_index = NIG.id }
-		change_influence_percentage = yes
-		NIG = {
-			set_temp_variable = { treasury_change = -1 }
-			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = 1 }
-			modify_international_investment_effect = yes
-			country_event = { id = diplomatic_response.1 days = 1 }
-		}
-		random_owned_controlled_state = {
-			limit = {
-				infrastructure < 5
+		if = {
+			limit = { NOT = { has_country_flag = NIG_already_invested_in_flag } }
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = NIG.id }
+			change_influence_percentage = yes
+			NIG = {
+				set_temp_variable = { treasury_change = -1 }
+				modify_treasury_effect = yes
+				set_temp_variable = { int_investment_change = 1 }
+				modify_international_investment_effect = yes
+				country_event = { id = diplomatic_response.1 days = 1 }
 			}
-			add_building_construction = {
-				type = infrastructure
-				level = 1
-				instant_build = yes
+			random_owned_controlled_state = {
+				limit = {
+					infrastructure < 5
+				}
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
 			}
+			set_country_flag = NIG_already_invested_in_flag
 		}
-		set_country_flag = NIG_already_invested_in_flag
 		ai_chance = {
 			base = 10
 			modifier = {


### PR DESCRIPTION
## Summary

Fixes the non-focus validation failures left after the focus-tree validation branch was merged.

- Replaces deprecated faction creation with faction templates.
- Converts membership scans to maintained arrays.
- Replaces runtime nation triggers with initialization flags.
- Corrects tautological trigger conditions.

## Validation

- `check_common_mistakes.py`: passed.
- Non-focus style checks: passed.
- Full style output contains only focus-tree-standard warnings.
