### PR TITLE
Validation pipeline: dispatch + nightly revalidation, MIO and decision-log validators

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -7,9 +7,14 @@ Pre-commit and CI do not run the same hook set. Things that pass locally can sti
 `coding-pipeline.yml` triggers on `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_review`, targeting `main`, content-path filtered). Two extra entry points cover open PRs that get no pushes:
 
 - `workflow_dispatch` (inputs `pr_number`, `base_sha`) — manual re-run for an open PR, keyed on the PR's head branch as `ref`. The PR context is rebuilt from the inputs: `PR_NUMBER`/`HEAD_SHA`/`BASE_SHA` are `inputs.X || github.event.pull_request.X` everywhere they are used (workspace cache key, manifest, report). `detect-changes` skips `dorny/paths-filter` on dispatch (no checkout, no base ref) and treats every group as changed except `style` — the style job is diff-scoped, and a dispatch has no diff.
-- `nightly-pr-validation.yml` — cron (06:00 UTC) + manual dispatch. Lists open PRs targeting `main` and dispatches `coding-pipeline.yml` per PR, so validation tracks the merge ref after main advances. Fork PRs are skipped (dispatch refs must live in this repo); they still validate on every push.
+- `nightly-pr-validation.yml` — cron (06:00 UTC) + manual dispatch. Lists open PRs targeting `main` and dispatches `coding-pipeline.yml` per PR, so validation tracks the merge ref after main advances. `base_sha` is main's live head, resolved once per sweep: it is the only component of the workspace cache key that moves when main does, and cache keys are immutable, so a stale value would make `cache/save` a no-op and replay the previous run's tree. Fork PRs are skipped (dispatch refs must live in this repo); they still validate on every push. Two more classes are warned about and skipped rather than dispatched: a PR with no `refs/pull/N/merge` (it conflicts with main, and the pipeline checks that ref out) and a PR whose head branch predates the `workflow_dispatch` trigger (a dispatch runs the workflow file as it exists on `--ref`, so those branches need a rebase first).
 
-The report comment is only posted when a run has findings. A clean run deletes the previous report comment instead (#2702) — no comment means the last validated state was clean.
+A report comment is only created when a run has findings (#2702). A clean run never opens one, and what it does with an existing one depends on scope:
+
+- **full** (dispatch only, every validator ran and passed): deletes the comment.
+- **partial** (per-PR, only the changed groups' validators ran): rewrites the comment in place so it stops reporting an older commit, and leaves the PR uncommented if there was never a comment. It cannot delete, because a validator that did not run this time may still have live findings from an earlier push.
+
+Partial reports label themselves in the verdict banner and metadata strip. Scope is computed in the `validation-report` job and passed as `--validation-scope`.
 
 ## The split
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -2,6 +2,15 @@
 
 Pre-commit and CI do not run the same hook set. Things that pass locally can still fail CI, and vice versa. Read this before wiring, judging, or debugging any validator.
 
+## When the coding pipeline runs
+
+`coding-pipeline.yml` triggers on `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_review`, targeting `main`, content-path filtered). Two extra entry points cover open PRs that get no pushes:
+
+- `workflow_dispatch` (inputs `pr_number`, `base_sha`) — manual re-run for an open PR, keyed on the PR's head branch as `ref`. The PR context is rebuilt from the inputs: `PR_NUMBER`/`HEAD_SHA`/`BASE_SHA` are `inputs.X || github.event.pull_request.X` everywhere they are used (workspace cache key, manifest, report). `detect-changes` skips `dorny/paths-filter` on dispatch (no checkout, no base ref) and treats every group as changed except `style` — the style job is diff-scoped, and a dispatch has no diff.
+- `nightly-pr-validation.yml` — cron (06:00 UTC) + manual dispatch. Lists open PRs targeting `main` and dispatches `coding-pipeline.yml` per PR, so validation tracks the merge ref after main advances. Fork PRs are skipped (dispatch refs must live in this repo); they still validate on every push.
+
+The report comment is only posted when a run has findings. A clean run deletes the previous report comment instead (#2702) — no comment means the last validated state was clean.
+
 ## The split
 
 - Most content validators run **CI-only**: the `validate-core` / `validate-targeted` matrices in `.github/workflows/coding-pipeline.yml` are the gate. Their old `stages: [manual]` pre-commit hooks were removed (almost nobody ran them). On `git commit` only the fast subset runs — the `md-validate-content` dispatcher (`tools/precommit_validate.py`, which fans the commit-stage validators out in parallel), plus `check_common_mistakes.py` and `validate_defines.py`. To run a CI-only validator locally: `python3 tools/validation/validate_<topic>.py --staged --no-color` (drop `--staged` for a full-repo scan).
@@ -9,6 +18,9 @@ Pre-commit and CI do not run the same hook set. Things that pass locally can sti
 - `fix_loc_yaml.py`, `validate_localization_encoding.py`, `validate_mod_encoding.py` (all `tools/linting/`) are **pre-commit-only** — never run on CI. Web-UI edits or contributors with hooks disabled can land BOM or encoding regressions. (The old `check_braces.py` hook was absorbed into `tools/validation/validate_style.py`.)
 - `validate_defines.py` runs on pre-commit against the live install and on CI against the committed `tools/validation/vanilla_defines.txt` manifest. Regenerate the manifest with `gen_vanilla_defines_manifest.py` after a HOI4 version bump (same for `vanilla_sprites.txt` via `gen_vanilla_sprites_manifest.py`).
 - `validate_ideas.py` is wired into both pre-commit (`--staged --strict`) and CI (`--strict`) — the undefined-idea backlog was cleared, so both sides gate identically.
+- `validate_mios.py` runs on both sides with the same `--strict` (org-id format, `allowed = { original_tag = TAG }`, initial-trait naming, trait-grid x ≤ 9, non-empty `on_complete`). The id/allowed/on*complete checks gate; trait naming and x-bounds are WARNING-severity — the remaining ~30-item backlog surfaces in reports without gating. `generic*`/`GENERIC*`shared orgs are exempt, as are`generic*`-named initial traits (they reference shared traits in `MD_generic_organization.txt`). Negative x is the mod's standard organic-layout first column, so only the upper bound is a finding.
+- `validate_decisions.py` carries a WARNING-severity `missing-decision-log` check (complete_effect with effects but no `log =` line) — the ~650-decision backlog is report-only until cleared.
+- `validate_style.py` exempts `EH_` focus IDs via `_SHARED_FOCUS_PREFIXES` — the Event Horizon tree is generic (`event_horizon_generic_focus`) and `EH_` is its mod-wide domain prefix.
 - `validate_unused_textures.py` is wired into pre-commit as `stages: [manual]` only. CI cannot run it, so invoke the manual hook when a texture audit is needed.
 - `validate_set_variables.py` runs **CI-only**, `--strict` (its unused-variable backlog was cleared). No pre-commit hook; run it directly (`python3 tools/validation/validate_set_variables.py`) for a local check.
 - `validate_scripted_localisation.py` runs **CI-only**, `--strict` (its missing/unused scripted-loc backlog was cleared). No pre-commit hook; run it directly for a local check.

--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -60,15 +60,18 @@ permissions:
 # resources/documentation carries modifiers_documentation.md, the vanilla
 # modifier list validate_modifiers.py needs (~4000 names it would otherwise
 # false-positive on).
-# github.sha (the merge commit) is part of the key because the bundle holds
-# merge-ref content: reopening a PR after main advanced produces a new merge
-# commit for the same head sha, and without it consumers would restore the
-# stale pre-advance bundle.
+# The bundle key identifies the PR's exact merge tree. workflow_dispatch
+# receives the head SHA, so it substitutes the supplied base SHA for the merge
+# revision. A head/base pair invalidates the bundle after main moves.
 env:
+  CHECKOUT_REF: >-
+    ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number &&
+    format('refs/pull/{0}/merge', inputs.pr_number) || github.sha }}
   WORKSPACE_KEY: >-
-    md-workspace-v1-${{ inputs.pr_number ||
+    md-workspace-v2-${{ inputs.pr_number ||
     github.event.pull_request.number }}-${{
-    github.event.pull_request.head.sha || github.sha }}-${{ github.sha }}
+    github.event.pull_request.head.sha || github.sha }}-${{
+    inputs.base_sha || github.sha }}
   WORKSPACE_PATHS: |
     common
     events
@@ -160,6 +163,7 @@ jobs:
       # changed-file list straight from the GitHub API, so cloning the repo
       # just to diff locally is pure overhead.
       - name: Detect changed file groups
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
@@ -192,7 +196,8 @@ jobs:
               - 'common/units/**'
               - 'common/ai_templates/**'
               - 'common/scripted_effects/**'
-              # Sources of create_equipment_variant, slot-checked against the hull.
+              # Sources of create_equipment_variant, slot-checked against
+              # the hull.
               - 'history/countries/**'
               - 'common/national_focus/**'
               - 'events/**'
@@ -271,13 +276,14 @@ jobs:
     env:
       PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
     steps:
       # Checkout precedes the cache steps: hashFiles() below needs tools/ on
       # disk. Cone mode also materialises root files (CLAUDE.md, *.mod).
       - name: Checkout code
+        id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 1
           sparse-checkout: |
             common
@@ -301,7 +307,7 @@ jobs:
 
       - name: Restore shared validator disk cache
         id: valcache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .validation_cache
           key: >-
@@ -319,7 +325,7 @@ jobs:
           {
             echo "pr=$PR_NUMBER"
             echo "head_sha=$HEAD_SHA"
-            echo "merge_sha=${{ github.sha }}"
+            echo "merge_sha=${{ steps.checkout.outputs.commit }}"
             echo "run_id=${{ github.run_id }}"
             echo "cache=${{ steps.valcache.outputs.cache-matched-key }}"
           } | tee .workspace-manifest
@@ -328,7 +334,7 @@ jobs:
       # completes inside this step, so `needs: prepare-workspace` fully
       # orders save-before-restore for every consumer.
       - name: Save bundled workspace cache
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.WORKSPACE_PATHS }}
           key: ${{ env.WORKSPACE_KEY }}
@@ -365,7 +371,7 @@ jobs:
       # Built by prepare-workspace this run. If eviction broke a "Re-run
       # failed jobs", use "Re-run all jobs" so the bundle is rebuilt.
       - name: Restore prepared workspace
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.WORKSPACE_PATHS }}
           key: ${{ env.WORKSPACE_KEY }}
@@ -418,7 +424,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore prepared workspace
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.WORKSPACE_PATHS }}
           key: ${{ env.WORKSPACE_KEY }}
@@ -508,7 +514,7 @@ jobs:
       # Bundle includes the shared .validation_cache — one restore replaces
       # both the old checkout and per-validator cache steps.
       - name: Restore prepared workspace
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.WORKSPACE_PATHS }}
           key: ${{ env.WORKSPACE_KEY }}
