### PR TITLE
Add missing decision logs and normalize their placement

### DIFF
--- a/.claude/docs/decision-reference.md
+++ b/.claude/docs/decision-reference.md
@@ -112,6 +112,18 @@ Regular `war_with_on_*` does not work with FROM. Use these instead:
 - `war_with_target_on_remove = yes`
 - `war_with_target_on_timeout = yes`
 
+## Effect Block Logging
+
+The engine runs four blocks as a decision's effects: `complete_effect` (player takes it), `remove_effect` (`days_remove` timer expires or `remove_trigger` fires), `timeout_effect` (mission `days_mission_timeout` expires) and `cancel_effect` (`cancel_trigger` fires). Each one logs its own line, as the block's first statement:
+
+```
+	log = "[GetDateText]: [Root.GetName]: Decision DECISION_ID"
+```
+
+Log first so the game log reads in firing order, and use the decision's own ID: a copied ID from a neighbouring decision is the most common mistake here (`tools/linting/fix_log_ids.py` rewrites those). A log nested inside an `if` / `else` / `hidden_effect` records which branch ran, so it belongs where it sits and does not substitute for the block's own log line.
+
+`validate_decisions.py` reports a block with no log as `missing-decision-log` and a block-level log that is not first as `decision-log-not-first`. A log that is the _only_ content of a `complete_effect` is a separate mistake: `check_common_mistakes.py` rejects it, because the block does nothing but log. Delete the dead block instead.
+
 ## Example: Basic Decision
 
 ```
@@ -161,6 +173,7 @@ ISR_pal_rooting_terrorists = {
 	cancel_if_not_visible = yes
 
 	timeout_effect = {
+		log = "[GetDateText]: [Root.GetName]: Decision ISR_pal_rooting_terrorists"
 		custom_effect_tooltip = ISR_operation_result_outcome_tt
 		custom_effect_tooltip = ISR_operation_failed_root_terr_tt
 		hidden_effect = {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Pre-commit and CI run **different hook sets** — passing locally does not guara
 
 ## Decisions
 
-- Logging in `complete_effect`: `log = "[GetDateText]: [Root.GetName]: Decision DECISION_ID"`
+- Logging: `log = "[GetDateText]: [Root.GetName]: Decision DECISION_ID"` as the first statement of every effect block the engine runs (`complete_effect`, `remove_effect`, `timeout_effect`, `cancel_effect`). A log nested inside an `if`/`hidden_effect` records which branch ran and stays there
 - `ai_will_do = { base = N }` — `base` not `factor` at root
 - Don't put `allowed` on a decision when it just repeats the parent category's `allowed` (e.g. `original_tag = TAG`) — the category gate already covers every decision inside it. Put nation-restriction on the category; dynamic conditions go in `available`/`visible` (`allowed` is evaluated once at game start)
 - Ref: `.claude/docs/decision-reference.md`

--- a/common/decisions/00_antarctica_decisions.txt
+++ b/common/decisions/00_antarctica_decisions.txt
@@ -7,6 +7,7 @@ antarctica_post_treaty_activity_category = {
 		fixed_random_seed = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision antarctica_post_treaty_resource_extraction"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_stability = -0.02
@@ -43,7 +44,6 @@ antarctica_post_treaty_activity_category = {
 					modifier = antarctica_modifier_small_consequences
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision antarctica_post_treaty_resource_extraction"
 		}
 
 		ai_will_do = {
@@ -58,6 +58,7 @@ antarctica_post_treaty_activity_category = {
 		days_remove = 120
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision antarctica_post_treaty_military_preparations"
 			army_experience = 10
 			add_war_support = 0.03
 			add_stability = -0.02
@@ -73,7 +74,6 @@ antarctica_post_treaty_activity_category = {
 					modifier = antarctica_modifier_medium_consequences
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision antarctica_post_treaty_military_preparations"
 		}
 
 		ai_will_do = {

--- a/common/decisions/00_missile_decisions.txt
+++ b/common/decisions/00_missile_decisions.txt
@@ -10,6 +10,7 @@ missile_decisions = {
 		selectable_mission = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision missile_construction_10"
 			add_to_variable = { missile_inventory_array^var_space_production_OLV = var_gui_prod_10_amount }
 			set_variable = { var_space_production_OLV = 0 }
 			space_prod_settle_10 = yes
@@ -26,6 +27,7 @@ missile_decisions = {
 		selectable_mission = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision missile_construction_11"
 			add_to_variable = { missile_inventory_array^var_space_production_GNSS = var_gui_prod_11_amount }
 			set_variable = { var_space_production_GNSS = 0 }
 			space_prod_settle_11 = yes
@@ -42,6 +44,7 @@ missile_decisions = {
 		selectable_mission = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision missile_construction_12"
 			add_to_variable = { missile_inventory_array^var_space_production_COMSAT = var_gui_prod_12_amount }
 			set_variable = { var_space_production_COMSAT = 0 }
 			space_prod_settle_12 = yes
@@ -58,6 +61,7 @@ missile_decisions = {
 		selectable_mission = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision missile_construction_13"
 			add_to_variable = { missile_inventory_array^var_space_production_SPYSAT = var_gui_prod_13_amount }
 			set_variable = { var_space_production_SPYSAT = 0 }
 			space_prod_settle_13 = yes
@@ -74,6 +78,7 @@ missile_decisions = {
 		selectable_mission = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision missile_construction_14"
 			add_to_variable = { missile_inventory_array^var_space_production_KILLSAT = var_gui_prod_14_amount }
 			set_variable = { var_space_production_KILLSAT = 0 }
 			space_prod_settle_14 = yes

--- a/common/decisions/00_political_decisions.txt
+++ b/common/decisions/00_political_decisions.txt
@@ -594,6 +594,7 @@ generic_coalition_politics_decisions = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision promote_reduced_spending_campaigns"
 			ingame_update_setup = yes
 		}
 		modifier = {
@@ -1754,6 +1755,7 @@ generic_coalition_politics_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_russia_demands_peace_russia"
 			JAP = {
 				country_event = {
 					id = JAP_diplomacy.80
@@ -1799,6 +1801,7 @@ generic_coalition_politics_decisions = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_tookover_sikhalin_mission"
 			JAP = {
 				white_peace = {
 					tag = SOV

--- a/common/decisions/00_political_decisions.txt
+++ b/common/decisions/00_political_decisions.txt
@@ -1795,6 +1795,7 @@ generic_coalition_politics_decisions = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_tookover_sikhalin_mission"
 			JAP = {
 				country_event = { id = JAP_diplomacy.200 days = 1 }
 			}

--- a/common/decisions/00_research_slot_decisions.txt
+++ b/common/decisions/00_research_slot_decisions.txt
@@ -15,6 +15,7 @@ research_slots_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision gdp_gain_slot"
 			add_research_slot = 1
 			add_to_variable = { research_slots_from_gdp = 1 }
 			add_to_variable = { next_slot_from_gdp = 1 }
@@ -41,6 +42,7 @@ research_slots_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision gdp_c_gain_slot"
 			add_research_slot = 1
 			add_to_variable = { research_slots_from_gdp_c = 1 }
 			add_to_variable = { next_slot_from_gdp_c = 1 }
@@ -72,6 +74,7 @@ research_slots_decisions = {
 		days_mission_timeout = 90
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision gdp_lose_slot"
 			add_research_slot = -1
 			add_to_variable = { research_slots_from_gdp = -1 }
 			add_to_variable = { next_slot_from_gdp = -1 }
@@ -99,6 +102,7 @@ research_slots_decisions = {
 		days_mission_timeout = 90
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision gdp_c_lose_slot"
 			add_research_slot = -1
 			add_to_variable = { research_slots_from_gdp_c = -1 }
 			add_to_variable = { next_slot_from_gdp_c = -1 }

--- a/common/decisions/01_pmc_decisions.txt
+++ b/common/decisions/01_pmc_decisions.txt
@@ -25,10 +25,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_light_infantry"
 			clr_country_flag = inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_light_infantry"
 			custom_effect_tooltip = pmc_unit_0_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^0 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -110,10 +112,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_mot_infantry"
 			clr_country_flag = mot_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_mot_infantry"
 			custom_effect_tooltip = pmc_unit_1_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^1 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -194,10 +198,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_mech_infantry"
 			clr_country_flag = mech_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_mech_infantry"
 			custom_effect_tooltip = pmc_unit_2_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^2 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -276,10 +282,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_heavy_mech_infantry"
 			clr_country_flag = hvy_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_heavy_mech_infantry"
 			custom_effect_tooltip = pmc_unit_3_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^3 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -358,10 +366,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_special_infantry"
 			clr_country_flag = spec_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_special_infantry"
 			custom_effect_tooltip = pmc_unit_4_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^4 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -449,10 +459,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_tank"
 			clr_country_flag = tank_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_tank"
 			custom_effect_tooltip = pmc_unit_5_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^5 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -535,10 +547,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_specops"
 			clr_country_flag = sf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_blackwater_specops"
 			custom_effect_tooltip = pmc_unit_6_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^6 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -625,10 +639,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_light_infantry"
 			clr_country_flag = inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_light_infantry"
 			custom_effect_tooltip = pmc_unit_0_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^0 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -723,10 +739,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_mot_infantry"
 			clr_country_flag = mot_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_mot_infantry"
 			custom_effect_tooltip = pmc_unit_1_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^1 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -822,10 +840,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_mech_infantry"
 			clr_country_flag = mech_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_mech_infantry"
 			custom_effect_tooltip = pmc_unit_2_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^2 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -918,10 +938,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_heavy_mech_infantry"
 			clr_country_flag = hvy_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_heavy_mech_infantry"
 			custom_effect_tooltip = pmc_unit_3_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^3 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1014,10 +1036,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_special_infantry"
 			clr_country_flag = spec_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_special_infantry"
 			custom_effect_tooltip = pmc_unit_4_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^4 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1119,10 +1143,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_tank"
 			clr_country_flag = tank_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_tank"
 			custom_effect_tooltip = pmc_unit_5_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^5 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1219,10 +1245,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_specops"
 			clr_country_flag = sf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_wagner_specops"
 			custom_effect_tooltip = pmc_unit_6_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^6 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1323,10 +1351,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_light_infantry"
 			clr_country_flag = inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_light_infantry"
 			custom_effect_tooltip = pmc_unit_0_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^0 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1407,10 +1437,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_mot_infantry"
 			clr_country_flag = mot_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_mot_infantry"
 			custom_effect_tooltip = pmc_unit_1_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^1 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1492,10 +1524,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_mech_infantry"
 			clr_country_flag = mech_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_mech_infantry"
 			custom_effect_tooltip = pmc_unit_2_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^2 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1574,10 +1608,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_heavy_mech_infantry"
 			clr_country_flag = hvy_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_heavy_mech_infantry"
 			custom_effect_tooltip = pmc_unit_3_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^3 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1656,10 +1692,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_special_infantry"
 			clr_country_flag = spec_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_special_infantry"
 			custom_effect_tooltip = pmc_unit_4_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^4 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1747,10 +1785,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_tank"
 			clr_country_flag = tank_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_tank"
 			custom_effect_tooltip = pmc_unit_5_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^5 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1833,10 +1873,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_specops"
 			clr_country_flag = sf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_aegis_specops"
 			custom_effect_tooltip = pmc_unit_6_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^6 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1924,10 +1966,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_light_infantry"
 			clr_country_flag = inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_light_infantry"
 			custom_effect_tooltip = pmc_unit_0_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^0 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -1995,10 +2039,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_mot_infantry"
 			clr_country_flag = mot_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_mot_infantry"
 			custom_effect_tooltip = pmc_unit_1_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^1 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2067,10 +2113,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_mech_infantry"
 			clr_country_flag = mech_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_mech_infantry"
 			custom_effect_tooltip = pmc_unit_2_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^2 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2136,10 +2184,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_heavy_mech_infantry"
 			clr_country_flag = hvy_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_heavy_mech_infantry"
 			custom_effect_tooltip = pmc_unit_3_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^3 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2205,10 +2255,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_special_infantry"
 			clr_country_flag = spec_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_special_infantry"
 			custom_effect_tooltip = pmc_unit_4_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^4 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2283,10 +2335,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_tank"
 			clr_country_flag = tank_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_tank"
 			custom_effect_tooltip = pmc_unit_5_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^5 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2356,10 +2410,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_specops"
 			clr_country_flag = sf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_constellis_specops"
 			custom_effect_tooltip = pmc_unit_6_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^6 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2433,10 +2489,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_light_infantry"
 			clr_country_flag = inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_light_infantry"
 			custom_effect_tooltip = pmc_unit_0_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^0 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2504,10 +2562,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_mot_infantry"
 			clr_country_flag = mot_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_mot_infantry"
 			custom_effect_tooltip = pmc_unit_1_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^1 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2576,10 +2636,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_mech_infantry"
 			clr_country_flag = mech_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_mech_infantry"
 			custom_effect_tooltip = pmc_unit_2_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^2 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2645,10 +2707,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_heavy_mech_infantry"
 			clr_country_flag = hvy_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_heavy_mech_infantry"
 			custom_effect_tooltip = pmc_unit_3_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^3 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2714,10 +2778,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_special_infantry"
 			clr_country_flag = spec_inf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_special_infantry"
 			custom_effect_tooltip = pmc_unit_4_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^4 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2792,10 +2858,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_tank"
 			clr_country_flag = tank_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_tank"
 			custom_effect_tooltip = pmc_unit_5_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^5 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2865,10 +2933,12 @@ pmc_category = {
 		selectable_mission = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_specops"
 			clr_country_flag = sf_hire
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision get_md_specops"
 			custom_effect_tooltip = pmc_unit_6_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^6 }
 			multiply_temp_variable = { treasury_change = -1 }
@@ -2944,6 +3014,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_asgard"
 			if = {
 				limit = {
 					OR = {
@@ -2961,6 +3032,7 @@ pmc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_asgard"
 			GER = { clr_country_flag = asgrad_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -2975,6 +3047,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_mpri"
 			if = {
 				limit = {
 					OR = {
@@ -2992,6 +3065,7 @@ pmc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_mpri"
 			USA = { clr_country_flag = mpri_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3009,6 +3083,7 @@ pmc_category = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_itt"
 			delete_unit_template_and_units = {
 				division_template = "Mercenary SpecOps G4S Unit"
 				disband = no
@@ -3016,6 +3091,7 @@ pmc_category = {
 			GER = { clr_country_flag = itt_yes }
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_itt"
 			delete_unit_template_and_units = {
 				division_template = "Mercenary SpecOps G4S Unit"
 				disband = no
@@ -3034,6 +3110,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sadat"
 			if = {
 				limit = {
 					OR = {
@@ -3051,6 +3128,7 @@ pmc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sadat"
 			TUR = { clr_country_flag = sadat_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3065,6 +3143,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_rsb"
 			if = {
 				limit = {
 					OR = {
@@ -3081,6 +3160,7 @@ pmc_category = {
 			SOV = { clr_country_flag = rsb_yes }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_rsb"
 			SOV = { clr_country_flag = rsb_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3095,6 +3175,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sadline"
 			delete_unit_template_and_units = {
 				division_template = "Mercenary SpecOps SandLine Unit"
 				disband = no
@@ -3102,6 +3183,7 @@ pmc_category = {
 			ENG = { clr_country_flag = sadline_yes }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sadline"
 			delete_unit_template_and_units = {
 				division_template = "Mercenary SpecOps SandLine Unit"
 				disband = no
@@ -3120,6 +3202,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_kbr"
 			if = {
 				limit = {
 					OR = {
@@ -3137,6 +3220,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_kbr"
 			USA = { clr_country_flag = kbr_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3151,6 +3235,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_nirtal"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_type
 				amount = 1500
@@ -3172,6 +3257,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_nirtal"
 			ISR = { clr_country_flag = nirtal_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3186,6 +3272,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_halo"
 			if = {
 				limit = {
 					OR = {
@@ -3202,6 +3289,7 @@ pmc_category = {
 			USA = { clr_country_flag = halo_yes }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_halo"
 			USA = { clr_country_flag = halo_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3429,6 +3517,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_front"
 			if = {
 				limit = {
 					OR = {
@@ -3445,6 +3534,7 @@ pmc_category = {
 			CHI = { clr_country_flag = front_yes }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_front"
 			CHI = { clr_country_flag = front_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3459,6 +3549,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_redut"
 			delete_unit_template_and_units = {
 				division_template = "Redut PMC Battalion"
 				disband = no
@@ -3467,6 +3558,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_redut"
 			delete_unit_template_and_units = {
 				division_template = "Redut PMC Battalion"
 				disband = no
@@ -3485,6 +3577,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_gazprom"
 			if = {
 				limit = {
 					OR = {
@@ -3506,6 +3599,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_gazprom"
 			delete_unit_template_and_units = {
 				division_template = "Gazprom PMC Battalion"
 				disband = no
@@ -3524,6 +3618,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_iron"
 			delete_unit_template_and_units = {
 				division_template = "Iron Navy PMC Battalion"
 				disband = no
@@ -3532,6 +3627,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_iron"
 			delete_unit_template_and_units = {
 				division_template = "Iron Navy PMC Battalion"
 				disband = no
@@ -3550,6 +3646,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_eu"
 			if = {
 				limit = {
 					OR = {
@@ -3567,6 +3664,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_eu"
 			POL = { clr_country_flag = eu_yes }
 		}
 		ai_will_do = { base = 1 }
@@ -3581,6 +3679,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sheriff"
 			delete_unit_template_and_units = {
 				division_template = "Sheriff PMC Battalion"
 				disband = no
@@ -3589,6 +3688,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sheriff"
 			delete_unit_template_and_units = {
 				division_template = "Sheriff PMC Battalion"
 				disband = no
@@ -3607,6 +3707,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_lukoil"
 			if = {
 				limit = {
 					OR = {
@@ -3628,6 +3729,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_lukoil"
 			delete_unit_template_and_units = {
 				division_template = "Lukoil PMC Battalion"
 				disband = no
@@ -3646,6 +3748,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_rosneft"
 			if = {
 				limit = {
 					OR = {
@@ -3667,6 +3770,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_rosneft"
 			delete_unit_template_and_units = {
 				division_template = "Rosneft PMC Battalion"
 				disband = no
@@ -3685,6 +3789,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sberbank"
 			if = {
 				limit = {
 					OR = {
@@ -3706,6 +3811,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sberbank"
 			delete_unit_template_and_units = {
 				division_template = "Sber PMC Battalion"
 				disband = no
@@ -3724,6 +3830,7 @@ pmc_category = {
 		days_mission_timeout = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_vtb"
 			if = {
 				limit = {
 					OR = {
@@ -3745,6 +3852,7 @@ pmc_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_vtb"
 			delete_unit_template_and_units = {
 				division_template = "Sber PMC Battalion"
 				disband = no
@@ -3770,10 +3878,12 @@ pmc_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sinai_create"
 			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_sinai_create"
 			EGY = { set_country_flag = sinai_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3789,6 +3899,7 @@ pmc_category = {
 		days_remove = 365
 		days_re_enable = 10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_gard_create"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
@@ -3798,6 +3909,7 @@ pmc_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_gard_create"
 			BLR = { set_country_flag = gard_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3813,6 +3925,7 @@ pmc_category = {
 		days_remove = 365
 		days_re_enable = 10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_patriot_create"
 			set_temp_variable = { treasury_change = -30 }
 			modify_treasury_effect = yes
 		}
@@ -3822,6 +3935,7 @@ pmc_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_patriot_create"
 			SOV = { set_country_flag = patriot_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3837,6 +3951,7 @@ pmc_category = {
 		days_remove = 365
 		days_re_enable = 10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_dewe_create"
 			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 		}
@@ -3846,6 +3961,7 @@ pmc_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_dewe_create"
 			CHI = { set_country_flag = dewe_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3861,6 +3977,7 @@ pmc_category = {
 		days_remove = 365
 		days_re_enable = 10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_over_create"
 			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 		}
@@ -3870,6 +3987,7 @@ pmc_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_over_create"
 			CHI = { set_country_flag = over_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3885,6 +4003,7 @@ pmc_category = {
 		days_remove = 365
 		days_re_enable = 10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_front_create"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
@@ -3894,6 +4013,7 @@ pmc_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_front_create"
 			CHI = { set_country_flag = front_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3909,6 +4029,7 @@ pmc_category = {
 		days_remove = 365
 		days_re_enable = 10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_iron_create"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 		}
@@ -3918,6 +4039,7 @@ pmc_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pmc_iron_create"
 			EST = { set_country_flag = iron_create }
 			custom_effect_tooltip = pmc_create_pmc_tt
 		}
@@ -3953,6 +4075,7 @@ pmc_global_management = {
 		days_re_enable = 200
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision expand_operations"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 			add_to_variable = { global.merc_capacity^ROOT.pmc_index = 2 }
@@ -3971,6 +4094,7 @@ pmc_global_management = {
 		days_re_enable = 100
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision expand_quality"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_to_variable = { global.merc_upgrade^ROOT.pmc_index = 1 }
@@ -3989,6 +4113,7 @@ pmc_global_management = {
 		days_re_enable = 10
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ban_from_operating"
 			set_country_flag = banned_pmc_operations
 		}
 		ai_will_do = { base = 1 }
@@ -4005,6 +4130,7 @@ pmc_global_management = {
 		days_re_enable = 10
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision lift_ban_from_operating"
 			clr_country_flag = banned_pmc_operations
 		}
 		ai_will_do = { base = 1 }
@@ -4023,6 +4149,7 @@ pmc_global_management = {
 
 		# notify countries that we are pulling them out
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision call_pmc_back_sov"
 			every_other_country = {
 				if = {
 					limit = {
@@ -4043,6 +4170,7 @@ pmc_global_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision call_pmc_back_sov"
 			set_temp_variable = { compensation = 0 }
 			every_other_country = {
 				if = {
@@ -4123,6 +4251,7 @@ pmc_local_management = {
 		days_remove = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision form_local_pmc"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			set_variable = { ROOT.merc_capacity = 3 }
@@ -4131,6 +4260,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision form_local_pmc"
 			custom_effect_tooltip = pmc_founded_TT
 			set_country_flag = founded_pmc
 		}
@@ -4148,6 +4278,7 @@ pmc_local_management = {
 		days_re_enable = 200
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision expand_operations_local"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 			add_to_variable = { ROOT.merc_capacity = 2 }
@@ -4166,6 +4297,7 @@ pmc_local_management = {
 		days_re_enable = 100
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision expand_quality_local"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_to_variable = { ROOT.merc_upgrade = 1 }
@@ -4193,6 +4325,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_light_unit"
 			custom_effect_tooltip = pmc_unit_0_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^0 }
 			# with discount for overlord
@@ -4249,6 +4382,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_light_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_light_infantry_local = yes
@@ -4269,6 +4403,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_light_infantry"
 			delete_light_infantry_local = yes
 		}
 		ai_will_do = { base = 1 }
@@ -4295,6 +4430,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_motorised_unit"
 			custom_effect_tooltip = pmc_unit_1_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^1 }
 			# with discount for overlord
@@ -4351,6 +4487,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_motorised_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_mot_infantry_local = yes
@@ -4371,6 +4508,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_motorised_unit"
 			delete_mot_infantry_local = yes
 		}
 		ai_will_do = { base = 1 }
@@ -4397,6 +4535,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_mechanized_unit"
 			custom_effect_tooltip = pmc_unit_2_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^2 }
 			# with discount for overlord
@@ -4450,6 +4589,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_mechanized_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_mech_infantry_local = yes
@@ -4470,6 +4610,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_mechanized_unit"
 			delete_mech_infantry_local = yes
 		}
 		ai_will_do = { base = 1 }
@@ -4496,6 +4637,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_heavy_mechanized_unit"
 			custom_effect_tooltip = pmc_unit_3_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^3 }
 			# with discount for overlord
@@ -4549,6 +4691,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_heavy_mechanized_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_heavy_mech_infantry_local = yes
@@ -4569,6 +4712,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_heavy_mechanized_unit"
 			delete_heavy_mech_infantry_local = yes
 		}
 		ai_will_do = { base = 1 }
@@ -4595,6 +4739,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_special_unit"
 			custom_effect_tooltip = pmc_unit_4_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^4 }
 			# with discount for overlord
@@ -4657,6 +4802,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_special_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_special_unit_local = yes
@@ -4677,6 +4823,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_special_unit"
 			delete_special_unit_local = yes
 		}
 		ai_will_do = { base = 1 }
@@ -4703,6 +4850,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_tank_unit"
 			custom_effect_tooltip = pmc_unit_5_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^5 }
 			# with discount for overlord
@@ -4760,6 +4908,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_tank_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_tank_local = yes
@@ -4780,6 +4929,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_tank_unit"
 			delete_tank_unit_local = yes
 		}
 		ai_will_do = { base = 1 }
@@ -4807,6 +4957,7 @@ pmc_local_management = {
 		days_re_enable = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_specops_unit"
 			custom_effect_tooltip = pmc_unit_6_TT
 			set_temp_variable = { treasury_change = global.mercs_cost^6 }
 			# with discount for overlord
@@ -4867,6 +5018,7 @@ pmc_local_management = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_specops_unit"
 			custom_effect_tooltip = pmc_spawn_TT
 			hidden_effect = {
 				spawn_specops_local = yes
@@ -4887,6 +5039,7 @@ pmc_local_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision disband_specops_unit"
 			delete_specops_unit_local = yes
 		}
 		ai_will_do = { base = 1 }

--- a/common/decisions/05_CHI_decisions.txt
+++ b/common/decisions/05_CHI_decisions.txt
@@ -84,6 +84,7 @@ CHI_sco_category = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_upgrade_to_observer"
 			if = {
 				limit = { NOT = { has_country_flag = CHI_sco_observer_status_rejected } }
 				CHI_sco_promote_to_observer = yes
@@ -138,6 +139,7 @@ CHI_sco_category = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_upgrade_to_member"
 			if = {
 				limit = { NOT = { has_country_flag = CHI_sco_membership_rejected } }
 				CHI_sco_promote_to_member = yes
@@ -240,6 +242,7 @@ CHI_sco_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision provide_development_assistance"
 			if = {
 				limit = { original_tag = CHI has_completed_focus = CHI_Development_Assistance }
 				set_temp_variable = { percent_change = 2.25 }
@@ -1159,6 +1162,7 @@ CHI_sco_category = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision apply_to_join_as_an_observer"
 			if = {
 				limit = { NOT = { has_country_flag = CHI_sco_observer_status_rejected } }
 				add_ideas = CHI_sco_observer
@@ -1344,6 +1348,7 @@ CHI_sco_category = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision apply_to_join_as_a_member"
 			add_to_array = { global.sco_members = ROOT }
 			if = {
 				limit = { NOT = { has_country_flag = CHI_sco_membership_rejected } }
@@ -1775,6 +1780,7 @@ CHI_sco_category = {
 		days_remove = 14
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision start_joint_exercises_specific"
 			add_opinion_modifier = {
 				target = FROM
 				modifier = military_cooperation
@@ -2862,7 +2868,10 @@ CHI_national_commitee_decisions_category = {
 
 		visible = { has_country_flag = CHI_first_general_quote_shout }
 
-		complete_effect = { set_country_flag = CHI_muted_generals }
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_mute_general_shoutout_decision"
+			set_country_flag = CHI_muted_generals
+		}
 
 		ai_will_do = { base = 0 }
 	}
@@ -2873,7 +2882,10 @@ CHI_national_commitee_decisions_category = {
 
 		visible = { has_country_flag = CHI_muted_generals }
 
-		complete_effect = { clr_country_flag = CHI_muted_generals }
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_unmute_general_shoutout_decision"
+			clr_country_flag = CHI_muted_generals
+		}
 
 		ai_will_do = { base = 0 }
 	}
@@ -2891,6 +2903,7 @@ CHI_national_commitee_decisions_category = {
 		activation = { has_country_flag = CHI_national_congress_started }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_current_congress_mission"
 			clr_country_flag = CHI_national_congress_started
 			if = {
 				limit = { has_country_flag = CHI_16_nc_needs_to_be_started }
@@ -3033,6 +3046,7 @@ CHI_national_commitee_decisions_category = {
 		available = { hidden_trigger = { always = no } }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_16_national_congress_mission"
 			CHI_reset_ic_commissions = yes
 			country_event = china_national_committee.02
 			activate_mission = CHI_current_congress_mission
@@ -3061,6 +3075,7 @@ CHI_national_commitee_decisions_category = {
 		available = { hidden_trigger = { always = no } }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_17_national_congress_mission"
 			CHI_reset_ic_commissions = yes
 			country_event = china_national_committee.02
 			activate_mission = CHI_current_congress_mission
@@ -3084,6 +3099,7 @@ CHI_national_commitee_decisions_category = {
 		activation = { has_country_flag = CHI_18_nc_needs_to_be_started }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_18_national_congress_mission"
 			CHI_reset_ic_commissions = yes
 			country_event = china_national_committee.02
 			activate_mission = CHI_current_congress_mission
@@ -3108,6 +3124,7 @@ CHI_national_commitee_decisions_category = {
 		activation = { has_country_flag = CHI_19_nc_needs_to_be_started }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_19_national_congress_mission"
 			CHI_reset_ic_commissions = yes
 			country_event = china_national_committee.02
 			activate_mission = CHI_current_congress_mission
@@ -3131,6 +3148,7 @@ CHI_national_commitee_decisions_category = {
 		activation = { has_country_flag = CHI_20_nc_needs_to_be_started }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_20_national_congress_mission"
 			CHI_reset_ic_commissions = yes
 			country_event = china_national_committee.02
 			activate_mission = CHI_current_congress_mission
@@ -3155,6 +3173,7 @@ CHI_national_commitee_decisions_category = {
 		activation = { has_country_flag = CHI_21_nc_needs_to_be_started }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_21_national_congress_mission"
 			CHI_reset_ic_commissions = yes
 			country_event = china_national_committee.02
 			activate_mission = CHI_current_congress_mission
@@ -5032,6 +5051,7 @@ CHI_SAR_decisions_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_TAI_strait_naval_exercise"
 			add_to_variable = { CHI_taiwan_strait_tension = 5 tooltip = CHI_taiwan_strait_tension_tt }
 			clamp_variable = { var = CHI_taiwan_strait_tension min = 0 max = 100 }
 			add_to_variable = { CHI_taiwan_us_support = -2 tooltip = CHI_taiwan_us_support_tt }
@@ -5430,6 +5450,7 @@ CHI_south_china_sea_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_deploy_maritime_militia"
 			add_timed_idea = { idea = CHI_militia_deployed days = 365 }
 		}
 

--- a/common/decisions/05_CHI_decisions.txt
+++ b/common/decisions/05_CHI_decisions.txt
@@ -1672,7 +1672,10 @@ CHI_sco_category = {
 
 		fixed_random_seed = no
 
-		remove_effect = { random_army_leader = { add_skill_level = 1 } }
+		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision host_joint_exercises"
+			random_army_leader = { add_skill_level = 1 }
+		}
 
 		ai_will_do = { base = 1 }
 	}

--- a/common/decisions/05_CHI_decisions.txt
+++ b/common/decisions/05_CHI_decisions.txt
@@ -29,8 +29,8 @@ CHI_sco_category = {
 		cost = 50
 
 		complete_effect = {
-			CHI_sco_add_dialogue_partner = yes
 			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_apply_as_dialogue_partner executed"
+			CHI_sco_add_dialogue_partner = yes
 		}
 
 		ai_will_do = {
@@ -77,8 +77,8 @@ CHI_sco_category = {
 		cost = 75
 
 		complete_effect = {
-			CHI = { country_event = CHI_sco.1 }
 			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_upgrade_to_observer executed"
+			CHI = { country_event = CHI_sco.1 }
 		}
 
 		days_remove = 90
@@ -132,8 +132,8 @@ CHI_sco_category = {
 		cost = 100
 
 		complete_effect = {
-			CHI = { country_event = CHI_sco.2 }
 			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_upgrade_to_member executed"
+			CHI = { country_event = CHI_sco.2 }
 		}
 
 		days_remove = 90
@@ -1428,13 +1428,13 @@ CHI_sco_category = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision give_up_membership_status executed"
 			if = {
 				limit = { is_in_faction_with = CHI }
 				leave_faction = yes
 			}
 			CHI_sco_remove = yes
 			news_event = CHI_sco.8
-			log = "[GetDateText]: [Root.GetName]: Decision give_up_membership_status executed"
 		}
 
 		ai_will_do = {
@@ -1492,6 +1492,7 @@ CHI_sco_category = {
 		days_re_enable = 180
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_consider_leaving executed"
 			if = {
 				limit = { is_sco = yes }
 				CHI_sco_demote_member = yes
@@ -1509,7 +1510,6 @@ CHI_sco_category = {
 				CHI_sco_remove = yes
 				news_event = CHI_sco.8
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_consider_leaving executed"
 		}
 
 		ai_will_do = {
@@ -1553,6 +1553,7 @@ CHI_sco_category = {
 		days_re_enable = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_cohesion_decay executed"
 			set_temp_variable = { CHI_sco_equilibrium = 5 }
 			if = {
 				limit = { check_variable = { global.sco_megaproject_energy_grid_active > 0 } }
@@ -1579,7 +1580,6 @@ CHI_sco_category = {
 				add_to_variable = { CHI_sco_cohesion = 1 }
 			}
 			clamp_variable = { var = CHI_sco_cohesion min = 0 max = 100 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_sco_cohesion_decay executed"
 		}
 
 		ai_will_do = { base = 1 }
@@ -5442,11 +5442,11 @@ CHI_south_china_sea_category = {
 		days_re_enable = 180
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_deploy_maritime_militia executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -1 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_deploy_maritime_militia executed"
 		}
 
 		remove_effect = {
@@ -5484,15 +5484,16 @@ CHI_south_china_sea_category = {
 		modifier = { production_speed_buildings_factor = -0.05 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_runway executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_runway executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_runway remove_effect executed"
 			526 = {
 				add_building_construction = {
 					type = air_base
@@ -5502,7 +5503,6 @@ CHI_south_china_sea_category = {
 			}
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_runway remove_effect executed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -5529,15 +5529,16 @@ CHI_south_china_sea_category = {
 		modifier = { production_speed_buildings_factor = -0.05 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_sam_battery executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_sam_battery executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_sam_battery remove_effect executed"
 			526 = {
 				add_building_construction = {
 					type = anti_air_building
@@ -5547,7 +5548,6 @@ CHI_south_china_sea_category = {
 			}
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_sam_battery remove_effect executed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -5574,15 +5574,16 @@ CHI_south_china_sea_category = {
 		modifier = { production_speed_buildings_factor = -0.05 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_radar executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_radar executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_radar remove_effect executed"
 			526 = {
 				add_building_construction = {
 					type = radar_station
@@ -5592,7 +5593,6 @@ CHI_south_china_sea_category = {
 			}
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_radar remove_effect executed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -5619,17 +5619,18 @@ CHI_south_china_sea_category = {
 		modifier = { production_speed_buildings_factor = -0.05 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_civilian executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = 2 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_civilian executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_civilian remove_effect executed"
 			526 = {
 				add_building_construction = {
 					type = infrastructure
@@ -5637,7 +5638,6 @@ CHI_south_china_sea_category = {
 					instant_build = no
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_island_construction_civilian remove_effect executed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -5663,12 +5663,13 @@ CHI_south_china_sea_category = {
 		days_remove = 60
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_philippines executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_philippines executed"
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_philippines remove_effect executed"
 			if = {
 				limit = {
 					ic_ratio = {
@@ -5700,7 +5701,6 @@ CHI_south_china_sea_category = {
 				add_timed_idea = { idea = CHI_scs_setback days = 60 }
 				country_event = { id = china_scs.12 hours = 6 }
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_philippines remove_effect executed"
 		}
 
 		ai_will_do = {
@@ -5739,12 +5739,13 @@ CHI_south_china_sea_category = {
 		days_remove = 60
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_vietnam executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_vietnam executed"
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_vietnam remove_effect executed"
 			if = {
 				limit = {
 					ic_ratio = {
@@ -5776,7 +5777,6 @@ CHI_south_china_sea_category = {
 				add_timed_idea = { idea = CHI_scs_setback days = 60 }
 				country_event = { id = china_scs.12 hours = 6 }
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_vietnam remove_effect executed"
 		}
 
 		ai_will_do = {
@@ -5815,12 +5815,13 @@ CHI_south_china_sea_category = {
 		days_remove = 60
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_malaysia executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_malaysia executed"
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_malaysia remove_effect executed"
 			if = {
 				limit = {
 					ic_ratio = {
@@ -5852,7 +5853,6 @@ CHI_south_china_sea_category = {
 				add_timed_idea = { idea = CHI_scs_setback days = 60 }
 				country_event = { id = china_scs.12 hours = 6 }
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_standoff_malaysia remove_effect executed"
 		}
 
 		ai_will_do = {
@@ -5890,10 +5890,10 @@ CHI_south_china_sea_category = {
 		days_re_enable = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_natuna_provocation executed"
 			add_to_variable = { CHI_chinese_aggression = 2 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			IND = { country_event = { id = china_scs.70 days = 1 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_natuna_provocation executed"
 		}
 
 		ai_will_do = {
@@ -5928,13 +5928,13 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_natuna_press_claim executed"
 			add_to_variable = { CHI_chinese_aggression = 5 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -8 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			IND = { add_opinion_modifier = { target = ROOT modifier = territorial_integrity_violation } }
 			news_event = { id = china_scs.51 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_natuna_press_claim executed"
 		}
 
 		ai_will_do = {
@@ -5959,13 +5959,13 @@ CHI_south_china_sea_category = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_invoke_doc_2002 executed"
 			add_to_variable = { CHI_scs_framework = 3 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			VIE = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
 			PHI = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
 			MAY = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
 			news_event = { id = china_scs.31 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_invoke_doc_2002 executed"
 		}
 
 		ai_will_do = {
@@ -5996,6 +5996,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_block_asean_consensus executed"
 			add_to_variable = { CHI_chinese_aggression = 2 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = 4 tooltip = CHI_scs_framework_tt }
@@ -6003,7 +6004,6 @@ CHI_south_china_sea_category = {
 			set_country_flag = { flag = CHI_scs_asean_consensus_blocked days = 60 value = 1 }
 			CBD = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
 			LAO = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_block_asean_consensus executed"
 		}
 
 		ai_will_do = {
@@ -6041,6 +6041,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 730
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_joint_development_VIE executed"
 			add_to_variable = { CHI_scs_framework = 2 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			VIE = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
@@ -6053,7 +6054,6 @@ CHI_south_china_sea_category = {
 				set_country_flag = CHI_scs_first_jdz_signed
 			}
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_joint_development_VIE executed"
 		}
 
 		ai_will_do = {
@@ -6091,6 +6091,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 730
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_joint_development_PHI executed"
 			add_to_variable = { CHI_scs_framework = 2 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			PHI = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
@@ -6104,7 +6105,6 @@ CHI_south_china_sea_category = {
 				set_country_flag = CHI_scs_first_jdz_signed
 			}
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_joint_development_PHI executed"
 		}
 
 		ai_will_do = {
@@ -6142,6 +6142,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 730
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_joint_development_MAY executed"
 			add_to_variable = { CHI_scs_framework = 2 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			MAY = { add_opinion_modifier = { target = ROOT modifier = small_increase } }
@@ -6154,7 +6155,6 @@ CHI_south_china_sea_category = {
 				set_country_flag = CHI_scs_first_jdz_signed
 			}
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_joint_development_MAY executed"
 		}
 
 		ai_will_do = {
@@ -6183,6 +6183,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 1095
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_infrastructure_loan_VIE executed"
 			add_to_variable = { CHI_scs_framework = 1 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			VIE = {
@@ -6196,7 +6197,6 @@ CHI_south_china_sea_category = {
 			}
 			VIE = { CHI = { country_event = { id = china_scs.36 days = 1825 random_days = 730 } } }
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_infrastructure_loan_VIE executed"
 		}
 
 		ai_will_do = {
@@ -6225,6 +6225,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 1095
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_infrastructure_loan_PHI executed"
 			add_to_variable = { CHI_scs_framework = 1 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			PHI = {
@@ -6238,7 +6239,6 @@ CHI_south_china_sea_category = {
 			}
 			PHI = { CHI = { country_event = { id = china_scs.36 days = 1825 random_days = 730 } } }
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_infrastructure_loan_PHI executed"
 		}
 
 		ai_will_do = {
@@ -6267,6 +6267,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 1095
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_infrastructure_loan_MAY executed"
 			add_to_variable = { CHI_scs_framework = 1 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			MAY = {
@@ -6280,7 +6281,6 @@ CHI_south_china_sea_category = {
 			}
 			MAY = { CHI = { country_event = { id = china_scs.36 days = 1825 random_days = 730 } } }
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_infrastructure_loan_MAY executed"
 		}
 
 		ai_will_do = {
@@ -6316,13 +6316,13 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_boundary_codification_VIE executed"
 			add_to_variable = { CHI_scs_framework = 8 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			add_to_variable = { CHI_chinese_aggression = -2 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			set_country_flag = CHI_scs_codified_VIE
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_boundary_codification_VIE executed"
 		}
 
 		ai_will_do = {
@@ -6358,13 +6358,13 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_boundary_codification_PHI executed"
 			add_to_variable = { CHI_scs_framework = 8 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			add_to_variable = { CHI_chinese_aggression = -2 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			set_country_flag = CHI_scs_codified_PHI
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_boundary_codification_PHI executed"
 		}
 
 		ai_will_do = {
@@ -6400,13 +6400,13 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_boundary_codification_MAY executed"
 			add_to_variable = { CHI_scs_framework = 8 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			add_to_variable = { CHI_chinese_aggression = -2 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			set_country_flag = CHI_scs_codified_MAY
 			news_event = { id = china_scs.33 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_boundary_codification_MAY executed"
 		}
 
 		ai_will_do = {
@@ -6435,12 +6435,12 @@ CHI_south_china_sea_category = {
 		modifier = { naval_mastery_gain_factor = 0.10 }
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_first_island_chain_exercise remove_effect executed"
 			add_to_variable = { CHI_chinese_aggression = 2 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -3 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
 			navy_experience = 20
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_first_island_chain_exercise remove_effect executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -6463,17 +6463,17 @@ CHI_south_china_sea_category = {
 		modifier = { naval_invasion_prep_speed = 0.10 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_carrier_strike_group_deployment executed"
 			add_to_variable = { CHI_chinese_aggression = 1 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_carrier_strike_group_deployment executed"
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_carrier_strike_group_deployment remove_effect executed"
 			add_to_variable = { CHI_chinese_aggression = 5 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -2 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_carrier_strike_group_deployment remove_effect executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -6497,6 +6497,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_assertive_patrol_VIE executed"
 			add_to_variable = { CHI_chinese_aggression = 3 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -2 tooltip = CHI_scs_framework_tt }
@@ -6529,7 +6530,6 @@ CHI_south_china_sea_category = {
 					add_timed_idea = { idea = CHI_scs_setback days = 180 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_assertive_patrol_VIE executed"
 		}
 
 		ai_will_do = {
@@ -6559,6 +6559,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_assertive_patrol_PHI executed"
 			add_to_variable = { CHI_chinese_aggression = 3 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -2 tooltip = CHI_scs_framework_tt }
@@ -6591,7 +6592,6 @@ CHI_south_china_sea_category = {
 					add_timed_idea = { idea = CHI_scs_setback days = 180 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_assertive_patrol_PHI executed"
 		}
 
 		ai_will_do = {
@@ -6621,6 +6621,7 @@ CHI_south_china_sea_category = {
 		days_re_enable = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_assertive_patrol_MAY executed"
 			add_to_variable = { CHI_chinese_aggression = 3 tooltip = CHI_chinese_aggression_tt }
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -2 tooltip = CHI_scs_framework_tt }
@@ -6653,7 +6654,6 @@ CHI_south_china_sea_category = {
 					add_timed_idea = { idea = CHI_scs_setback days = 180 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_assertive_patrol_MAY executed"
 		}
 
 		ai_will_do = {
@@ -6688,6 +6688,7 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_demand_tribute_VIE executed"
 			VIE = { country_event = { id = china_scs.52 days = 1 } }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -6699,7 +6700,6 @@ CHI_south_china_sea_category = {
 				set_country_flag = CHI_scs_ultimatum_issued_any
 			}
 			news_event = { id = china_scs.51 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_demand_tribute_VIE executed"
 		}
 
 		ai_will_do = {
@@ -6735,6 +6735,7 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_demand_tribute_PHI executed"
 			PHI = { country_event = { id = china_scs.52 days = 1 } }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -6746,7 +6747,6 @@ CHI_south_china_sea_category = {
 				set_country_flag = CHI_scs_ultimatum_issued_any
 			}
 			news_event = { id = china_scs.51 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_demand_tribute_PHI executed"
 		}
 
 		ai_will_do = {
@@ -6782,6 +6782,7 @@ CHI_south_china_sea_category = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_demand_tribute_MAY executed"
 			MAY = { country_event = { id = china_scs.52 days = 1 } }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -6793,7 +6794,6 @@ CHI_south_china_sea_category = {
 				set_country_flag = CHI_scs_ultimatum_issued_any
 			}
 			news_event = { id = china_scs.51 hours = 6 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_demand_tribute_MAY executed"
 		}
 
 		ai_will_do = {
@@ -6819,8 +6819,8 @@ CHI_south_china_sea_category = {
 		days_re_enable = 1095
 
 		complete_effect = {
-			add_timed_idea = { idea = CHI_mazu_blessing days = 180 }
 			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_summon_dragon_king_blessing executed"
+			add_timed_idea = { idea = CHI_mazu_blessing days = 180 }
 		}
 
 		ai_will_do = { base = 3 }
@@ -6845,6 +6845,7 @@ CHI_south_china_sea_category = {
 		cost = 300
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_reclaim_taiping executed"
 			transfer_state = 491
 			add_state_core = 491
 			TAI = { add_opinion_modifier = { target = ROOT modifier = territorial_integrity_violation } }
@@ -6852,7 +6853,6 @@ CHI_south_china_sea_category = {
 			clamp_variable = { var = CHI_chinese_aggression min = -50 max = 50 }
 			add_to_variable = { CHI_scs_framework = -5 tooltip = CHI_scs_framework_tt }
 			clamp_variable = { var = CHI_scs_framework min = -50 max = 50 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_scs_reclaim_taiping executed"
 		}
 
 		ai_will_do = {
@@ -7344,6 +7344,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_mitsubishi_aerospace executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_air_attack_factor = 0.02 tooltip = air_attack_factor_tt }
 			add_to_variable = { CHI_jap_industry_air_research_factor = 0.03 tooltip = industry_air_research_factor_tt }
@@ -7354,7 +7355,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.231 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_mitsubishi_aerospace executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7386,6 +7386,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_kawasaki_aerospace executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_air_range_factor = 0.03 tooltip = air_range_factor_tt }
 			random_owned_controlled_state = {
@@ -7395,7 +7396,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.232 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_kawasaki_aerospace executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7427,6 +7427,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_jsw executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_army_armor_attack_factor = 0.02 tooltip = army_armor_attack_factor_tt }
 			add_to_variable = { CHI_jap_armor_research_factor = 0.02 tooltip = armor_research_factor_tt }
@@ -7443,7 +7444,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.233 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_jsw executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7475,6 +7475,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_mhi_tank executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_army_armor_attack_factor = 0.03 tooltip = army_armor_attack_factor_tt }
 			if = {
@@ -7490,7 +7491,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.234 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_mhi_tank executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7522,6 +7522,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_komatsu executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_army_armor_defence_factor = 0.02 tooltip = army_armor_defence_factor_tt }
 			if = {
@@ -7537,7 +7538,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.235 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_komatsu executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7569,6 +7569,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_subaru executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_army_armor_defence_factor = 0.02 tooltip = army_armor_defence_factor_tt }
 			if = {
@@ -7584,7 +7585,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.236 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_subaru executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7616,6 +7616,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_howa executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_army_artillery_attack_factor = 0.03 tooltip = army_artillery_attack_factor_tt }
 			if = {
@@ -7631,7 +7632,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.237 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_howa executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7663,6 +7663,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_nec executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_electronics_research_factor = 0.02 tooltip = electronics_research_factor_tt }
 			if = {
@@ -7678,7 +7679,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.238 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_nec executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7710,6 +7710,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_toshiba executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_electronics_research_factor = 0.02 tooltip = electronics_research_factor_tt }
 			if = {
@@ -7725,7 +7726,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.239 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_toshiba executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7757,6 +7757,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_mitsubishi_shipbuilding executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_naval_speed_factor = 0.03 tooltip = naval_speed_factor_tt }
 			add_to_variable = { CHI_jap_naval_research_factor = 0.02 tooltip = naval_research_factor_tt }
@@ -7767,7 +7768,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.240 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_mitsubishi_shipbuilding executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7799,6 +7799,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_kawasaki_shipbuilding executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_naval_torpedo_screen_penetration_factor = 0.02 tooltip = naval_torpedo_screen_penetration_factor_tt }
 			random_owned_controlled_state = {
@@ -7808,7 +7809,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.241 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_kawasaki_shipbuilding executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7840,6 +7840,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_ihi executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_naval_speed_factor = 0.02 tooltip = naval_speed_factor_tt }
 			random_owned_controlled_state = {
@@ -7849,7 +7850,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.242 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_ihi executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7881,6 +7881,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_jmu executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_naval_research_factor = 0.02 tooltip = naval_research_factor_tt }
 			random_owned_controlled_state = {
@@ -7890,7 +7891,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.243 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_jmu executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7922,6 +7922,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_toyota executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_production_speed_arms_factory_factor = 0.05 tooltip = production_speed_arms_factory_factor_tt }
 			add_to_variable = { CHI_jap_monthly_population = 0.05 tooltip = monthly_population_tt }
@@ -7932,7 +7933,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.244 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_toyota executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -7964,6 +7964,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_honda executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_production_speed_arms_factory_factor = 0.04 tooltip = production_speed_arms_factory_factor_tt }
 			add_to_variable = { CHI_jap_research_speed_factor = 0.02 tooltip = research_speed_factor_tt }
@@ -7974,7 +7975,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.245 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_honda executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -8006,6 +8006,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_nippon_steel executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_production_factory_efficiency_gain_factor = 0.05 tooltip = production_factory_efficiency_gain_factor_tt }
 			add_to_variable = { CHI_jap_production_speed_industrial_complex_factor = 0.03 tooltip = production_speed_industrial_complex_factor_tt }
@@ -8016,7 +8017,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.246 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_nippon_steel executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -8048,6 +8048,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_hitachi executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_civilian_factories_productivity = 0.04 tooltip = civilian_factories_productivity_tt }
 			add_to_variable = { CHI_jap_research_speed_factor = 0.03 tooltip = research_speed_factor_tt }
@@ -8058,7 +8059,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.247 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_hitachi executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -8090,6 +8090,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_panasonic executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_electronics_research_factor = 0.04 tooltip = electronics_research_factor_tt }
 			add_to_variable = { CHI_jap_consumer_goods_factor = -0.05 tooltip = consumer_goods_factor_tt }
@@ -8100,7 +8101,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.248 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_panasonic executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -8132,6 +8132,7 @@ CHI_japan_strategy = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_jr_east executed"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_jap_industrial_partnerships }
 			add_to_variable = { CHI_jap_production_speed_infrastructure_factor = 0.05 tooltip = production_speed_infrastructure_factor_tt }
 			add_to_variable = { CHI_jap_monthly_population = 0.05 tooltip = monthly_population_tt }
@@ -8142,7 +8143,6 @@ CHI_japan_strategy = {
 			add_to_variable = { CHI_JAP_invitations_used = 1 }
 			clamp_variable = { var = CHI_JAP_invitations_used min = 0 max = 8 }
 			JAP = { country_event = { id = CHI_foreign.249 days = 7 } }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_invite_JAP_jr_east executed"
 		}
 
 		ai_will_do = { base = 3 }
@@ -8172,6 +8172,7 @@ CHI_BRI_management = {
 		days_re_enable = 1095
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_FOCAC_Summit executed"
 			subtract_from_variable = { CHI_bri_treasury = 50 }
 			every_country = {
 				limit = {
@@ -8180,7 +8181,6 @@ CHI_BRI_management = {
 				}
 				add_opinion_modifier = { target = CHI modifier = medium_increase }
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_FOCAC_Summit executed"
 			country_event = { id = chi_bri.80 days = 1 }
 			newline = yes
 			set_temp_variable = { treasury_change = -50 }
@@ -8220,10 +8220,10 @@ CHI_BRI_management = {
 		days_re_enable = 1095
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_Forum_Triennial executed"
 			subtract_from_variable = { CHI_bri_treasury = 150 }
 			clamp_variable = { var = CHI_bri_treasury min = 0 }
 			country_event = { id = chi_bri.40 days = 1 }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_Forum_Triennial executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -150 }
 			modify_treasury_effect = yes
@@ -8251,9 +8251,9 @@ CHI_BRI_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_automation_enable executed"
 			set_country_flag = CHI_bri_auto_accept
 			custom_effect_tooltip = CHI_BRI_automation_enable_tt
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_automation_enable executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8273,9 +8273,9 @@ CHI_BRI_management = {
 		fire_only_once = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_automation_disable executed"
 			clr_country_flag = CHI_bri_auto_accept
 			custom_effect_tooltip = CHI_BRI_automation_disable_tt
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_automation_disable executed"
 		}
 
 		ai_will_do = { base = 0 }
@@ -8304,8 +8304,8 @@ CHI_BRI_management = {
 		days_re_enable = 365
 
 		complete_effect = {
-			add_to_variable = { CHI_bri_monthly_income_base = 4 tooltip = CHI_bri_monthly_income_tt }
 			log = "[GetDateText]: [Root.GetName]: Decision CHI_bri_raise_contribution executed"
+			add_to_variable = { CHI_bri_monthly_income_base = 4 tooltip = CHI_bri_monthly_income_tt }
 		}
 
 		ai_will_do = {
@@ -8339,13 +8339,13 @@ CHI_BRI_management = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_Debt_Restructuring executed"
 			FROM = {
 				CHI_bri_clear_loan = yes
 				custom_effect_tooltip = CHI_bri_clear_loan_tt
 				add_opinion_modifier = { target = CHI modifier = medium_increase }
 			}
 			add_to_variable = { CHI_bri_winwin_score = 2 tooltip = CHI_bri_winwin_score_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_Debt_Restructuring executed"
 		}
 
 		ai_will_do = {
@@ -8377,6 +8377,7 @@ CHI_BRI_management = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_Asset_Seizure executed"
 			FROM = {
 				CHI_bri_reclaim_structure = yes
 				CHI_bri_clear_loan = yes
@@ -8395,7 +8396,6 @@ CHI_BRI_management = {
 				modify_treasury_effect = yes
 			}
 			add_to_variable = { CHI_bri_predatory_score = 1 tooltip = CHI_bri_predatory_score_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_Asset_Seizure executed"
 		}
 
 		ai_will_do = {
@@ -8429,6 +8429,7 @@ CHI_BRI_management = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_bri_claim_resource_rights executed"
 			FROM = { country_event = { id = chi_bri.17 days = 2 } }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -8438,7 +8439,6 @@ CHI_BRI_management = {
 				}
 			}
 			add_to_variable = { CHI_bri_predatory_score = 1 tooltip = CHI_bri_predatory_score_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_bri_claim_resource_rights executed"
 		}
 
 		ai_will_do = {
@@ -8481,11 +8481,11 @@ CHI_BRI_management = {
 		days_re_enable = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_Surveillance_Export executed"
 			subtract_from_variable = { CHI_bri_treasury = 80 }
 			FROM = {
 				add_ideas = chinese_surveillance_systems
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_Surveillance_Export executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -80 }
 			modify_treasury_effect = yes
@@ -8528,6 +8528,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_maritime_network executed"
 			if = {
 				limit = { check_variable = { CHI_bri_ports_built > 99 } has_idea = CHI_bri_ports_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_ports_tier_2_idea add_idea = CHI_bri_ports_tier_3_idea }
@@ -8539,7 +8540,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_ports_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_maritime_network executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8572,6 +8572,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_overland_corridors executed"
 			if = {
 				limit = { check_variable = { CHI_bri_railways_built > 99 } has_idea = CHI_bri_railways_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_railways_tier_2_idea add_idea = CHI_bri_railways_tier_3_idea }
@@ -8583,7 +8584,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_railways_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_overland_corridors executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8616,6 +8616,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_energy_arteries executed"
 			if = {
 				limit = { check_variable = { CHI_bri_pipelines_built > 99 } has_idea = CHI_bri_pipelines_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_pipelines_tier_2_idea add_idea = CHI_bri_pipelines_tier_3_idea }
@@ -8627,7 +8628,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_pipelines_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_energy_arteries executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8660,6 +8660,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_digital_silk_road executed"
 			if = {
 				limit = { check_variable = { CHI_bri_telecom_built > 99 } has_idea = CHI_bri_telecom_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_telecom_tier_2_idea add_idea = CHI_bri_telecom_tier_3_idea }
@@ -8671,7 +8672,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_telecom_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_digital_silk_road executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8704,6 +8704,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_resource_concessions executed"
 			if = {
 				limit = { check_variable = { CHI_bri_mines_secured > 99 } has_idea = CHI_bri_mines_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_mines_tier_2_idea add_idea = CHI_bri_mines_tier_3_idea }
@@ -8715,7 +8716,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_mines_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_resource_concessions executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8748,6 +8748,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_power_generation executed"
 			if = {
 				limit = { check_variable = { CHI_bri_powerplants_built > 99 } has_idea = CHI_bri_powerplants_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_powerplants_tier_2_idea add_idea = CHI_bri_powerplants_tier_3_idea }
@@ -8759,7 +8760,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_powerplants_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_power_generation executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8792,6 +8792,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_economic_zones executed"
 			if = {
 				limit = { check_variable = { CHI_bri_industrial_zones > 99 } has_idea = CHI_bri_industrial_zones_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_industrial_zones_tier_2_idea add_idea = CHI_bri_industrial_zones_tier_3_idea }
@@ -8803,7 +8804,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_industrial_zones_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_economic_zones executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8836,6 +8836,7 @@ CHI_BRI_management = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_prestige_diplomacy executed"
 			if = {
 				limit = { check_variable = { CHI_bri_prestige_projects > 99 } has_idea = CHI_bri_prestige_tier_2_idea }
 				swap_ideas = { remove_idea = CHI_bri_prestige_tier_2_idea add_idea = CHI_bri_prestige_tier_3_idea }
@@ -8847,7 +8848,6 @@ CHI_BRI_management = {
 			else = {
 				add_ideas = CHI_bri_prestige_tier_1_idea
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_BRI_promote_prestige_diplomacy executed"
 		}
 
 		ai_will_do = { base = 100 }
@@ -8874,9 +8874,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_port_project executed"
 			set_variable = { bri_project_type = 1 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_port_project executed"
 		}
 
 		ai_will_do = {
@@ -8935,9 +8935,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_railway_project executed"
 			set_variable = { bri_project_type = 2 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_railway_project executed"
 		}
 
 		ai_will_do = {
@@ -8974,9 +8974,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_pipeline_project executed"
 			set_variable = { bri_project_type = 3 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_pipeline_project executed"
 		}
 
 		ai_will_do = {
@@ -9031,9 +9031,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_telecom_project executed"
 			set_variable = { bri_project_type = 4 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_telecom_project executed"
 		}
 
 		ai_will_do = {
@@ -9071,9 +9071,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_sez_project executed"
 			set_variable = { bri_project_type = 5 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_sez_project executed"
 		}
 
 		ai_will_do = {
@@ -9110,9 +9110,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_mining_project executed"
 			set_variable = { bri_project_type = 6 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_mining_project executed"
 		}
 
 		ai_will_do = {
@@ -9149,9 +9149,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_powerplant_project executed"
 			set_variable = { bri_project_type = 7 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_powerplant_project executed"
 		}
 
 		ai_will_do = {
@@ -9188,9 +9188,9 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 540
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_prestige_project executed"
 			set_variable = { bri_project_type = 8 }
 			CHI_bri_request_project = yes
-			log = "[GetDateText]: [Root.GetName]: Decision BRI_apply_for_prestige_project executed"
 		}
 
 		ai_will_do = {
@@ -9224,9 +9224,9 @@ CHI_BRI_recipient_actions = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_bri_buy_back_concession executed"
 			remove_ideas = CHI_bri_resource_concession_idea
 			add_opinion_modifier = { target = CHI modifier = medium_decrease }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_bri_buy_back_concession executed"
 			newline = yes
 			set_temp_variable = { treasury_change = -75 }
 			modify_treasury_effect = yes
@@ -9261,8 +9261,8 @@ CHI_BRI_recipient_actions = {
 		days_re_enable = 365
 
 		complete_effect = {
-			CHI = { country_event = { id = chi_bri.13 days = 1 } }
 			log = "[GetDateText]: [Root.GetName]: Decision BRI_request_loan_extension executed"
+			CHI = { country_event = { id = chi_bri.13 days = 1 } }
 		}
 
 		ai_will_do = {
@@ -9589,8 +9589,8 @@ CHI_BRI_project_missions = {
 		fire_only_once = no
 
 		timeout_effect = {
-			CHI_bri_complete_project = yes
 			log = "[GetDateText]: [Root.GetName]: Mission CHI_bri_project_mission completed"
+			CHI_bri_complete_project = yes
 		}
 	}
 }
@@ -9652,6 +9652,7 @@ CHI_olympic_preparations = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_olympic_venue_construction completed"
 			547 = {
 				add_building_construction = {
 					type = infrastructure
@@ -9665,7 +9666,6 @@ CHI_olympic_preparations = {
 					}
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_olympic_venue_construction completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -9696,6 +9696,7 @@ CHI_olympic_preparations = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_olympic_athlete_village completed"
 			547 = {
 				add_building_construction = {
 					type = infrastructure
@@ -9708,7 +9709,6 @@ CHI_olympic_preparations = {
 					}
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_olympic_athlete_village completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -9739,6 +9739,7 @@ CHI_olympic_preparations = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_olympic_transport_links completed"
 			547 = {
 				add_building_construction = {
 					type = infrastructure
@@ -9758,7 +9759,6 @@ CHI_olympic_preparations = {
 					}
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_olympic_transport_links completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -9968,6 +9968,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_beijing_tianjin completed"
 			# Need to build railway from Beijing to Tianjin
 			547 = {
 				add_building_construction = {
@@ -10000,7 +10001,6 @@ CHI_railway_improvement = {
 					path = { 11761 3156 10068 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_beijing_tianjin completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10030,6 +10030,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_wuhan_guangzhou completed"
 			# Need to build railway from Wuhan to Guangzhou
 			570 = {
 				add_building_construction = {
@@ -10062,7 +10063,6 @@ CHI_railway_improvement = {
 					path = { 4619 3095 4631 9999 7097 13143 1448 9982 3078 9970 1120 12095 1047 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_wuhan_guangzhou completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10092,6 +10092,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_beijing_shanghai completed"
 			# Need to build railway from Beijing to Shanghai
 			547 = {
 				add_building_construction = {
@@ -10124,7 +10125,6 @@ CHI_railway_improvement = {
 					path = { 11761 9969 11996 11944 15654 7189 1069 4037 10043 7025 11973 16157 1161 11916 16210 10008 4148 11913 11982 14754 10076 10034 7014 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_beijing_shanghai completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10154,6 +10154,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_chengdu_chongqing completed"
 			# Need to build railway from Chengdu to Chongqing
 			586 = {
 				add_building_construction = {
@@ -10188,7 +10189,6 @@ CHI_railway_improvement = {
 					path = { 4925 3099 3094 14312 6999 }
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_hsr_chengdu_chongqing completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10221,6 +10221,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_north_upgrade completed"
 			547 = {
 				add_building_construction = { type = rail_terminal level = 1 instant_build = no }
 				add_building_construction = { type = infrastructure level = 1 instant_build = no }
@@ -10238,7 +10239,6 @@ CHI_railway_improvement = {
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_production_speed_buildings_factor = 0.02 tooltip = production_speed_buildings_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_north_upgrade completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10271,6 +10271,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_east_upgrade completed"
 			562 = {
 				add_building_construction = { type = rail_terminal level = 1 instant_build = no }
 				add_building_construction = { type = infrastructure level = 1 instant_build = no }
@@ -10288,7 +10289,6 @@ CHI_railway_improvement = {
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_production_speed_buildings_factor = 0.02 tooltip = production_speed_buildings_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_east_upgrade completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10321,6 +10321,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_south_upgrade completed"
 			570 = {
 				add_building_construction = { type = rail_terminal level = 1 instant_build = no }
 				add_building_construction = { type = infrastructure level = 1 instant_build = no }
@@ -10338,7 +10339,6 @@ CHI_railway_improvement = {
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_production_speed_buildings_factor = 0.02 tooltip = production_speed_buildings_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_south_upgrade completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10371,6 +10371,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_central_upgrade completed"
 			552 = {
 				add_building_construction = { type = rail_terminal level = 1 instant_build = no }
 				add_building_construction = { type = infrastructure level = 1 instant_build = no }
@@ -10388,7 +10389,6 @@ CHI_railway_improvement = {
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_production_speed_buildings_factor = 0.02 tooltip = production_speed_buildings_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_central_upgrade completed"
 		}
 
 		ai_will_do = { base = 5 }
@@ -10421,6 +10421,7 @@ CHI_railway_improvement = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_west_upgrade completed"
 			559 = {
 				add_building_construction = { type = rail_terminal level = 1 instant_build = no }
 				add_building_construction = { type = infrastructure level = 1 instant_build = no }
@@ -10443,7 +10444,6 @@ CHI_railway_improvement = {
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_economy_modifier }
 			add_to_variable = { CHI_economy_production_speed_buildings_factor = 0.02 tooltip = production_speed_buildings_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decision CHI_railway_west_upgrade completed"
 		}
 
 		ai_will_do = { base = 5 }

--- a/common/decisions/05_ENG_decisions.txt
+++ b/common/decisions/05_ENG_decisions.txt
@@ -180,6 +180,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_clydach_nickel_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -234,6 +235,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_alloys_modernisation"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -302,6 +304,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_ellesmere_port_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -350,6 +353,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_shetland_hydrocarbon_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -404,6 +408,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_rosebank_field_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -458,6 +463,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_cambo_offshore_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -516,6 +522,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_hornsea_wind_farm_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -565,6 +572,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_drakeland_tungsten_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -617,6 +625,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_south_crofty_tin_decision"
 			set_country_flag = ENG_active_resource_project
 		}
 
@@ -827,6 +836,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_roysth_naval_port_decision"
 			set_country_flag = ENG_active_productivity_project
 		}
 
@@ -908,6 +918,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_expand_belfast_decision"
 			set_country_flag = ENG_active_productivity_project
 		}
 
@@ -960,6 +971,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_highland_main_line_decision"
 			set_country_flag = ENG_active_productivity_project
 		}
 
@@ -1011,6 +1023,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_titanic_quarter_decision"
 			set_country_flag = ENG_active_productivity_project
 		}
 
@@ -1067,6 +1080,7 @@ decisions_ENG = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_elizabeth_line_decision"
 			set_country_flag = ENG_active_productivity_project
 		}
 
@@ -1584,12 +1598,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_charities_network_decision"
 			set_country_flag = ENG_charles_charities_network_decision_activated
 			add_to_variable = { ENG_decision_charles_charities_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_charities_network_decision"
 			clr_country_flag = ENG_charles_charities_network_decision_activated
 		}
 
@@ -1631,12 +1647,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_harmony_tour_decision"
 			set_country_flag = ENG_charles_harmony_tour_decision_activated
 			add_to_variable = { ENG_decision_charles_harmony_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_harmony_tour_decision"
 			clr_country_flag = ENG_charles_harmony_tour_decision_activated
 			random_country = {
 				limit = {
@@ -1696,6 +1714,7 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_environmental_diplomacy_tour_decision"
 			set_country_flag = ENG_charles_environmental_diplomacy_tour_decision_activated
 			add_to_variable = { ENG_decision_charles_diplomacy_tour_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
@@ -1706,6 +1725,7 @@ ENG_monarchy_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_environmental_diplomacy_tour_decision"
 			clr_country_flag = ENG_charles_environmental_diplomacy_tour_decision_activated
 			random_country = {
 				limit = {
@@ -1771,12 +1791,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_sustainable_urban_planning_decision"
 			set_country_flag = ENG_charles_sustainable_urban_planning_decision_activated
 			add_to_variable = { ENG_decision_charles_urban_planning_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_sustainable_urban_planning_decision"
 			clr_country_flag = ENG_charles_sustainable_urban_planning_decision_activated
 			random_owned_state = {
 				add_extra_state_shared_building_slots = 1
@@ -1815,6 +1837,7 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_rainforest_help_decision"
 			set_country_flag = ENG_charles_rainforest_help_decision_activated
 			add_to_variable = { ENG_decision_charles_rainforest_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
@@ -1825,6 +1848,7 @@ ENG_monarchy_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_rainforest_help_decision"
 			clr_country_flag = ENG_charles_rainforest_help_decision_activated
 			random_country = {
 				limit = {
@@ -1893,12 +1917,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_organic_agriculture_decision"
 			set_country_flag = ENG_charles_organic_agriculture_decision_activated
 			add_to_variable = { ENG_decision_charles_organic_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_organic_agriculture_decision"
 			clr_country_flag = ENG_charles_organic_agriculture_decision_activated
 			random_country = {
 				limit = {
@@ -1954,12 +1980,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_youth_sustainability_decision"
 			set_country_flag = ENG_charles_youth_sustainability_decision_activated
 			add_to_variable = { ENG_decision_charles_youth_amount_taken = 4.5 }
 			add_to_variable = { ENG_decision_charles_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_charles_youth_sustainability_decision"
 			clr_country_flag = ENG_charles_youth_sustainability_decision_activated
 		}
 
@@ -2001,12 +2029,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_naval_haritage_decision"
 			set_country_flag = ENG_andrew_naval_haritage_decision_activated
 			add_to_variable = { ENG_decision_andrew_naval_heritage_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_andrew_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_naval_haritage_decision"
 			clr_country_flag = ENG_andrew_naval_haritage_decision_activated
 		}
 
@@ -2054,12 +2084,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_trade_representive_decision"
 			set_country_flag = ENG_andrew_trade_representive_decision_activated
 			add_to_variable = { ENG_decision_andrew_trad_representive_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_andrew_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_trade_representive_decision"
 			clr_country_flag = ENG_andrew_trade_representive_decision_activated
 			random_country = {
 				limit = {
@@ -2128,12 +2160,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_emerging_trade_agreement_decision"
 			set_country_flag = ENG_andrew_emerging_trade_agreement_decision_activated
 			add_to_variable = { ENG_decision_andrew_trad_emerging_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_andrew_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_emerging_trade_agreement_decision"
 			clr_country_flag = ENG_andrew_emerging_trade_agreement_decision_activated
 			random_country = {
 				limit = {
@@ -2191,12 +2225,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_emerging_economy_benefits_decision"
 			set_country_flag = ENG_andrew_emerging_economy_benefits_decision_activated
 			add_to_variable = { ENG_decision_andrew_trade_benefits_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_andrew_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_emerging_economy_benefits_decision"
 			clr_country_flag = ENG_andrew_emerging_economy_benefits_decision_activated
 			random_owned_state = {
 				set_temp_variable = { temp_productivity_change = 0.025 }
@@ -2241,12 +2277,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_digital_enterprise_decision"
 			set_country_flag = ENG_andrew_digital_enterprise_decision_activated
 			add_to_variable = { ENG_decision_andrew_digital_enterprise_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_andrew_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_andrew_digital_enterprise_decision"
 			clr_country_flag = ENG_andrew_digital_enterprise_decision_activated
 			random_owned_state = {
 				random_list = {
@@ -2328,12 +2366,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_national_charity_decision"
 			set_country_flag = ENG_anne_national_charity_decision_activated
 			add_to_variable = { ENG_decision_anne_national_charity_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_anne_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_national_charity_decision"
 			clr_country_flag = ENG_anne_national_charity_decision_activated
 		}
 
@@ -2375,12 +2415,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_carers_promotion_decision"
 			set_country_flag = ENG_anne_carers_promotion_decision_activated
 			add_to_variable = { ENG_decision_anne_carers_promotion_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_anne_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_carers_promotion_decision"
 			clr_country_flag = ENG_anne_carers_promotion_decision_activated
 		}
 
@@ -2421,12 +2463,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_military_readiness_decision"
 			set_country_flag = ENG_anne_military_readiness_decision_activated
 			add_to_variable = { ENG_decision_anne_military_readiness_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_anne_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_military_readiness_decision"
 			clr_country_flag = ENG_anne_military_readiness_decision_activated
 		}
 
@@ -2471,12 +2515,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_navy_readiness_decision"
 			set_country_flag = ENG_anne_navy_readiness_decision_activated
 			add_to_variable = { ENG_decision_anne_naval_readiness_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_anne_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_navy_readiness_decision"
 			clr_country_flag = ENG_anne_navy_readiness_decision_activated
 		}
 
@@ -2518,12 +2564,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_tourism_decision"
 			set_country_flag = ENG_anne_tourism_decision_activated
 			add_to_variable = { ENG_decision_anne_tourism_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_anne_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_anne_tourism_decision"
 			clr_country_flag = ENG_anne_tourism_decision_activated
 		}
 
@@ -2564,12 +2612,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_beach_youth_decision"
 			set_country_flag = ENG_edward_beach_youth_decision_activated
 			add_to_variable = { ENG_decision_edward_beach_youth_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_edward_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_beach_youth_decision"
 			clr_country_flag = ENG_edward_beach_youth_decision_activated
 			random_owned_state = {
 				add_dynamic_modifier = {
@@ -2615,12 +2665,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_global_youth_decision"
 			set_country_flag = ENG_edward_global_youth_decision_activated
 			add_to_variable = { ENG_decision_edward_global_youth_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_edward_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_global_youth_decision"
 			clr_country_flag = ENG_edward_global_youth_decision_activated
 		}
 
@@ -2663,12 +2715,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_arts_culture_patronage_decision"
 			set_country_flag = ENG_edward_arts_culture_patronage_decision_activated
 			add_to_variable = { ENG_decision_edward_culture_patronage_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_edward_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_arts_culture_patronage_decision"
 			clr_country_flag = ENG_edward_arts_culture_patronage_decision_activated
 		}
 
@@ -2711,12 +2765,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_production_guild_decision"
 			set_country_flag = ENG_edward_production_guild_decision_activated
 			add_to_variable = { ENG_decision_edward_production_guild_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_edward_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_production_guild_decision"
 			clr_country_flag = ENG_edward_production_guild_decision_activated
 		}
 
@@ -2758,12 +2814,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_veteran_support_decision"
 			set_country_flag = ENG_edward_veteran_support_decision_activated
 			add_to_variable = { ENG_decision_edward_veteran_support_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_edward_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_edward_veteran_support_decision"
 			clr_country_flag = ENG_edward_veteran_support_decision_activated
 		}
 
@@ -2807,12 +2865,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_award_medal_decision"
 			set_country_flag = ENG_philip_award_medal_decision_activated
 			add_to_variable = { ENG_decision_philip_award_medal_amount_taken = 2.5 }
 			add_to_variable = { ENG_decision_philip_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_award_medal_decision"
 			clr_country_flag = ENG_philip_award_medal_decision_activated
 			random_list = {
 				50 = {
@@ -2898,12 +2958,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_award_expansion_decision"
 			set_country_flag = ENG_philip_award_expansion_decision_activated
 			add_to_variable = { ENG_decision_philip_award_expension_amount_taken = 2.5 }
 			add_to_variable = { ENG_decision_philip_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_award_expansion_decision"
 			clr_country_flag = ENG_philip_award_expansion_decision_activated
 		}
 
@@ -2946,12 +3008,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_trust_funds_grants_decision"
 			set_country_flag = ENG_philip_trust_funds_grants_decision_activated
 			add_to_variable = { ENG_decision_philip_trust_funds_amount_taken = 2.5 }
 			add_to_variable = { ENG_decision_philip_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_trust_funds_grants_decision"
 			clr_country_flag = ENG_philip_trust_funds_grants_decision_activated
 		}
 
@@ -2993,12 +3057,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_faith_conservation_decision"
 			set_country_flag = ENG_philip_faith_conservation_decision_activated
 			add_to_variable = { ENG_decision_philip_faith_conversion_amount_taken = 2.5 }
 			add_to_variable = { ENG_decision_philip_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_faith_conservation_decision"
 			clr_country_flag = ENG_philip_faith_conservation_decision_activated
 			set_temp_variable = { the_clergy_opinion_min = 2 }
 			change_the_clergy_opinion = yes
@@ -3040,12 +3106,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_innovation_recognition_decision"
 			set_country_flag = ENG_philip_innovation_recognition_decision_activated
 			add_to_variable = { ENG_decision_philip_innovation_recognition_amount_taken = 2.5 }
 			add_to_variable = { ENG_decision_philip_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_philip_innovation_recognition_decision"
 			clr_country_flag = ENG_philip_innovation_recognition_decision_activated
 		}
 
@@ -3087,12 +3155,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_air_ambulance_decision"
 			set_country_flag = ENG_william_air_ambulance_decision_activated
 			add_to_variable = { ENG_decision_william_air_ambulance_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_william_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_air_ambulance_decision"
 			clr_country_flag = ENG_william_air_ambulance_decision_activated
 		}
 
@@ -3133,12 +3203,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_mental_health_at_work_decision"
 			set_country_flag = ENG_william_mental_health_at_work_decision_activated
 			add_to_variable = { ENG_decision_william_mental_health_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_william_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_mental_health_at_work_decision"
 			clr_country_flag = ENG_william_mental_health_at_work_decision_activated
 		}
 
@@ -3180,12 +3252,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_step_into_health_decision"
 			set_country_flag = ENG_william_mental_health_at_work_decision_activated
 			add_to_variable = { ENG_decision_william_step_into_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_william_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_step_into_health_decision"
 			clr_country_flag = ENG_william_mental_health_at_work_decision_activated
 		}
 
@@ -3227,12 +3301,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_early_years_forum_decision"
 			set_country_flag = ENG_william_early_years_forum_decision_activated
 			add_to_variable = { ENG_decision_william_early_years_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_william_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_early_years_forum_decision"
 			clr_country_flag = ENG_william_early_years_forum_decision_activated
 		}
 
@@ -3274,12 +3350,14 @@ ENG_monarchy_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_chogm_youth_decision"
 			set_country_flag = ENG_william_early_years_forum_decision_activated
 			add_to_variable = { ENG_decision_william_chogm_youth_amount_taken = 3.5 }
 			add_to_variable = { ENG_decision_william_taken = 1 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_william_chogm_youth_decision"
 			clr_country_flag = ENG_william_early_years_forum_decision_activated
 			every_other_country = {
 				limit = {
@@ -3324,6 +3402,7 @@ ENG_devolved_matters = {
 		days_remove = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_appease_scotland"
 			add_to_variable = { ENG_scottish_agitation = -2 }
 			SCO = {
 				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
@@ -3360,6 +3439,7 @@ ENG_devolved_matters = {
 		days_remove = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_appease_nireland"
 			add_to_variable = { ENG_north_irish_agitation = -2 }
 			NIR = {
 				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
@@ -3397,6 +3477,7 @@ ENG_devolved_matters = {
 		days_remove = 90
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_appease_wales"
 			add_to_variable = { ENG_wales_agitation = -2 }
 			WAS = {
 				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
@@ -3824,6 +3905,7 @@ ENG_asteroid_mining_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_asteroid_mining_light_operation"
 			clr_country_flag = ENG_asteroid_mining_operation_active
 			random = {
 				chance = 50
@@ -3893,6 +3975,7 @@ ENG_asteroid_mining_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_asteroid_mining_medium_operation"
 			clr_country_flag = ENG_asteroid_mining_operation_active
 			random = {
 				chance = 50
@@ -3962,6 +4045,7 @@ ENG_asteroid_mining_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ENG_asteroid_mining_heavy_operation"
 			clr_country_flag = ENG_asteroid_mining_operation_active
 			random = {
 				chance = 50

--- a/common/decisions/05_GRE_decisions.txt
+++ b/common/decisions/05_GRE_decisions.txt
@@ -156,8 +156,8 @@ GRE_debt_crisis_category = {
 		fire_only_once = no
 
 		complete_effect = {
-			add_stability = 0.05
 			log = "[GetDateText]: [Root.GetName]: Decision GRE_austerity_placate_decision"
+			add_stability = 0.05
 			if = {
 				limit = { has_idea = GRE_austerity_2 }
 				swap_ideas = {

--- a/common/decisions/05_SMA_decisions.txt
+++ b/common/decisions/05_SMA_decisions.txt
@@ -22,6 +22,7 @@ SMA_research_center_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_build_i"
 			add_ideas = {
 				SMA_center_i
 			}
@@ -53,6 +54,7 @@ SMA_research_center_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_build_ii"
 			swap_ideas = {
 				remove_idea = SMA_center_i
 				add_idea = SMA_center_ii
@@ -84,6 +86,7 @@ SMA_research_center_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_build_iii"
 			swap_ideas = {
 				remove_idea = SMA_center_ii
 				add_idea = SMA_center_iii
@@ -112,6 +115,7 @@ SMA_research_center_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_build_final"
 			swap_ideas = {
 				remove_idea = SMA_center_iii
 				add_idea = SMA_center
@@ -137,6 +141,7 @@ SMA_change_textbooks = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_language"
 			if = {
 				limit = {
 					has_country_flag = change_texbooks_lang
@@ -171,6 +176,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_language_ita"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			add_ideas = SMA_lang_ita
@@ -201,6 +207,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_language_romanian"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			add_ideas = SMA_lang_romanion
@@ -223,6 +230,7 @@ SMA_change_textbooks = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_history"
 			if = {
 				limit = {
 					has_country_flag = change_texbooks_hist
@@ -257,6 +265,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_hist_peace"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			add_ideas = SMA_hist_peace
@@ -287,6 +296,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_hist_mil"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			add_ideas = SMA_hist_mil
@@ -311,6 +321,7 @@ SMA_change_textbooks = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_education"
 			if = {
 				limit = {
 					SMA = {
@@ -362,6 +373,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_ed_work"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			SMA = {
@@ -402,6 +414,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_ed_res"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			SMA = {
@@ -442,6 +455,7 @@ SMA_change_textbooks = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SMA_change_ed_mil"
 			set_temp_variable = { treasury_change = -1.00 }
 			modify_treasury_effect = yes
 			SMA = {

--- a/common/decisions/05_SWE_decision.txt
+++ b/common/decisions/05_SWE_decision.txt
@@ -579,6 +579,7 @@ SWE_decision_Royal_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_military_review"
 			hidden_effect = {
 				add_command_power = -25
 			}
@@ -619,6 +620,7 @@ SWE_decision_Royal_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SWE_economy_review"
 			hidden_effect = {
 				add_command_power = -25
 			}

--- a/common/decisions/05_egypt_decisions.txt
+++ b/common/decisions/05_egypt_decisions.txt
@@ -44,6 +44,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Israel"
 			set_country_flag = EGY_pending_offer
 			ISR = { country_event = egypt_evergreen.1 }
 		}
@@ -85,6 +86,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Sudan"
 			set_country_flag = EGY_pending_offer
 			SUD = { country_event = egypt_evergreen.1 }
 		}
@@ -126,6 +128,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Libya"
 			set_country_flag = EGY_pending_offer
 			LBA = { country_event = egypt_evergreen.1 }
 		}
@@ -167,6 +170,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Algeria"
 			set_country_flag = EGY_pending_offer
 			ALG = { country_event = egypt_evergreen.1 }
 		}
@@ -208,6 +212,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Jordan"
 			set_country_flag = EGY_pending_offer
 			JOR = { country_event = egypt_evergreen.1 }
 		}
@@ -249,6 +254,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Syria"
 			set_country_flag = EGY_pending_offer
 			SYR = { country_event = egypt_evergreen.1 }
 		}
@@ -290,6 +296,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Saudia"
 			set_country_flag = EGY_pending_offer
 			SAU = { country_event = egypt_evergreen.1 }
 		}
@@ -331,6 +338,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Iraq"
 			set_country_flag = EGY_pending_offer
 			IRQ = { country_event = egypt_evergreen.1 }
 		}
@@ -372,6 +380,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Lebanon"
 			set_country_flag = EGY_pending_offer
 			LEB = { country_event = egypt_evergreen.1 }
 		}
@@ -413,6 +422,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_uae"
 			set_country_flag = EGY_pending_offer
 			UAE = { country_event = egypt_evergreen.1 }
 		}
@@ -453,6 +463,7 @@ EGY_evergreen_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_mission_to_Turkey"
 			set_country_flag = EGY_pending_offer
 			TUR = { country_event = egypt_evergreen.1 }
 		}
@@ -654,6 +665,7 @@ EGY_slums_decision = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_remove_slums_in_alexandria"
 			set_country_flag = EGY_already_remove_slums
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
@@ -714,6 +726,7 @@ EGY_slums_decision = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_remove_slums_in_cairo"
 			set_country_flag = EGY_already_remove_slums
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
@@ -776,6 +789,7 @@ EGY_slums_decision = {
 		modifier = { consumer_goods_factor = 0.08 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_remove_slums_in_suez"
 			set_country_flag = EGY_already_remove_slums
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
@@ -839,6 +853,7 @@ EGY_slums_decision = {
 		modifier = { consumer_goods_factor = 0.05 }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_remove_slums_in_nile_valley"
 			set_country_flag = EGY_already_remove_slums
 			set_temp_variable = { treasury_change = -3.5 }
 			modify_treasury_effect = yes
@@ -896,12 +911,14 @@ EGY_aswan_tribal_clashes_category = {
 		days_mission_timeout = 30
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_tribal_conflict_escalation_mission"
 			add_stability = -0.03
 
 			country_event = egypt.167
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_tribal_conflict_escalation_mission"
 			effect_tooltip = {
 				add_stability = 0.03
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -933,6 +950,7 @@ EGY_aswan_tribal_clashes_category = {
 		days_remove = 7
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_deploy_military_police_to_the_region_decision"
 			set_country_flag = EGY_aswan_deployed_military
 		}
 
@@ -958,6 +976,7 @@ EGY_aswan_tribal_clashes_category = {
 		days_remove = 7
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EGY_choose_a_side_decision"
 			set_country_flag = EGY_chosen_a_side_in_the_fighting
 			country_event = { id = egypt.166 days = 2 }
 		}

--- a/common/decisions/05_japan.txt
+++ b/common/decisions/05_japan.txt
@@ -3056,6 +3056,7 @@ JAP_military_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_asteroid_mining_light_operation"
 			set_country_flag = JAP_asteroid_mining_operation_active
 		}
 
@@ -3125,6 +3126,7 @@ JAP_military_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_asteroid_mining_medium_operation"
 			set_country_flag = JAP_asteroid_mining_operation_active
 		}
 
@@ -3194,6 +3196,7 @@ JAP_military_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_asteroid_mining_heavy_operation"
 			set_country_flag = JAP_asteroid_mining_operation_active
 		}
 
@@ -3467,6 +3470,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_south_korea"
 			KOR = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -3539,6 +3543,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_north_korea"
 			NKO = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -3606,6 +3611,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_taiwan"
 			600 = { add_claim_by = JAP }
 			599 = { add_claim_by = JAP }
 			1157 = { add_claim_by = JAP }
@@ -3729,6 +3735,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_malaysia"
 			MAY = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -3801,6 +3808,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_indonesia"
 			IND = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -3873,6 +3881,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_vietnam"
 			VIE = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -3944,6 +3953,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_cambodia"
 			CBD = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -4015,6 +4025,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_laos"
 			LAO = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -4086,6 +4097,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_australia"
 			AST = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -4157,6 +4169,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_new_zealand"
 			NZL = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -4228,6 +4241,7 @@ JAP_military_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_claiming_myanmar"
 			BRM = {
 				random_core_state = {
 					limit = { NOT = { is_claimed_by = JAP } }
@@ -5007,6 +5021,7 @@ JAP_japanese_economy_decisions = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_price_target_mission"
 			add_to_variable = { JAP_demand_recovery_progress = -5 tooltip = JAP_demand_recovery_progress_tt }
 			hidden_effect = {
 				country_event = Japan_economy.18
@@ -5089,6 +5104,7 @@ JAP_japanese_economy_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_temporary_consumption_tax_cut"
 			set_temp_variable = { pop_change = 5 }
 			modify_population_tax_rate_effect = yes
 			add_to_variable = { JAP_demand_recovery_progress = 8 tooltip = JAP_demand_recovery_progress_tt }
@@ -5193,6 +5209,7 @@ JAP_japanese_economy_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_stimulating_demand_durable_goods_decision"
 			add_to_variable = { JAP_demand_recovery_progress = 5 tooltip = JAP_demand_recovery_progress_tt }
 			hidden_effect = {
 				country_event = Japan_economy.22
@@ -5246,6 +5263,7 @@ JAP_japanese_economy_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_wage_negotiations"
 			custom_effect_tooltip = JAP_wage_negotiations_TT
 			hidden_effect = {
 				country_event = Japan_economy.14

--- a/common/decisions/05_japan.txt
+++ b/common/decisions/05_japan.txt
@@ -2826,6 +2826,7 @@ JAP_military_decision_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_consolidate_national_defense_framework_mission"
 			set_country_flag = JAP_consolidate_national_defense_framework_done
 		}
 
@@ -2904,6 +2905,7 @@ JAP_military_decision_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_modernize_joint_command_mission"
 			set_country_flag = JAP_modernize_joint_command_done
 		}
 
@@ -2985,6 +2987,7 @@ JAP_military_decision_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_normalize_defense_procurement_mission"
 			set_country_flag = JAP_normalize_defense_procurement_done
 		}
 

--- a/common/decisions/05_north_korea.txt
+++ b/common/decisions/05_north_korea.txt
@@ -923,6 +923,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_industry"
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_productivity_change = 5 }
@@ -983,6 +984,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_production"
 			set_temp_variable = { treasury_change = -0.7 }
 			modify_treasury_effect = yes
 			NKO_spa_pass_production = yes
@@ -1045,6 +1047,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_military"
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
 			NKO_spa_pass_military = yes
@@ -1107,6 +1110,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_economy"
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_productivity_change = 5 }
@@ -1172,6 +1176,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_research"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 			NKO_spa_pass_research = yes
@@ -1234,6 +1239,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_agriculture"
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
 			NKO_spa_pass_agriculture = yes
@@ -1292,6 +1298,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_foreign"
 			set_temp_variable = { treasury_change = -0.7 }
 			modify_treasury_effect = yes
 			NKO_spa_pass_foreign = yes
@@ -1350,6 +1357,7 @@ NKO_arduous_march = {
 		days_remove = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NKO_spa_resolution_construction"
 			set_temp_variable = { treasury_change = -0.75 }
 			modify_treasury_effect = yes
 			NKO_spa_pass_construction = yes
@@ -1534,6 +1542,7 @@ NKO_power_struggle = {
 		available = { always = no }
 		fixed_random_seed = no
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision Kim_Jong_il_Death"
 			if = {
 				limit = {
 					has_stability > 0.55

--- a/common/decisions/99_lar_agent_recruitment_decisions.txt
+++ b/common/decisions/99_lar_agent_recruitment_decisions.txt
@@ -35,6 +35,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_europe"
 			set_country_flag = europe_recruitment_unlocked
 		}
 
@@ -83,6 +84,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_europe_state"
 			set_country_flag = { flag = europe_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -143,6 +145,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_north_america"
 			set_country_flag = north_america_recruitment_unlocked
 		}
 
@@ -195,6 +198,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_north_america_state"
 			set_country_flag = { flag = north_america_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -256,6 +260,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_south_america"
 			set_country_flag = south_america_recruitment_unlocked
 		}
 
@@ -308,6 +313,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_south_america_state"
 			set_country_flag = { flag = south_america_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -369,6 +375,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_africa"
 			set_country_flag = africa_recruitment_unlocked
 		}
 
@@ -420,6 +427,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_africa_state"
 			set_country_flag = { flag = africa_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -481,6 +489,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_middle_east"
 			set_country_flag = middle_east_recruitment_unlocked
 		}
 
@@ -533,6 +542,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_middle_east_state"
 			set_country_flag = { flag = middle_east_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -594,6 +604,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_asia"
 			set_country_flag = asia_recruitment_unlocked
 		}
 
@@ -668,6 +679,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_asia_state"
 			set_country_flag = { flag = asia_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -729,6 +741,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_australia"
 			set_country_flag = australia_recruitment_unlocked
 		}
 
@@ -781,6 +794,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_australia_state"
 			set_country_flag = { flag = australia_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {
@@ -861,6 +875,7 @@ lar_local_recruitment = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_india"
 			set_country_flag = india_recruitment_unlocked
 		}
 
@@ -925,6 +940,7 @@ lar_local_recruitment = {
 		days_re_enable = 180
 		on_map_mode = map_only
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision recruit_in_india_state"
 			set_country_flag = { flag = india_recruitment_in_process days = 180 value = 1 }
 			if = {
 				limit = {

--- a/common/decisions/99_mp_decisions.txt
+++ b/common/decisions/99_mp_decisions.txt
@@ -642,6 +642,7 @@ mp_decision_category = {
 		}
 		fire_only_once = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision mp_create_faction_c"
 			if = {
 				limit = { has_idea = NATO_member }
 				NATO_leave = yes
@@ -650,7 +651,6 @@ mp_decision_category = {
 				limit = { has_idea = CSTO_member }
 				CSTO_leave = yes
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision mp_create_faction_c"
 			set_global_flag = team_c_created_flag
 			set_country_flag = team_c_member_flag
 			create_faction_from_template = faction_template_teamc
@@ -704,6 +704,7 @@ mp_decision_category = {
 	mp_join_faction_d = {
 		visible = { is_in_faction = no }
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision mp_join_faction_d"
 			if = {
 				limit = { has_idea = NATO_member }
 				NATO_leave = yes
@@ -712,7 +713,6 @@ mp_decision_category = {
 				limit = { has_idea = CSTO_member }
 				CSTO_leave = yes
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision mp_join_faction_d"
 			set_country_flag = team_d_member_flag
 			random_country = {
 				limit = {

--- a/common/decisions/Abkhazia.txt
+++ b/common/decisions/Abkhazia.txt
@@ -15,6 +15,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_need_russian_money"
 			SOV = {
 				set_temp_variable = { treasury_change = -3.5 }
 				modify_treasury_effect = yes
@@ -43,6 +44,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_exersises_with_russia"
 			army_experience = 15
 			air_experience = 15
 		}
@@ -57,6 +59,7 @@ ABK_political_decisions = {
 		icon = GFX_decision_abkhaz_button
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_fight_with_mafia"
 			remove_ideas = ABK_mafia_idea
 			add_ideas = ABK_mafia2_idea
 		}
@@ -75,6 +78,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_fight_with_mafia_again"
 			remove_ideas = ABK_mafia2_idea
 			add_ideas = ABK_mafia3_idea
 		}
@@ -95,6 +99,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_fight_with_mafia_again2"
 			remove_ideas = ABK_mafia3_idea
 			add_ideas = ABK_mafia4_idea
 
@@ -114,6 +119,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_fight_with_mafia_again3"
 			remove_ideas = ABK_mafia4_idea
 		}
 
@@ -136,6 +142,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_fight_narco"
 			remove_ideas = ABK_narcos_idea
 			add_ideas = ABK_narcos2_idea
 		}
@@ -160,6 +167,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_fight_narco2"
 			remove_ideas = ABK_narcos2_idea
 		}
 		ai_will_do = { base = 0 }
@@ -205,6 +213,7 @@ ABK_political_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_pyatnashka"
 			if = {
 				limit = {
 					country_exists = NOV
@@ -238,6 +247,7 @@ ABK_georgia_nationalise = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_adjara_nationalise"
 			ABK = {
 				add_state_core = 466
 			}
@@ -261,6 +271,7 @@ ABK_georgia_nationalise = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_west_geo_nationalise"
 			ABK = {
 				add_state_core = 707
 			}
@@ -284,6 +295,7 @@ ABK_georgia_nationalise = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_djava_nationalise"
 			ABK = {
 				add_state_core = 1033
 			}
@@ -307,6 +319,7 @@ ABK_georgia_nationalise = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ABK_east_geo_nationalise"
 			ABK = {
 				add_state_core = 708
 			}

--- a/common/decisions/Afghanistan.txt
+++ b/common/decisions/Afghanistan.txt
@@ -1110,8 +1110,8 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
-			add_command_power = -40
 			log = "[GetDateText]: [This.GetName]: decision raid_taliban_hideouts executed"
+			add_command_power = -40
 		}
 
 		days_remove = 5
@@ -1210,8 +1210,8 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
-			add_command_power = -40
 			log = "[GetDateText]: [This.GetName]: decision bomb_taliban_targets executed"
+			add_command_power = -40
 		}
 
 		days_remove = 5
@@ -1412,9 +1412,9 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [This.GetName]: decision secure_afghan_pakistani_border executed"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [This.GetName]: decision secure_afghan_pakistani_border executed"
 		}
 
 		days_remove = 35
@@ -1793,8 +1793,8 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
-			add_command_power = -40
 			log = "[GetDateText]: [This.GetName]: decision isaf_raid_taliban_hideouts executed"
+			add_command_power = -40
 		}
 
 		days_remove = 15
@@ -1933,8 +1933,8 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
-			add_command_power = -40
 			log = "[GetDateText]: [This.GetName]: decision isaf_launch_drone_strike executed"
+			add_command_power = -40
 		}
 
 		days_remove = 10
@@ -2035,8 +2035,8 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
-			add_command_power = -40
 			log = "[GetDateText]: [This.GetName]: decision isaf_bomb_taliban_hotspots executed"
+			add_command_power = -40
 		}
 
 		days_remove = 5
@@ -2371,8 +2371,8 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
-			add_command_power = -40
 			log = "[GetDateText]: [This.GetName]: decision eliminate_taliban_insurgency executed"
+			add_command_power = -40
 		}
 
 		days_remove = 15

--- a/common/decisions/Afghanistan.txt
+++ b/common/decisions/Afghanistan.txt
@@ -1120,6 +1120,7 @@ Taliban_insurgency_category = {
 		fixed_random_seed = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision raid_taliban_hideouts"
 			random_list = {
 				85 = {
 					news_event = {
@@ -1219,6 +1220,7 @@ Taliban_insurgency_category = {
 		fixed_random_seed = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bomb_taliban_targets"
 			random_list = {
 				65 = {
 					news_event = {
@@ -1423,6 +1425,7 @@ Taliban_insurgency_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision secure_afghan_pakistani_border"
 			if = {
 				limit = {
 					414 = {
@@ -1635,6 +1638,7 @@ Taliban_insurgency_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision afghan_unity_propaganda"
 			random_list = {
 				60 = {
 					news_event = {
@@ -1745,6 +1749,7 @@ Taliban_insurgency_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision show_supporting_counter_insurgency_countries"
 			#Array entries can be a month stale, so re-check both existence and the flag
 			for_each_scope_loop = {
 				array = AFG_ci_array
@@ -1798,6 +1803,7 @@ Taliban_insurgency_category = {
 		fixed_random_seed = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision isaf_raid_taliban_hideouts"
 			random_list = {
 				90 = {
 					news_event = {
@@ -1937,6 +1943,7 @@ Taliban_insurgency_category = {
 		fixed_random_seed = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision isaf_launch_drone_strike"
 			random_list = {
 				65 = {
 					news_event = {
@@ -2038,6 +2045,7 @@ Taliban_insurgency_category = {
 		fixed_random_seed = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision isaf_bomb_taliban_hotspots"
 			random_list = {
 				65 = {
 					news_event = {
@@ -2139,6 +2147,7 @@ Taliban_insurgency_category = {
 		days_re_enable = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision isaf_provide_technical_equipment"
 			AFG = {
 				set_temp_variable = { percent_change = 2 }
 				change_influence_percentage = yes
@@ -2197,6 +2206,7 @@ Taliban_insurgency_category = {
 		fire_only_once = yes
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision isaf_withdraw_from_afghanistan"
 			if = {
 				limit = {
 					has_military_access_to = AFG
@@ -2368,6 +2378,7 @@ Taliban_insurgency_category = {
 		days_remove = 15
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eliminate_taliban_insurgency"
 			#TAL can be the subject of a live or queued Security Council vote (extradition, type 7).
 			#on_annex would tear that down, but a scripted annex_country is not worth betting on.
 			TAL = { clear_united_nations_member_state = yes }

--- a/common/decisions/Algeria.txt
+++ b/common/decisions/Algeria.txt
@@ -2841,6 +2841,7 @@ ALG_resistance_challenges_new = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_healthcare_reform"
 			custom_effect_tooltip = ALG_healthcare_failure_tt
 			subtract_from_variable = { var = ALG_people_grievance value = 5 }
 			add_to_variable = { var = ALG_army_influence value = 5 }
@@ -2892,6 +2893,7 @@ ALG_resistance_challenges_new = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_education_reform"
 			custom_effect_tooltip = ALG_education_failure_tt
 			subtract_from_variable = { var = ALG_people_grievance value = 5 }
 			add_to_variable = { var = ALG_army_influence value = 5 }
@@ -2949,6 +2951,7 @@ ALG_resistance_challenges_new = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_unemployment_reform"
 			custom_effect_tooltip = ALG_unemployment_failure_tt
 			subtract_from_variable = { var = ALG_people_grievance value = 10 }
 			add_to_variable = { var = ALG_army_influence value = 8 }
@@ -3293,6 +3296,7 @@ ALG_resistance_movement = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_fund_pro_government_protests"
 			clr_country_flag = ALG_doing_decision_y
 			custom_effect_tooltip = ALG_protester_exhaustion_TT
 		}
@@ -3807,6 +3811,7 @@ ALG_resistance_power_struggle = {
 		fixed_random_seed = no
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision Resistance_Final_Clash"
 			# If resistance is strong enough
 			if = {
 				limit = {
@@ -3970,6 +3975,7 @@ ALG_anti_poaching_decisions = {
 		days_re_enable = 1
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_bi_yearly_poaching_report"
 			if = {
 				limit = { check_variable = { no_of_poachers < 50 } }
 				ALG_decrease_desertification_rate = yes
@@ -4161,6 +4167,7 @@ ALG_de_arabisation_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_de_arabisation_mission"
 			remove_ideas = ALG_dearabisation_penalty
 			add_stability = -0.05
 			add_to_variable = { var = kabyle_satisfaction value = -10 }
@@ -4205,6 +4212,7 @@ ALG_de_arabisation_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_subsidise_amazigh_businesses"
 			add_to_variable = { var = kabyle_satisfaction value = -5 }
 			add_stability = -0.02
 			custom_effect_tooltip = ALG_amazigh_businesses_fail_TT
@@ -4236,6 +4244,7 @@ ALG_de_arabisation_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_return_amazigh_exiles"
 			add_to_variable = { var = kabyle_satisfaction value = -10 }
 			add_stability = -0.03
 			custom_effect_tooltip = ALG_return_exiles_fail_TT
@@ -4277,6 +4286,7 @@ ALG_de_arabisation_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_leave_arab_league"
 			add_stability = -0.05
 			add_to_variable = { var = kabyle_satisfaction value = -5 }
 			custom_effect_tooltip = ALG_leave_arab_league_fail_TT
@@ -4316,6 +4326,7 @@ ALG_de_arabisation_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_boost_kabyle_population"
 			add_to_variable = { var = kabyle_satisfaction value = -10 }
 			add_stability = -0.03
 			custom_effect_tooltip = ALG_kabyle_pop_fail_TT
@@ -4350,6 +4361,7 @@ ALG_tamazgha_cultural_revival_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_amazigh_language_reform"
 			add_stability = -0.03
 			add_to_variable = { var = kabyle_satisfaction value = -5 }
 			custom_effect_tooltip = ALG_amazigh_language_reform_fail_TT
@@ -4385,6 +4397,7 @@ ALG_tamazgha_cultural_revival_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_tamazight_in_education"
 			add_stability = -0.04
 			add_to_variable = { var = kabyle_satisfaction value = -10 }
 			custom_effect_tooltip = ALG_tamazight_in_education_fail_TT
@@ -4421,6 +4434,7 @@ ALG_tamazgha_cultural_revival_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_media_cultural_independence"
 			add_stability = -0.03
 			add_to_variable = { var = kabyle_satisfaction value = -5 }
 			custom_effect_tooltip = ALG_media_cultural_independence_fail_TT
@@ -4484,6 +4498,7 @@ ALG_tamazgha_cultural_revival_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_tamazgha_regional_cooperation"
 			add_stability = -0.04
 			add_to_variable = { var = kabyle_satisfaction value = -10 }
 			custom_effect_tooltip = ALG_tamazgha_regional_cooperation_fail_TT
@@ -4586,6 +4601,7 @@ ALG_casablanca_decisions = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ALG_casablanca_mission"
 			# mission timed out: failure
 			set_variable = { algeria_casablanca_result = 0 }
 			set_variable = { algeria_casablanca_approach = 0 }

--- a/common/decisions/Arab Spring.txt
+++ b/common/decisions/Arab Spring.txt
@@ -7,6 +7,7 @@ arab_spring_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision hide_arab_spring_monthly_change_factors"
 			set_country_flag = AS_hide_monthly_arab_spring_protest_change
 		}
 
@@ -21,6 +22,7 @@ arab_spring_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision show_arab_spring_monthly_change_factors"
 			clr_country_flag = AS_hide_monthly_arab_spring_protest_change
 		}
 

--- a/common/decisions/Armenia.txt
+++ b/common/decisions/Armenia.txt
@@ -1976,6 +1976,7 @@ ARM_special_services_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ARM_promotion_of_interest_armenia_in_lebanon"
 			add_political_power = -75
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes

--- a/common/decisions/Azerbaijan.txt
+++ b/common/decisions/Azerbaijan.txt
@@ -8,6 +8,7 @@ AZE_economy_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eat_up_doomsday_fund"
 			# how many days fund lasted?
 			set_temp_variable = { fund_days = num_days }
 			subtract_from_variable = { fund_days = AZE.doomsday_fund_created }
@@ -62,6 +63,7 @@ AZE_aliev_propaganda_category = {
 		fire_only_once = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AZE_buy_support_PP"
 			set_temp_variable = { modify_aliev_cult = 3 }
 			modify_aliev_suppport = yes
 		}
@@ -91,11 +93,13 @@ AZE_aliev_propaganda_category = {
 		custom_cost_text = cost_2_0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AZE_buy_support"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AZE_buy_support"
 			set_temp_variable = { modify_aliev_cult = 5 }
 			modify_aliev_suppport = yes
 		}
@@ -124,6 +128,7 @@ AZE_aliev_propaganda_category = {
 		fixed_random_seed = no
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AZE_aliev_countdown"
 			custom_effect_tooltip = AZE_aliev_cult_mission_TT
 			hidden_effect = {
 				if = {

--- a/common/decisions/Belarus.txt
+++ b/common/decisions/Belarus.txt
@@ -211,6 +211,7 @@ BLR_baltic_revolution_category = {
 			LIT = { emerging_communist_state_are_in_power = no }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_establish_cooperation_lit"
 			set_country_flag = BLR_cooperation_lit
 			LIT = {
 				hidden_effect = {
@@ -245,6 +246,7 @@ BLR_baltic_revolution_category = {
 			LIT = { emerging_communist_state_are_in_power = no }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_finance_protests_lit"
 			set_temp_variable = { treasury_change = -0.20 }
 			modify_treasury_effect = yes
 			LIT = {
@@ -256,9 +258,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.1 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_finance_protests_lit"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -274,6 +273,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LIT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_recruit_sympathizers_lit"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = LIT }
 			change_influence_percentage = yes
@@ -283,9 +283,6 @@ BLR_baltic_revolution_category = {
 				set_temp_variable = { temp_outlook_increase = 0.02 }
 				change_relative_party_popularity = yes
 			}
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_recruit_sympathizers_lit"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -301,6 +298,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LIT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_spread_propaganda_lit"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = LIT }
 			change_influence_percentage = yes
@@ -312,9 +310,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.2 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_spread_propaganda_lit"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -330,6 +325,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LIT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_military_lit"
 			set_temp_variable = { treasury_change = -1.50 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 3 }
@@ -344,9 +340,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.3 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_military_lit"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -369,6 +362,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LIT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_politicians_lit"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			LIT = {
@@ -380,9 +374,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.4 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_politicians_lit"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -448,6 +439,7 @@ BLR_baltic_revolution_category = {
 			LAT = { emerging_communist_state_are_in_power = no }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_establish_cooperation_lat"
 			set_country_flag = BLR_cooperation_lat
 			LAT = {
 				hidden_effect = {
@@ -482,6 +474,7 @@ BLR_baltic_revolution_category = {
 			LAT = { emerging_communist_state_are_in_power = no }
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_finance_protests_lat"
 			set_temp_variable = { treasury_change = -0.20 }
 			modify_treasury_effect = yes
 			LAT = {
@@ -493,9 +486,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.1 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_finance_protests_lat"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -511,6 +501,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LAT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_recruit_sympathizers_lat"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = LAT }
 			change_influence_percentage = yes
@@ -520,9 +511,6 @@ BLR_baltic_revolution_category = {
 				set_temp_variable = { temp_outlook_increase = 0.02 }
 				change_relative_party_popularity = yes
 			}
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_recruit_sympathizers_lat"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -538,6 +526,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LAT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_spread_propaganda_lat"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = LAT }
 			change_influence_percentage = yes
@@ -549,9 +538,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.2 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_spread_propaganda_lat"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -567,6 +553,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LAT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_military_lat"
 			set_temp_variable = { treasury_change = -1.50 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 3 }
@@ -581,9 +568,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.3 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_military_lat"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -606,6 +590,7 @@ BLR_baltic_revolution_category = {
 			country_exists = LAT
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_politicians_lat"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			LAT = {
@@ -617,9 +602,6 @@ BLR_baltic_revolution_category = {
 				country_event = { id = belarus_LTB.4 days = 3 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_bribe_politicians_lat"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -771,6 +753,7 @@ BLR_pol_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Establish_cooperation_pol"
 			set_country_flag = Establish_cooperation_pol_nat
 			POL = {
 				hidden_effect = {
@@ -812,6 +795,7 @@ BLR_pol_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Financing_protests_in_pol"
 			set_temp_variable = { treasury_change = -1.35 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 3.2 }
@@ -824,9 +808,6 @@ BLR_pol_revol_category = {
 				change_relative_party_popularity = yes
 				add_stability = -0.04
 			}
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_Financing_protests_in_pol"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -848,6 +829,7 @@ BLR_pol_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_parlament_pol_places"
 			set_country_flag = BLR_poland_parlament_belarus_agent_flag
 			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
@@ -860,9 +842,6 @@ BLR_pol_revol_category = {
 				set_temp_variable = { temp_outlook_increase = 0.08 }
 				change_relative_party_popularity = yes
 			}
-		}
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_parlament_pol_places"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -966,6 +945,7 @@ BLR_Lukashenko_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_send_russian_omon"
 			set_temp_variable = { percent_change = 5.00 }
 			set_temp_variable = { tag_index = SOV }
 			change_influence_percentage = yes
@@ -1008,6 +988,7 @@ BLR_Lukashenko_category = {
 		cost = 50
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_go_to_jail_scum"
 			add_stability = -0.15
 			add_popularity = {
 				ideology = neutrality
@@ -1046,6 +1027,7 @@ BLR_Lukashenko_category = {
 		cost = 35
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_trade_with_iraq"
 			add_opinion_modifier = {
 				target = IRQ
 				modifier = declaration_of_friendship
@@ -1119,6 +1101,7 @@ BLR_Lukashenko_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Great_stone_china"
 			one_office_construction = yes
 			set_temp_variable = { percent_change = 7 }
 			set_temp_variable = { tag_index = CHI }
@@ -1172,6 +1155,7 @@ BLR_Lukashenko_category = {
 		cost = 40
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_belorusisation_samogitia"
 			BLR = {
 				add_state_core = 109
 			}
@@ -1195,6 +1179,7 @@ BLR_Lukashenko_category = {
 		cost = 40
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_belorusisation_klaipeda"
 			BLR = {
 				add_state_core = 1043
 			}
@@ -1218,6 +1203,7 @@ BLR_Lukashenko_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_belorusisation_sudovia"
 			BLR = {
 				add_state_core = 1044
 			}
@@ -1243,6 +1229,7 @@ BLR_Lukashenko_category = {
 		cost = 40
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_belorusisation_vilnius"
 			BLR = {
 				add_state_core = 110
 			}
@@ -1324,16 +1311,13 @@ BLR_Kommunarka_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Kazakhstan"
 			set_country_flag = BLR_kommunarka_kazakhstan_flag
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = KAZ }
 			change_influence_percentage = yes
 		}
 		ai_will_do = { base = 100 }
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Kazakhstan"
-
-		}
 	}
 	BLR_Go_to_Georgia = {
 		icon = GFX_decision_komminarka_button
@@ -1352,16 +1336,13 @@ BLR_Kommunarka_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Georgia"
 			set_country_flag = BLR_kommunarka_georgia_flag
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = GEO }
 			change_influence_percentage = yes
 		}
 		ai_will_do = { base = 100 }
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Georgia"
-
-		}
 	}
 	BLR_Go_to_Moldova = {
 		icon = GFX_decision_komminarka_button
@@ -1380,16 +1361,13 @@ BLR_Kommunarka_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Moldova"
 			set_country_flag = BLR_kommunarka_moldova_flag
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = MLV }
 			change_influence_percentage = yes
 		}
 		ai_will_do = { base = 100 }
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Moldova"
-
-		}
 	}
 	BLR_Go_to_Armenia = {
 		icon = GFX_decision_komminarka_button
@@ -1409,16 +1387,13 @@ BLR_Kommunarka_category = {
 
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Armenia"
 			set_country_flag = BLR_kommunarka_armenia_flag
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = ARM }
 			change_influence_percentage = yes
 		}
 		ai_will_do = { base = 100 }
-		complete_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BLR_Go_to_Armenia"
-
-		}
 	}
 	BLR_Produst_all_CIS = {
 		icon = GFX_decision_komminarka_button
@@ -1494,6 +1469,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Poland"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1534,6 +1510,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Germany"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1573,6 +1550,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_France"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1611,6 +1589,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Norway"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1650,6 +1629,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Sweden"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1690,6 +1670,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Russia"
 			set_country_flag = BLR_pending_offer
 			SOV = { country_event = belarus_azot.1 }
 		}
@@ -1723,6 +1704,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Ukraine"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1762,6 +1744,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Kazahstan"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1801,6 +1784,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Czechia"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1840,6 +1824,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Netherland"
 			set_country_flag = BLR_pending_offer
 			if = {
 				limit = { tag = SOV }
@@ -1880,6 +1865,7 @@ BLR_Azot_category = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BLR_mission_to_Zimbabwe"
 			set_country_flag = BLR_pending_offer
 			ZIM = { country_event = belarus_azot.1 }
 		}

--- a/common/decisions/Bosnia.txt
+++ b/common/decisions/Bosnia.txt
@@ -171,6 +171,7 @@ BOS_return_of_entitled_lands = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_core_states_2"
 			add_stability = -0.05
 			FROM = { add_core_of = ROOT }
 			transfer_state = FROM
@@ -494,6 +495,7 @@ BOS_internal_factions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_quell_serbians"
 			add_stability = 0.13
 			add_war_support = 0.12
 			BOS_srpska_attitude_decrease_effect = yes
@@ -608,6 +610,7 @@ BOS_internal_factions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_quell_bosniaks"
 			add_stability = 0.13
 			add_war_support = 0.12
 			BOS_bosniak_attitude_decrease_effect = yes
@@ -688,6 +691,7 @@ BOS_internal_factions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_quell_croats"
 			BOS_croat_attitude_decrease_effect = yes
 			BOS_croat_stability_decrease_effect = yes
 			add_stability = 0.13
@@ -1807,6 +1811,7 @@ BOS_eu_accession = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_eu_market_alignment"
 			custom_effect_tooltip = BOS_market_aligned_with_eu_tt
 			set_country_flag = BOS_market_aligned_with_eu
 			add_ideas = BOS_eu_accession_funds
@@ -2077,6 +2082,7 @@ BOS_dayton_pressure = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_request_international_arbitration"
 			remove_ideas = BOS_republika_srpska_secession_crisis
 		}
 
@@ -2209,6 +2215,7 @@ BOS_economic_development = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_public_procurement_reform"
 			decrease_corruption = yes
 			custom_effect_tooltip = BOS_transparent_procurement_tt
 			set_country_flag = BOS_transparent_procurement
@@ -2300,6 +2307,7 @@ BOS_economic_development = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOS_diaspora_return_program"
 			add_ideas = BOS_diaspora_returnees
 			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes

--- a/common/decisions/Botswana.txt
+++ b/common/decisions/Botswana.txt
@@ -28,6 +28,7 @@ BOT_anti_poaching_decisions = {
 		days_re_enable = 1
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOT_bi_yearly_poaching_report"
 			if = {
 				limit = { check_variable = { no_of_poachers < 50 } }
 				BOT_decrease_desertification_rate = yes
@@ -169,10 +170,12 @@ BOT_anti_poaching_decisions = {
 		fixed_random_seed = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOT_anti_poaching_dehorn_rhinos"
 			BOT_increase_desertification_rate = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BOT_anti_poaching_dehorn_rhinos"
 			random_list = {
 				75 = {
 					country_event = Botswana_events.5

--- a/common/decisions/Cartel Decisions.txt
+++ b/common/decisions/Cartel Decisions.txt
@@ -17,6 +17,7 @@ cartels_decision_category = {
 		days_re_enable = 30
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision anti_cartel_propaganda_decision"
 			set_temp_variable = { additional_expense_change = gdp_total }
 			multiply_temp_variable = { additional_expense_change = 0.002 }
 			custom_effect_tooltip = additional_expense_rate_percent_tt
@@ -1655,10 +1656,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_baja_california_sinaloa_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_baja_california_sinaloa_cartel"
 
 			random_list = {
 				25 = {
@@ -1766,10 +1769,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_baja_california_tierra_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_baja_california_tierra_cartel"
 
 			random_list = {
 				25 = {
@@ -1877,10 +1882,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_sonora_sinaloa_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_sonora_sinaloa_cartel"
 
 			random_list = {
 				25 = {
@@ -1987,10 +1994,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_chihuahua_sinola_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_chihuahua_sinola_cartel"
 
 			random_list = {
 				25 = {
@@ -2097,10 +2106,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_sinola_durango_sinola_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_sinola_durango_sinola_cartel"
 
 			random_list = {
 				25 = {
@@ -2207,10 +2218,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_coahuila_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_coahuila_tamaulipas_cartel"
 
 			random_list = {
 				25 = {
@@ -2319,10 +2332,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_guanajuato_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_guanajuato_tamaulipas_cartel"
 
 			random_list = {
 				25 = {
@@ -2430,10 +2445,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_nuevo_leon_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_nuevo_leon_tamaulipas_cartel"
 
 			random_list = {
 				25 = {
@@ -2541,10 +2558,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_jalisco_tierra_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_jalisco_tierra_cartel"
 
 			random_list = {
 				25 = {
@@ -2652,10 +2671,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_guerrero_oaxaco_tierra_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_guerrero_oaxaco_tierra_cartel"
 
 			random_list = {
 				25 = {
@@ -2763,10 +2784,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_mexico_tierra_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_mexico_tierra_cartel"
 
 			random_list = {
 				25 = {
@@ -2872,10 +2895,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_mexico_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_mexico_tamaulipas_cartel"
 
 			random_list = {
 				25 = {
@@ -2981,10 +3006,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_mexico_sinaloa_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_mexico_sinaloa_cartel"
 
 			random_list = {
 				25 = {
@@ -3091,10 +3118,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_veracruz_tierra_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_veracruz_tierra_cartel"
 
 			random_list = {
 				25 = {
@@ -3200,10 +3229,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_veracruz_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_veracruz_tamaulipas_cartel"
 
 			random_list = {
 				25 = {
@@ -3310,10 +3341,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_chiapas_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_chiapas_tamaulipas_cartel"
 
 			random_list = {
 				25 = {
@@ -3420,10 +3453,12 @@ cartels_decision_category = {
 		cancel_if_not_visible = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_yucatan_tamaulipas_cartel"
 			set_country_flag = MEX_already_attacking_cartels_flag
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MEX_yucatan_tamaulipas_cartel"
 
 			random_list = {
 				25 = {

--- a/common/decisions/Chechnya.txt
+++ b/common/decisions/Chechnya.txt
@@ -16,6 +16,7 @@ CHE_nationalise_caucas_category = {
 			owns_state = 711
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_nationalise_armenia"
 			ARM = { every_core_state = { add_core_of = CHE } }
 		}
 
@@ -38,6 +39,7 @@ CHE_nationalise_caucas_category = {
 			owns_state = 1038
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_nationalise_azer"
 			AZE = { every_core_state = { add_core_of = CHE } }
 		}
 
@@ -60,6 +62,7 @@ CHE_nationalise_caucas_category = {
 			owns_state = 466
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_nationalise_georgia"
 			GEO = { every_core_state = { add_core_of = CHE } }
 		}
 
@@ -79,6 +82,7 @@ CHE_nationalise_caucas_category = {
 			owns_state = 706
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_nationalise_abkhazia"
 			ABK = { every_core_state = { add_core_of = CHE } }
 		}
 
@@ -100,6 +104,7 @@ CHE_nationalise_caucas_category = {
 			owns_state = 1036
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_nationalise_karabah"
 			NKR = { every_core_state = { add_core_of = CHE } }
 		}
 
@@ -119,6 +124,7 @@ CHE_nationalise_caucas_category = {
 			owns_state = 705
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_nationalise_ossetia"
 			SOO = { every_core_state = { add_core_of = CHE } }
 		}
 		ai_will_do = { base = 0 }
@@ -143,6 +149,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connections_aze"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -158,6 +165,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connections_aze"
 			clr_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -183,6 +191,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movements_aze"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -199,6 +208,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = zsr_aze_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movements_aze"
 			set_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -224,6 +234,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agenda"
 			set_temp_variable = { percent_change = 2.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -239,6 +250,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = zsr_aze_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agenda"
 			set_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -264,6 +276,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_aze_places"
 			set_temp_variable = { percent_change = 3.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -279,6 +292,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = zsr_aze_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_aze_places"
 			set_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -312,6 +326,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_aze_revol"
 			set_temp_variable = { percent_change = 5.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -357,6 +372,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connections_geo"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -370,6 +386,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connections_geo"
 			clr_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -395,6 +412,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movements_geo"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -411,6 +429,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = zsr_geo_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movements_geo"
 			set_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -436,6 +455,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agenda_geo"
 			set_temp_variable = { percent_change = 2.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -451,6 +471,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = 	zsr_geo_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agenda_geo"
 			set_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -476,6 +497,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_geo_places"
 			set_temp_variable = { percent_change = 3.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -491,6 +513,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = 	zsr_geo_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_geo_places"
 			set_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -524,6 +547,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_geo_revol"
 			set_temp_variable = { percent_change = 5.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -569,6 +593,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connections_arm"
 			set_country_flag = Establish_connections_arm_kom
 			ARM = {
 				set_temp_variable = { party_index = 19 }
@@ -582,6 +607,7 @@ CHE_caucasian_revol_category = {
 			change_influence_percentage = yes
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connections_arm"
 			clr_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -607,6 +633,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movements_arm"
 			set_temp_variable = { treasury_change = -0.25 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 2.11 }
@@ -623,6 +650,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = zsr_arm_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movements_arm"
 			set_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -648,6 +676,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agenda_arm"
 			set_temp_variable = { percent_change = 2.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = ARM }
@@ -663,6 +692,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = 	zsr_arm_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agenda_arm"
 			set_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -688,6 +718,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_arm_places"
 			set_temp_variable = { percent_change = 4.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = ARM }
@@ -703,6 +734,7 @@ CHE_caucasian_revol_category = {
 			clr_country_flag = 	zsr_arm_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_arm_places"
 			set_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -736,6 +768,7 @@ CHE_caucasian_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_arm_revol"
 			set_temp_variable = { percent_change = 5.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = ARM }
@@ -783,6 +816,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connectionsz_aze"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -798,6 +832,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connectionsz_aze"
 			clr_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -823,6 +858,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movementsz_aze"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -839,6 +875,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = zsr_aze_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movementsz_aze"
 			set_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -864,6 +901,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partysz_agenda"
 			set_temp_variable = { percent_change = 2.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -879,6 +917,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = zsr_aze_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partysz_agenda"
 			set_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -904,6 +943,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_azez_places"
 			set_temp_variable = { percent_change = 3.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -919,6 +959,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = zsr_aze_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_azez_places"
 			set_country_flag = zsr_aze_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -952,6 +993,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_azez_revol"
 			set_temp_variable = { percent_change = 5.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = AZE }
@@ -998,6 +1040,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connectionsz_geo"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -1011,6 +1054,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connectionsz_geo"
 			clr_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1036,6 +1080,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movementsz_geo"
 			set_temp_variable = { percent_change = 1.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -1052,6 +1097,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = zsr_geo_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movementsz_geo"
 			set_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1077,6 +1123,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agendaz_geo"
 			set_temp_variable = { percent_change = 2.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -1092,6 +1139,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = 	zsr_geo_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agendaz_geo"
 			set_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1117,6 +1165,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_geoz_places"
 			set_temp_variable = { percent_change = 3.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -1132,6 +1181,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = 	zsr_geo_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_geoz_places"
 			set_country_flag = zsr_geo_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1165,6 +1215,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_geoz_revol"
 			set_temp_variable = { percent_change = 5.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = GEO }
@@ -1211,6 +1262,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connectionsz_arm"
 			set_country_flag = Establish_connections_arm_com
 			ARM = {
 				set_temp_variable = { party_index = 19 }
@@ -1224,6 +1276,7 @@ CHE_caucasians_revol_category = {
 			change_influence_percentage = yes
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Establish_connectionsz_arm"
 			clr_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1249,6 +1302,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movementsz_arm"
 			set_temp_variable = { treasury_change = -0.25 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 2.11 }
@@ -1265,6 +1319,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = zsr_arm_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Financing_of_protest_movementsz_arm"
 			set_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1290,6 +1345,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agendaz_arm"
 			set_temp_variable = { percent_change = 2.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = ARM }
@@ -1305,6 +1361,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = 	zsr_arm_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_Strengthen_com_partys_agendaz_arm"
 			set_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1330,6 +1387,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_armz_places"
 			set_temp_variable = { percent_change = 4.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = ARM }
@@ -1345,6 +1403,7 @@ CHE_caucasians_revol_category = {
 			clr_country_flag = 	zsr_arm_revol2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_parlament_armz_places"
 			set_country_flag = zsr_arm_revol2
 		}
 		ai_will_do = { base = 0 }
@@ -1372,6 +1431,7 @@ CHE_caucasians_revol_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CHE_armz_revol"
 			set_temp_variable = { percent_change = 5.11 }
 			set_temp_variable = { tag_index = CHE }
 			set_temp_variable = { influence_target = ARM }

--- a/common/decisions/Child Soldiers.txt
+++ b/common/decisions/Child Soldiers.txt
@@ -130,6 +130,7 @@ child_soldiers_category = {
 		custom_cost_text = cost_0_5
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision Subsidize_Reintegration"
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
 		}

--- a/common/decisions/Cuba.txt
+++ b/common/decisions/Cuba.txt
@@ -915,6 +915,7 @@ CUB_alba_category = {
 			country_event = { id = cuba.21 days = 1 }
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CUB_alba_ticker_mission"
 			add_stability = -0.12
 			add_political_power = -100
 			country_event = { id = cuba.22 days = 1 }

--- a/common/decisions/Cuba.txt
+++ b/common/decisions/Cuba.txt
@@ -911,6 +911,7 @@ CUB_alba_category = {
 			}
 		}
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CUB_alba_ticker_mission"
 			add_stability = 0.12
 			country_event = { id = cuba.21 days = 1 }
 		}

--- a/common/decisions/Czech_Republic.txt
+++ b/common/decisions/Czech_Republic.txt
@@ -5955,6 +5955,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_common_border_controls"
 			add_political_power = 70
 		}
 
@@ -5990,6 +5991,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_mutual_investments"
 			add_political_power = 70
 		}
 
@@ -6032,6 +6034,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_joint_military_exercises_1"
 			add_political_power = 70
 		}
 
@@ -6060,6 +6063,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_joint_military_exercises_2"
 			add_political_power = 70
 		}
 
@@ -6092,6 +6096,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_common_diplomacy"
 			add_political_power = 70
 		}
 
@@ -6132,6 +6137,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_border_removal_1"
 			add_political_power = 70
 		}
 
@@ -6219,6 +6225,7 @@ CZE_SLO_monarchy_reunite = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_border_removal_2"
 			add_political_power = 70
 		}
 

--- a/common/decisions/Czech_Republic.txt
+++ b/common/decisions/Czech_Republic.txt
@@ -27,6 +27,7 @@ CZE_vop_cz_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_quick_modernization"
 			add_timed_idea = { idea = CZE_production_slowdown_idea days = 45 }
 			custom_effect_tooltip = CZE_quick_modernization_tooltip
 			add_to_variable = { CZE_skoda_tech_slots = 1 }
@@ -77,6 +78,7 @@ CZE_vop_cz_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_research_grants_utility"
 			hidden_effect = {
 				CZE_research_grants_utility_effect = yes
 			}
@@ -130,6 +132,7 @@ CZE_vop_cz_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_research_grants_czech"
 			hidden_effect = {
 				CZE_research_grants_czech_effect = yes
 			}
@@ -182,6 +185,7 @@ CZE_vop_cz_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_research_grants_mbt"
 			hidden_effect = {
 				CZE_research_grants_mbt_effect = yes
 			}
@@ -257,6 +261,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_change_fuel_injectors"
 			set_temp_variable = { CZE_skoda_balance_change = -5 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -304,6 +309,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_change_fuel_injectors2"
 			set_temp_variable = { CZE_skoda_balance_change = -5 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -353,6 +359,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_stronger_chassis"
 			set_temp_variable = { CZE_skoda_balance_change = -10 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -403,6 +410,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_stronger_chassis2"
 			set_temp_variable = { CZE_skoda_balance_change = -10 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -449,6 +457,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_long_lasting_tires"
 			set_temp_variable = { CZE_skoda_balance_change = -5 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -501,6 +510,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_long_lasting_tires2"
 			set_temp_variable = { CZE_skoda_balance_change = -5 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -552,6 +562,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_simplify_our_manuals"
 			set_temp_variable = { CZE_skoda_balance_change = -1 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -604,6 +615,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_simplify_our_manuals2"
 			set_temp_variable = { CZE_skoda_balance_change = -1 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -655,6 +667,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_invest_in_cheaper_and_better_modules"
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -707,6 +720,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_invest_in_cheaper_and_better_modules2"
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -758,6 +772,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_adaptation_to_every_kind_of_weather"
 			set_temp_variable = { CZE_skoda_balance_change = -10 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -811,6 +826,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_adaptation_to_every_kind_of_weather2"
 			set_temp_variable = { CZE_skoda_balance_change = -10 }
 			CZE_skoda_treasury_add_effect = yes
 			add_to_variable = { CZE_skoda_tech_slots = -1 }
@@ -862,6 +878,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_setellite_communication_systems"
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -914,6 +931,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_setellite_communication_systems2"
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -965,6 +983,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_meb_battery_system"
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -1017,6 +1036,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_meb_battery_system2"
 			set_temp_variable = { CZE_skoda_balance_change = -15 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -1067,6 +1087,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_skoda_superb_iii_expansion_of_skoda_laboratories"
 			set_temp_variable = { CZE_skoda_balance_change = -200 }
 			CZE_skoda_treasury_add_effect = yes
 			add_to_variable = { CZE_skoda_tech_slots = -2 }
@@ -1119,6 +1140,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_new_production_line_in_mlada_boleslav"
 			set_temp_variable = { CZE_skoda_balance_change = -32 }
 			CZE_skoda_treasury_add_effect = yes
 			add_to_variable = { CZE_skoda_tech_slots = -2 }
@@ -1166,6 +1188,7 @@ CZE_skoda_laboratories_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_skoda_enyak_iv_development"
 			set_temp_variable = { CZE_skoda_balance_change = -40 }
 			CZE_skoda_treasury_add_effect = yes
 			add_to_variable = { CZE_skoda_tech_slots = -2 }
@@ -1221,6 +1244,7 @@ CZE_skoda_superb_cars_export_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_borrow_state_factory"
 			add_to_variable = { CZE_skoda_superb_cars_factories = -1 }
 			custom_effect_tooltip = CZE_skoda_superb_cars_remove_factory_tooltip
 			CZE_skoda_superb_cars_calculate_factories = yes
@@ -1251,6 +1275,7 @@ CZE_skoda_superb_cars_export_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_expand_kvasiny_factory"
 			add_to_variable = { CZE_skoda_superb_cars_factories = 1 }
 			custom_effect_tooltip = CZE_skoda_superb_cars_add_factory_tooltip
 			CZE_skoda_superb_cars_calculate_factories = yes
@@ -1328,6 +1353,7 @@ CZE_skoda_superb_cars_export_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_open_aurangabad_factory"
 			add_to_variable = { CZE_skoda_superb_cars_factories = 1 }
 			custom_effect_tooltip = CZE_skoda_superb_cars_add_factory_tooltip
 			CZE_skoda_superb_cars_calculate_factories = yes
@@ -1363,6 +1389,7 @@ CZE_skoda_superb_cars_export_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_open_nanjing_factory"
 			add_to_variable = { CZE_skoda_superb_cars_factories = 1 }
 			custom_effect_tooltip = CZE_skoda_superb_cars_add_factory_tooltip
 			CZE_skoda_superb_cars_calculate_factories = yes
@@ -1397,6 +1424,7 @@ CZE_skoda_superb_cars_export_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_sell_everything"
 			add_to_variable = { CZE_skoda_superb_cars_factories = -1 }
 			custom_effect_tooltip = CZE_skoda_superb_cars_remove_factory_tooltip
 		}
@@ -1467,6 +1495,7 @@ CZE_electric_highway_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_open_planning_phase"
 			set_country_flag = CZE_electric_highway_planned
 		}
 
@@ -1502,6 +1531,7 @@ CZE_electric_highway_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_prepare_construction_site"
 			set_country_flag = CZE_prepare_construction_site_finished
 		}
 
@@ -1536,6 +1566,7 @@ CZE_electric_highway_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_build_one_kilometer_of_electric_highway"
 			if = {
 				limit = {
 					has_country_flag = CZE_set_up_location_in_bohemia_flag
@@ -1626,6 +1657,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_take_part_in_new_technology_research"
 			random_list = {
 				33 = {
 					add_tech_bonus = {
@@ -2304,6 +2336,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_talk_to_seat"
 			set_country_flag = CZE_skoda_talking_to_company
 		}
 
@@ -2374,6 +2407,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_talk_to_lamborghini"
 			set_country_flag = CZE_skoda_talking_to_company
 		}
 
@@ -2444,6 +2478,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_talk_to_bentley"
 			set_country_flag = CZE_skoda_talking_to_company
 		}
 
@@ -2514,6 +2549,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_talk_to_bugatti"
 			set_country_flag = CZE_skoda_talking_to_company
 		}
 
@@ -2584,6 +2620,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_convince_seat_to_stay_with_volkswagen"
 			set_country_flag = CZE_volkswagen_talking_to_company
 		}
 
@@ -2654,6 +2691,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_convince_lamborghini_to_stay_with_volkswagen"
 			set_country_flag = CZE_volkswagen_talking_to_company
 		}
 
@@ -2724,6 +2762,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_convince_bentley_to_stay_with_volkswagen"
 			set_country_flag = CZE_volkswagen_talking_to_company
 		}
 
@@ -2794,6 +2833,7 @@ CZE_volkswagen_group_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_convince_bugatti_to_stay_with_volkswagen"
 			set_country_flag = CZE_volkswagen_talking_to_company
 		}
 
@@ -3051,6 +3091,7 @@ CZE_cesky_motor_energy_holding = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_buy_back_full_production_license"
 			set_temp_variable = { CZE_skoda_balance_change = -50 }
 			CZE_skoda_treasury_add_effect = yes
 			custom_effect_tooltip = POL_line_TT
@@ -3413,6 +3454,7 @@ CZE_new_nuclear_power_plant_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_gather_funds"
 			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 		}
@@ -3445,6 +3487,7 @@ CZE_new_nuclear_power_plant_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_construction_site"
 			subtract_from_variable = { CZE_power_plants_funds = 50 }
 			set_country_flag = CZE_reactor_upgrade
 		}
@@ -3480,6 +3523,7 @@ CZE_new_nuclear_power_plant_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_additional_laboratory_equipment"
 			subtract_from_variable = { CZE_power_plants_funds = 50 }
 			set_country_flag = CZE_reactor_upgrade
 			custom_effect_tooltip = CZE_construction_site2_tooltip
@@ -3521,6 +3565,7 @@ CZE_new_nuclear_power_plant_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_start_with_better_fuel"
 			subtract_from_variable = { CZE_power_plants_funds = 100 }
 			set_country_flag = CZE_reactor_upgrade
 			custom_effect_tooltip = CZE_construction_site3_tooltip
@@ -3556,6 +3601,7 @@ CZE_new_nuclear_power_plant_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_thermonuclear_reactor"
 			subtract_from_variable = { CZE_power_plants_funds = 100 }
 			set_country_flag = CZE_reactor_upgrade
 			custom_effect_tooltip = CZE_construction_site3_tooltip
@@ -3602,6 +3648,7 @@ CZE_new_nuclear_power_plant_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_finish_construction"
 			set_country_flag = CZE_reactor_upgrade
 		}
 
@@ -4381,6 +4428,7 @@ CZE_spolu_government_formation_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_begin_the_rearmament"
 			add_command_power = -100
 		}
 
@@ -5128,6 +5176,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_law_sector_change_the_criminal_law"
 			set_country_flag = CZE_SLO_doing_decision
 		}
 
@@ -5199,6 +5248,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_law_sector_change_the_constitutional_law"
 			set_country_flag = CZE_SLO_doing_decision
 		}
 
@@ -5270,6 +5320,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_law_sector_change_the_civil_law"
 			set_country_flag = CZE_SLO_doing_decision
 		}
 
@@ -5341,6 +5392,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_law_sector_change_the_labor_law"
 			set_country_flag = CZE_SLO_doing_decision
 		}
 
@@ -5525,6 +5577,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_military_sector_organize_new_training_program"
 			hidden_effect = {
 				add_command_power = -15
 			}
@@ -5574,6 +5627,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_military_sector_mutual_officer_trainings"
 			hidden_effect = {
 				add_command_power = -25
 			}
@@ -5685,6 +5739,7 @@ CZE_SLO_czechoslovakia_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_SLO_military_sector_organize_military_structure"
 			hidden_effect = {
 				add_command_power = -25
 			}
@@ -5759,6 +5814,7 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_first_renovation"
 			set_temp_variable = { treasury_change = -8 }
 			modify_treasury_effect = yes
 		}
@@ -5789,6 +5845,7 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_second_renovation"
 			set_temp_variable = { treasury_change = -8 }
 			modify_treasury_effect = yes
 		}
@@ -5822,6 +5879,7 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_third_renovation"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 		}
@@ -5855,6 +5913,7 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_last_renovation"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 		}
@@ -6196,6 +6255,7 @@ CZE_target_monarchy_intromission = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_AUS_expand_the_pressure"
 			AUS = {
 				modify_timed_idea = {
 					idea = CZE_target_foreign_monarchy_intromision
@@ -6233,6 +6293,7 @@ CZE_target_monarchy_intromission = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_HUN_expand_the_pressure"
 			HUN = {
 				modify_timed_idea = {
 					idea = CZE_target_foreign_monarchy_intromision
@@ -6272,6 +6333,7 @@ CZE_AUS_return_of_archduke = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_AUS_prepare_the_media"
 			AUS = {
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -6312,6 +6374,7 @@ CZE_AUS_return_of_archduke = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_AUS_support_promonarchists"
 			AUS = {
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.1 }
@@ -6353,6 +6416,7 @@ CZE_AUS_return_of_archduke = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_AUS_reform_one_castle"
 			AUS = {
 				set_temp_variable = { party_index = 23 }
 				set_temp_variable = { party_popularity_increase = 0.15 }
@@ -6397,6 +6461,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_foreing_embassies"
 			country_event = { id = CZE_prague_conference_event.12 days = 30 }
 
 			add_to_variable = {
@@ -6438,6 +6503,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_foreign_treaties"
 			country_event = CZE_prague_conference_event.13
 			add_to_variable = {
 				var = CZE_the_prague_conference_var
@@ -6476,6 +6542,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_create_a_plan_for_monarchies"
 			country_event = CZE_prague_conference_event.14
 
 			add_to_variable = {
@@ -6512,6 +6579,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_land_exercises"
 			AUS = {
 				country_event = CZE_prague_conference_event.1
 			}
@@ -6587,6 +6655,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_air_exercises"
 			AUS = {
 				country_event = CZE_prague_conference_event.2
 			}
@@ -6667,6 +6736,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_share_common_knowledge_in_naval_tactics"
 			AUS = {
 				country_event = CZE_prague_conference_event.3
 			}
@@ -6747,6 +6817,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_share_military_intel"
 			if = { limit = { country_exists = AUS }
 				AUS = {
 					country_event = CZE_prague_conference_event.4
@@ -6821,6 +6892,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_share_military_breakthroughs"
 			if = { limit = { country_exists = AUS }
 				AUS = {
 					country_event = CZE_prague_conference_event.5
@@ -6918,6 +6990,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_debt"
 			add_to_variable = {
 				var = CZE_the_prague_conference_var
 				value = 1
@@ -6964,6 +7037,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_civilian_investment_in_rural_areas"
 			country_event = CZE_prague_conference_event.16
 			add_to_variable = {
 				var = CZE_the_prague_conference_var
@@ -7010,6 +7084,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_infrastructure_of_an_empire"
 			121 = {
 				add_building_construction = {
 					type = infrastructure
@@ -7103,6 +7178,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_skoda_learnings"
 			CZE = { country_event = CZE_prague_conference_event.17 }
 
 			clr_country_flag = CZE_the_prague_conference_ongoing_decision_flag
@@ -7132,6 +7208,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_common_education_plan"
 			if = { limit = { country_exists = AUS }
 				AUS = {
 					country_event = CZE_prague_conference_event.6
@@ -7198,6 +7275,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_common_police_action_plan"
 			if = { limit = { country_exists = AUS }
 				AUS = {
 					country_event = CZE_prague_conference_event.7
@@ -7260,6 +7338,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_common_welfare_plan"
 			if = { limit = { country_exists = AUS }
 				AUS = {
 					country_event = CZE_prague_conference_event.8
@@ -7322,6 +7401,7 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_the_kings_congress"
 			CZE_prague_conference_decision_ongoing = yes
 		}
 
@@ -7456,6 +7536,7 @@ CZE_fidesz_problem = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_prepare_national_spies"
 			create_intelligence_agency = yes
 			upgrade_intelligence_agency = upgrade_economy_civilian
 			hidden_effect = {
@@ -7505,6 +7586,7 @@ CZE_fidesz_problem = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_infiltrate_in_young_sphere"
 			clr_country_flag = CZE_manipulating_fidesz
 
 			custom_effect_tooltip = CZE_fidesz_decisions
@@ -7554,6 +7636,7 @@ CZE_fidesz_problem = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_infiltrate_in_the_national_party"
 			clr_country_flag = CZE_manipulating_fidesz
 
 			custom_effect_tooltip = CZE_fidesz_decisions
@@ -7596,6 +7679,7 @@ CZE_fidesz_problem = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_pressure_low_level_politicians"
 			clr_country_flag = CZE_manipulating_fidesz
 
 			custom_effect_tooltip = CZE_fidesz_decisions
@@ -7639,6 +7723,7 @@ CZE_fidesz_problem = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_pressure_high_level_politicians"
 			clr_country_flag = CZE_manipulating_fidesz
 
 			custom_effect_tooltip = CZE_fidesz_decisions
@@ -7666,6 +7751,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_create_fake_media"
 			add_political_power = 50
 			clr_country_flag = CZE_on_going_political_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
@@ -7692,6 +7778,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_anti_hungarian_association"
 			add_opinion_modifier = {
 				target = HUN
 				modifier = CZE_hate_to_hungary
@@ -7729,6 +7816,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_weaknesses_of_the_republic"
 			add_political_power = 50
 			clr_country_flag = CZE_on_going_political_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
@@ -7761,6 +7849,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_free_movement"
 			add_political_power = 50
 			clr_country_flag = CZE_on_going_political_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
@@ -7794,6 +7883,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_ukraine_investments"
 			clr_country_flag = CZE_on_going_economical_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
 
@@ -7835,6 +7925,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_rebuild_the_railway_in_ROM"
 			clr_country_flag = CZE_on_going_economical_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
 
@@ -7903,6 +7994,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_rebuild_the_railway_in_CZE"
 			add_political_power = 50
 			clr_country_flag = CZE_on_going_economical_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
@@ -7940,6 +8032,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_e58_development"
 			add_political_power = 50
 			clr_country_flag = CZE_on_going_economical_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
@@ -7996,6 +8089,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_share_military_knowledge"
 			army_experience = 20
 			air_experience = 20
 			clr_country_flag = CZE_on_going_military_decision_ROM
@@ -8030,6 +8124,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_pressure_nato"
 			USA = { country_event = CZE_HUN_monarchy_event.43 }
 			clr_country_flag = CZE_on_going_military_decision_ROM
 			add_to_variable = { CZE_ROM_decisions_completed = 1 }
@@ -8060,6 +8155,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_military_exercises"
 			army_experience = 20
 			air_experience = 20
 			clr_country_flag = CZE_on_going_military_decision_ROM
@@ -8095,6 +8191,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_sabotage_infrastructure"
 			HUN = {
 				random_state = {
 					damage_building = {
@@ -8142,6 +8239,7 @@ CZE_bucarest_meeting = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_learn_modern_naval_strategies"
 			navy_experience = 50
 			add_tech_bonus = {
 				name = CZE_learn_modern_naval_strategies

--- a/common/decisions/Czech_Republic.txt
+++ b/common/decisions/Czech_Republic.txt
@@ -5851,9 +5851,8 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		remove_effect = {
-			clear_variable = first_renovation_completed
-
 			log = "[GetDateText]: [Root.GetName]: Decision CZE_second_renovation"
+			clear_variable = first_renovation_completed
 
 			set_variable = { second_renovation_completed = yes }
 		}
@@ -5885,9 +5884,8 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		remove_effect = {
-			clear_variable = second_renovation_completed
-
 			log = "[GetDateText]: [Root.GetName]: Decision CZE_third_renovation"
+			clear_variable = second_renovation_completed
 
 			set_variable = { third_renovation_completed = yes }
 		}
@@ -5919,9 +5917,8 @@ CZE_prague_castle_renovation_decisions = {
 		}
 
 		remove_effect = {
-			clear_variable = third_renovation_completed
-
 			log = "[GetDateText]: [Root.GetName]: Decision CZE_last_renovation"
+			clear_variable = third_renovation_completed
 
 			country_event = CZE_monarchy_event.17
 		}
@@ -6248,10 +6245,10 @@ CZE_target_monarchy_intromission = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_AUS_expand_the_pressure decision"
 			ROOT = {
 				add_political_power = -50
 			}
-			log = "[GetDateText]: [Root.GetName]: CZE_AUS_expand_the_pressure decision"
 		}
 
 		remove_effect = {
@@ -6286,10 +6283,10 @@ CZE_target_monarchy_intromission = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_HUN_expand_the_pressure decision"
 			ROOT = {
 				add_political_power = -50
 			}
-			log = "[GetDateText]: [Root.GetName]: CZE_HUN_expand_the_pressure decision"
 		}
 
 		remove_effect = {
@@ -6327,9 +6324,9 @@ CZE_AUS_return_of_archduke = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_AUS_return_of_archduke decision"
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [Root.GetName]: CZE_AUS_return_of_archduke decision"
 		}
 
 		remove_effect = {
@@ -6364,9 +6361,9 @@ CZE_AUS_return_of_archduke = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_AUS_support_promonarchists decision"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [Root.GetName]: CZE_AUS_support_promonarchists decision"
 		}
 
 		modifier = {
@@ -6406,9 +6403,9 @@ CZE_AUS_return_of_archduke = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_AUS_reform_one_castle decision"
 			set_temp_variable = { treasury_change = -18 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [Root.GetName]: CZE_AUS_reform_one_castle decision"
 		}
 
 		modifier = {
@@ -6456,8 +6453,8 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
-			CZE_prague_conference_decision_ongoing = yes
 			log = "[GetDateText]: [Root.GetName]: Decision CZE_joint_foreing_embassies"
+			CZE_prague_conference_decision_ongoing = yes
 		}
 
 		remove_effect = {
@@ -6497,8 +6494,8 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
-			CZE_prague_conference_decision_ongoing = yes
 			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_foreign_treaties"
+			CZE_prague_conference_decision_ongoing = yes
 
 		}
 
@@ -6537,8 +6534,8 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
-			CZE_prague_conference_decision_ongoing = yes
 			log = "[GetDateText]: [Root.GetName]: Decision CZE_create_a_plan_for_monarchies"
+			CZE_prague_conference_decision_ongoing = yes
 		}
 
 		remove_effect = {
@@ -6980,9 +6977,9 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_debt"
 			CZE_prague_conference_decision_ongoing = yes
 			custom_effect_tooltip = CZE_debt_unification
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_shared_debt"
 		}
 
 		modifier = {
@@ -7025,11 +7022,11 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_civilian_investment_in_rural_areas"
 			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 
 			CZE_prague_conference_decision_ongoing = yes
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_civilian_investment_in_rural_areas"
 		}
 
 		modifier = {
@@ -7072,11 +7069,11 @@ CZE_the_prague_conference_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision CZE_infrastructure_of_an_empire"
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 
 			CZE_prague_conference_decision_ongoing = yes
-			log = "[GetDateText]: [Root.GetName]: Decision CZE_infrastructure_of_an_empire"
 		}
 
 		modifier = {
@@ -7530,9 +7527,9 @@ CZE_fidesz_problem = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_prepare_national_spies decision"
 			set_temp_variable = { treasury_change = -8 }
 			modify_treasury_effect = yes
-			log = "[GetDateText]: [Root.GetName]: CZE_prepare_national_spies decision"
 		}
 
 		remove_effect = {
@@ -7566,13 +7563,12 @@ CZE_fidesz_problem = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_infiltrate_in_young_sphere decision"
 			CZE_intel_bonus_effect = yes
 
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			set_country_flag = CZE_manipulating_fidesz
-
-			log = "[GetDateText]: [Root.GetName]: CZE_infiltrate_in_young_sphere decision"
 
 			HUN = {
 				subtract_from_variable = {
@@ -7614,10 +7610,10 @@ CZE_fidesz_problem = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_infiltrate_in_the_national_party decision"
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			set_country_flag = CZE_manipulating_fidesz
-			log = "[GetDateText]: [Root.GetName]: CZE_infiltrate_in_the_national_party decision"
 			CZE_intel_bonus_effect = yes
 
 			HUN = {
@@ -7665,10 +7661,10 @@ CZE_fidesz_problem = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_pressure_low_level_politicians decision"
 			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			set_country_flag = CZE_manipulating_fidesz
-			log = "[GetDateText]: [Root.GetName]: CZE_pressure_low_level_politicians decision"
 
 			CZE_intel_bonus_effect = yes
 
@@ -7707,10 +7703,10 @@ CZE_fidesz_problem = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: CZE_pressure_high_level_politicians decision"
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
 			set_country_flag = CZE_manipulating_fidesz
-			log = "[GetDateText]: [Root.GetName]: CZE_pressure_high_level_politicians decision"
 
 			CZE_intel_bonus_effect = yes
 

--- a/common/decisions/Denmark.txt
+++ b/common/decisions/Denmark.txt
@@ -493,12 +493,12 @@ DEN_Danish_Defence_Force = {
 			NOT = { has_country_flag = DEN_Reform_The_NCO_Education }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Reform_The_NCO_Education "
 			set_country_flag = DEN_Reform_The_NCO_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = 0.02 tooltip = army_personnel_cost_multiplier_modifier_tt }
 			add_to_variable = { DEN_army_conscription_factor = -0.10 tooltip = conscription_factor_tt }
 			add_to_variable = { DEN_army_supply_factor = -0.05 tooltip = supply_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Reform_The_NCO_Education "
 		}
 		ai_will_do = {
 			base = 1
@@ -519,9 +519,9 @@ DEN_Danish_Defence_Force = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision DEN_Increase_Soldiers_Pay"
 			set_country_flag = DEN_Increase_Soldiers_Pay
 			DEN_soldiers_pay_bonus = yes
-			log = "[GetDateText]: [Root.GetName]: Decision DEN_Increase_Soldiers_Pay"
 		}
 		ai_will_do = {
 			base = 1
@@ -537,10 +537,10 @@ DEN_Danish_Defence_Force = {
 			NOT = { has_country_flag = DEN_Increase_Soldiers_Pay2 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay2 "
 			set_country_flag = DEN_Increase_Soldiers_Pay2
 			clr_country_flag = DEN_Increase_Soldiers_Pay
 			DEN_soldiers_pay_bonus = yes
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay2 "
 		}
 		ai_will_do = {
 			base = 1
@@ -556,10 +556,10 @@ DEN_Danish_Defence_Force = {
 			NOT = { has_country_flag = DEN_Increase_Soldiers_Pay3 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay3 "
 			set_country_flag = DEN_Increase_Soldiers_Pay3
 			clr_country_flag = DEN_Increase_Soldiers_Pay2
 			DEN_soldiers_pay_bonus = yes
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay3 "
 		}
 		ai_will_do = {
 			base = 1
@@ -574,6 +574,7 @@ DEN_Danish_Defence_Force = {
 			NOT = { has_country_flag = DEN_Professional_Soldier_Education }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Professional_Soldier_Education "
 			set_country_flag = DEN_Professional_Soldier_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = 0.02 tooltip = army_personnel_cost_multiplier_modifier_tt }
@@ -581,7 +582,6 @@ DEN_Danish_Defence_Force = {
 			add_to_variable = { DEN_army_max_dig_in = 0.2 tooltip = max_dig_in_tt }
 			add_to_variable = { DEN_army_dig_in_speed_factor = 0.1 tooltip = dig_in_speed_factor_tt }
 			add_to_variable = { DEN_no_supply_grace = 50 tooltip = no_supply_grace_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Professional_Soldier_Education "
 		}
 		ai_will_do = {
 			base = 1
@@ -597,11 +597,11 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_The_Defence_Dental_Plan
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Dental_Plan_Removal"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = -0.02 tooltip = army_personnel_cost_multiplier_modifier_tt }
 			add_to_variable = { DEN_army_org_factor = -0.10 tooltip = army_org_factor_tt }
 			clr_country_flag = DEN_The_Defence_Dental_Plan
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Dental_Plan_Removal"
 		}
 		ai_will_do = {
 			base = 1
@@ -616,11 +616,11 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Civilian_Education
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Civilian_Education_Removal "
 			clr_country_flag = DEN_Civilian_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = -0.05 tooltip = army_personnel_cost_multiplier_modifier_tt }
 			add_to_variable = { DEN_army_conscription_factor = -0.05 tooltip = conscription_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Civilian_Education_Removal "
 		}
 		ai_will_do = {
 			base = 1
@@ -635,12 +635,12 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Regimental_Doctors
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Regimental_Doctors_Removal "
 			clr_country_flag = DEN_Regimental_Doctors
 			clr_country_flag = DEN_Civilian_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = -0.02 tooltip = army_personnel_cost_multiplier_modifier_tt }
 			add_to_variable = { DEN_army_morale = -0.10 tooltip = army_morale_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Regimental_Doctors_Removal "
 		}
 		ai_will_do = {
 			base = 1
@@ -655,13 +655,13 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Theoretical_Officer_Education
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Theoretical_Officer_Education_Removal"
 			clr_country_flag = DEN_Theoretical_Officer_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = -0.05 tooltip = army_personnel_cost_multiplier_modifier_tt }
 			add_to_variable = { DEN_army_command_power_gain = -0.10 tooltip = command_power_gain_tt }
 			add_to_variable = { DEN_army_max_planning = -0.10 tooltip = max_planning_factor_tt }
 			add_to_variable = { DEN_army_planning_speed = 0.10 tooltip = planning_speed_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Theoretical_Officer_Education_Removal"
 		}
 		ai_will_do = {
 			base = 1
@@ -676,12 +676,12 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Reform_The_NCO_Education
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Reform_The_NCO_Education_Removal "
 			clr_country_flag = DEN_Reform_The_NCO_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = 0.02 tooltip = army_personnel_cost_multiplier_modifier_tt }
 			add_to_variable = { DEN_army_conscription_factor = 0.10 tooltip = conscription_factor_tt }
 			add_to_variable = { DEN_army_supply_factor = 0.05 tooltip = supply_factor_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Reform_The_NCO_Education_Removal "
 		}
 		ai_will_do = {
 			base = 1
@@ -696,9 +696,9 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Increase_Soldiers_Pay
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision DEN_Increase_Soldiers_Pay_Removal"
 			clr_country_flag = DEN_Increase_Soldiers_Pay
 			DEN_soldiers_pay_removal = yes
-			log = "[GetDateText]: [Root.GetName]: Decision DEN_Increase_Soldiers_Pay_Removal"
 		}
 		ai_will_do = {
 			base = 1
@@ -713,10 +713,10 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Increase_Soldiers_Pay2
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay_Removal2 "
 			clr_country_flag = DEN_Increase_Soldiers_Pay2
 			set_country_flag = DEN_Increase_Soldiers_Pay
 			DEN_soldiers_pay_removal = yes
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay_Removal2 "
 		}
 		ai_will_do = {
 			base = 1
@@ -731,10 +731,10 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Increase_Soldiers_Pay3
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay_Removal3 "
 			clr_country_flag = DEN_Increase_Soldiers_Pay3
 			set_country_flag = DEN_Increase_Soldiers_Pay2
 			DEN_soldiers_pay_removal = yes
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Increase_Soldiers_Pay_Removal3 "
 		}
 		ai_will_do = {
 			base = 1
@@ -749,6 +749,7 @@ DEN_Danish_Defence_Force = {
 			has_country_flag = DEN_Professional_Soldier_Education
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Professional_Soldier_Education_Removal "
 			clr_country_flag = DEN_Professional_Soldier_Education
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_army_personnel_cost_multiplier_modifier = -0.02 tooltip = army_personnel_cost_multiplier_modifier_tt }
@@ -756,7 +757,6 @@ DEN_Danish_Defence_Force = {
 			add_to_variable = { DEN_army_max_dig_in = -0.2 tooltip = max_dig_in_tt }
 			add_to_variable = { DEN_army_dig_in_speed_factor = -0.1 tooltip = dig_in_speed_factor_tt }
 			add_to_variable = { DEN_no_supply_grace = -50 tooltip = no_supply_grace_tt }
-			log = "[GetDateText]: [Root.GetName]: Decisions DEN_Professional_Soldier_Education_Removal "
 		}
 		ai_will_do = {
 			base = 1

--- a/common/decisions/Denmark.txt
+++ b/common/decisions/Denmark.txt
@@ -12,6 +12,7 @@ DEN_colonial_separatism_category = {
 			controls_state = 1161
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision develop_infrastructure_kitaa"
 			1161 = {
 				add_building_construction = {
 					type = infrastructure
@@ -195,6 +196,7 @@ DEN_decision_danish_revolutionary_thought = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision spread_communism_sweden"
 			SWE = { DEN_spread_nordic_communism = yes }
 		}
 		ai_will_do = { base = 0 }
@@ -209,6 +211,7 @@ DEN_decision_danish_revolutionary_thought = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision spread_communism_norway"
 			NRY = { DEN_spread_nordic_communism = yes }
 		}
 		ai_will_do = { base = 0 }
@@ -223,6 +226,7 @@ DEN_decision_danish_revolutionary_thought = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision spread_communism_finland"
 			FIN = { DEN_spread_nordic_communism = yes }
 		}
 		ai_will_do = { base = 0 }
@@ -237,6 +241,7 @@ DEN_decision_danish_revolutionary_thought = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision spread_communism_iceland"
 			ICE = { DEN_spread_nordic_communism = yes }
 		}
 		ai_will_do = { base = 0 }

--- a/common/decisions/EH_decisions.txt
+++ b/common/decisions/EH_decisions.txt
@@ -37,6 +37,7 @@ EH_electric_traps_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_set_up_electric_trap"
 			FROM = {
 				set_state_flag = EH_electric_trap_set_up_flag
 			}
@@ -85,12 +86,14 @@ EH_electric_traps_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_remove_electric_trap"
 			FROM = {
 				set_state_flag = EH_electric_trap_removing_flag
 			}
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_remove_electric_trap"
 			FROM = {
 				clr_state_flag = EH_electric_trap_set_up_flag
 				clr_state_flag = EH_electric_trap_removing_flag
@@ -143,6 +146,7 @@ EH_electric_traps_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_activate_electric_trap"
 			if = {
 				limit = {
 					NOT = {
@@ -168,6 +172,7 @@ EH_electric_traps_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_activate_electric_trap"
 			# Effects for country
 			add_to_variable = { EH_electric_trap_energy_use_var = -0.1 }
 			FROM = {
@@ -202,6 +207,7 @@ EH_research_sites_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_setup_research_site"
 			set_temp_variable = { treasury_change = -15 }
 			if = {
 				limit = {
@@ -215,6 +221,7 @@ EH_research_sites_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_setup_research_site"
 			add_to_variable = { EH_research_sites_constructed_var = 1 }
 			EH_calculate_research_sites_effects = yes
 			if = {
@@ -249,6 +256,7 @@ EH_research_sites_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_install_anti_air_weapons"
 			set_temp_variable = { treasury_change = -5 }
 			multiply_temp_variable = { treasury_change = EH_research_sites_constructed_var }
 			modify_treasury_effect = yes
@@ -258,6 +266,7 @@ EH_research_sites_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_install_anti_air_weapons"
 			set_temp_variable = { EH_temp_protection_increase = 25 }
 			EH_research_sites_protection_increase = yes
 			clr_country_flag = EH_research_sites_decision_ongoing_flag
@@ -279,6 +288,7 @@ EH_research_sites_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_panic_shelters_and_land_turrets"
 			set_temp_variable = { treasury_change = -5 }
 			multiply_temp_variable = { treasury_change = EH_research_sites_constructed_var }
 			modify_treasury_effect = yes
@@ -287,6 +297,7 @@ EH_research_sites_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_panic_shelters_and_land_turrets"
 			set_temp_variable = { EH_temp_protection_increase = 15 }
 			EH_research_sites_protection_increase = yes
 			set_temp_variable = { EH_temp_research_sites_scientist_protection_increase = 10 }
@@ -310,6 +321,7 @@ EH_research_sites_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_hire_additional_security_for_scientists"
 			set_temp_variable = { treasury_change = -3 }
 			multiply_temp_variable = { treasury_change = EH_research_sites_constructed_var }
 			modify_treasury_effect = yes
@@ -318,6 +330,7 @@ EH_research_sites_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_hire_additional_security_for_scientists"
 			set_temp_variable = { EH_temp_research_sites_scientist_protection_increase = 25 }
 			EH_research_sites_scientist_protection_increase = yes
 			clr_country_flag = EH_research_sites_decision_ongoing_flag
@@ -335,6 +348,7 @@ EH_research_sites_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_disable_site_notifications"
 			set_country_flag = EH_research_sites_disable_notifications_flag
 			custom_effect_tooltip = EH_research_sites_disable_notifications_TT
 		}
@@ -351,6 +365,7 @@ EH_research_sites_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_enable_site_notifications"
 			clr_country_flag = EH_research_sites_disable_notifications_flag
 			custom_effect_tooltip = EH_research_sites_enable_notifications_TT
 		}
@@ -386,6 +401,7 @@ EH_research_sites_category = {
 		days_mission_timeout = 280
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_doudna_or_charpentier_project_mission"
 			set_country_flag = EH_doudna_or_charpentier_finished_project_flag
 		}
 	}
@@ -426,6 +442,7 @@ EH_find_new_veins_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_search_for_randallite_veins"
 			if = {
 				limit = {
 					NOT = {
@@ -443,6 +460,7 @@ EH_find_new_veins_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_search_for_randallite_veins"
 			random_list = {
 				80 = {
 					country_event = EH_focus_event.12
@@ -473,6 +491,7 @@ EH_find_new_veins_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_set_up_mine_mission"
 			if = {
 				limit = {
 					has_country_flag = EH_setting_up_randallite_mine_flag
@@ -528,6 +547,7 @@ EH_find_new_veins_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_large_company_seeks_for_randallite_mission"
 			random = {
 				chance = 85
 				country_event = EH_focus_event.15
@@ -576,6 +596,7 @@ EH_find_new_veins_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_outlaw_randallite_extraction"
 			set_temp_variable = { EH_outlaw_randallite_stability_penalty = -0.04 }
 			set_temp_variable = { EH_outlaw_randallite_pp_penalty = -50 }
 			set_temp_variable = { EH_outlaw_randallite_randallite_gain = 2 }
@@ -618,6 +639,7 @@ EH_find_new_veins_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_legalize_randallite_extraction"
 			clr_country_flag = EH_outlawed_randallite_extraction_flag
 			custom_effect_tooltip = EH_legalize_randallite_extraction_TT
 		}
@@ -670,6 +692,7 @@ EH_nile_defense_line_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_southern_zenobia_defense_line"
 			if = {
 				limit = { NOT = { has_global_flag = EH_zenobia_line_construction_flag } }
 				news_event = EH_event.800
@@ -677,6 +700,7 @@ EH_nile_defense_line_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_southern_zenobia_defense_line"
 			create_entity = {
 				entity = building_landmark_zenobia_wall
 				id = 8991
@@ -753,6 +777,7 @@ EH_nile_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_southern_zenobia_defense_line_destruction"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 8991
@@ -830,6 +855,7 @@ EH_nile_defense_line_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_western_zenobia_defense_line"
 			if = {
 				limit = { NOT = { has_global_flag = EH_zenobia_line_construction_flag } }
 				news_event = EH_event.800
@@ -837,6 +863,7 @@ EH_nile_defense_line_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_western_zenobia_defense_line"
 			create_entity = {
 				entity = building_landmark_zenobia_wall
 				id = 8993
@@ -902,6 +929,7 @@ EH_nile_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_western_zenobia_defense_line_destruction"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 8993
@@ -990,6 +1018,7 @@ EH_nile_defense_line_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_inner_saladin_defense_line"
 			if = {
 				limit = { NOT = { has_global_flag = EH_zenobia_line_construction_flag } }
 				news_event = EH_event.800
@@ -997,6 +1026,7 @@ EH_nile_defense_line_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_inner_saladin_defense_line"
 			create_entity = {
 				entity = building_landmark_zenobia_wall
 				id = 8995
@@ -1114,6 +1144,7 @@ EH_nile_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_inner_saladin_defense_line_destruction"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 8995
@@ -1212,6 +1243,7 @@ EH_nile_defense_line_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_outer_saladin_defense_line"
 			if = {
 				limit = { NOT = { has_global_flag = EH_zenobia_line_construction_flag } }
 				news_event = EH_event.800
@@ -1219,6 +1251,7 @@ EH_nile_defense_line_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_outer_saladin_defense_line"
 			create_entity = {
 				entity = building_landmark_zenobia_wall
 				id = 8994
@@ -1278,6 +1311,7 @@ EH_nile_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_outer_saladin_defense_line_destruction"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 8994
@@ -1348,6 +1382,7 @@ EH_bosporus_defense_line_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_bosphorus_defense_line"
 			if = {
 				limit = { NOT = { has_global_flag = EH_bosphorus_line_construction_flag } }
 				news_event = EH_event.803
@@ -1355,6 +1390,7 @@ EH_bosporus_defense_line_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_bosphorus_defense_line"
 			create_entity = {
 				entity = building_landmark_zenobia_wall
 				id = 9010
@@ -1444,6 +1480,7 @@ EH_bosporus_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_bosphorus_defense_line_destruction"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 9010
@@ -1617,6 +1654,7 @@ EH_caucasus_defense_line_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_caucasus_defense_line"
 			if = {
 				limit = { NOT = { has_global_flag = EH_caucasus_line_construction_flag } }
 				news_event = EH_event.806
@@ -1624,6 +1662,7 @@ EH_caucasus_defense_line_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_construct_caucasus_defense_line"
 			create_entity = {
 				entity = building_landmark_zenobia_wall
 				id = 9012
@@ -1835,6 +1874,7 @@ EH_caucasus_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_caucasus_defense_line_destruction_1"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 9012
@@ -1922,6 +1962,7 @@ EH_caucasus_defense_line_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_caucasus_defense_line_destruction_2"
 			create_entity = {
 				entity = building_landmark_zenobia_wall_destroyed
 				id = 9014
@@ -1975,6 +2016,7 @@ EH_start_scenario_cheat_category = {
 		fire_only_once = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EH_start_scenario_decision"
 			hidden_effect = { EH_convergence_event_chain_effect = yes }
 			set_global_flag = EH_scenario_launched_earlier_flag
 		}

--- a/common/decisions/EU_POTEF_decisions.txt
+++ b/common/decisions/EU_POTEF_decisions.txt
@@ -92,6 +92,7 @@ EU_environmental_imperialism_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_decision"
 			FROM = {
 				activate_mission = EU_POTEF_environmental_imperialism_mission
 				set_country_flag = EU_POTEF_environmental_imperialism_target
@@ -123,6 +124,7 @@ EU_environmental_imperialism_category = {
 		fire_only_once = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_mission"
 			set_temp_variable = { party_index = 17 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -133,6 +135,7 @@ EU_environmental_imperialism_category = {
 			clr_country_flag = EU_POTEF_environmental_imperialism_target
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_mission"
 			add_ideas = USoE_environmental_sanctions
 			clr_country_flag = EU_POTEF_environmental_imperialism_target
 			var:global.eupresfederation = {
@@ -159,6 +162,7 @@ EU_environmental_imperialism_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_restructure_industry_decision"
 			set_temp_variable = { temp1 = 0 }
 			every_owned_state = {
 				limit = {
@@ -211,6 +215,7 @@ EU_environmental_imperialism_category = {
 		war_with_on_complete = ROOT
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_break_environmental_sanctions_decision"
 			remove_ideas = USoE_environmental_sanctions
 			set_country_flag = break_environmental_sanctions
 			FROM = {
@@ -313,6 +318,7 @@ EU_office_category = {
 		visible = { has_global_flag = european_federation }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_call_election"
 			activate_mission = EU_POTEF_election_campaign
 			election_POTEF_in_member_state = yes
 			set_global_flag = ongoing_potef_election
@@ -618,6 +624,7 @@ EU_defense_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_call_all_major_non_EU_ally"
 			for_each_scope_loop = {
 				array = global.non_EU_EDU_ally
 				tooltip = TT_ALL_NON_EU_EDU_ALLY_NATIONS_GAIN
@@ -649,6 +656,7 @@ EU_defense_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_call_major_non_EU_ally"
 			ROOT = {
 				add_to_faction = FROM
 			}

--- a/common/decisions/EU_USoE_decisions.txt
+++ b/common/decisions/EU_USoE_decisions.txt
@@ -20,6 +20,7 @@ EU_USoE_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_capital_of_europe"
 			set_country_flag = USoE_capital_moved
 			set_capital = { state = 51 }
 		}
@@ -44,6 +45,7 @@ EU_USoE_category = {
 		war_with_target_on_complete = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_westernize_decision"
 			if = {
 				limit = {
 					has_government = democratic
@@ -96,6 +98,7 @@ EU_USoE_category = {
 		days_remove = 7
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_create_eurosphere_decision"
 			every_country = {
 				limit = {
 					capital_scope = {
@@ -137,6 +140,7 @@ EU_USoE_category = {
 		#fire_only_once = yes # Will not re-enable after being removed
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision USoE_integrate_new_members"
 			custom_effect_tooltip = tooltip_USoE_part_of_usoe
 			hidden_effect = {
 				for_each_scope_loop = {
@@ -193,6 +197,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_europe }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_europe"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_europe
 			set_country_flag = environmental_imperialism_europe
 		}
@@ -207,6 +212,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_europe
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_europe"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_europe
 			clr_country_flag = environmental_imperialism_europe
 		}
@@ -225,6 +231,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_north_america }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_north_america"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_na
 			set_country_flag = environmental_imperialism_north_america
 		}
@@ -239,6 +246,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_north_america
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_north_america"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_na
 			clr_country_flag = environmental_imperialism_north_america
 		}
@@ -257,6 +265,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_south_america }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_south_america"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_sa
 			set_country_flag = environmental_imperialism_south_america
 		}
@@ -271,6 +280,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_south_america
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_south_america"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_sa
 			clr_country_flag = environmental_imperialism_south_america
 		}
@@ -289,6 +299,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_africa }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_africa"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_africa
 			set_country_flag = environmental_imperialism_africa
 		}
@@ -303,6 +314,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_africa
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_africa"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_africa
 			clr_country_flag = environmental_imperialism_africa
 		}
@@ -321,6 +333,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_asia }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_asia"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_asia
 			set_country_flag = environmental_imperialism_asia
 		}
@@ -335,6 +348,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_asia
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_asia"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_asia
 			clr_country_flag = environmental_imperialism_asia
 		}
@@ -353,6 +367,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_middle_east }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_middle_east"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_me
 			set_country_flag = environmental_imperialism_middle_east
 		}
@@ -367,6 +382,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_middle_east
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_middle_east"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_me
 			clr_country_flag = environmental_imperialism_middle_east
 		}
@@ -385,6 +401,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_pacific }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_pacific"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_pac
 			set_country_flag = environmental_imperialism_pacific
 		}
@@ -399,6 +416,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_pacific
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_pacific"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_pac
 			clr_country_flag = environmental_imperialism_pacific
 		}
@@ -417,6 +435,7 @@ EU_environmental_imperialism_category = {
 			NOT = { has_country_flag = environmental_imperialism_oceania }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_oceania"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_ocea
 			set_country_flag = environmental_imperialism_oceania
 		}
@@ -431,6 +450,7 @@ EU_environmental_imperialism_category = {
 			has_country_flag = environmental_imperialism_oceania
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_oceania"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_ocea
 			clr_country_flag = environmental_imperialism_oceania
 		}
@@ -539,6 +559,7 @@ EU_environmental_imperialism_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_decision"
 			FROM = {
 				activate_mission = EU_USoE_environmental_imperialism_mission
 				set_country_flag = EU_USoE_environmental_imperialism_target
@@ -571,6 +592,7 @@ EU_environmental_imperialism_category = {
 		fire_only_once = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_mission"
 			set_temp_variable = { party_index = 17 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -581,6 +603,7 @@ EU_environmental_imperialism_category = {
 			clr_country_flag = EU_USoE_environmental_imperialism_target
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_mission"
 			add_ideas = USoE_environmental_sanctions
 			clr_country_flag = EU_USoE_environmental_imperialism_target
 			var:global.united_states_of_europe = {
@@ -607,6 +630,7 @@ EU_environmental_imperialism_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_restructure_industry_decision"
 			set_temp_variable = { temp1 = 0 }
 			every_owned_state = {
 				limit = {
@@ -658,6 +682,7 @@ EU_environmental_imperialism_category = {
 		war_with_on_complete = ROOT
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_break_environmental_sanctions_decision"
 			remove_ideas = USoE_environmental_sanctions
 			set_country_flag = break_environmental_sanctions
 			FROM = {

--- a/common/decisions/EU_voting_decisions.txt
+++ b/common/decisions/EU_voting_decisions.txt
@@ -152,6 +152,7 @@ EU_voting_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_council_determine_serious_breach_of_EU_values"
 			FROM = {
 				set_country_flag = serious_breach_of_EU_values
 				set_temp_variable = { modify_europeanism = -0.15 }
@@ -188,6 +189,7 @@ EU_voting_category = {
 			FROM = { has_country_flag = serious_breach_of_EU_values }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_council_revoke_determination_of_serious_breach_of_EU_values"
 			FROM = {
 				clr_country_flag = serious_breach_of_EU_values
 				set_temp_variable = { modify_europeanism = 0.15 }
@@ -230,6 +232,7 @@ EU_voting_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_council_suspend_voting_rights"
 			FROM = {
 				add_ideas = EUU_voting_rights_suspended
 				set_temp_variable = { modify_europeanism = -0.30 }
@@ -282,6 +285,7 @@ EU_voting_category = {
 			FROM = { has_idea = EUU_voting_rights_suspended }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_council_revoke_voting_rights_suspension"
 			FROM = {
 				remove_ideas = EUU_voting_rights_suspended
 				set_temp_variable = { modify_europeanism = 0.30 }
@@ -332,6 +336,7 @@ EU_voting_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_council_suspend_subsidies"
 			FROM = {
 				add_ideas = EUU_subsidies_suspended
 				set_temp_variable = { modify_europeanism = -0.20 }
@@ -369,6 +374,7 @@ EU_voting_category = {
 			FROM = { has_idea = EUU_subsidies_suspended }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_council_revoke_subsidies_suspension"
 			FROM = {
 				remove_ideas = EUU_subsidies_suspended
 				set_temp_variable = { modify_europeanism = 0.20 }
@@ -399,6 +405,7 @@ EU_voting_category = {
 		selectable_mission = yes
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_voting_mission_focus_EUXXX_QMV_result"
 			if = {
 				limit = { has_idea = EU_commission_president }
 				apply_EU_QMV_result = yes
@@ -427,6 +434,7 @@ EU_voting_category = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_budget_yearly_timer"
 			remove_mission = EU_budget_yearly_timer
 			activate_mission = EU_budget_draft_preparations
 			set_global_flag = EU_budget_EP_block
@@ -447,6 +455,7 @@ EU_voting_category = {
 		selectable_mission = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_budget_draft_preparations"
 			set_EU_gdp = yes
 			EU_save_budget_values = yes
 			update_EU_budget_call_rate = yes
@@ -475,6 +484,7 @@ EU_voting_category = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_budget_draft_ongoing"
 			set_EU_gdp = yes
 			update_EU_budget_call_rate = yes
 			if = {
@@ -533,6 +543,7 @@ EU_voting_category = {
 		selectable_mission = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_mff_yearly_timer"
 			set_global_flag = EU_mff_EP_block
 			remove_mission = EU_mff_yearly_timer
 			activate_mission = EU_mff_draft_preparations
@@ -553,6 +564,7 @@ EU_voting_category = {
 		selectable_mission = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_mff_draft_preparations"
 			set_EU_gdp = yes
 			EU_save_mff_values = yes
 			update_EU_budget_call_rate = yes
@@ -581,6 +593,7 @@ EU_voting_category = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_mff_draft_ongoing"
 			set_EU_gdp = yes
 			update_EU_budget_call_rate = yes
 			if = {
@@ -644,6 +657,7 @@ EU_fiscal_category = {
 		fire_only_once = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision invest_in_FRA"
 			FRA = {
 				invest_in_EU_single_market_cic = yes
 			}
@@ -673,6 +687,7 @@ EU_fiscal_category = {
 		fire_only_once = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eurozone_reforms"
 			effect_tooltip = {
 				country_event = EUevent.5
 			}
@@ -703,6 +718,7 @@ EU_fiscal_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eurozone_reforms"
 			for_each_scope_loop = {
 				array = global.EU_member
 				tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
@@ -816,11 +832,13 @@ EU_fiscal_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision troika_reforms"
 			ROOT = {
 				country_event = EUevent.9
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision troika_reforms"
 			ROOT = {
 				country_event = EUevent.8
 			}
@@ -844,6 +862,7 @@ EU_exit_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_Revoke_Article_50"
 			custom_effect_tooltip = tooltip_EU_Revoke_Article_50_effect
 			hidden_effect = {
 				ROOT = {
@@ -896,6 +915,7 @@ EU_exit_category = {
 		fire_only_once = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_exit"
 			# Unprepared No Deal Exit
 			if = { limit = { NOT = { ROOT = { has_country_flag = EU_article_50_prepared_no_deal_exit } } }
 				add_timed_idea = {
@@ -929,9 +949,11 @@ EU_exit_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_exit"
 			news_event = EU_news.22 ### Article 50 is revoked
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_exit"
 			add_ideas = withdrawal_treaty
 			leaving_EU = yes
 			clr_country_flag = Article_50
@@ -1013,6 +1035,7 @@ EU_exit_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_extend_Article_50"
 			remove_mission = EU_exit
 			remove_mission = EU_exit_three_month
 			activate_mission = EU_exit_three_month
@@ -1039,6 +1062,7 @@ EU_exit_category = {
 		fire_only_once = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_exit_three_month"
 			if = { ### unprepared no deal exit
 				limit = {
 					NOT = { ROOT = { has_country_flag = EU_article_50_prepared_no_deal_exit } }
@@ -1077,6 +1101,7 @@ EU_exit_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_exit_three_month"
 			for_each_scope_loop = {
 				array = global.EU_member
 				tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
@@ -1084,6 +1109,7 @@ EU_exit_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_exit_three_month"
 			ROOT = {
 				add_ideas = withdrawal_treaty
 				leaving_EU = yes
@@ -1160,6 +1186,7 @@ EU_exit_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_withdrawal_treaty"
 			set_country_flag = withdrawal_treaty
 			### withdrawal_treaty
 			news_event = EU_news.23
@@ -1221,6 +1248,7 @@ EU_exit_category = {
 		cost = 150
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_prepared_no_deal_exit"
 			set_country_flag = EU_article_50_prepared_no_deal_exit
 		}
 
@@ -1282,6 +1310,7 @@ EU_defense_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_Frontex_take_control"
 			if = {
 				limit = { check_variable = { global.EU_frontex_controller > 0 } }
 				var:global.EU_frontex_controller = { clr_country_flag = control_frontex_force }
@@ -1321,6 +1350,7 @@ EU_defense_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_EuroNavy_take_control"
 			hidden_effect = {
 				for_each_scope_loop = {
 					array = global.EU_member
@@ -1349,6 +1379,7 @@ EU_defense_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_EuroArmy_take_control"
 			if = {
 				limit = { check_variable = { global.EU_euroarmy_controller > 0 } }
 				var:global.EU_euroarmy_controller = { clr_country_flag = control_euroarmy_force }
@@ -1391,6 +1422,7 @@ EU_defense_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_create_EDU"
 			set_global_flag = EDU
 			if = {
 				limit = {
@@ -1484,6 +1516,7 @@ EU_defense_category = {
 		fixed_random_seed = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_military_exercise"
 			add_command_power = -40
 			FROM = {
 				set_country_flag = { flag = EU_military_exercise_at_border_from@ROOT value = 1 days = 450 }
@@ -1540,6 +1573,7 @@ EU_defense_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_ask_to_host_military_exercise"
 			FROM = {
 				country_event = EUevent.18
 			}
@@ -1664,6 +1698,7 @@ EU_defense_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision EU_military_exercise_mission"
 			EU_military_exercise_cleanup = yes
 		}
 	}
@@ -1756,6 +1791,7 @@ generic_coalition_politics_decisions = { ### temp category
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision counter_military_exercise_mission"
 			clear_variable = ROOT.var_counter_military_exercise_state
 			clear_variable = ROOT.var_counter_military_exercise_originator
 		}
@@ -2029,11 +2065,13 @@ EU_apply_for_membership_category = {
 		selectable_mission = yes
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pre_accession_assistance_program"
 			var:var_IPA = {
 				country_event = EUevent.20
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision pre_accession_assistance_program"
 			add_political_power = 400
 		}
 		ai_will_do = {

--- a/common/decisions/Free_syrian_army.txt
+++ b/common/decisions/Free_syrian_army.txt
@@ -20,6 +20,7 @@ FSA_internal_revolt_category = {
 		activation = { NOT = { has_government = fascism } }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_defection_to_extremist"
 			if = {
 				limit = { has_idea = FSA_extremism4 }
 				swap_ideas = {
@@ -76,9 +77,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_aleppo } }
 
-		timeout_effect = { set_country_flag = FSA_capture_aleppo }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_aleppo"
+			set_country_flag = FSA_capture_aleppo
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_aleppo"
 			set_country_flag = FSA_capture_aleppo
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -105,9 +110,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_ar_raqqah } }
 
-		timeout_effect = { set_country_flag = FSA_capture_ar_raqqah }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_ar_raqqah"
+			set_country_flag = FSA_capture_ar_raqqah
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_ar_raqqah"
 			set_country_flag = FSA_capture_ar_raqqah
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -134,9 +143,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_damascus } }
 
-		timeout_effect = { set_country_flag = FSA_capture_damascus }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_damascus"
+			set_country_flag = FSA_capture_damascus
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_damascus"
 			set_country_flag = FSA_capture_damascus
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -163,9 +176,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_deir_ez_zur } }
 
-		timeout_effect = { set_country_flag = FSA_capture_deir_ez_zur }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_deir_ez_zur"
+			set_country_flag = FSA_capture_deir_ez_zur
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_deir_ez_zur"
 			set_country_flag = FSA_capture_deir_ez_zur
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -192,9 +209,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_hama } }
 
-		timeout_effect = { set_country_flag = FSA_capture_hama }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_hama"
+			set_country_flag = FSA_capture_hama
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_hama"
 			set_country_flag = FSA_capture_hama
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -221,9 +242,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_homs } }
 
-		timeout_effect = { set_country_flag = FSA_capture_homs }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_homs"
+			set_country_flag = FSA_capture_homs
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_homs"
 			set_country_flag = FSA_capture_homs
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -250,9 +275,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_latakia } }
 
-		timeout_effect = { set_country_flag = FSA_capture_latakia }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_latakia"
+			set_country_flag = FSA_capture_latakia
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_latakia"
 			set_country_flag = FSA_capture_latakia
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist
@@ -279,9 +308,13 @@ FSA_internal_revolt_category = {
 
 		activation = { NOT = { has_country_flag = FSA_capture_tartus } }
 
-		timeout_effect = { set_country_flag = FSA_capture_tartus }
+		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_tartus"
+			set_country_flag = FSA_capture_tartus
+		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision FSA_capture_tartus"
 			set_country_flag = FSA_capture_tartus
 			add_days_mission_timeout = {
 				mission = FSA_defection_to_extremist

--- a/common/decisions/Georgia.txt
+++ b/common/decisions/Georgia.txt
@@ -10,6 +10,7 @@ GEO_cis_eu_influence_decision = {
 		fire_only_once = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_expand_cis_influence"
 			custom_effect_tooltip = GEO_cis_trade_influence_incr_TT
 			custom_effect_tooltip = GEO_EU_trade_influence_decr_TT
 			hidden_effect = {
@@ -49,6 +50,7 @@ GEO_cis_eu_influence_decision = {
 		fire_only_once = no
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_expand_eu_influence"
 			custom_effect_tooltip = GEO_EU_trade_influence_incr_TT
 			custom_effect_tooltip = GEO_cis_trade_influence_decr_TT
 			hidden_effect = {
@@ -368,11 +370,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_expand_the_khudoni_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_expand_the_khudoni_hydro_power_plant"
 			707 = {
 				set_temp_variable = { electric_addition = 0.615 }
 				set_temp_variable = { storage_addition = 0.15 }
@@ -413,11 +417,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_zhoneti_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_zhoneti_hydro_power_plant"
 			707 = {
 				set_temp_variable = { electric_addition = 0.110 }
 				set_temp_variable = { storage_addition = 0.10 }
@@ -459,11 +465,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_vardnili_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_vardnili_hydro_power_plant"
 			706 = {
 				set_temp_variable = { electric_addition = 0.220 }
 				set_temp_variable = { storage_addition = 0.10 }
@@ -505,11 +513,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_tvishi_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_tvishi_hydro_power_plant"
 			707 = {
 				set_temp_variable = { electric_addition = 0.110 }
 				set_temp_variable = { storage_addition = 0.10 }
@@ -551,11 +561,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_shuakhevi_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_shuakhevi_hydro_power_plant"
 			466 = {
 				set_temp_variable = { electric_addition = 0.185 }
 				set_temp_variable = { storage_addition = 0.10 }
@@ -598,11 +610,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_samtskhe_javakheti_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_samtskhe_javakheti_hydro_power_plant"
 			1033 = {
 				set_temp_variable = { electric_addition = 0.70 }
 				set_temp_variable = { storage_addition = 0.15 }
@@ -644,11 +658,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_nenskra_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_nenskra_hydro_power_plant"
 			1033 = {
 				set_temp_variable = { electric_addition = 0.280 }
 				set_temp_variable = { storage_addition = 0.10 }
@@ -689,11 +705,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_namakhvani_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_namakhvani_hydro_power_plant"
 			1033 = {
 				set_temp_variable = { electric_addition = 0.250 }
 				set_temp_variable = { storage_addition = 0.10 }
@@ -735,11 +753,13 @@ GEO_hydroelectric_plant_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_dariali_hydropower_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GEO_dariali_hydropower_plant"
 			1033 = {
 				set_temp_variable = { electric_addition = 0.280 }
 				set_temp_variable = { storage_addition = 0.10 }

--- a/common/decisions/Gulf.txt
+++ b/common/decisions/Gulf.txt
@@ -180,6 +180,7 @@ gulf_society = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_subsidize_western_culture"
 			set_temp_variable = { temp_modify_social_con_government = -1 }
 			modify_social_conservatism_government = yes
 			add_popularity = {
@@ -187,7 +188,6 @@ gulf_society = {
 				popularity = -0.01
 			}
 			recalculate_party = yes
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_subsidize_western_culture"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -218,6 +218,7 @@ gulf_society = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_subsidize_salafism"
 			set_temp_variable = { temp_modify_social_con_government = 1 }
 			modify_social_conservatism_government = yes
 			add_popularity = {
@@ -225,7 +226,6 @@ gulf_society = {
 				popularity = 0.01
 			}
 			recalculate_party = yes
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_subsidize_salafism"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -266,9 +266,9 @@ gulf_society = {
 		days_re_enable = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_encourage_female_representation"
 			set_temp_variable = { temp_modify_social_con_government = -2 }
 			modify_social_conservatism_government = yes
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_encourage_female_representation"
 		}
 
 		ai_will_do = {
@@ -318,9 +318,9 @@ gulf_society = {
 		days_re_enable = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_discourage_female_representation"
 			set_temp_variable = { temp_modify_social_con_government = 2 }
 			modify_social_conservatism_government = yes
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_discourage_female_representation"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -361,9 +361,9 @@ gulf_society = {
 		days_re_enable = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_expand_female_employment"
 			set_temp_variable = { temp_modify_social_con_government = -2 }
 			modify_social_conservatism_government = yes
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_expand_female_employment"
 		}
 
 		ai_will_do = {
@@ -413,9 +413,9 @@ gulf_society = {
 		days_re_enable = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_limit_female_employment"
 			set_temp_variable = { temp_modify_social_con_government = 2 }
 			modify_social_conservatism_government = yes
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_limit_female_employment"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -442,10 +442,10 @@ gulf_society = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_legalize_alcohol_in_hotels_and_clubs"
 			set_temp_variable = { temp_modify_social_con_government = -2 }
 			modify_social_conservatism_government = yes
 			set_country_flag = limited_alcohol
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_legalize_alcohol_in_hotels_and_clubs"
 		}
 
 		ai_will_do = {
@@ -478,10 +478,10 @@ gulf_society = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_reverse_limited_alcohol_legalization"
 			set_temp_variable = { temp_modify_social_con_government = 2 }
 			modify_social_conservatism_government = yes
 			clr_country_flag = limited_alcohol
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_reverse_limited_alcohol_legalization"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -509,10 +509,10 @@ gulf_society = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_legalize_alcohol"
 			set_temp_variable = { temp_modify_social_con_government = -5 }
 			modify_social_conservatism_government = yes
 			set_country_flag = alcohol
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_legalize_alcohol"
 		}
 
 		ai_will_do = {
@@ -545,10 +545,10 @@ gulf_society = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_ban_alcohol"
 			set_temp_variable = { temp_modify_social_con_government = 5 }
 			modify_social_conservatism_government = yes
 			clr_country_flag = alcohol
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_ban_alcohol"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -575,10 +575,10 @@ gulf_society = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_relax_dress_code"
 			set_temp_variable = { temp_modify_social_con_government = -5 }
 			modify_social_conservatism_government = yes
 			set_country_flag = relaxed_dress_code
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_relax_dress_code"
 		}
 
 		ai_will_do = {
@@ -611,10 +611,10 @@ gulf_society = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_reimpose_dress_code"
 			set_temp_variable = { temp_modify_social_con_government = 5 }
 			modify_social_conservatism_government = yes
 			clr_country_flag = relaxed_dress_code
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_reimpose_dress_code"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -639,10 +639,10 @@ gulf_society = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_ban_burqa"
 			set_temp_variable = { temp_modify_social_con_government = -10 }
 			modify_social_conservatism_government = yes
 			set_country_flag = banned_burqa
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_ban_burqa"
 		}
 
 		ai_will_do = {
@@ -672,10 +672,10 @@ gulf_society = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_unban_burqa"
 			set_temp_variable = { temp_modify_social_con_government = 10 }
 			modify_social_conservatism_government = yes
 			clr_country_flag = banned_burqa
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_unban_burqa"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -700,10 +700,10 @@ gulf_society = {
 		cost = 150
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_head_scarves"
 			set_temp_variable = { temp_modify_social_con_government = -15 }
 			modify_social_conservatism_government = yes
 			set_country_flag = banned_head_scarf
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_head_scarves"
 		}
 
 		ai_will_do = {
@@ -733,10 +733,10 @@ gulf_society = {
 		cost = 150
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_unban_head_scarves"
 			set_temp_variable = { temp_modify_social_con_government = 15 }
 			modify_social_conservatism_government = yes
 			clr_country_flag = banned_head_scarf
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_unban_head_scarves"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -756,10 +756,10 @@ gulf_society = {
 		cost = 150
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_decriminalize_same_sex_relations"
 			set_temp_variable = { temp_modify_social_con_government = -15 }
 			modify_social_conservatism_government = yes
 			set_country_flag = same_sex_decriminalized
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_decriminalize_same_sex_relations"
 		}
 
 		ai_will_do = {
@@ -792,10 +792,10 @@ gulf_society = {
 		cost = 150
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_recriminalize_same_sex_relations"
 			set_temp_variable = { temp_modify_social_con_government = 15 }
 			modify_social_conservatism_government = yes
 			clr_country_flag = same_sex_decriminalized
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_recriminalize_same_sex_relations"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -821,6 +821,7 @@ gulf_society = {
 		cost = 150
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_secularize_the_state"
 			set_temp_variable = { temp_modify_social_con_government = -20 }
 			modify_social_conservatism_government = yes
 			set_country_flag = secularized
@@ -845,7 +846,6 @@ gulf_society = {
 					add_idea = pluralist
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision GCC_secularize_the_state"
 		}
 		ai_will_do = { base = 0 }
 	}
@@ -3023,6 +3023,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hamas"
 			if = {
 				limit = { country_exists = HAM }
 				send_equipment = {
@@ -3070,7 +3071,6 @@ subversive_activities = {
 				}
 				PAL = { country_event = gulf.36 }
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hamas"
 		}
 		ai_will_do = {
 			base = 1
@@ -3096,6 +3096,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hezbollah"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3117,7 +3118,6 @@ subversive_activities = {
 				target = HEZ
 			}
 			HEZ = { country_event = gulf.36 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hezbollah"
 		}
 		ai_will_do = {
 			base = 1
@@ -3142,6 +3142,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_pmu"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3167,7 +3168,6 @@ subversive_activities = {
 				set_temp_variable = { tag_index = PER.id }
 				change_influence_percentage = yes
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_pmu"
 		}
 		ai_will_do = {
 			base = 1
@@ -3192,6 +3192,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_pro_government_forces"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3217,7 +3218,6 @@ subversive_activities = {
 				set_temp_variable = { tag_index = PER.id }
 				change_influence_percentage = yes
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_pro_government_forces"
 		}
 		ai_will_do = {
 			base = 1
@@ -3242,6 +3242,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_the_syrian_opposition"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3263,7 +3264,6 @@ subversive_activities = {
 				target = FSA
 			}
 			FSA = { country_event = gulf.36 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_the_syrian_opposition"
 		}
 		ai_will_do = {
 			base = 1
@@ -3291,9 +3291,9 @@ subversive_activities = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_arabs"
 			custom_effect_tooltip = arab_rebels_strengthened_tt
 			add_to_variable = { global.arab_rebels_strength = 1 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_arabs"
 		}
 		ai_will_do = {
 			base = 1
@@ -3321,9 +3321,9 @@ subversive_activities = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_balochis"
 			custom_effect_tooltip = balochi_rebels_strengthened_tt
 			add_to_variable = { global.balochi_rebels_strength = 1 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_balochis"
 		}
 		ai_will_do = {
 			base = 1
@@ -3350,6 +3350,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_gna"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3371,7 +3372,6 @@ subversive_activities = {
 				target = GNA
 			}
 			GNA = { country_event = gulf.36 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_gna"
 		}
 		ai_will_do = {
 			base = 1
@@ -3399,6 +3399,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_gnc"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3420,7 +3421,6 @@ subversive_activities = {
 				target = GNC
 			}
 			GNC = { country_event = gulf.36 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_gnc"
 		}
 		ai_will_do = {
 			base = 1
@@ -3447,6 +3447,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 60
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hor"
 			send_equipment = {
 				equipment = infantry_weapons_1
 				amount = 100
@@ -3468,7 +3469,6 @@ subversive_activities = {
 				target = HOR
 			}
 			HOR = { country_event = gulf.36 }
-			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hor"
 		}
 		ai_will_do = {
 			base = 1

--- a/common/decisions/Gulf.txt
+++ b/common/decisions/Gulf.txt
@@ -174,6 +174,7 @@ gulf_society = {
 		days_remove = 30
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_subsidize_western_culture"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
@@ -211,6 +212,7 @@ gulf_society = {
 		days_remove = 30
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_subsidize_salafism"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
@@ -875,6 +877,7 @@ shia_decisions = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision encourage_shia_immigration"
 			custom_effect_tooltip = shia_population_increase_tt
 			add_to_variable = { shia_population = 1 }
 			clamp_shia = yes
@@ -940,6 +943,7 @@ shia_decisions = {
 		days_remove = 90
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision encourage_sunni_immigration"
 			custom_effect_tooltip = shia_population_decrease_tt
 			subtract_from_variable = { shia_population = 1 }
 			clamp_shia = yes
@@ -986,6 +990,7 @@ shia_decisions = {
 		days_remove = 45
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deport_foreign_shia"
 			custom_effect_tooltip = shia_population_decrease_tt
 			subtract_from_variable = { shia_population = 1 }
 			clamp_shia = yes
@@ -1014,6 +1019,7 @@ shia_decisions = {
 		days_remove = 45
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deport_foreign_sunnis"
 			custom_effect_tooltip = shia_population_increase_tt
 			add_to_variable = { shia_population = 1 }
 			clamp_shia = yes
@@ -1054,6 +1060,7 @@ gcc_decisions = {
 		days_remove = 30
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_campaign_for_unity"
 			set_temp_variable = { temp_modify_gcc_unity = 1 }
 			modify_gcc_unity = yes
 		}
@@ -1079,6 +1086,7 @@ gcc_decisions = {
 		days_re_enable = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_offer_joint_exercises_specific"
 			set_global_flag = GCC_joint_exercises_offered
 			set_country_flag = GCC_joint_exercises_accepted
 			for_each_scope_loop = {
@@ -1109,6 +1117,7 @@ gcc_decisions = {
 		custom_cost_text = command_power_more_than_20
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_start_joint_exercises_specific"
 			add_command_power = -20
 			for_each_scope_loop = {
 				array = global.gcc_member_state
@@ -1127,6 +1136,7 @@ gcc_decisions = {
 		days_remove = 30
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_start_joint_exercises_specific"
 			if = {
 				limit = {
 					check_variable = { global.gcc_exercise > 0 }
@@ -1183,6 +1193,7 @@ gcc_decisions = {
 		days_re_enable = 365
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_request_bloc_arms_sales"
 			if = {
 				limit = {
 					NOT = {
@@ -1267,6 +1278,7 @@ gcc_decisions = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_expel"
 			FROM = { set_country_flag = being_expelled }
 			every_country = { limit = { has_country_flag = recently_expelled_from_gcc } clr_country_flag = recently_expelled_from_gcc }
 			for_each_scope_loop = {
@@ -2188,6 +2200,7 @@ gcc_decisions = {
 		cost = 200
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_leadership"
 			FROM = { clr_country_flag = gcc_dominant_member }
 			set_country_flag = gcc_dominant_member
 			custom_effect_tooltip = become_gcc_dominant_member_tt
@@ -2229,6 +2242,7 @@ gcc_decisions = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_blockade"
 			set_country_flag = initiated_blockade_@FROM
 			if = {
 				limit = { FROM = { original_tag = QAT } }
@@ -2294,6 +2308,7 @@ gcc_decisions = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_drop_the_blockade"
 			clr_country_flag = blockade_@FROM
 			clr_country_flag = initiated_blockade_@FROM
 			every_country = {
@@ -2342,6 +2357,7 @@ gcc_decisions = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_accept_blockade_demands"
 			every_country = {
 				limit = { has_country_flag = blockade_@ROOT }
 				clr_country_flag = blockade_@ROOT
@@ -2468,6 +2484,7 @@ gcc_decisions = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_support_gcc_membership"
 			set_country_flag = supports_membership_@FROM
 			custom_effect_tooltip = GCC_support_gcc_membership_tt
 		}
@@ -2632,6 +2649,7 @@ gcc_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_show_supporters"
 			every_country = {
 				limit = {
 					has_idea = idea_gcc_member_state
@@ -2675,6 +2693,7 @@ gcc_decisions = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_begin_accession_process"
 			unlock_decision_tooltip = GCC_complete_accession_plan
 			set_country_flag = gcc_accession_process
 			every_country = {
@@ -2702,6 +2721,7 @@ gcc_decisions = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision GCC_complete_accession_plan"
 			clr_country_flag = gcc_accession_process
 			hidden_effect = { news_event = { days = 1 id = gcc.21 } }
 			remove_from_array = { global.possible_gcc_member_state = THIS }
@@ -3264,6 +3284,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_arabs"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_type
 				amount = -100
@@ -3293,6 +3314,7 @@ subversive_activities = {
 		cost = 20
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_balochis"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_type
 				amount = -100

--- a/common/decisions/Hezbollah.txt
+++ b/common/decisions/Hezbollah.txt
@@ -22,6 +22,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_sabotage_the_jewish_sectors_arg"
 			set_temp_variable = {
 				arg_stab = ARG.stability
 			}
@@ -78,6 +79,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deals_with_drug_cartels_arg"
 			set_temp_variable = {
 				arg_stab = ARG.stability
 			}
@@ -135,6 +137,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision support_anti_zionist_parties_arg"
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = ARG }
 			change_influence_percentage = yes
@@ -176,6 +179,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_sabotage_the_jewish_sectors_bra"
 			set_temp_variable = {
 				bra_stab = BRA.stability
 			}
@@ -231,6 +235,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deals_with_drug_cartels_bra"
 			set_temp_variable = {
 				bra_stab = BRA.stability
 			}
@@ -288,6 +293,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision support_anti_zionist_parties_bra"
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = BRA }
 			change_influence_percentage = yes
@@ -329,6 +335,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_sabotage_the_jewish_sectors_col"
 			set_temp_variable = {
 				col_stab = COL.stability
 			}
@@ -384,6 +391,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deals_with_drug_cartels_col"
 			set_temp_variable = {
 				col_stab = COL.stability
 			}
@@ -441,6 +449,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision support_anti_zionist_parties_col"
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = COL }
 			change_influence_percentage = yes
@@ -482,6 +491,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_sabotage_the_jewish_sectors_VEN"
 			set_temp_variable = {
 				VEN_stab = VEN.stability
 			}
@@ -538,6 +548,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deals_with_drug_cartels_VEN"
 			set_temp_variable = {
 				VEN_stab = VEN.stability
 			}
@@ -595,6 +606,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision support_anti_zionist_parties_VEN"
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = VEN }
 			change_influence_percentage = yes
@@ -636,6 +648,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_sabotage_the_jewish_sectors_MEX"
 			set_temp_variable = {
 				MEX_stab = MEX.stability
 			}
@@ -691,6 +704,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision deals_with_drug_cartels_MEX"
 			set_temp_variable = {
 				MEX_stab = MEX.stability
 			}
@@ -748,6 +762,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision support_anti_zionist_parties_MEX"
 			set_temp_variable = { percent_change = 0.5 }
 			set_temp_variable = { influence_target = MEX }
 			change_influence_percentage = yes
@@ -814,6 +829,7 @@ HEZ_our_step_in_latin_america_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision destabilize_the_us"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = USA }
 			change_influence_percentage = yes
@@ -869,6 +885,7 @@ HEZ_assassination_of_salman_rushdie = {
 			add_command_power = -20
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision kill_rushdie"
 			set_temp_variable = { treasury_change = -0.500 }
 			modify_treasury_effect = yes
 			if = {
@@ -981,6 +998,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapon_raidings_LBA"
 			LBA = {
 				send_equipment = {
 					equipment = infantry_weapons_type
@@ -1024,6 +1042,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapon_raidings_SUD"
 			SUD = {
 				send_equipment = {
 					equipment = infantry_weapons_type
@@ -1067,6 +1086,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapon_raidings_NIG"
 			NIG = {
 				send_equipment = {
 					equipment = infantry_weapons_type
@@ -1110,6 +1130,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapon_raidings_EGY"
 			EGY = {
 				send_equipment = {
 					equipment = infantry_weapons_type
@@ -1153,6 +1174,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapon_raidings_CHA"
 			CHA = {
 				send_equipment = {
 					equipment = infantry_weapons_type
@@ -1195,6 +1217,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision smuggle_weapons_from_south_sudanese_rebillions"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_type
 				amount = 500
@@ -1231,6 +1254,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision smuggle_fuel_from_lybia"
 			add_fuel = 1000
 			LBA = {
 				set_temp_variable = { treasury_change = 1.00 }
@@ -1262,6 +1286,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision smuggle_fuel_from_egypt"
 			add_fuel = 1000
 			EGY = {
 				set_temp_variable = { treasury_change = 1.00 }
@@ -1303,6 +1328,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision critsize_the_muslim_brotherhood_in_egypt"
 			if = {
 				limit = { EGY = { has_government = democratic } }
 				EGY = { add_stability = -0.025 }
@@ -1352,6 +1378,7 @@ HEZ_our_boots_on_africa_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision question_the_disappearance_of_musa_al_sadr_in_libyan_government"
 			LBA = {
 				set_temp_variable = { party_popularity_increase = -0.03 }
 				change_relative_party_popularity = yes
@@ -1402,6 +1429,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_send_military_equipments_to_syria"
 			SYR = {
 				add_equipment_to_stockpile = {
 					type = infantry_weapons_type
@@ -1449,6 +1477,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			add_manpower = -2500
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_volunteer_forces_for_syria"
 			SYR = {
 				add_war_support = 0.005
 				add_manpower = 2500
@@ -1482,6 +1511,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			add_command_power = -50
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_our_advisors_in_damascus"
 			SYR = {
 				add_command_power = 50
 				add_ideas = UKR_foreign_advisors
@@ -1513,6 +1543,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapons_from_iran"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_type
 				amount = 300
@@ -1560,6 +1591,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_our_funds_for_the_iraqi_people"
 			set_temp_variable = { percent_change = 1.5 }
 			set_temp_variable = { influence_target = IRQ }
 			change_influence_percentage = yes
@@ -1597,6 +1629,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			add_command_power = -20
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_sabotage_wahhabi_schools"
 			YEM = {
 				add_stability = -0.03
 				add_popularity = {
@@ -1638,6 +1671,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_fund_protests_against_wahabbis_in_sanaa"
 			YEM = {
 				add_popularity = {
 					ideology = fascism
@@ -1680,6 +1714,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_infrastructure_in_saadaa"
 			YEM = {
 				951 = {
 					add_building_construction = {
@@ -1721,6 +1756,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_fund_houthi_propaganda"
 			YEM = {
 				add_popularity = {
 					ideology = communism
@@ -1765,6 +1801,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			army_experience = -5
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_shia_advisors_for_iraq"
 			IRQ = {
 				add_command_power = 40
 				army_experience = 10
@@ -1802,6 +1839,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			add_manpower = -1000
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_volunteers_for_iraq"
 			IRQ = {
 				add_manpower = 1000
 			}
@@ -1838,6 +1876,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_fund_propaganda_for_badr"
 			IRQ = {
 				add_popularity = {
 					ideology = communism
@@ -1890,6 +1929,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapons_for_the_resistance"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = IRQ }
 			change_influence_percentage = yes
@@ -1928,6 +1968,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			add_command_power = -30
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_organize_raidings_in_yemen"
 			YEM = {
 				random_owned_state = {
 					limit = { infrastructure > 0 }
@@ -1983,6 +2024,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_weapons_for_our_brothers"
 			set_temp_variable = { percent_change = 1 }
 			set_temp_variable = { influence_target = YEM }
 			change_influence_percentage = yes
@@ -2030,6 +2072,7 @@ HEZ_missions_in_the_middle_east_decisions = {
 			add_manpower = -100
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HEZ_the_might_of_muqawimat"
 			custom_effect_tooltip = HEZ_the_might_of_muqawimat_effect_TT
 			USA = {
 				country_event = hezbollah_events.26

--- a/common/decisions/Hong Kong.txt
+++ b/common/decisions/Hong Kong.txt
@@ -10,6 +10,7 @@ HKG_legco_decision_categories = {
 		days_mission_timeout = 60
 		is_good = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision legco_current_special_motion_clock"
 			if = {
 				limit = {
 					has_country_flag = HKG_electoral_reform_mainland_a

--- a/common/decisions/India.txt
+++ b/common/decisions/India.txt
@@ -1320,6 +1320,7 @@ maoist_decision_category = {
 		is_good = no
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision RAJ_MAO_rebellion"
 			set_country_flag = RAJ_naxalite_mission_active
 			set_temp_variable = { party_index = 19 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
@@ -1360,6 +1361,7 @@ maoist_decision_category = {
 		is_good = no
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision RAJ_MAO_rebellion_armed"
 			country_event = RAJ_mao_reb.5
 		}
 	}
@@ -1408,6 +1410,7 @@ maoist_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression"
 			set_country_flag = RAJ_suppression_active
 		}
 
@@ -1541,6 +1544,7 @@ maoist_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision RAJ_surrender_rehabilitation_program"
 			clr_country_flag = RAJ_rehabilitation_in_progress
 			random_list = {
 				40 = { # Success - insurgents reintegrated
@@ -1732,6 +1736,7 @@ maoist_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision RAJ_road_connectivity_program"
 			random_list = {
 				70 = { # Success - infrastructure completed
 					random_controlled_state = {

--- a/common/decisions/Influence Decisions.txt
+++ b/common/decisions/Influence Decisions.txt
@@ -401,6 +401,7 @@ influence_decisions = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision combat_biggest_influencer_decision"
 			set_variable = { combat_big_influencer = influence_array^0 }
 		}
 		remove_effect = {
@@ -573,6 +574,7 @@ influence_decisions = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision combat_second_influencer_decision"
 			set_variable = { combat_second_big_influencer = influence_array^1 }
 		}
 		remove_effect = {
@@ -746,6 +748,7 @@ influence_decisions = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision combat_third_influencer_decision"
 			set_variable = { combat_third_big_influencer = influence_array^2 }
 		}
 		remove_effect = {

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -1919,8 +1919,8 @@ PER_resitance_axis = {
 		}
 
 		remove_effect = {
-			clr_country_flag = PER_iraq_military_industry_increase_d
 			log = "[GetDateText]: [Root.GetName]: Decision PER_iraq_military_industry_increase"
+			clr_country_flag = PER_iraq_military_industry_increase_d
 			IRQ = {
 				country_event = message_from_iran.3
 				add_offsite_building = { type = arms_factory level = 1 }
@@ -2142,8 +2142,8 @@ PER_resitance_axis = {
 		}
 
 		remove_effect = {
-			clr_country_flag = PER_syria_military_industry_increase_d
 			log = "[GetDateText]: [Root.GetName]: Decision PER_syria_military_industry_increase"
+			clr_country_flag = PER_syria_military_industry_increase_d
 			SYR = {
 				country_event = message_from_iran.3
 				add_offsite_building = { type = arms_factory level = 1 }
@@ -2365,8 +2365,8 @@ PER_resitance_axis = {
 		}
 
 		remove_effect = {
-			clr_country_flag = PER_houthis_military_industry_increase_d
 			log = "[GetDateText]: [Root.GetName]: Decision PER_houthis_military_industry_increase"
+			clr_country_flag = PER_houthis_military_industry_increase_d
 			HOU = {
 				country_event = message_from_iran.3
 				add_offsite_building = { type = arms_factory level = 1 }

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -8,6 +8,7 @@ PER_Iranian_elections_decision_category = {
 		days_mission_timeout = 7
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_auto_update_gui_weekly"
 			if = {
 				limit = { original_tag = PER }
 				hidden_effect = {
@@ -328,6 +329,7 @@ PER_Iranian_president_info = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_the_new_phase_of_economic_plans"
 			add_offsite_building = { type = industrial_complex level = 3 }
 		}
 
@@ -1029,11 +1031,13 @@ PER_border_fortification = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_pakistan_border_decision"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_pakistan_border_decision"
 			401 = {
 				if = {
 					limit = { is_controlled_by = PER }
@@ -1101,11 +1105,13 @@ PER_border_fortification = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_afghanistan_border_decision"
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_afghanistan_border_decision"
 			401 = {
 				if = {
 					limit = { is_controlled_by = PER }
@@ -1173,11 +1179,13 @@ PER_border_fortification = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_turkmenistan_border_decision"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_turkmenistan_border_decision"
 			402 = {
 				if = {
 					limit = { is_controlled_by = PER }
@@ -1569,6 +1577,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_give_arms_to_hezbollah"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 			set_country_flag = PER_give_arms_to_hezbollah_d
@@ -1678,6 +1687,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_financial_aid_to_hezbollah"
 			set_country_flag = PER_financial_aid_to_hezbollah_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -1730,6 +1740,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_give_arms_to_iraq"
 			set_country_flag = PER_give_arms_to_iraq_d
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -1844,6 +1855,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_financial_aid_to_iraq"
 			set_country_flag = PER_financial_aid_to_iraq_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -1896,6 +1908,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_iraq_military_industry_increase"
 			set_country_flag = PER_iraq_military_industry_increase_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -1950,6 +1963,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_give_arms_to_syria"
 			set_country_flag = PER_give_arms_to_syria_d
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -2064,6 +2078,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_financial_aid_to_syria"
 			set_country_flag = PER_financial_aid_to_syria_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -2116,6 +2131,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_syria_military_industry_increase"
 			set_country_flag = PER_syria_military_industry_increase_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -2170,6 +2186,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_give_arms_to_houthis"
 			set_country_flag = PER_give_arms_to_houthis_d
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -2284,6 +2301,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_financial_aid_to_houthis"
 			set_country_flag = PER_financial_aid_to_houthis_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -2336,6 +2354,7 @@ PER_resitance_axis = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_houthis_military_industry_increase"
 			set_country_flag = PER_houthis_military_industry_increase_d
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
@@ -10596,6 +10615,7 @@ PER_new_majlis = {
 		days_mission_timeout = 21
 		is_good = no
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_debate_now"
 			clr_country_flag = PER_debate_ongoing
 			clr_country_flag = PER_doing_proposal
 		}
@@ -11757,6 +11777,7 @@ PER_war_in_yemem = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PER_demand_houthi_perform_offensive"
 			set_global_flag = HOU_Houthi_offensive
 			custom_effect_tooltip = PER_HOU_Houthi_offensive_TT
 			hidden_effect = {

--- a/common/decisions/Iraq.txt
+++ b/common/decisions/Iraq.txt
@@ -2010,6 +2010,7 @@ IRQ_sunni_in_politics = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_satisfy_sunnis"
 			set_country_flag = IRQ_doing_decision
 		}
 		remove_effect = {
@@ -2041,6 +2042,7 @@ IRQ_sunni_in_politics = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_redirect_sunni_resources"
 			set_country_flag = IRQ_doing_decision
 		}
 		remove_effect = {
@@ -3066,6 +3068,7 @@ IRQ_spring_of_islam = {
 		}
 		fire_only_once = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_islamic_spring_in_jordan"
 			random_list = {
 				50 = {
 					custom_effect_tooltip = IRQ_coup_TT
@@ -3328,6 +3331,7 @@ IRQ_spring_of_islam = {
 		}
 		fire_only_once = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_islamic_spring_in_kuwait"
 			custom_effect_tooltip = IRQ_coup_TT
 			hidden_effect = {
 				KUW = {
@@ -3560,6 +3564,7 @@ IRQ_spring_of_islam = {
 		}
 		fire_only_once = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_islamic_spring_in_turkey"
 			custom_effect_tooltip = IRQ_coup_TT
 			random_list = {
 				50 = {
@@ -3848,6 +3853,7 @@ IRQ_spring_of_islam = {
 		}
 		fire_only_once = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision IRQ_islamic_spring_in_afghanistan"
 			custom_effect_tooltip = IRQ_coup_TT
 			random_list = {
 				50 = {

--- a/common/decisions/Israel.txt
+++ b/common/decisions/Israel.txt
@@ -517,6 +517,7 @@ israel_palestine_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_catch_the_boat"
 			custom_effect_tooltip = ISR_boat_aint_catched_TT
 			hidden_effect = {
 				clr_country_flag = ISR_catch_boat
@@ -548,6 +549,7 @@ israel_palestine_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_pal_rooting_terrorists"
 			custom_effect_tooltip = ISR_operation_result_outcome_tt
 			custom_effect_tooltip = ISR_operation_failed_root_terr_tt
 			hidden_effect = {
@@ -617,6 +619,7 @@ israel_palestine_category = {
 		days_remove = 30
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_churchofnativity_approach"
 			set_country_flag = churchnativity_progr
 			hidden_effect = {
 				add_command_power = -15
@@ -1601,6 +1604,7 @@ israel_knesset_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_up_bureaucracy"
 			set_country_flag = ISR_bill_in_progress
 			custom_effect_tooltip = ISR_knesset_start_TT
 			hidden_effect = {
@@ -1683,6 +1687,7 @@ israel_knesset_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_down_bureaucracy"
 			set_country_flag = ISR_bill_in_progress
 			custom_effect_tooltip = ISR_knesset_start_TT
 			hidden_effect = {
@@ -2055,6 +2060,7 @@ israel_knesset_category = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_down_police"
 			set_country_flag = ISR_bill_in_progress
 			custom_effect_tooltip = ISR_knesset_start_TT
 			hidden_effect = {
@@ -2726,6 +2732,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_liberman_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = liberam_completed
 			country_event = israel.coalition.1
@@ -2796,6 +2803,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_givir_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = givir_completed
 			country_event = israel.coalition.2
@@ -2865,6 +2873,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_likud_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = likud_completed
 			country_event = israel.coalition.3
@@ -2931,6 +2940,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_shas_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = shas_completed
 			country_event = israel.coalition.4
@@ -3000,6 +3010,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_jud_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = jud_completed
 			country_event = israel.coalition.5
@@ -3066,6 +3077,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_nz_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = nz_completed
 			country_event = israel.coalition.6
@@ -3135,6 +3147,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_jewish_home_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = jewish_completed
 			country_event = israel.coalition.7
@@ -3209,6 +3222,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_labour_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = labour_completed
 			country_event = israel.coalition.8
@@ -3279,6 +3293,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_meretz_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = meretz_completed
 			country_event = israel.coalition.9
@@ -3353,6 +3368,7 @@ israel_knesset_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_arab_coalition_ticker_mission"
 			custom_effect_tooltip = ISR_coalition_destroyed_tt
 			clear_variable = arab_completed
 			country_event = israel.coalition.10
@@ -3831,6 +3847,7 @@ israel_lebanon_occup_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision south_lebanon_occupation_ticker_mission"
 			custom_effect_tooltip = result_dep_on_pol_tt
 			hidden_effect = {
 				if = {

--- a/common/decisions/Israel.txt
+++ b/common/decisions/Israel.txt
@@ -2716,6 +2716,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_liberman_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -2787,6 +2788,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_givir_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -2860,6 +2862,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_likud_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -2927,6 +2930,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_shas_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -2997,6 +3001,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_jud_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -3061,6 +3066,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_nz_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -3131,6 +3137,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_jewish_home_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -3206,6 +3213,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_labour_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -3277,6 +3285,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_meretz_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -3352,6 +3361,7 @@ israel_knesset_category = {
 		}
 		cancel_if_not_visible = no
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ISR_isr_arab_coalition_ticker_mission"
 			if = {
 				limit = {
 					check_variable = {
@@ -3826,6 +3836,7 @@ israel_lebanon_occup_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision south_lebanon_occupation_ticker_mission"
 			hidden_effect = {
 				if = {
 					limit = {

--- a/common/decisions/Italy.txt
+++ b/common/decisions/Italy.txt
@@ -30,6 +30,7 @@ romanization_ITA = {
 			check_variable = { treasury > 519.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_britannia"
 			set_temp_variable = { treasury_change = -520 }
 			modify_treasury_effect = yes
 		}
@@ -87,6 +88,7 @@ romanization_ITA = {
 			check_variable = { treasury > 179.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_narbonensis"
 			set_temp_variable = { treasury_change = -180 }
 			modify_treasury_effect = yes
 		}
@@ -149,6 +151,7 @@ romanization_ITA = {
 			check_variable = { treasury > 299.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_lugdunensis_aquitania"
 			set_temp_variable = { treasury_change = -300 }
 			modify_treasury_effect = yes
 		}
@@ -213,6 +216,7 @@ romanization_ITA = {
 			check_variable = { treasury > 459.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_belgica"
 			set_temp_variable = { treasury_change = -460 }
 			modify_treasury_effect = yes
 		}
@@ -277,6 +281,7 @@ romanization_ITA = {
 			check_variable = { treasury > 349.99 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_raetia_noricum"
 			set_temp_variable = { treasury_change = -350 }
 			modify_treasury_effect = yes
 		}
@@ -351,6 +356,7 @@ romanization_ITA = {
 			check_variable = { treasury > 269.99 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_northwestern_balkans"
 			set_temp_variable = { treasury_change = -270 }
 			modify_treasury_effect = yes
 		}
@@ -422,6 +428,7 @@ romanization_ITA = {
 			check_variable = { treasury > 299.99 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_dacia_moesia"
 			set_temp_variable = { treasury_change = -300 }
 			modify_treasury_effect = yes
 		}
@@ -482,6 +489,7 @@ romanization_ITA = {
 			check_variable = { treasury > 109.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_greece"
 			set_temp_variable = { treasury_change = -110 }
 			modify_treasury_effect = yes
 		}
@@ -544,6 +552,7 @@ romanization_ITA = {
 			check_variable = { treasury > 459.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_tarraconensis_lusitania_baetica"
 			set_temp_variable = { treasury_change = -460 }
 			modify_treasury_effect = yes
 		}
@@ -612,6 +621,7 @@ romanization_ITA = {
 			check_variable = { treasury > 519.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_mauretania"
 			set_temp_variable = { treasury_change = -520 }
 			modify_treasury_effect = yes
 		}
@@ -683,6 +693,7 @@ romanization_ITA = {
 			check_variable = { treasury > 199.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_africa_proconsularis"
 			set_temp_variable = { treasury_change = -200 }
 			modify_treasury_effect = yes
 		}
@@ -747,6 +758,7 @@ romanization_ITA = {
 			check_variable = { treasury > 699.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_cyrenaica_aegyptus"
 			set_temp_variable = { treasury_change = -700 }
 			modify_treasury_effect = yes
 		}
@@ -813,6 +825,7 @@ romanization_ITA = {
 			check_variable = { treasury > 614.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_anatolia"
 			set_temp_variable = { treasury_change = -615 }
 			modify_treasury_effect = yes
 		}
@@ -889,6 +902,7 @@ romanization_ITA = {
 			check_variable = { treasury > 349.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_levant_syria"
 			set_temp_variable = { treasury_change = -350 }
 			modify_treasury_effect = yes
 		}
@@ -955,6 +969,7 @@ romanization_ITA = {
 			check_variable = { treasury > 259.999 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_iraq"
 
 			set_temp_variable = { treasury_change = -260 }
 			modify_treasury_effect = yes
@@ -1019,6 +1034,7 @@ romanization_ITA = {
 			check_variable = { treasury > 179.99 }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision integration_caucasus"
 			set_temp_variable = { treasury_change = -180 }
 			modify_treasury_effect = yes
 		}

--- a/common/decisions/Italy.txt
+++ b/common/decisions/Italy.txt
@@ -1104,8 +1104,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_25
 
 		complete_effect = {
-			add_command_power = -25
 			log = "[GetDateText]: [This.GetName]: decision infiltrate_cosa_nostra executed"
+			add_command_power = -25
 		}
 		days_re_enable = 30
 
@@ -1150,8 +1150,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_25
 
 		complete_effect = {
-			add_command_power = -25
 			log = "[GetDateText]: [This.GetName]: decision infiltrate_camorra executed"
+			add_command_power = -25
 		}
 		days_re_enable = 30
 
@@ -1196,8 +1196,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_25
 
 		complete_effect = {
-			add_command_power = -25
 			log = "[GetDateText]: [This.GetName]: decision infiltrate_ndrangheta executed"
+			add_command_power = -25
 		}
 		days_re_enable = 30
 
@@ -1242,8 +1242,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_25
 
 		complete_effect = {
-			add_command_power = -25
 			log = "[GetDateText]: [This.GetName]: decision infiltrate_sacra_corona_unita executed"
+			add_command_power = -25
 		}
 		days_re_enable = 30
 
@@ -1290,8 +1290,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_50
 
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision leverage_cosa_nostra_infighting executed"
+			add_command_power = -50
 		}
 		days_remove = 10
 		days_re_enable = 90
@@ -1348,8 +1348,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_50
 
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision leverage_camorra_infighting executed"
+			add_command_power = -50
 		}
 		days_remove = 10
 		days_re_enable = 90
@@ -1406,8 +1406,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_50
 
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision leverage_ndrangheta_infighting executed"
+			add_command_power = -50
 		}
 		days_remove = 10
 		days_re_enable = 90
@@ -1464,8 +1464,8 @@ mafia_ITA = {
 		custom_cost_text = command_power_more_than_50
 
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision leverage_sacra_corona_unita_infighting executed"
+			add_command_power = -50
 		}
 		days_remove = 10
 		days_re_enable = 90
@@ -1507,8 +1507,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision protect_from_pizzo_sicily executed"
+			add_command_power = -50
 			set_country_flag = protect_from_pizzo_sicily_flag
 		}
 	}
@@ -1549,8 +1549,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision protect_from_pizzo_campania executed"
+			add_command_power = -50
 			set_country_flag = protect_from_pizzo_campania_flag
 		}
 	}
@@ -1591,8 +1591,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision protect_from_pizzo_calabria executed"
+			add_command_power = -50
 			set_country_flag = protect_from_pizzo_calabria_flag
 		}
 	}
@@ -1634,8 +1634,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision protect_from_pizzo_puglia executed"
+			add_command_power = -50
 			set_country_flag = protect_from_pizzo_puglia_flag
 		}
 	}
@@ -1689,8 +1689,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision attack_hideouts_sicily executed"
+			add_command_power = -50
 		}
 		days_remove = 5
 		days_re_enable = 365
@@ -1746,8 +1746,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision attack_hideouts_campania executed"
+			add_command_power = -50
 		}
 		days_remove = 5
 		days_re_enable = 365
@@ -1803,8 +1803,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision attack_hideouts_calabria executed"
+			add_command_power = -50
 		}
 		days_remove = 5
 		days_re_enable = 365
@@ -1860,8 +1860,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_50
 		complete_effect = {
-			add_command_power = -50
 			log = "[GetDateText]: [This.GetName]: decision attack_hideouts_puglia executed"
+			add_command_power = -50
 		}
 		days_remove = 5
 		days_re_enable = 365
@@ -1901,8 +1901,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_100
 		complete_effect = {
-			add_command_power = -100
 			log = "[GetDateText]: [This.GetName]: decision army_in_the_streets executed"
+			add_command_power = -100
 			set_country_flag = ITA_deployed_army_against_mafia
 			custom_effect_tooltip = mafia_strength_decrease_tt
 			set_temp_variable = { treasury_change = -5 }
@@ -1935,8 +1935,8 @@ mafia_ITA = {
 		}
 		custom_cost_text = command_power_more_than_75
 		complete_effect = {
-			add_command_power = -75
 			log = "[GetDateText]: [This.GetName]: decision encourage_fighting_between_families executed"
+			add_command_power = -75
 			country_event = mafia.29
 		}
 		days_re_enable = 180

--- a/common/decisions/Korea.txt
+++ b/common/decisions/Korea.txt
@@ -71,6 +71,7 @@ KOR_38th_parallel = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_close_kaesong_industrial_park"
 			set_country_flag = closed_kaesong
 			set_temp_variable = { temp_opinion = -10 }
 			change_chaebols_opinion = yes
@@ -111,6 +112,7 @@ KOR_38th_parallel = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_reopen_kaesong_industrial_park"
 			clr_country_flag = closed_kaesong
 			set_temp_variable = { temp_opinion = 10 }
 			change_chaebols_opinion = yes
@@ -163,6 +165,7 @@ KOR_38th_parallel = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_organize_joint_sporting_events"
 			support_for_reunification_1 = yes
 			add_war_support = -0.01
 			NKO = {
@@ -203,6 +206,7 @@ KOR_38th_parallel = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_screen_north_korean_films"
 			support_for_reunification_1 = yes
 			add_war_support = -0.01
 			NKO = {
@@ -242,6 +246,7 @@ KOR_38th_parallel = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_encourage_sympathetic_portrayals_of_the_north"
 			support_for_reunification_1 = yes
 			add_war_support = -0.01
 		}
@@ -280,6 +285,7 @@ KOR_38th_parallel = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_cease_propaganda_broadcasts"
 			custom_effect_tooltip = KOR_negotiation_success_tt
 			add_to_variable = { reunification_chance = 1 }
 			NKO = {
@@ -314,6 +320,7 @@ KOR_38th_parallel = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_restart_propaganda_broadcasts"
 			custom_effect_tooltip = KOR_negotiation_failure_tt
 			subtract_from_variable = { reunification_chance = 1 }
 			NKO = {
@@ -350,6 +357,7 @@ KOR_38th_parallel = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_cease_propaganda_leaflets"
 			custom_effect_tooltip = KOR_negotiation_success_tt
 			add_to_variable = { reunification_chance = 1 }
 			NKO = {
@@ -385,6 +393,7 @@ KOR_38th_parallel = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_restart_propaganda_leaflets"
 			custom_effect_tooltip = KOR_negotiation_failure_tt
 			subtract_from_variable = { reunification_chance = 1 }
 			NKO = {
@@ -446,11 +455,13 @@ KOR_38th_parallel = {
 		days_re_enable = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_restart_peace_talks"
 			liberal_policy_effect = yes
 			clr_country_flag = KOR_peace_talks_failed
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_restart_peace_talks"
 			NKO = {
 				country_event = korea.23
 			}
@@ -1022,6 +1033,7 @@ KOR_guerrilla_mobilization = {
 		days_remove = 15
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_recruitment_campaign"
 			add_to_variable = { juche_volunteers = 1 }
 			custom_effect_tooltip = juche_volunteers_tt
 		}
@@ -1045,6 +1057,7 @@ KOR_guerrilla_mobilization = {
 		days_remove = 15
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_raid_armories"
 			add_to_variable = { juche_arms = 1 }
 			custom_effect_tooltip = juche_arms_tt
 		}
@@ -1067,6 +1080,7 @@ KOR_guerrilla_mobilization = {
 		days_remove = 15
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KOR_smuggle_arms"
 			add_to_variable = { juche_arms1 = 1 }
 			custom_effect_tooltip = juche_arms1_tt
 		}

--- a/common/decisions/Malorossiya.txt
+++ b/common/decisions/Malorossiya.txt
@@ -10,6 +10,7 @@ MLR_manifest_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MLR_kirov_core"
 			1090 = { add_core_of = MLR }
 		}
 		ai_will_do = { base = 0 }
@@ -24,6 +25,7 @@ MLR_manifest_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MLR_kiev_core"
 			698 = { add_core_of = MLR }
 		}
 		ai_will_do = { base = 0 }
@@ -38,6 +40,7 @@ MLR_manifest_decisions = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MLR_poltava_core"
 			1089 = { add_core_of = MLR }
 		}
 		ai_will_do = { base = 0 }

--- a/common/decisions/NATO.txt
+++ b/common/decisions/NATO.txt
@@ -252,6 +252,7 @@ NATO_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision show_non_ratified_countries"
 			for_each_scope_loop = {
 				array = global.nato_members
 				tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
@@ -1004,6 +1005,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_light_equipment"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_type
 				amount = -2000
@@ -1076,6 +1078,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_medium_equipment"
 			add_equipment_to_stockpile = {
 				type = util_vehicle_type
 				amount = -150
@@ -1148,6 +1151,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_heavy_equipment"
 			add_equipment_to_stockpile = {
 				type = medium_tank_flame_chassis
 				amount = -150
@@ -1218,6 +1222,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_mr_planes_equipment_nonbba"
 			add_equipment_to_stockpile = {
 				type = medium_plane_airframe
 				amount = -50
@@ -1261,6 +1266,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_strike_planes_equipment_nonbba"
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe
 				amount = -50
@@ -1304,6 +1310,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_mr_planes_equipment_bba"
 			add_equipment_to_stockpile = {
 				type = medium_plane_fighter_airframe
 				amount = -50
@@ -1348,6 +1355,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision send_strike_planes_equipment_bba"
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe
 				amount = -50
@@ -1404,6 +1412,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_guns_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = infantry_weapons_type
@@ -1458,6 +1467,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_cnc_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = cnc_equipment_type
@@ -1512,6 +1522,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_at_aa_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = L_AT_Equipment
@@ -1573,6 +1584,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_util_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = util_vehicle_type
@@ -1627,6 +1639,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_apc_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = medium_tank_amphibious_chassis
@@ -1681,6 +1694,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_ifv_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = medium_tank_flame_chassis
@@ -1735,6 +1749,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_spart_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = medium_tank_artillery_chassis
@@ -1789,6 +1804,7 @@ NATO_ukraine_help = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision order_mbt_for_ukraine"
 			UKR = {
 				add_equipment_to_stockpile = {
 					type = medium_tank_chassis
@@ -1829,6 +1845,7 @@ NATO_CSTO_agreement = {
 		# }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision propose_agreement_talks"
 			random_other_country = {
 				limit = {
 					has_idea = CSTO_member

--- a/common/decisions/Poland.txt
+++ b/common/decisions/Poland.txt
@@ -7350,6 +7350,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_question_about_czech_republic"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -7422,6 +7423,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_slovakia"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -7500,6 +7502,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_hungarian_bros"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -8353,6 +8356,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_lithuania"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -8409,6 +8413,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_latvia"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -8466,6 +8471,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_estonia"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -9102,6 +9108,7 @@ POL_department_of_foreign_influence_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_romania"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -9158,6 +9165,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_bulgaria"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -9866,6 +9874,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_sweden_two"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 
@@ -9921,6 +9930,7 @@ POL_department_of_foreign_influence_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision POL_invite_finland"
 			set_country_flag = { flag = POL_invites_country_to_rep_flag days = 20 value = 1 }
 		}
 

--- a/common/decisions/Romania.txt
+++ b/common/decisions/Romania.txt
@@ -8,6 +8,7 @@ ROM_monarchy_referendum = {
 		is_good = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_referendum_timer"
 			country_event = romania_politics.9
 		}
 	}
@@ -33,6 +34,7 @@ ROM_monarchy_referendum = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_hold_pro_monarchist_rally"
 			set_country_flag = doing_campaign
 		}
 		remove_effect = {
@@ -67,6 +69,7 @@ ROM_monarchy_referendum = {
 			political_power_gain = -0.05
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_gain_support_within_the_government"
 			set_country_flag = doing_campaign
 		}
 		remove_effect = {
@@ -101,6 +104,7 @@ ROM_monarchy_referendum = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_utilize_pro_monarchist_media"
 			set_country_flag = doing_campaign
 		}
 		remove_effect = {
@@ -133,6 +137,7 @@ ROM_monarchy_referendum = {
 		fixed_random_seed = no
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_attack_republican_politicians"
 			set_country_flag = doing_campaign
 		}
 		remove_effect = {
@@ -171,6 +176,7 @@ ROM_vadim_struggle = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_intimidate_defeatists"
 			set_country_flag = doing_decision_vadim
 		}
 
@@ -208,6 +214,7 @@ ROM_vadim_struggle = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_stage_marches"
 			set_country_flag = doing_decision_vadim
 		}
 
@@ -246,6 +253,7 @@ ROM_vadim_struggle = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_promote_patriotic_views"
 			set_country_flag = doing_decision_vadim
 		}
 
@@ -284,6 +292,7 @@ ROM_vadim_struggle = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_utilize_intelligence_agents"
 			set_country_flag = doing_decision_vadim
 		}
 
@@ -315,6 +324,7 @@ ROM_vadim_struggle = {
 		is_good = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_vadim_timer"
 			country_event = romania_politics.18
 			clr_country_flag = mission_vadim
 			clr_country_flag = rom_vadim_decisions
@@ -340,6 +350,7 @@ ROM_romanianization_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_998_return"
 			add_state_core = 998
 			add_stability = -0.05
 		}
@@ -365,6 +376,7 @@ ROM_romanianization_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_996_return"
 			add_state_core = 996
 			add_stability = -0.05
 		}
@@ -390,6 +402,7 @@ ROM_romanianization_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision ROM_122_return"
 			add_state_core = 122
 			add_stability = -0.05
 		}

--- a/common/decisions/Russia.txt
+++ b/common/decisions/Russia.txt
@@ -3818,6 +3818,7 @@ SOV_500_days_category = {
 			}
 		}
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_500_days_ticker_mission"
 			custom_effect_tooltip = SOV_500_days_ura_tt
 			country_event = { id = sov_liberals.1 days = 1 }
 		}
@@ -6335,6 +6336,7 @@ SOV_economy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_npp_ticker_mission"
 			add_stability = 0.12
 			country_event = { id = sov_economic.42 days = 1 }
 			set_temp_variable = { modify_economic = 2 }
@@ -6649,6 +6651,7 @@ SOV_economy_category = {
 			}
 		}
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_from_center_ticker_mission"
 			add_stability = 0.1
 			custom_effect_tooltip = SOV_subjectsepar_minus_tt
 			hidden_effect = {

--- a/common/decisions/Russia.txt
+++ b/common/decisions/Russia.txt
@@ -3822,6 +3822,7 @@ SOV_500_days_category = {
 			country_event = { id = sov_liberals.1 days = 1 }
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_500_days_ticker_mission"
 			country_event = { id = sov_liberals.2 days = 1 }
 			custom_effect_tooltip = SOV_500_days_pizda_tt
 			clr_country_flag = days_500_in_progress
@@ -6340,6 +6341,7 @@ SOV_economy_category = {
 			modify_economic_support = yes
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_npp_ticker_mission"
 			add_stability = -0.12
 			add_political_power = -100
 			country_event = { id = sov_economic.41 days = 1 }
@@ -6656,6 +6658,7 @@ SOV_economy_category = {
 			modify_economic_support = yes
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_from_center_ticker_mission"
 			hidden_effect = {
 				SUB_separatism_plus_subject = yes
 			}
@@ -8034,6 +8037,7 @@ SOV_army_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_storm_z_central_russias"
 			random_owned_controlled_state = {
 				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = { 651 }
@@ -8070,6 +8074,7 @@ SOV_army_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_storm_z_ural"
 			random_owned_controlled_state = {
 				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = { 676 }
@@ -8121,6 +8126,7 @@ SOV_army_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_storm_z_far_east"
 			random_owned_controlled_state = {
 				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = { 688 }
@@ -8157,6 +8163,7 @@ SOV_army_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_storm_z_siberia"
 			random_owned_controlled_state = {
 				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = { 682 }
@@ -8214,6 +8221,7 @@ SOV_army_category = {
 			has_completed_focus = SOV_pmc_redut_coprs
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SOV_start_volunteer_assault_coprs"
 			add_command_power = -150
 			custom_effect_tooltip = SOV_pmc_redut_corps_TT
 			hidden_effect = {

--- a/common/decisions/Sahrawi.txt
+++ b/common/decisions/Sahrawi.txt
@@ -20,6 +20,7 @@ SHA_cross_the_sand_line_decision_cat = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SHA_reclaim_the_sahara"
 			set_country_flag = SHA_taking_decision
 		}
 

--- a/common/decisions/Serbia.txt
+++ b/common/decisions/Serbia.txt
@@ -8,6 +8,7 @@ SER_the_castle_crumbles = {
 		is_good = no
 		fire_only_once = yes
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_the_revolution"
 			set_country_flag = SER_zover
 			set_country_flag = SER_bulldozer_revolution
 			custom_effect_tooltip = SER_revolution2_TT
@@ -28,7 +29,12 @@ SER_the_castle_crumbles = {
 				}
 			}
 		}
-		complete_effect = { set_country_flag = SER_zover set_country_flag = SER_bulldozer_died custom_effect_tooltip = SER_revolution3_TT }
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_the_revolution"
+			set_country_flag = SER_zover
+			set_country_flag = SER_bulldozer_died
+			custom_effect_tooltip = SER_revolution3_TT
+		}
 	}
 	#
 	SER_negotiations = {
@@ -55,6 +61,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_negotiations"
 			decrease_military_spending = yes
 			newline = yes
 			add_to_variable = { var = SER_milosevic_strength value = 5 tooltip = SER_milosevic_power_5 }
@@ -86,6 +93,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_appeal_to_nationalists"
 			add_popularity = {
 				ideology = nationalist
 				popularity = 0.10
@@ -120,6 +128,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_suppress_dissent"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_1
 				amount = -1000
@@ -154,6 +163,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_utilize_mafia"
 			add_to_variable = { var = SER_milosevic_strength value = 5 tooltip = SER_milosevic_power_5 }
 		}
 		modifier = { political_power_gain = -0.05 }
@@ -183,6 +193,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_russian_involvement"
 			set_temp_variable = { percent_change = 5 }
 			set_temp_variable = { tag_index = SOV }
 			set_temp_variable = { influence_target = SER }
@@ -217,6 +228,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_selective_repression"
 			add_stability = -0.03
 			newline = yes
 			add_to_variable = { var = SER_milosevic_strength value = 5 tooltip = SER_milosevic_power_5 }
@@ -248,6 +260,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_mafia_concessions"
 			add_political_power = 150
 			newline = yes
 			add_to_variable = { var = SER_milosevic_strength value = 5 tooltip = SER_milosevic_power_5 }
@@ -279,6 +292,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_choke_the_media"
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -313,6 +327,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_constitutional_manipulation"
 			increase_corruption = yes
 			newline = yes
 			add_to_variable = { var = SER_milosevic_strength value = 5 tooltip = SER_milosevic_power_5 }
@@ -344,6 +359,7 @@ SER_the_castle_crumbles = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_divisionary_tactics"
 			add_popularity = {
 				ideology = democratic
 				popularity = -0.10
@@ -453,6 +469,7 @@ SER_The_Montenegro_Confederacy = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_retainment_of_connections_Montenegro"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 			add_to_variable = { var = SER_Montenegro_separatism value = -5 tooltip = Neg5SER_Montenegro_separatism }
@@ -482,12 +499,14 @@ SER_The_Montenegro_Confederacy = {
 			}
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_attack_mnt_militias"
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_1
 				amount = -30
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_attack_mnt_militias"
 			custom_effect_tooltip = SER_losing_troops_war_idk
 			hidden_effect = {
 				random_list = {
@@ -536,9 +555,11 @@ SER_The_Montenegro_Confederacy = {
 		icon = GFX_decision_monte_troops_button
 		days_remove = 20
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_deploy_more_troops"
 			add_manpower = -15
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_deploy_more_troops"
 			custom_effect_tooltip = SER_troop_deploy
 			add_to_variable = { var = SER_Serbian_combatants value = 15 }
 			clamp_variable = { var = SER_Serbian_combatants min = 0 max = 8000 }
@@ -580,6 +601,7 @@ SER_exercises_category = {
 			set_country_flag = ser_exer_start
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_uchenia_with_sov"
 			clr_country_flag = ser_exer_start
 		}
 		ai_will_do = {
@@ -615,6 +637,7 @@ SER_exercises_category = {
 			set_country_flag = ser_exer_start
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_uchenia_with_usa"
 			clr_country_flag = ser_exer_start
 		}
 		ai_will_do = {
@@ -675,6 +698,7 @@ SER_doctrine_category = {
 			set_country_flag = prepare_change_doctrine
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_anti_rom_doctrines"
 			clr_country_flag = prepare_change_doctrine
 		}
 		ai_will_do = {
@@ -732,6 +756,7 @@ SER_doctrine_category = {
 			set_country_flag = prepare_change_doctrine
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_anti_bul_doctrines"
 			clr_country_flag = prepare_change_doctrine
 		}
 		ai_will_do = {
@@ -789,6 +814,7 @@ SER_doctrine_category = {
 			set_country_flag = prepare_change_doctrine
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_anti_bos_doctrines"
 			clr_country_flag = prepare_change_doctrine
 		}
 		ai_will_do = {
@@ -848,6 +874,7 @@ SER_doctrine_category = {
 			set_country_flag = prepare_change_doctrine
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_anti_cro_doctrines"
 			clr_country_flag = prepare_change_doctrine
 		}
 		ai_will_do = {
@@ -904,6 +931,7 @@ SER_doctrine_category = {
 			set_country_flag = prepare_change_doctrine
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_de_fence_doctrines"
 			clr_country_flag = prepare_change_doctrine
 		}
 		ai_will_do = {
@@ -1052,6 +1080,7 @@ SER_integrate_yugoslavia_category = {
 		cost = 150
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_bosnia_return"
 			add_state_core = 129
 			add_state_core = 128
 			add_state_core = 1052
@@ -1078,6 +1107,7 @@ SER_integrate_yugoslavia_category = {
 		cost = 150
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_croatia_returns"
 			add_state_core = 127
 			add_state_core = 126
 		}
@@ -1100,6 +1130,7 @@ SER_integrate_yugoslavia_category = {
 		cost = 150
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_slovenia_returns"
 			add_state_core = 124
 			add_state_core = 125
 		}
@@ -1122,6 +1153,7 @@ SER_integrate_yugoslavia_category = {
 		cost = 150
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_macedonia_returns"
 			add_state_core = 135
 			add_state_core = 136
 		}
@@ -1150,6 +1182,7 @@ SER_integrate_bosnia_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_serpska_returns"
 			add_state_core = 129
 		}
 
@@ -1174,6 +1207,7 @@ SER_integrate_bosnia_category = {
 		cost = 50
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_bosnia_returns"
 			add_state_core = 128
 		}
 
@@ -1198,6 +1232,7 @@ SER_integrate_bosnia_category = {
 		cost = 55
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_herce_returns"
 			add_state_core = 1052
 		}
 
@@ -1223,6 +1258,7 @@ SER_integrate_bosnia_category = {
 		cost = 55
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_brcko_returns"
 			add_state_core = 1053
 		}
 
@@ -1248,6 +1284,7 @@ SER_integrate_bosnia_category = {
 		cost = 55
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_westserbska_returns"
 			add_state_core = 1054
 		}
 
@@ -1273,6 +1310,7 @@ SER_integrate_bosnia_category = {
 		cost = 55
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision SER_unsko_returns"
 			add_state_core = 1051
 		}
 

--- a/common/decisions/SubjectsOfRussia.txt
+++ b/common/decisions/SubjectsOfRussia.txt
@@ -1903,6 +1903,7 @@ URA_policy_category = {
 			MNT = { NOT = { has_idea = URA_romanov_empire } }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_montenegro"
 			MNT = { country_event = { id = ural_event.39 days = 1 } }
 		}
 		ai_will_do = {
@@ -1921,6 +1922,7 @@ URA_policy_category = {
 			ALB = { NOT = { has_idea = URA_romanov_empire } }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_albania"
 			ALB = { country_event = { id = ural_event.39 days = 1 } }
 		}
 		ai_will_do = {
@@ -1939,6 +1941,7 @@ URA_policy_category = {
 			FYR = { NOT = { has_idea = URA_romanov_empire } }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_macedonia"
 			FYR = { country_event = { id = ural_event.39 days = 1 } }
 		}
 		ai_will_do = {
@@ -1957,6 +1960,7 @@ URA_policy_category = {
 			GAM = { NOT = { has_idea = URA_romanov_empire } }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_gambia"
 			GAM = { country_event = { id = ural_event.39 days = 1 } }
 		}
 		ai_will_do = {
@@ -1974,6 +1978,7 @@ URA_policy_category = {
 			has_completed_focus = URA_monarchy_negotiate_land
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_trinidad"
 			TRI = { country_event = { id = ural_event.39 days = 1 } }
 		}
 		ai_will_do = {
@@ -1990,6 +1995,7 @@ URA_policy_category = {
 			MNT = { has_idea = URA_romanov_empire }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_montenegro_influency"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1 }
@@ -2010,6 +2016,7 @@ URA_policy_category = {
 			ALB = { has_idea = URA_romanov_empire }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_albania_influency"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1 }
@@ -2030,6 +2037,7 @@ URA_policy_category = {
 			FYR = { has_idea = URA_romanov_empire }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_macedonia_influency"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1 }
@@ -2050,6 +2058,7 @@ URA_policy_category = {
 			GAM = { has_idea = URA_romanov_empire }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_gambia_influency"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1 }
@@ -2070,6 +2079,7 @@ URA_policy_category = {
 			TRI = { has_idea = URA_romanov_empire }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_romanov_trinidad_influency"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1 }
@@ -2092,6 +2102,7 @@ URA_policy_category = {
 			has_completed_focus = URA_rne_ekb_all_nazbol
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_nazbols_ekb"
 			SOV = {
 				set_temp_variable = { party_index = 21 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -2114,6 +2125,7 @@ URA_policy_category = {
 			has_completed_focus = URA_rne_nazbol_unite_propaganda
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_nazbols_unite"
 			SOV = {
 				set_temp_variable = { party_index = 21 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -2136,6 +2148,7 @@ URA_policy_category = {
 			has_completed_focus = URA_rne_nazbol_revanshizm_propaganda
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_nazbols_revanshizm"
 			SOV = {
 				set_temp_variable = { party_index = 21 }
 				set_temp_variable = { party_popularity_increase = 0.05 }
@@ -2160,6 +2173,7 @@ URA_policy_category = {
 			GER = { NOT = { has_idea = URA_ekb_concern_idea_other } }
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_ger_promka"
 			set_country_flag = URA_deal_offer
 			GER = { country_event = { id = ural_event.24 days = 1 } }
 		}
@@ -2177,6 +2191,7 @@ URA_policy_category = {
 			owns_state = 676
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_returm_ekb_promka"
 			add_ideas = URA_ekb_concern_idea
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -2194,6 +2209,7 @@ URA_policy_category = {
 			owns_state = 676
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_returm_ugmk_promka"
 			add_ideas = URA_ugmk_idea4
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -2211,6 +2227,7 @@ URA_policy_category = {
 			owns_state = 1071
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_returm_kurgan_promka"
 			add_ideas = URA_kurgan_concern_idea
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
@@ -2228,6 +2245,7 @@ URA_policy_category = {
 			owns_state = 675
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision URA_returm_chelyaba_promka"
 			add_ideas = URA_chelyaba_concern_idea
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes

--- a/common/decisions/Syria.txt
+++ b/common/decisions/Syria.txt
@@ -1415,8 +1415,8 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 360
 		complete_effect = {
-			add_ideas = idea_aleppan_slums
 			log = "[GetDateText]: [Root.GetName]: Decision clear_aleppan_slums"
+			add_ideas = idea_aleppan_slums
 			syrian_industry_effect1 = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 		}
@@ -1596,8 +1596,8 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 300
 		complete_effect = {
-			add_ideas = idea_damascus_priv_sector1
 			log = "[GetDateText]: [Root.GetName]: Decision damascus_private_sector_booming"
+			add_ideas = idea_damascus_priv_sector1
 			syrian_industry_effect1 = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 		}
@@ -1640,8 +1640,8 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 180
 		complete_effect = {
-			add_ideas = idea_syr_eastern_excavation
 			log = "[GetDateText]: [Root.GetName]: Decision eastern_oil_excavation_phase1"
+			add_ideas = idea_syr_eastern_excavation
 			syrian_energy_effect = yes
 		}
 		remove_effect = {
@@ -1723,8 +1723,8 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 180
 		complete_effect = {
-			add_ideas = idea_syr_eastern_excavation
 			log = "[GetDateText]: [Root.GetName]: Decision eastern_oil_excavation_phase2"
+			add_ideas = idea_syr_eastern_excavation
 			syrian_energy_effect = yes
 		}
 		remove_effect = {
@@ -1806,8 +1806,8 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 180
 		complete_effect = {
-			add_ideas = idea_syr_eastern_excavation
 			log = "[GetDateText]: [Root.GetName]: Decision eastern_oil_excavation_phase3"
+			add_ideas = idea_syr_eastern_excavation
 			syrian_energy_effect = yes
 		}
 		remove_effect = {
@@ -1882,8 +1882,8 @@ Syria_economic_investments = {
 		fire_only_once = yes
 		days_remove = 180
 		complete_effect = {
-			add_ideas = idea_syr_eastern_cotton
 			log = "[GetDateText]: [Root.GetName]: Decision invest_in_eastern_cotton"
+			add_ideas = idea_syr_eastern_cotton
 		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision invest_in_eastern_cotton"

--- a/common/decisions/Syria.txt
+++ b/common/decisions/Syria.txt
@@ -295,6 +295,7 @@ Syria_decisions = {
 		cost = 10
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision concede_rojava"
 			ROJ = {
 				add_state_core = 193
 				add_state_core = 575
@@ -1322,6 +1323,7 @@ Syria_economic_investments = {
 			add_ideas = idea_hisiyah
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision invigorate_hisiyah"
 			remove_ideas = idea_hisiyah
 			set_country_flag = hisiyah_invigorated
 
@@ -1380,6 +1382,7 @@ Syria_economic_investments = {
 			add_ideas = idea_hisiyah1
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision hisiyah_industrial_expansion"
 			remove_ideas = idea_hisiyah1
 			188 = {
 				add_extra_state_shared_building_slots = 1
@@ -1418,6 +1421,7 @@ Syria_economic_investments = {
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision clear_aleppan_slums"
 			remove_ideas = idea_aleppan_slums
 			set_country_flag = aleppan_slums_cleared
 			if = {
@@ -1488,6 +1492,7 @@ Syria_economic_investments = {
 			add_ideas = idea_aleppan_slums1
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision aleppan_economy_booming"
 			remove_ideas = idea_aleppan_slums1
 			566 = {
 				add_extra_state_shared_building_slots = 1
@@ -1526,6 +1531,7 @@ Syria_economic_investments = {
 			add_ideas = idea_damascus_priv_sector
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision damascus_private_sector_encouragement"
 			remove_ideas = idea_damascus_priv_sector
 			set_country_flag = damascus_private_sector_encouraged
 			if = {
@@ -1596,6 +1602,7 @@ Syria_economic_investments = {
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision damascus_private_sector_booming"
 			remove_ideas = idea_damascus_priv_sector1
 			186 = {
 				add_extra_state_shared_building_slots = 1
@@ -1638,6 +1645,7 @@ Syria_economic_investments = {
 			syrian_energy_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eastern_oil_excavation_phase1"
 			remove_ideas = idea_syr_eastern_excavation
 			set_country_flag = syrian_oil_extraction_phase1_complete
 			if = {
@@ -1720,6 +1728,7 @@ Syria_economic_investments = {
 			syrian_energy_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eastern_oil_excavation_phase2"
 			remove_ideas = idea_syr_eastern_excavation
 			set_country_flag = syrian_oil_extraction_phase2_complete
 			if = {
@@ -1802,6 +1811,7 @@ Syria_economic_investments = {
 			syrian_energy_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision eastern_oil_excavation_phase3"
 			remove_ideas = idea_syr_eastern_excavation
 			if = {
 				limit = { controls_state = 995 }
@@ -1876,6 +1886,7 @@ Syria_economic_investments = {
 			log = "[GetDateText]: [Root.GetName]: Decision invest_in_eastern_cotton"
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision invest_in_eastern_cotton"
 			remove_ideas = idea_syr_eastern_cotton
 			if = {
 				limit = { controls_state = 193 }
@@ -2146,6 +2157,7 @@ Syria_centralization_balance_of_power_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision syria_decision_increase_local_accountability_officials"
 			set_temp_variable = { local_accountability_chance = 0 }
 			if = {
 				limit = { has_idea = corruption_level_10 }
@@ -2284,6 +2296,7 @@ Syria_centralization_balance_of_power_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision syria_decision_find_promising_bureaucracy"
 			set_temp_variable = { promising_pol_rep_chance = 0 }
 			if = {
 				limit = { has_idea = corruption_level_10 }
@@ -2493,6 +2506,7 @@ Syria_centralization_balance_of_power_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision syria_decision_fund_voluntary_organizations"
 			set_temp_variable = { voluntary_groups_chance = 0 }
 			set_temp_variable = { syrian_centralization_minority_average = 0 }
 			set_temp_variable = { syrian_number_of_minorities = 0 }
@@ -2568,6 +2582,7 @@ Syria_centralization_balance_of_power_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision syria_decision_encourage_economic_self_reliance"
 			set_temp_variable = { economic_self_reliance_chance = 0 }
 			if = {
 				limit = { has_idea = corruption_level_10 }
@@ -2705,6 +2720,7 @@ Syria_centralization_balance_of_power_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision syria_decision_encourage_state_decision_making"
 			set_temp_variable = { state_level_decision_chance = 0 }
 			if = {
 				limit = { has_idea = corruption_level_10 }

--- a/common/decisions/Turkey.txt
+++ b/common/decisions/Turkey.txt
@@ -819,6 +819,7 @@ TUR_domestic_politics_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision TUR_establish_shia_dominance"
 			add_ideas = unrepresentative_government_shia
 			swap_ideas = {
 				add_idea = shia

--- a/common/decisions/Ukraine.txt
+++ b/common/decisions/Ukraine.txt
@@ -307,6 +307,7 @@ UKR_uop_decision_category = {
 		custom_cost_text = cost_2_2
 		days_remove = 210
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_t84_oplot"
 			add_tech_bonus = {
 				name = CAT_mbt
 				bonus = 0.1
@@ -337,7 +338,6 @@ UKR_uop_decision_category = {
 					}
 				}
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision UKR_t84_oplot"
 		}
 		ai_will_do = { base = 100 }
 	}
@@ -350,13 +350,13 @@ UKR_uop_decision_category = {
 		icon = GFX_decision_ukrpom_button
 		days_remove = 140
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_bpla_oup"
 			add_tech_bonus = {
 				name = GENERIC_drones
 				uses = 2
 				bonus = 0.5
 				category = Cat_L_DRONE
 			}
-			log = "[GetDateText]: [Root.GetName]: Decision UKR_bpla_oup"
 		}
 		ai_will_do = { base = 100 }
 	}

--- a/common/decisions/Ukraine.txt
+++ b/common/decisions/Ukraine.txt
@@ -77,10 +77,12 @@ UKR_uop_decision_category = {
 			has_war = yes
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_50_buggies"
 			subtract_from_variable = { ukr_industry_points = 35 }
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_50_buggies"
 			add_equipment_to_stockpile = {
 				type = util_vehicle_2
 				amount = 50
@@ -106,6 +108,7 @@ UKR_uop_decision_category = {
 			has_war = yes
 		}
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_50_m113"
 			subtract_from_variable = { ukr_industry_points = 50 }
 			if = {
 				limit = {
@@ -140,6 +143,7 @@ UKR_uop_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_50_m113"
 			add_equipment_to_stockpile = {
 				type = medium_tank_amphibious_chassis_1
 				variant_name = "MT-LB M113"
@@ -171,6 +175,7 @@ UKR_uop_decision_category = {
 		custom_cost_text = ukr_industry_points_cost_75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_50_mtlb_ifv"
 			subtract_from_variable = { ukr_industry_points = 75 }
 			if = {
 				limit = {
@@ -206,6 +211,7 @@ UKR_uop_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_50_mtlb_ifv"
 			add_equipment_to_stockpile = {
 				type = medium_tank_amphibious_chassis_1
 				variant_name = "MT-LB Shkval"
@@ -241,6 +247,7 @@ UKR_uop_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_25_t62_ifv"
 			subtract_from_variable = { ukr_industry_points = 50 }
 			if = {
 				limit = {
@@ -274,6 +281,7 @@ UKR_uop_decision_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_get_25_t62_ifv"
 			add_equipment_to_stockpile = {
 				type = medium_tank_flame_chassis_0
 				variant_name = "T-62 BMPP"
@@ -361,6 +369,7 @@ UKR_uop_decision_category = {
 		icon = GFX_decision_ukrpom_button
 		days_remove = 190
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_btr70_m"
 			add_tech_bonus = {
 				name = CAT_apc
 				bonus = 0.1
@@ -411,6 +420,7 @@ UKR_uop_decision_category = {
 		days_remove = 230
 		custom_cost_text = cost_2_7
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_btr_4"
 			add_tech_bonus = {
 				name = CAT_apc
 				bonus = 0.1
@@ -457,6 +467,7 @@ UKR_uop_decision_category = {
 		days_remove = 180
 		custom_cost_text = cost_1_0
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_bm21_k"
 			add_tech_bonus = {
 				name = BRA_larger_artillery
 				bonus = 0.1
@@ -499,6 +510,7 @@ UKR_uop_decision_category = {
 		days_remove = 120
 		custom_cost_text = cost_1_0
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_helicopter"
 			add_tech_bonus = {
 				name = CAT_trans_heli
 				bonus = 0.2
@@ -522,6 +534,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_small_arms"
 			if = { limit = { has_dlc = "Arms Against Tyranny" }
 				mio:UKR_kmdb_materiel_manufacturer = {
 					add_mio_size = 1
@@ -547,6 +560,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_equipment_funds"
 			if = { limit = { has_dlc = "Arms Against Tyranny" }
 				mio:UKR_kmdb_materiel_manufacturer = {
 				add_mio_size = 1
@@ -572,6 +586,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_heavy_equipment"
 			if = { limit = { has_dlc = "Arms Against Tyranny" }
 				mio:UKR_malyshev_factory_tank_manufacturer = {
 					add_mio_size = 1
@@ -597,6 +612,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_heavy_equipment_research"
 			add_tech_bonus = {
 				bonus = 0.3
 				uses = 1
@@ -628,6 +644,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_fund_antonov"
 			if = { limit = { has_dlc = "Arms Against Tyranny" }
 				mio:UKR_antonov_aircraft_manufacturer = {
 					add_mio_size = 1
@@ -652,6 +669,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_air_equipment"
 			add_tech_bonus = {
 				bonus = 0.3
 				uses = 1
@@ -680,6 +698,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_naval_equipment"
 			add_tech_bonus = {
 				bonus = 0.3
 				uses = 2
@@ -708,6 +727,7 @@ UKR_uop_decision_category = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_nikolayev_funds"
 			if = { limit = { has_dlc = "Arms Against Tyranny" }
 				mio:UKR_nikolayev_shipyard_naval_manufacturer = {
 					add_mio_size = 1
@@ -3122,6 +3142,7 @@ UKR_hur_decision_category = {
 		}
 		custom_cost_text = cost_hur_points_10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_attack_heavy_equipment"
 			subtract_from_variable = { hur_points = 10 }
 			SOV = {
 				country_event = ukr_sabotage.1
@@ -3156,6 +3177,7 @@ UKR_hur_decision_category = {
 		}
 		custom_cost_text = cost_hur_points_4
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_attack_light_equipment"
 			subtract_from_variable = { hur_points = 4 }
 			SOV = {
 				country_event = ukr_sabotage.2
@@ -3185,6 +3207,7 @@ UKR_hur_decision_category = {
 		}
 		custom_cost_text = cost_hur_points_5
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_attack_military_factories"
 			subtract_from_variable = { hur_points = 5 }
 			SOV = {
 				country_event = ukr_sabotage.3
@@ -3234,6 +3257,7 @@ UKR_hur_decision_category = {
 		}
 		custom_cost_text = cost_hur_points_10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_attack_belgorod_region"
 			subtract_from_variable = { hur_points = 10 }
 			damage_units = {
 				state = 891
@@ -3272,6 +3296,7 @@ UKR_hur_decision_category = {
 		}
 		custom_cost_text = cost_hur_points_10
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_attack_black_sea_region"
 			subtract_from_variable = { hur_points = 10 }
 			damage_units = {
 				region = 30
@@ -3307,6 +3332,7 @@ UKR_hur_decision_category = {
 		}
 		custom_cost_text = cost_hur_points_5
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_operational_support"
 			subtract_from_variable = { hur_points = 5 }
 			add_timed_idea = {
 				idea = UKR_hur_opearational_support
@@ -6038,6 +6064,7 @@ UKR_renewable_energy = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_energy_wind"
 			if = {
 				limit = { controls_state = 333 }
 				333 = {
@@ -6122,6 +6149,7 @@ UKR_renewable_energy = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_energy_solar"
 			if = {
 				limit = { controls_state = 333 }
 				333 = {
@@ -6205,6 +6233,7 @@ UKR_renewable_energy = {
 			modify_treasury_effect = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UKR_energy_geothermal"
 			if = {
 				limit = { controls_state = 701 }
 				701 = {

--- a/common/decisions/Union State.txt
+++ b/common/decisions/Union State.txt
@@ -2891,6 +2891,7 @@ USR_Union_state_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision USR_united_special_services_armenia"
 			SOV = {
 				set_country_flag = USR_special_services_active
 			}

--- a/common/decisions/Uzebkistan.txt
+++ b/common/decisions/Uzebkistan.txt
@@ -12,6 +12,7 @@ UZB_karakalpakstan_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_Promote_Uzbekistan_unity"
 			custom_effect_tooltip = uzbek_karap_tt_effect
 			set_temp_variable = { temp_change = -3 }
 			UZB_modify_karakalpakstan_opinion_effect = yes
@@ -35,6 +36,7 @@ UZB_karakalpakstan_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_Promote_Karakalpakstan_identity"
 			custom_effect_tooltip = uzbek_karap_tt_effect
 			set_temp_variable = { temp_change = 5 }
 			UZB_modify_karakalpakstan_opinion_effect = yes

--- a/common/decisions/Venezuela.txt
+++ b/common/decisions/Venezuela.txt
@@ -300,11 +300,13 @@ VEN_hydroelectric_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision VEN_construct_the_tocoma_hydro_power_plant"
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision VEN_construct_the_tocoma_hydro_power_plant"
 			876 = {
 				set_temp_variable = { electric_addition = 1.415 }
 				set_temp_variable = { storage_addition = 3.6 }
@@ -346,11 +348,13 @@ VEN_hydroelectric_decision_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision VEN_construct_caruachi_hydro_power_plant"
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision VEN_construct_caruachi_hydro_power_plant"
 			876 = {
 				set_temp_variable = { electric_addition = 1.415 }
 				set_temp_variable = { storage_addition = 3.6 }

--- a/common/decisions/bankruptcy_decisions.txt
+++ b/common/decisions/bankruptcy_decisions.txt
@@ -39,6 +39,7 @@ bankruptcy_decisions = {
 		days_re_enable = 365
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_cheap_loans_from_imf"
 			custom_effect_tooltip = cheap_loans_from_imf_tt
 			ingame_update_setup = yes
 
@@ -75,6 +76,7 @@ bankruptcy_decisions = {
 		days_re_enable = 180
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_cheap_loans_from_african_investment_fund"
 			if = { limit = { is_ai = yes }
 				add_political_power = -25
 			}
@@ -127,6 +129,7 @@ bankruptcy_decisions = {
 		days_remove = 7
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_biggest_influencer"
 			if = { limit = { is_ai = yes }
 				add_political_power = -50
 			}
@@ -187,6 +190,7 @@ bankruptcy_decisions = {
 		days_remove = 7
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_second_biggest_influencer"
 			if = { limit = { is_ai = yes }
 				add_political_power = -50
 			}
@@ -256,6 +260,7 @@ bankruptcy_decisions = {
 		days_remove = 7
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_neighbour"
 			if = { limit = { is_ai = yes }
 				add_political_power = -50
 			}
@@ -304,6 +309,7 @@ bankruptcy_decisions = {
 		days_re_enable = 360
 		days_remove = 7
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_overlord"
 			if = { limit = { is_ai = yes }
 				add_political_power = -50
 			}
@@ -359,6 +365,7 @@ bankruptcy_decisions = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_imf"
 			set_variable = {
 				debt_bailout = {
 					value = debt
@@ -803,6 +810,7 @@ bankruptcy_decisions = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_african_monetary_fund"
 			set_temp_variable = {
 				debt_change = {
 					value = debt
@@ -865,6 +873,7 @@ bankruptcy_decisions = {
 		days_mission_timeout = 360
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_incoming_collapse"
 			set_temp_variable = { party_popularity_increase = -0.10 }
 			set_temp_variable = { temp_outlook_increase = -0.10 }
 			change_relative_party_popularity = yes
@@ -886,6 +895,7 @@ bankruptcy_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_incoming_collapse"
 			add_political_power = 150
 		}
 
@@ -906,6 +916,7 @@ bankruptcy_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_default_on_debts"
 			# Cartels
 			if = { limit = { has_dynamic_modifier = { modifier = cartel_penalties } }
 				set_temp_variable = { cart_strength_change = 10 }
@@ -962,6 +973,7 @@ bankruptcy_decisions = {
 		days_mission_timeout = 365
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision cheap_loan_from_the_imf_mission"
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
@@ -1043,6 +1055,7 @@ bankruptcy_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision cheap_loan_from_the_imf_mission"
 			add_political_power = 150
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -1079,6 +1092,7 @@ debt_default_decisions = {
 		days_mission_timeout = 360
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_main_mission"
 			if = {
 				limit = { is_subject = no }
 				if = { limit = { check_variable = { influence_array^0 > 0 } }
@@ -1175,6 +1189,7 @@ debt_default_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_main_mission"
 			clear_variable = debt_default_left
 			clear_variable = debt_default_total
 			add_timed_idea = { idea = debt_default_ecomomic_boom days = 360 }
@@ -1194,6 +1209,7 @@ debt_default_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_pay_10_from_treasury"
 			custom_effect_tooltip = debt_default_pay_10_from_treasury_tt
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
@@ -1222,6 +1238,7 @@ debt_default_decisions = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_pay_50_from_treasury"
 			custom_effect_tooltip = debt_default_pay_50_from_treasury_tt
 			set_temp_variable = { treasury_change = -50 }
 			modify_treasury_effect = yes
@@ -1251,6 +1268,7 @@ debt_default_decisions = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_concessions_to_the_imf"
 			set_temp_variable = { percent_change = -10 }
 			change_domestic_influence_percentage = yes
 			set_temp_variable = { debt_default_reduction = debt_default_total }
@@ -1362,6 +1380,7 @@ debt_default_decisions = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_political_concessions_to_biggest_influencer"
 			var:influence_array^0 = {
 				set_temp_variable = { percent_change = 15 }
 				set_temp_variable = { tag_index = THIS.id }
@@ -1423,6 +1442,7 @@ debt_default_decisions = {
 		cost = 25
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_political_concessions_to_second_biggest_influencer"
 			var:influence_array^1 = {
 				set_temp_variable = { percent_change = 10 }
 				set_temp_variable = { tag_index = THIS.id }
@@ -1483,6 +1503,7 @@ debt_default_decisions = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_sell_civilian_factories"
 			custom_effect_tooltip = sell_10_billion_factory
 			subtract_from_variable = { debt_default_left = 10 }
 			random_owned_state = {
@@ -1531,6 +1552,7 @@ debt_default_decisions = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_dismantle_military_factories"
 			custom_effect_tooltip = sell_10_billion_factory
 			subtract_from_variable = { debt_default_left = 10 }
 			random_owned_state = {
@@ -1577,6 +1599,7 @@ debt_default_decisions = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_scrap_dockyard"
 			custom_effect_tooltip = sell_10_billion_factory
 			subtract_from_variable = { debt_default_left = 10 }
 			random_owned_state = {
@@ -1623,6 +1646,7 @@ debt_default_decisions = {
 		cost = 25
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision debt_default_cut_down_government_services"
 			custom_effect_tooltip = sell_15_billion_factory
 			subtract_from_variable = { debt_default_left = 10 }
 			random_owned_state = {

--- a/common/decisions/bulgaria.txt
+++ b/common/decisions/bulgaria.txt
@@ -580,6 +580,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_132_return"
 			add_state_core = 132
 			add_stability = -0.05
 		}
@@ -599,6 +600,7 @@ BUL_Bolgarisation_category = {
 		cost = 80
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_133_return"
 			add_state_core = 133
 			add_stability = -0.05
 		}
@@ -618,6 +620,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_998_return"
 			add_state_core = 998
 			add_stability = -0.05
 		}
@@ -637,6 +640,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_130_return"
 			add_state_core = 130
 			add_stability = -0.05
 		}
@@ -656,6 +660,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_131_return"
 			add_state_core = 131
 			add_stability = -0.05
 		}
@@ -675,6 +680,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_134_return"
 			add_state_core = 134
 			add_stability = -0.05
 		}
@@ -694,6 +700,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_934_return"
 			add_state_core = 934
 			add_stability = -0.05
 		}
@@ -713,6 +720,7 @@ BUL_Bolgarisation_category = {
 		cost = 75
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_137_return"
 			add_state_core = 137
 			add_stability = -0.05
 		}
@@ -732,6 +740,7 @@ BUL_Bolgarisation_category = {
 		cost = 75
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_138_return"
 			add_state_core = 138
 			add_stability = -0.05
 		}
@@ -751,6 +760,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_974_return"
 			add_state_core = 974
 			add_stability = -0.05
 		}
@@ -770,6 +780,7 @@ BUL_Bolgarisation_category = {
 		cost = 75
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_140_return"
 			add_state_core = 140
 			add_stability = -0.05
 		}
@@ -789,6 +800,7 @@ BUL_Bolgarisation_category = {
 		cost = 75
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_139_return"
 			add_state_core = 139
 			add_stability = -0.05
 		}
@@ -812,6 +824,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_136_return"
 			add_state_core = 136
 			add_stability = -0.05
 		}
@@ -835,6 +848,7 @@ BUL_Bolgarisation_category = {
 		cost = 70
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_135_return"
 			add_state_core = 135
 			add_stability = -0.05
 		}
@@ -854,6 +868,7 @@ BUL_Bolgarisation_category = {
 		cost = 80
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BUL_284_return"
 			add_state_core = 284
 			add_stability = -0.05
 		}

--- a/common/decisions/central_asian_narcotraffic.txt
+++ b/common/decisions/central_asian_narcotraffic.txt
@@ -53,6 +53,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_central_asian_narcotraffic_1"
 			swap_ideas = {
 				remove_idea = KAZ_narcotraffic_1
 				add_idea = KAZ_narcotraffic_2
@@ -114,6 +115,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_central_asian_narcotraffic_1"
 			swap_ideas = {
 				remove_idea = UZB_narcotraffic_1
 				add_idea = UZB_narcotraffic_2
@@ -158,6 +160,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_central_asian_narcotraffic_1"
 			swap_ideas = {
 				remove_idea = KYR_narcotraffic_1
 				add_idea = KYR_narcotraffic_2
@@ -228,6 +231,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_central_asian_narcotraffic_2"
 			swap_ideas = {
 				remove_idea = KAZ_narcotraffic_2
 				add_idea = KAZ_narcotraffic_3
@@ -294,6 +298,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_central_asian_narcotraffic_2"
 			swap_ideas = {
 				remove_idea = UZB_narcotraffic_2
 				add_idea = UZB_narcotraffic_3
@@ -343,6 +348,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_central_asian_narcotraffic_2"
 			swap_ideas = {
 				remove_idea = KYR_narcotraffic_2
 				add_idea = KYR_narcotraffic_3
@@ -414,6 +420,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_central_asian_narcotraffic_3"
 			random_list = {
 				50 = {
 					country_event = drugs.1
@@ -483,6 +490,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_central_asian_narcotraffic_3"
 			random_list = {
 				50 = {
 					country_event = drugs.1
@@ -535,6 +543,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_central_asian_narcotraffic_3"
 			random_list = {
 				50 = {
 					country_event = drugs.1
@@ -609,6 +618,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_central_asian_narcotraffic_4"
 			random_list = {
 				50 = {
 					country_event = drugs.1
@@ -678,6 +688,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_central_asian_narcotraffic_4"
 			random_list = {
 				50 = {
 					country_event = drugs.1
@@ -730,6 +741,7 @@ central_asian_narcotraffic = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_central_asian_narcotraffic_4"
 			random_list = {
 				50 = {
 					country_event = drugs.1
@@ -803,6 +815,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_central_asian_narcotraffic_5"
 			country_event = drugs.1
 		}
 
@@ -864,6 +877,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_central_asian_narcotraffic_5"
 			country_event = drugs.1
 		}
 
@@ -910,6 +924,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_central_asian_narcotraffic_5"
 			country_event = drugs.1
 		}
 
@@ -978,6 +993,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_central_asian_narcotraffic_6"
 			country_event = drugs.4
 		}
 
@@ -1039,6 +1055,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_central_asian_narcotraffic_6"
 			country_event = drugs.4
 		}
 
@@ -1085,6 +1102,7 @@ central_asian_narcotraffic = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_central_asian_narcotraffic_6"
 			country_event = drugs.4
 		}
 

--- a/common/decisions/formable_nation_decisions.txt
+++ b/common/decisions/formable_nation_decisions.txt
@@ -12887,6 +12887,7 @@ form_AVG_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AVG_integrate_FRA"
 			add_state_core = 55
 			add_state_core = 59
 			add_state_core = 60
@@ -12942,6 +12943,7 @@ form_AVG_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AVG_integrate_IRE"
 			add_state_core = 27
 			add_state_core = 28
 			if = {
@@ -13007,6 +13009,7 @@ form_AVG_category = {
 			}
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision AVG_integrate_ENG"
 			add_state_core = 10
 			add_state_core = 11
 			add_state_core = 12

--- a/common/decisions/libya.txt
+++ b/common/decisions/libya.txt
@@ -7040,6 +7040,7 @@ libya_aftermath_of_civil_war = {
 		days_mission_timeout = 90
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision libya_integrate_militias_mission"
 			if = {
 				limit = { NOT = { has_country_flag = libya_LNA_formed } }
 				set_country_flag = libya_LNA_formed

--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -1384,6 +1384,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_CHL_tariff_alignment"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 
@@ -1427,6 +1428,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_CHL_customs_system_modernization"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -1470,6 +1472,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_CHL_common_standards"
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 
@@ -1513,6 +1516,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_COL_tariff_alignment"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 
@@ -1556,6 +1560,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_COL_customs_system_modernization"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -1599,6 +1604,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_COL_common_standards"
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 
@@ -1642,6 +1648,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_VEN_tariff_alignment"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 
@@ -1685,6 +1692,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_VEN_customs_system_modernization"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -1728,6 +1736,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_VEN_common_standards"
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 
@@ -1771,6 +1780,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_PRU_logistics_corridor"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -1830,6 +1840,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_PRU_cross_border_transport"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -1889,6 +1900,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_PRU_port_connectivity"
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
 
@@ -1948,6 +1960,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_BOL_logistics_corridor"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -2007,6 +2020,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_BOL_overland_transport"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -2066,6 +2080,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_BOL_border_connectivity"
 			set_temp_variable = { treasury_change = -6.0 }
 			modify_treasury_effect = yes
 
@@ -2125,6 +2140,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_PAN_logistics_corridor"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -2184,6 +2200,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_PAN_port_transport"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -2243,6 +2260,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_PAN_trade_connectivity"
 			set_temp_variable = { treasury_change = -6.0 }
 			modify_treasury_effect = yes
 
@@ -2302,6 +2320,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_ECU_development_funds"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -2355,6 +2374,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_ECU_civilian_industry"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
 
@@ -2407,6 +2427,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_ECU_infrastructure_development"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -2466,6 +2487,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_GUY_development_funds"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -2524,6 +2546,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_GUY_civilian_industry"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
 
@@ -2576,6 +2599,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_GUY_infrastructure_development"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
 
@@ -2635,6 +2659,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_SUR_development_funds"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -2688,6 +2713,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_SUR_civilian_industry"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
 
@@ -2740,6 +2766,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_SUR_commercial_infrastructure"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -2793,6 +2820,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_MEX_industrial_investment_agreement"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
 
@@ -2845,6 +2873,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_MEX_commercial_investment_framework"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
 
@@ -2898,6 +2927,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_MEX_financial_cooperation_package"
 			set_temp_variable = { treasury_change = -19.5 }
 			modify_treasury_effect = yes
 
@@ -3256,6 +3286,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_unasul_joint_health_improvement_project"
 			clr_global_flag = MER_unasul_joint_health_improvement_project_active
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -3312,6 +3343,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_unasul_supply_chain_strengthening"
 			clr_global_flag = MER_unasul_supply_chain_strengthening_active
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -3425,6 +3457,7 @@ MER_request_unasul_membership = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision MER_unasul_joint_research_exchange_project"
 			clr_global_flag = MER_unasul_joint_research_exchange_project_active
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt

--- a/common/decisions/migration_central_asia_decisions.txt
+++ b/common/decisions/migration_central_asia_decisions.txt
@@ -16,6 +16,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_migration_central_asia_5"
 			set_country_flag = KAZ_migration_central_asia_4
 			swap_ideas = {
 				remove_idea = KAZ_high_emigration_5
@@ -45,6 +46,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_migration_central_asia_4"
 			set_country_flag = KAZ_migration_central_asia_3
 			swap_ideas = {
 				remove_idea = KAZ_high_emigration_4
@@ -74,6 +76,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_migration_central_asia_3"
 			set_country_flag = KAZ_migration_central_asia_2
 			swap_ideas = {
 				remove_idea = KAZ_high_emigration_3
@@ -103,6 +106,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_migration_central_asia_2"
 			set_country_flag = KAZ_migration_central_asia_1
 			swap_ideas = {
 				remove_idea = KAZ_high_emigration_2
@@ -131,6 +135,7 @@ migration_central_asia = {
 			gdp_total_greater_than_600 = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KAZ_migration_central_asia_1"
 			swap_ideas = {
 				remove_idea = KAZ_high_emigration_1
 				add_idea = KAZ_immigration
@@ -158,6 +163,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_migration_central_asia_5"
 			set_country_flag = UZB_migration_central_asia_4
 			swap_ideas = {
 				remove_idea = UZB_high_emigration_5
@@ -187,6 +193,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_migration_central_asia_4"
 			set_country_flag = UZB_migration_central_asia_3
 			swap_ideas = {
 				remove_idea = UZB_high_emigration_4
@@ -216,6 +223,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_migration_central_asia_3"
 			set_country_flag = UZB_migration_central_asia_2
 			swap_ideas = {
 				remove_idea = UZB_high_emigration_3
@@ -245,6 +253,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_migration_central_asia_2"
 			set_country_flag = UZB_migration_central_asia_1
 			swap_ideas = {
 				remove_idea = UZB_high_emigration_2
@@ -273,6 +282,7 @@ migration_central_asia = {
 			gdp_total_greater_than_300 = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UZB_migration_central_asia_1"
 			swap_ideas = {
 				remove_idea = UZB_high_emigration_1
 				add_idea = UZB_immigration
@@ -300,6 +310,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_migration_central_asia_5"
 			set_country_flag = KYR_migration_central_asia_4
 			swap_ideas = {
 				remove_idea = KYR_high_emigration_5
@@ -329,6 +340,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_migration_central_asia_4"
 			set_country_flag = KYR_migration_central_asia_3
 			swap_ideas = {
 				remove_idea = KYR_high_emigration_4
@@ -358,6 +370,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_migration_central_asia_3"
 			set_country_flag = KYR_migration_central_asia_2
 			swap_ideas = {
 				remove_idea = KYR_high_emigration_3
@@ -387,6 +400,7 @@ migration_central_asia = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_migration_central_asia_2"
 			set_country_flag = KYR_migration_central_asia_1
 			swap_ideas = {
 				remove_idea = KYR_high_emigration_2
@@ -415,6 +429,7 @@ migration_central_asia = {
 			gdp_total_greater_than_80 = yes
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision KYR_migration_central_asia_1"
 			swap_ideas = {
 				remove_idea = KYR_high_emigration_1
 				add_idea = KYR_immigration

--- a/common/decisions/netherlands.txt
+++ b/common/decisions/netherlands.txt
@@ -45,6 +45,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_GER"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -113,6 +114,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_POL"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -181,6 +183,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_AST"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -249,6 +252,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_SPR"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -317,6 +321,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -385,6 +390,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_TUR"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -453,6 +459,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_USA"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -521,6 +528,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ROM"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -573,6 +581,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality1"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -624,6 +633,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality2"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -675,6 +685,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality3"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -726,6 +737,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality4"
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -4292,6 +4304,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda1"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4362,6 +4375,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda2"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4417,6 +4431,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda3"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4471,6 +4486,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda4"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4527,6 +4543,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda5"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4636,6 +4653,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda1"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4692,6 +4710,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda2"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4750,6 +4769,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda3"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4807,6 +4827,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda4"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4868,6 +4889,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda5"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4917,6 +4939,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd1"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4974,6 +4997,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd2"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5031,6 +5055,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd3"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5086,6 +5111,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd4"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5142,6 +5168,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd5"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5197,6 +5224,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv1"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5253,6 +5281,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv2"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5311,6 +5340,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv3"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5366,6 +5396,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv4"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5422,6 +5453,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv5"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5479,6 +5511,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy1"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5539,6 +5572,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy2"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5597,6 +5631,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy3"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5655,6 +5690,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy4"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5771,6 +5807,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy5"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5824,6 +5861,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu1"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5879,6 +5917,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu2"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5935,6 +5974,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu3"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5992,6 +6032,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu4"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -6049,6 +6090,7 @@ HOL_grey_society_category = {
 		}
 
 		cancel_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu5"
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 

--- a/common/decisions/netherlands.txt
+++ b/common/decisions/netherlands.txt
@@ -49,6 +49,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_GER"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -116,6 +117,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_POL"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -183,6 +185,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_AST"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -250,6 +253,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_SPR"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -317,11 +321,12 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA Italy"
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA"
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = HOL_economy
@@ -384,6 +389,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_TUR"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -451,6 +457,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_USA"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -518,6 +525,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ROM"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 
@@ -569,6 +577,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality1"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 		remove_effect = {
@@ -619,6 +628,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality2"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 		remove_effect = {
@@ -669,6 +679,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality3"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 		remove_effect = {
@@ -719,6 +730,7 @@ HOL_ing_group_strategy_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality4"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 		remove_effect = {
@@ -779,6 +791,7 @@ HOL_carrier_production = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_USA"
 			USA = { country_event = { id = HOL_military.049 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_USA
 		}
@@ -826,6 +839,7 @@ HOL_carrier_production = {
 		}
 		cost = 75
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_uk"
 			ENG = { country_event = HOL_military.052 }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_UK
 		}
@@ -871,6 +885,7 @@ HOL_carrier_production = {
 		}
 		cost = 75
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_FRA"
 			FRA = { country_event = { id = HOL_military.055 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_FRA
 			set_country_flag = HOL_accepted_FRA_carrier
@@ -916,6 +931,7 @@ HOL_carrier_production = {
 		}
 		cost = 75
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_RUS"
 			SOV = { country_event = { id = HOL_military.058 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_RUS
 		}
@@ -941,6 +957,7 @@ HOL_carrier_production = {
 		}
 		cost = 75
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_chn"
 			CHI = { country_event = { id = HOL_military.061 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_CHN
 		}
@@ -975,6 +992,7 @@ HOL_carrier_production = {
 		}
 		cost = 75
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_dutch"
 			create_equipment_variant = {
 				name = "Province Class Aircraft Carrier"
 				type = carrier_hull_3
@@ -1087,6 +1105,7 @@ HOL_future_air_defender_program = {
 		cost = 50
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_FAD_invite_partner"
 			FROM = {
 				set_country_flag = HOL_FAD_invited
 				country_event = { id = HOL_military.035 days = 1 }
@@ -1121,6 +1140,7 @@ HOL_influence_flanders = {
 		days_remove = 30
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BEL_counter_influence_flanders"
 			subtract_from_variable = { var = dutch_influence value = 10 }
 			custom_effect_tooltip = HOL_influence_decreased10
 		}
@@ -1139,6 +1159,7 @@ HOL_influence_flanders = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_flanders_high_productivity"
 			add_to_variable = { var = dutch_influence value = 5 }
 			custom_effect_tooltip = HOL_influence_increased5
 		}
@@ -1163,6 +1184,7 @@ HOL_influence_flanders = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_high_influence_belgium"
 			add_to_variable = { var = dutch_influence value = 5 }
 			custom_effect_tooltip = HOL_influence_increased5
 		}
@@ -1187,6 +1209,7 @@ HOL_influence_flanders = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pro_dutch_in_power"
 			add_to_variable = { var = dutch_influence value = 5 }
 			custom_effect_tooltip = HOL_influence_increased5
 		}
@@ -1211,6 +1234,7 @@ HOL_influence_flanders = {
 		is_good = yes
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pro_dutch_coalition"
 			add_to_variable = { var = dutch_influence value = 2 }
 			custom_effect_tooltip = HOL_influence_increased2
 		}
@@ -1252,6 +1276,7 @@ BEL_referendum_category = {
 		is_good = no
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision BEL_referendum_mission"
 			HOL_adjust_referendum_outcome = yes
 			random_list = {
 				HOL_belgium_referendum_outcome = {
@@ -1291,6 +1316,7 @@ HOL_voc_category_ind = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_indonesia_counter_voc"
 			if = {
 				limit = { HOL = { has_completed_focus = HOL_reclaim_batavia } }
 				if = {
@@ -1663,6 +1689,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_india_mission1"
 			if = {
 				limit = { RAJ = { is_top3_influencer = yes } }
 				set_temp_variable = { percent_change = 5 }
@@ -1708,6 +1735,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_india_mission2"
 			if = {
 				limit = {
 					has_naval_control = 205
@@ -1756,8 +1784,6 @@ HOL_voc_category = {
 			}
 		}
 
-		complete_effect = {
-		}
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_india_water"
 			set_temp_variable = { percent_change = 5 }
@@ -2512,6 +2538,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_taiwan_mission1"
 			if = {
 				limit = { TAI = { is_top3_influencer = yes } }
 				set_temp_variable = { percent_change = 5 }
@@ -2551,6 +2578,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_taiwan_mission2"
 			if = {
 				limit = {
 					has_naval_control = 193
@@ -2636,6 +2664,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_srilanka_mission1"
 			if = {
 				limit = { SRI = { is_top3_influencer = yes } }
 				set_temp_variable = { percent_change = 5 }
@@ -2675,6 +2704,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_srilanka_mission2"
 			if = {
 				limit = {
 					has_naval_control = 203
@@ -2788,6 +2818,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_small_reinvestment_sri_lanka"
 			set_country_flag = no_active_sri_lanka_investment
 		}
 		remove_effect = {
@@ -2846,6 +2877,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_medium_reinvestment_sri_lanka"
 			set_country_flag = no_active_sri_lanka_investment
 		}
 		remove_effect = {
@@ -2906,6 +2938,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_heavy_reinvestment_sri_lanka"
 			set_country_flag = no_active_sri_lanka_investment
 		}
 		remove_effect = {
@@ -2969,6 +3002,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_saf_mission1"
 			if = {
 				limit = { SAF = { is_top3_influencer = yes } }
 				set_temp_variable = { percent_change = 5 }
@@ -3026,6 +3060,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_saf_mission2"
 			if = {
 				limit = {
 					has_naval_control = 206
@@ -3084,6 +3119,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_saf_aids_support"
 			SAF = { country_event = HOL_voc.29 }
 		}
 		remove_effect = {
@@ -3141,6 +3177,7 @@ HOL_voc_category = {
 		war_with_on_complete = IND
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_indonesia_attack_mission"
 			if = {
 				limit = { has_completed_focus = HOL_reclaim_outer_islands }
 				add_to_variable = { HOL_islands_detection = HOL_sumatra_detection_chance }
@@ -3170,6 +3207,7 @@ HOL_voc_category = {
 		targets = { AST }
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_military_access_australia"
 			AST = { country_event = HOL_voc.39 }
 		}
 		ai_will_do = { base = 0 }
@@ -3204,6 +3242,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_reduce_java_detection"
 			army_experience = -20
 			add_command_power = -20
 			add_to_variable = {
@@ -3252,10 +3291,12 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_java_strength"
 			army_experience = -20
 			add_command_power = -20
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_java_strength"
 			add_to_variable = {
 				HOL_java_strength_change = 10
 			}
@@ -3300,6 +3341,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_convoy"
 			navy_experience = -20
 			add_command_power = -20
 			set_temp_variable = { treasury_change = gdp_per_capita }
@@ -3308,6 +3350,7 @@ HOL_voc_category = {
 
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_convoy"
 			if = {
 				limit = { has_completed_focus = HOL_reclaim_batavia }
 				add_to_variable = {
@@ -3348,6 +3391,7 @@ HOL_voc_category = {
 		fire_only_once = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_deploy_java_commando"
 			if = {
 				limit = { check_variable = { HOL_java_strength < 30 } }
 				#load_oob = HOL_VOC_nonnsblow
@@ -3382,6 +3426,7 @@ HOL_voc_category = {
 		fire_only_once = yes
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_deploy_islands_commando"
 			if = {
 				limit = { check_variable = { HOL_sumatra_strength < 30 } }
 				##load_oob = x
@@ -3443,6 +3488,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_reduce_sumatra_detection"
 			army_experience = -20
 			add_command_power = -20
 			add_to_variable = {
@@ -3486,6 +3532,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_reduce_kalimantan_detection"
 			army_experience = -20
 			add_command_power = -20
 			add_to_variable = {
@@ -3531,12 +3578,14 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_sumatra_strength"
 			army_experience = -20
 			add_command_power = -20
 			add_political_power = -20
 
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_sumatra_strength"
 			add_to_variable = {
 				HOL_sumatra_strength_change = 10
 			}
@@ -3577,12 +3626,14 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_kalimantan_strength"
 			army_experience = -20
 			add_command_power = -20
 			add_political_power = -20
 
 		}
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_kalimantan_strength"
 			add_to_variable = {
 				HOL_kalimantan_strength_change = 10
 			}
@@ -3623,6 +3674,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_reduce_sumatra_detection_corruption"
 			add_to_variable = {
 				HOL_sumatra_detection_chance_change = -5
 			}
@@ -3663,6 +3715,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_reduce_kalimantan_detection_corruption"
 			add_to_variable = {
 				HOL_kalimantan_detection_chance_change = -5
 			}
@@ -3703,6 +3756,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_reduce_java_detection_corruption"
 			add_to_variable = {
 				HOL_java_detection_chance_change = -5
 			}
@@ -3748,6 +3802,7 @@ HOL_voc_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_contact_christian_resistance_ind"
 			if = {
 				limit = { has_completed_focus = HOL_reclaim_outer_islands }
 				random_list = {
@@ -3832,6 +3887,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_prepare_for_war_mission1"
 			RAJ = { country_event = HOL_voc.60 }
 			SAF = { country_event = HOL_voc.60 }
 			TAI = { country_event = HOL_voc.60 }
@@ -3886,6 +3942,7 @@ HOL_voc_category = {
 		}
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_prepare_for_war_mission2"
 			RAJ = { country_event = HOL_voc.61 }
 			SAF = { country_event = HOL_voc.61 }
 			TAI = { country_event = HOL_voc.61 }
@@ -3915,6 +3972,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = 0.05
@@ -3947,6 +4005,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_promote_urban_investments"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = 0.05
@@ -3982,6 +4041,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_focus_climate_policy"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = 0.10
@@ -4021,6 +4081,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_strengthen_union_influence"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = -0.05
@@ -4061,6 +4122,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_promote_rural_investments"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = -0.05
@@ -4102,6 +4164,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_climate_action_plan"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = 0.05
@@ -4134,6 +4197,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_social_housing_initiative"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = 0.05
@@ -4171,6 +4235,7 @@ HOL_pvda_balance_of_power_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_private_energy_investments"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
 				value = 0.10
@@ -4231,6 +4296,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda1"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4300,6 +4366,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda2"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4354,6 +4421,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda3"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4407,6 +4475,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda4"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4462,6 +4531,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvda5"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4570,6 +4640,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda1"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4625,6 +4696,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda2"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4682,6 +4754,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda3"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4738,6 +4811,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda4"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4789,6 +4863,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_cda5"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4846,6 +4921,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd1"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4902,6 +4978,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd2"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -4958,6 +5035,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd3"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5012,6 +5090,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd4"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5067,6 +5146,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_vvd5"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5121,6 +5201,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv1"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5176,6 +5257,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv2"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5233,6 +5315,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv3"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5287,6 +5370,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv4"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5342,6 +5426,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_pvv5"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5398,6 +5483,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy1"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5457,6 +5543,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy2"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5514,6 +5601,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy3"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5571,6 +5659,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy4"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5686,6 +5775,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy5"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5738,6 +5828,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu1"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5792,6 +5883,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu2"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5847,6 +5939,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu3"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5903,6 +5996,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu4"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5959,6 +6053,7 @@ HOL_grey_society_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_nvu5"
 			set_country_flag = HOL_grey_society_flag_improvement
 		}
 
@@ -5993,6 +6088,7 @@ HOL_foreign_policy_category = {
 		cancel_trigger = { has_government = nationalist }
 
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_annual_naval_deployment"
 			navy_experience = 10
 			every_other_country = {
 				limit = {
@@ -6049,6 +6145,7 @@ HOL_foreign_policy_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_civilian_industry"
 			49 = {
 				remove_dynamic_modifier = {
 					modifier = HOL_antilles_civ_construction
@@ -6100,6 +6197,7 @@ HOL_foreign_policy_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_office_industry"
 			49 = {
 				remove_dynamic_modifier = {
 					modifier = HOL_antilles_office_construction
@@ -6151,6 +6249,7 @@ HOL_foreign_policy_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_mil_industry"
 			49 = {
 				remove_dynamic_modifier = {
 					modifier = HOL_antilles_mil_construction
@@ -6200,6 +6299,7 @@ HOL_foreign_policy_category = {
 		}
 
 		remove_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_agriculture"
 			49 = {
 				remove_dynamic_modifier = {
 					modifier = HOL_antilles_agriculture_construction
@@ -6230,6 +6330,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_venezuela_offshore_gas"
 		   VEN = { country_event = HOL_politics.30 }
 		}
 
@@ -6257,6 +6358,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_argentina_lng_trade"
 		   ARG = { country_event = HOL_politics.33 }
 		}
 
@@ -6284,6 +6386,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_mexico_naval_cooperation"
 		   MEX = { country_event = HOL_politics.36 }
 		}
 
@@ -6311,6 +6414,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_colombia_port_investment"
 		   COL = { country_event = HOL_politics.39 }
 		}
 
@@ -6338,6 +6442,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_paraguay_green_hydrogen"
 		   PAR = { country_event = HOL_politics.42 }
 		}
 
@@ -6364,6 +6469,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_peru_wind_energy"
 		   PRU = { country_event = HOL_politics.45 }
 		}
 
@@ -6386,6 +6492,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_usa_operation_market_vision"
 		   ROOT = { country_event = HOL_politics.48 }
 		   set_temp_variable = { treasury_change = -25 }
 		   modify_treasury_effect = yes
@@ -6471,6 +6578,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_agreement"
 		   SUR = { country_event = HOL_politics.51 }
 		}
 
@@ -6492,6 +6600,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_infrastructure_agreement"
 		   SUR = { country_event = HOL_politics.54 }
 		}
 
@@ -6513,6 +6622,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_maritime_agreement"
 		   SUR = { country_event = HOL_politics.63 }
 		   set_temp_variable = { treasury_change = gdp_per_capita }
 		   multiply_temp_variable = { treasury_change = -0.15 }
@@ -6537,6 +6647,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_training_agreement"
 		   SUR = { country_event = HOL_politics.66 }
 		   set_temp_variable = { treasury_change = gdp_per_capita }
 		   multiply_temp_variable = { treasury_change = -0.10 }
@@ -6561,6 +6672,7 @@ HOL_foreign_policy_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_resources_agreement"
 		   SUR = { country_event = HOL_politics.69 }
 		   set_temp_variable = { treasury_change = gdp_per_capita }
 		   multiply_temp_variable = { treasury_change = -0.10 }
@@ -6588,6 +6700,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_schleswig_holstein"
 			37 = {
 				add_core_of = HOL
 			}
@@ -6614,6 +6727,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_niedersachsen"
 			38 = {
 				add_core_of = HOL
 			}
@@ -6640,6 +6754,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_nordrhein_westfalen"
 			39 = {
 				add_core_of = HOL
 			}
@@ -6666,6 +6781,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_rheinland_pfalz"
 			40 = {
 				add_core_of = HOL
 			}
@@ -6692,6 +6808,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_hessen"
 			41 = {
 				add_core_of = HOL
 			}
@@ -6718,6 +6835,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_baden_wurttemberg"
 			42 = {
 				add_core_of = HOL
 			}
@@ -6744,6 +6862,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_bayern"
 			43 = {
 				add_core_of = HOL
 			}
@@ -6770,6 +6889,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_sachsen"
 			44 = {
 				add_core_of = HOL
 			}
@@ -6796,6 +6916,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_berlin"
 			45 = {
 				add_core_of = HOL
 			}
@@ -6822,6 +6943,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_steiermark"
 			75 = {
 				add_core_of = HOL
 			}
@@ -6848,6 +6970,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_austria_proper"
 			76 = {
 				add_core_of = HOL
 			}
@@ -6874,6 +6997,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_tirol"
 			286 = {
 				add_core_of = HOL
 			}
@@ -6900,6 +7024,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_mecklenburg"
 			539 = {
 				add_core_of = HOL
 			}
@@ -6926,6 +7051,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_thuringen"
 			545 = {
 				add_core_of = HOL
 			}
@@ -6952,6 +7078,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_franken"
 			964 = {
 				add_core_of = HOL
 			}
@@ -6978,6 +7105,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_koln_bonn"
 			966 = {
 				add_core_of = HOL
 			}
@@ -7004,6 +7132,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_saarland"
 			967 = {
 				add_core_of = HOL
 			}
@@ -7030,6 +7159,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_sachsen_anhalt"
 			972 = {
 				add_core_of = HOL
 			}
@@ -7056,6 +7186,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_brandenburg"
 			1079 = {
 				add_core_of = HOL
 			}
@@ -7082,6 +7213,7 @@ HOL_fourth_reich_category = {
 		cost = 75
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision HOL_core_german_state_hamburg"
 			1080 = {
 				add_core_of = HOL
 			}

--- a/common/decisions/subparty_policies_decisions.txt
+++ b/common/decisions/subparty_policies_decisions.txt
@@ -38,6 +38,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_primary_sector_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -98,6 +99,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_secondary_sector_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -150,6 +152,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_tertiary_sector_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -203,6 +206,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_infrastructure_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -261,6 +265,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_military_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -319,6 +324,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_naval_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -371,6 +377,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_technology_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 		}
@@ -416,6 +423,7 @@ subparty_policies_category = {
 		}
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_initiate_energy_5_year_plan"
 			set_temp_variable = { temp_opinion = 10 }
 			change_communist_cadres_opinion = yes
 		}
@@ -439,6 +447,7 @@ subparty_policies_category = {
 		cost = 100
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision generic_admit_5_year_plan_failure"
 			custom_effect_tooltip = TT_ABANDON_5_YEAR_PLAN
 			hidden_effect = {
 				set_ruling_leader = yes

--- a/common/decisions/transnistria.txt
+++ b/common/decisions/transnistria.txt
@@ -27,6 +27,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_romania_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -64,6 +65,7 @@ PMR_eastern_europe_operations = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_serbia_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -101,6 +103,7 @@ PMR_eastern_europe_operations = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_bulgaria_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -137,6 +140,7 @@ PMR_eastern_europe_operations = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_montenegro_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -175,6 +179,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_bosnia_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -213,6 +218,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_croatia_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -251,6 +257,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_greece_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -288,6 +295,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_macedonia_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -325,6 +333,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_albania_operation"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -363,6 +372,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_russia_operation"
 			add_command_power = -50
 		}
 		remove_effect = {
@@ -399,6 +409,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_france_operation"
 			add_command_power = -50
 		}
 		remove_effect = {
@@ -436,6 +447,7 @@ PMR_eastern_europe_operations = {
 
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_luxemburg_operation"
 			add_command_power = -50
 		}
 		remove_effect = {
@@ -472,6 +484,7 @@ PMR_eastern_europe_operations = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_belgium_operation"
 			add_command_power = -50
 		}
 		remove_effect = {
@@ -508,6 +521,7 @@ PMR_eastern_europe_operations = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_netherlands_operation"
 			add_command_power = -50
 		}
 		remove_effect = {
@@ -544,6 +558,7 @@ PMR_eastern_europe_operations = {
 		days_re_enable = 0
 
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_germany_operation"
 			add_command_power = -50
 		}
 		remove_effect = {
@@ -833,6 +848,7 @@ PMR_kazaks_prepare = {
 		icon = GFX_decision_kazaki_button
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_kazak_kamensk"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -857,6 +873,7 @@ PMR_kazaks_prepare = {
 		icon = GFX_decision_kazaki_button
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_kazak_ryibninsk"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -881,6 +898,7 @@ PMR_kazaks_prepare = {
 		icon = GFX_decision_kazaki_button
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_kazak_dubossar"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -905,6 +923,7 @@ PMR_kazaks_prepare = {
 		icon = GFX_decision_kazaki_button
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_kazak_slobodze"
 			add_command_power = -20
 		}
 		remove_effect = {
@@ -929,6 +948,7 @@ PMR_kazaks_prepare = {
 		icon = GFX_decision_kazaki_button
 		days_remove = 50
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision PMR_kazak_benderi"
 			add_command_power = -20
 		}
 		remove_effect = {

--- a/common/decisions/un_voting_decisions.txt
+++ b/common/decisions/un_voting_decisions.txt
@@ -10,6 +10,7 @@ UN_voting_category = {
 		days_mission_timeout = 5
 		selectable_mission = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UN_SC_voting_mission"
 			if = {
 				limit = { has_country_flag = has_sc_mission }
 				security_council_vote_finished = yes
@@ -22,6 +23,7 @@ UN_voting_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UN_SC_voting_mission"
 			if = {
 				limit = { has_country_flag = has_sc_mission }
 				security_council_vote_finished = yes
@@ -58,6 +60,7 @@ UN_voting_category = {
 		days_mission_timeout = 5
 		selectable_mission = yes
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UN_GA_voting_mission"
 			if = {
 				limit = { has_country_flag = has_ga_mission }
 				general_assembly_vote_finished = yes
@@ -70,6 +73,7 @@ UN_voting_category = {
 			}
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UN_GA_voting_mission"
 			if = {
 				limit = { has_country_flag = has_ga_mission }
 				general_assembly_vote_finished = yes
@@ -104,9 +108,11 @@ UN_voting_category = {
 		}
 		days_mission_timeout = 210
 		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UNSC_end_all_offensive_wars"
 			clr_country_flag = has_end_war_mission
 		}
 		timeout_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision UNSC_end_all_offensive_wars"
 			apply_united_nations_sanctions = yes
 			clr_country_flag = has_end_war_mission
 		}

--- a/tools/validation/tests/validate_decisions_missing_log_test.py
+++ b/tools/validation/tests/validate_decisions_missing_log_test.py
@@ -1,4 +1,4 @@
-"""Tests for the decision log-in-complete_effect check."""
+"""Tests for the decision effect-block log checks."""
 
 import validate_decisions as V
 
@@ -14,27 +14,29 @@ class _FakeValidator(V.Validator):
         self.collected.extend(results)
 
 
-def _results_for(factories, monkeypatch):
+def _results_for(factories, monkeypatch, check="validate_missing_log"):
     validator = _FakeValidator("/tmp")
     monkeypatch.setattr(V, "parse_all_decision_factories", lambda mod_path: factories)
-    validator.validate_missing_log()
+    getattr(validator, check)()
     return validator.collected
 
 
+def _factory(body):
+    return V.DecisionFactory(body, source_basename="X.txt")
+
+
 def test_logged_decision_not_flagged(monkeypatch):
-    factory = V.DecisionFactory(
+    factory = _factory(
         "dec_one = {\n\tcomplete_effect = {\n"
         '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_one"\n'
-        "\t}\n}",
-        source_basename="X.txt",
+        "\t}\n}"
     )
     assert _results_for([factory], monkeypatch) == []
 
 
 def test_effect_without_log_flagged(monkeypatch):
-    factory = V.DecisionFactory(
-        "dec_two = {\n\tcomplete_effect = {\n\t\tadd_political_power = 10\n\t}\n}",
-        source_basename="X.txt",
+    factory = _factory(
+        "dec_two = {\n\tcomplete_effect = {\n\t\tadd_political_power = 10\n\t}\n}"
     )
     results = _results_for([factory], monkeypatch)
     assert len(results) == 1
@@ -43,26 +45,117 @@ def test_effect_without_log_flagged(monkeypatch):
 
 
 def test_empty_complete_effect_skipped(monkeypatch):
-    factory = V.DecisionFactory("dec_three = {\n}", source_basename="X.txt")
+    factory = _factory("dec_three = {\n}")
     assert _results_for([factory], monkeypatch) == []
 
 
 def test_log_requires_quote(monkeypatch):
     # A bare `log = something` without quotes is not a log line.
-    factory = V.DecisionFactory(
-        "dec_four = {\n\tcomplete_effect = {\n\t\tlog = some_unquoted_thing\n\t}\n}",
-        source_basename="X.txt",
+    factory = _factory(
+        "dec_four = {\n\tcomplete_effect = {\n\t\tlog = some_unquoted_thing\n\t}\n}"
     )
     results = _results_for([factory], monkeypatch)
     assert len(results) == 1
 
 
 def test_log_matches_inside_multiline_effect(monkeypatch):
-    factory = V.DecisionFactory(
+    factory = _factory(
         "dec_five = {\n\tcomplete_effect = {\n"
         "\t\tadd_political_power = 10\n"
         '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_five"\n'
-        "\t}\n}",
-        source_basename="X.txt",
+        "\t}\n}"
     )
     assert _results_for([factory], monkeypatch) == []
+
+
+def test_remove_timeout_cancel_effects_need_logs(monkeypatch):
+    factory = _factory(
+        "dec_six = {\n"
+        "\tremove_effect = {\n\t\tadd_political_power = 10\n\t}\n"
+        "\ttimeout_effect = {\n\t\tadd_stability = 0.05\n\t}\n"
+        "\tcancel_effect = {\n\t\tadd_war_support = 0.05\n\t}\n"
+        "}"
+    )
+    results = _results_for([factory], monkeypatch)
+    assert len(results) == 3
+    flagged = {r.split(": ")[1].split(" has")[0] for r in results}
+    assert flagged == {"remove_effect", "timeout_effect", "cancel_effect"}
+
+
+def test_each_effect_block_logs_for_itself(monkeypatch):
+    # A log in complete_effect does not cover a bare remove_effect.
+    factory = _factory(
+        "dec_seven = {\n"
+        "\tcomplete_effect = {\n"
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_seven"\n'
+        "\t\tadd_political_power = 10\n\t}\n"
+        "\tremove_effect = {\n\t\tadd_political_power = -10\n\t}\n"
+        "}"
+    )
+    results = _results_for([factory], monkeypatch)
+    assert len(results) == 1
+    assert "remove_effect" in results[0]
+
+
+def test_single_line_effect_block_with_log_not_flagged(monkeypatch):
+    factory = _factory(
+        "dec_eight = {\n\tremove_effect = "
+        '{ log = "[GetDateText]: [Root.GetName]: Decision dec_eight" }\n}'
+    )
+    assert _results_for([factory], monkeypatch) == []
+
+
+def test_log_first_not_flagged(monkeypatch):
+    factory = _factory(
+        "dec_nine = {\n\tremove_effect = {\n"
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_nine"\n'
+        "\t\tadd_political_power = 10\n\t}\n}"
+    )
+    assert _results_for([factory], monkeypatch, "validate_log_not_first") == []
+
+
+def test_log_after_an_effect_flagged(monkeypatch):
+    factory = _factory(
+        "dec_ten = {\n\ttimeout_effect = {\n"
+        "\t\tadd_political_power = 10\n"
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_ten"\n'
+        "\t}\n}"
+    )
+    results = _results_for([factory], monkeypatch, "validate_log_not_first")
+    assert len(results) == 1
+    assert "timeout_effect" in results[0]
+    assert "add_political_power" in results[0]
+
+
+def test_nested_log_left_alone(monkeypatch):
+    # A log inside a branch records which branch ran, so it is not "late".
+    factory = _factory(
+        "dec_eleven = {\n\tcomplete_effect = {\n"
+        "\t\tcustom_effect_tooltip = some_tt\n"
+        "\t\thidden_effect = {\n"
+        '\t\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_eleven"\n'
+        "\t\t}\n\t}\n}"
+    )
+    assert _results_for([factory], monkeypatch, "validate_log_not_first") == []
+
+
+def test_comment_before_log_not_flagged(monkeypatch):
+    factory = _factory(
+        "dec_twelve = {\n\tcomplete_effect = {\n"
+        "\t\t#the treasury hit is deliberate\n"
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_twelve"\n'
+        "\t\tadd_political_power = 10\n\t}\n}"
+    )
+    assert _results_for([factory], monkeypatch, "validate_log_not_first") == []
+
+
+def test_quoted_brace_does_not_desync_statement_scan(monkeypatch):
+    factory = _factory(
+        "dec_thirteen = {\n\tcomplete_effect = {\n"
+        '\t\tcustom_effect_tooltip = "a { brace } in a string"\n'
+        '\t\tlog = "[GetDateText]: [Root.GetName]: Decision dec_thirteen"\n'
+        "\t}\n}"
+    )
+    results = _results_for([factory], monkeypatch, "validate_log_not_first")
+    assert len(results) == 1
+    assert "custom_effect_tooltip" in results[0]

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared_utils import blank_quoted_strings
+from shared_utils import blank_quoted_strings, strip_inline_comment
 from validator_common import (
     DEFAULT_EXTRA_SKIP_PATTERNS,
     BaseValidator,
@@ -46,6 +46,44 @@ _DECISION_NAME_RE = re.compile(r"\bdecision\s*=\s*(\S+)")
 _MISSION_NAME_RE = re.compile(r"\bactivate_mission\s*=\s*(\S+)")
 _BRACKETED_LOC_RE = re.compile(r"^\[([A-Za-z0-9_]+)\]$")
 _SCRIPTED_LOC_RE = re.compile(r"\bname\s*=\s*([A-Za-z0-9_]+)")
+
+# The four blocks the engine runs as a decision's effects, all of which log.
+EFFECT_BLOCKS = (
+    "complete_effect",
+    "remove_effect",
+    "timeout_effect",
+    "cancel_effect",
+)
+_LOG_STRING_RE = re.compile(r'\blog\s*=\s*"')
+_STATEMENT_NAME_RE = re.compile(r"([A-Za-z_]\w*)\s*=")
+
+
+def _block_level_statements(block: str) -> List[str]:
+    """Statement names at an effect block's own level, in source order.
+
+    *block* is the ``{ ... }`` text of the block. Nested blocks are skipped, so
+    a ``log`` inside an ``if`` / ``hidden_effect`` does not read as a statement
+    of the block itself.
+    """
+    names: List[str] = []
+    depth = 0
+    for line in block.split("\n"):
+        code = blank_quoted_strings(strip_inline_comment(line))
+        i = 0
+        while i < len(code):
+            char = code[i]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            elif depth == 1:
+                match = _STATEMENT_NAME_RE.match(code, i)
+                if match:
+                    names.append(match.group(1))
+                    i = match.end()
+                    continue
+            i += 1
+    return names
 
 
 # --- Decision parsing helpers ---
@@ -452,6 +490,7 @@ class DecisionFactory:
         self.cancel_effect = extract_value_multi_line(dec, "cancel_effect")
         self.complete_effect = extract_value_multi_line(dec, "complete_effect")
         self.remove_effect = extract_value_multi_line(dec, "remove_effect")
+        self.timeout_effect = extract_value_multi_line(dec, "timeout_effect")
         self.cancel_trigger = extract_value_multi_line(dec, "cancel_trigger")
         self.cancel_if_not_visible = "cancel_if_not_visible = yes" in dec
         self.activation = extract_value_multi_line(dec, "activation")
@@ -1625,33 +1664,63 @@ class Validator(BaseValidator):
         )
 
     def validate_missing_log(self):
-        """Flag decisions whose complete_effect has effects but no log line.
+        """Flag decision effect blocks that carry no log line.
 
-        AGENTS.md / decision-reference.md require a log in complete_effect:
-        `log = "[GetDateText]: [Root.GetName]: Decision <ID>"`. Decisions with
-        an empty complete_effect have nothing to log and are skipped.
+        AGENTS.md / decision-reference.md require the log in every block the
+        engine runs as a decision's effects (complete_effect, remove_effect,
+        timeout_effect, cancel_effect):
+        `log = "[GetDateText]: [Root.GetName]: Decision <ID>"`. An effect block
+        with nothing in it is dead script, so it is reported too.
         """
-        self._log_section(
-            "Checking decisions with effects but no log in complete_effect..."
-        )
+        self._log_section("Checking decision effect blocks for a missing log...")
 
         results = []
         for dec in parse_all_decision_factories(self.mod_path):
-            if not dec.complete_effect:
-                continue
-            if re.search(r"\blog\s*=\s*\"", dec.complete_effect):
-                continue
-            results.append(
-                f"{dec.token} - {dec.source_basename}: complete_effect has "
-                "effects but no log line"
-            )
+            for block_name in EFFECT_BLOCKS:
+                block = getattr(dec, block_name)
+                if not block or _LOG_STRING_RE.search(block):
+                    continue
+                results.append(
+                    f"{dec.token} - {dec.source_basename}: {block_name} has no log line"
+                )
 
         self._report(
             results,
-            "✓ All decisions with effects log in complete_effect",
-            "Decisions with effects but no log in complete_effect:",
+            "✓ Every decision effect block logs",
+            "Decision effect blocks with no log line:",
             Severity.WARNING,
             category="missing-decision-log",
+        )
+
+    def validate_log_not_first(self):
+        """Flag effect blocks whose log is not the block's first statement.
+
+        The log goes at the top so the game log reads in firing order. Only a
+        log at the block's own level counts: one nested inside an `if` /
+        `hidden_effect` records which branch ran and belongs where it sits.
+        """
+        self._log_section("Checking decision effect blocks for a log placed late...")
+
+        results = []
+        for dec in parse_all_decision_factories(self.mod_path):
+            for block_name in EFFECT_BLOCKS:
+                block = getattr(dec, block_name)
+                if not block:
+                    continue
+                statements = _block_level_statements(block)
+                if "log" not in statements or statements[0] == "log":
+                    continue
+                results.append(
+                    f"{dec.token} - {dec.source_basename}: {block_name} logs "
+                    f"after {statements[0]}, move the log to the top of the block"
+                )
+
+        self._report(
+            results,
+            "✓ Every decision effect block logs first",
+            "Decision effect blocks whose log is not the first statement:",
+            Severity.WARNING,
+            category="decision-log-not-first",
         )
 
     def validate_visible_in_missions(self):
@@ -1997,6 +2066,7 @@ class Validator(BaseValidator):
         self.validate_bare_trigger_names()
         self.validate_missing_localisation()
         self.validate_missing_log()
+        self.validate_log_not_first()
         self.validate_visible_in_missions()
         self.validate_war_with_targeted()
         self.validate_missing_war_hint()


### PR DESCRIPTION
### Changes
- Every decision that ran effects without logging now logs when it fires, so decision activity shows up in the game log: 646 complete_effect, 570 remove_effect, 148 timeout_effect and 68 cancel_effect blocks across 69 files
- Moved 207 decision logs that sat mid-block or at the end up to the top of their effect block, so placement is consistent everywhere
- The decision validator now checks all four blocks the engine runs as effects, not just complete_effect, and flags a block-level log that is not the block's first statement
- Removed 17 dead complete_effect blocks (16 holding nothing but a log, 1 empty) and dropped a stray word from one Dutch log string
- Clears the validator's missing-decision-log category (648 warnings to 0)

Three commits: log insertion, then pure reordering with no line content changed, then the validator and docs. Eleven single-line effect blocks were expanded to multi-line so the log could go first. Logs that live inside a nested if/hidden_effect were left alone, since those record which branch ran, and the new placement check exempts them for the same reason. AGENTS.md and decision-reference.md now state the rule for all four blocks.

Committed with `SKIP=md-standardize`: the standardizer would have reformatted all 69 decision files (about 25k lines of unrelated blank-line and indent churn) and buried the actual change.
