### PR TITLE
fix(eu): guard on_startup_euu_action with EU_initialized flag to prevent corruption on save load (#2748)

### DIFF
--- a/common/scripted_effects/00_missiles_scripted_effects.txt
+++ b/common/scripted_effects/00_missiles_scripted_effects.txt
@@ -10,15 +10,17 @@
 ### production gui ###
 
 on_startup_satellites = {
-
-	every_country = {
-		set_variable = { var_space_production_OLV = 0 }
-		set_variable = { var_space_production_GNSS = 0 }
-		set_variable = { var_space_production_COMSAT = 0 }
-		set_variable = { var_space_production_SPYSAT = 0 }
-		set_variable = { var_space_production_KILLSAT = 0 }
+	if = {
+		limit = { NOT = { has_global_flag = satellites_initialized } }
+		set_global_flag = satellites_initialized
+		every_country = {
+			set_variable = { var_space_production_OLV = 0 }
+			set_variable = { var_space_production_GNSS = 0 }
+			set_variable = { var_space_production_COMSAT = 0 }
+			set_variable = { var_space_production_SPYSAT = 0 }
+			set_variable = { var_space_production_KILLSAT = 0 }
+		}
 	}
-
 }
 
 set_prod_display_arrays = {

--- a/common/scripted_effects/01_international_systems_effects.txt
+++ b/common/scripted_effects/01_international_systems_effects.txt
@@ -37,265 +37,269 @@ process_auto_ga_vote = {
 }
 
 on_startup_international = {
-	add_to_array = { global.PMC_Companies = 001 } #Blackwater
-	add_to_array = { global.PMC_Companies = 002 } #Aegis
-	add_to_array = { global.PMC_Companies = 003 } #Constellis
-	add_to_array = { global.PMC_Companies = 004 } #Wagner
-	add_to_array = { global.PMC_Companies = 031 } #MD
-	add_to_array = { global.PMC_Companies = 005 } #MPRI
-	add_to_array = { global.PMC_Companies = 006 } #SADAT
-	add_to_array = { global.PMC_Companies = 007 } #RSB_Group
-	add_to_array = { global.PMC_Companies = 008 } #SandLine
-	add_to_array = { global.PMC_Companies = 009 } #KBR Supply
-	add_to_array = { global.PMC_Companies = 010 } #Nirtal
-	add_to_array = { global.PMC_Companies = 011 } #HALO
-	add_to_array = { global.PMC_Companies = 012 } #Defense Conseil
-	add_to_array = { global.PMC_Companies = 013 } #GardaWorld
-	add_to_array = { global.PMC_Companies = 014 } #European Security Academy
-	add_to_array = { global.PMC_Companies = 015 } #g4s
-	add_to_array = { global.PMC_Companies = 016 } #Asgard
-	add_to_array = { global.PMC_Companies = 017 } #Union of Tribes of Sinai
-	add_to_array = { global.PMC_Companies = 018 } #Gard
-	add_to_array = { global.PMC_Companies = 019 } #Patriot
-	add_to_array = { global.PMC_Companies = 020 } #Dewe Security Services
-	add_to_array = { global.PMC_Companies = 021 } #China OGS
-	add_to_array = { global.PMC_Companies = 022 } #Front
-	add_to_array = { global.PMC_Companies = 023 } #Redut
-	add_to_array = { global.PMC_Companies = 024 } #Gazprom
-	add_to_array = { global.PMC_Companies = 025 } #Iron
-	add_to_array = { global.PMC_Companies = 026 } #Sheriff
-	add_to_array = { global.PMC_Companies = 027 } #Lukoil
-	add_to_array = { global.PMC_Companies = 028 } #Rosneft
-	add_to_array = { global.PMC_Companies = 029 } #Sberbank
-	add_to_array = { global.PMC_Companies = 030 } #VTB
-
-	add_to_array = { global.PMC_units_major = 001 }
-	add_to_array = { global.PMC_units_major = 002 }
-	add_to_array = { global.PMC_units_major = 003 }
-	add_to_array = { global.PMC_units_major = 004 }
-	add_to_array = { global.PMC_units_major = 031 }
-
-	add_to_array = { global.PMC_units_minor = 008 }
-	add_to_array = { global.PMC_units_minor = 013 }
-	add_to_array = { global.PMC_units_minor = 015 }
-	add_to_array = { global.PMC_units_minor = 017 }
-	add_to_array = { global.PMC_units_minor = 018 }
-	add_to_array = { global.PMC_units_minor = 019 }
-	add_to_array = { global.PMC_units_minor = 020 }
-	add_to_array = { global.PMC_units_minor = 023 }
-	add_to_array = { global.PMC_units_minor = 024 }
-	add_to_array = { global.PMC_units_minor = 025 }
-	add_to_array = { global.PMC_units_minor = 026 }
-	add_to_array = { global.PMC_units_minor = 027 }
-	add_to_array = { global.PMC_units_minor = 028 }
-	add_to_array = { global.PMC_units_minor = 029 }
-	add_to_array = { global.PMC_units_minor = 030 }
-
-	add_to_array = { global.PMC_buffs = 005 }
-	add_to_array = { global.PMC_buffs = 006 }
-	add_to_array = { global.PMC_buffs = 007 }
-	add_to_array = { global.PMC_buffs = 009 }
-	add_to_array = { global.PMC_buffs = 010 }
-	add_to_array = { global.PMC_buffs = 011 }
-	add_to_array = { global.PMC_buffs = 012 }
-	add_to_array = { global.PMC_buffs = 014 }
-	add_to_array = { global.PMC_buffs = 016 }
-	add_to_array = { global.PMC_buffs = 021 }
-	add_to_array = { global.PMC_buffs = 022 }
-	add_to_array = { global.PMC_buffs = 024 }
-	add_to_array = { global.PMC_buffs = 026 }
-	add_to_array = { global.PMC_buffs = 027 }
-	add_to_array = { global.PMC_buffs = 028 }
-	add_to_array = { global.PMC_buffs = 029 }
-	add_to_array = { global.PMC_buffs = 030 }
-
-	add_to_array = { global.p5_sc_members = CHI }
-	add_to_array = { global.p5_sc_members = FRA }
-	add_to_array = { global.p5_sc_members = SOV }
-	add_to_array = { global.p5_sc_members = USA }
-	add_to_array = { global.p5_sc_members = ENG }
-
-	add_to_array = { global.security_council_members = ARG } #Latin America / Caribbean
-	add_to_array = { global.security_council_members = CAN } #Europe & Others
-	add_to_array = { global.security_council_members = MAY } #Asian & African
-	add_to_array = { global.security_council_members = NAM } #Asian & African
-	add_to_array = { global.security_council_members = HOL } #Europe & Others
-	#Dividing line for doolitle sanity on building this shit
-	add_to_array = { global.security_council_members = UKR } #Europe & Others
-	add_to_array = { global.security_council_members = TUN } #Asian & African
-	add_to_array = { global.security_council_members = MAL } #Asian & African
-	add_to_array = { global.security_council_members = JAM } #Latin America / Caribbean
-	add_to_array = { global.security_council_members = BAN } #Asian & African
-
-	add_to_array = { global.security_council_members = CHI } #Security Council Permanant Members
-	add_to_array = { global.security_council_members = FRA }
-	add_to_array = { global.security_council_members = SOV }
-	add_to_array = { global.security_council_members = USA }
-	add_to_array = { global.security_council_members = ENG }
-
-	add_to_array = { global.at_members = ARG }
-	add_to_array = { global.at_members = AUS }
-	add_to_array = { global.at_members = AST }
-	add_to_array = { global.at_members = BEL }
-	add_to_array = { global.at_members = BRA }
-	add_to_array = { global.at_members = BUL }
-	add_to_array = { global.at_members = CAN }
-	add_to_array = { global.at_members = CHL }
-	add_to_array = { global.at_members = CHI }
-	add_to_array = { global.at_members = COL }
-	add_to_array = { global.at_members = CZE }
-	add_to_array = { global.at_members = DEN }
-	add_to_array = { global.at_members = ECU }
-	add_to_array = { global.at_members = ENG }
-	add_to_array = { global.at_members = FIN }
-	add_to_array = { global.at_members = FRA }
-	add_to_array = { global.at_members = GER }
-	add_to_array = { global.at_members = GRE }
-	add_to_array = { global.at_members = GUA }
-	add_to_array = { global.at_members = HUN }
-	add_to_array = { global.at_members = ITA }
-	add_to_array = { global.at_members = JAP }
-	add_to_array = { global.at_members = KOR }
-	add_to_array = { global.at_members = NKO }
-	add_to_array = { global.at_members = NRY }
-	add_to_array = { global.at_members = NZL }
-	add_to_array = { global.at_members = PAP }
-	add_to_array = { global.at_members = POL }
-	add_to_array = { global.at_members = PRU }
-	add_to_array = { global.at_members = RAJ }
-	add_to_array = { global.at_members = ROM }
-	add_to_array = { global.at_members = SAF }
-	add_to_array = { global.at_members = SLO }
-	add_to_array = { global.at_members = SOV }
-	add_to_array = { global.at_members = SPR }
-	add_to_array = { global.at_members = SWE }
-	add_to_array = { global.at_members = SWI }
-	add_to_array = { global.at_members = TUR }
-	add_to_array = { global.at_members = UKR }
-	add_to_array = { global.at_members = URG }
-	add_to_array = { global.at_members = VEN }
-	add_to_array = { global.at_members = HOL }
-
-	add_to_array = { global.atcp_members = ARG }
-	add_to_array = { global.atcp_members = AST }
-	add_to_array = { global.atcp_members = BEL }
-	add_to_array = { global.atcp_members = BRA }
-	add_to_array = { global.atcp_members = BUL }
-	add_to_array = { global.atcp_members = CHL }
-	add_to_array = { global.atcp_members = CHI }
-	add_to_array = { global.atcp_members = ECU }
-	add_to_array = { global.atcp_members = FIN }
-	add_to_array = { global.atcp_members = FRA }
-	add_to_array = { global.atcp_members = GER }
-	add_to_array = { global.atcp_members = RAJ }
-	add_to_array = { global.atcp_members = ITA }
-	add_to_array = { global.atcp_members = JAP }
-	add_to_array = { global.atcp_members = KOR }
-	add_to_array = { global.atcp_members = HOL }
-	add_to_array = { global.atcp_members = NZL }
-	add_to_array = { global.atcp_members = NRY }
-	add_to_array = { global.atcp_members = PRU }
-	add_to_array = { global.atcp_members = POL }
-	add_to_array = { global.atcp_members = SOV }
-	add_to_array = { global.atcp_members = SAF }
-	add_to_array = { global.atcp_members = SPR }
-	add_to_array = { global.atcp_members = SWE }
-	add_to_array = { global.atcp_members = ENG }
-	add_to_array = { global.atcp_members = USA }
-	add_to_array = { global.atcp_members = URG }
-
-	for_each_scope_loop = {
-		array = global.atcp_members
-		set_country_flag = is_antarctica_atcp_consultative_member
-	}
-
-	# Original-owner flags for curated NSAs that ship with lacks_international_recognition.
-	# Drives recognition.1 / recognition.4 events so the parent state is notified when a third
-	# country grants or withdraws recognition of the breakaway.
-	if = { limit = { country_exists = YEM } YEM = { set_country_flag = original_owner_HOU } }
-	if = { limit = { country_exists = SOM } SOM = { set_country_flag = original_owner_AIA } }
-	if = { limit = { country_exists = SYR } SYR = { set_country_flag = original_owner_ROJ } }
-	if = { limit = { country_exists = LEB } LEB = { set_country_flag = original_owner_HEZ } }
-	if = { limit = { country_exists = AFG } AFG = { set_country_flag = original_owner_TAL } }
-	if = { limit = { country_exists = ISR } ISR = { set_country_flag = original_owner_HAM } }
-	if = { limit = { country_exists = UKR } UKR = { set_country_flag = original_owner_DPR set_country_flag = original_owner_LPR } }
-	if = { limit = { country_exists = AZE } AZE = { set_country_flag = original_owner_NKR } }
-	if = { limit = { country_exists = SER } SER = { set_country_flag = original_owner_KOS } }
-	if = { limit = { country_exists = GEO } GEO = { set_country_flag = original_owner_ABK set_country_flag = original_owner_SOO } }
-	# Kurdistan is claimed across four parent states
-	if = { limit = { country_exists = IRQ } IRQ = { set_country_flag = original_owner_KUR } }
-	if = { limit = { country_exists = PER } PER = { set_country_flag = original_owner_KUR } }
-	if = { limit = { country_exists = TUR } TUR = { set_country_flag = original_owner_KUR } }
-	if = { limit = { country_exists = SYR } SYR = { set_country_flag = original_owner_KUR } }
-
-	# Pre-seeded recognitions reflecting real-world state at the 2000 game start.
-	# Each block sets the Recognised_<TAG> flag on the granter side AND bumps Granted_Recognition
-	# on the breakaway side so the variable stays consistent with the flag set.
-
-	# Taiwan (ROC) — 21 UN members recognised the ROC in 2000 (later defections happened post-2000)
-	if = { limit = { country_exists = TAI }
-		if = { limit = { country_exists = GUA } GUA = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = HON } HON = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = NIC } NIC = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = PAN } PAN = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = PAR } PAR = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = DOM } DOM = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = ELS } ELS = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = BLZ } BLZ = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = HAI } HAI = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = SEN } SEN = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = CHA } CHA = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = GAM } GAM = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = LIB } LIB = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = MLW } MLW = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = SAO } SAO = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = SWA } SWA = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = NAU } NAU = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = PAU } PAU = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = MAR } MAR = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = SOL } SOL = { set_country_flag = Recognised_TAI } }
-		if = { limit = { country_exists = TUL } TUL = { set_country_flag = Recognised_TAI } }
-		TAI = { add_to_variable = { Granted_Recognition = 21 } }
-	}
-
-	# Taliban Afghanistan (TAL) — recognised by Pakistan, Saudi Arabia, UAE in 2000
-	if = { limit = { country_exists = TAL }
-		if = { limit = { country_exists = PAK } PAK = { set_country_flag = Recognised_TAL } }
-		if = { limit = { country_exists = SAU } SAU = { set_country_flag = Recognised_TAL } }
-		if = { limit = { country_exists = UAE } UAE = { set_country_flag = Recognised_TAL } }
-		TAL = { add_to_variable = { Granted_Recognition = 3 } }
-	}
-
-	# Abkhazia (ABK) — Russia formally recognised in 2008; pre-seeded for game start so the
-	# breakaway doesn't begin from absolute zero.
 	if = {
-		limit = {
-			country_exists = ABK
-			country_exists = SOV
-		}
-		SOV = { set_country_flag = Recognised_ABK }
-		ABK = { add_to_variable = { Granted_Recognition = 1 } }
-	}
+		limit = { NOT = { has_global_flag = international_systems_initialized } }
+		set_global_flag = international_systems_initialized
+		add_to_array = { global.PMC_Companies = 001 } #Blackwater
+		add_to_array = { global.PMC_Companies = 002 } #Aegis
+		add_to_array = { global.PMC_Companies = 003 } #Constellis
+		add_to_array = { global.PMC_Companies = 004 } #Wagner
+		add_to_array = { global.PMC_Companies = 031 } #MD
+		add_to_array = { global.PMC_Companies = 005 } #MPRI
+		add_to_array = { global.PMC_Companies = 006 } #SADAT
+		add_to_array = { global.PMC_Companies = 007 } #RSB_Group
+		add_to_array = { global.PMC_Companies = 008 } #SandLine
+		add_to_array = { global.PMC_Companies = 009 } #KBR Supply
+		add_to_array = { global.PMC_Companies = 010 } #Nirtal
+		add_to_array = { global.PMC_Companies = 011 } #HALO
+		add_to_array = { global.PMC_Companies = 012 } #Defense Conseil
+		add_to_array = { global.PMC_Companies = 013 } #GardaWorld
+		add_to_array = { global.PMC_Companies = 014 } #European Security Academy
+		add_to_array = { global.PMC_Companies = 015 } #g4s
+		add_to_array = { global.PMC_Companies = 016 } #Asgard
+		add_to_array = { global.PMC_Companies = 017 } #Union of Tribes of Sinai
+		add_to_array = { global.PMC_Companies = 018 } #Gard
+		add_to_array = { global.PMC_Companies = 019 } #Patriot
+		add_to_array = { global.PMC_Companies = 020 } #Dewe Security Services
+		add_to_array = { global.PMC_Companies = 021 } #China OGS
+		add_to_array = { global.PMC_Companies = 022 } #Front
+		add_to_array = { global.PMC_Companies = 023 } #Redut
+		add_to_array = { global.PMC_Companies = 024 } #Gazprom
+		add_to_array = { global.PMC_Companies = 025 } #Iron
+		add_to_array = { global.PMC_Companies = 026 } #Sheriff
+		add_to_array = { global.PMC_Companies = 027 } #Lukoil
+		add_to_array = { global.PMC_Companies = 028 } #Rosneft
+		add_to_array = { global.PMC_Companies = 029 } #Sberbank
+		add_to_array = { global.PMC_Companies = 030 } #VTB
 