@@ -519,23 +525,14 @@ jobs:
         with:
           python-version: "3.x"
 
-      # Per-matrix opt-out: `strict: false` makes the validator informational
-      # (still produces the log + PR comment but exits 0 on findings). An entry
-      # that omits the field keeps gating behavior — never fail open by default.
       - name: Run validation
         run: |
-          if [ "${{ matrix.validator.strict }}" != "false" ]; then
-            python3 tools/validation/${{ matrix.validator.script }} \
-              --strict --no-color --workers 4 \
-              --output validation-${{ matrix.validator.name }}.log
-          else
-            python3 tools/validation/${{ matrix.validator.script }} \
-              --no-color --workers 4 \
-              --output validation-${{ matrix.validator.name }}.log
-          fi
+          python3 tools/validation/${{ matrix.validator.script }} \
+            --strict --no-color --workers 4 \
+            --output validation-${{ matrix.validator.name }}.log
 
       - name: Upload results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: validation-${{ matrix.validator.name }}-results
@@ -685,7 +682,7 @@ jobs:
       # bulk-skipping the whole job.
       - name: Restore prepared workspace
         if: matrix.validator.should_run == 'true'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.WORKSPACE_PATHS }}
           key: ${{ env.WORKSPACE_KEY }}
@@ -709,7 +706,7 @@ jobs:
           fi
       - name: Upload results
         if: always() && matrix.validator.should_run == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: validation-${{ matrix.validator.name }}-results
           path: |
@@ -735,6 +732,7 @@ jobs:
       - name: Checkout tooling
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 1
           filter: blob:none
           sparse-checkout: |
@@ -751,7 +749,7 @@ jobs:
             --strict --no-color --output validation-file-paths.log
 
       - name: Upload results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: validation-file-paths-results
@@ -767,7 +765,7 @@ jobs:
   validation-report:
     name: Generate Validation Report
     runs-on: ubuntu-latest
-    needs: [validate-core, validate-targeted, validate-paths]
+    needs: [structural-lint, validate-core, validate-targeted, validate-paths]
     permissions:
       contents: read
       pull-requests: write
@@ -780,12 +778,19 @@ jobs:
     env:
       PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      VALIDATION_SCOPE: >-
+        ${{ github.event_name == 'workflow_dispatch' &&
+        needs.structural-lint.result == 'success' &&
+        needs.validate-core.result == 'success' &&
+        needs.validate-targeted.result == 'success' &&
+        needs.validate-paths.result == 'success' && 'full' || 'partial' }}
     steps:
       # Checkout the report generator + the report_lib package it imports.
       # Stays much smaller than a full checkout — we skip everything else.
       - name: Checkout report tooling
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 1
           sparse-checkout: |
             tools/generate_validation_report.py
@@ -793,12 +798,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
       - name: Download all validation results
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: validation-*-results
           path: validation-results
@@ -809,19 +814,24 @@ jobs:
         run: |
           workflow_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
           workflow_url="$workflow_url/actions/runs/$GITHUB_RUN_ID"
-          python3 tools/generate_validation_report.py \
-            --results-dir validation-results \
-            --output report.md \
-            --pr-number "$PR_NUMBER" \
-            --commit-sha "$HEAD_SHA" \
-            --workflow-run-url "$workflow_url" \
-            --github-repository "${{ github.repository }}" \
-            --post-comment \
-            --checks-api \
+          args=(
+            --results-dir validation-results
+            --output report.md
+            --pr-number "$PR_NUMBER"
+            --commit-sha "$HEAD_SHA"
+            --workflow-run-url "$workflow_url"
+            --github-repository "${{ github.repository }}"
+            --validation-scope "$VALIDATION_SCOPE"
+            --checks-api
             --print
+          )
+          if [ -n "$PR_NUMBER" ]; then
+            args+=(--post-comment)
+          fi
+          python3 tools/generate_validation_report.py "${args[@]}"
 
       - name: Upload combined report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: validation-report

--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
       base_sha:
-        description: "PR base branch sha, for the workspace cache key"
+        description: "Current head of the PR's base branch (workspace cache key)"
         required: false
         type: string
 
@@ -60,9 +60,13 @@ permissions:
 # resources/documentation carries modifiers_documentation.md, the vanilla
 # modifier list validate_modifiers.py needs (~4000 names it would otherwise
 # false-positive on).
-# The bundle key identifies the PR's exact merge tree. workflow_dispatch
-# receives the head SHA, so it substitutes the supplied base SHA for the merge
-# revision. A head/base pair invalidates the bundle after main moves.
+# The bundle key identifies the PR's exact merge tree as (pr, head sha, base
+# revision). On pull_request the base component is github.sha, the merge commit
+# itself. A workflow_dispatch run has no merge commit in context, so the caller
+# supplies the base branch's *current* head instead. Cache keys are immutable,
+# so a key that doesn't move when main moves makes cache/save a no-op and hands
+# every validator the previous run's bundle; nightly-pr-validation.yml resolves
+# that head live for exactly this reason.
 env:
   CHECKOUT_REF: >-
     ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number &&
@@ -342,7 +346,9 @@ jobs:
       # cache/save only warns on failure. Without this check a failed save
       # leaves this job green while every consumer dies on
       # fail-on-cache-miss, and "Re-run failed jobs" can never recover
-      # because the green prepare-workspace won't re-run.
+      # because the green prepare-workspace won't re-run. An entry left by an
+      # earlier run satisfies this check, which is correct: the key identifies
+      # the merge tree, so a same-key survivor holds the same content.
       - name: Verify the bundle exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -525,11 +531,20 @@ jobs:
         with:
           python-version: "3.x"
 
+      # Per-matrix opt-out: `strict: false` makes the validator informational
+      # (still produces the log + PR comment but exits 0 on findings). An entry
+      # that omits the field keeps gating behavior — never fail open by default.
       - name: Run validation
         run: |
-          python3 tools/validation/${{ matrix.validator.script }} \
-            --strict --no-color --workers 4 \
-            --output validation-${{ matrix.validator.name }}.log
+          if [ "${{ matrix.validator.strict }}" != "false" ]; then
+            python3 tools/validation/${{ matrix.validator.script }} \
+              --strict --no-color --workers 4 \
+              --output validation-${{ matrix.validator.name }}.log
+          else
+            python3 tools/validation/${{ matrix.validator.script }} \
+              --no-color --workers 4 \
+              --output validation-${{ matrix.validator.name }}.log
+          fi
 
       - name: Upload results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -771,10 +786,14 @@ jobs:
       pull-requests: write
       checks: write
     # Run the report whether validators passed or failed, but not if the run
-    # was cancelled. (The workflow only triggers on pull_request, so no event
-    # guard is needed.)
+    # was cancelled. Both triggers land here; the PR-specific steps are gated
+    # on PR_NUMBER, which a manual dispatch without pr_number leaves empty.
     if: ${{ !cancelled() }}
     # PR context rebuilt for workflow_dispatch runs — see prepare-workspace.
+    # VALIDATION_SCOPE is `full` only on a dispatch where every validator ran
+    # and passed. A pull_request run gates validators on the changed file
+    # groups, so its "no findings" may only refresh an existing report comment,
+    # never delete one.
     env:
       PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -26,11 +26,27 @@ on:
       # workflow but skip every validator, posting an empty report.
       # Changes under tools/ are smoke-tested by tools-validation.yml instead.
       - ".github/workflows/coding-pipeline.yml"
+  # Manual re-runs for open PRs (e.g. after main advanced) and the periodic
+  # revalidation dispatched by nightly-pr-validation.yml. Dispatched runs are
+  # keyed on the PR's head branch (ref), so the same pull_request context is
+  # rebuilt from the inputs — see PR_NUMBER/BASE_SHA below.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to validate (nightly revalidation)"
+        required: false
+        type: string
+      base_sha:
+        description: "PR base branch sha, for the workspace cache key"
+        required: false
+        type: string
 
 concurrency:
+  # Same group for a push-triggered run and a dispatched run of the same PR:
+  # the periodic revalidation cancels an in-flight run instead of doubling it.
   group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number ||
