### PR TITLE
Changed energy.8.a text from "Thank You" to "They Will Regret This"

### DIFF
--- a/localisation/english/0_energy_l_english.yml
+++ b/localisation/english/0_energy_l_english.yml
@@ -220,7 +220,7 @@
 
  energy.8.t: "[FROM.GetNameWithFlag] Ignored Our Demands"
  energy.8.d: "They have told us to eat pressure."
- energy.8.a: "Thank you"
+ energy.8.a: "They Will Regret This"
 
  energy.9.t: "[FROM.GetNameWithFlag] Allowed the Construction"
  energy.9.d: "They have allowed us and are sponsoring our construction. We should not be stopped by any other power."


### PR DESCRIPTION
energy.8.a is the event  a nation receives when another nation ignores the aforementioned nation's demand to stop enrichment facility construction. The response box text was "Thank You", which makes little sense. Changed to "They Will Regret This" to be more relevant to the situation.