-	# South Ossetia (SOO) — same as ABK, recognised by Russia.
-	if = {
-		limit = {
-			country_exists = SOO
-			country_exists = SOV
-		}
-		SOV = { set_country_flag = Recognised_SOO }
-		SOO = { add_to_variable = { Granted_Recognition = 1 } }
-	}
+		add_to_array = { global.PMC_units_major = 001 }
+		add_to_array = { global.PMC_units_major = 002 }
+		add_to_array = { global.PMC_units_major = 003 }
+		add_to_array = { global.PMC_units_major = 004 }
+		add_to_array = { global.PMC_units_major = 031 }
 
-	# Stagger initial AI campaign cooldowns so unrecognised states don't all fire on month 1.
-	# random_list spreads each NSA's first action across the opening 9 months.
-	for_each_scope_loop = {
-		array = global.Unrecognised_States
-		random_list = {
-			25 = { }
-			25 = { set_country_flag = { flag = recog_ai_cooldown days = 30 value = 1 } }
-			25 = { set_country_flag = { flag = recog_ai_cooldown days = 120 value = 1 } }
-			25 = { set_country_flag = { flag = recog_ai_cooldown days = 270 value = 1 } }
+		add_to_array = { global.PMC_units_minor = 008 }
+		add_to_array = { global.PMC_units_minor = 013 }
+		add_to_array = { global.PMC_units_minor = 015 }
+		add_to_array = { global.PMC_units_minor = 017 }
+		add_to_array = { global.PMC_units_minor = 018 }
+		add_to_array = { global.PMC_units_minor = 019 }
+		add_to_array = { global.PMC_units_minor = 020 }
+		add_to_array = { global.PMC_units_minor = 023 }
+		add_to_array = { global.PMC_units_minor = 024 }
+		add_to_array = { global.PMC_units_minor = 025 }
+		add_to_array = { global.PMC_units_minor = 026 }
+		add_to_array = { global.PMC_units_minor = 027 }
+		add_to_array = { global.PMC_units_minor = 028 }
+		add_to_array = { global.PMC_units_minor = 029 }
+		add_to_array = { global.PMC_units_minor = 030 }
+
+		add_to_array = { global.PMC_buffs = 005 }
+		add_to_array = { global.PMC_buffs = 006 }
+		add_to_array = { global.PMC_buffs = 007 }
+		add_to_array = { global.PMC_buffs = 009 }
+		add_to_array = { global.PMC_buffs = 010 }
+		add_to_array = { global.PMC_buffs = 011 }
+		add_to_array = { global.PMC_buffs = 012 }
+		add_to_array = { global.PMC_buffs = 014 }
+		add_to_array = { global.PMC_buffs = 016 }
+		add_to_array = { global.PMC_buffs = 021 }
+		add_to_array = { global.PMC_buffs = 022 }
+		add_to_array = { global.PMC_buffs = 024 }
+		add_to_array = { global.PMC_buffs = 026 }
+		add_to_array = { global.PMC_buffs = 027 }
+		add_to_array = { global.PMC_buffs = 028 }
+		add_to_array = { global.PMC_buffs = 029 }
+		add_to_array = { global.PMC_buffs = 030 }
+
+		add_to_array = { global.p5_sc_members = CHI }
+		add_to_array = { global.p5_sc_members = FRA }
+		add_to_array = { global.p5_sc_members = SOV }
+		add_to_array = { global.p5_sc_members = USA }
+		add_to_array = { global.p5_sc_members = ENG }
+
+		add_to_array = { global.security_council_members = ARG } #Latin America / Caribbean
+		add_to_array = { global.security_council_members = CAN } #Europe & Others
+		add_to_array = { global.security_council_members = MAY } #Asian & African
+		add_to_array = { global.security_council_members = NAM } #Asian & African
+		add_to_array = { global.security_council_members = HOL } #Europe & Others
+		#Dividing line for doolitle sanity on building this shit
+		add_to_array = { global.security_council_members = UKR } #Europe & Others
+		add_to_array = { global.security_council_members = TUN } #Asian & African
+		add_to_array = { global.security_council_members = MAL } #Asian & African
+		add_to_array = { global.security_council_members = JAM } #Latin America / Caribbean
+		add_to_array = { global.security_council_members = BAN } #Asian & African
+
+		add_to_array = { global.security_council_members = CHI } #Security Council Permanant Members
+		add_to_array = { global.security_council_members = FRA }
+		add_to_array = { global.security_council_members = SOV }
+		add_to_array = { global.security_council_members = USA }
+		add_to_array = { global.security_council_members = ENG }
+
+		add_to_array = { global.at_members = ARG }
+		add_to_array = { global.at_members = AUS }
+		add_to_array = { global.at_members = AST }
+		add_to_array = { global.at_members = BEL }
+		add_to_array = { global.at_members = BRA }
+		add_to_array = { global.at_members = BUL }
+		add_to_array = { global.at_members = CAN }
+		add_to_array = { global.at_members = CHL }
+		add_to_array = { global.at_members = CHI }
+		add_to_array = { global.at_members = COL }
+		add_to_array = { global.at_members = CZE }
+		add_to_array = { global.at_members = DEN }
+		add_to_array = { global.at_members = ECU }
+		add_to_array = { global.at_members = ENG }
+		add_to_array = { global.at_members = FIN }
+		add_to_array = { global.at_members = FRA }
+		add_to_array = { global.at_members = GER }
+		add_to_array = { global.at_members = GRE }
+		add_to_array = { global.at_members = GUA }
+		add_to_array = { global.at_members = HUN }
+		add_to_array = { global.at_members = ITA }
+		add_to_array = { global.at_members = JAP }
+		add_to_array = { global.at_members = KOR }
+		add_to_array = { global.at_members = NKO }
+		add_to_array = { global.at_members = NRY }
+		add_to_array = { global.at_members = NZL }
+		add_to_array = { global.at_members = PAP }
+		add_to_array = { global.at_members = POL }
+		add_to_array = { global.at_members = PRU }
+		add_to_array = { global.at_members = RAJ }
+		add_to_array = { global.at_members = ROM }
+		add_to_array = { global.at_members = SAF }
+		add_to_array = { global.at_members = SLO }
+		add_to_array = { global.at_members = SOV }
+		add_to_array = { global.at_members = SPR }
+		add_to_array = { global.at_members = SWE }
+		add_to_array = { global.at_members = SWI }
+		add_to_array = { global.at_members = TUR }
+		add_to_array = { global.at_members = UKR }
+		add_to_array = { global.at_members = URG }
+		add_to_array = { global.at_members = VEN }
+		add_to_array = { global.at_members = HOL }
+
+		add_to_array = { global.atcp_members = ARG }
+		add_to_array = { global.atcp_members = AST }
+		add_to_array = { global.atcp_members = BEL }
+		add_to_array = { global.atcp_members = BRA }
+		add_to_array = { global.atcp_members = BUL }
+		add_to_array = { global.atcp_members = CHL }
+		add_to_array = { global.atcp_members = CHI }
+		add_to_array = { global.atcp_members = ECU }
+		add_to_array = { global.atcp_members = FIN }
+		add_to_array = { global.atcp_members = FRA }
+		add_to_array = { global.atcp_members = GER }
+		add_to_array = { global.atcp_members = RAJ }
+		add_to_array = { global.atcp_members = ITA }
+		add_to_array = { global.atcp_members = JAP }
+		add_to_array = { global.atcp_members = KOR }
+		add_to_array = { global.atcp_members = HOL }
+		add_to_array = { global.atcp_members = NZL }
+		add_to_array = { global.atcp_members = NRY }
+		add_to_array = { global.atcp_members = PRU }
+		add_to_array = { global.atcp_members = POL }
+		add_to_array = { global.atcp_members = SOV }
+		add_to_array = { global.atcp_members = SAF }
+		add_to_array = { global.atcp_members = SPR }
+		add_to_array = { global.atcp_members = SWE }
+		add_to_array = { global.atcp_members = ENG }
+		add_to_array = { global.atcp_members = USA }
+		add_to_array = { global.atcp_members = URG }
+
+		for_each_scope_loop = {
+			array = global.atcp_members
+			set_country_flag = is_antarctica_atcp_consultative_member
+		}
+
+		# Original-owner flags for curated NSAs that ship with lacks_international_recognition.
+		# Drives recognition.1 / recognition.4 events so the parent state is notified when a third
+		# country grants or withdraws recognition of the breakaway.
+		if = { limit = { country_exists = YEM } YEM = { set_country_flag = original_owner_HOU } }
+		if = { limit = { country_exists = SOM } SOM = { set_country_flag = original_owner_AIA } }
+		if = { limit = { country_exists = SYR } SYR = { set_country_flag = original_owner_ROJ } }
+		if = { limit = { country_exists = LEB } LEB = { set_country_flag = original_owner_HEZ } }
+		if = { limit = { country_exists = AFG } AFG = { set_country_flag = original_owner_TAL } }
+		if = { limit = { country_exists = ISR } ISR = { set_country_flag = original_owner_HAM } }
+		if = { limit = { country_exists = UKR } UKR = { set_country_flag = original_owner_DPR set_country_flag = original_owner_LPR } }
+		if = { limit = { country_exists = AZE } AZE = { set_country_flag = original_owner_NKR } }
+		if = { limit = { country_exists = SER } SER = { set_country_flag = original_owner_KOS } }
+		if = { limit = { country_exists = GEO } GEO = { set_country_flag = original_owner_ABK set_country_flag = original_owner_SOO } }
+		# Kurdistan is claimed across four parent states
+		if = { limit = { country_exists = IRQ } IRQ = { set_country_flag = original_owner_KUR } }
+		if = { limit = { country_exists = PER } PER = { set_country_flag = original_owner_KUR } }
+		if = { limit = { country_exists = TUR } TUR = { set_country_flag = original_owner_KUR } }
+		if = { limit = { country_exists = SYR } SYR = { set_country_flag = original_owner_KUR } }
+
+		# Pre-seeded recognitions reflecting real-world state at the 2000 game start.
+		# Each block sets the Recognised_<TAG> flag on the granter side AND bumps Granted_Recognition
+		# on the breakaway side so the variable stays consistent with the flag set.
+
+		# Taiwan (ROC) — 21 UN members recognised the ROC in 2000 (later defections happened post-2000)
+		if = { limit = { country_exists = TAI }
+			if = { limit = { country_exists = GUA } GUA = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = HON } HON = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = NIC } NIC = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = PAN } PAN = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = PAR } PAR = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = DOM } DOM = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = ELS } ELS = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = BLZ } BLZ = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = HAI } HAI = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = SEN } SEN = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = CHA } CHA = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = GAM } GAM = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = LIB } LIB = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = MLW } MLW = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = SAO } SAO = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = SWA } SWA = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = NAU } NAU = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = PAU } PAU = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = MAR } MAR = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = SOL } SOL = { set_country_flag = Recognised_TAI } }
+			if = { limit = { country_exists = TUL } TUL = { set_country_flag = Recognised_TAI } }
+			TAI = { add_to_variable = { Granted_Recognition = 21 } }
+		}
+
+		# Taliban Afghanistan (TAL) — recognised by Pakistan, Saudi Arabia, UAE in 2000
+		if = { limit = { country_exists = TAL }
+			if = { limit = { country_exists = PAK } PAK = { set_country_flag = Recognised_TAL } }
+			if = { limit = { country_exists = SAU } SAU = { set_country_flag = Recognised_TAL } }
+			if = { limit = { country_exists = UAE } UAE = { set_country_flag = Recognised_TAL } }
+			TAL = { add_to_variable = { Granted_Recognition = 3 } }
+		}
+
+		# Abkhazia (ABK) — Russia formally recognised in 2008; pre-seeded for game start so the
+		# breakaway doesn't begin from absolute zero.
+		if = {
+			limit = {
+				country_exists = ABK
+				country_exists = SOV
+			}
+			SOV = { set_country_flag = Recognised_ABK }
+			ABK = { add_to_variable = { Granted_Recognition = 1 } }
+		}
+
+		# South Ossetia (SOO) — same as ABK, recognised by Russia.
+		if = {
+			limit = {
+				country_exists = SOO
+				country_exists = SOV
+			}
+			SOV = { set_country_flag = Recognised_SOO }
+			SOO = { add_to_variable = { Granted_Recognition = 1 } }
+		}
+
+		# Stagger initial AI campaign cooldowns so unrecognised states don't all fire on month 1.
+		# random_list spreads each NSA's first action across the opening 9 months.
+		for_each_scope_loop = {
+			array = global.Unrecognised_States
+			random_list = {
+				25 = { }
+				25 = { set_country_flag = { flag = recog_ai_cooldown days = 30 value = 1 } }
+				25 = { set_country_flag = { flag = recog_ai_cooldown days = 120 value = 1 } }
+				25 = { set_country_flag = { flag = recog_ai_cooldown days = 270 value = 1 } }
+			}
 		}
 	}
 }

