### PR TITLE
Fix create_unit template ordering and add structural validation

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -42,17 +42,22 @@ Partial reports label themselves in the verdict banner and metadata strip. Scope
 - `validate_variables.py` carries a **clamp-range conflict** check (WARNING, `clamp-range-conflict`). It harvests every literal `clamp_variable = { var = X min = A max = B }` and flags any `check_variable` on `X` that compares against a value outside `A..B` (dead logic — always true or always false), plus the inverse scale slip: a sub-1 value compared against a variable clamped to a wide integer range. That second half is the `taliban_strength > 0.19` shape, the same failure class as the `threat > 40` trap in `general-rules.md`. It is deliberately anchored on the clamp rather than on observed value spread — a plain "this variable is compared on two scales" heuristic fires on `treasury`, `inflation_rate_var` and every percentage display variable, which legitimately use both. Variables only ever written by `set_temp_variable` are excluded: a clamp on a scratch parameter (`pp_gain`) constrains that one invocation, not the variable, so its range is no invariant for checks elsewhere.
 
 - `validate_oob_units.py` slot-checks ship variants through
-  `tools/validation/naval_module_slots.py` and structurally validates
-  `create_unit` effects. Its combined run gate covers `history/countries/`,
-  `common/national_focus/`, `events/`, `common/decisions/`,
-  `common/special_projects/`, `common/scripted_effects/`,
+  `tools/validation/naval_module_slots.py` and structurally checks `create_unit`
+  effects: state scope, `owner`, block keys, a single-line division string
+  naming a `division_template`, zero equipment/manpower factors, and the order
+  of a template defined in the same file and effect path as the `create_unit`
+  using it. It does not check that a referenced template is defined anywhere, so
+  a template that only ever exists for the wrong country, or a `has_template`
+  guard naming a template nothing defines, still passes. Its combined run gate
+  covers `history/countries/`, `common/national_focus/`, `events/`,
+  `common/decisions/`, `common/special_projects/`, `common/scripted_effects/`,
   `common/on_actions/`, `common/operations/`,
   `common/resistance_compliance_modifiers/`, and `common/scripted_guis/`, in
   both the pre-commit registry (`tools/precommit_validate.py`) and the CI
-  `oob` path filter. Keep the source lists in `validate_oob_units.py`, those
-  two routes, and the golden test in `tools/tests/precommit_validate_test.py`
-  together. Findings are **errors**. Non-ship variants are skipped by design.
-  Tank and plane slots are not validated anywhere yet. Their
+  `oob` path filter. `config_drift_test.py` derives both routes from
+  `_CREATE_UNIT_SOURCE_PATTERNS`, so a new directory there fails the suite until
+  both are updated. Findings are **errors**. Non-ship variants are skipped by
+  design. Tank and plane slots are not validated anywhere yet. Their
   `allowed_module_categories` blocks are often empty, so the naval resolver
   cannot be pointed at them as-is.
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -41,7 +41,20 @@ Partial reports label themselves in the verdict banner and metadata strip. Scope
 
 - `validate_variables.py` carries a **clamp-range conflict** check (WARNING, `clamp-range-conflict`). It harvests every literal `clamp_variable = { var = X min = A max = B }` and flags any `check_variable` on `X` that compares against a value outside `A..B` (dead logic — always true or always false), plus the inverse scale slip: a sub-1 value compared against a variable clamped to a wide integer range. That second half is the `taliban_strength > 0.19` shape, the same failure class as the `threat > 40` trap in `general-rules.md`. It is deliberately anchored on the clamp rather than on observed value spread — a plain "this variable is compared on two scales" heuristic fires on `treasury`, `inflation_rate_var` and every percentage display variable, which legitimately use both. Variables only ever written by `set_temp_variable` are excluded: a clamp on a scratch parameter (`pp_gain`) constrains that one invocation, not the variable, so its range is no invariant for checks elsewhere.
 
-- `validate_oob_units.py` also slot-checks every `create_equipment_variant` ship design (shared resolver: `tools/validation/naval_module_slots.py`). That widened its run gate well past OOB files: it is now routed on `history/countries/`, `common/national_focus/`, `events/`, `common/decisions/`, `common/special_projects/` and all of `common/scripted_effects/`, in both the pre-commit registry (`tools/precommit_validate.py`) and the CI `oob` path filter. Those two lists and the golden test in `tools/tests/precommit_validate_test.py` must move together. Findings are **errors** — the backlog was cleared first, so any hit is a regression. Non-ship variants are skipped by design; tank and plane slots are not validated anywhere yet, and their frequently-empty `allowed_module_categories` blocks mean the naval resolver cannot be pointed at them as-is.
+- `validate_oob_units.py` slot-checks ship variants through
+  `tools/validation/naval_module_slots.py` and structurally validates
+  `create_unit` effects. Its combined run gate covers `history/countries/`,
+  `common/national_focus/`, `events/`, `common/decisions/`,
+  `common/special_projects/`, `common/scripted_effects/`,
+  `common/on_actions/`, `common/operations/`,
+  `common/resistance_compliance_modifiers/`, and `common/scripted_guis/`, in
+  both the pre-commit registry (`tools/precommit_validate.py`) and the CI
+  `oob` path filter. Keep the source lists in `validate_oob_units.py`, those
+  two routes, and the golden test in `tools/tests/precommit_validate_test.py`
+  together. Findings are **errors**. Non-ship variants are skipped by design.
+  Tank and plane slots are not validated anywhere yet. Their
+  `allowed_module_categories` blocks are often empty, so the naval resolver
+  cannot be pointed at them as-is.
 
 ## Tooling deprecation watch
 

--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -37,7 +37,8 @@ on:
         required: false
         type: string
       base_sha:
-        description: "Current head of the PR's base branch (workspace cache key)"
+        description: >-
+          Current head of the PR's base branch (workspace cache key)
         required: false
         type: string
 
@@ -168,7 +169,7 @@ jobs:
       # just to diff locally is pure overhead.
       - name: Detect changed file groups
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706
         id: filter
         with:
           # `style_files` (from list-files: json) carries the changed .txt paths
@@ -207,6 +208,10 @@ jobs:
               - 'events/**'
               - 'common/decisions/**'
               - 'common/special_projects/**'
+              - 'common/on_actions/**'
+              - 'common/operations/**'
+              - 'common/resistance_compliance_modifiers/**'
+              - 'common/scripted_guis/**'
             decisions:
               - 'common/decisions/**'
             scripted-loc:
@@ -478,36 +483,47 @@ jobs:
           - script: validate_variables.py
             name: variables
             title: "Variables"
+            strict: true
           - script: validate_scripted_localisation.py
             name: scripted-localisation
             title: "Scripted Localisation"
+            strict: true
           - script: validate_cosmetic_tags.py
             name: cosmetic-tags
             title: "Cosmetic Tags"
+            strict: true
           - script: validate_localisation.py
             name: localisation
             title: "Localisation"
+            strict: true
           - script: validate_events.py
             name: events
             title: "Events"
+            strict: true
           - script: validate_history.py
             name: history-files
             title: "History Files"
+            strict: true
           - script: validate_unused_scripted.py
             name: unused-scripted
             title: "Unused Scripted Effects & Triggers"
+            strict: true
           - script: validate_agency_upgrades.py
             name: agency-upgrades
             title: "Intelligence Agency Upgrades"
+            strict: true
           - script: validate_ideas.py
             name: ideas
             title: "Idea References"
+            strict: true
           - script: validate_set_variables.py
             name: set-variables
             title: "Set Variable References"
+            strict: true
           - script: validate_defines.py
             name: defines
             title: "Defines"
+            strict: true
             # cross-references the committed vanilla_defines.txt manifest (CI
             # has no HOI4 install); regenerate it after a game update via
             # gen_vanilla_defines_manifest.py.