-    github.ref }}
+    ${{ github.workflow }}-${{ inputs.pr_number ||
+    github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Least privilege: validator jobs run PR-authored code and only need to read.
@@ -50,8 +66,9 @@ permissions:
 # stale pre-advance bundle.
 env:
   WORKSPACE_KEY: >-
-    md-workspace-v1-${{ github.event.pull_request.number }}-${{
-    github.event.pull_request.head.sha }}-${{ github.sha }}
+    md-workspace-v1-${{ inputs.pr_number ||
+    github.event.pull_request.number }}-${{
+    github.event.pull_request.head.sha || github.sha }}-${{ github.sha }}
   WORKSPACE_PATHS: |
     common
     events
@@ -75,26 +92,69 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      common: ${{ steps.filter.outputs.common }}
-      events: ${{ steps.filter.outputs.events }}
-      history: ${{ steps.filter.outputs.history }}
-      localisation: ${{ steps.filter.outputs.localisation }}
-      ai-strategy: ${{ steps.filter.outputs.ai-strategy }}
-      ai-navy: ${{ steps.filter.outputs.ai-navy }}
-      ai-equipment: ${{ steps.filter.outputs.ai-equipment }}
-      factions: ${{ steps.filter.outputs.factions }}
-      oob: ${{ steps.filter.outputs.oob }}
-      decisions: ${{ steps.filter.outputs.decisions }}
-      scripted-loc: ${{ steps.filter.outputs.scripted-loc }}
-      scripted-guis: ${{ steps.filter.outputs.scripted-guis }}
-      interface: ${{ steps.filter.outputs.interface }}
-      national-focus: ${{ steps.filter.outputs.national-focus }}
-      on-actions: ${{ steps.filter.outputs.on-actions }}
-      scripted-effects: ${{ steps.filter.outputs.scripted-effects }}
-      style: ${{ steps.filter.outputs.style }}
+      common: >-
+        ${{ steps.filter.outputs.common ||
+        steps.dispatch.outputs.common }}
+      events: >-
+        ${{ steps.filter.outputs.events ||
+        steps.dispatch.outputs.events }}
+      history: >-
+        ${{ steps.filter.outputs.history ||
+        steps.dispatch.outputs.history }}
+      localisation: >-
+        ${{ steps.filter.outputs.localisation ||
+        steps.dispatch.outputs.localisation }}
+      ai-strategy: >-
+        ${{ steps.filter.outputs.ai-strategy ||
+        steps.dispatch.outputs.ai-strategy }}
+      ai-navy: >-
+        ${{ steps.filter.outputs.ai-navy ||
+        steps.dispatch.outputs.ai-navy }}
+      ai-equipment: >-
+        ${{ steps.filter.outputs.ai-equipment ||
+        steps.dispatch.outputs.ai-equipment }}
+      factions: >-
+        ${{ steps.filter.outputs.factions ||
+        steps.dispatch.outputs.factions }}
+      oob: >-
+        ${{ steps.filter.outputs.oob ||
+        steps.dispatch.outputs.oob }}
+      decisions: >-
+        ${{ steps.filter.outputs.decisions ||
+        steps.dispatch.outputs.decisions }}
+      scripted-loc: >-
+        ${{ steps.filter.outputs.scripted-loc ||
+        steps.dispatch.outputs.scripted-loc }}
+      scripted-guis: >-
+        ${{ steps.filter.outputs.scripted-guis ||
+        steps.dispatch.outputs.scripted-guis }}
+      interface: >-
+        ${{ steps.filter.outputs.interface ||
+        steps.dispatch.outputs.interface }}
+      national-focus: >-
+        ${{ steps.filter.outputs.national-focus ||
+        steps.dispatch.outputs.national-focus }}
+      on-actions: >-
+        ${{ steps.filter.outputs.on-actions ||
+        steps.dispatch.outputs.on-actions }}
+      scripted-effects: >-
+        ${{ steps.filter.outputs.scripted-effects ||
+        steps.dispatch.outputs.scripted-effects }}
+      style: >-
+        ${{ steps.filter.outputs.style ||
+        steps.dispatch.outputs.style }}
+      # Diff file list — only meaningful on pull_request; dispatch runs have
+      # no diff, so the style job is skipped outright (see dispatch step).
       style-files: ${{ steps.filter.outputs.style_files }}
-      mod: ${{ steps.filter.outputs.mod }}
-      content: ${{ steps.filter.outputs.content }}
+      mod: >-
+        ${{ steps.filter.outputs.mod ||
+        steps.dispatch.outputs.mod }}
+      content: >-
+        ${{ steps.filter.outputs.content ||
+        steps.dispatch.outputs.content }}
+      mios: >-
+        ${{ steps.filter.outputs.mios ||
+        steps.dispatch.outputs.mios }}
     steps:
       # No checkout — on pull_request events dorny/paths-filter fetches the
       # changed-file list straight from the GitHub API, so cloning the repo
@@ -150,6 +210,8 @@ jobs:
               - 'common/national_focus/**'
             on-actions:
               - 'common/on_actions/**'
+            mios:
+              - 'common/military_industrial_organization/**'
             scripted-effects:
               - 'common/scripted_effects/**'
             style:
@@ -169,6 +231,25 @@ jobs:
               - 'interface/**'
               - '*.mod'
 
+      # workflow_dispatch runs have no PR diff to filter, and paths-filter
+      # would need a checkout (plus a base ref) to diff anything — this job
+      # deliberately checks out nothing. Treat every group as changed so the
+      # full validation set runs; the job outputs above fall back to these.
+      - name: Treat all groups as changed on dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: dispatch
+        run: |
+          for out in common events history localisation ai-strategy \
+              ai-navy ai-equipment factions oob decisions scripted-loc \
+              scripted-guis interface national-focus on-actions \
+              scripted-effects mod content mios; do
+            echo "$out=true" >> "$GITHUB_OUTPUT"
+          done
+          # style is diff-scoped (MD_STAGED_FILES from the changed-file
+          # list); there is no diff on dispatch, so skip the style job
+          # instead of running it against an empty file list.
+          echo "style=false" >> "$GITHUB_OUTPUT"
+
   # ───────────────────────────────────────────────────────────────
   # Prepare workspace — the run's single checkout. Bundles the validated
   # directories plus the shared .validation_cache (warmed on main by
@@ -184,6 +265,13 @@ jobs:
       contents: read
       # actions: read lets the post-save step verify the bundle exists.
       actions: read
+    # PR context rebuilt for workflow_dispatch runs (inputs are null on
+    # pull_request, the event fields are null on dispatch — the `||` picks
+    # whichever is populated).
+    env:
+      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
     steps:
       # Checkout precedes the cache steps: hashFiles() below needs tools/ on
       # disk. Cone mode also materialises root files (CLAUDE.md, *.mod).
@@ -219,7 +307,7 @@ jobs:
           key: >-
             md-valcache-v1-${{ runner.os }}-${{
             steps.toolshash.outputs.hash }}-${{
-            github.event.pull_request.base.sha }}
+            inputs.base_sha || github.event.pull_request.base.sha }}
           restore-keys: |
             md-valcache-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-
 
