### PR TITLE
Ask bug reports where the bug is

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,14 +7,20 @@ type: bug
 assignees: ""
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**What happens**
+What you saw, and what you expected instead.
+
+**Where**
+The file and line if you know it (e.g. `common/decisions/05_ENG_decisions.txt:3256`), plus the focus, decision, event, idea or GUI ID involved. Paste the matching `error.log` line if there is one.
+
+**Versions**
+Game version and checksum, MD version (release number, or the dev branch date you pulled).
 
 **To Reproduce**
-Steps to reproduce the behavior.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+1.
+2.
+3.
 
 **Operating System**
 
@@ -23,4 +29,4 @@ If applicable, add screenshots to help explain your problem.
 - [ ] Mac
 
 **Additional context**
-Add any other context about the problem here.
+Screenshots, a save game, or anything else that helps.


### PR DESCRIPTION
### Changes
- Bug reports now ask where the bug is (file and line, script ID, error.log line) and which game and MD version it was seen on, instead of only a description and screenshots
- Folded the vague "describe the bug" prompt into what happened vs what was expected
