### PR TITLE
fix(iraq): lower infrastructure mission requirement and decouple GUI …

### DIFF
--- a/common/decisions/Iraq.txt
+++ b/common/decisions/Iraq.txt
@@ -2103,7 +2103,7 @@ IRQ_sunni_in_politics = {
 		}
 		available = {
 			168 = {
-				infrastructure > 4
+				infrastructure > 1
 			}
 		}
 		days_mission_timeout = 130
@@ -2128,7 +2128,7 @@ IRQ_sunni_in_politics = {
 		}
 		available = {
 			167 = {
-				infrastructure > 4
+				infrastructure > 1
 			}
 		}
 		days_mission_timeout = 130
@@ -2153,7 +2153,7 @@ IRQ_sunni_in_politics = {
 		}
 		available = {
 			166 = {
-				infrastructure > 4
+				infrastructure > 1
 			}
 		}
 		days_mission_timeout = 130

--- a/common/scripted_effects/99_IRQ_scripted_effects.txt
+++ b/common/scripted_effects/99_IRQ_scripted_effects.txt
@@ -75,6 +75,7 @@ IRQ_update_economic_union_modifiers = {
 }
 
 IRQ_conduct_attack = {
+	IRQ_update_dirty_variable = yes
 	if = {
 		limit = {
 			check_variable = {
@@ -4828,5 +4829,16 @@ IRQ_government_change = {
 				anti_zionist
 			}
 		}
+	}
+}
+
+IRQ_update_dirty_variable = {
+	if = {
+		limit = { is_ai = no }
+		if = {
+			limit = { NOT = { has_variable = global.update_irq_ui } }
+			set_variable = { global.update_irq_ui = 0 }
+		}
+		add_to_variable = { global.update_irq_ui = 1 }
 	}
 }

--- a/common/scripted_guis/99_IRQ_scripted_guis.txt
+++ b/common/scripted_guis/99_IRQ_scripted_guis.txt
@@ -13,7 +13,7 @@ scripted_gui = {
 	Iraq_civil_war_gui = {
 		context_type = decision_category
 		window_name = "Iraq_civil_war_decision_ui_window"
-		dirty = global.md_gui_dirty
+		dirty = global.update_irq_ui
 		ai_enabled = { always = yes }
 		ai_check = { always = yes }
 
@@ -627,7 +627,7 @@ scripted_gui = {
 	american_playing_cards = {
 		context_type = decision_category
 		window_name = "american_cards_decision_ui_window"
-		dirty = global.md_gui_dirty
+		dirty = global.update_irq_ui
 		ai_enabled = { always = yes }
 		ai_check = { always = yes }
 

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -5469,7 +5469,7 @@ country_event = {
 				}
 				NOT = {
 					168 = {
-						infrastructure > 4
+						infrastructure > 1
 					}
 				}
 			}
@@ -5536,7 +5536,7 @@ country_event = {
 				}
 				NOT = {
 					166 = {
-						infrastructure > 4
+						infrastructure > 1
 					}
 				}
 			}
@@ -5576,7 +5576,7 @@ country_event = {
 				}
 				NOT = {
 					167 = {
-						infrastructure > 4
+						infrastructure > 1
 					}
 				}
 			}


### PR DESCRIPTION
This Pull Request resolves issue #2568 and cleans up the Iraq GUI dirty variable handling:
### 1. Fix Issue #2568 (Impossible Iraq Infrastructure Mission)
* Lowered the infrastructure requirement for the Sunni infrastructure missions (Anbar, Salahuddin, Nineveh) in `common/decisions/Iraq.txt` and `events/Iraq.txt` from `infrastructure > 4` (Level 5) down to `infrastructure > 1` (Level 2).
* Starting infrastructure in these provinces is Level 1, making Level 5 impossible to reach in 130 days. Level 2 is achievable within the mission timeframe.
### 2. GUI Dirty Variable Performance Refactor
* Decoupled `Iraq_civil_war_gui` and `american_playing_cards` in `common/scripted_guis/99_IRQ_scripted_guis.txt` from `global.md_gui_dirty` (which ran daily).
* Created a dedicated `IRQ_update_dirty_variable` (`global.update_irq_ui`) in `99_IRQ_scripted_effects.txt` and attached it to attack triggers and button clicks, rendering the UI smoothly without unnecessary daily ticks.
### Verification
* Tested in-game via `event iraq_civil_war.1` and `event iraq_md.12`. Both the civil war map GUI and mission requirements display and update correctly.

Closes #2568 
Closes #2618