### PR TITLE
ai_strategy initial pass

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,0 @@
-preliminary testing shows ai not really building mils in some cases, not building rail terminals, other weird stuff
-make ai build at least some mils
-check usage of build_building (weight based) and building_target (abs value) through existing code
-fix network building conditions
-add rail terminal building
-add building toward faction goals: infra, mils, network

--- a/TODO
+++ b/TODO
@@ -1,0 +1,6 @@
+preliminary testing shows ai not really building mils in some cases, not building rail terminals, other weird stuff
+make ai build at least some mils
+check usage of build_building (weight based) and building_target (abs value) through existing code
+fix network building conditions
+add rail terminal building
+add building toward faction goals: infra, mils, network

--- a/common/ai_strategy/MD_econ_ai.txt
+++ b/common/ai_strategy/MD_econ_ai.txt
@@ -355,7 +355,7 @@ AI_military_factories_India = {
 	}
 	abort_when_not_enabled = yes
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = arms_factory
 		value = 15
 	}
@@ -371,7 +371,7 @@ AI_military_factories_China = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = arms_factory
 		value = 4
 	}
@@ -387,7 +387,7 @@ AI_military_factories_China2 = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = arms_factory
 		value = 2
 	}
@@ -457,7 +457,7 @@ AI_generic_office_construction = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = offices
 		value = 1
 	}
@@ -486,7 +486,7 @@ AI_generic_office_construction_sup = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = offices
 		value = 10
 	}
@@ -501,7 +501,7 @@ AI_generic_office_construction1_SOV = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = offices
 		value = 1
 	}
@@ -516,7 +516,7 @@ AI_generic_office_construction2_SOV = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = offices
 		value = 3
 	}
@@ -530,7 +530,7 @@ AI_generic_office_construction3_SOV = {
 	}
 	abort_when_not_enabled = yes
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = offices
 		value = 10
 	}
@@ -646,7 +646,7 @@ AI_fuel_power_plant_focuses = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = fossil_powerplant
 		value = 200
 	}
@@ -691,7 +691,7 @@ AI_build_nuclear_reactors_2 = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = nuclear_reactor
 		value = 15
 	}
@@ -705,7 +705,7 @@ AI_build_renewable_energy_infrastructure = {
 	abort_when_not_enabled = yes
 
 	ai_strategy = {
-		type = building_target
+		type = build_building
 		id = renewable_energy_infra
 		value = 20
 	}
@@ -717,16 +717,16 @@ AI_stop_building_civilian_industry = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = industrial_complex value = -50 }
-	ai_strategy = { type = building_target id = arms_factory value = -50 }
-	ai_strategy = { type = building_target id = dockyard value = -50 }
-	ai_strategy = { type = building_target id = agriculture_district value = -50 }
-	ai_strategy = { type = building_target id = microchip_plant value = -50 }
-	ai_strategy = { type = building_target id = composite_plant value = -50 }
+	ai_strategy = { type = build_building id = industrial_complex value = -50 }
+	ai_strategy = { type = build_building id = arms_factory value = -50 }
+	ai_strategy = { type = build_building id = dockyard value = -50 }
+	ai_strategy = { type = build_building id = agriculture_district value = -50 }
+	ai_strategy = { type = build_building id = microchip_plant value = -50 }
+	ai_strategy = { type = build_building id = composite_plant value = -50 }
 
 	# Create Other Infrastructure While Low unemployment
