### PR TITLE
Chips & Composites Expressions

### DIFF
--- a/.claude/docs/md-custom-modifiers.md
+++ b/.claude/docs/md-custom-modifiers.md
@@ -234,6 +234,7 @@ Country-tag-specific modifiers (prefixed `CZE_`, `ITA_`, `JAP_`) must only appea
 | ------------------------------------ |
 | `civilian_chip_consumption_modifier` |
 | `industry_chip_consumption_modifier` |
+| `country_extra_microchip_per_plant_modifier` |
 
 ### Outlook Campaign Costs
 

--- a/.claude/docs/md-custom-modifiers.md
+++ b/.claude/docs/md-custom-modifiers.md
@@ -234,7 +234,6 @@ Country-tag-specific modifiers (prefixed `CZE_`, `ITA_`, `JAP_`) must only appea
 | ------------------------------------ |
 | `civilian_chip_consumption_modifier` |
 | `industry_chip_consumption_modifier` |
-| `country_extra_microchip_per_plant_modifier` |
 
 ### Outlook Campaign Costs
 

--- a/common/scripted_effects/00_microchip_effects.txt
+++ b/common/scripted_effects/00_microchip_effects.txt
@@ -303,46 +303,70 @@ civilian_microchip_consumption = {
 	#Higher GDP/C will increase the multiplier applied to the population
 	#IE, high pop but low GDP/C should result in a lower consumption amount than a low pop, high GDP/C nation
 	#Since higher GDP/C = higher developed = higher population technology demand
-	set_temp_variable = { base_chip_consumption = population_total }
-	multiply_temp_variable = { base_chip_consumption = gdp_per_capita }
-	multiply_temp_variable = { base_chip_consumption = 0.00025 }
+	set_temp_variable = {
+		base_chip_consumption = {
+			value = population_total
+			multiply = gdp_per_capita
+			multiply = 0.00025
+			add = {
+				value = population_total
+				multiply = gdp_per_capita
+				multiply = 0.00025
+				multiply = modifier@civilian_chip_consumption_modifier
+			}
+			add = {
+				value = office_park_total
+				multiply = offices_manpower_fulfillment
+				multiply = 0.25
+				add = {
+					value = office_park_total
+					multiply = offices_manpower_fulfillment
+					multiply = 0.25
+					multiply = modifier@industry_chip_consumption_modifier
+				}
+			}
+			round = yes
+		}
+	}
 
-	set_temp_variable = { chip_mult_amount = base_chip_consumption }
-	multiply_temp_variable = { chip_mult_amount = modifier@civilian_chip_consumption_modifier }
-	add_to_temp_variable = { base_chip_consumption = chip_mult_amount }
-
-	set_temp_variable = { office_base_amount = office_park_total }
-	multiply_temp_variable = { office_base_amount = offices_manpower_fulfillment }
-	multiply_temp_variable = { office_base_amount = 0.25 }
-	set_temp_variable = { office_chip_mult = office_base_amount }
-	multiply_temp_variable = { office_chip_mult = modifier@industry_chip_consumption_modifier }
-
-	add_to_temp_variable = { office_base_amount = office_chip_mult }
-
-	add_to_temp_variable = { base_chip_consumption = office_base_amount }
-
-	round_temp_variable = base_chip_consumption
-
-	set_temp_variable = { total_microchips = resource_produced@microchips }
-	subtract_from_temp_variable = { total_microchips = resource_exported@microchips }
-	add_to_temp_variable = { total_microchips = resource_imported@microchips }
+	set_temp_variable = {
+		total_microchips = {
+			value = resource_produced@microchips
+			subtract = resource_exported@microchips
+			add = resource_imported@microchips
+		}
+	}
 
 	#Check if at war. If at war, the military gets priority for the microchip demand
 	#If not at war, civs get priority
 	set_temp_variable = { base_stab_adjust = 0 }
 	if = {
 		limit = { has_war = yes }
-		subtract_from_temp_variable = { total_microchips = resource_consumed@microchips }
+		set_temp_variable = {
+			total_microchips = {
+				value = total_microchips
+				subtract = resource_consumed@microchips
+			}
+		}
 
 		if = {
 			limit = { check_variable = { total_microchips < 1 } }
 			#Nothing left for civilians, since there is military deficit and we at war, yo
-			multiply_temp_variable = { base_chip_consumption = -1 }
+			set_temp_variable = {
+				base_chip_consumption = {
+					value = base_chip_consumption
+					multiply = -1
+				}
+			}
 			set_temp_variable = { base_stab_adjust = base_chip_consumption }
 			set_temp_variable = { base_chip_consumption = 0 }
 		} else = {
-			set_temp_variable = { total_chip_buffer = total_microchips }
-			subtract_from_temp_variable = { total_chip_buffer = base_chip_consumption }
+			set_temp_variable = {
+				total_chip_buffer = {
+					value = total_microchips
+					subtract = base_chip_consumption
+				}
+			}
 
 			if = {
 				#total chip buffer here is how many in the hole we are
@@ -350,7 +374,12 @@ civilian_microchip_consumption = {
 				limit = { check_variable = { total_chip_buffer < 0 } }
 				#we have a deficit of chips after civ consumption, run the math
 				set_temp_variable = { base_stab_adjust = total_chip_buffer }
-				add_to_temp_variable = { base_chip_consumption = total_chip_buffer }
+				set_temp_variable = {
+					base_chip_consumption = {
+						value = base_chip_consumption
+						add = total_chip_buffer
+					}
+				}
 
 			} else = {
 				#we have enough chips!
@@ -360,15 +389,21 @@ civilian_microchip_consumption = {
 	} else = {
 		#Civis get their chips first here, so we will allow a deficit during peacetime for mil production
 		#This can still lead to instability, if civ demand is not met, but if it is met, hey, we're happy!
-		subtract_from_temp_variable = { total_microchips = base_chip_consumption }
+		set_temp_variable = {
+			total_microchips = {
+				value = total_microchips
+				subtract = base_chip_consumption
+			}
+		}
 		set_temp_variable = { base_stab_adjust = total_microchips }
 	}
 
-	multiply_temp_variable = { base_stab_adjust = 0.001 }
-	clamp_temp_variable = {
-		var = base_stab_adjust
-		min = -0.15
-		max = 0.15
+	set_temp_variable = {
+		base_stab_adjust = {
+			value = base_stab_adjust
+			multiply = 0.001
+			clamp = { min = -0.15 max = 0.15 }
+		}
 	}
 
 	#Set how much is consumed here. During military conflict, civs will just consume what is left

--- a/common/scripted_effects/00_microchip_effects.txt
+++ b/common/scripted_effects/00_microchip_effects.txt
@@ -103,62 +103,15 @@ microchip_update = {
 
 		#Starting produced needs to be set manually, else math has a seizure. Math will never be perfect, because it ignores all the stacked modifiers
 		#But I just don't care anymore, because I just want this to work, damnit
-		# Fallback check for old saves
-		if = {
-			limit = { NOT = { has_variable = country_extra_microchip_per_plant } }
-			set_variable = { country_extra_microchip_per_plant = 0 }
-			if = {
-				limit = { has_tech = microchip_production_2 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_2
-			}
-			if = {
-				limit = { has_tech = microchip_production_3 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_3
-			}
-			if = {
-				limit = { has_tech = microchip_production_4 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_4
-			}
-			if = {
-				limit = { has_tech = microchip_production_5 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_5
-			}
-			if = {
-				limit = { has_tech = microchip_production_6 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_6
-			}
-			if = {
-				limit = { has_tech = microchip_production_7 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_7
-			}
-			if = {
-				limit = { has_tech = microchip_production_8 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_8
-			}
-			if = {
-				limit = { has_tech = microchip_production_9 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_9
-			}
-			if = {
-				limit = { has_tech = microchip_production_10 }
-				add_to_variable = { country_extra_microchip_per_plant = 1 }
-				set_country_flag = md_applied_microchip_production_10
+		set_temp_variable = {
+			country_microchip_produced = {
+				value = microchip_plant_total
+				multiply = {
+					value = 20
+					add = country_extra_microchip_per_plant
+				}
 			}
 		}
-
-		set_temp_variable = { country_microchip_per_plant = 20 }
-		add_to_temp_variable = { country_microchip_per_plant = country_extra_microchip_per_plant }
-
-		set_temp_variable = { country_microchip_produced = microchip_plant_total }
-		multiply_temp_variable = { country_microchip_produced = country_microchip_per_plant }
 
 		set_temp_variable = { country_microchip_reducer = 0 }
 
@@ -176,24 +129,37 @@ microchip_update = {
 			multiply_temp_variable = { country_tech_remaining = -1 }
 			multiply_temp_variable = { country_rare_remaining = -1 }
 
-			if = {
-				limit = {
-					check_variable = { country_rare_remaining > 0 }
+			set_temp_variable = {
+				country_microchip_reducer = {
+					value = 0
+					add = {
+						max = {
+							value = 0
+							max = country_rare_remaining
+						}
+					}
+					add = {
+						max = {
+							value = 0
+							max = {
+								value = country_tech_remaining
+								multiply = 1.25
+								round = yes
+							}
+						}
+					}
 				}
-				add_to_temp_variable = { country_microchip_reducer = country_rare_remaining }
 			}
-			if = {
-				limit = {
-					check_variable = { country_tech_remaining > 0 }
-				}
-				multiply_temp_variable = { country_tech_remaining = 1.25 }
-				round_temp_variable = country_tech_remaining
-				add_to_temp_variable = { country_microchip_reducer = country_tech_remaining }
-			}
+
 			set_variable = { country_microchip_production_var = country_microchip_reducer }
-			set_temp_variable = { country_microchip_reducer_max = country_microchip_produced }
-			multiply_temp_variable = { country_microchip_reducer_max = 0.95 }
-			round_temp_variable = country_microchip_reducer_max
+
+			set_temp_variable = {
+				country_microchip_reducer_max = {
+					value = country_microchip_produced
+					multiply = 0.95
+					round = yes
+				}
+			}
 		}
 		else = {
 			#There should be no reduction here, because we have a surplus of all inputs
@@ -205,11 +171,18 @@ microchip_update = {
 			limit = {
 				check_variable = { energy_difference_variable < 0 }
 			}
-			set_temp_variable = { starting_chip_amount = country_microchip_produced }
-			subtract_from_temp_variable = { starting_chip_amount = country_microchip_production_var }
-			multiply_temp_variable = { starting_chip_amount = unfulfilled_energy_demand_dynmod_var }
-			add_to_variable = { country_microchip_production_var = starting_chip_amount }
-			round_variable = country_microchip_production_var
+
+			set_variable = {
+				country_microchip_production_var = {
+					value = country_microchip_production_var
+					add = {
+						value = country_microchip_produced
+						subtract = country_microchip_production_var
+						multiply = unfulfilled_energy_demand_dynmod_var
+					}
+					round = yes
+				}
+			}
 		}
 
 		if = {
@@ -222,7 +195,6 @@ microchip_update = {
 				limit = { check_variable = { country_microchip_production_var > 0 } }
 
 				subtract_from_variable = { country_microchip_production_var = tai_chip_resource_use_improvements }
-
 			}
 		}
 
@@ -243,52 +215,15 @@ composite_update = {
 		set_temp_variable = { country_rare_remaining = resource@chromium }
 		set_temp_variable = { country_rubber_remaining = resource@rubber }
 
-		# Fallback check for old saves
-		if = {
-			limit = { NOT = { has_variable = country_extra_composite_per_plant } }
-			set_variable = { country_extra_composite_per_plant = 0 }
-			if = {
-				limit = { has_tech = composite_production_2 }
-				add_to_variable = { country_extra_composite_per_plant = 1 }
-				set_country_flag = md_applied_composite_production_2
-			}
-			if = {
-				limit = { has_tech = composite_production_3 }
-				add_to_variable = { country_extra_composite_per_plant = 1 }
-				set_country_flag = md_applied_composite_production_3
-			}
-			if = {
-				limit = { has_tech = composite_production_4 }
-				add_to_variable = { country_extra_composite_per_plant = 2 }
-				set_country_flag = md_applied_composite_production_4
-			}
-			if = {
-				limit = { has_tech = composite_production_5 }
-				add_to_variable = { country_extra_composite_per_plant = 2 }
-				set_country_flag = md_applied_composite_production_5
-			}
-			if = {
-				limit = { has_tech = composite_production_6 }
-				add_to_variable = { country_extra_composite_per_plant = 2 }
-				set_country_flag = md_applied_composite_production_6
-			}
-			if = {
-				limit = { has_tech = composite_production_7 }
-				add_to_variable = { country_extra_composite_per_plant = 2 }
-				set_country_flag = md_applied_composite_production_7
-			}
-			if = {
-				limit = { has_tech = composite_production_8 }
-				add_to_variable = { country_extra_composite_per_plant = 2 }
-				set_country_flag = md_applied_composite_production_8
+		set_temp_variable = {
+			country_composite_produced = {
+				value = composite_plant_total
+				multiply = {
+					value = 20
+					add = country_extra_composite_per_plant
+				}
 			}
 		}
-
-		set_temp_variable = { country_composite_per_plant = 20 }
-		add_to_temp_variable = { country_composite_per_plant = country_extra_composite_per_plant }
-
-		set_temp_variable = { country_composite_produced = composite_plant_total }
-		multiply_temp_variable = { country_composite_produced = country_composite_per_plant }
 
 		set_temp_variable = { country_composite_reducer = 0 }
 
@@ -307,24 +242,37 @@ composite_update = {
 			multiply_temp_variable = { country_rare_remaining = -1 }
 			multiply_temp_variable = { country_rubber_remaining = -1 }
 
-			if = {
-				limit = {
-					check_variable = { country_rare_remaining > 0 }
+			set_temp_variable = {
+				country_composite_reducer = {
+					value = 0
+					add = {
+						max = {
+							value = 0
+							max = country_rare_remaining
+						}
+					}
+					add = {
+						max = {
+							value = 0
+							max = {
+								value = country_rubber_remaining
+								multiply = 1.5
+								round = yes
+							}
+						}
+					}
 				}
-				add_to_temp_variable = { country_composite_reducer = country_rare_remaining }
 			}
-			if = {
-				limit = {
-					check_variable = { country_rubber_remaining > 0 }
-				}
-				multiply_temp_variable = { country_rubber_remaining = 1.5 }
-				round_temp_variable = country_rubber_remaining
-				add_to_temp_variable = { country_composite_reducer = country_rubber_remaining }
-			}
+
 			set_variable = { country_composite_production_var = country_composite_reducer }
-			set_temp_variable = { country_composite_reducer_max = country_composite_produced }
-			multiply_temp_variable = { country_composite_reducer_max = 0.95 }
-			round_temp_variable = country_composite_reducer_max
+
+			set_temp_variable = {
+				country_composite_reducer_max = {
+					value = country_composite_produced
+					multiply = 0.95
+					round = yes
+				}
+			}
 			#Clamp the max at -90% of production, this number can be adjusted
 			clamp_variable = {
 				var = country_composite_production_var
@@ -437,7 +385,7 @@ md_tech_microchip_production_2_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_2 }
 		}
 		set_country_flag = md_applied_microchip_production_2
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 1 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -452,7 +400,7 @@ md_tech_microchip_production_3_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_3 }
 		}
 		set_country_flag = md_applied_microchip_production_3
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 2 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -467,7 +415,7 @@ md_tech_microchip_production_4_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_4 }
 		}
 		set_country_flag = md_applied_microchip_production_4
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 3 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -482,7 +430,7 @@ md_tech_microchip_production_5_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_5 }
 		}
 		set_country_flag = md_applied_microchip_production_5
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 4 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -497,7 +445,7 @@ md_tech_microchip_production_6_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_6 }
 		}
 		set_country_flag = md_applied_microchip_production_6
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 5 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -512,7 +460,7 @@ md_tech_microchip_production_7_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_7 }
 		}
 		set_country_flag = md_applied_microchip_production_7
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 6 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -527,7 +475,7 @@ md_tech_microchip_production_8_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_8 }
 		}
 		set_country_flag = md_applied_microchip_production_8
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 7 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -542,7 +490,7 @@ md_tech_microchip_production_9_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_9 }
 		}
 		set_country_flag = md_applied_microchip_production_9
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 8 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -557,7 +505,7 @@ md_tech_microchip_production_10_effect = {
 			NOT = { has_country_flag = md_applied_microchip_production_10 }
 		}
 		set_country_flag = md_applied_microchip_production_10
-		add_to_variable = { country_extra_microchip_per_plant = 1 }
+		set_variable = { country_extra_microchip_per_plant = 9 }
 		modify_building_resources = {
 			building = microchip_plant
 			resource = microchips
@@ -572,7 +520,7 @@ md_tech_composite_production_2_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_2 }
 		}
 		set_country_flag = md_applied_composite_production_2
-		add_to_variable = { country_extra_composite_per_plant = 1 }
+		set_variable = { country_extra_composite_per_plant = 1 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites
@@ -587,7 +535,7 @@ md_tech_composite_production_3_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_3 }
 		}
 		set_country_flag = md_applied_composite_production_3
-		add_to_variable = { country_extra_composite_per_plant = 1 }
+		set_variable = { country_extra_composite_per_plant = 2 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites
@@ -602,7 +550,7 @@ md_tech_composite_production_4_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_4 }
 		}
 		set_country_flag = md_applied_composite_production_4
-		add_to_variable = { country_extra_composite_per_plant = 2 }
+		set_variable = { country_extra_composite_per_plant = 4 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites
@@ -617,7 +565,7 @@ md_tech_composite_production_5_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_5 }
 		}
 		set_country_flag = md_applied_composite_production_5
-		add_to_variable = { country_extra_composite_per_plant = 2 }
+		set_variable = { country_extra_composite_per_plant = 6 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites
@@ -632,7 +580,7 @@ md_tech_composite_production_6_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_6 }
 		}
 		set_country_flag = md_applied_composite_production_6
-		add_to_variable = { country_extra_composite_per_plant = 2 }
+		set_variable = { country_extra_composite_per_plant = 8 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites
@@ -647,7 +595,7 @@ md_tech_composite_production_7_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_7 }
 		}
 		set_country_flag = md_applied_composite_production_7
-		add_to_variable = { country_extra_composite_per_plant = 2 }
+		set_variable = { country_extra_composite_per_plant = 10 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites
@@ -662,7 +610,7 @@ md_tech_composite_production_8_effect = {
 			NOT = { has_country_flag = md_applied_composite_production_8 }
 		}
 		set_country_flag = md_applied_composite_production_8
-		add_to_variable = { country_extra_composite_per_plant = 2 }
+		set_variable = { country_extra_composite_per_plant = 12 }
 		modify_building_resources = {
 			building = composite_plant
 			resource = composites

--- a/common/scripted_effects/00_microchip_effects.txt
+++ b/common/scripted_effects/00_microchip_effects.txt
@@ -133,12 +133,14 @@ microchip_update = {
 				country_microchip_reducer = {
 					value = 0
 					add = {
+						value = 0
 						max = {
 							value = 0
 							max = country_rare_remaining
 						}
 					}
 					add = {
+						value = 0
 						max = {
 							value = 0
 							max = {
@@ -246,12 +248,14 @@ composite_update = {
 				country_composite_reducer = {
 					value = 0
 					add = {
+						value = 0
 						max = {
 							value = 0
 							max = country_rare_remaining
 						}
 					}
 					add = {
+						value = 0
 						max = {
 							value = 0
 							max = {


### PR DESCRIPTION
Converts the math for chips & composites to work off math expressions, rather than off normal math. Also removed a block of if checks, by adjusting how the microchip effects that set at technologies. Removed save backwards compatability; we do not need 10 if checks for that, just let them unlock it on the next tech where it get set.