@@ -229,8 +317,8 @@ jobs:
         run: |
           mkdir -p .validation_cache
           {
-            echo "pr=${{ github.event.pull_request.number }}"
-            echo "head_sha=${{ github.event.pull_request.head.sha }}"
+            echo "pr=$PR_NUMBER"
+            echo "head_sha=$HEAD_SHA"
             echo "merge_sha=${{ github.sha }}"
             echo "run_id=${{ github.run_id }}"
             echo "cache=${{ steps.valcache.outputs.cache-matched-key }}"
@@ -478,6 +566,7 @@ jobs:
       needs.detect-changes.outputs.national-focus == 'true' ||
       needs.detect-changes.outputs.on-actions == 'true' ||
       needs.detect-changes.outputs.scripted-effects == 'true' ||
+      needs.detect-changes.outputs.mios == 'true' ||
       needs.detect-changes.outputs.events == 'true' ||
       needs.detect-changes.outputs.history == 'true' ||
       needs.detect-changes.outputs.localisation == 'true' ||
@@ -517,6 +606,11 @@ jobs:
             title: "Validate Faction System"
             strict: true
             should_run: ${{ needs.detect-changes.outputs.factions }}
+          - script: validate_mios.py
+            name: mios
+            title: "Validate MIO Organizations"
+            strict: true
+            should_run: ${{ needs.detect-changes.outputs.mios }}
           - script: validate_scripted_gui.py
             name: scripted-gui
             title: "Validate Scripted GUIs"
@@ -682,6 +776,10 @@ jobs:
     # was cancelled. (The workflow only triggers on pull_request, so no event
     # guard is needed.)
     if: ${{ !cancelled() }}
+    # PR context rebuilt for workflow_dispatch runs — see prepare-workspace.
+    env:
+      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       # Checkout the report generator + the report_lib package it imports.
       # Stays much smaller than a full checkout — we skip everything else.
@@ -714,8 +812,8 @@ jobs:
           python3 tools/generate_validation_report.py \
             --results-dir validation-results \
             --output report.md \
-            --pr-number "${{ github.event.pull_request.number }}" \
-            --commit-sha "${{ github.event.pull_request.head.sha }}" \
+            --pr-number "$PR_NUMBER" \
+            --commit-sha "$HEAD_SHA" \
             --workflow-run-url "$workflow_url" \
             --github-repository "${{ github.repository }}" \
             --post-comment \

--- a/.github/workflows/nightly-pr-validation.yml
+++ b/.github/workflows/nightly-pr-validation.yml
@@ -1,0 +1,47 @@
+name: Nightly PR Revalidation
+
+# Re-runs the coding pipeline for every open PR against its head branch, so
+# validation tracks the PR's merge ref after main advances. pull_request
+# events only fire on pushes: a PR that sits open while main moves gets stale
+# checks with no way to refresh them short of a re-push. This workflow
+# dispatches coding-pipeline.yml (workflow_dispatch) for each open PR, which
+# rebuilds the PR context from the pr_number/base_sha inputs.
+#
+# Fork PRs are skipped: workflow_dispatch refs must live in this repo, so a
+# fork's head branch cannot be dispatched. Fork PRs still validate on every
+# push via the normal pull_request trigger.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  # Needed to dispatch coding-pipeline.yml for each open PR.
+  actions: write
+
+concurrency:
+  group: nightly-pr-revalidation
+  cancel-in-progress: true
+
+jobs:
+  revalidate-open-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch validation for open PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pulls_url="repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100"
+          prs=$(gh api "$pulls_url" \
+            --jq '.[] | select(.head.repo.full_name == env.GITHUB_REPOSITORY) |
+            [.number, .head.ref, .base.sha] | @tsv')
+          count=0
+          while IFS=$'\t' read -r num ref base_sha; do
+            [ -z "$num" ] && continue
+            gh workflow run "coding-pipeline.yml" --ref "$ref" \
+              -f pr_number="$num" -f base_sha="$base_sha"
+            count=$((count + 1))
+          done <<< "$prs"
+          echo "Dispatched coding-pipeline for $count open PR(s)"

--- a/.github/workflows/nightly-pr-validation.yml
+++ b/.github/workflows/nightly-pr-validation.yml
@@ -10,6 +10,10 @@ name: Nightly PR Revalidation
 # Fork PRs are skipped: workflow_dispatch refs must live in this repo, so a
 # fork's head branch cannot be dispatched. Fork PRs still validate on every
 # push via the normal pull_request trigger.
+#
+# A dispatch runs the workflow file as it exists on the PR's head branch, so a
+# branch that predates the workflow_dispatch trigger cannot be revalidated
+# until it is rebased. Those PRs are warned about and skipped, not fatal.
 
 on:
   schedule:
@@ -33,15 +37,38 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # main's live head, not each PR's `.base.sha`: that field is the base
+          # tip from the PR's last synchronize and does not move when main does,
+          # so it would never invalidate the workspace bundle keyed on it.
+          base_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')
+          # --paginate: without it the sweep silently stops at the 100 most
+          # recently updated open PRs.
           pulls_url="repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100"
-          prs=$(gh api "$pulls_url" \
+          prs=$(gh api --paginate "$pulls_url" \
             --jq '.[] | select(.head.repo.full_name == env.GITHUB_REPOSITORY) |
-            [.number, .head.ref, .base.sha] | @tsv')
-          count=0
-          while IFS=$'\t' read -r num ref base_sha; do
+            [.number, .head.ref] | @tsv')
+          sent=0
+          skipped=0
+          while IFS=$'\t' read -r num ref; do
             [ -z "$num" ] && continue
-            gh workflow run "coding-pipeline.yml" --ref "$ref" \
-              -f pr_number="$num" -f base_sha="$base_sha"
-            count=$((count + 1))
+            # A PR that conflicts with main has no refs/pull/N/merge, and
+            # coding-pipeline checks that ref out. Skip it instead of letting
+            # the dispatched run die on checkout and read as pipeline breakage.
+            if ! gh api "repos/$GITHUB_REPOSITORY/git/ref/pull/$num/merge" \
+                --silent 2>/dev/null; then
+              echo "::warning::PR #$num has no merge ref (conflicts with main?), skipped"
+              skipped=$((skipped + 1))
+              continue
+            fi
+            # A branch predating the trigger (or its inputs) is rejected with a
+            # 422, and `bash -e` would end the sweep at the first one.
+            if gh workflow run "coding-pipeline.yml" --ref "$ref" \
+                -f pr_number="$num" -f base_sha="$base_sha"; then
+              sent=$((sent + 1))
+            else
+              echo "::warning::PR #$num ($ref) could not be dispatched; rebase" \
+                "onto main to pick up the workflow_dispatch trigger"
+              skipped=$((skipped + 1))
+            fi
           done <<< "$prs"
-          echo "Dispatched coding-pipeline for $count open PR(s)"
+          echo "Dispatched coding-pipeline for $sent open PR(s), skipped $skipped"

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -33,3 +33,29 @@ jobs:
                   && echo "deleted cache ${id}" \
                   || echo "cache ${id} already gone"
               done
+
+      # nightly-pr-validation dispatches coding-pipeline on the PR's head
+      # branch, so the bundles that run saves are scoped to refs/heads/<branch>
+      # and the merge-ref sweep above never sees them. Same-repo PRs only, and
+      # restricted to the md-workspace- prefix: the branch itself may live on.
+      - name: Delete workspace bundles scoped to this PR's head branch
+        if: >-
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Through env, never inline ${{ }}: this is pull_request_target and a
+          # branch name is contributor-controlled text.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          [ -n "$HEAD_REF" ] || exit 0
+          # -f, not a hand-built query string: gh url-encodes the value, so a
+          # branch name containing & or # cannot rewrite the request.
+          gh api --paginate --method GET "repos/${{ github.repository }}/actions/caches" \
+            -f ref="refs/heads/${HEAD_REF}" -F per_page=100 \
+            --jq '.actions_caches[]
+                  | select(.key | startswith("md-workspace-")) | .id' \
+            | while read -r id; do
+                gh api -X DELETE "repos/${{ github.repository }}/actions/caches/${id}" \
+                  && echo "deleted cache ${id}" \
+                  || echo "cache ${id} already gone"
+              done

--- a/.github/workflows/tools-validation.yml
+++ b/.github/workflows/tools-validation.yml
@@ -6,6 +6,7 @@ on:
       - 'tools/**'
       - '.pre-commit-config.yaml'
       - '.github/workflows/coding-pipeline.yml'
+      - '.github/workflows/nightly-pr-validation.yml'
       - '.github/workflows/tools-validation.yml'
       - '.github/workflows/validator-cache.yml'
 
@@ -60,14 +61,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-          # config_drift_test reads these two config files to compare the
-          # validator set declared in each. pyproject.toml supplies the pytest
-          # testpaths so all four test dirs are collected.
+          # config_drift_test reads the pre-commit config and these workflows to
+          # compare the validator set declared in each, and to check the
+          # pipeline wiring around them. pyproject.toml supplies the pytest
+          # testpaths so all six test dirs are collected.
           sparse-checkout: |
             tools
             pyproject.toml
             .pre-commit-config.yaml
             .github/workflows/coding-pipeline.yml
+            .github/workflows/nightly-pr-validation.yml
             .github/workflows/tools-validation.yml
             .github/workflows/validator-cache.yml
           sparse-checkout-cone-mode: false

--- a/tools/generate_validation_report.py
+++ b/tools/generate_validation_report.py
@@ -28,6 +28,7 @@ from report_lib import (  # noqa: E402
     MAX_ISSUES_STEP_SUMMARY,
     ReportContext,
     dedupe,
+    delete_comment,
     load_all,
     post_checks,
     post_comment,
@@ -175,23 +176,39 @@ def main() -> int:
                     file=sys.stderr,
                 )
                 return 1
-            success, message = post_comment(
-                repo_owner,
-                repo_name,
-                args.pr_number,
-                body,
-                args.github_token,
-            )
-            (print if success else _err)(f"PR comment: {message}")
-            # A read-only GITHUB_TOKEN (fork PRs get one regardless of the
-            # workflow's permissions block) can't post comments. Don't fail the
-            # job over it — the report still uploads as an artifact. Mirrors the
-            # Checks API handling below.
-            if not success:
-                _err(
-                    "PR comment could not be posted; continuing. "
-                    "See the validation-report artifact for the full report."
+            if not deduped:
+                # No findings: drop the previous run's comment instead of
+                # posting an empty report (#2702).
+                success, message = delete_comment(
+                    repo_owner,
+                    repo_name,
+                    args.pr_number,
+                    args.github_token,
                 )
+                (print if success else _err)(f"No findings — {message}")
+                if not success:
+                    _err(
+                        "Stale report comment could not be deleted; continuing. "
+                        "See the validation-report artifact for the full report."
+                    )
+            else:
+                success, message = post_comment(
+                    repo_owner,
+                    repo_name,
+                    args.pr_number,
+                    body,
+                    args.github_token,
+                )
+                (print if success else _err)(f"PR comment: {message}")
+                # A read-only GITHUB_TOKEN (fork PRs get one regardless of the
+                # workflow's permissions block) can't post comments. Don't fail the
+                # job over it — the report still uploads as an artifact. Mirrors the
+                # Checks API handling below.
+                if not success:
+                    _err(
+                        "PR comment could not be posted; continuing. "
+                        "See the validation-report artifact for the full report."
+                    )
 
         if args.checks_api:
             if not args.commit_sha:

--- a/tools/generate_validation_report.py
+++ b/tools/generate_validation_report.py
@@ -69,6 +69,15 @@ def build_report(results_dir: str, ctx: ReportContext):
     return body, step_body, runs, deduped, truncated
 
 
+def should_delete_comment(runs, deduped, validation_scope: str) -> bool:
+    return (
+        validation_scope == "full"
+        and bool(runs)
+        and not deduped
+        and all(run.status == "passed" for run in runs)
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Generate the Millennium Dawn validation PR report",
@@ -79,6 +88,11 @@ def main() -> int:
     parser.add_argument("--commit-sha")
     parser.add_argument("--workflow-run-url")
     parser.add_argument("--artifact-url")
+    parser.add_argument(
+        "--validation-scope",
+        choices=("partial", "full"),
+        default="partial",
+    )
     parser.add_argument("--print", action="store_true")
     parser.add_argument(
         "--post-comment",
@@ -176,21 +190,25 @@ def main() -> int:
                     file=sys.stderr,
                 )
                 return 1
-            if not deduped:
-                # No findings: drop the previous run's comment instead of
-                # posting an empty report (#2702).
+            if should_delete_comment(runs, deduped, args.validation_scope):
                 success, message = delete_comment(
                     repo_owner,
                     repo_name,
                     args.pr_number,
                     args.github_token,
                 )
-                (print if success else _err)(f"No findings — {message}")
+                (print if success else _err)(f"No findings: {message}")
                 if not success:
                     _err(
                         "Stale report comment could not be deleted; continuing. "
                         "See the validation-report artifact for the full report."
                     )
+            elif not deduped:
+                print(
+                    "No findings from partial or incomplete validation; retaining "
+                    "the existing PR comment.",
+                    file=sys.stderr,
+                )
             else:
                 success, message = post_comment(
                     repo_owner,

--- a/tools/generate_validation_report.py
+++ b/tools/generate_validation_report.py
@@ -70,6 +70,7 @@ def build_report(results_dir: str, ctx: ReportContext):
 
 
 def should_delete_comment(runs, deduped, validation_scope: str) -> bool:
+    """Only a full run proves the PR clean, so only a full run may delete."""
     return (
         validation_scope == "full"
         and bool(runs)
@@ -123,6 +124,7 @@ def main() -> int:
         artifact_url=args.artifact_url,
         date_utc=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
         repo=args.github_repository,
+        validation_scope=args.validation_scope,
     )
 
     body, step_body, runs, deduped, truncated = build_report(args.results_dir, ctx)
@@ -197,36 +199,29 @@ def main() -> int:
                     args.pr_number,
                     args.github_token,
                 )
-                (print if success else _err)(f"No findings: {message}")
-                if not success:
-                    _err(
-                        "Stale report comment could not be deleted; continuing. "
-                        "See the validation-report artifact for the full report."
-                    )
-            elif not deduped:
-                print(
-                    "No findings from partial or incomplete validation; retaining "
-                    "the existing PR comment.",
-                    file=sys.stderr,
-                )
             else:
+                # A clean partial run refreshes an existing comment so it stops
+                # reporting an older commit, but never opens a new one: only the
+                # changed groups' validators ran, so it cannot clear a finding
+                # an unrun validator would still report.
                 success, message = post_comment(
                     repo_owner,
                     repo_name,
                     args.pr_number,
                     body,
                     args.github_token,
+                    update_only=not deduped,
                 )
-                (print if success else _err)(f"PR comment: {message}")
-                # A read-only GITHUB_TOKEN (fork PRs get one regardless of the
-                # workflow's permissions block) can't post comments. Don't fail the
-                # job over it — the report still uploads as an artifact. Mirrors the
-                # Checks API handling below.
-                if not success:
-                    _err(
-                        "PR comment could not be posted; continuing. "
-                        "See the validation-report artifact for the full report."
-                    )
+            (print if success else _err)(f"PR comment: {message}")
+            # A read-only GITHUB_TOKEN (fork PRs get one regardless of the
+            # workflow's permissions block) can't write comments. Don't fail the
+            # job over it — the report still uploads as an artifact. Mirrors the
+            # Checks API handling below.
+            if not success:
+                _err(
+                    "PR comment could not be updated; continuing. "
+                    "See the validation-report artifact for the full report."
+                )
 
         if args.checks_api:
             if not args.commit_sha:

--- a/tools/precommit_validate.py
+++ b/tools/precommit_validate.py
@@ -135,6 +135,10 @@ _REGISTRY = [
         ],
     ),
     _Spec("validate_events", [("events/", TXT)]),
+    _Spec(
+        "validate_mios",
+        [("common/military_industrial_organization/organizations/", TXT)],
+    ),
 ]
 
 

--- a/tools/report_lib/__init__.py
+++ b/tools/report_lib/__init__.py
@@ -15,7 +15,7 @@ The CLI is `tools/generate_validation_report.py`.
 """
 
 from .checks_api import post_checks
-from .comment import REPORT_MARKER, find_existing_comment, post_comment
+from .comment import REPORT_MARKER, delete_comment, find_existing_comment, post_comment
 from .dedupe import dedupe
 from .loader import discover_validator_runs, load_all
 from .markdown import MAX_ISSUES_STEP_SUMMARY, render
@@ -37,5 +37,6 @@ __all__ = [
     "REPORT_MARKER",
     "find_existing_comment",
     "post_comment",
+    "delete_comment",
     "post_checks",
 ]

--- a/tools/report_lib/comment.py
+++ b/tools/report_lib/comment.py
@@ -12,6 +12,7 @@ import urllib.request
 from typing import Optional, Tuple
 
 REPORT_MARKER = "<!-- md-validation-report:v1 -->"
+_PAGE_SIZE = 100
 
 
 def find_existing_comment(comments: list) -> Optional[dict]:
@@ -38,22 +39,22 @@ def post_comment(
     pr_number: str,
     body: str,
     github_token: str,
+    update_only: bool = False,
 ) -> Tuple[bool, str]:
     """Create or update the validation report PR comment.
 
-    Returns (success, message).
+    With *update_only* an absent comment stays absent: used when a run has
+    nothing to report but an older comment must stop showing an earlier
+    commit's findings. Returns (success, message).
     """
     api_base = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
     headers = _auth_headers(github_token)
 
-    try:
-        comments = _get_comments(f"{api_base}/issues/{pr_number}/comments", headers)
-    except urllib.error.HTTPError as e:
-        return False, _fmt_http_error("list comments", e)
-    except Exception as e:
-        return False, f"list comments: {e}"
-
-    existing = find_existing_comment(comments)
+    existing, error = _find_report_comment(api_base, pr_number, headers)
+    if error:
+        return False, error
+    if not existing and update_only:
+        return True, "no existing comment to refresh"
     try:
         if existing:
             comment_id = existing["id"]
@@ -91,14 +92,9 @@ def delete_comment(
     api_base = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
     headers = _auth_headers(github_token)
 
-    try:
-        comments = _get_comments(f"{api_base}/issues/{pr_number}/comments", headers)
-    except urllib.error.HTTPError as e:
-        return False, _fmt_http_error("list comments", e)
-    except Exception as e:
-        return False, f"list comments: {e}"
-
-    existing = find_existing_comment(comments)
+    existing, error = _find_report_comment(api_base, pr_number, headers)
+    if error:
+        return False, error
     if not existing:
         return True, "no report comment to delete"
     try:
@@ -125,16 +121,23 @@ def _auth_headers(github_token: str) -> dict:
     }
 
 
-def _get_comments(url: str, headers: dict) -> list:
+def _find_report_comment(api_base: str, pr_number: str, headers: dict):
+    """Return (comment_or_None, error_message_or_None)."""
     comments = []
-    separator = "&" if "?" in url else "?"
     page = 1
-    while True:
-        batch = _get(f"{url}{separator}per_page=100&page={page}", headers)
-        comments.extend(batch)
-        if len(batch) < 100:
-            return comments
-        page += 1
+    url = f"{api_base}/issues/{pr_number}/comments"
+    try:
+        while True:
+            batch = _get(f"{url}?per_page={_PAGE_SIZE}&page={page}", headers)
+            comments.extend(batch)
+            if len(batch) < _PAGE_SIZE:
+                break
+            page += 1
+    except urllib.error.HTTPError as e:
+        return None, _fmt_http_error("list comments", e)
+    except Exception as e:
+        return None, f"list comments: {e}"
+    return find_existing_comment(comments), None
 
 
 def _get(url: str, headers: dict) -> list:

--- a/tools/report_lib/comment.py
+++ b/tools/report_lib/comment.py
@@ -76,6 +76,46 @@ def post_comment(
         return False, f"post comment: {e}"
 
 
+def delete_comment(
+    repo_owner: str,
+    repo_name: str,
+    pr_number: str,
+    github_token: str,
+) -> Tuple[bool, str]:
+    """Delete the bot's validation report comment, if one exists.
+
+    Used when a run has no findings: the previous run's comment would
+    otherwise linger with stale warnings, and there is nothing new to post.
+    Returns (success, message).
+    """
+    api_base = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+    headers = _auth_headers(github_token)
+
+    try:
+        comments = _get(f"{api_base}/issues/{pr_number}/comments", headers)
+    except urllib.error.HTTPError as e:
+        return False, _fmt_http_error("list comments", e)
+    except Exception as e:
+        return False, f"list comments: {e}"
+
+    existing = find_existing_comment(comments)
+    if not existing:
+        return True, "no report comment to delete"
+    try:
+        req = urllib.request.Request(
+            f"{api_base}/issues/comments/{existing['id']}",
+            headers=headers,
+            method="DELETE",
+        )
+        with urllib.request.urlopen(req):
+            pass
+        return True, f"deleted comment #{existing['id']}"
+    except urllib.error.HTTPError as e:
+        return False, _fmt_http_error("delete comment", e)
+    except Exception as e:
+        return False, f"delete comment: {e}"
+
+
 def _auth_headers(github_token: str) -> dict:
     return {
         "Authorization": f"Bearer {github_token}",

--- a/tools/report_lib/comment.py
+++ b/tools/report_lib/comment.py
@@ -47,7 +47,7 @@ def post_comment(
     headers = _auth_headers(github_token)
 
     try:
-        comments = _get(f"{api_base}/issues/{pr_number}/comments", headers)
+        comments = _get_comments(f"{api_base}/issues/{pr_number}/comments", headers)
     except urllib.error.HTTPError as e:
         return False, _fmt_http_error("list comments", e)
     except Exception as e:
@@ -92,7 +92,7 @@ def delete_comment(
     headers = _auth_headers(github_token)
 
     try:
-        comments = _get(f"{api_base}/issues/{pr_number}/comments", headers)
+        comments = _get_comments(f"{api_base}/issues/{pr_number}/comments", headers)
     except urllib.error.HTTPError as e:
         return False, _fmt_http_error("list comments", e)
     except Exception as e:
@@ -125,24 +125,43 @@ def _auth_headers(github_token: str) -> dict:
     }
 
 
+def _get_comments(url: str, headers: dict) -> list:
+    comments = []
+    separator = "&" if "?" in url else "?"
+    page = 1
+    while True:
+        batch = _get(f"{url}{separator}per_page=100&page={page}", headers)
+        comments.extend(batch)
+        if len(batch) < 100:
+            return comments
+        page += 1
+
+
 def _get(url: str, headers: dict) -> list:
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return _decode_json(resp)
 
 
 def _post(url: str, payload: dict, headers: dict) -> dict:
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     with urllib.request.urlopen(req) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return _decode_json(resp)
 
 
 def _patch(url: str, payload: dict, headers: dict) -> dict:
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="PATCH")
     with urllib.request.urlopen(req) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return _decode_json(resp)
+
+
+def _decode_json(response):
+    try:
+        return json.loads(response.read().decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise ValueError("invalid JSON response") from e
 
 
 def _fmt_http_error(label: str, e: urllib.error.HTTPError) -> str:

--- a/tools/report_lib/markdown.py
+++ b/tools/report_lib/markdown.py
@@ -49,7 +49,7 @@ def render(
     parts.append("# Validation Report")
     parts.append("")
 
-    verdict = _render_verdict(runs)
+    verdict = _render_verdict(runs, ctx.validation_scope)
     if verdict:
         parts.append(verdict)
         parts.append("")
@@ -137,7 +137,7 @@ def _severity_icon(errors: int, warnings: int) -> str:
 # ── Verdict banner ─────────────────────────────────────────────────────────────
 
 
-def _render_verdict(runs: List[ValidatorRun]) -> str:
+def _render_verdict(runs: List[ValidatorRun], validation_scope: str = "full") -> str:
     """A GitHub alert callout giving an at-a-glance pass/fail verdict."""
     if not runs:
         return ""
@@ -153,9 +153,12 @@ def _render_verdict(runs: List[ValidatorRun]) -> str:
         line = f"{_plural(total_warnings, 'warning')} to review. None block merge."
         return f"> [!WARNING]\n> ⚠️ {line}"
 
-    return (
-        f"> [!NOTE]\n> ✅ All {_plural(len(runs), 'validator')} passed. Nothing to fix."
+    tail = (
+        "Nothing to fix."
+        if validation_scope == "full"
+        else "Nothing to fix in the file groups this diff touches."
     )
+    return f"> [!NOTE]\n> ✅ All {_plural(len(runs), 'validator')} passed. {tail}"
 
 
 # ── Metadata strip ─────────────────────────────────────────────────────────────
@@ -171,6 +174,8 @@ def _render_metadata_strip(ctx: ReportContext) -> str:
         bits.append(f"**Run:** [step summary]({ctx.workflow_run_url})")
     if ctx.date_utc:
         bits.append(f"**Date:** {ctx.date_utc}")
+    if ctx.validation_scope != "full":
+        bits.append("**Scope:** changed file groups only")
     return " · ".join(bits)
 
 

--- a/tools/report_lib/models.py
+++ b/tools/report_lib/models.py
@@ -77,3 +77,6 @@ class ReportContext:
     artifact_url: Optional[str] = None
     date_utc: Optional[str] = None
     repo: Optional[str] = None  # "owner/name", used to build blob links to file:line
+    # "partial" when only the validators covering the diff ran, which makes a
+    # clean report a weaker claim, so the rendered body has to say which.
+    validation_scope: str = "full"

--- a/tools/report_lib/tests/comment_test.py
+++ b/tools/report_lib/tests/comment_test.py
@@ -1,9 +1,14 @@
-"""Tests for `report_lib.comment.find_existing_comment` and delete_comment."""
+"""Tests for `report_lib.comment` discovery, posting and deletion."""
 
 from contextlib import nullcontext
 
 from report_lib import comment as C
-from report_lib.comment import REPORT_MARKER, delete_comment, find_existing_comment
+from report_lib.comment import (
+    REPORT_MARKER,
+    delete_comment,
+    find_existing_comment,
+    post_comment,
+)
 
 
 def _comment(body, bot=True, cid=1):
@@ -81,3 +86,38 @@ def test_delete_comment_falls_back_to_legacy_title(monkeypatch):
     success, message = delete_comment("owner", "repo", "7", "token")
     assert success
     assert "deleted comment #9" in message
+
+
+def test_update_only_does_not_create_a_comment(monkeypatch):
+    # A clean partial run must not open a comment on a PR that never had one.
+    monkeypatch.setattr(C, "_get", lambda *a, **k: [])
+
+    def fail(*a, **k):
+        raise AssertionError("update_only must not POST")
+
+    monkeypatch.setattr(C, "_post", fail)
+    success, message = post_comment(
+        "owner", "repo", "7", "body", "token", update_only=True
+    )
+    assert success
+    assert "no existing comment" in message
+
+
+def test_update_only_refreshes_an_existing_comment(monkeypatch):
+    comments = [_comment(f"{REPORT_MARKER}\n# Validation Report\nold", cid=42)]
+    monkeypatch.setattr(C, "_get", lambda *a, **k: comments)
+    patched = []
+    monkeypatch.setattr(
+        C, "_patch", lambda url, payload, headers: patched.append((url, payload)) or {}
+    )
+    success, message = post_comment(
+        "owner", "repo", "7", "fresh body", "token", update_only=True
+    )
+    assert success
+    assert "updated comment #42" in message
+    assert patched == [
+        (
+            "https://api.github.com/repos/owner/repo/issues/comments/42",
+            {"body": "fresh body"},
+        )
+    ]

--- a/tools/report_lib/tests/comment_test.py
+++ b/tools/report_lib/tests/comment_test.py
@@ -1,6 +1,15 @@
-"""Tests for `report_lib.comment.find_existing_comment`."""
+"""Tests for `report_lib.comment.find_existing_comment` and delete_comment."""
 
-from report_lib.comment import REPORT_MARKER, find_existing_comment
+from report_lib import comment as C
+from report_lib.comment import REPORT_MARKER, delete_comment, find_existing_comment
+
+
+class _Resp:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
 
 
 def _comment(body, bot=True, cid=1):
@@ -45,3 +54,42 @@ def test_returns_none_when_no_match():
         _comment("another bot saying something", cid=2),
     ]
     assert find_existing_comment(comments) is None
+
+
+def test_delete_comment_noop_without_existing(monkeypatch):
+    monkeypatch.setattr(C, "_get", lambda *a, **k: [])
+    success, message = delete_comment("owner", "repo", "7", "token")
+    assert success
+    assert "no report comment" in message
+
+
+def test_delete_comment_removes_marker_comment(monkeypatch):
+    comments = [_comment(f"{REPORT_MARKER}\n# Validation Report\nstuff", cid=42)]
+    monkeypatch.setattr(C, "_get", lambda *a, **k: comments)
+    deleted = []
+
+    def fake_urlopen(req):
+        deleted.append(req.full_url)
+        assert req.method == "DELETE"
+        return _Resp()
+
+    monkeypatch.setattr(C.urllib.request, "urlopen", fake_urlopen)
+    success, message = delete_comment("owner", "repo", "7", "token")
+    assert success
+    assert "deleted comment #42" in message
+    assert deleted == ["https://api.github.com/repos/owner/repo/issues/comments/42"]
+
+
+def test_delete_comment_falls_back_to_legacy_title(monkeypatch):
+    comments = [_comment("# Validation Report\nlegacy, no marker", cid=9)]
+    monkeypatch.setattr(C, "_get", lambda *a, **k: comments)
+    deleted = []
+
+    def fake_urlopen(req):
+        deleted.append(req.full_url)
+        return _Resp()
+
+    monkeypatch.setattr(C.urllib.request, "urlopen", fake_urlopen)
+    success, message = delete_comment("owner", "repo", "7", "token")
+    assert success
+    assert "deleted comment #9" in message

--- a/tools/report_lib/tests/comment_test.py
+++ b/tools/report_lib/tests/comment_test.py
@@ -1,15 +1,9 @@
 """Tests for `report_lib.comment.find_existing_comment` and delete_comment."""
 
+from contextlib import nullcontext
+
 from report_lib import comment as C
 from report_lib.comment import REPORT_MARKER, delete_comment, find_existing_comment
-
-
-class _Resp:
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        return False
 
 
 def _comment(body, bot=True, cid=1):
@@ -71,7 +65,7 @@ def test_delete_comment_removes_marker_comment(monkeypatch):
     def fake_urlopen(req):
         deleted.append(req.full_url)
         assert req.method == "DELETE"
-        return _Resp()
+        return nullcontext()
 
     monkeypatch.setattr(C.urllib.request, "urlopen", fake_urlopen)
     success, message = delete_comment("owner", "repo", "7", "token")
@@ -83,13 +77,7 @@ def test_delete_comment_removes_marker_comment(monkeypatch):
 def test_delete_comment_falls_back_to_legacy_title(monkeypatch):
     comments = [_comment("# Validation Report\nlegacy, no marker", cid=9)]
     monkeypatch.setattr(C, "_get", lambda *a, **k: comments)
-    deleted = []
-
-    def fake_urlopen(req):
-        deleted.append(req.full_url)
-        return _Resp()
-
-    monkeypatch.setattr(C.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(C.urllib.request, "urlopen", lambda _req: nullcontext())
     success, message = delete_comment("owner", "repo", "7", "token")
     assert success
     assert "deleted comment #9" in message

--- a/tools/report_lib/tests/markdown_test.py
+++ b/tools/report_lib/tests/markdown_test.py
@@ -50,8 +50,20 @@ def test_render_verdict_note_when_all_pass():
     body = render(runs, [], _ctx())
     assert "> [!NOTE]" in body
     assert "All 2 validators passed" in body
+    assert "Nothing to fix." in body
     # No table when everything is clean.
     assert "| Validator | Errors | Warnings |" not in body
+
+
+def test_render_qualifies_a_clean_partial_run():
+    # A per-PR run only gates the validators covering the changed groups, so a
+    # clean result must not read as "the whole mod is clean".
+    runs = [ValidatorRun(name="events", title="Events", status="passed")]
+    ctx = _ctx()
+    ctx.validation_scope = "partial"
+    body = render(runs, [], ctx)
+    assert "Nothing to fix in the file groups this diff touches." in body
+    assert "**Scope:** changed file groups only" in body
 
 
 def test_render_links_file_to_blob_when_repo_known():

--- a/tools/tests/precommit_validate_test.py
+++ b/tools/tests/precommit_validate_test.py
@@ -71,6 +71,10 @@ _GOLDEN = {
     },
     "localisation/english/MD_focus_SER_l_english.yml": {"validate_ideas"},
     "common/factions/x.txt": {"validate_style"},
+    "common/military_industrial_organization/organizations/MD_ISR_organizations.txt": {
+        "validate_style",
+        "validate_mios",
+    },
     "history/countries/x.txt": {
         "validate_style",
         "validate_ideas",

--- a/tools/tests/validation_report_scope_test.py
+++ b/tools/tests/validation_report_scope_test.py
@@ -1,0 +1,49 @@
+"""Scope gating for the validation report's PR-comment behaviour.
+
+Deleting the report comment claims the PR is clean, so only a full run may do
+it. A per-PR run gates each validator on the file groups the diff touches, and
+a validator that did not run this time can still have live findings from an
+earlier push.
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO_ROOT, "tools"))
+
+from generate_validation_report import should_delete_comment  # noqa: E402
+from report_lib import Issue, Severity, ValidatorRun  # noqa: E402
+
+
+def _passed():
+    return [ValidatorRun(name="events", title="Events", status="passed")]
+
+
+def test_full_clean_run_deletes():
+    assert should_delete_comment(_passed(), [], "full")
+
+
+def test_partial_clean_run_never_deletes():
+    assert not should_delete_comment(_passed(), [], "partial")
+
+
+def test_findings_keep_the_comment():
+    issue = Issue(
+        severity=Severity.WARNING,
+        category="missing-decision-log",
+        message="no log line",
+        file="common/decisions/x.txt",
+        line=12,
+        validator="decisions",
+    )
+    assert not should_delete_comment(_passed(), [issue], "full")
+
+
+def test_warning_only_validator_keeps_the_comment():
+    runs = [ValidatorRun(name="events", title="Events", status="warnings")]
+    assert not should_delete_comment(runs, [], "full")
+
+
+def test_no_validator_output_keeps_the_comment():
+    assert not should_delete_comment([], [], "full")

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -34,6 +34,7 @@ PRECOMMIT = REPO_ROOT / ".pre-commit-config.yaml"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "coding-pipeline.yml"
 TOOLS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tools-validation.yml"
 VALIDATOR_CACHE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validator-cache.yml"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly-pr-validation.yml"
 
 # Validators intentionally absent from the CI matrices. Each needs a reason.
 CI_EXEMPT = {
@@ -338,11 +339,34 @@ def test_validator_cache_restore_is_source_hash_scoped():
         )
 
 
+def test_nightly_keys_the_bundle_on_the_live_base_tip():
+    # WORKSPACE_KEY's base component is the only thing that invalidates the
+    # bundle when main advances under a PR that got no pushes. Cache keys are
+    # immutable, so a base that doesn't move makes cache/save a no-op and every
+    # validator restores the previous run's tree while the run reports green.
+    config = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    step = next(
+        step
+        for step in config["jobs"]["revalidate-open-prs"]["steps"]
+        if "gh workflow run" in step.get("run", "")
+    )
+    script = "\n".join(
+        line for line in step["run"].splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "commits/main" in script, (
+        "the nightly must resolve main's live head for base_sha"
+    )
+    assert ".base.sha" not in script, (
+        "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    )
+
+
 def test_tools_validation_triggers_for_consumed_configuration():
     paths = _pull_request_paths(TOOLS_WORKFLOW)
     assert {
         ".pre-commit-config.yaml",
         ".github/workflows/coding-pipeline.yml",
+        ".github/workflows/nightly-pr-validation.yml",
         ".github/workflows/validator-cache.yml",
     } <= paths
 
@@ -355,7 +379,10 @@ def test_tools_tests_checkout_consumed_workflows():
         if step.get("uses", "").startswith("actions/checkout@")
     )
     sparse_paths = set(checkout["with"]["sparse-checkout"].splitlines())
-    assert ".github/workflows/validator-cache.yml" in sparse_paths
+    assert {
+        ".github/workflows/validator-cache.yml",
+        ".github/workflows/nightly-pr-validation.yml",
+    } <= sparse_paths
 
 
 def test_manual_texture_audit_always_runs():

--- a/tools/validation/tests/validate_decisions_missing_log_test.py
+++ b/tools/validation/tests/validate_decisions_missing_log_test.py
@@ -1,0 +1,68 @@
+"""Tests for the decision log-in-complete_effect check."""
+
+import validate_decisions as V
+
+
+class _FakeValidator(V.Validator):
+    """Validator whose _report collects results instead of rendering."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.collected = []
+
+    def _report(self, results, ok_msg, fail_msg, severity=None, category=""):
+        self.collected.extend(results)
+
+
+def _results_for(factories, monkeypatch):
+    validator = _FakeValidator("/tmp")
+    monkeypatch.setattr(V, "parse_all_decision_factories", lambda mod_path: factories)
+    validator.validate_missing_log()
+    return validator.collected
+
+
+def test_logged_decision_not_flagged(monkeypatch):
+    factory = V.DecisionFactory(
+        "dec_one = {\n\tcomplete_effect = {\n"
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_one"\n'
+        "\t}\n}",
+        source_basename="X.txt",
+    )
+    assert _results_for([factory], monkeypatch) == []
+
+
+def test_effect_without_log_flagged(monkeypatch):
+    factory = V.DecisionFactory(
+        "dec_two = {\n\tcomplete_effect = {\n\t\tadd_political_power = 10\n\t}\n}",
+        source_basename="X.txt",
+    )
+    results = _results_for([factory], monkeypatch)
+    assert len(results) == 1
+    assert "dec_two" in results[0]
+    assert "no log" in results[0]
+
+
+def test_empty_complete_effect_skipped(monkeypatch):
+    factory = V.DecisionFactory("dec_three = {\n}", source_basename="X.txt")
+    assert _results_for([factory], monkeypatch) == []
+
+
+def test_log_requires_quote(monkeypatch):
+    # A bare `log = something` without quotes is not a log line.
+    factory = V.DecisionFactory(
+        "dec_four = {\n\tcomplete_effect = {\n\t\tlog = some_unquoted_thing\n\t}\n}",
+        source_basename="X.txt",
+    )
+    results = _results_for([factory], monkeypatch)
+    assert len(results) == 1
+
+
+def test_log_matches_inside_multiline_effect(monkeypatch):
+    factory = V.DecisionFactory(
+        "dec_five = {\n\tcomplete_effect = {\n"
+        "\t\tadd_political_power = 10\n"
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_five"\n'
+        "\t}\n}",
+        source_basename="X.txt",
+    )
+    assert _results_for([factory], monkeypatch) == []

--- a/tools/validation/tests/validate_mios_test.py
+++ b/tools/validation/tests/validate_mios_test.py
@@ -1,0 +1,107 @@
+"""Tests for `validate_mios.py` (MIO organization definitions)."""
+
+import validate_mios as V
+
+
+def _validator(tmp_path):
+    return V.Validator(str(tmp_path))
+
+
+def test_shared_org_ids_are_exempt(tmp_path):
+    v = _validator(tmp_path)
+    v._check_id("generic_tank_equipment_organization", "f.txt", 0)
+    v._check_id("GENERIC_marshall_tractor_works", "f.txt", 0)
+    assert not v._issues
+
+
+def test_non_tag_id_flagged(tmp_path):
+    v = _validator(tmp_path)
+    v._check_id("norinco_manufacturer", "f.txt", 3)
+    assert v._issues[0].category == "org-id-format"
+    assert v._issues[0].line == 4
+
+
+def test_allowed_tag_mismatch_flagged(tmp_path):
+    v = _validator(tmp_path)
+    body = "\tallowed = { original_tag = GER }\n"
+    v._check_allowed("FRA_naval_manufacturer", body, "f.txt", 0)
+    assert v._issues[0].category == "org-allowed-tag"
+    assert "original_tag = FRA" in v._issues[0].message
+
+
+def test_allowed_tag_match_passes(tmp_path):
+    v = _validator(tmp_path)
+    body = "\tallowed = { original_tag = ISR }\n"
+    v._check_allowed("ISR_rafael_materiel_manufacturer", body, "f.txt", 0)
+    assert not v._issues
+
+
+def test_initial_trait_naming(tmp_path):
+    v = _validator(tmp_path)
+    good = "initial_trait = {\n\tname = GER_Mercedes_trait\n}"
+    v._check_initial_trait("GER_mercedes_manufacturer", good, "f.txt", 0)
+    assert not v._issues
+    bad = "initial_trait = {\n\tname = tank_facility_foundry\n}"
+    v._check_initial_trait("NKO_second_economic_committee", bad, "f.txt", 0)
+    assert v._issues[0].category == "initial-trait-name"
+
+
+def test_generic_initial_trait_reference_is_exempt(tmp_path):
+    v = _validator(tmp_path)
+    body = (
+        "initial_trait = {\n\tname = generic_mio_initial_trait_infantry_manufacturer\n}"
+    )
+    v._check_initial_trait("ARG_fabricaciones_militares_manufacturer", body, "f.txt", 0)
+    assert not v._issues
+
+
+def test_position_x_bounds(tmp_path):
+    v = _validator(tmp_path)
+    v._check_positions("\tposition = { x = -1 y = 0 }\n", "f.txt", 0)
+    assert not v._issues
+    v._check_positions("\tposition = { x = 12 y = 3 }\n", "f.txt", 0)
+    assert v._issues[0].category == "trait-x-bounds"
+
+
+def test_empty_on_complete_flagged(tmp_path):
+    v = _validator(tmp_path)
+    v._check_on_complete("\ton_complete = {\n\t}\n", "f.txt", 0)
+    assert v._issues[0].category == "on-complete-empty"
+    v._check_on_complete(
+        "\ton_complete = { expenditure_for_mio_upgrade = yes }\n", "f.txt", 0
+    )
+    assert len(v._issues) == 1
+
+
+def test_full_run_on_fixture_dir(tmp_path):
+    org_dir = tmp_path / V.ORG_DIR
+    org_dir.mkdir(parents=True)
+    (org_dir / "MD_TEST_organizations.txt").write_text(
+        "TST_bad_org = {\n"
+        "\tallowed = { original_tag = GER }\n"
+        "\tinitial_trait = {\n"
+        "\t\tname = wrong_name\n"
+        "\t}\n"
+        "\tposition = { x = 12 y = 0 }\n"
+        "\ton_complete = {\n"
+        "\t}\n"
+        "}\n"
+        "\n"
+        "generic_shared = {\n"
+        "\tallowed = { always = no }\n"
+        "}\n"
+    )
+    v = _validator(tmp_path)
+    v.run_validations()
+    assert sorted(i.category for i in v._issues) == [
+        "initial-trait-name",
+        "on-complete-empty",
+        "org-allowed-tag",
+        "trait-x-bounds",
+    ]
+    by_cat = {i.category: i for i in v._issues}
+    assert "org-id-format" not in by_cat
+    assert by_cat["org-allowed-tag"].severity == "error"
+    assert by_cat["on-complete-empty"].severity == "error"
+    assert by_cat["trait-x-bounds"].severity == "warning"
+    assert by_cat["initial-trait-name"].severity == "warning"

--- a/tools/validation/tests/validate_style_focus_format_test.py
+++ b/tools/validation/tests/validate_style_focus_format_test.py
@@ -1,0 +1,17 @@
+"""Tests for `validate_style.py` focus ID format exemptions."""
+
+import validate_style as V
+
+
+def test_shared_focus_prefixes_are_exempt():
+    assert V._has_focus_format("USoE_focus_x")
+    assert V._has_focus_format("POTEF_focus_x")
+    assert V._has_focus_format("AFRICAN_UNION_focus_x")
+    assert V._has_focus_format("GENERIC_focus_x")
+    assert V._has_focus_format("EH_whole_new_dawn")
+
+
+def test_tag_focus_format_still_required():
+    assert V._has_focus_format("FIJ_focus_economic_relief_fund")
+    assert not V._has_focus_format("fiji_focus_economic_relief_fund")
+    assert not V._has_focus_format("dummy_focus")

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -1624,6 +1624,37 @@ class Validator(BaseValidator):
             category="missing-decision-localisation",
         )
 
+    def validate_missing_log(self):
+        """Flag decisions whose complete_effect has effects but no log line.
+
+        AGENTS.md / decision-reference.md require a log in complete_effect:
+        `log = "[GetDateText]: [Root.GetName]: Decision <ID>"`. Decisions with
+        an empty complete_effect have nothing to log and are skipped.
+        """
+        self._log_section(
+            "Checking decisions with effects but no log in complete_effect..."
+        )
+
+        factories = parse_all_decision_factories(self.mod_path)
+        results = []
+        for dec in factories:
+            if not dec.complete_effect:
+                continue
+            if re.search(r"\blog\s*=\s*\"", dec.complete_effect):
+                continue
+            results.append(
+                f"{dec.token} - {dec.source_basename}: complete_effect has "
+                "effects but no log line"
+            )
+
+        self._report(
+            results,
+            "✓ All decisions with effects log in complete_effect",
+            "Decisions with effects but no log in complete_effect:",
+            Severity.WARNING,
+            category="missing-decision-log",
+        )
+
     def validate_visible_in_missions(self):
         """Flag missions that have a visible block.
 
@@ -1966,6 +1997,7 @@ class Validator(BaseValidator):
         self.validate_visible_equals_available()
         self.validate_bare_trigger_names()
         self.validate_missing_localisation()
+        self.validate_missing_log()
         self.validate_visible_in_missions()
         self.validate_war_with_targeted()
         self.validate_missing_war_hint()

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -1635,9 +1635,8 @@ class Validator(BaseValidator):
             "Checking decisions with effects but no log in complete_effect..."
         )
 
-        factories = parse_all_decision_factories(self.mod_path)
         results = []
-        for dec in factories:
+        for dec in parse_all_decision_factories(self.mod_path):
             if not dec.complete_effect:
                 continue
             if re.search(r"\blog\s*=\s*\"", dec.complete_effect):

--- a/tools/validation/validate_mios.py
+++ b/tools/validation/validate_mios.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Validate Military-Industrial Organization definitions in Millennium Dawn.
+
+Rules from .claude/docs/mio-reference.md + AGENTS.md:
+  * org ids are TAG_organization_name (3-uppercase tag prefix); the shared
+    GENERIC_/generic_ orgs are exempt
+  * orgs pin their tag with allowed = { original_tag = TAG }
+  * initial traits are named TAG_<...>_trait (or reference a shared
+    generic_* trait from MD_generic_organization.txt)
+  * trait grid x never exceeds 9 (negative x is the standard organic-layout
+    first column; only the upper bound is a finding)
+  * on_complete blocks are never empty (they need expenditure_for_mio_upgrade
+    = yes or custom effects)
+"""
+
+import glob
+import os
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+from validator_common import BaseValidator, run_validator_main
+
+ORG_DIR = "common/military_industrial_organization/organizations"
+
+# Top-level org definition: `TAG_name = {` at column 0.
+ORG_DEF_RE = re.compile(r"^([A-Za-z0-9_]+)\s*=\s*\{", re.MULTILINE)
+TAG_PREFIX_RE = re.compile(r"^([A-Z]{3})_")
+SHARED_PREFIXES = ("GENERIC_", "generic_")
+
+ORIGINAL_TAG_RE = re.compile(r"\boriginal_tag\s*=\s*([A-Z][A-Z0-9_]{1,7})\b")
+INITIAL_TRAIT_NAME_RE = re.compile(
+    r"initial_trait\s*=\s*\{\s*name\s*=\s*([A-Za-z0-9_]+)"
+)
+POSITION_X_RE = re.compile(r"position\s*=\s*\{\s*x\s*=\s*(-?\d+)")
+ON_COMPLETE_RE = re.compile(r"on_complete\s*=\s*\{([^{}]*)\}")
+
+
+def _block_spans(text: str) -> List[Tuple[int, int, str]]:
+    """Yield (start, end, key) spans of every top-level `key = {` block."""
+    spans = []
+    for m in ORG_DEF_RE.finditer(text):
+        depth = 1
+        i = m.end()
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        spans.append((m.start(), i, m.group(1)))
+    return spans
+
+
+class Validator(BaseValidator):
+    TITLE = "MIOS"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _org_files(self) -> List[str]:
+        pattern = str(Path(self.mod_path) / ORG_DIR / "*.txt")
+        files = sorted(glob.iglob(pattern))
+        if not self.staged_only:
+            return files
+        staged = set(os.path.abspath(f) for f in (self.staged_files or []))
+        return [f for f in files if os.path.abspath(f) in staged]
+
+    def run_validations(self):
+        files = self._org_files()
+        if self.staged_only and not files:
+            self.log("No staged MIO files found — skipping MIO validation", "warning")
+            return
+
+        org_count = 0
+        for filepath in files:
+            try:
+                text = Path(filepath).read_text(encoding="utf-8")
+            except OSError:
+                continue
+            rel = Path(filepath).relative_to(self.mod_path).as_posix()
+            for start, end, org_id in _block_spans(text):
+                org_count += 1
+                body = text[start:end]
+                body_offset = text.count("\n", 0, start)
+                self._check_id(org_id, rel, body_offset)
+                self._check_allowed(org_id, body, rel, body_offset)
+                self._check_initial_trait(org_id, body, rel, body_offset)
+                self._check_positions(body, rel, body_offset)
+                self._check_on_complete(body, rel, body_offset)
+
+        self.log(f"  Scanned {len(files)} files | {org_count} organizations")
+
+    @staticmethod
+    def _is_shared(org_id: str) -> bool:
+        return any(org_id.startswith(p) for p in SHARED_PREFIXES)
+
+    def _check_id(self, org_id: str, rel: str, body_offset: int):
+        if self._is_shared(org_id):
+            return
+        if not TAG_PREFIX_RE.match(org_id):
+            self.add_error(
+                "org-id-format",
+                f"MIO ID {org_id} must be TAG_organization_name",
+                rel,
+                body_offset + 1,
+            )
+
+    def _check_allowed(self, org_id: str, body: str, rel: str, body_offset: int):
+        if self._is_shared(org_id):
+            return
+        m = TAG_PREFIX_RE.match(org_id)
+        if not m:
+            return
+        tag = m.group(1)
+        if not any(m2.group(1) == tag for m2 in ORIGINAL_TAG_RE.finditer(body)):
+            self.add_error(
+                "org-allowed-tag",
+                f"MIO {org_id} must pin its tag with "
+                f"allowed = {{ original_tag = {tag} }}",
+                rel,
+                body_offset + 1,
+            )
+
+    def _check_initial_trait(self, org_id: str, body: str, rel: str, body_offset: int):
+        m = INITIAL_TRAIT_NAME_RE.search(body)
+        if not m:
+            return
+        name = m.group(1)
+        line = body_offset + body.count("\n", 0, m.start()) + 1
+        if name.startswith("generic_"):
+            return
+        prefix = org_id.split("_", 1)[0]
+        if not name.startswith(prefix + "_") or not name.endswith("_trait"):
+            self.add_warning(
+                "initial-trait-name",
+                f"initial_trait name '{name}' must be {prefix}_<name>_trait "
+                f"(e.g. {prefix}_norinco_trait)",
+                rel,
+                line,
+            )
+
+    def _check_positions(self, body: str, rel: str, body_offset: int):
+        for m in POSITION_X_RE.finditer(body):
+            x = int(m.group(1))
+            if x > 9:
+                line = body_offset + body.count("\n", 0, m.start()) + 1
+                self.add_warning(
+                    "trait-x-bounds",
+                    f"trait position x = {x} must stay inside 0..9",
+                    rel,
+                    line,
+                )
+
+    def _check_on_complete(self, body: str, rel: str, body_offset: int):
+        for m in ON_COMPLETE_RE.finditer(body):
+            if m.group(1).strip():
+                continue
+            line = body_offset + body.count("\n", 0, m.start()) + 1
+            self.add_error(
+                "on-complete-empty",
+                "on_complete is empty; add expenditure_for_mio_upgrade = yes "
+                "or custom effects",
+                rel,
+                line,
+            )
+
+
+if __name__ == "__main__":
+    run_validator_main(Validator, "Validate MIO organization definitions")

--- a/tools/validation/validate_mios.py
+++ b/tools/validation/validate_mios.py
@@ -55,12 +55,9 @@ def _block_spans(text: str) -> List[Tuple[int, int, str]]:
 class Validator(BaseValidator):
     TITLE = "MIOS"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _org_files(self) -> List[str]:
         pattern = str(Path(self.mod_path) / ORG_DIR / "*.txt")
-        files = sorted(glob.iglob(pattern))
+        files = sorted(glob.glob(pattern))
         if not self.staged_only:
             return files
         staged = set(os.path.abspath(f) for f in (self.staged_files or []))
@@ -93,7 +90,7 @@ class Validator(BaseValidator):
 
     @staticmethod
     def _is_shared(org_id: str) -> bool:
-        return any(org_id.startswith(p) for p in SHARED_PREFIXES)
+        return org_id.startswith(SHARED_PREFIXES)
 
     def _check_id(self, org_id: str, rel: str, body_offset: int):
         if self._is_shared(org_id):
@@ -142,9 +139,18 @@ class Validator(BaseValidator):
 
     def _check_positions(self, body: str, rel: str, body_offset: int):
         for m in POSITION_X_RE.finditer(body):
-            x = int(m.group(1))
+            line = body_offset + body.count("\n", 0, m.start()) + 1
+            try:
+                x = int(m.group(1))
+            except ValueError:
+                self.add_error(
+                    "trait-x-invalid",
+                    "trait position x must be an integer",
+                    rel,
+                    line,
+                )
+                continue
             if x > 9:
-                line = body_offset + body.count("\n", 0, m.start()) + 1
                 self.add_warning(
                     "trait-x-bounds",
                     f"trait position x = {x} must stay inside 0..9",

--- a/tools/validation/validate_mios.py
+++ b/tools/validation/validate_mios.py
@@ -139,23 +139,13 @@ class Validator(BaseValidator):
 
     def _check_positions(self, body: str, rel: str, body_offset: int):
         for m in POSITION_X_RE.finditer(body):
-            line = body_offset + body.count("\n", 0, m.start()) + 1
-            try:
-                x = int(m.group(1))
-            except ValueError:
-                self.add_error(
-                    "trait-x-invalid",
-                    "trait position x must be an integer",
-                    rel,
-                    line,
-                )
-                continue
+            x = int(m.group(1))
             if x > 9:
                 self.add_warning(
                     "trait-x-bounds",
                     f"trait position x = {x} must stay inside 0..9",
                     rel,
-                    line,
+                    body_offset + body.count("\n", 0, m.start()) + 1,
                 )
 
     def _check_on_complete(self, body: str, rel: str, body_offset: int):

--- a/tools/validation/validate_style.py
+++ b/tools/validation/validate_style.py
@@ -39,7 +39,13 @@ _RE_FOCUS_FORMAT = re.compile(r"^[A-Z]{3}_[a-zA-Z0-9_-]+$", re.M | re.U)
 _RE_NEWS_EVENT = re.compile(r"news_event\s*=\s*\{")
 _RE_OPTION = re.compile(r"\boption\s*=\s*\{")
 
-_SHARED_FOCUS_PREFIXES = ("USoE", "POTEF", "AFRICAN_UNION", "GENERIC")
+_SHARED_FOCUS_PREFIXES = (
+    "USoE",
+    "POTEF",
+    "AFRICAN_UNION",
+    "GENERIC",
+    "EH",
+)  # EH: Event Horizon generic tree
 
 
 def _check_brace_matching(text: str, path: str):

--- a/tools/validation/validate_style.py
+++ b/tools/validation/validate_style.py
@@ -264,10 +264,9 @@ def _check_focus_standards(text: str, path: str):
 
 
 def _has_focus_format(focus_id: str) -> bool:
-    for prefix in _SHARED_FOCUS_PREFIXES:
-        if focus_id.startswith(prefix):
-            return True
-    return bool(_RE_FOCUS_FORMAT.match(focus_id))
+    return focus_id.startswith(_SHARED_FOCUS_PREFIXES) or bool(
+        _RE_FOCUS_FORMAT.match(focus_id)
+    )
 
 
 def _check_event_log_standards(text: str, path: str):

--- a/tools/validation/validate_style.py
+++ b/tools/validation/validate_style.py
@@ -39,13 +39,8 @@ _RE_FOCUS_FORMAT = re.compile(r"^[A-Z]{3}_[a-zA-Z0-9_-]+$", re.M | re.U)
 _RE_NEWS_EVENT = re.compile(r"news_event\s*=\s*\{")
 _RE_OPTION = re.compile(r"\boption\s*=\s*\{")
 
-_SHARED_FOCUS_PREFIXES = (
-    "USoE",
-    "POTEF",
-    "AFRICAN_UNION",
-    "GENERIC",
-    "EH",
-)  # EH: Event Horizon generic tree
+# EH is the Event Horizon generic tree's mod-wide domain prefix, not a tag.
+_SHARED_FOCUS_PREFIXES = ("USoE", "POTEF", "AFRICAN_UNION", "GENERIC", "EH")
 
 
 def _check_brace_matching(text: str, path: str):


### PR DESCRIPTION
Covers #2702, #2703, #2704, and the EH exemption part of #2705.

## #2703 — pipeline runs on every push + periodically for open PRs
- `coding-pipeline.yml` gains `workflow_dispatch` (`pr_number`/`base_sha` inputs). PR context is rebuilt via `inputs.X || github.event.pull_request.X` (workspace cache key, manifest, report) so a dispatched run behaves like a PR run.
- `detect-changes` skips `dorny/paths-filter` on dispatch and treats every group as changed; `style` is skipped (diff-scoped, no diff exists on dispatch).
- New `nightly-pr-validation.yml` (cron 06:00 UTC + manual dispatch): lists open PRs targeting main and dispatches the pipeline per PR on its head branch. Fork PRs are skipped (dispatch refs must live in this repo) — they still validate on every push.
- Push and dispatched runs of the same PR share a concurrency group, so the nightly pass cancels an in-flight run instead of doubling it.

## #2702 — no empty report comments
- `delete_comment()` added to `report_lib/comment.py`.
- `generate_validation_report.py` no longer posts a comment when a run has zero findings; it deletes the previous run's stale comment instead. Checks API + artifact upload unchanged.

## #2704 — new validators
- New `validate_mios.py`, wired into the pre-commit dispatcher registry, the `validate-targeted` CI matrix, a new `mios` detect-changes group, the golden coverage test, and 7 unit tests.
  - ERROR (gating): org-id format `TAG_organization_name`, `allowed = { original_tag = TAG }` pin, empty `on_complete`.
  - WARNING (report-only, backlog ~30): initial-trait naming, trait-grid x > 9.
  - `generic_`/`GENERIC_` shared orgs exempt; negative x exempt (the mod's standard organic-layout first column).
- `validate_decisions.py`: new `missing-decision-log` WARNING check (complete_effect with effects but no `log =` line). 648-hit backlog, report-only until cleared.

## #2705 (partial) — EH exemption only
- `EH_` added to `_SHARED_FOCUS_PREFIXES` (`validate_style.py`): the Event Horizon tree is generic (`event_horizon_generic_focus`) and `EH_` is its mod-wide domain prefix. 49 warnings cleared; the remaining 348-warning content backlog is intentionally untouched.

## Verification
- Full pytest suite green (723 tests, incl. config-drift guard and golden coverage test).
- Scoped `pre-commit run` passes on all changed files.
- Local runs: `validate_style` 397→348, `validate_mios` 30 warnings/0 errors, `validate_decisions` +648 report-only warnings.

## Assumptions
- Nightly cron at 06:00 UTC.
- Dispatched runs validate the head branch, not the merge ref — a branch stale vs main can surface findings a merge-ref run would not.