-	ai_strategy = { type = building_target id = internet_station value = 25 }
-	ai_strategy = { type = building_target id = infrastructure value = 25 }
+	ai_strategy = { type = build_building id = internet_station value = 25 }
+	ai_strategy = { type = build_building id = infrastructure value = 25 }
 }
 
 AI_reduce_construction_on_deficit = {
@@ -737,10 +737,10 @@ AI_reduce_construction_on_deficit = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = industrial_complex value = -20 }
-	ai_strategy = { type = building_target id = arms_factory value = -20 }
-	ai_strategy = { type = building_target id = dockyard value = -20 }
-	ai_strategy = { type = building_target id = offices value = -10 }
+	ai_strategy = { type = build_building id = industrial_complex value = -20 }
+	ai_strategy = { type = build_building id = arms_factory value = -20 }
+	ai_strategy = { type = build_building id = dockyard value = -20 }
+	ai_strategy = { type = build_building id = offices value = -10 }
 }
 
 AI_halt_construction_major_crisis = {
@@ -750,12 +750,12 @@ AI_halt_construction_major_crisis = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = industrial_complex value = -50 }
-	ai_strategy = { type = building_target id = arms_factory value = -50 }
-	ai_strategy = { type = building_target id = dockyard value = -50 }
-	ai_strategy = { type = building_target id = offices value = -50 }
-	ai_strategy = { type = building_target id = microchip_plant value = -50 }
-	ai_strategy = { type = building_target id = composite_plant value = -50 }
+	ai_strategy = { type = build_building id = industrial_complex value = -50 }
+	ai_strategy = { type = build_building id = arms_factory value = -50 }
+	ai_strategy = { type = build_building id = dockyard value = -50 }
+	ai_strategy = { type = build_building id = offices value = -50 }
+	ai_strategy = { type = build_building id = microchip_plant value = -50 }
+	ai_strategy = { type = build_building id = composite_plant value = -50 }
 }
 
 AI_accelerate_construction_on_surplus = {
@@ -767,8 +767,8 @@ AI_accelerate_construction_on_surplus = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = industrial_complex value = 10 }
-	ai_strategy = { type = building_target id = offices value = 5 }
+	#ai_strategy = { type = build_building id = industrial_complex value = 10 }
+	ai_strategy = { type = build_building id = offices value = 5 }
 }
 
 AI_build_agricultural_districts = {
@@ -778,7 +778,7 @@ AI_build_agricultural_districts = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = agriculture_district value = 50 }
+	ai_strategy = { type = build_building id = agriculture_district value = 50 }
 }
 
 AI_no_military_industry = {
@@ -789,87 +789,36 @@ AI_no_military_industry = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = arms_factory value = -50 }
+	ai_strategy = { type = build_building id = arms_factory value = -50 }
 }
 
-AI_internet_station_level_one = {
+AI_internet_station = {
 	enable = {
-		has_tech = internet2
 		any_owned_state = {
 			free_building_slots = {
 				building = internet_station
-				size < 2
+				size > 0
 			}
 		}
 	}
 	abort_when_not_enabled = yes
 
 	# Good for Keeping Productivity Up
-	ai_strategy = { type = building_target id = internet_station value = 100 }
+	ai_strategy = { type = build_building id = internet_station value = 20 }
 }
 
-AI_internet_station_level_two = {
+AI_rail_terminal = {
 	enable = {
-		has_tech = internet3
 		any_owned_state = {
 			free_building_slots = {
-				building = internet_station
-				size < 3
+				building = rail_terminal
+				size > 0
 			}
 		}
 	}
 	abort_when_not_enabled = yes
 
-	# Good for Keeping Productivity Up
-	ai_strategy = { type = building_target id = internet_station value = 100 }
-}
-
-AI_internet_station_level_three = {
-	enable = {
-		has_tech = internet4
-		any_owned_state = {
-			free_building_slots = {
-				building = internet_station
-				size < 4
-			}
-		}
-	}
-	abort_when_not_enabled = yes
-
-	# Good for Keeping Productivity Up
-	ai_strategy = { type = building_target id = internet_station value = 100 }
-}
-
-AI_internet_station_level_four = {
-	enable = {
-		has_tech = internet5
-		any_owned_state = {
-			free_building_slots = {
-				building = internet_station
-				size < 5
-			}
-		}
-	}
-	abort_when_not_enabled = yes
-
-	# Good for Keeping Productivity Up
-	ai_strategy = { type = building_target id = internet_station value = 100 }
-}
-
-AI_internet_station_level_five = {
-	enable = {
-		has_tech = internet6
-		any_owned_state = {
-			free_building_slots = {
-				building = internet_station
-				size < 6
-			}
-		}
-	}
-	abort_when_not_enabled = yes
-
-	# Good for Keeping Productivity Up
-	ai_strategy = { type = building_target id = internet_station value = 100 }
+	ai_strategy = { type = build_building id = rail_terminal value = 20 }
 }
 
 #Microchip & Composite AI
@@ -895,8 +844,8 @@ default_build_chip_and_composite = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = build_building id = microchip_plant value = 25 }
-	ai_strategy = { type = build_building id = composite_plant value = 25 }
+	ai_strategy = { type = build_building id = microchip_plant value = 15 }
+	ai_strategy = { type = build_building id = composite_plant value = 15 }
 }
 
 want_chip_factories = {
@@ -913,7 +862,6 @@ want_chip_factories = {
 	}
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = microchip_plant value = 100 }
 	ai_strategy = { type = build_building id = microchip_plant value = 50 }
 }
 