--- a/common/scripted_effects/99_eu_scripted_effects.txt
+++ b/common/scripted_effects/99_eu_scripted_effects.txt
@@ -724,7 +724,12 @@ on_startup_euu_action = {
 	}
 
 	# Configure European Union startup values and information
-	if = { limit = { NOT = { has_global_flag = GAME_RULE_eu_disabled } }
+	if = {
+		limit = {
+			NOT = { has_global_flag = GAME_RULE_eu_disabled }
+			NOT = { has_global_flag = EU_initialized }
+		}
+		set_global_flag = EU_initialized
 		EUU = {
 			add_to_array = { global.EU_potential_votes = 101 } # Charter of Fundamental Rights of the EU
 			add_to_array = { global.EU_potential_votes = 102 } # European Convention
@@ -987,41 +992,41 @@ on_startup_euu_action = {
 		set_variable = { global.eunavy = EUU.id }
 		set_variable = { global.euambassador = EUU.id }
 		set_variable = { global.eupresfederation = EUU.id }
+
+		add_to_array = { global.EU_parl_party_number = 0 }
+		add_to_array = { global.EU_parl_party_number = 1 }
+		add_to_array = { global.EU_parl_party_number = 2 }
+		add_to_array = { global.EU_parl_party_number = 3 }
+		add_to_array = { global.EU_parl_party_number = 4 }
+		add_to_array = { global.EU_parl_party_number = 5 }
+		add_to_array = { global.EU_parl_party_number = 6 }
+		add_to_array = { global.EU_parl_party_number = 7 }
+		add_to_array = { global.EU_parl_party_number = 8 }
+		add_to_array = { global.EU_parl_party_number = 9 }
+		add_to_array = { global.EU_parl_party_number = 10 }
+		add_to_array = { global.EU_parl_party_number = 11 }
+		add_to_array = { global.EU_parl_party_number = 12 }
+		add_to_array = { global.EU_parl_party_number = 13 }
+		add_to_array = { global.EU_parl_party_number = 14 }
+		add_to_array = { global.EU_parl_party_number = 15 }
+		add_to_array = { global.EU_parl_party_number = 16 }
+		add_to_array = { global.EU_parl_party_number = 17 }
+		add_to_array = { global.EU_parl_party_number = 18 }
+		add_to_array = { global.EU_parl_party_number = 19 }
+		add_to_array = { global.EU_parl_party_number = 20 }
+		add_to_array = { global.EU_parl_party_number = 21 }
+		add_to_array = { global.EU_parl_party_number = 22 }
+		add_to_array = { global.EU_parl_party_number = 23 }
+
+		clear_array = global.MEP_PG_party_array
+		resize_array = { global.MEP_PG_party_array = 24 }
+		clear_array = global.MEP_Ratio_PG_array
+		resize_array = { global.MEP_Ratio_PG_array = 24 }
+		clear_array = global.PG_party_support_array
+		resize_array = { global.PG_party_support_array = 24 }
+		clear_array = global.EU_draft_party_array
+		resize_array = { global.EU_draft_party_array = 24 }
 	}
-
-	add_to_array = { global.EU_parl_party_number = 0 }
-	add_to_array = { global.EU_parl_party_number = 1 }
-	add_to_array = { global.EU_parl_party_number = 2 }
-	add_to_array = { global.EU_parl_party_number = 3 }
-	add_to_array = { global.EU_parl_party_number = 4 }
-	add_to_array = { global.EU_parl_party_number = 5 }
-	add_to_array = { global.EU_parl_party_number = 6 }
-	add_to_array = { global.EU_parl_party_number = 7 }
-	add_to_array = { global.EU_parl_party_number = 8 }
-	add_to_array = { global.EU_parl_party_number = 9 }
-	add_to_array = { global.EU_parl_party_number = 10 }
-	add_to_array = { global.EU_parl_party_number = 11 }
-	add_to_array = { global.EU_parl_party_number = 12 }
-	add_to_array = { global.EU_parl_party_number = 13 }
-	add_to_array = { global.EU_parl_party_number = 14 }
-	add_to_array = { global.EU_parl_party_number = 15 }
-	add_to_array = { global.EU_parl_party_number = 16 }
-	add_to_array = { global.EU_parl_party_number = 17 }
-	add_to_array = { global.EU_parl_party_number = 18 }
-	add_to_array = { global.EU_parl_party_number = 19 }
-	add_to_array = { global.EU_parl_party_number = 20 }
-	add_to_array = { global.EU_parl_party_number = 21 }
-	add_to_array = { global.EU_parl_party_number = 22 }
-	add_to_array = { global.EU_parl_party_number = 23 }
-
-	clear_array = global.MEP_PG_party_array
-	resize_array = { global.MEP_PG_party_array = 24 }
-	clear_array = global.MEP_Ratio_PG_array
-	resize_array = { global.MEP_Ratio_PG_array = 24 }
-	clear_array = global.PG_party_support_array
-	resize_array = { global.PG_party_support_array = 24 }
-	clear_array = global.EU_draft_party_array
-	resize_array = { global.EU_draft_party_array = 24 }
 
 	update_eu_dirty_variable = yes
 }


### PR DESCRIPTION
Resolves #2748.

### Problem
In `common/on_actions/00_on_actions.txt`, `on_startup_euu_action` is called on `on_startup`. In HOI4, `on_startup` fires both at campaign start and every time a save game is loaded.
Because `on_startup_euu_action` in `common/scripted_effects/99_eu_scripted_effects.txt` lacked an initialization guard, re-loading a save file re-ran EU setup, resetting all EU office holder variables (`global.eucouncil`, `global.eu_commission`, `global.eucentralbank`, etc.) back to `EUU.id`, duplicating EU law/member arrays, and resetting Europeanism values. This caused the UI to show the player/EUU holding all offices simultaneously and triggered a crash on the daily budget tick.

### Fix
1. Wrapped EU initialization in `99_eu_scripted_effects.txt` with `NOT = { has_global_flag = EU_initialized }` and `set_global_flag = EU_initialized`.
2. Added initialization guards to `on_startup_satellites` and `on_startup_international` to prevent array duplication and variable resets on save load.

### Verification
Verified in-game by assigning EU offices and reloading save games. Office holders, laws, and arrays remain intact and stable across save reloads.