### PR TITLE
Fix blank nations in the Auto-Influencer Report (#2543)

### DIFF
--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -913,29 +913,31 @@ on_actions = {
 							# Dense report list: auto_influence_array is sparse (removals zero the slot in place)
 							clear_array = auto_influence_target_array
 
+							# Unique iterator names: change_influence_percentage's nested loops write the shared temp v/i.
 							for_each_loop = {
 								array = auto_influence_array
-								value = v
+								value = auto_target
+								index = auto_slot
 								if = {
 									limit = {
-										NOT = { check_variable = { v = 0 } }
-										var:v = { exists = yes }
-										NOT = { var:v = { PREV = { has_country_flag = spread_influence@PREV } } }
+										NOT = { check_variable = { auto_target = 0 } }
+										var:auto_target = { exists = yes }
+										NOT = { var:auto_target = { PREV = { has_country_flag = spread_influence@PREV } } }
 									}
 									if = { limit = { is_debug = yes }
-										log = "[GetDateText]: [ROOT.GetName]: Index:[?i], Auto influencing [?var:v.GetName]"
+										log = "[GetDateText]: [THIS.GetName]: Index:[?auto_slot], Auto influencing [?var:auto_target.GetName]"
 									}
-									set_temp_variable = { influence_target = v }
+									set_temp_variable = { influence_target = auto_target }
 									change_influence_percentage = yes
 									add_to_variable = { nations_influenced = 1 }
-									add_to_array = { auto_influence_target_array = v }
-									var:v = {
+									add_to_array = { auto_influence_target_array = auto_target }
+									var:auto_target = {
 										PREV = { spread_influence_cooldown_effect = yes }
 									}
 								}
 								else = {
 									if = { limit = { is_debug = yes }
-										log = "[GetDateText]: [ROOT.GetName]: Index:[?i], Auto influencing failed to influence on index [?i]"
+										log = "[GetDateText]: [THIS.GetName]: Index:[?auto_slot], Auto influencing failed to influence on index [?auto_slot]"
 									}
 								}
 							}

--- a/common/scripted_effects/00_influence_scripted_effects.txt
+++ b/common/scripted_effects/00_influence_scripted_effects.txt
@@ -1006,7 +1006,7 @@ update_auto_influence_array = {
 		}
 	}
 
-	clamp_variable = { var = ROOT.auto_influence_users min = 0 max = 10 }
+	clamp_variable = { var = auto_influence_users min = 0 max = 10 }
 	update_dirty_influence_var = yes
 }
 
@@ -1067,7 +1067,7 @@ remove_auto_influencer_request = {
 }
 
 # Effect: spread_influence_cooldown_effect
-# Purpose: sets the game rule country flags for spread_influence so we do not copy this code everywhere. 
+# Purpose: sets the game rule country flags for spread_influence so we do not copy this code everywhere.
 spread_influence_cooldown_effect = {
 	if = { limit = { has_game_rule = { rule = rule_spread_influence_cooldown_limits option = spread_influence_14_days } }
 		set_country_flag = { flag = spread_influence@PREV value = 1 days = 14 }


### PR DESCRIPTION
### Changes
- The Monthly Auto-Influencer Report now names each influenced nation and shows its real influence percentage instead of a blank line and 0.00%
- Auto-influence no longer risks skipping targets partway through the monthly sweep
- Auto-influencer slot count is clamped on the right nation in multiplayer

Closes #2543