@@ -934,7 +882,6 @@ want_comp_factories = {
 
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = composite_plant value = 50 }
 	ai_strategy = { type = build_building id = composite_plant value = 25 }
 }
 
@@ -949,6 +896,5 @@ want_enrichment_facilities = {
 
 	abort_when_not_enabled = yes
 
-	ai_strategy = { type = building_target id = enrichment_facility value = 25 }
 	ai_strategy = { type = build_building id = enrichment_facility value = 25 }
 }

--- a/common/ai_strategy/MD_econ_ai.txt
+++ b/common/ai_strategy/MD_econ_ai.txt
@@ -212,7 +212,7 @@ minor_military_factories = {
 	ai_strategy = {
 		type = building_target
 		id = arms_factory
-		value = 2
+		value = 8
 	}
 }
 
@@ -297,7 +297,7 @@ AI_major_military_factories = {
 	ai_strategy = {
 		type = building_target
 		id = arms_factory
-		value = 20
+		value = 35
 	}
 }
 
@@ -322,7 +322,7 @@ AI_major_military_factories2 = {
 	ai_strategy = {
 		type = building_target
 		id = arms_factory
-		value = 7
+		value = 8
 	}
 }
 
@@ -341,7 +341,7 @@ AI_military_factories_Russia = {
 	ai_strategy = {
 		type = building_target
 		id = arms_factory
-		value = 20
+		value = 35
 	}
 }
 

--- a/common/ai_strategy/faction_ai.txt
+++ b/common/ai_strategy/faction_ai.txt
@@ -29,9 +29,6 @@ AI_faction_goal_technology_sharing = {
 	ai_strategy = {
 		type = build_building
 		id = internet_station
-		value = 1
+		value = 25
 	}
 }
-
-#short term
-

--- a/common/ai_strategy/faction_ai.txt
+++ b/common/ai_strategy/faction_ai.txt
@@ -1,0 +1,37 @@
+#generic goals
+
+AI_faction_goal_economic_integration = {
+	enable = {
+		has_faction_goal = faction_goal_economic_integration
+		num_of_available_civilian_factories < 15
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 15
+	}
+}
+
+AI_faction_goal_technology_sharing = {
+	enable = {
+		has_faction_goal = faction_goal_technology_sharing
+		any_owned_state = {
+			free_building_slots = {
+				building = internet_station
+				size > 0
+			}
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = build_building
+		id = internet_station
+		value = 1
+	}
+}
+
+#short term
+


### PR DESCRIPTION
add ai building towards faction goals (for now civs and network)
add ai building rail terminals
simplify ai building network infra
fix building_target (abs value) vs build_building (weighted) usage
fix some building_target not reaching enable thresholds for strategy
closes #2732
