### PR TITLE
Tighten Hong Kong annexation timing and add world notification (#2535)

### DIFF
--- a/common/national_focus/05_china.txt
+++ b/common/national_focus/05_china.txt
@@ -20025,10 +20025,10 @@ focus_tree = {
 			595 = {
 				owns_or_subject_of = yes
 				custom_trigger_tooltip = {
-					tooltip = CHI_sinicization_HKG_req_90_tt
+					tooltip = CHI_sinicization_HKG_req_95_tt
 					check_variable = {
 						var = HKG_sinicization_var
-						value = 90
+						value = 95
 						compare = greater_than_or_equals
 					}
 				}
@@ -20072,6 +20072,8 @@ focus_tree = {
 			}
 			newline = yes
 			annex_country = { target = HKG  transfer_troops = yes }
+			newline = yes
+			news_event = { id = hongkong_news.10 days = 1 }
 			newline = yes
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt

--- a/common/national_focus/hongkong.txt
+++ b/common/national_focus/hongkong.txt
@@ -43,6 +43,10 @@ focus_tree = {
 			modifier = { factor = 0 NOT = { has_government = communism } }
 			modifier = {
 				factor = 0
+				NOT = { check_variable = { influence_array^0 = CHI } }
+			}
+			modifier = {
+				factor = 0
 				NOT = { check_variable = { influence_array_val^0 > 79 } }
 			}
 		}
@@ -121,7 +125,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = HKG_loyal_puppet
 
-		cost = 10
+		cost = 8
 
 		prerequisite = { focus = HKG_loyal_puppet }
 
@@ -131,7 +135,6 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_patriots_governing"
 			set_temp_variable = { sinicization_base_change = 3 }
 			CHI_apply_sinicization_HKG = yes
-			add_political_power = -50
 			add_stability = 0.05
 			add_timed_idea = {
 				idea = HKG_loyalist_civil_service_purge
@@ -193,11 +196,12 @@ focus_tree = {
 		prerequisite = { focus = HKG_suppress_cantonese_local_culture }
 		prerequisite = { focus = HKG_reduce_size_of_LegCo }
 
-		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_FOREIGN_POLICY }
+		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_FOREIGN_POLICY FOCUS_FILTER_ANNEXATION }
 
 		available = {
 			CHI = { has_completed_focus = CHI_SAR_one_system_declaration }
 			595 = {
+				owns_or_subject_of = yes
 				custom_trigger_tooltip = {
 					tooltip = CHI_sinicization_HKG_req_95_tt
 					check_variable = {
@@ -207,6 +211,9 @@ focus_tree = {
 					}
 				}
 			}
+			is_subject_of = CHI
+			check_variable = { influence_array^0 = CHI }
+			check_variable = { influence_array_val^0 > 79.999 }
 		}
 
 		completion_reward = {
@@ -223,12 +230,12 @@ focus_tree = {
 				limit = { is_subject_of = CHI }
 				CHI = {
 					country_event = { id = china_sar.048  hours = 6 }
+					news_event = { id = hongkong_news.10 days = 1 }
 					annex_country = {
 						target = HKG
 						transfer_troops = yes
 					}
 				}
-				news_event = { id = hongkong_news.10 days = 1 }
 			}
 			custom_effect_tooltip = HKG_gong_zyu_ou_integration_tt
 		}
@@ -1479,14 +1486,13 @@ focus_tree = {
 		y = 1
 		relative_position_id = HKG_gong_hei_fat_coi
 
-		cost = 10
+		cost = 8
 
 		prerequisite = { focus = HKG_gong_hei_fat_coi }
 
 		search_filters = { FOCUS_FILTER_ECONOMY }
 
 		completion_reward = {
-			add_political_power = -50
 			set_temp_variable = { treasury_change = -1.5 }
 			modify_treasury_effect = yes
 			if = {
@@ -1690,7 +1696,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = HKG_gong_hei_fat_coi
 
-		cost = 10
+		cost = 8
 
 		prerequisite = { focus = HKG_attract_foreign_investment }
 		mutually_exclusive = { focus = HKG_chinese_entrepreneurs }
@@ -1698,7 +1704,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_TRADE FOCUS_FILTER_FOREIGN_INVESTMENTS }
 
 		completion_reward = {
-			add_political_power = -50
 			set_temp_variable = { treasury_change = 5.20 }
 			modify_treasury_effect = yes
 			add_opinion_modifier = {
@@ -1735,7 +1740,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = HKG_gong_hei_fat_coi
 
-		cost = 10
+		cost = 8
 
 		prerequisite = { focus = HKG_attract_foreign_investment }
 		mutually_exclusive = { focus = HKG_european_business }
@@ -1743,7 +1748,6 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_TRADE FOCUS_FILTER_FOREIGN_INVESTMENTS }
 
 		completion_reward = {
-			add_political_power = -50
 			set_temp_variable = { treasury_change = 8.40 }
 			modify_treasury_effect = yes
 			add_opinion_modifier = {
@@ -2227,7 +2231,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = HKG_hong_kong_police_force
 
-		cost = 10
+		cost = 8
 
 		prerequisite = { focus = HKG_hong_kong_police_force }
 
@@ -2235,7 +2239,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_anti_terrorist_train"
-			add_political_power = -10
 			army_experience = 100
 			add_manpower = 1500
 			set_temp_variable = { treasury_change = -2.0 }

--- a/common/national_focus/hongkong.txt
+++ b/common/national_focus/hongkong.txt
@@ -26,6 +26,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_loyal_puppet"
+			set_temp_variable = { sinicization_base_change = 2 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 50
 			add_stability = -0.03
 			add_popularity = { ideology = communism popularity = 0.05 }
@@ -39,6 +41,10 @@ focus_tree = {
 		ai_will_do = {
 			base = 5
 			modifier = { factor = 0 NOT = { has_government = communism } }
+			modifier = {
+				factor = 0
+				NOT = { check_variable = { influence_array_val^0 > 79 } }
+			}
 		}
 	}
 
@@ -58,6 +64,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_promote_patriotism"
+			set_temp_variable = { sinicization_base_change = 3 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 50
 			add_ideas = HKG_patriotic_loyalist_drive
 			add_popularity = { ideology = communism popularity = 0.04 }
@@ -87,6 +95,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_suppress_cantonese_local_culture"
+			set_temp_variable = { sinicization_base_change = 3 }
+			CHI_apply_sinicization_HKG = yes
 			add_stability = -0.05
 			add_war_support = -0.02
 			add_popularity = { ideology = communism popularity = 0.06 }
@@ -119,6 +129,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_patriots_governing"
+			set_temp_variable = { sinicization_base_change = 3 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = -50
 			add_stability = 0.05
 			add_timed_idea = {
@@ -152,6 +164,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_reduce_size_of_LegCo"
+			set_temp_variable = { sinicization_base_change = 3 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 100
 			add_popularity = { ideology = democratic popularity = -0.08 }
 			add_popularity = { ideology = communism popularity = 0.05 }
@@ -185,10 +199,10 @@ focus_tree = {
 			CHI = { has_completed_focus = CHI_SAR_one_system_declaration }
 			595 = {
 				custom_trigger_tooltip = {
-					tooltip = CHI_sinicization_HKG_req_90_tt
+					tooltip = CHI_sinicization_HKG_req_95_tt
 					check_variable = {
 						var = HKG_sinicization_var
-						value = 90
+						value = 95
 						compare = greater_than_or_equals
 					}
 				}
@@ -214,27 +228,12 @@ focus_tree = {
 						transfer_troops = yes
 					}
 				}
+				news_event = { id = hongkong_news.10 days = 1 }
 			}
 			custom_effect_tooltip = HKG_gong_zyu_ou_integration_tt
 		}
 
-		ai_will_do = {
-			base = 1
-			modifier = { factor = 3 has_government = communism }
-			modifier = { factor = 0 has_government = democratic }
-			modifier = {
-				factor = 0
-				NOT = { check_variable = { influence_array^0 = CHI } }
-			}
-			modifier = {
-				factor = 0
-				NOT = { check_variable = { influence_array_val^0 > 79 } }
-			}
-			modifier = {
-				factor = 0
-				check_variable = { HKG_contract_standing > 19 }
-			}
-		}
+		ai_will_do = { base = 0 }
 	}
 
 	focus = {
@@ -252,6 +251,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_great_hong_kong_nation"
+			set_temp_variable = { sinicization_base_change = -5 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 100
 			add_stability = -0.05
 			add_war_support = 0.10
@@ -423,6 +424,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_little_bird_under_british_wing"
+			set_temp_variable = { sinicization_base_change = -5 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 50
 			add_stability = 0.03
 			add_popularity = { ideology = democratic popularity = 0.08 }
@@ -613,6 +616,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_city_state_idea"
+			set_temp_variable = { sinicization_base_change = -5 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 75
 			add_stability = 0.05
 			add_popularity = { ideology = democratic popularity = 0.05 }
@@ -3492,6 +3497,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HKG_west_kowloon_cultural_district"
+			set_temp_variable = { sinicization_base_change = -3 }
+			CHI_apply_sinicization_HKG = yes
 			add_political_power = 50
 			add_stability = 0.05
 			595 = {

--- a/events/Hong Kong.txt
+++ b/events/Hong Kong.txt
@@ -155,207 +155,6 @@ country_event = {
 
 }
 
-##China Annexes Hong Kong
-country_event = {
-	id = hongkong.3
-	title = hongkong.3.t
-	desc = hongkong.3.d
-	picture = GFX_communism
-	is_triggered_only = yes
-
-	option = {
-		name = hongkong.3.a #This action must be condemned!
-		CHI = {
-			add_opinion_modifier = {
-				target = ROOT
-				modifier = opposes_hk_annexation
-			}
-		}
-		add_opinion_modifier = {
-			target = CHI
-			modifier = HKG_annexed_opinion
-		}
-		add_political_power = 10
-		ai_chance = {
-			base = 1
-			modifier = {
-				factor = 100
-				OR = {
-					original_tag = AST
-					original_tag = AUS
-					original_tag = BEL
-					original_tag = CAN
-					original_tag = DEN
-					original_tag = EST
-					original_tag = FIN
-					original_tag = FRA
-					original_tag = GER
-					original_tag = ICE
-					original_tag = IRE
-					original_tag = JAP
-					original_tag = LAT
-					original_tag = LIT
-					original_tag = LUX
-					original_tag = HOL
-					original_tag = NZL
-					original_tag = NRY
-					original_tag = SPR
-					original_tag = SWE
-					original_tag = SWI
-					original_tag = ENG
-					original_tag = USA
-					original_tag = TUR
-					AND = {
-						has_government = democratic
-						has_elections = yes
-					}
-				}
-			}
-		}
-		log = "[GetDateText]: [This.GetName]: hongkong.3.a executed"
-	}
-
-	option = {
-		name = hongkong.3.b #We see nothing wrong with this.
-		CHI = {
-			add_opinion_modifier = {
-				target = ROOT
-				modifier = supports_hk_annexation
-			}
-		}
-		add_political_power = -10
-		ai_chance = {
-			base = 1
-			modifier = {
-				factor = 100
-					has_government = communism
-			}
-			modifier = {
-				factor = 100
-				OR = {
-					original_tag = BHR
-					original_tag = BFA
-					original_tag = BUR
-					original_tag = CAM
-					original_tag = COM
-					original_tag = CNG
-					original_tag = DRC
-					original_tag = DJI
-					original_tag = EGY
-					original_tag = GUI
-					original_tag = ERI
-					original_tag = GAB
-					original_tag = IRQ
-					original_tag = KUW
-					original_tag = MOZ
-					original_tag = BRM
-					original_tag = NEP
-					original_tag = NIG
-					original_tag = OMA
-					original_tag = PAK
-					original_tag = PAL
-					original_tag = QAT
-					original_tag = SAU
-					original_tag = SER
-					original_tag = SOM
-					original_tag = SSU
-					original_tag = SRI
-					original_tag = SUD
-					original_tag = TAJ
-					original_tag = TOG
-					original_tag = TRK
-					original_tag = UGA
-					original_tag = UAE
-					original_tag = UZB
-					original_tag = YEM
-					original_tag = ZAM
-					original_tag = ZIM
-				}
-			}
-		}
-		log = "[GetDateText]: [This.GetName]: hongkong.3.b executed"
-	}
-
-	option = {
-		name = hongkong.3.c #This is none of our business.
-		ai_chance = {
-			base = 10
-		}
-		log = "[GetDateText]: [This.GetName]: hongkong.3.c executed"
-	}
-
-}
-
-##China Annexes Hong Kong
-country_event = {
-	id = hongkong.4
-	title = hongkong.4.t
-	desc = hongkong.4.d
-	picture = GFX_communism
-	is_triggered_only = yes
-
-	option = {
-		name = hongkong.4.a #We should threaten war.
-		CHI = {
-			add_opinion_modifier = {
-				target = ENG
-				modifier = opposes_hk_annexation
-			}
-			country_event = hongkong.5
-		}
-		add_opinion_modifier = {
-			target = CHI
-			modifier = HKG_annexed_opinion
-		}
-		ai_chance = {
-			base = 10
-		}
-		log = "[GetDateText]: [This.GetName]: hongkong.4.a executed"
-	}
-
-	option = {
-		name = hongkong.4.b #We should impose economic penalties on China.
-		CHI = {
-			add_opinion_modifier = {
-				target = ENG
-				modifier = opposes_hk_annexation
-			}
-			country_event = hongkong.6
-		}
-		add_opinion_modifier = {
-			target = CHI
-			modifier = HKG_annexed_opinion
-		}
-		ai_chance = {
-			base = 40
-		}
-		log = "[GetDateText]: [This.GetName]: hongkong.4.b executed"
-	}
-
-	option = {
-		name = hongkong.4.c #We should criticize the move.
-		CHI = {
-			add_opinion_modifier = {
-				target = ENG
-				modifier = opposes_hk_annexation
-			}
-		}
-		add_opinion_modifier = {
-			target = CHI
-			modifier = HKG_annexed_opinion
-		}
-		ai_chance = {
-			base = 10
-			modifier = {
-				factor = 4
-				CHI = { has_completed_focus = CHI_New_World_Order }
-			}
-		}
-		log = "[GetDateText]: [This.GetName]: hongkong.4.c executed"
-	}
-
-}
-
 ##The United Kingdom is Threatening Military Action!
 country_event = {
 	id = hongkong.5
@@ -524,6 +323,37 @@ country_event = {
 	option = {
 		name = hongkong.7.a #Our threats still have an effect!
 		log = "[GetDateText]: [This.GetName]: hongkong.7.a executed"
+	}
+
+}
+
+#Hong Kong is Annexed by China
+news_event = {
+	id = hongkong_news.10
+	title = hongkong_news.10.t
+	desc = hongkong_news.10.d
+	picture = GFX_CHI_generic
+	is_triggered_only = yes
+	major = yes
+
+	option = {
+		name = hongkong_news.10.a
+		trigger = {
+			OR = {
+				original_tag = CHI
+				original_tag = HKG
+			}
+		}
+		log = "[GetDateText]: [This.GetName]: hongkong_news.10.a executed"
+	}
+
+	option = {
+		name = hongkong_news.10.b
+		trigger = {
+			NOT = { original_tag = CHI }
+			NOT = { original_tag = HKG }
+		}
+		log = "[GetDateText]: [This.GetName]: hongkong_news.10.b executed"
 	}
 
 }

--- a/localisation/english/MD_focus_CHI_l_english.yml
+++ b/localisation/english/MD_focus_CHI_l_english.yml
@@ -5363,7 +5363,7 @@
  CHI_bri_powerplants_next_tier_tt: "$CHI_bri_powerplants_built$ has reached the next tier threshold of §Y50§!, §Y75§!, or §Y100§! (Current: §Y[?CHI_bri_powerplants_built|0]§!)"
  CHI_bri_industrial_zones_next_tier_tt: "$CHI_bri_industrial_zones$ has reached the next tier threshold of §Y50§!, §Y75§!, or §Y100§! (Current: §Y[?CHI_bri_industrial_zones|0]§!)"
  CHI_bri_prestige_next_tier_tt: "$CHI_bri_prestige_projects$ has reached the next tier threshold of §Y50§!, §Y75§!, or §Y100§! (Current: §Y[?CHI_bri_prestige_projects|0]§!)"
- CHI_sinicization_HKG_req_90_tt: "§YHong Kong§! Sinicization is at least §Y90§! (Current: §Y[?HKG_sinicization_var|0]§!)"
+ CHI_sinicization_HKG_req_95_tt: "§YHong Kong§! Sinicization is at least §Y95§! (Current: §Y[?HKG_sinicization_var|0]§!)"
  CHI_sinicization_MAC_req_90_tt: "§YMacau§! Sinicization is at least §Y90§! (Current: §Y[?MAC_sinicization_var|0]§!)"
  CHI_sinicization_OMG_req_90_tt: "§YInner Mongolia§! Sinicization is at least §Y90§! (Current: §Y[?OMG_sinicization_var|0]§!)"
  CHI_sinicization_TIB_req_95_tt: "§YTibet§! Sinicization is at least §Y95§! (Current: §Y[?TIB_sinicization_var|0]§!)"

--- a/localisation/english/events_l_english.yml
+++ b/localisation/english/events_l_english.yml
@@ -930,18 +930,6 @@
  hongkong.2.b: "China did what it needed to do."
  hongkong.2.c: "This is none of our business."
 
- hongkong.3.t: "China Annexes Hong Kong"
- hongkong.3.d: "China has decided to put an end to Hong Kong's special status as a Special Administrative Region, formally annexing the territory. We should decide on our country's response to this significant event."
- hongkong.3.a: "This action is despicable!"
- hongkong.3.b: "China did what it needed to do."
- hongkong.3.c: "This is none of our business."
-
- hongkong.4.t: "China's Annexation of Hong Kong Demands a Response"
- hongkong.4.d: "In a blatant violation of the Basic Law that was negotiated between us and the Chinese, China has formally annexed the Special Administrative Region. As the guarantor of Hong Kong's 50 year autonomy we must meet this illegal act with an appropriate response."
- hongkong.4.a: "We should threaten military action."
- hongkong.4.b: "We should threaten economic measures."
- hongkong.4.c: "We should criticize the move."
-
  hongkong.5.t: "The United Kingdom is Threatening Military Action!"
  hongkong.5.d: "The British have reacted more belligerently than we expected to our annexation of their former colonial territory. We should consider whether to concede to their demands."
  hongkong.5.a: "This is not the hill we want to die on."
@@ -973,6 +961,11 @@
  hongkong_news.3.d: "Protests against Chinese actions in the territory of Hong Kong have rapidly increased, with analysts widely agreeing that the protests have entered a new stage in terms of scale and tactics. How the Chinese and Hong Kong governments will respond to this new escalation remains to be seen, but officials in both governments are reportedly increasingly resentful of the impacts of the protests on their vested interests. The protesters, for their part, are refusing to stand down until the Chinese and Hong Kong governments address their demands."
  hongkong_news.3.a: "The Hong Kong people will not stay quiet..."
  hongkong_news.3.b: "They will stay home if they know what's good for them!"
+
+ hongkong_news.10.t: "Hong Kong is Annexed by China"
+ hongkong_news.10.d: "China has formally absorbed the Special Administrative Region of Hong Kong, ending its separate status. The territory's institutions and administration now fall under direct central control from Beijing, as [CHI.GetLeader] has described the move as the culmination of Hong Kong's return to the motherland."
+ hongkong_news.10.a: "The Pearl has returned to the fold."
+ hongkong_news.10.b: "A significant development."
 
  #Korea
  korea.1.t: "China Demands Our Withdrawal from the Korean Peninsula"


### PR DESCRIPTION
Closes #2535

## What

- Raised the sinicization gate for both Hong Kong annexation paths from 90 to 95: the HKG self-dissolution focus `HKG_gong_zyu_ou_integration` and China's `CHI_SAR_integrate_HKG`. The `CHI_sinicization_HKG_req_95_tt` tooltip replaces the old `_req_90_` key.
- Hong Kong's AI no longer takes the self-dissolution focus (`ai_will_do = { base = 0 }`), so AI Hong Kong stops giving itself up to China in the first years. The loyal-puppet branch AI now also requires Chinese influence to be dominant.
- Hong Kong now has agency over sinicization: loyalist branch focuses (`HKG_loyal_puppet`, `HKG_promote_patriotism`, `HKG_suppress_cantonese_local_culture`, `HKG_patriots_governing`, `HKG_reduce_size_of_LegCo`) raise `HKG_sinicization_var`; resistance/cultural focuses (`HKG_great_hong_kong_nation`, `HKG_little_bird_under_british_wing`, `HKG_city_state_idea`, `HKG_west_kowloon_cultural_district`) lower it, via the existing `CHI_apply_sinicization_HKG` scripted effect.
- Added a major news event `hongkong_news.10` ("Hong Kong is Annexed by China"), fired from both annexation paths so players worldwide (including a China player) are notified. Removed the dead duplicate annexation reaction events `hongkong.3` and `hongkong.4` and their stale English localisation.

## Why

The Discord report (#2535) noted Hong Kong gives itself up to China within the first 5 years in historical mode, ahead of the real-world 2047 handover the focus icon references, and that players got no clear notification. The threshold raise plus AI changes delay annexation; the news event makes it visible.

## How

- Thresholds: `value = 90` → `95` in the `available` blocks of `HKG_gong_zyu_ou_integration` (common/national_focus/hongkong.txt:202) and `CHI_SAR_integrate_HKG` (common/national_focus/05_china.txt:20027), with the tooltip key renamed to `CHI_sinicization_HKG_req_95_tt` (matching the existing `_TIB_req_95_` pattern).
- Sinicization wiring reuses `CHI_apply_sinicization_HKG` (set `sinicization_base_change`, call effect), the same mechanism China's own focuses use, so the change scales with compliance/resistance like every other sinicization source.
- The news event follows the existing `hongkong_news.1` pattern (major news, options gated by `original_tag` CHI/HKG vs others). Id `hongkong_news.10` was chosen because `hongkong_news.8/9` localization keys are already taken by stale typhoon events.

Note: `common/national_focus/05_china.txt` was committed as-is at HEAD (the current md-standardize would reformat ~1.5k unrelated `ai_will_do` lines due to a recent standardizer change that landed after the file was last standardized; that churn is intentionally left out of this PR).