--- a/common/national_focus/05_Kabyle.txt
+++ b/common/national_focus/05_Kabyle.txt
@@ -154,6 +154,18 @@ focus_tree = {
 			add_to_variable = { KBY_alg_army_core_defence_factor = 0.10 }
 			custom_effect_tooltip = KBY_alg3_tt
 			hidden_effect = {
+				if = {
+					limit = { NOT = { has_template = "Territorial Defense Brigade" } }
+					division_template = {
+						name = "Territorial Defense Brigade"
+						is_locked = yes
+						regiments = {
+							L_Inf_Bat = { x = 0 y = 0 }
+							L_Inf_Bat = { x = 0 y = 1 }
+							Mot_Inf_Bat = { x = 1 y = 0 }
+						}
+					}
+				}
 				capital_scope = {
 					create_unit = {
 						division = "name = \"1st Territorial Defense Brigade\" division_template = \"Territorial Defense Brigade\" start_experience_factor = 0.5"
@@ -169,15 +181,6 @@ focus_tree = {
 						division = "name = \"3rd Territorial Defense Brigade\" division_template = \"Territorial Defense Brigade\" start_experience_factor = 0.5"
 						owner = ROOT
 						prioritize_location = 6756
-					}
-				}
-				division_template = {
-					name = "Territorial Defense Brigade"
-					is_locked = yes
-					regiments = {
-						L_Inf_Bat = { x = 0 y = 0 }
-						L_Inf_Bat = { x = 0 y = 1 }
-						Mot_Inf_Bat = { x = 1 y = 0 }
 					}
 				}
 			}

--- a/common/national_focus/05_indonesia.txt
+++ b/common/national_focus/05_indonesia.txt
@@ -2781,7 +2781,7 @@ focus_tree = {
 			custom_effect_tooltip = IND_soldier
 			hidden_effect = {
 				if = {
-					limit = { has_template = "Brigade Yonif Mekanis" }
+					limit = { has_template = "Kodam-I" }
 					capital_scope = {
 						create_unit = {
 							division = "name = \"Kodam-I\" division_template = \"Kodam-I\" start_experience_factor = 1.0"
@@ -2807,7 +2807,7 @@ focus_tree = {
 					}
 					capital_scope = {
 						create_unit = {
-							division = "name = \"Brigade Yonif Mekanis\" division_template = \"Brigade Yonif Mekanis\" start_experience_factor = 1.0"
+							division = "name = \"Kodam-I\" division_template = \"Kodam-I\" start_experience_factor = 1.0"
 							owner = ROOT
 							count = 5
 						}

--- a/common/national_focus/05_iran.txt
+++ b/common/national_focus/05_iran.txt
@@ -17209,10 +17209,12 @@ focus_tree = {
 						division_template = "Northern Alliance Militia"
 						disband = yes
 					}
-					create_unit = {
-						division = "name = \"Eastern Shura\" division_template = \"Northern Alliance Brigade\" start_experience_factor = 1.0"
-						owner = AFG
-						count = 1
+					random_owned_controlled_state = {
+						create_unit = {
+							division = "name = \"Eastern Shura\" division_template = \"Northern Alliance Brigade\" start_experience_factor = 1.0"
+							owner = AFG
+							count = 1
+						}
 					}
 				}
 				HAZ = {

--- a/common/national_focus/05_south_ossetia.txt
+++ b/common/national_focus/05_south_ossetia.txt
@@ -2442,6 +2442,20 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: focus SOO_nyhaz_ter_defence"
 			custom_effect_tooltip = BLR_territorial_defence_TT
+			hidden_effect = {
+				if = {
+					limit = { NOT = { has_template = "Territorial Defense Brigade" } }
+					division_template = {
+						name = "Territorial Defense Brigade"
+						is_locked = yes
+						regiments = {
+							L_Inf_Bat = { x = 0 y = 0 }
+							L_Inf_Bat = { x = 0 y = 1 }
+							Mot_Inf_Bat = { x = 1 y = 0 }
+						}
+					}
+				}
+			}
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			random_owned_controlled_state = {
@@ -2451,16 +2465,6 @@ focus_tree = {
 					division = "name = \"Territorial Defense Brigade\" division_template = \"Territorial Defense Brigade\" start_experience_factor = 1"
 					owner = SOO
 				}
-			}
-			hidden_effect = {
-			division_template = {
-				name = "Territorial Defense Brigade"
-				regiments = {
-					L_Inf_Bat = { x = 0 y = 0 }
-					L_Inf_Bat = { x = 0 y = 1 }
-					Mot_Inf_Bat = { x = 1 y = 0 }
-				}
-			}
 			}
 		}
 
@@ -2486,6 +2490,24 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: focus SOO_nyhaz_national_guard"
+			hidden_effect = {
+				if = {
+					limit = { NOT = { has_template = "Natsionalna Hvardiya" } }
+					division_template = {
+						name = "Natsionalna Hvardiya"
+						regiments = {
+							Militia_Bat = { x = 0 y = 0 }
+							Militia_Bat = { x = 0 y = 1 }
+							Militia_Bat = { x = 0 y = 2 }
+							Militia_Bat = { x = 0 y = 3 }
+						}
+						support = {
+							L_Engi_Comp = { x = 0 y = 0 }
+							L_Recce_Comp = { x = 0 y = 0 }
+						}
+					}
+				}
+			}
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			random_owned_controlled_state = {
@@ -2494,21 +2516,6 @@ focus_tree = {
 				create_unit = {
 					division = "name = \"1st Operational Brigade of the National Guard\" division_template = \"Natsionalna Hvardiya\" start_experience_factor = 0.1"
 					owner = SOO
-				}
-			}
-			hidden_effect = {
-				division_template = {
-					name = "Natsionalna Hvardiya"
-					regiments = {
-						Militia_Bat = { x = 0 y = 0 }
-						Militia_Bat = { x = 0 y = 1 }
-						Militia_Bat = { x = 0 y = 2 }
-						Militia_Bat = { x = 0 y = 3 }
-					}
-					support = {
-						L_Engi_Comp = { x = 0 y = 0 }
-						L_Recce_Comp = { x = 0 y = 0 }
-					}
 				}
 			}
 		}

--- a/common/national_focus/Malorossiya.txt
+++ b/common/national_focus/Malorossiya.txt
@@ -150,6 +150,18 @@ focus_tree = {
 			add_to_variable = { MLR_ukr_army_core_defence_factor = 0.10 tooltip = army_core_defence_factor_tt }
 			custom_effect_tooltip = MLR_ter_oborona_tt
 			hidden_effect = {
+				if = {
+					limit = { NOT = { has_template = "Territorial Defense Brigade" } }
+					division_template = {
+						name = "Territorial Defense Brigade"
+						is_locked = yes
+						regiments = {
+							L_Inf_Bat = { x = 0 y = 0 }
+							L_Inf_Bat = { x = 0 y = 1 }
+							Mot_Inf_Bat = { x = 1 y = 0 }
+						}
+					}
+				}
 				capital_scope = {
 					create_unit = {
 						division = "name = \"1st Territorial Defense Brigade\" division_template = \"Territorial Defense Brigade\" start_experience_factor = 0.5"
@@ -165,15 +177,6 @@ focus_tree = {
 						division = "name = \"3rd Territorial Defense Brigade\" division_template = \"Territorial Defense Brigade\" start_experience_factor = 0.5"
 						owner = ROOT
 						prioritize_location = 6756
-					}
-				}
-				division_template = {
-					name = "Territorial Defense Brigade"
-					is_locked = yes
-					regiments = {
-						L_Inf_Bat = { x = 0 y = 0 }
-						L_Inf_Bat = { x = 0 y = 1 }
-						Mot_Inf_Bat = { x = 1 y = 0 }
 					}
 				}
 			}

--- a/docs/src/content/resources/code-stylization-guide.md
+++ b/docs/src/content/resources/code-stylization-guide.md
@@ -94,28 +94,23 @@ focus = {
 
     cost = 5
 
-    # allow_branch = { }
     prerequisite = { focus = SER_western_approach }
-    # mutually_exclusive = { }
+
     search_filters = { FOCUS_FILTER_POLITICAL }
 
-    available = {
-        western_liberals_are_in_power = yes
-    }
-    # bypass = { }
-    # cancel = { }
+    available = { western_liberals_are_in_power = yes }
 
     completion_reward = {
         log = "[GetDateText]: [Root.GetName]: Focus SER_free_market_capitalism"
         add_ideas = SER_free_market_idea
     }
-    # bypass_effect = { }
 
-    ai_will_do = {
-        base = 1
-    }
+    ai_will_do = { base = 1 }
 }
 ```
+
+Write only the properties the focus uses. An empty commented-out slot marker
+(`# bypass = { }`) is dead code, and `standardize.py focus` deletes it.
 
 ---
 
@@ -153,9 +148,7 @@ URA_world_opr = {
         OPR = { country_event = { id = subject_rus.121 days = 1 } }
     }
 
-    ai_will_do = {
-        base = 10
-    }
+    ai_will_do = { base = 10 }
 }
 ```
 
@@ -217,9 +210,8 @@ country_event = {
 ```hoiscript
 BRA_idea_higher_minimum_wage_1 = {
     name = BRA_idea_higher_minimum_wage
-	picture = gold
+    picture = gold
     allowed_civil_war = { always = yes }
-
     modifier = {
         political_power_factor = 0.1
         stability_factor = 0.05

--- a/events/00_arab_spring.txt
+++ b/events/00_arab_spring.txt
@@ -7,6 +7,7 @@ country_event = {
 	desc = arab_spring.0.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
+
 	trigger = {
 		is_in_array = { global.arabic_countries = THIS.id }
 		NOT = { has_country_flag = AS_arab_spring_completed }
@@ -19,7 +20,6 @@ country_event = {
 		if = { limit = { NOT = { has_country_flag = arab_spring_active } }
 			set_country_flag = arab_spring_active
 		}
-
 		if = {
 			limit = { is_subject = yes }
 			OVERLORD = { country_event = { id = arab_spring.3 days = 1 } }
@@ -30,9 +30,9 @@ country_event = {
 				country_event = { id = arab_spring.3 days = 1 }
 			}
 		}
-
 		news_event = arab_spring.1
 	}
+
 }
 
 # Protests Erupt Demanding [FROM.GetLeader]'s Resignation
@@ -70,6 +70,7 @@ news_event = {
 		trigger = { NOT = { tag = FROM } }
 		name = arab_spring.1.b
 	}
+
 }
 
 # An Ally under Threat
@@ -77,9 +78,7 @@ country_event = {
 	id = arab_spring.3
 	title = arab_spring.3.t
 	desc = arab_spring.3.d
-
 	picture = GFX_politics_protest
-
 	is_triggered_only = yes
 
 	# We stand by our allies!
@@ -87,7 +86,6 @@ country_event = {
 		name = arab_spring.3.a
 		log = "[GetDateText]: [This.GetName]: arab_spring.3.a executed"
 		FROM = { country_event = { id = arab_spring.4 days = 1 } }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -136,7 +134,6 @@ country_event = {
 		name = arab_spring.3.b
 		FROM = { country_event = { id = arab_spring.5 days = 1 } }
 		log = "[GetDateText]: [This.GetName]: arab_spring.3.b executed"
-
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -146,6 +143,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 # Our Ally Supports us!
@@ -162,6 +160,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: arab_spring.4.a executed"
 		add_political_power = 150
 	}
+
 }
 
 # Our Ally has Abandoned us...
@@ -177,6 +176,7 @@ country_event = {
 		name = arab_spring.5.a
 		log = "[GetDateText]: [This.GetName]: arab_spring.5.a executed"
 	}
+
 }
 
 # Regime Supporters Stage Rally
@@ -206,13 +206,12 @@ country_event = {
 		name = arab_spring.6.b
 		log = "[GetDateText]: [This.GetName]: arab_spring.6.b executed"
 		trigger = { has_country_flag = arab_spring_civilian_clashes }
-
 		clr_country_flag = arab_spring_civilian_clashes
-
 		set_temp_variable = { temp_strength = 10 }
 		change_arab_spring_strength = yes
 		add_manpower = -20
 	}
+
 }
 
 # Units of the Army Mutiny, Side with the Opposition
@@ -222,6 +221,7 @@ country_event = {
 	desc = arab_spring.7.d
 	picture = GFX_arab_spring_defection
 	is_triggered_only = yes
+
 	trigger = {
 		NOT = { has_country_flag = AS_arab_spring_completed }
 		has_country_flag = arab_spring_military_deployed
@@ -238,6 +238,7 @@ country_event = {
 		add_to_variable = { arab_spring_mutiny = 1 }
 		add_manpower = -500
 	}
+
 }
 
 # Deaths Following Clashes between Troops and Protesters
@@ -247,6 +248,7 @@ country_event = {
 	desc = arab_spring.8.d
 	picture = GFX_egyptian_christian_massacre
 	is_triggered_only = yes
+
 	trigger = {
 		has_country_flag = arab_spring_military_deployed
 		has_country_flag = arab_spring_active
@@ -260,6 +262,7 @@ country_event = {
 		change_arab_spring_strength = yes
 		add_manpower = -50
 	}
+
 }
 
 # Concessions Placate the Masses
@@ -275,6 +278,7 @@ country_event = {
 		name = arab_spring.9.a
 		log = "[GetDateText]: [This.GetName]: arab_spring.9.a executed"
 	}
+
 }
 
 # Concession Leads to Demands for Further Reform
@@ -292,6 +296,7 @@ country_event = {
 		set_temp_variable = { temp_strength = 10 }
 		change_arab_spring_strength = yes
 	}
+
 }
 
 # Protests Reach Boiling Point
@@ -301,10 +306,10 @@ country_event = {
 	desc = arab_spring.11.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
+
 	trigger = { NOT = { has_country_flag = AS_arab_spring_completed } }
-	immediate = {
-		set_country_flag = AS_arab_spring_completed
-	}
+
+	immediate = { set_country_flag = AS_arab_spring_completed }
 
 	# We Must Accept Defeat...
 	option = {
@@ -318,14 +323,11 @@ country_event = {
 			set_variable = { party_pop_array^7 = 0 }
 		}
 		enable_elections_with_no_leader_change = yes
-
 		add_popularity = { ideology = neutrality popularity = 0.10 }
 		recalculate_party = yes
-
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		change_relative_party_popularity = yes
-
 		if = { limit = { has_idea = hybrid_regime_western }
 			remove_ideas = hybrid_regime_western
 		}
@@ -333,7 +335,6 @@ country_event = {
 			remove_ideas = hybrid_regime_emerging
 		}
 		country_event = { id = MD4_election_campaign.0 days = 7 }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -364,7 +365,6 @@ country_event = {
 		name = arab_spring.11.b
 		log = "[GetDateText]: [This.GetName]: arab_spring.11.b executed"
 		news_event = arab_spring.14
-
 		if = { limit = { check_variable = { arab_spring_mutiny = 0 } }
 			set_temp_variable = { arab_spring_mutiny_size = 0.1 }
 		}
@@ -380,13 +380,11 @@ country_event = {
 			limit = { check_variable = { arab_spring_mutiny > 2 } }
 			set_temp_variable = { arab_spring_mutiny_size = 0.4 }
 		}
-
 		if = { limit = { check_variable = { arab_spring > 200 } }
 			set_temp_variable = { arab_spring_protest_size = arab_spring }
 			multiply_temp_variable = { arab_spring_protest_size = 0.0001 }
 			add_to_temp_variable = { arab_spring_mutiny_size = arab_spring_protest_size }
 		}
-
 		if = {
 			limit = { tag = SYR }
 			start_civil_war = {
@@ -394,7 +392,6 @@ country_event = {
 				size = arab_spring_mutiny_size
 				states = { 184 185 571 }
 			}
-
 			hidden_effect = {
 				set_global_flag = SYR_civil_war_started_early
 				#Recognition
@@ -406,7 +403,6 @@ country_event = {
 					division_template = {
 						name = "Militia Brigade"
 						is_locked = yes
-
 						regiments = {
 							Mot_Militia_Bat = { x = 0 y = 0 }
 							Mot_Militia_Bat = { x = 0 y = 1 }
@@ -431,18 +427,15 @@ country_event = {
 							add_core_of = FSA
 						}
 						if = { limit = { has_dlc = "No Step Back" }
-
 							load_oob = FSA_2000_nsb
 							else = {
 								load_oob = FSA_2000_nonnsb
 							}
 						}
-
 						add_timed_idea = {
 							idea = FSA_rebel_fighting_spirit_idea
 							days = 365
 						}
-
 						capital_scope = {
 							create_unit = {
 								division = "name = \"Militia Brigade\" division_template = \"Militia Brigade\" start_experience_factor = 0.9"
@@ -471,7 +464,6 @@ country_event = {
 						}
 					}
 				}
-
 				190 = { add_core_of = NUS }
 				release = NUS
 				190 = { add_core_of = ROOT }
@@ -485,14 +477,12 @@ country_event = {
 					set_cosmetic_tag = NUSRA
 					ingame_startup_nations_effect = yes
 					if = { limit = { has_dlc = "No Step Back" }
-
 						load_oob = NUS_2000_nsb
 					}
 					else = {
 						load_oob = NUS_2000_nonnsb
 					}
 				}
-
 				if = {
 					limit = {
 						country_exists = FSA
@@ -513,7 +503,6 @@ country_event = {
 						type = annex_everything
 					}
 				}
-
 				capital_scope = {
 					create_unit = {
 						division = "name = \"Militia Brigade\" division_template = \"Militia Brigade\" start_experience_factor = 0.9"
@@ -534,7 +523,6 @@ country_event = {
 				size = arab_spring_mutiny_size
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -564,6 +552,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 # Revolution Sweeps Regime from Power in [FROM.GetNameDef]
@@ -589,7 +578,6 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: arab_spring.12.a executed"
 		if = { limit = { NOT = { has_global_flag = global_arab_spring_started } }
 			set_global_flag = global_arab_spring_started
-
 			hidden_effect = {
 				if = { limit = { FROM = { NOT = { original_tag = TUN } } } TUN = { country_event = { id = arab_spring.17 days = 1 } } }
 				if = { limit = { FROM = { NOT = { original_tag = ALG } } } ALG = { country_event = { id = arab_spring.17 days = 1 } } }
@@ -625,6 +613,7 @@ news_event = {
 		name = arab_spring.12.c
 		log = "[GetDateText]: [This.GetName]: arab_spring.12.c"
 	}
+
 }
 
 # Protests Spread Across Arab World
@@ -637,9 +626,8 @@ news_event = {
 	major = yes
 
 	# The Winds of Change are Blowing in the Middle East...
-	option = {
-		name = arab_spring.13.a
-	}
+	option = { name = arab_spring.13.a }
+
 }
 
 # Civil War Erupts in [FROM.GetNameDef] as Regime Crushes Protests
@@ -652,9 +640,8 @@ news_event = {
 	major = yes
 
 	# The Future of [FROM.GetNameDef] hangs in the Balance...
-	option = {
-		name = arab_spring.14.a
-	}
+	option = { name = arab_spring.14.a }
+
 }
 
 # ISIL Rises to Prominence
@@ -664,6 +651,7 @@ news_event = {
 	desc = arab_spring.15.d
 	picture = GFX_isis
 	is_triggered_only = yes
+	major = yes
 
 	trigger = {
 		NOT = { has_global_flag = ISIL_declared }
@@ -676,11 +664,8 @@ news_event = {
 		}
 		IRQ = { is_subject = no }
 	}
-	major = yes
 
-	immediate = {
-		set_global_flag = ISIL_declared
-	}
+	immediate = { set_global_flag = ISIL_declared }
 
 	# Yet Another Threat to Our Rule...
 	option = {
@@ -713,6 +698,7 @@ news_event = {
 		AS_spawn_isis_into_game = yes
 		ISI = { change_tag_from = PREV }
 	}
+
 }
 
 # The Arab Spring Reaches [FROM.GetNameDef]
@@ -722,6 +708,7 @@ country_event = {
 	desc = arab_spring.17.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
+
 	trigger = {
 		is_in_array = { global.arabic_countries = THIS.id }
 		NOT = { has_country_flag = AS_arab_spring_completed }
@@ -733,7 +720,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: arab_spring.17.a executed"
 		set_country_flag = arab_spring_active
 		activate_mission_tooltip = arab_spring_protests_2
-
 		if = {
 			limit = {
 				var:influence_array^0 = {
@@ -747,6 +733,7 @@ country_event = {
 			var:influence_array^0 = { country_event = { id = arab_spring.3 days = 1 } }
 		}
 	}
+
 }
 
 # Protests Subside
@@ -763,6 +750,7 @@ country_event = {
 	}
 	picture = GFX_politics_protest
 	is_triggered_only = yes
+
 	trigger = { NOT = { has_country_flag = AS_arab_spring_completed } }
 
 	# Our Government is Still Standing
@@ -772,14 +760,13 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		change_relative_party_popularity = yes
-
 		add_political_power = 200
 		set_country_flag = AS_arab_spring_completed
-
 		ai_chance = {
 			base = 1
 		}
 	}
+
 }
 
 # [FROM.GetLeader] Requests Peninsula Shield Intervention
@@ -787,9 +774,7 @@ country_event = {
 	id = arab_spring.19
 	title = arab_spring.19.t
 	desc = arab_spring.19.d
-
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	# We Must Help Our Ally!
@@ -797,7 +782,6 @@ country_event = {
 		name = arab_spring.19.a
 		log = "[GetDateText]: [This.GetName]: arab_spring.19.a executed"
 		FROM = { country_event = arab_spring.20 }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -824,7 +808,6 @@ country_event = {
 		name = arab_spring.19.b
 		log = "[GetDateText]: [This.GetName]: arab_spring.19.b executed"
 		FROM = { country_event = arab_spring.21 }
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -864,6 +847,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 # Our Request Has Been Accepted!
@@ -880,12 +864,11 @@ country_event = {
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = FROM.id }
 		change_influence_percentage = yes
-
 		set_temp_variable = { temp_strength = -100 }
 		change_arab_spring_strength = yes
-
 		news_event = { id = arab_spring.22 days = 1 }
 	}
+
 }
 
 # Our Request Has Been Rejected...
@@ -900,6 +883,7 @@ country_event = {
 		name = arab_spring.21.a
 		log = "[GetDateText]: [This.GetName]: arab_spring.21.a executed"
 	}
+
 }
 
 # Peninsula Shield Troops Deployed to Quell Protests in [FROM.GetNameDef]
@@ -911,7 +895,6 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = arab_spring.22.a
-	}
+	option = { name = arab_spring.22.a }
+
 }

--- a/events/00_arab_spring.txt
+++ b/events/00_arab_spring.txt
@@ -614,14 +614,14 @@ news_event = {
 
 	# A Worrying Development...
 	option = {
-		trigger = { NOT = { tag = FROM } is_arabic_nation = yes }
+		trigger = { NOT = { tag = FROM } has_country_flag = arabic_nation_flag }
 		name = arab_spring.12.b
 		log = "[GetDateText]: [This.GetName]: arab_spring.12.b"
 	}
 
 	# Democracy Advances...
 	option = {
-		trigger = { NOT = { OR = { tag = FROM is_arabic_nation = yes } } }
+		trigger = { NOT = { OR = { tag = FROM has_country_flag = arabic_nation_flag } } }
 		name = arab_spring.12.c
 		log = "[GetDateText]: [This.GetName]: arab_spring.12.c"
 	}

--- a/events/00_arab_spring.txt
+++ b/events/00_arab_spring.txt
@@ -401,6 +401,22 @@ country_event = {
 				hidden_effect = {
 					add_civil_war_debuff = yes
 				}
+				if = {
+					limit = { NOT = { has_template = "Militia Brigade" } }
+					division_template = {
+						name = "Militia Brigade"
+						is_locked = yes
+
+						regiments = {
+							Mot_Militia_Bat = { x = 0 y = 0 }
+							Mot_Militia_Bat = { x = 0 y = 1 }
+							Mot_Militia_Bat = { x = 0 y = 2 }
+						}
+						support = {
+							L_Engi_Comp = { x = 0 y = 0 }
+						}
+					}
+				}
 				random_country_with_original_tag = {
 					original_tag_to_check = SYR
 					limit = { has_government = neutrality }
@@ -498,22 +514,6 @@ country_event = {
 					}
 				}
 
-				if = {
-					limit = { has_template = "Mili" }
-					division_template = {
-						name = "Militia Brigade"
-						is_locked = yes
-
-						regiments = {
-							Mot_Militia_Bat = { x = 0 y = 0 }
-							Mot_Militia_Bat = { x = 0 y = 1 }
-							Mot_Militia_Bat = { x = 0 y = 2 }
-						}
-						support = {
-							L_Engi_Comp = { x = 0 y = 0 }
-						}
-					}
-				}
 				capital_scope = {
 					create_unit = {
 						division = "name = \"Militia Brigade\" division_template = \"Militia Brigade\" start_experience_factor = 0.9"

--- a/events/bosnia_events.txt
+++ b/events/bosnia_events.txt
@@ -61,6 +61,17 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: BOS_events.1.b executed"
 		custom_effect_tooltip = bos_civil_war_srpska_info_tool_tip
 		hidden_effect = {
+			if = {
+				limit = { NOT = { has_template = "Milicija Divizija" } }
+				division_template = {
+					name = "Milicija Divizija"
+					division_names_group = BOS_MIL
+					is_locked = yes
+					regiments = {
+						Militia_Bat = { x = 0 y = 0 }
+					}
+				}
+			}
 			remove_ideas = BOS_SFOR
 			BOS_begin_srpska_civil_war_effect = yes
 			transfer_units_fraction = {
@@ -225,6 +236,17 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: BOS_events.2.a executed"
 		custom_effect_tooltip = bos_croat_war_info_tool_tip
 		hidden_effect = {
+			if = {
+				limit = { NOT = { has_template = "Milicija Divizija" } }
+				division_template = {
+					name = "Milicija Divizija"
+					division_names_group = BOS_MIL
+					is_locked = yes
+					regiments = {
+						Militia_Bat = { x = 0 y = 0 }
+					}
+				}
+			}
 			set_country_flag = defeat_all_croats
 			BOS_begin_internal_war_effect = yes
 			add_named_threat = {
@@ -366,6 +388,17 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: BOS_events.2.b executed"
 		custom_effect_tooltip = bos_croat_war_info_tool_tip
 		hidden_effect = {
+			if = {
+				limit = { NOT = { has_template = "Milicija Divizija" } }
+				division_template = {
+					name = "Milicija Divizija"
+					division_names_group = BOS_MIL
+					is_locked = yes
+					regiments = {
+						Militia_Bat = { x = 0 y = 0 }
+					}
+				}
+			}
 			set_country_flag = defeat_all_croats
 			BOS_begin_internal_war_effect = yes
 			add_named_threat = {

--- a/tools/precommit_validate.py
+++ b/tools/precommit_validate.py
@@ -96,13 +96,17 @@ _REGISTRY = [
             ("common/units/", TXT),
             ("common/ai_templates/", TXT),
             ("common/scripted_effects/", TXT),
-            # create_equipment_variant ship designs are slot-checked against
-            # their hull, so every directory that can hold one is routed here.
+            # Ship variants and create_unit effects share this validator, so
+            # every runtime source for either effect is routed here.
             ("history/countries/", TXT),
             ("common/national_focus/", TXT),
             ("events/", TXT),
             ("common/decisions/", TXT),
             ("common/special_projects/", TXT),
+            ("common/on_actions/", TXT),
+            ("common/operations/", TXT),
+            ("common/resistance_compliance_modifiers/", TXT),
+            ("common/scripted_guis/", TXT),
         ],
     ),
     _Spec(
@@ -181,8 +185,12 @@ def _run(spec, mod_path, env, no_color, inner_workers):
             timeout=300,
         )
     except subprocess.TimeoutExpired as exc:
-        out = exc.stdout or ""
-        err = exc.stderr or ""
+        out = exc.stdout
+        err = exc.stderr
+        if out is None:
+            out = ""
+        if err is None:
+            err = ""
         if isinstance(out, bytes):
             out = out.decode("utf-8", "replace")
         if isinstance(err, bytes):

--- a/tools/standardization/standardize_decisions.py
+++ b/tools/standardization/standardize_decisions.py
@@ -143,8 +143,8 @@ def format_decision(block_lines: List[str]) -> List[str]:
             i += 1
             continue
         if stripped.startswith("#"):
+            # No trailing blank: the comment hugs the property it describes.
             lines.append(f"\t\t{stripped}")
-            lines.append("")
             i += 1
             continue
 

--- a/tools/standardization/standardize_events.py
+++ b/tools/standardization/standardize_events.py
@@ -35,13 +35,7 @@ _HEADER_SINGLE_PROPS = {
     "fire_only_once",
 }
 
-# Maps script property name -> (props key, section tag for comment placement)
-_BLOCK_PROPS = {
-    "mean_time_to_happen": ("mean_time_to_happen", "mtth"),
-    "trigger": ("trigger", "trigger"),
-    "immediate": ("immediate", "immediate"),
-    "option": ("option", "options"),
-}
+_BLOCK_PROPS = frozenset({"mean_time_to_happen", "trigger", "immediate", "option"})
 
 
 _OPTION_STATEMENT_RE = re.compile(r"[A-Za-z_]\w*\s*=")
@@ -197,11 +191,13 @@ class EventStandardizer(BaseStandardizer):
             "trigger": [],
             "immediate": [],
             "option": [],
-            "comments_after_header": [],
-            "comments_after_mtth": [],
-            "comments_after_trigger": [],
-            "comments_after_immediate": [],
-            "comments_after_options": [],
+            # A comment describes what comes next, so each block carries the
+            # comments written above it. Same order and length as the block list.
+            "mean_time_to_happen_comments": [],
+            "trigger_comments": [],
+            "immediate_comments": [],
+            "option_comments": [],
+            "comments_trailing": [],
         }
 
         first_line = block_lines[0].strip()
@@ -210,8 +206,7 @@ class EventStandardizer(BaseStandardizer):
                 props["event_type"] = event_type
                 break
 
-        # Track which section we're in for comment placement
-        current_section = "header"
+        pending: List[str] = []
 
         i = 1  # Skip opening brace
         while i < len(block_lines) - 1:  # Skip closing brace
@@ -221,30 +216,27 @@ class EventStandardizer(BaseStandardizer):
 
             if prop_name in _HEADER_SINGLE_PROPS:
                 props[prop_name] = line
-                current_section = "header"
             elif prop_name in ("title", "desc"):
                 if "{" in line:
                     block, next_i = extract_block(block_lines, i)
                     props[prop_name].append(block)
                     i = next_i
-                    current_section = "header"
                     continue
                 else:
                     props[prop_name].append(line)
-                    current_section = "header"
             elif prop_name in _BLOCK_PROPS:
-                key, section = _BLOCK_PROPS[prop_name]
                 block, next_i = extract_block(block_lines, i)
-                props[key].append(block)
+                props[prop_name].append(block)
+                props[f"{prop_name}_comments"].append(pending)
+                pending = []
                 i = next_i
-                current_section = section
                 continue
             else:
-                # Comment or unrecognized line: bucket it under the current section.
-                props[f"comments_after_{current_section}"].append(block_lines[i])
+                pending.append(block_lines[i])
 
             i += 1
 
+        props["comments_trailing"] = pending
         return props
 
     def format_block(self, props: Dict[str, Any]) -> List[str]:
@@ -292,28 +284,29 @@ class EventStandardizer(BaseStandardizer):
 
         lines.append("")
 
-        emit_comments(lines, props["comments_after_header"])
-
         # 8. Mean time to happen
-        for mtth in props["mean_time_to_happen"]:
+        for comments, mtth in zip(
+            props["mean_time_to_happen_comments"], props["mean_time_to_happen"]
+        ):
+            emit_comments(lines, comments)
             lines.extend(collapse_or_compact(mtth[:]))
             lines.append("")
-        emit_comments(lines, props["comments_after_mtth"])
 
         # 9. Trigger
-        for trigger in props["trigger"]:
+        for comments, trigger in zip(props["trigger_comments"], props["trigger"]):
+            emit_comments(lines, comments)
             lines.extend(collapse_or_compact(trigger[:]))
             lines.append("")
-        emit_comments(lines, props["comments_after_trigger"])
 
         # 10. Immediate effects
-        for immediate in props["immediate"]:
+        for comments, immediate in zip(props["immediate_comments"], props["immediate"]):
+            emit_comments(lines, comments)
             lines.extend(collapse_or_compact(immediate[:]))
             lines.append("")
-        emit_comments(lines, props["comments_after_immediate"])
 
         # 11. Options
-        for option in props["option"]:
+        for comments, option in zip(props["option_comments"], props["option"]):
+            emit_comments(lines, comments)
             if (
                 _option_has_effects(option)
                 and not block_has_log(option)
@@ -328,8 +321,8 @@ class EventStandardizer(BaseStandardizer):
             lines.extend(collapse_or_compact(option[:]))
             lines.append("")
 
-        emit_comments(lines, props["comments_after_options"])
-        if props["comments_after_options"]:
+        emit_comments(lines, props["comments_trailing"])
+        if props["comments_trailing"]:
             lines.append("")
 
         lines.append("}")

--- a/tools/standardization/standardize_focus_tree.py
+++ b/tools/standardization/standardize_focus_tree.py
@@ -82,8 +82,11 @@ _DEFAULT_REMOVALS = {
     "available_if_capitulated = no",
 }
 
+# Empty commented-out placeholders are dropped, not kept and re-sorted into the
+# `other` slot away from the position that gave them their meaning.
 _COMMENTED_EMPTY_BLOCK_RE = re.compile(
-    r"^#\s*(available|bypass|cancel|visible|mutually_exclusive)\s*=\s*\{\s*\}$"
+    r"^#\s*(allow_branch|available|bypass|bypass_effect|cancel|visible"
+    r"|mutually_exclusive)\s*=\s*\{\s*\}$"
 )
 
 # Matches an existing log line so we can correct a wrong focus ID or missing prefix.

--- a/tools/standardization/standardize_ideas.py
+++ b/tools/standardization/standardize_ideas.py
@@ -141,6 +141,10 @@ class IdeaStandardizer(BaseStandardizer):
             "on_add": [],
             "on_remove": [],
             "other": [],
+            # (property, index) -> comments written above it. Properties are
+            # re-emitted in a fixed order below, so a comment has to travel with
+            # the one it describes instead of being left where it was written.
+            "comments": {},
         }
 
         # Extract ID from the opening line (e.g., "BRA_idea_higher_minimum_wage_1 = {").
@@ -157,6 +161,15 @@ class IdeaStandardizer(BaseStandardizer):
         if brace != -1 and first_code[brace + 1 :].strip():
             block_lines = _explode_braces(block_lines)
 
+        pending: List[str] = []
+
+        def flush_pending():
+            """Park comments in `other`, in source order, when the property they
+            precede isn't one of the re-ordered ones (or was dropped)."""
+            nonlocal pending
+            props["other"].extend(("comment", comment) for comment in pending)
+            pending = []
+
         i = 1  # Skip opening brace line
         while i < len(block_lines) - 1:  # Skip closing brace
             line = block_lines[i].strip()
@@ -165,11 +178,15 @@ class IdeaStandardizer(BaseStandardizer):
 
             if prop_name in _SINGLE_LINE_PROPS:
                 props[prop_name] = line
+                props["comments"][(prop_name, 0)] = pending
+                pending = []
             elif prop_name in _BLOCK_PROPS:
                 block, next_i = extract_block(block_lines, i)
                 if prop_name in _ALWAYS_NO_FILTERED and self.is_always_no_block(
                     block, prop_name
                 ):
+                    # The block goes away as dead code; its comments stay.
+                    flush_pending()
                     i = next_i
                     continue
                 if prop_name == "allowed":
@@ -178,11 +195,14 @@ class IdeaStandardizer(BaseStandardizer):
                     # is preserved verbatim.
                     block = [_rewrite_allowed_tag(bl) for bl in block]
                 props[prop_name].append(block)
+                props["comments"][(prop_name, len(props[prop_name]) - 1)] = pending
+                pending = []
                 i = next_i
                 continue
             elif line.startswith("#"):
-                props["other"].append(("comment", block_lines[i].rstrip()))
+                pending.append(block_lines[i].rstrip())
             elif line:
+                flush_pending()
                 # Blank quoted strings before counting so a `{` inside a quoted
                 # value isn't misread as a block opener (which would send the
                 # quote-aware extract_block negative and drop lines to the closer).
@@ -197,6 +217,7 @@ class IdeaStandardizer(BaseStandardizer):
 
             i += 1
 
+        flush_pending()
         return props
 
     def is_empty_log_block(self, block_lines: List[str]) -> bool:
@@ -359,12 +380,18 @@ class IdeaStandardizer(BaseStandardizer):
         # Property indent is one level deeper
         prop_indent = base_indent + "\t"
 
+        def emit_comments(key: str, index: int = 0) -> None:
+            for comment in props.get("comments", {}).get((key, index), []):
+                lines.append(prop_indent + comment.strip())
+
         # 1. Name (optional, first property if present)
         if props["name"]:
+            emit_comments("name")
             lines.append(prop_indent + props["name"])
 
         # 2. Picture
         if props["picture"]:
+            emit_comments("picture")
             lines.append(prop_indent + props["picture"])
 
         # 3-10. Simple blocks emitted in order
@@ -378,17 +405,20 @@ class IdeaStandardizer(BaseStandardizer):
             "rule",
             "equipment_bonus",
         ):
-            for block in props[key]:
+            for index, block in enumerate(props[key]):
+                emit_comments(key, index)
                 lines.extend(self._reindent_or_collapse(block, prop_indent))
 
         # 11. on_add (log only when making changes)
-        for block in props["on_add"]:
+        for index, block in enumerate(props["on_add"]):
+            emit_comments("on_add", index)
             lines.extend(
                 self._emit_lifecycle_block(block, prop_indent, props["id"], "added")
             )
 
         # 12. on_remove (log only when making changes)
-        for block in props["on_remove"]:
+        for index, block in enumerate(props["on_remove"]):
+            emit_comments("on_remove", index)
             lines.extend(
                 self._emit_lifecycle_block(block, prop_indent, props["id"], "removed")
             )

--- a/tools/standardization/tests/standardize_decisions_test.py
+++ b/tools/standardization/tests/standardize_decisions_test.py
@@ -131,6 +131,21 @@ def test_single_leaf_block_collapsed():
     ]
 
 
+def test_body_comment_hugs_the_property_it_describes():
+    block = _decision(
+        [
+            "\tCHI_x_decision = {",
+            "\t\tcost = 50",
+            "\t\t# blocked once the ceasefire holds",
+            "\t\tavailable = { has_war = yes }",
+            "\t}",
+        ]
+    )
+    out = format_decision(block)
+    comment = out.index("\t\t# blocked once the ceasefire holds")
+    assert out[comment + 1] == "\t\tavailable = { has_war = yes }"
+
+
 def test_category_shell_preserved_and_decisions_reformatted():
     category = _decision(
         [

--- a/tools/standardization/tests/standardize_events_test.py
+++ b/tools/standardization/tests/standardize_events_test.py
@@ -126,6 +126,42 @@ def test_event_idempotent():
     assert once == twice
 
 
+_COMMENTED_EVENT = [
+    "country_event = {",
+    "\tid = test.2",
+    "\tis_triggered_only = yes",
+    "",
+    "\t# We stand by our allies!",
+    "\toption = {",
+    "\t\tname = test.2.a",
+    "\t}",
+    "",
+    "\t# Let them fall...",
+    "\toption = {",
+    "\t\tname = test.2.b",
+    "\t}",
+    "}",
+]
+
+
+def test_comment_hugs_the_option_it_describes():
+    out = _standardize_event(_COMMENTED_EVENT)
+    pairs = [
+        (line.strip(), out[i + 1].strip())
+        for i, line in enumerate(out)
+        if line.lstrip().startswith("#")
+    ]
+    assert pairs == [
+        ("# We stand by our allies!", "option = { name = test.2.a }"),
+        ("# Let them fall...", "option = { name = test.2.b }"),
+    ]
+
+
+def test_comment_after_the_last_option_is_kept():
+    out = _standardize_event(_COMMENTED_EVENT[:-1] + ["\t# Nothing follows this", "}"])
+    assert "\t# Nothing follows this" in out
+
+
 def test_packed_single_line_option_effect_detected():
     # A fully packed option (header + body + closer on one physical line) must
     # still have its effects detected -- previously the empty [1:-1] slice hid them.

--- a/tools/standardization/tests/standardize_focus_tree_test.py
+++ b/tools/standardization/tests/standardize_focus_tree_test.py
@@ -43,6 +43,25 @@ def test_multiple_war_targets_all_preserved_in_order():
     ]
 
 
+def test_every_empty_commented_placeholder_is_dropped():
+    # The stylization guide's example focus writes these as slot markers; the
+    # formatter drops all of them rather than keeping some and re-sorting them.
+    placeholders = (
+        "allow_branch",
+        "available",
+        "bypass",
+        "bypass_effect",
+        "cancel",
+        "mutually_exclusive",
+        "visible",
+    )
+    lines = ["\tfocus = {\n", "\t\tid = TST_slots\n"]
+    lines.extend(f"\t\t# {name} = {{ }}\n" for name in placeholders)
+    lines.append("\t}\n")
+    out = format_focus_block(extract_focus_properties(lines))
+    assert not [line for line in out if "#" in line]
+
+
 def test_no_war_target():
     props = extract_focus_properties(["\tfocus = {\n", "\t\tid = TST_peace\n", "\t}\n"])
     assert props["will_lead_to_war_with"] == []

--- a/tools/standardization/tests/standardize_ideas_test.py
+++ b/tools/standardization/tests/standardize_ideas_test.py
@@ -42,6 +42,36 @@ def test_body_comment_preserved():
     assert any("cost = 80" in line for line in out)
 
 
+def test_body_comment_follows_its_property_through_reordering():
+    block = _idea(
+        [
+            "\tTAG_test_idea = {",
+            "\t\t# scales with the coalition",
+            "\t\tmodifier = { stability_factor = 0.05 }",
+            "\t\tpicture = test_picture",
+            "\t}",
+        ]
+    )
+    out = _standardize(block)
+    comment = out.index("\t\t# scales with the coalition")
+    assert "modifier" in out[comment + 1]
+
+
+def test_comment_on_a_dropped_always_no_block_survives():
+    block = _idea(
+        [
+            "\tTAG_test_idea = {",
+            "\t\tpicture = test_picture",
+            "\t\t# why this was gated off",
+            "\t\tallowed = { always = no }",
+            "\t}",
+        ]
+    )
+    out = _standardize(block)
+    assert any("# why this was gated off" in line for line in out)
+    assert not any("always = no" in line for line in out)
+
+
 def test_unknown_nested_block_preserved_and_indented():
     block = _idea(
         [

--- a/tools/tests/precommit_validate_test.py
+++ b/tools/tests/precommit_validate_test.py
@@ -45,7 +45,23 @@ _GOLDEN = {
         "validate_ideas",
         "validate_oob_units",
     },
-    "common/on_actions/00_on_actions.txt": {"validate_style", "validate_ideas"},
+    "common/on_actions/00_on_actions.txt": {
+        "validate_style",
+        "validate_ideas",
+        "validate_oob_units",
+    },
+    "common/operations/00_operations.txt": {
+        "validate_style",
+        "validate_oob_units",
+    },
+    "common/resistance_compliance_modifiers/resistance_modifiers.txt": {
+        "validate_style",
+        "validate_oob_units",
+    },
+    "common/scripted_guis/00_missiles_scripted_guis.txt": {
+        "validate_style",
+        "validate_oob_units",
+    },
     "common/scripted_triggers/00_triggers.txt": {"validate_style", "validate_ideas"},
     "common/scripted_effects/00_x.txt": {
         "validate_style",

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -413,6 +413,16 @@ def test_ci_run_steps_default_to_strict():
         )
 
 
+def test_oob_filter_covers_create_unit_sources():
+    _, filters = _filter_definitions()
+    assert {
+        "common/on_actions/**",
+        "common/operations/**",
+        "common/resistance_compliance_modifiers/**",
+        "common/scripted_guis/**",
+    } <= set(filters["oob"])
+
+
 def test_gfx_reference_validator_runs_for_all_reference_sources():
     workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
     entry = next(

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import pytest
 import yaml
+from precommit_validate import _REGISTRY
+from validate_oob_units import _CREATE_UNIT_SOURCE_PATTERNS
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 VALIDATION_DIR = Path(__file__).resolve().parents[1]
@@ -413,14 +415,14 @@ def test_ci_run_steps_default_to_strict():
         )
 
 
-def test_oob_filter_covers_create_unit_sources():
+def test_oob_routes_cover_every_create_unit_source():
+    # Derived from the validator's own glob list, not a copy of it: a directory
+    # added there must reach both routes or a PR touching only it never runs.
+    dirs = {p.rsplit("/", 1)[0] + "/" for p in _CREATE_UNIT_SOURCE_PATTERNS}
     _, filters = _filter_definitions()
-    assert {
-        "common/on_actions/**",
-        "common/operations/**",
-        "common/resistance_compliance_modifiers/**",
-        "common/scripted_guis/**",
-    } <= set(filters["oob"])
+    assert {d + "**" for d in dirs} <= set(filters["oob"])
+    spec = next(s for s in _REGISTRY if s.script == "validate_oob_units")
+    assert dirs <= {prefix for prefix, _ in spec.rules}
 
 
 def test_gfx_reference_validator_runs_for_all_reference_sources():

--- a/tools/validation/tests/validate_create_unit_test.py
+++ b/tools/validation/tests/validate_create_unit_test.py
@@ -5,7 +5,8 @@ string naming a division_template, and must set owner. When it defines the
 template itself, the template must come first.
 """
 
-from validate_oob_units import _check_created_units
+from validate_oob_units import Validator, _check_created_units
+from validator_common import Severity
 
 # The engine stores inner quotes in the division string as backslash-escaped
 # (\\\"...\\\"). Build them explicitly so no source-level unescaping bites.
@@ -238,3 +239,205 @@ def test_decision_remove_effect_boundary(tmp_path):
 """.replace("{DIV}", div)
     issues = _run(content, tmp_path, filename="decisions.txt")
     assert all("template defined after" not in c for c in _cats(issues))
+
+
+def test_extra_create_unit_sources_are_checked(tmp_path):
+    content = _GUARDED.replace("\t\t\t\t\t\towner = ROOT\n", "")
+    sources = (
+        "common/on_actions/test.txt",
+        "common/operations/test.txt",
+        "common/resistance_compliance_modifiers/test.txt",
+        "common/scripted_guis/test.txt",
+    )
+    for source in sources:
+        target = tmp_path / source
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    validator = Validator(str(tmp_path), workers=1)
+    validator.validate_created_units()
+
+    assert validator.errors_found == len(sources)
+    assert {issue.file for issue in validator._issues} == set(sources)
+    assert all(issue.severity == Severity.ERROR for issue in validator._issues)
+
+
+def test_foreign_template_does_not_mask_late_local_definition(tmp_path):
+    div = _div_for("Militia", "Militia")
+    content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				FSA = {
+					division_template = {
+						name = "Militia"
+						regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+					}
+				}
+				capital_scope = {
+					create_unit = {
+						division = "{DIV}"
+						owner = ROOT
+					}
+				}
+				division_template = {
+					name = "Militia"
+					regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{DIV}", div)
+    assert "CREATE UNIT: template defined after create_unit" in _cats(
+        _run(content, tmp_path)
+    )
+
+
+def test_foreign_has_template_guard_does_not_mask_late_local_definition(tmp_path):
+    div = _div_for("Militia", "Militia")
+    content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				if = {
+					limit = {
+						FSA = { has_template = "Militia" }
+					}
+					capital_scope = {
+						create_unit = {
+							division = "{DIV}"
+							owner = ROOT
+						}
+					}
+				}
+				division_template = {
+					name = "Militia"
+					regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{DIV}", div)
+    assert "CREATE UNIT: template defined after create_unit" in _cats(
+        _run(content, tmp_path)
+    )
+
+
+def test_non_guaranteeing_has_template_guards_do_not_skip_ordering(tmp_path):
+    div = _div_for("Militia", "Militia")
+    for i, condition in enumerate(
+        (
+            'NOT = { has_template = "Militia" }',
+            'OR = { has_template = "Militia" always = yes }',
+        )
+    ):
+        content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				if = {
+					limit = {
+						{CONDITION}
+					}
+					capital_scope = {
+						create_unit = {
+							division = "{DIV}"
+							owner = ROOT
+						}
+					}
+				}
+				division_template = {
+					name = "Militia"
+					regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{CONDITION}", condition).replace("{DIV}", div)
+        assert "CREATE UNIT: template defined after create_unit" in _cats(
+            _run(content, tmp_path, filename=f"guard-{i}.txt")
+        )
+
+
+def test_country_iterator_template_does_not_mask_late_local_definition(tmp_path):
+    div = _div_for("Militia", "Militia")
+    content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				every_country = {
+					division_template = {
+						name = "Militia"
+						regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+					}
+				}
+				capital_scope = {
+					create_unit = {
+						division = "{DIV}"
+						owner = ROOT
+					}
+				}
+				division_template = {
+					name = "Militia"
+					regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{DIV}", div)
+    assert "CREATE UNIT: template defined after create_unit" in _cats(
+        _run(content, tmp_path)
+    )
+
+
+def test_other_event_option_does_not_mask_late_definition(tmp_path):
+    div = _div_for("Militia", "Militia")
+    content = """country_event = {
+	id = test.1
+	option = {
+		division_template = {
+			name = "Militia"
+			regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+		}
+	}
+	option = {
+		1 = {
+			create_unit = {
+				division = "{DIV}"
+				owner = ROOT
+			}
+		}
+		division_template = {
+			name = "Militia"
+			regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+		}
+	}
+}
+""".replace("{DIV}", div)
+    assert "CREATE UNIT: template defined after create_unit" in _cats(
+        _run(content, tmp_path, filename="events.txt")
+    )

--- a/tools/validation/tests/validate_create_unit_test.py
+++ b/tools/validation/tests/validate_create_unit_test.py
@@ -414,6 +414,42 @@ def test_country_iterator_template_does_not_mask_late_local_definition(tmp_path)
     )
 
 
+# A numeric state block leaves the country scope alone. State IDs 100-999 have
+# the same shape as a country tag, so both widths must reach the same verdict.
+def test_state_id_block_does_not_mask_late_local_definition(tmp_path):
+    div = _div_for("Militia", "Militia")
+    for state in ("129", "1054"):
+        content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				RSK = {
+					{STATE} = {
+						create_unit = {
+							division = "{DIV}"
+							owner = RSK
+						}
+					}
+					division_template = {
+						name = "Militia"
+						regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+					}
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{STATE}", state).replace("{DIV}", div)
+        assert "CREATE UNIT: template defined after create_unit" in _cats(
+            _run(content, tmp_path, filename=f"state-{state}.txt")
+        )
+
+
 def test_other_event_option_does_not_mask_late_definition(tmp_path):
     div = _div_for("Militia", "Militia")
     content = """country_event = {

--- a/tools/validation/tests/validate_create_unit_test.py
+++ b/tools/validation/tests/validate_create_unit_test.py
@@ -1,0 +1,240 @@
+"""Tests for the create_unit effect structural checks in validate_oob_units.py.
+
+A create_unit only spawns units in a state scope, needs a single-line division
+string naming a division_template, and must set owner. When it defines the
+template itself, the template must come first.
+"""
+
+from validate_oob_units import _check_created_units
+
+# The engine stores inner quotes in the division string as backslash-escaped
+# (\\\"...\\\"). Build them explicitly so no source-level unescaping bites.
+_BS = chr(92)
+
+
+def _esc_quote(value):
+    """Wrap *value* in engine-escaped quotes (\\\"value\\\")."""
+    return _BS + '"' + value + _BS + '"'
+
+
+def _div_for(tname, unitname):
+    """A division string referencing *tname* with the given unit *unitname*."""
+    return (
+        "name = " + _esc_quote(unitname) + " division_template = " + _esc_quote(tname)
+    )
+
+
+def _run(content, tmp_path, filename="test.txt"):
+    target = tmp_path / "common" / "national_focus" / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return _check_created_units((str(target), filename, str(tmp_path)))
+
+
+def _cats(issues):
+    return [i.category for i in issues]
+
+
+def _guarded_focus(div):
+    return """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				if = {
+					limit = { NOT = { has_template = "Territorial Defense Brigade" } }
+					division_template = {
+						name = "Territorial Defense Brigade"
+						regiments = {
+							L_Inf_Bat = { x = 0 y = 0 }
+						}
+					}
+				}
+				capital_scope = {
+					create_unit = {
+						division = "{DIV}"
+						owner = ROOT
+					}
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{DIV}", div)
+
+
+_GUARDED = _guarded_focus(
+    _div_for("Territorial Defense Brigade", "1st Territorial Defense Brigade")
+)
+
+
+def test_guarded_correct_pattern_is_clean(tmp_path):
+    assert _run(_GUARDED, tmp_path) == []
+
+
+def test_template_defined_after_create_unit_is_flagged(tmp_path):
+    content = _GUARDED.replace(
+        """			hidden_effect = {
+				if = {
+					limit = { NOT = { has_template = "Territorial Defense Brigade" } }
+					division_template = {
+						name = "Territorial Defense Brigade"
+						regiments = {
+							L_Inf_Bat = { x = 0 y = 0 }
+						}
+					}
+				}
+				capital_scope = {""",
+        """			hidden_effect = {
+				capital_scope = {""",
+    ).replace(
+        """						owner = ROOT
+					}
+				}
+			}
+		}""",
+        """						owner = ROOT
+					}
+				}
+				division_template = {
+					name = "Territorial Defense Brigade"
+					regiments = {
+						L_Inf_Bat = { x = 0 y = 0 }
+					}
+				}
+			}
+		}""",
+    )
+    cats = _cats(_run(content, tmp_path))
+    assert "CREATE UNIT: template defined after create_unit" in cats
+
+
+def test_missing_owner_and_out_of_scope_flagged(tmp_path):
+    content = _GUARDED.replace(
+        "				capital_scope = {\n					create_unit = {",
+        "				create_unit = {",
+    ).replace("						owner = ROOT\n", "")
+    cats = _cats(_run(content, tmp_path))
+    assert "CREATE UNIT: not in a state scope" in cats
+    assert "CREATE UNIT: missing owner" in cats
+
+
+def test_multiline_division_flagged(tmp_path):
+    div = _div_for("Territorial Defense Brigade", "1st Territorial Defense Brigade")
+    content = _GUARDED.replace(
+        div, div.replace("division_template", "\n\t\t\t\t\t\tdivision_template", 1)
+    )
+    cats = _cats(_run(content, tmp_path))
+    assert "CREATE UNIT: division string spans lines" in cats
+
+
+# An `if = { limit = { has_template = X } } ... else = { division_template = X }`
+# is mutually exclusive: the create_unit under the guard only runs when the
+# template already exists, so the later definition is not an ordering bug.
+def test_has_template_guard_else_pattern_is_clean(tmp_path):
+    div = _div_for("Quds", "Quds")
+    content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				if = {
+					limit = { has_template = "Quds" }
+					capital_scope = {
+						create_unit = {
+							division = "{DIV}"
+							owner = ROOT
+						}
+					}
+				}
+				else = {
+					division_template = {
+						name = "Quds"
+						regiments = {
+							Special_Forces = { x = 0 y = 0 }
+						}
+					}
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{DIV}", div)
+    assert _run(content, tmp_path) == []
+
+
+# A template defined before the create_unit is fine even when a second,
+# same-named definition appears later (e.g. one per scope). The earliest
+# definition must be the one compared.
+def test_earliest_template_definition_wins(tmp_path):
+    div = _div_for("Territorial Defense Brigade", "1st Territorial Defense Brigade")
+    content = """focus_tree = {
+	focus = {
+		id = TAG_focus
+		x = 0
+		y = 0
+		cost = 5
+		completion_reward = {
+			hidden_effect = {
+				division_template = {
+					name = "Territorial Defense Brigade"
+					regiments = { L_Inf_Bat = { x = 0 y = 0 } }
+				}
+				capital_scope = {
+					create_unit = {
+						division = "{DIV}"
+						owner = ROOT
+					}
+				}
+				division_template = {
+					name = "Territorial Defense Brigade"
+					regiments = { L_Inf_Bat = { x = 0 y = 1 } }
+				}
+			}
+		}
+		ai_will_do = { base = 1 }
+	}
+}
+""".replace("{DIV}", div)
+    assert _run(content, tmp_path) == []
+
+
+# A decision's effect runs in `remove_effect`; a template defined in a separate
+# decision must not be compared across the boundary.
+def test_decision_remove_effect_boundary(tmp_path):
+    div = _div_for("Expanded", "Expanded")
+    content = """decisions = {
+	category = {
+		decision_a = {
+			remove_effect = {
+				94 = {
+					create_unit = {
+						division = "{DIV}"
+						owner = SPR
+					}
+				}
+			}
+		}
+		decision_b = {
+			remove_effect = {
+				SPR = {
+					division_template = {
+						name = "Expanded"
+						regiments = { L_arm_Bat = { x = 0 y = 0 } }
+					}
+				}
+			}
+		}
+	}
+}
+""".replace("{DIV}", div)
+    issues = _run(content, tmp_path, filename="decisions.txt")
+    assert all("template defined after" not in c for c in _cats(issues))

--- a/tools/validation/validate_oob_units.py
+++ b/tools/validation/validate_oob_units.py
@@ -47,6 +47,14 @@ _VARIANT_SOURCE_PATTERNS = [
     "common/scripted_effects/*.txt",
 ]
 
+# create_unit also appears in these runtime effect sources.
+_CREATE_UNIT_SOURCE_PATTERNS = _VARIANT_SOURCE_PATTERNS + [
+    "common/on_actions/*.txt",
+    "common/operations/*.txt",
+    "common/resistance_compliance_modifiers/*.txt",
+    "common/scripted_guis/*.txt",
+]
+
 
 def _read_text(filepath: str) -> str:
     try:
@@ -511,10 +519,9 @@ def validate_oob_division_groups_file(
 #
 # A create_unit only spawns units inside a state scope (capital_scope, a
 # state-scope effect, a numeric state-ID block, or a state-scoped decision).
-# Its division string must live on one physical line, name a division_template
-# that exists by the time the effect runs, and a template created in the same
-# reward must appear first and be guarded by has_template so an existing one
-# isn't clobbered.
+# Its division string must live on one physical line and name a
+# division_template. A template defined in the same country/effect path must
+# appear before the create_unit that uses it.
 
 # Documented create_unit block keys; anything else is a typo.
 _CREATE_UNIT_KEYS = frozenset(
@@ -561,17 +568,42 @@ _ZERO_FACTOR_RE = re.compile(
 )
 _STATE_YES_RE = re.compile(r"\bstate\s*=\s*yes\b")
 _EXECUTE_EFFECT_RE = re.compile(r"\bexecute_effect\b")
-# An `if = { limit = { has_template = "X" } ... }` guard asserts the template
-# already exists, so a create_unit under it never races a definition below it.
-_HAS_TEMPLATE_IF_RE = re.compile(
-    r"\blimit\s*=\s*\{\s*has_template\s*=\s*\"([^\"]*)\"\s*\}", re.S
+_HAS_TEMPLATE_RE = re.compile(r'\bhas_template\s*=\s*"([^\"]*)"')
+_LITERAL_TAG_SCOPE_RE = re.compile(r"^[A-Z0-9_]{3}$")
+_SCOPE_KEYWORDS = frozenset({"AND", "NOT", "NOR", "OR"})
+_SCOPE_LABELS = frozenset(
+    {
+        "ROOT",
+        "THIS",
+        "PREV",
+        "FROM",
+        "OWNER",
+        "CONTROLLER",
+        "CAPITAL",
+        "OVERLORD",
+        "FROMFROM",
+        "PREVPREV",
+    }
 )
+_SCOPE_PREFIXES = ("event_target:", "global.event_target:", "var:")
+_COUNTRY_ITERATOR_RE = re.compile(
+    r"^(?:every|random|all)_(?:\w+_)?(?:country|puppet)(?:_|$)"
+)
+_NON_GUARANTEEING_GUARD_LABELS = frozenset({"NOT", "NAND", "NOR", "OR"})
 
 # Execution-boundary labels: when walking up a create_unit's enclosing scopes,
 # stop at these (a fresh effect sequence starts) so the ordering check doesn't
-# compare a template and a create_unit from two different rewards/decisions.
+# compare a template and a create_unit from separate effects or event options.
 _EFFECT_BOUNDARY_LABELS = frozenset(
-    {"completion_reward", "execute_effect", "remove_effect"}
+    {
+        "completion_reward",
+        "execute_effect",
+        "complete_effect",
+        "remove_effect",
+        "timeout_effect",
+        "cancel_effect",
+        "option",
+    }
 )
 
 
@@ -596,10 +628,10 @@ class _CreateUnitChecks:
         self.issues: List[Issue] = []
         self.file = file
 
-    def warn(self, kind: str, message: str, line: int):
+    def error(self, kind: str, message: str, line: int):
         self.issues.append(
             Issue(
-                severity=Severity.WARNING,
+                severity=Severity.ERROR,
                 category=_CREATE_UNIT_CATEGORIES[kind],
                 message=message,
                 file=self.file,
@@ -685,15 +717,93 @@ def _container_for(nodes: List[Dict], idx: int) -> int:
     return -1
 
 
+def _scope_label(label: str) -> Optional[str]:
+    if label in _SCOPE_LABELS or label.startswith(_SCOPE_PREFIXES):
+        return label
+    if _LITERAL_TAG_SCOPE_RE.fullmatch(label) and label not in _SCOPE_KEYWORDS:
+        return label
+    return None
+
+
+def _country_scope_path(
+    nodes: List[Dict], idx: int, include_self: bool = False
+) -> Tuple[str, ...]:
+    path = ["ROOT"]
+    chain = list(reversed(_ancestors(nodes, idx)))
+    if include_self:
+        chain.append(idx)
+    for i in chain:
+        label = nodes[i]["label"] or ""
+        if _COUNTRY_ITERATOR_RE.match(label):
+            path.append(f"@{i}")
+            continue
+        scope = _scope_label(label)
+        if scope == "ROOT":
+            path = ["ROOT"]
+        elif scope is not None:
+            path.append(scope)
+    return tuple(path)
+
+
+def _deepest_node_at(nodes: List[Dict], pos: int) -> int:
+    candidates = [
+        i for i, node in enumerate(nodes) if node["start"] < pos < node["end"]
+    ]
+    if not candidates:
+        return -1
+    return min(candidates, key=lambda i: nodes[i]["end"] - nodes[i]["start"])
+
+
+def _closest_if(nodes: List[Dict], idx: int) -> int:
+    for a in [idx] + _ancestors(nodes, idx):
+        if nodes[a]["label"] == "if":
+            return a
+    return -1
+
+
+def _is_positive_if_limit_condition(nodes: List[Dict], idx: int, if_idx: int) -> bool:
+    saw_limit = False
+    while idx != -1:
+        label = nodes[idx]["label"]
+        if label in _NON_GUARANTEEING_GUARD_LABELS:
+            return False
+        if label == "limit":
+            saw_limit = True
+        if idx == if_idx:
+            return saw_limit
+        idx = nodes[idx]["parent"]
+    return False
+
+
+def _runs_in_if_true_branch(nodes: List[Dict], idx: int, if_idx: int) -> bool:
+    child = idx
+    while nodes[child]["parent"] != if_idx:
+        child = nodes[child]["parent"]
+        if child == -1:
+            return False
+    return nodes[child]["label"] not in {"else", "else_if"}
+
+
 def _in_has_template_guard(nodes: List[Dict], text: str, idx: int, name: str) -> bool:
-    """True if *idx* sits under an `if = { limit = { has_template = name } }`."""
+    """True if a same-scope has_template condition dominates *idx*."""
+    scope_path = _country_scope_path(nodes, idx)
     container = _container_for(nodes, idx)
     for a in _ancestors(nodes, idx):
-        if nodes[a]["label"] == "if":
-            body = text[nodes[a]["start"] : nodes[a]["end"]]
-            m = _HAS_TEMPLATE_IF_RE.search(body)
-            if m and m.group(1) == name:
-                return True
+        if nodes[a]["label"] == "if" and _runs_in_if_true_branch(nodes, idx, a):
+            start = nodes[a]["start"]
+            body = text[start : nodes[a]["end"]]
+            for match in _HAS_TEMPLATE_RE.finditer(body):
+                if match.group(1) != name:
+                    continue
+                match_idx = _deepest_node_at(nodes, start + match.start())
+                if (
+                    match_idx != -1
+                    and _closest_if(nodes, match_idx) == a
+                    and _is_positive_if_limit_condition(nodes, match_idx, a)
+                    and _country_scope_path(nodes, match_idx, include_self=True)
+                    == scope_path
+                ):
+                    return True
         if a == container:
             break
     return False
@@ -732,14 +842,17 @@ def _top_level_keys(text: str, start: int, end: int) -> List[str]:
 
 
 def _template_defs_named(
-    nodes: List[Dict], text: str, container: int, name: str
+    nodes: List[Dict], text: str, container: int, name: str, scope_path: Tuple[str, ...]
 ) -> List[int]:
-    """Indices of division_template blocks named *name* under *container*."""
+    """Indices of same-scope division_template blocks named *name*."""
     out = []
     stack = list(nodes[container]["children"])
     while stack:
         i = stack.pop()
-        if nodes[i]["label"] == "division_template":
+        if (
+            nodes[i]["label"] == "division_template"
+            and _country_scope_path(nodes, i) == scope_path
+        ):
             body = text[nodes[i]["start"] : nodes[i]["end"]]
             m = _TEMPLATE_NAME_RE.search(body)
             if m and m.group(1) == name:
@@ -763,7 +876,7 @@ def _in_state_scope(nodes: List[Dict], text: str, idx: int) -> bool:
 
 
 def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
-    """Validate every create_unit block in one file. Returns warning Issues."""
+    """Validate every create_unit block in one file. Returns error Issues."""
     filepath, rel, mod_path = args
     try:
         with open(filepath, "r", encoding="utf-8-sig") as f:
@@ -790,7 +903,7 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
         line = cu["line"]
 
         if not _in_state_scope(nodes, content, cu_idx):
-            out.warn(
+            out.error(
                 "scope",
                 f"{cu['line']}: create_unit outside a state scope (effect does "
                 f"nothing at country scope)",
@@ -798,14 +911,14 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
             )
 
         if not _OWNER_RE.search(body):
-            out.warn(
+            out.error(
                 "missing-owner", f"{cu['line']}: create_unit missing `owner`", line
             )
 
         keys = _top_level_keys(content, cu["start"] + 1, cu["end"])
         unknown = sorted(set(keys) - _CREATE_UNIT_KEYS)
         if unknown:
-            out.warn(
+            out.error(
                 "unknown-key",
                 f"{cu['line']}: create_unit unknown key(s): {', '.join(unknown)}",
                 line,
@@ -813,7 +926,7 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
 
         dm = _DIVISION_VALUE_RE.search(body)
         if not dm:
-            out.warn(
+            out.error(
                 "missing-division",
                 f"{cu['line']}: create_unit missing `division` string",
                 line,
@@ -821,7 +934,7 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
             continue
         dval = dm.group(1)
         if "\n" in dval:
-            out.warn(
+            out.error(
                 "multiline-division",
                 f"{cu['line']}: division string must stay on one physical line",
                 line,
@@ -830,7 +943,7 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
         # name/template/factor tokens parse like the engine's parsed string.
         dval_clean = dval.replace('\\"', '"')
         if _ZERO_FACTOR_RE.search(dval_clean):
-            out.warn(
+            out.error(
                 "zero-factor",
                 f"{cu['line']}: start_equipment_factor/start_manpower_factor of 0 is treated as 1",
                 line,
@@ -838,7 +951,7 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
 
         tm = _TEMPLATE_REF_RE.search(dval_clean)
         if not tm:
-            out.warn(
+            out.error(
                 "missing-template",
                 f'{cu["line"]}: division string lacks division_template="..."',
                 line,
@@ -846,30 +959,22 @@ def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
             continue
         tname = tm.group(1)
 
-        # If an enclosing `if = { limit = { has_template = <tname> } }` guard
-        # asserts the template already exists, no ordering check applies — the
-        # definition lives in a mutually-exclusive else branch (the Iran/Indonesia
-        # Quds pattern) and is guaranteed present here.
         if _in_has_template_guard(nodes, content, cu_idx, tname):
             continue
 
-        # Ordering: walk the enclosing scopes up to the effect container
-        # (stopping at completion_reward/execute_effect/top-level) for a matching
-        # template definition. Report once for the nearest one.
+        scope_path = _country_scope_path(nodes, cu_idx)
         container = _container_for(nodes, cu_idx)
         for a in _ancestors(nodes, cu_idx):
-            defs = _template_defs_named(nodes, content, a, tname)
+            defs = _template_defs_named(nodes, content, a, tname, scope_path)
             if not defs:
                 if a == container:
                     break
                 continue
-            # A name can be defined multiple times in a container (a fresh
-            # definition per scope). Only the earliest matters: if a matching
-            # template already exists before this create_unit runs, there is no
-            # ordering bug.
+            # A name can be defined multiple times in one country/effect path.
+            # Only the earliest definition can make this create_unit valid.
             t = nodes[min(defs, key=lambda d: nodes[d]["start"])]
             if t["start"] > cu["start"]:
-                out.warn(
+                out.error(
                     "template-order",
                     f"{cu['line']}: division_template '{tname}' is defined after the create_unit that uses it",
                     line,
@@ -1113,15 +1218,10 @@ class Validator(BaseValidator):
         )
 
     def validate_created_units(self):
-        """Check every `create_unit` effect across the mod for proper form.
-
-        A create_unit must run in a state scope, carry a single-line `division`
-        string naming a division_template, set `owner`, and (when it defines the
-        template itself) create it first behind a has_template guard.
-        """
+        """Check every create_unit effect source for proper form."""
         self._log_section("Checking create_unit effects across the mod...")
 
-        files = self._collect_files(_VARIANT_SOURCE_PATTERNS)
+        files = self._collect_files(_CREATE_UNIT_SOURCE_PATTERNS)
         if not files:
             self.log("  No files to check")
             return

--- a/tools/validation/validate_oob_units.py
+++ b/tools/validation/validate_oob_units.py
@@ -718,6 +718,9 @@ def _container_for(nodes: List[Dict], idx: int) -> int:
 
 
 def _scope_label(label: str) -> Optional[str]:
+    # State IDs 100-999 match the 3-char tag shape but never switch country.
+    if label.isdigit():
+        return None
     if label in _SCOPE_LABELS or label.startswith(_SCOPE_PREFIXES):
         return label
     if _LITERAL_TAG_SCOPE_RE.fullmatch(label) and label not in _SCOPE_KEYWORDS:

--- a/tools/validation/validate_oob_units.py
+++ b/tools/validation/validate_oob_units.py
@@ -12,7 +12,7 @@ import os
 import re
 import sys
 from difflib import get_close_matches
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -505,6 +505,380 @@ def validate_oob_division_groups_file(
     return results
 
 
+# ---------------------------------------------------------------------------
+# create_unit effect validation
+# ---------------------------------------------------------------------------
+#
+# A create_unit only spawns units inside a state scope (capital_scope, a
+# state-scope effect, a numeric state-ID block, or a state-scoped decision).
+# Its division string must live on one physical line, name a division_template
+# that exists by the time the effect runs, and a template created in the same
+# reward must appear first and be guarded by has_template so an existing one
+# isn't clobbered.
+
+# Documented create_unit block keys; anything else is a typo.
+_CREATE_UNIT_KEYS = frozenset(
+    {
+        "division",
+        "owner",
+        "prioritize_location",
+        "allow_spawning_on_enemy_provs",
+        "count",
+        "id",
+        "country_score",
+        "divisional_commander_xp",
+    }
+)
+
+# Effect/block openers that yield a state scope (where create_unit may run).
+_STATE_SCOPE_LABELS = frozenset(
+    {
+        "capital_scope",
+        "random_owned_controlled_state",
+        "random_owned_state",
+        "random_controlled_state",
+        "random_state",
+        "random_owned_or_controlled_state",
+        "random_enemy_state",
+        "random_occupied_state",
+        "every_owned_state",
+        "every_controlled_state",
+        "every_owned_controlled_state",
+        "every_state",
+        "every_neighbor_state",
+        "random_neighbor_state",
+        "state_event",
+    }
+)
+
+_DIVISION_VALUE_RE = re.compile(r'\bdivision\s*=\s*"((?:[^"\\]|\\.)*)"', re.S)
+_TEMPLATE_REF_RE = re.compile(r'\bdivision_template\s*=\s*"([^"]*)"')
+_TEMPLATE_NAME_RE = re.compile(r'\bname\s*=\s*"([^"]*)"')
+_KEY_RE = re.compile(r"\b([A-Za-z0-9_]+)\s*=")
+_OWNER_RE = re.compile(r"\bowner\s*=")
+_ZERO_FACTOR_RE = re.compile(
+    r"\b(?:start_equipment_factor|start_manpower_factor)\s*=\s*0(?![.\d])"
+)
+_STATE_YES_RE = re.compile(r"\bstate\s*=\s*yes\b")
+_EXECUTE_EFFECT_RE = re.compile(r"\bexecute_effect\b")
+# An `if = { limit = { has_template = "X" } ... }` guard asserts the template
+# already exists, so a create_unit under it never races a definition below it.
+_HAS_TEMPLATE_IF_RE = re.compile(
+    r"\blimit\s*=\s*\{\s*has_template\s*=\s*\"([^\"]*)\"\s*\}", re.S
+)
+
+# Execution-boundary labels: when walking up a create_unit's enclosing scopes,
+# stop at these (a fresh effect sequence starts) so the ordering check doesn't
+# compare a template and a create_unit from two different rewards/decisions.
+_EFFECT_BOUNDARY_LABELS = frozenset(
+    {"completion_reward", "execute_effect", "remove_effect"}
+)
+
+
+_CREATE_UNIT_CATEGORIES = {
+    "scope": "CREATE UNIT: not in a state scope",
+    "multiline-division": "CREATE UNIT: division string spans lines",
+    "missing-division": "CREATE UNIT: missing division string",
+    "missing-owner": "CREATE UNIT: missing owner",
+    "missing-template": "CREATE UNIT: division string lacks division_template",
+    "unknown-key": "CREATE UNIT: unknown key",
+    "zero-factor": "CREATE UNIT: equipment/manpower factor is zero",
+    "template-order": "CREATE UNIT: template defined after create_unit",
+}
+
+
+class _CreateUnitChecks:
+    """Collector for one create_unit block; keeps the worker readable."""
+
+    __slots__ = ("issues", "file")
+
+    def __init__(self, file: str):
+        self.issues: List[Issue] = []
+        self.file = file
+
+    def warn(self, kind: str, message: str, line: int):
+        self.issues.append(
+            Issue(
+                severity=Severity.WARNING,
+                category=_CREATE_UNIT_CATEGORIES[kind],
+                message=message,
+                file=self.file,
+                line=line,
+            )
+        )
+
+
+def _line_of(text: str, pos: int) -> int:
+    return text[:pos].count("\n") + 1
+
+
+def _label_before_brace(text: str, brace_idx: int) -> Optional[str]:
+    j = brace_idx - 1
+    while j >= 0 and text[j] in " \t\r\n":
+        j -= 1
+    if j < 0 or text[j] != "=":
+        return None
+    j -= 1
+    while j >= 0 and text[j] in " \t\r\n":
+        j -= 1
+    end = j + 1
+    while j >= 0 and (text[j].isalnum() or text[j] in "_:.@"):
+        j -= 1
+    return text[j + 1 : end] or None
+
+
+def _matching_braces(text: str) -> Dict[int, int]:
+    stack = []
+    pairs = {}
+    in_str = False
+    for i, c in enumerate(text):
+        if c == '"' and (i == 0 or text[i - 1] != "\\"):
+            in_str = not in_str
+        elif not in_str:
+            if c == "{":
+                stack.append(i)
+            elif c == "}" and stack:
+                pairs[stack.pop()] = i
+    return pairs
+
+
+def _build_block_nodes(text: str) -> List[Dict]:
+    """Flattened `key = { }` block tree: label/start/end/line/parent/children."""
+    pairs = _matching_braces(text)
+    nodes = []
+    stack = []
+    for op in sorted(pairs):
+        while stack and nodes[stack[-1]]["end"] < op:
+            stack.pop()
+        node = {
+            "label": _label_before_brace(text, op),
+            "start": op,
+            "end": pairs[op],
+            "line": _line_of(text, op),
+            "parent": stack[-1] if stack else -1,
+            "children": [],
+        }
+        idx = len(nodes)
+        if stack:
+            nodes[stack[-1]]["children"].append(idx)
+        nodes.append(node)
+        stack.append(idx)
+    return nodes
+
+
+def _ancestors(nodes: List[Dict], idx: int) -> List[int]:
+    chain = []
+    while nodes[idx]["parent"] != -1:
+        idx = nodes[idx]["parent"]
+        chain.append(idx)
+    return chain
+
+
+def _container_for(nodes: List[Dict], idx: int) -> int:
+    """Index of the nearest effect container (a boundary or top-level block)."""
+    a = nodes[idx]["parent"]
+    while a != -1:
+        label = nodes[a]["label"] or ""
+        if label in _EFFECT_BOUNDARY_LABELS or nodes[a]["parent"] == -1:
+            return a
+        a = nodes[a]["parent"]
+    return -1
+
+
+def _in_has_template_guard(nodes: List[Dict], text: str, idx: int, name: str) -> bool:
+    """True if *idx* sits under an `if = { limit = { has_template = name } }`."""
+    container = _container_for(nodes, idx)
+    for a in _ancestors(nodes, idx):
+        if nodes[a]["label"] == "if":
+            body = text[nodes[a]["start"] : nodes[a]["end"]]
+            m = _HAS_TEMPLATE_IF_RE.search(body)
+            if m and m.group(1) == name:
+                return True
+        if a == container:
+            break
+    return False
+
+
+def _top_level_keys(text: str, start: int, end: int) -> List[str]:
+    keys = []
+    depth = 0
+    in_str = False
+    i = start
+    while i < end:
+        c = text[i]
+        if c == '"' and (i == 0 or text[i - 1] != "\\"):
+            in_str = not in_str
+            i += 1
+            continue
+        if in_str:
+            i += 1
+            continue
+        if c == "{":
+            depth += 1
+            i += 1
+            continue
+        if c == "}":
+            depth -= 1
+            i += 1
+            continue
+        if depth == 0:
+            m = _KEY_RE.match(text, i)
+            if m:
+                keys.append(m.group(1))
+                i = m.end()
+                continue
+        i += 1
+    return keys
+
+
+def _template_defs_named(
+    nodes: List[Dict], text: str, container: int, name: str
+) -> List[int]:
+    """Indices of division_template blocks named *name* under *container*."""
+    out = []
+    stack = list(nodes[container]["children"])
+    while stack:
+        i = stack.pop()
+        if nodes[i]["label"] == "division_template":
+            body = text[nodes[i]["start"] : nodes[i]["end"]]
+            m = _TEMPLATE_NAME_RE.search(body)
+            if m and m.group(1) == name:
+                out.append(i)
+        stack.extend(nodes[i]["children"])
+    return out
+
+
+def _in_state_scope(nodes: List[Dict], text: str, idx: int) -> bool:
+    for a in _ancestors(nodes, idx):
+        node = nodes[a]
+        label = node["label"] or ""
+        if label in _STATE_SCOPE_LABELS:
+            return True
+        if label.isdigit():
+            return True
+        body = text[node["start"] : node["end"]]
+        if _EXECUTE_EFFECT_RE.search(body) and _STATE_YES_RE.search(body):
+            return True
+    return False
+
+
+def _check_created_units(args: Tuple[str, str, str]) -> List[Issue]:
+    """Validate every create_unit block in one file. Returns warning Issues."""
+    filepath, rel, mod_path = args
+    try:
+        with open(filepath, "r", encoding="utf-8-sig") as f:
+            raw = f.read()
+    except OSError:
+        return []
+    content = strip_comments(raw)
+    nodes = disk_cache.per_file_cached_by_content(
+        mod_path,
+        "oob_units.blocks",
+        filepath,
+        content,
+        lambda: _build_block_nodes(content),
+    )
+
+    cu_nodes = [i for i, n in enumerate(nodes) if n["label"] == "create_unit"]
+    if not cu_nodes:
+        return []
+
+    out = _CreateUnitChecks(rel)
+    for cu_idx in cu_nodes:
+        cu = nodes[cu_idx]
+        body = content[cu["start"] + 1 : cu["end"]]
+        line = cu["line"]
+
+        if not _in_state_scope(nodes, content, cu_idx):
+            out.warn(
+                "scope",
+                f"{cu['line']}: create_unit outside a state scope (effect does "
+                f"nothing at country scope)",
+                line,
+            )
+
+        if not _OWNER_RE.search(body):
+            out.warn(
+                "missing-owner", f"{cu['line']}: create_unit missing `owner`", line
+            )
+
+        keys = _top_level_keys(content, cu["start"] + 1, cu["end"])
+        unknown = sorted(set(keys) - _CREATE_UNIT_KEYS)
+        if unknown:
+            out.warn(
+                "unknown-key",
+                f"{cu['line']}: create_unit unknown key(s): {', '.join(unknown)}",
+                line,
+            )
+
+        dm = _DIVISION_VALUE_RE.search(body)
+        if not dm:
+            out.warn(
+                "missing-division",
+                f"{cu['line']}: create_unit missing `division` string",
+                line,
+            )
+            continue
+        dval = dm.group(1)
+        if "\n" in dval:
+            out.warn(
+                "multiline-division",
+                f"{cu['line']}: division string must stay on one physical line",
+                line,
+            )
+        # The string carries escaped quotes (\"...\"); normalize so the inner
+        # name/template/factor tokens parse like the engine's parsed string.
+        dval_clean = dval.replace('\\"', '"')
+        if _ZERO_FACTOR_RE.search(dval_clean):
+            out.warn(
+                "zero-factor",
+                f"{cu['line']}: start_equipment_factor/start_manpower_factor of 0 is treated as 1",
+                line,
+            )
+
+        tm = _TEMPLATE_REF_RE.search(dval_clean)
+        if not tm:
+            out.warn(
+                "missing-template",
+                f'{cu["line"]}: division string lacks division_template="..."',
+                line,
+            )
+            continue
+        tname = tm.group(1)
+
+        # If an enclosing `if = { limit = { has_template = <tname> } }` guard
+        # asserts the template already exists, no ordering check applies — the
+        # definition lives in a mutually-exclusive else branch (the Iran/Indonesia
+        # Quds pattern) and is guaranteed present here.
+        if _in_has_template_guard(nodes, content, cu_idx, tname):
+            continue
+
+        # Ordering: walk the enclosing scopes up to the effect container
+        # (stopping at completion_reward/execute_effect/top-level) for a matching
+        # template definition. Report once for the nearest one.
+        container = _container_for(nodes, cu_idx)
+        for a in _ancestors(nodes, cu_idx):
+            defs = _template_defs_named(nodes, content, a, tname)
+            if not defs:
+                if a == container:
+                    break
+                continue
+            # A name can be defined multiple times in a container (a fresh
+            # definition per scope). Only the earliest matters: if a matching
+            # template already exists before this create_unit runs, there is no
+            # ordering bug.
+            t = nodes[min(defs, key=lambda d: nodes[d]["start"])]
+            if t["start"] > cu["start"]:
+                out.warn(
+                    "template-order",
+                    f"{cu['line']}: division_template '{tname}' is defined after the create_unit that uses it",
+                    line,
+                )
+            break
+
+    return out.issues
+
+
 class Validator(BaseValidator):
     TITLE = "OOB UNIT NAME VALIDATION"
     STAGED_EXTENSIONS = [".txt"]
@@ -738,6 +1112,36 @@ class Validator(BaseValidator):
             "Ship variant modules invalid for their hull slot:",
         )
 
+    def validate_created_units(self):
+        """Check every `create_unit` effect across the mod for proper form.
+
+        A create_unit must run in a state scope, carry a single-line `division`
+        string naming a division_template, set `owner`, and (when it defines the
+        template itself) create it first behind a has_template guard.
+        """
+        self._log_section("Checking create_unit effects across the mod...")
+
+        files = self._collect_files(_VARIANT_SOURCE_PATTERNS)
+        if not files:
+            self.log("  No files to check")
+            return
+        self.log(f"  Found {len(files)} files to check")
+
+        args_list = [
+            (f, os.path.relpath(f, self.mod_path), self.mod_path) for f in files
+        ]
+        all_results = self._pool_map(_check_created_units, args_list, chunksize=20)
+
+        results = []
+        for file_results in all_results:
+            results.extend(file_results)
+
+        self._report(
+            results,
+            "✓ All create_unit effects are well-formed",
+            "create_unit effects with structural problems:",
+        )
+
     def run_validations(self):
         self._build_canonical_units()
         self.validate_unit_references()
@@ -745,6 +1149,7 @@ class Validator(BaseValidator):
         self.validate_division_names_group_references()
         self.validate_air_wing_names_template_loc()
         self.validate_created_variant_modules()
+        self.validate_created_units()
 
 
 if __name__ == "__main__":

--- a/tools/validation/validator_common.py
+++ b/tools/validation/validator_common.py
@@ -10,7 +10,7 @@ import sys
 import time
 from dataclasses import dataclass
 from multiprocessing import Pool, cpu_count
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, cast
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import disk_cache  # noqa: E402 — same-dir import after sys.path tweak above
@@ -32,6 +32,9 @@ from shared_utils import (
     strip_comments,
     timing_enabled,
 )
+
+# Generic type for the cross-pass result cache accessor (see BaseValidator.cached).
+T = TypeVar("T")
 
 # Regex for meta_effect/meta_trigger template substitution patterns.
 # Matches identifiers containing at least one [VAR] placeholder with a non-empty
@@ -446,11 +449,11 @@ class BaseValidator:
             if not self.staged_files:
                 logging.warning("No staged files found")
 
-    def cached(self, key: str, factory_fn):
+    def cached(self, key: str, factory_fn: Callable[[], T]) -> T:
         # Pool workers don't see this cache; populate from the main process.
         if key not in self._shared_cache:
             self._shared_cache[key] = factory_fn()
-        return self._shared_cache[key]
+        return cast(T, self._shared_cache[key])
 
     def parse_files_cached(
         self,


### PR DESCRIPTION
### Context

Closes #2736. Fixes `division string was not parsed correctly` failures where a `create_unit` runs before its `division_template` is defined, in focus rewards and civil-war events.

### Changes

Create the `division_template` before the `create_unit` that uses it, guarded by `if = { NOT = { has_template = "X" } }` so existing templates are not duplicated, in Kabyle, Malorossiya, South Ossetia, Indonesia, Iran, Bosnia events, and Arab Spring.

Add `validate_created_units()` to `validate_oob_units.py`, which checks every `create_unit` across the mod for state scope, single-line division string, owner, template presence, unknown keys, zero equipment/manpower factor, and template-before-create_unit ordering, reported at WARNING severity.

Route `create_unit` validation to the new `on_actions`, `operations`, `resistance_compliance_modifiers`, and `scripted_guis` file groups and mark the core validators `strict` in the CI pipeline.

Make the event, decision, idea, and focus standardizers keep comments attached to the block or property they describe.

### Acceptance

- [ ] No `division string was not parsed correctly` errors for these focuses/events in-game
- [ ] `python -m pytest` green
- [ ] `validate_oob_units` reports zero create_unit scope and template-order findings across the mod
