### PR TITLE
Reformat and sort 00_yearly_effects.txt

### DIFF
--- a/common/scripted_effects/00_yearly_effects.txt
+++ b/common/scripted_effects/00_yearly_effects.txt
@@ -1,55 +1,106 @@
 # Author(s): AngriestBird
 MD_event_on_startup_events = {
+	if = { limit = { has_game_rule = { rule = rule_god_of_war option = yes } } every_country = { limit = { is_ai = no } country_event = { id = god_of_war_event.1 days = 1 } } }
+	if = { limit = { has_game_rule = { rule = allow_enable_world_war option = yes } } every_country = { limit = { is_ai = no } country_event = { id = world_war.1 days = 1 } } }
+	if = { limit = { SNA = { is_ai = no } } SNA = { country_event = { id = somalia.1 days = 90 random_days = 60 } } }
+	if = { limit = { SOM = { is_ai = no } } SOM = { country_event = { id = somalia.1 days = 90 random_days = 60 } } }
 	if = {
 		limit = {
-			has_game_rule = {
-				rule = rule_god_of_war
-				option = yes
-			}
+			SNA = { is_ai = yes }
+			SOM = { is_ai = yes }
 		}
-
-		every_country = {
-			limit = { is_ai = no }
-			country_event = { id = god_of_war_event.1 days = 1 }
-		}
+		SNA = { country_event = { id = somalia.1 days = 90 random_days = 60 } }
 	}
-
-	if = {
-		limit = {
-			has_game_rule = {
-				rule = allow_enable_world_war
-				option = yes
-			}
-		}
-
-		every_country = {
-			limit = { is_ai = no }
-			country_event = { id = world_war.1 days = 1 }
-		}
+	AFG = {
+		news_event = { id = AfghanistanNews.11 days = 30 random_days = 15 }
+		news_event = { id = AfghanistanNews.13 days = 90 random_days = 30 }
+		news_event = { id = AfghanistanNews.14 days = 105 random_days = 36 }
 	}
-	# Events with known dates that should fire with the 2000 start date.
-	CAM = {
-		country_event = { id = Cameroon.1 days = 50 random_days = 50 }
+	ALG = {
+		country_event = algeria_intro.1
+		country_event = { id = ALG_terror.1000 days = 365 }
 	}
-	SLV = {
-		country_event = { id = slovenia.0 days = 1 } # Subideology party catch-up for mid-game starts
-		country_event = { id = slovenia.7 days = 186 } # Youth Party of Slovenia founded (Jul 2000)
+	BOS = { country_event = { id = BOS_political.8 days = 270 random_days = 60 } }
+	BOT = { country_event = { id = Botswana_pulse.8 days = 240 random_days = 60 } }
+	BRA = { country_event = { id = brazil_flavour_events.8 days = 30 random_days = 45 } }
+	CAM = { country_event = { id = Cameroon.1 days = 50 random_days = 50 } }
+	CAN = { country_event = { id = canada.100 days = 3 } }
+	CAR = { country_event = { id = central_africa.2 days = 274 random_days = 10 } }
+	CDI = { country_event = { id = ivory_coast_md.1 days = 190 random_days = 20 } }
+	CZE = {
+		country_event = { id = CZE_scripted_event.1 days = 266 random_days = 4 }
+		country_event = { id = CZE_TV_Crisis.01 days = 359 random_days = 7 }
+	}
+	DEN = {
+		country_event = { id = denmark.22 days = 181 random_days = 5 }
+		country_event = { id = denmark.1 days = 150 random_days = 30 random_hours = 24 }
+	}
+	ECU = {
+		country_event = { id = ecuador.1 days = 9 hours = 6 }
+		country_event = { id = ecuador.2 days = 21 hours = 6 }
+		country_event = { id = ecuador.3 days = 21 hours = 9 }
+	}
+	ENG = {
+		country_event = britain_md.25
+		country_event = { id = british_flavor.1 days = 3 }
+		country_event = { id = british_flavor.2 days = 25 }
+		country_event = { id = british_flavor.3 days = 15 }
+		country_event = { id = british_flavor.4 days = 31 random_days = 28 }
+		country_event = { id = british_flavor.5 days = 31 random_days = 28 }
+		country_event = { id = british_flavor.6 days = 58 random_days = 31 }
+		country_event = { id = british_flavor.7 days = 58 random_days = 31 }
+		country_event = { id = british_flavor.8 days = 99 random_days = 31 }
+		country_event = { id = british_flavor.9 days = 130 random_days = 31 }
+		country_event = { id = british_flavor.10 days = 160 random_days = 31 }
+		country_event = { id = british_flavor.11 days = 160 random_days = 31 }
+		country_event = { id = british_flavor.12 days = 191 random_days = 31 }
+		country_event = { id = british_flavor.13 days = 191 random_days = 31 }
+		country_event = { id = british_flavor.14 days = 218 random_days = 31 }
+		country_event = { id = british_flavor.15 days = 249 random_days = 31 }
+		country_event = { id = british_flavor.16 days = 249 random_days = 31 }
+		country_event = { id = british_flavor.17 days = 249 random_days = 31 }
+		country_event = { id = british_flavor.18 days = 280 random_days = 31 }
+	}
+	EST = {
+		country_event = { id = estonia.12 days = 54 }
+		country_event = { id = estonia.100 days = 120 random_days = 60 }
+	}
+	FIJ = { country_event = { id = fiji_news.1 days = 138 } }
+	FRA = { country_event = { id = france_md.504 days = 90 random_days = 14 } }
+	GER = {
+		country_event = { id = germany.369 days = 3 }
+		country_event = { id = germany_yearly.29 days = 1 }
+		news_event = { id = GER_news.03 days = 176 random_days = 28 }
+		news_event = { id = GER_news.07 days = 189 random_days = 5 }
+	}
+	GRE = { if = { limit = { country_exists = GER } country_event = { id = germany.512 days = 200 } } }
+	HAI = {
+		country_event = { id = haiti.1 days = 123 }
+		country_event = { id = haiti.4 days = 330 }
 	}
 	HKG = {
-		country_event = { id = hongkong.11 days = 59 }                     # PCCW wins the HKT bidding (Feb 2000)
-		news_event = { id = hongkong_news.4 days = 150 random_days = 60 }  # 123 Democratic Alliance disbands
-		country_event = { id = hongkong_legco.1 days = 253 }               # 2000 LegCo election (Sep 2000)
+		country_event = { id = hongkong.11 days = 59 }
+		news_event = { id = hongkong_news.4 days = 150 random_days = 60 }
+		country_event = { id = hongkong_legco.1 days = 253 }
 	}
-	PHI = {
-		if = { limit = { date > 2016.6.30 } country_event = { id = philippines.1 days = 1 } } # Federals catch-up for mid-game starts
+	HOL = { country_event = { id = HOL_common_event.10 days = 134 random_days = 7 } }
+	IRQ = { country_event = { id = iraq_yearly.1 days = 1 random_days = 360 } }
+	JAP = {
+		country_event = { id = japan_classic.15 days = 91 }
+		country_event = { id = japan_classic.18 days = 134 }
+		country_event = { id = JAP_historical.121006001 days = 279 }
 	}
-	MOR = {
-		if = { limit = { date > 2016.6.1 } country_event = { id = morocco.401 days = 1 } } # CUN catch-up for mid-game starts
+	KOR = { country_event = { id = korea.19 days = 72 } }
+	LBA = { country_event = { id = LibyaRandomEvents.1 days = 120 random_days = 90 } }
+	MOR = { if = { limit = { date > 2016.6.1 } country_event = { id = morocco.401 days = 1 } } }
+	NIG = {
+		country_event = { id = nigeria_md.100 days = 3 random_days = 30 }
+		country_event = { id = nigeria_md.101 days = 120 random_days = 60 }
 	}
-	IRQ = {
-		country_event = { id = iraq_yearly.1 days = 1 random_days = 360 }
-	}
+	NRY = { country_event = { id = norway.1 days = 3 random_days = 7 } }
 	PER = {
+		set_country_flag = PER_mek_insurgency_active
+		set_variable = { PER_mek_strength = 15 }
 		country_event = { id = iranian_focus.178 days = 1 random_days = 360 }
 		country_event = { id = iranian_focus.179 days = 90 }
 		country_event = { id = iranian_focus.180 days = 12 }
@@ -57,65 +108,16 @@ MD_event_on_startup_events = {
 		country_event = { id = iranian_focus.182 days = 66 }
 		country_event = { id = iranian_focus.191 days = 120 }
 		country_event = { id = iranian_events.300 days = 200 }
-
+		country_event = iranian_events.900
 	}
-	GER = {
-		country_event = { id = germany.369 days = 3 } # Information Event
-		country_event = { id = germany_yearly.29 days = 1 } # Welcome
-		news_event = { id = GER_news.03 days = 176 random_days = 28 } # concord goes down
-		news_event = { id = GER_news.07 days = 189 random_days = 5 }
-	}
-	GRE = {
-		if = {
-			limit = { country_exists = GER }
-			# Greek submarine programme turns to the German yards
-			country_event = { id = germany.512 days = 200 }
-		}
-	}
-	NRY = {
-		country_event = { id = norway.1 days = 3 random_days = 7 }
-	}
-	ECU = {
-		country_event = { id = ecuador.1 days = 9 hours = 6 }
-		country_event = { id = ecuador.2 days = 21 hours = 6 }
-		country_event = { id = ecuador.3 days = 21 hours = 9 }
-	}
-	SOL = {
-		country_event = { id = Solomon_Islands.1 days = 1 random_days = 230 }
-		country_event = { id = Solomon_Islands.2 days = 200 random_days = 110 }
-	}
-	ENG = {
-		country_event = britain_md.25 # Information Event
-
-		# Flavor Events
-		# January
-		country_event = { id = british_flavor.1 days = 3 }
-		country_event = { id = british_flavor.2 days = 25 }
-		country_event = { id = british_flavor.3 days = 15 }
-		# February
-		country_event = { id = british_flavor.4 days = 31 random_days = 28 }
-		country_event = { id = british_flavor.5 days = 31 random_days = 28 }
-		# March
-		country_event = { id = british_flavor.6 days = 58 random_days = 31 }
-		country_event = { id = british_flavor.7 days = 58 random_days = 31 }
-		# April
-		country_event = { id = british_flavor.8 days = 99 random_days = 31 }
-		# May
-		country_event = { id = british_flavor.9 days = 130 random_days = 31 }
-		# June
-		country_event = { id = british_flavor.10 days = 160 random_days = 31 }
-		country_event = { id = british_flavor.11 days = 160 random_days = 31 }
-		# July
-		country_event = { id = british_flavor.12 days = 191 random_days = 31 }
-		country_event = { id = british_flavor.13 days = 191 random_days = 31 }
-		# August
-		country_event = { id = british_flavor.14 days = 218 random_days = 31 }
-		# September
-		country_event = { id = british_flavor.15 days = 249 random_days = 31 }
-		country_event = { id = british_flavor.16 days = 249 random_days = 31 }
-		country_event = { id = british_flavor.17 days = 249 random_days = 31 }
-		# October
-		country_event = { id = british_flavor.18 days = 280 random_days = 31 }
+	PHI = { if = { limit = { date > 2016.6.30 } country_event = { id = philippines.1 days = 1 } } }
+	PMR = { country_event = { id = transnistria.43 days = 1 } }
+	POL = { country_event = { id = poland.9 days = 240 random_days = 30 } }
+	RAJ = {
+		country_event = { id = indian_event.41 days = 59 random_days = 1 }
+		country_event = { id = indian_event.42 days = 141 random_days = 1 }
+		country_event = { id = indian_event.43 days = 120 random_days = 30 }
+		country_event = { id = indian_event.44 days = 132 random_days = 2 }
 	}
 	ROM = {
 		country_event = { id = romania_politics.1 days = 100 random_days = 30 }
@@ -124,30 +126,38 @@ MD_event_on_startup_events = {
 		country_event = { id = romania_misc.2 days = 39 }
 		country_event = { id = romania_misc.3 days = 254 }
 	}
-	POL = {
-		country_event = { id = poland.9 days = 240 random_days = 30 }
+	SEN = {
+		country_event = { id = senegal_md.1 days = 45 random_days = 30 }
+		country_event = { id = senegal_md.7 days = 18 }
+	}
+	SER = { country_event = { id = Serbia.1 days = 14 } }
+	SIA = { if = { limit = { date < 2001.1.1 } country_event = { id = thailand.215 days = 2 } } }
+	SIN = { country_event = { id = singapore.101 days = 180 random_days = 90 } }
+	SLV = {
+		country_event = { id = slovenia.0 days = 1 }
+		country_event = { id = slovenia.7 days = 186 }
+	}
+	SOL = {
+		country_event = { id = Solomon_Islands.1 days = 1 random_days = 230 }
+		country_event = { id = Solomon_Islands.2 days = 200 random_days = 110 }
 	}
 	SOV = {
-		# Kursk Submarine Disaster
 		country_event = { id = russia.1 days = 144 random_days = 86 }
 		country_event = { id = russia.611 days = 50 }
-		# Canonization of the Romanov Family
 		country_event = { id = russia.119 days = 160 random_days = 50 }
 	}
-	PER = {
-		country_event = iranian_events.900 # Information Event
+	SPR = {
+		country_event = { id = spain.501 days = 30 random_days = 10 }
+		country_event = { id = spain.213 days = 130 random_days = 70 }
 	}
-	PMR = {
-		country_event = { id = transnistria.43 days = 1 } # Information Event
+	SWE = { country_event = { id = Sweden_Forsvarsbeslutet.10 days = 5 } }
+	SYR = {
+		if = { limit = { has_game_rule = { rule = historic_events option = yes } } country_event = { id = SyriaFocus.39 days = 150 random_days = 30 } }
+		else = { country_event = { id = SyriaFocus.39 days = 150 random_days = 365 } }
 	}
-	AFG = {
-		news_event = { id = AfghanistanNews.11 days = 30 random_days = 15 }
-		news_event = { id = AfghanistanNews.13 days = 90 random_days = 30 }
-		news_event = { id = AfghanistanNews.14 days = 105 random_days = 36 }
-	}
-	TUR = {
-		country_event = { id = Turkey.5 days = 120 }
-	}
+	TAI = { country_event = { id = taiwan.2 days = 240 random_days = 25 random_hours = 24 } }
+	TAJ = { country_event = { id = tajik_lore.0 days = 120 } }
+	TUR = { country_event = { id = Turkey.5 days = 120 } }
 	USA = {
 		country_event = { id = usa.1000 days = 120 random_days = 25 random_hours = 20 }
 		country_event = { id = usa.2 days = 270 random_days = 30 random_hours = 20 }
@@ -163,177 +173,70 @@ MD_event_on_startup_events = {
 		country_event = { id = usa.35 days = 130 random_days = 135 }
 		country_event = { id = usa.36 days = 219 random_days = 8 }
 		country_event = { id = usa.53 days = 3 random_hours = 2 }
-		country_event = { id = shuttlelaunch.1 days = 41 } #First shuttle launch of 2000
-		country_event = { id = USA_treason_event.1 days = 286 } #Choose to commit Election Fraud
-
-		# Economic Events
-		country_event = { id = USA_unrest_event.1 days = 30 random_days = 336 } #Grass Root Libertarian Movement
-		country_event = { id = USA_unrest_event.2 days = 61 random_days = 305 } #Grass Root Isolationist Parties
-
-		if = { limit = { has_game_rule = { rule = USA_ai_behavior option = GREAT_COLLAPSE } }
-			country_event = { id = USA_collapse_event.1 days = 2 random_days = 20 } #New Millennia New Crisis
-		}
+		country_event = { id = shuttlelaunch.1 days = 41 }
+		country_event = { id = USA_treason_event.1 days = 286 }
+		country_event = { id = USA_unrest_event.1 days = 30 random_days = 336 }
+		country_event = { id = USA_unrest_event.2 days = 61 random_days = 305 }
+		if = { limit = { has_game_rule = { rule = USA_ai_behavior option = GREAT_COLLAPSE } } country_event = { id = USA_collapse_event.1 days = 2 random_days = 20 } }
 	}
-	FIJ = {
-		country_event = { id = fiji_news.1 days = 138 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.41 days = 59 random_days = 1 } #Tata buys stuff
-		country_event = { id = indian_event.42 days = 141 random_days = 1 } #Clinton comes to india
-		country_event = { id = indian_event.43 days = 120 random_days = 30 } #Cricket match
-		country_event = { id = indian_event.44 days = 132 random_days = 2 } #Cricket match
-	}
-	KOR = {
-		country_event = { id = korea.19 days = 72 } #check if elections are allowed before starting national assembly event chain
-	}
-	DEN = {
-		# Øresundsbroen
-		country_event = { id = denmark.22 days = 181 random_days = 5 }
-		# Eurovision 2000
-		country_event = { id = denmark.1 days = 150 random_days = 30 random_hours = 24 }
-	}
-	CAN = {
-		# Air Canada acquires Canadian Airlines
-		country_event = { id = canada.100 days = 3 }
-	}
-	SPR = {
-		country_event = { id = spain.501 days = 30 random_days = 10 } # Give or take 10 Days
-		country_event = { id = spain.213 days = 130 random_days = 70 }
-	}
-	CDI = {
-		# 2000 Election Event
-		country_event = { id = ivory_coast_md.1 days = 190 random_days = 20 }
-	}
-	SEN = {
-		# 2000 Intro Election EVent
-		country_event = { id = senegal_md.1 days = 45 random_days = 30 }
-		country_event = { id = senegal_md.7 days = 18 }
-	}
-	SIN = {
-		# Singaporean Airline Flight
-		country_event = { id = singapore.101 days = 180 random_days = 90 }
-	}
-	BOT = {
-		country_event = { id = Botswana_pulse.8 days = 240 random_days = 60 } #Negro of Banyoles
-	}
-	LBA = {
-		country_event = { id = LibyaRandomEvents.1 days = 120 random_days = 90 } #Cabinet shuffle
-	}
-	EST = {
-		# Estonia's National Day
-		country_event = { id = estonia.12 days = 54 }
-		country_event = { id = estonia.100 days = 120 random_days = 60 }
-	}
-	VEN = {
-		country_event = { id = venezuela.100 days = 200 }
-	}
-	SER = {
-		# Arkan shot at the Hotel Continental (15 January 2000)
-		country_event = { id = Serbia.1 days = 14 }
-	}
-
-	# Accounts For Players in the SOM/SNA
-	if = { limit = { SNA = { is_ai = no } }
-		SNA = {
-			country_event = { id = somalia.1 days = 90 random_days = 60 }
-		}
-	}
-	if = { limit = { SOM = { is_ai = no } }
-		SOM = {
-			country_event = { id = somalia.1 days = 90 random_days = 60 }
-		}
-	}
+	VEN = { country_event = { id = venezuela.100 days = 200 } }
+}
+trigger_year_2001_events = {
 	if = {
 		limit = {
-			SNA = { is_ai = yes }
-			SOM = { is_ai = yes }
+			has_game_rule = { rule = rule_event_horizon_scenario option = BLITZ }
+			NOT = { has_global_flag = EH_scenario_launched_earlier_flag }
 		}
-		SNA = {
-			country_event = { id = somalia.1 days = 90 random_days = 60 }
-		}
+		random_country = { EH_convergence_event_chain_effect = yes }
 	}
-	HAI = {
-		# Local Elections
-		country_event = { id = haiti.1 days = 123 }
-		# 2000 Elections
-		country_event = { id = haiti.4 days = 330 }
-	}
-	FRA = {
-		# The McDonald's Bombing
-		country_event = { id = france_md.504 days = 90 random_days = 14 }
-	}
-	CAR = {
-		# The Status of Jean-Luc Mandaba
-		country_event = { id = central_africa.2 days = 274 random_days = 10 }
-	}
-	SYR = {
-		# Death of Hafez al-Assad
-		if = {
-			limit = {
-				has_game_rule = {
-					rule = historic_events
-					option = yes
-				}
-			}
-			country_event = { id = SyriaFocus.39 days = 150 random_days = 30 }
-		}
-		else = {
-			country_event = { id = SyriaFocus.39 days = 150 random_days = 365 }
-		}
-	}
+	AFG = { country_event = { id = Afghanistan.3 days = 195 random_days = 365 } }
+	ALG = { country_event = { id = ALG_black_spring.1 days = 134 } }
+	BOS = { country_event = { id = BOS_political.9 days = 330 random_days = 30 } }
+	BOT = { country_event = { id = Botswana_pulse.9 days = 55 random_days = 30 } }
 	BRA = {
-		country_event = { id = brazil_flavour_events.8 days = 30 random_days = 45 }
+		country_event = { id = brazil_flavour_events.1 days = 190 random_days = 15 }
+		country_event = { id = brazil_flavour_events.4 days = 253 random_days = 10 }
 	}
-	CZE = {
-		# Random Events
-		country_event = { id = CZE_scripted_event.1 days = 266 random_days = 4 } #Protests during the IMF meeting in Prague
-		country_event = { id = CZE_TV_Crisis.01 days = 359 random_days = 7 } #TV Crisis
+	CAR = { country_event = { id = central_africa.5 days = 120 random_days = 16 } }
+	CHI = { country_event = { id = CHI_political_events.6 days = 91 random_days = 7 } }
+	CRO = { country_event = { id = CRO_political.1 days = 141 } }
+	DRC = { if = { limit = { NOT = { is_in_array = { ruling_party = 18 } } } country_event = { id = DRC.0 days = 19 } } }
+	EST = {
+		news_event = { id = estonia.5 days = 150 }
+		country_event = { id = estonia.102 days = 45 }
+		country_event = { id = estonia.101 days = 200 random_days = 60 }
 	}
-	SWE = {
-		country_event = { id = Sweden_Forsvarsbeslutet.10 days = 5 }
+	FYR = {
+		country_event = { id = FYR_political.1 days = 46 }
+		country_event = { id = FYR_political.2 days = 224 }
 	}
-	NIG = {
-		# 2000 - Sharia Law is established as a legal system in Zamfara State
-		country_event = { id = nigeria_md.100 days = 3 random_days = 30 }
-		# 2000 - Religious Violence in Kaduna
-		country_event = { id = nigeria_md.101 days = 120 random_days = 60 }
+	GEO = { country_event = { id = geo_misc.100 days = 200 random_days = 95 } }
+	GER = {
+		country_event = { id = germany.1 days = 1 random_days = 300 }
+		country_event = { id = germany_yearly.30 days = 1 }
+		news_event = { id = GER_news.04 days = 70 random_days = 28 }
+		news_event = { id = GER_news.08 days = 176 random_days = 300 }
 	}
-	BOS = {
-		country_event = { id = BOS_political.8 days = 270 random_days = 60 }
-	}
-	HOL = {
-		country_event = { id = HOL_common_event.10 days = 134 random_days = 7 }
-	}
-	TAJ = {
-		country_event = { id = tajik_lore.0 days = 120 }
-	}
-	TAI = {
-		country_event = { id = taiwan.2 days = 240 random_days = 25 random_hours = 24 }
+	GRE = { country_event = { id = greece.500 days = 160 random_days = 30 } }
+	HAI = { country_event = { id = haiti.5 days = 120 random_days = 90 } }
+	IND = { country_event = { id = indonesia.69 days = 90 } }
+	IRQ = { country_event = { id = iraq_yearly.2 days = 1 random_days = 360 } }
+	ITA = {
+		country_event = { id = italy_md.60 days = 200 }
+		country_event = { id = italy_md.70 days = 1 random_days = 360 random_hours = 24 }
 	}
 	JAP = {
-		country_event = { id = japan_classic.15 days = 91 } #Keizo Obuchi suffers a stroke
-		country_event = { id = japan_classic.18 days = 134 } #Yoshirō Mori's Emperor gaffe
-		country_event = { id = JAP_historical.121006001 days = 279 } #2000 Tottori Earthquake
+		country_event = { id = JAP_historical.130210001 days = 39 }
+		country_event = { id = JAP_historical.130324001 days = 83 }
+		country_event = { id = JAP_historical.20010426 days = 115 }
+		country_event = { id = JAP_historical.9130901001 days = 244 }
+		country_event = { id = JAP_historical.131201001 days = 335 }
 	}
-	ALG = {
-		country_event = algeria_intro.1
-		country_event = { id = ALG_terror.1000 days = 365 }
-	}
-	SIA = {
-		if = { limit = { date < 2001.1.1 } country_event = { id = thailand.215 days = 2 } } # Information Event
-	}
-}
-
-# 2000s
-trigger_year_2001_events = {
-	SIA = {
-		# Shin Corp asset-concealment case (3 Aug 2001)
-		country_event = { id = thailand.74 days = 217 }
-	}
-	GRE = {
-		# Death of Stephen Saunders - June 2000
-		country_event = { id = greece.500 days = 160 random_days = 30 }
-	}
+	JUB = { country_event = { id = somalia.5 days = 170 random_days = 20 } }
+	KAZ = { if = { limit = { is_subject = no } country_event = { id = centralkaz.3 days = 348 } } }
+	KYR = { if = { limit = { has_game_rule = { rule = historic_events option = yes } } country_event = { id = centralkyr.3 days = 274 } } }
+	LBA = { country_event = { id = LibyaFamily.50 days = 147 } }
+	NIG = { country_event = { id = nigeria_md.117 days = 270 random_days = 25 } }
 	PER = {
 		country_event = { id = iranian_focus.164 days = 30 }
 		country_event = { id = iranian_focus.183 days = 55 }
@@ -341,47 +244,66 @@ trigger_year_2001_events = {
 		country_event = { id = iranian_focus.198 days = 155 }
 		country_event = { id = iranian_focus.199 days = 185 }
 		country_event = { id = iranian_focus.200 days = 210 }
-
-		# Flavor Events
 		country_event = { id = iranian_flavor.2 days = 35 random_days = 20 }
 		country_event = { id = iranian_flavor.1 days = 120 random_days = 30 }
+		country_event = { id = PER_election_events.2 days = 90 }
 	}
-	GER = {
-		country_event = { id = germany.1 days = 1 random_days = 300 } #NPD Investigation
-		country_event = { id = germany_yearly.30 days = 1 }
-		news_event = { id = GER_news.04 days = 70 random_days = 28 }
-		news_event = { id = GER_news.08 days = 176 random_days = 300 }
+	POL = { country_event = { id = poland.11 days = 200 random_days = 30 } }
+	RAJ = { country_event = { id = indian_event.45 days = 352 random_days = 1 } }
+	ROM = {
+		country_event = { id = romania_misc.4 days = 100 }
+		country_event = { id = romania_misc.5 days = 220 }
+		if = { limit = { NOT = { nationalist_right_wing_populists_are_in_power = yes } } country_event = { id = romania_misc.6 days = 300 } }
 	}
-	TAL = {
-		country_event = { id = iranian_focus.184 days = 264 }
+	SAO = { country_event = { id = Sao_Tome_e_Principe.1 days = 210 } }
+	SER = {
+		country_event = { id = Serbia.19 days = 90 }
+		country_event = { id = Serbia.28 days = 178 }
 	}
-	SAO = {
-		country_event = { id = Sao_Tome_e_Principe.1 days = 210 }
+	SIA = { country_event = { id = thailand.74 days = 217 } }
+	SIN = {
+		country_event = { id = singapore.102 days = 210 random_days = 45 }
+		country_event = { id = singapore.103 days = 120 random_days = 45 }
+		country_event = { id = singapore.10000 days = 120 random_days = 45 }
+	}
+	SMA = { country_event = { id = SMA.2 days = 60 random_days = 30 } }
+	SPR = { country_event = { id = spain.214 random_days = 360 random_hours = 24 } }
+	SWE = {
+		country_event = { id = Sweden.22 days = 73 random_days = 30 }
+		country_event = { id = Sweden.23 days = 134 random_days = 30 }
+		country_event = { id = Sweden.24 days = 334 random_days = 30 }
+	}
+	TAJ = {
+		country_event = { id = tajik_lore.3 days = 34 random_hours = 8 }
+		country_event = { id = tajik_lore.4 days = 39 random_hours = 8 }
+		country_event = { id = tajik_lore.5 days = 48 random_hours = 5 }
+		country_event = { id = tajik_lore.6 days = 54 random_hours = 10 }
+	}
+	TAL = { country_event = { id = iranian_focus.184 days = 264 } }
+	TUR = {
+		country_event = { id = TUR_flavor_event.1 days = 260 }
+		random = {
+			chance = 30
+			country_event = { id = Turkey.3 days = 185 }
+		}
 	}
 	USA = {
-		country_event = { id = usa.10 days = 1 random_days = 300 } #End of Peanuts
-		country_event = { id = usa.37 days = 74 random_days = 15 } #Mac OS X
-		country_event = { id = usa.39 days = 14 random_days = 4 } #Launch of Wikipedia
-		country_event = { id = usa.60 days = 30 random_days = 180 } #Death of Gus Hall
-		country_event = { id = USA_econ_event.19 days = 50 random_days = 61 } #Feb 20th, 2001
-		country_event = { id = USA_econ_event.18 days = 297 random_days = 61 } #Oct 23rd, 2001
+		country_event = { id = usa.10 days = 1 random_days = 300 }
+		country_event = { id = usa.37 days = 74 random_days = 15 }
+		country_event = { id = usa.39 days = 14 random_days = 4 }
+		country_event = { id = usa.60 days = 30 random_days = 180 }
+		country_event = { id = USA_econ_event.19 days = 50 random_days = 61 }
+		country_event = { id = USA_econ_event.18 days = 297 random_days = 61 }
 		country_event = { id = USA_econ_event.9 days = 62 }
 		country_event = { id = USA_econ_event.8 days = 31 random_days = 335 }
-		country_event = { id = USA_unrest_event.3 days = 1 random_days = 365 } #Grass Root Socialist Movements
-		country_event = { id = USA_unrest_event.4 days = 1 random_days = 365 } #Grass Root Nationalist Movements
-		country_event = { id = USA_econ_event.50 days = 1 random_days = 828 } #Mass Media Event
-		country_event = { id = usa.999 days = 20 } #Election (AI Only)
-		country_event = { id = usa.80 days = 1 random_days = 365 } # F-35 Program Event
-		country_event = { id = usa.94 days = 20 } # Ending eternal clinton
-
-		# 9/11 Event
+		country_event = { id = USA_unrest_event.3 days = 1 random_days = 365 }
+		country_event = { id = USA_unrest_event.4 days = 1 random_days = 365 }
+		country_event = { id = USA_econ_event.50 days = 1 random_days = 828 }
+		country_event = { id = usa.999 days = 20 }
+		country_event = { id = usa.80 days = 1 random_days = 365 }
+		country_event = { id = usa.94 days = 20 }
 		if = {
-			limit = {
-				has_game_rule = {
-					rule = historic_events
-					option = yes
-				}
-			}
+			limit = { has_game_rule = { rule = historic_events option = yes } }
 			country_event = { id = wot.0 days = 218 }
 			country_event = { id = wot.1 days = 243 random_days = 30 }
 		}
@@ -390,315 +312,9 @@ trigger_year_2001_events = {
 			country_event = { id = wot.1 days = 255 random_days = 366 }
 		}
 	}
-	KYR = {
-		if = {
-			limit = {
-				has_game_rule = {
-					rule = historic_events
-					option = yes
-				}
-			}
-			country_event = { id = centralkyr.3 days = 274 }
-		}
-	}
-	POL = {
-		country_event = { id = poland.11 days = 200 random_days = 30 }
-	}
-	IRQ = {
-		country_event = { id = iraq_yearly.2 days = 1 random_days = 360 }
-	}
-	KAZ = {
-		if = { limit = { is_subject = no }
-			country_event = { id = centralkaz.3 days = 348 }
-		}
-	}
-	DRC = {
-		if = { limit = { NOT = { is_in_array = { ruling_party = 18 } } }
-			country_event = { id = DRC.0 days = 19 }
-		}
-	}
-	SIN = {
-		# Singapore Embassies Attack Plot
-		country_event = { id = singapore.102 days = 210 random_days = 45 }
-		# Malaysian-Singporean Disputes
-		country_event = { id = singapore.103 days = 120 random_days = 45 }
-		# Tropical Storm Vamei
-		country_event = { id = singapore.10000 days = 120 random_days = 45 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.45 days = 352 random_days = 1 } #lakshar e taiba attack
-	}
-	ROM = {
-		country_event = { id = romania_misc.4 days = 100 }
-		country_event = { id = romania_misc.5 days = 220 }
-		if = {
-			limit = {
-				NOT = {
-					nationalist_right_wing_populists_are_in_power = yes
-				}
-			}
-			country_event = { id = romania_misc.6 days = 300 }
-		}
-	}
-	SPR = {
-		# ETA Car Bombing
-		country_event = { id = spain.214 random_days = 360 random_hours = 24 }
-	}
-	IND = {
-		# Kaslimantan
-		country_event = { id = indonesia.69 days = 90 }
-	}
-	SMA = {
-		# Constitytion
-		country_event = { id = SMA.2 days = 60 random_days = 30 }
-	}
-	EST = {
-		news_event = { id = estonia.5 days = 150 }
-		country_event = { id = estonia.102 days = 45 }
-		country_event = { id = estonia.101 days = 200 random_days = 60 }
-	}
-	TUR = {
-		# 2001 Economic Crash
-		country_event = { id = TUR_flavor_event.1 days = 260 }
-		random = {
-			chance = 30
-			country_event = { id = Turkey.3 days = 185 }
-		}
-	}
-	LBA = {
-		#Khamis Gaddafi turns 18
-		country_event = { id = LibyaFamily.50 days = 147 }
-	}
-	JUB = {
-		# The Formation of the Juba Valley Alliance
-		country_event = { id = somalia.5 days = 170 random_days = 20 }
-	}
-	HAI = {
-		# Student Protests Against Aristide
-		country_event = { id = haiti.5 days = 120 random_days = 90 }
-	}
-	CAR = {
-		# The May Coup
-		country_event = { id = central_africa.5 days = 120 random_days = 16 }
-	}
-	ITA = {
-		country_event = { id = italy_md.60 days = 200 }
-		# A Warrior King
-		country_event = { id = italy_md.70 days = 1 random_days = 360 random_hours = 24 }
-	}
-	BOT = {
-		# Execution of Mariette Bosch
-		country_event = { id = Botswana_pulse.9 days = 55 random_days = 30 }
-	}
-	JAP = {
-		country_event = { id = JAP_historical.130210001 days = 39 } # Ehime-Maru Disaster
-		country_event = { id = JAP_historical.130324001 days = 83 } #2001 Geiyo Earthquake
-		country_event = { id = JAP_historical.20010426 days = 115 } # Yoshirō Mori Resigns, Junichiro Koizumi Becomes Prime Minister
-		country_event = { id = JAP_historical.9130901001 days = 244 } #Kabukicho Building Fire
-		country_event = { id = JAP_historical.131201001 days = 335 } #The Birth of Princess Aiko
-	}
-	AFG = {
-		country_event = { id = Afghanistan.3 days = 195 random_days = 365 }
-	}
-	BRA = {
-		# Kidnapping of Patricia Abravenel
-		country_event = { id = brazil_flavour_events.1 days = 190 random_days = 15 }
-		# 2001 - Assassination of Antonio "Toninho" da Costa Santos
-		country_event = { id = brazil_flavour_events.4 days = 253 random_days = 10 }
-	}
-	SWE = {
-		country_event = { id = Sweden.22 days = 73 random_days = 30 }
-		country_event = { id = Sweden.23 days = 134 random_days = 30 }
-		country_event = { id = Sweden.24 days = 334 random_days = 30 }
-	}
-	NIG = {
-		# 2001 - The Zaki Biam Massacre
-		country_event = { id = nigeria_md.117 days = 270 random_days = 25 }
-	}
-	BOS = {
-		country_event = { id = BOS_political.9 days = 330 random_days = 30 }
-	}
-	CRO = {
-		# Gotovina indicted by the ICTY
-		country_event = { id = CRO_political.1 days = 141 }
-	}
-	SER = {
-		# Milosevic arrested (1 April 2001)
-		country_event = { id = Serbia.19 days = 90 }
-		# Milosevic extradited to The Hague (28 June 2001)
-		country_event = { id = Serbia.28 days = 178 }
-	}
-	FYR = {
-		# NLA seizes Tanusevci, clashes spread in the northwest (February 2001)
-		country_event = { id = FYR_political.1 days = 46 }
-		# Ohrid Framework Agreement (13 August 2001)
-		country_event = { id = FYR_political.2 days = 224 }
-	}
-	GEO = {
-		# Lia Radiological Accident
-		country_event = { id = geo_misc.100 days = 200 random_days = 95 }
-	}
-	TAJ = {
-		country_event = { id = tajik_lore.3 days = 34 random_hours = 8 }
-		country_event = { id = tajik_lore.4 days = 39 random_hours = 8 }
-		country_event = { id = tajik_lore.5 days = 48 random_hours = 5 }
-		country_event = { id = tajik_lore.6 days = 54 random_hours = 10 }
-	}
-	UZB = {
-		country_event = { id = tajik_lore.8 days = 55 random_hours = 10 }
-	}
-	PER = {
-		# 2001 Election Notification
-		country_event = { id = PER_election_events.2 days = 90 }
-	}
-	ALG = {
-		country_event = { id = ALG_black_spring.1 days = 134 }
-	}
-	CHI = {
-		country_event = { id = CHI_political_events.6 days = 91 random_days = 7 }
-	}
-
-	# Event Horizon Blitz Mode
-	if = {
-		limit = {
-			has_game_rule = {
-				rule = rule_event_horizon_scenario
-				option = BLITZ
-			}
-			NOT = { has_global_flag = EH_scenario_launched_earlier_flag }
-		}
-		random_country = { EH_convergence_event_chain_effect = yes }
-	}
+	UZB = { country_event = { id = tajik_lore.8 days = 55 random_hours = 10 } }
 }
 trigger_year_2002_events = {
-	PER = {
-		country_event = { id = iranian_focus.163 days = 1 random_days = 300 }
-		country_event = { id = iranian_flavor.3 days = 70 random_days = 60 }
-	}
-	ARM = {
-		country_event = { id = arme.192 days = 20 random_days = 320 }
-	}
-	GER = {
-		country_event = { id = germany_yearly.31 days = 1 }
-		country_event = { id = germany_yearly.1 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.2 days = 1 random_days = 360 }
-		news_event = { id = GER_news.05 days = 36 random_days = 10 }
-		news_event = { id = GER_news.06 days = 176 random_days = 28 }
-		news_event = { id = GER_news.09 days = 30 random_days = 300 }
-	}
-	USA = {
-		country_event = { id = USA_econ_event.20 days = 92 random_days = 61 } #Apr 1st, 2002
-		country_event = { id = USA_econ_event.21 days = 253 random_days = 61 } #Sep 9th, 2002
-		country_event = { id = USA_unrest_event.5 days = 2 random_days = 365 } #Grass Root Green Party Movements
-		country_event = { id = USA_unrest_event.6 days = 2 random_days = 365 } #Plutocratic Liberals Worry Public
-
-	}
-	IRQ = {
-		country_event = { id = iraq_yearly.3 days = 1 random_days = 360 }
-	}
-	ROM = {
-		if = {
-			limit = {
-				western_social_democrats_are_in_power = yes
-			}
-			country_event = { id = romania_politics.3 days = 55 }
-		}
-		country_event = { id = romania_misc.7 days = 136 }
-	}
-	CAN = {
-		#Softwood Lumber Dispute
-		country_event = { id = canada_md_politics.3 days = 114 random_days = 5 }
-	}
-	KYR = {
-		if = {
-			limit = {
-				has_country_leader = {
-					name = "Askar Akayev"
-					ruling_only = yes
-				}
-			}
-			country_event = { id = centralkyr.6 days = 74 }
-		}
-	}
-	SIN = {
-		# The Esplanade
-		country_event = { id = singapore.105 days = 180 random_days = 45 }
-	}
-	SOV = {
-		# Lebed
-		country_event = { id = russia.62 days = 180 random_days = 45 }
-		# Crashing of the Su-37
-		country_event = { id = russia.120 days = 330 random_days = 25 }
-	}
-	SPR = {
-		# Gibraltar 2002 Referendum
-		country_event = { id = spain.261 days = 90 random_days = 210 random_hours = 24 }
-		# Espana 2000 Forms
-		country_event = { id = spain.208 random_days = 180 random_hours = 24 }
-		# Spain Commits State Terrorism
-		country_event = { id = spain.243 days = 60 random_days = 90 random_hours = 24 }
-		# Banning Batasuna
-		country_event = { id = spain.215 random_days = 360 random_hours = 24 }
-	}
-	SWE = {
-		country_event = { id = Sweden.25 days = 56 random_days = 10 }
-		country_event = { id = Sweden.26 days = 212 random_days = 30 }
-	}
-	IND = {
-		# Timor Leste Referendum
-		country_event = { id = indonesia.2 days = 90 }
-		# Bali Attack
-		country_event = { id = indonesia.37 days = 292 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.18 days = 90 } #2002 Family
-	}
-	FRA = {
-		# Bombing in Lumio -- Could not find an exact date on this
-		country_event = { id = france_md.500 days = 30 random_days = 180 }
-	}
-	HAI = {
-		# Student Protest
-		country_event = { id = haiti.6 days = 30 random_days = 180 }
-	}
-	BOT = {
-		# Mosadi Seboko crowned
-		country_event = { id = Botswana_pulse.11 days = 30 random_days = 300 }
-	}
-	ISR = {
-		# Passover Massacre
-		country_event = { id = israel.67 days = 81 }
-	}
-	BRA = {
-		country_event = { id = brazil_flavour_events.5 days = 180 random_days = 20 }
-		# 2002 - Lula Wins the Presidential Election
-		country_event = { id = brazil.4 days = 300 }
-	}
-	CZE = {
-		# 2002 political rotation
-		country_event = { id = CZE_political_tree_event.1 days = 182 }
-		# 2002 masive floods
-		country_event = { id = CZE_czech.28 days = 247 random_days = 10 }
-	}
-	NIG = {
-		# 2002 - The Bakassi Peninsula
-		country_event = { id = nigeria_md.103 days = 220 random_days = 60 }
-		# 2002 - Religious Riots in Abuja over Miss World
-		country_event = { id = nigeria_md.102 days = 280 random_days = 60 }
-		# 2002 - Lagos Armoury Explosion
-		country_event = { id = nigeria_md.106 days = 1 random_days = 30 }
-	}
-	HOL = {
-		country_event = { id = HOL_politics.02 days = 70 random_days = 20 }
-		if = { limit = { NOT = { has_completed_focus = HOL_paars } }
-			country_event = { id = HOL_politics.72 days = 100 random_days = 30 }
-		}
-	}
-	UZB = {
-		country_event = { id = tajik_lore.9 days = 270 }
-	}
-
-	# Trigger the African Union formation event for Libya if it's a random country
 	random_country_with_original_tag = {
 		original_tag_to_check = LBA
 		country_event = { id = AfricanUnion.4 days = 170 random_days = 10 }
@@ -710,166 +326,81 @@ trigger_year_2002_events = {
 		country_event = { id = ALG_terror.1005 days = 215 }
 		country_event = { id = ALG_terror.1006 days = 354 }
 	}
-	KYR = {
-		if = {
-			limit = {
-				NOT = {
-					has_game_rule = {
-						rule = historic_events
-						option = yes
-					}
-				}
-			}
-			country_event = { id = centralkyr.3 days = 257 }
-		}
+	ARM = { country_event = { id = arme.192 days = 20 random_days = 320 } }
+	BOT = { country_event = { id = Botswana_pulse.11 days = 30 random_days = 300 } }
+	BRA = {
+		country_event = { id = brazil_flavour_events.5 days = 180 random_days = 20 }
+		country_event = { id = brazil.4 days = 300 }
 	}
-	USA = {
-		country_event = { id = spaceshuttle.1 days = 33 } #NASA funding event to avoid columbia disaster
+	CAN = { country_event = { id = canada_md_politics.3 days = 114 random_days = 5 } }
+	CZE = {
+		country_event = { id = CZE_political_tree_event.1 days = 182 }
+		country_event = { id = CZE_czech.28 days = 247 random_days = 10 }
 	}
-	SIA = {
-		# New Aspiration Party absorbed into Thai Rak Thai
-		SIA_merge_nap_into_trt = yes
-	}
-}
-trigger_year_2003_events = {
-	GRE = {
-		country_event = { id = greece.501 days = 60 random_days = 30 }
-		country_event = { id = greece.502 days = 120 random_days = 30 }
-	}
-	HKG = {
-		# Death of Leslie Cheung (1 April 2003)
-		news_event = { id = hongkong_news.6 days = 90 }
-		# WHO travel advisory over the SARS outbreak (2 April 2003)
-		news_event = { id = hongkong_news.5 days = 91 }
-		# Death of Anita Mui (30 December 2003)
-		news_event = { id = hongkong_news.7 days = 363 }
-	}
-	SER = {
-		country_event = { id = Serbia.14 days = 1 random_days = 350 }
-		# The State Union of Serbia and Montenegro (4 February 2003)
-		country_event = { id = Serbia.30 days = 34 }
-		# Djindjic assassination plot uncovered (chain lands 12 March 2003)
-		country_event = { id = Serbia.3 days = 60 }
-	}
+	FRA = { country_event = { id = france_md.500 days = 30 random_days = 180 } }
 	GER = {
-		country_event = { id = germany.26 days = 1 random_days = 360 } #Women can join Bundeswehr
-		country_event = { id = germany_yearly.32 days = 1 }
-		news_event = { id = GER_news.13 days = 289 } #hostages desert
+		country_event = { id = germany_yearly.31 days = 1 }
+		country_event = { id = germany_yearly.1 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.2 days = 1 random_days = 360 }
+		news_event = { id = GER_news.05 days = 36 random_days = 10 }
+		news_event = { id = GER_news.06 days = 176 random_days = 28 }
+		news_event = { id = GER_news.09 days = 30 random_days = 300 }
 	}
-	SAO = {
-		country_event = { id = Sao_Tome_e_Principe.2 days = 22 }
-		country_event = { id = Sao_Tome_e_Principe.3 days = 197 }
-	}
-	USA = {
-		country_event = { id = USA_econ_event.22 days = 64 random_days = 61 } #Mar 3rd, 2003
-		country_event = { id = USA_econ_event.23 days = 232 random_days = 61 } #Aug 19th, 2003
-		if = {
-			limit = {
-				is_historical_focus_on = no
-			}
-			country_event = { id = USA_crisis_event.1 days = 1 random_days = 90 } #1st Mini Crisis Chain
-		}
-	}
-	ROM = {
-		if = {
-			limit = {
-				western_social_democrats_are_in_power = yes
-			}
-			country_event = { id = romania_politics.19 days = 70 }
-		}
-		country_event = { id = romania_misc.8 days = 100 }
-		country_event = { id = romania_misc.9 days = 300 }
-	}
-	CAN = {
-		#Ontario Goes Dark
-		country_event = { id = canada_md_politics.4 days = 225 random_days = 5 }
-		#Operation Medusa
-		country_event = { id = canada_md_politics.8 days = 212 random_days = 5 }
-	}
-	KOR = {
-		country_event = { id = korea.19 days = 64 } #check if elections are allowed before starting the national assembly event chain
-	}
-	SIN = {
-		# The Esplanade
-		country_event = { id = singapore.106 days = 120 random_days = 45 }
-		# The Major Research Center Opens
-		country_event = { id = singapore.107 days = 120 random_days = 45 }
-	}
-	SPR = {
-		# Alternativa Espanola
-		country_event = { id = spain.209 random_days = 180 random_hours = 24 }
-		# San Sebastian Attacks Thwarted
-		country_event = { id = spain.216 random_days = 360 random_hours = 24 }
-	}
-	SWE = {
-		country_event = { id = Sweden.27 days = 234 random_days = 30 }
+	HAI = { country_event = { id = haiti.6 days = 30 random_days = 180 } }
+	HOL = {
+		country_event = { id = HOL_politics.02 days = 70 random_days = 20 }
+		if = { limit = { NOT = { has_completed_focus = HOL_paars } } country_event = { id = HOL_politics.72 days = 100 random_days = 30 } }
 	}
 	IND = {
-		# The Raid
-		country_event = { id = indonesia.477 days = 125 }
+		country_event = { id = indonesia.2 days = 90 }
+		country_event = { id = indonesia.37 days = 292 }
 	}
-	AZE = {
-		country_event = { id = azeev.9 days = 120 random_days = 50 }
+	IRQ = { country_event = { id = iraq_yearly.3 days = 1 random_days = 360 } }
+	ISR = { country_event = { id = israel.67 days = 81 } }
+	KYR = {
+		if = { limit = { has_country_leader = { name = "Askar Akayev" ruling_only = yes } } country_event = { id = centralkyr.6 days = 74 } }
+		if = { limit = { NOT = { has_game_rule = { rule = historic_events option = yes } } } country_event = { id = centralkyr.3 days = 257 } }
+	}
+	NIG = {
+		country_event = { id = nigeria_md.103 days = 220 random_days = 60 }
+		country_event = { id = nigeria_md.102 days = 280 random_days = 60 }
+		country_event = { id = nigeria_md.106 days = 1 random_days = 30 }
 	}
 	PER = {
-		# 2003-12-26 Bam Earthquake
-		country_event = { id = iranian_events.1 days = 120 random_days = 45 }
-		country_event = { id = iranian_flavor.4 days = 55 random_days = 60 }
+		country_event = { id = iranian_focus.163 days = 1 random_days = 300 }
+		country_event = { id = iranian_flavor.3 days = 70 random_days = 60 }
 	}
-	TUR = {
-		country_event = { id = Turkey.100 days = 140 } #General Elections
-		country_event = { id = TUR_flavor_event.2 days = 100 } #Bingol Earthquake
-		country_event = { id = TUR_flavor_event.3 days = 304 } #2003 Bombings
-		country_event = { id = Turkish_mafia.1200 days = 202 } #Kurdish Rights
-		country_event = { id = TUR_flavor_event.17 days = 202 } #Kurdish Rights
+	ROM = {
+		if = { limit = { western_social_democrats_are_in_power = yes } country_event = { id = romania_politics.3 days = 55 } }
+		country_event = { id = romania_misc.7 days = 136 }
 	}
-	JAP = {
-		country_event = { id = JAP_historical.150526001 days = 146 } # 2003 Miyagi Earthquake
-		country_event = { id = JAP_historical.150726001 days = 206 } # 2003 Second Miyagi Consecutive Earthquakes
-		country_event = { id = JAP_historical.150926001 days = 269 } # 2003 Hokkaido earthquake
-		country_event = { id = JAP_historical.20030926 days = 268 }
+	SIA = { SIA_merge_nap_into_trt = yes }
+	SIN = { country_event = { id = singapore.105 days = 180 random_days = 45 } }
+	SOV = {
+		country_event = { id = russia.62 days = 180 random_days = 45 }
+		country_event = { id = russia.120 days = 330 random_days = 25 }
 	}
-	HAI = {
-		# Demand Reparations
-		country_event = { id = haiti.7 days = 95 random_days = 15 }
-		# Tropical Airways Flight 1301
-		country_event = { id = haiti.17 days = 219 random_days = 10 }
-		# Amiot Métayer and the Cannibal Army
-		country_event = { id = haiti.10 days = 250 random_days = 10 }
-		# Astride Supports Assault
-		country_event = { id = haiti.12 days = 335 random_days = 15 }
+	SPR = {
+		country_event = { id = spain.261 days = 90 random_days = 210 random_hours = 24 }
+		country_event = { id = spain.208 random_days = 180 random_hours = 24 }
+		country_event = { id = spain.243 days = 60 random_days = 90 random_hours = 24 }
+		country_event = { id = spain.215 random_days = 360 random_hours = 24 }
 	}
-	CAR = {
-		# Bozizé Returns Seizing Bangui
-		country_event = { id = central_africa.8 days = 90 random_days = 20 }
+	SWE = {
+		country_event = { id = Sweden.25 days = 56 random_days = 10 }
+		country_event = { id = Sweden.26 days = 212 random_days = 30 }
 	}
-	MAL = {
-		# 2002 Presidential Elections
-		country_event = { id = mali.1 days = 109 random_days = 15 }
+	TUR = { country_event = { id = TUR_flavor_event.18 days = 90 } }
+	USA = {
+		country_event = { id = USA_econ_event.20 days = 92 random_days = 61 }
+		country_event = { id = USA_econ_event.21 days = 253 random_days = 61 }
+		country_event = { id = USA_unrest_event.5 days = 2 random_days = 365 }
+		country_event = { id = USA_unrest_event.6 days = 2 random_days = 365 }
+		country_event = { id = spaceshuttle.1 days = 33 }
 	}
-	MOR = {
-		# 2003 Casablanca Bombings
-		country_event = { id = morocco.400 days = 120 }
-	}
-	BRA = {
-		# Canal Hotel Bombing
-		country_event = { id = brazil_flavour_events.6 days = 190 random_days = 15 }
-	}
-	BOS = {
-		country_event = { id = BOS_events.55 days = 270 random_days = 30 }
-		country_event = { id = BOS_political.10 days = 50 random_days = 30 }
-		country_event = { id = BOS_political.11 days = 330 random_days = 30 }
-	}
-	CRO = {
-		# EU membership application submitted in Athens
-		country_event = { id = CRO_political.3 days = 52 }
-	}
-
-	COM = {
-		country_event = { id = comoros.20 days = 32 random_days = 27 }
-	}
-
-	### PMC Content
+	UZB = { country_event = { id = tajik_lore.9 days = 270 } }
+}
+trigger_year_2003_events = {
 	# B-2-3; w-0-0;A-1-0,C-1-2,M-0-0
 	add_to_variable = { global.merc_capacity^0 = 2 }
 	add_to_variable = { global.merc_upgrade^0 = 1 }
@@ -889,46 +420,118 @@ trigger_year_2003_events = {
 		country_event = { id = algeria_disaster.1 days = 141 }
 		country_event = { id = ALG_terror.1007 days = 165 }
 	}
-	CHI = {
-		country_event = { id = CHI_political_events.1 days = 71 random_days = 30 }
+	AZE = { country_event = { id = azeev.9 days = 120 random_days = 50 } }
+	BOS = {
+		country_event = { id = BOS_events.55 days = 270 random_days = 30 }
+		country_event = { id = BOS_political.10 days = 50 random_days = 30 }
+		country_event = { id = BOS_political.11 days = 330 random_days = 30 }
+	}
+	BRA = { country_event = { id = brazil_flavour_events.6 days = 190 random_days = 15 } }
+	CAN = {
+		country_event = { id = canada_md_politics.4 days = 225 random_days = 5 }
+		country_event = { id = canada_md_politics.8 days = 212 random_days = 5 }
+	}
+	CAR = { country_event = { id = central_africa.8 days = 90 random_days = 20 } }
+	CHI = { country_event = { id = CHI_political_events.1 days = 71 random_days = 30 } }
+	COM = { country_event = { id = comoros.20 days = 32 random_days = 27 } }
+	CRO = { country_event = { id = CRO_political.3 days = 52 } }
+	GER = {
+		country_event = { id = germany.26 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.32 days = 1 }
+		news_event = { id = GER_news.13 days = 289 }
+	}
+	GRE = {
+		country_event = { id = greece.501 days = 60 random_days = 30 }
+		country_event = { id = greece.502 days = 120 random_days = 30 }
+	}
+	HAI = {
+		country_event = { id = haiti.7 days = 95 random_days = 15 }
+		country_event = { id = haiti.17 days = 219 random_days = 10 }
+		country_event = { id = haiti.10 days = 250 random_days = 10 }
+		country_event = { id = haiti.12 days = 335 random_days = 15 }
+	}
+	HKG = {
+		# Death of Leslie Cheung (1 April 2003)
+		news_event = { id = hongkong_news.6 days = 90 }
+		# WHO travel advisory over the SARS outbreak (2 April 2003)
+		news_event = { id = hongkong_news.5 days = 91 }
+		# Death of Anita Mui (30 December 2003)
+		news_event = { id = hongkong_news.7 days = 363 }
+	}
+	IND = { country_event = { id = indonesia.477 days = 125 } }
+	JAP = {
+		country_event = { id = JAP_historical.150526001 days = 146 }
+		country_event = { id = JAP_historical.150726001 days = 206 }
+		country_event = { id = JAP_historical.150926001 days = 269 }
+		country_event = { id = JAP_historical.20030926 days = 268 }
+	}
+	KOR = { country_event = { id = korea.19 days = 64 } }
+	MAL = { country_event = { id = mali.1 days = 109 random_days = 15 } }
+	MOR = { country_event = { id = morocco.400 days = 120 } }
+	PER = {
+		country_event = { id = iranian_events.1 days = 120 random_days = 45 }
+		country_event = { id = iranian_flavor.4 days = 55 random_days = 60 }
+	}
+	ROM = {
+		if = { limit = { western_social_democrats_are_in_power = yes } country_event = { id = romania_politics.19 days = 70 } }
+		country_event = { id = romania_misc.8 days = 100 }
+		country_event = { id = romania_misc.9 days = 300 }
+	}
+	SAO = {
+		country_event = { id = Sao_Tome_e_Principe.2 days = 22 }
+		country_event = { id = Sao_Tome_e_Principe.3 days = 197 }
+	}
+	SER = {
+		country_event = { id = Serbia.14 days = 1 random_days = 350 }
+		country_event = { id = Serbia.30 days = 34 }
+		country_event = { id = Serbia.3 days = 60 }
+	}
+	SIN = {
+		country_event = { id = singapore.106 days = 120 random_days = 45 }
+		country_event = { id = singapore.107 days = 120 random_days = 45 }
+	}
+	SPR = {
+		country_event = { id = spain.209 random_days = 180 random_hours = 24 }
+		country_event = { id = spain.216 random_days = 360 random_hours = 24 }
+	}
+	SWE = { country_event = { id = Sweden.27 days = 234 random_days = 30 } }
+	TUR = {
+		country_event = { id = Turkey.100 days = 140 }
+		country_event = { id = TUR_flavor_event.2 days = 100 }
+		country_event = { id = TUR_flavor_event.3 days = 304 }
+		country_event = { id = Turkish_mafia.1200 days = 202 }
+		country_event = { id = TUR_flavor_event.17 days = 202 }
+	}
+	USA = {
+		country_event = { id = USA_econ_event.22 days = 64 random_days = 61 }
+		country_event = { id = USA_econ_event.23 days = 232 random_days = 61 }
+		if = { limit = { is_historical_focus_on = no } country_event = { id = USA_crisis_event.1 days = 1 random_days = 90 } }
 	}
 }
 trigger_year_2004_events = {
-	KOS = {
-		# The March unrest (17 March 2004)
-		country_event = { id = kosovo.10 days = 76 }
+	ALG = {
+		country_event = { id = ALG_terror.1008 days = 72 }
+		country_event = { id = algeria_gspc.2 days = 183 }
 	}
-	SLV = {
-		# NATO accession celebrations (29 March 2004)
-		country_event = { id = slovenia.9 days = 88 }
-		# EU accession celebrations (1 May 2004)
-		country_event = { id = slovenia.10 days = 121 }
+	ARM = {
+		if = { limit = { has_government = communism } country_event = { id = arme.193 days = 102 } }
+		country_event = { id = arme.194 days = 19 }
 	}
+	BOS = {
+		country_event = { id = BOS_political.13 days = 240 random_days = 30 }
+		# SFOR hands over to EUFOR (2 December 2004); fires early so the guard beats BOS_SFOR's 1797-day timer expiring the same day
+		country_event = { id = BOS_political.33 days = 334 }
+	}
+	BRA = { country_event = { id = brazil_flavour_events.7 days = 90 random_days = 15 } }
+	CAN = { country_event = { id = canada_md_politics.5 days = 40 random_days = 5 } }
+	CAR = { country_event = { id = central_africa.10 days = 180 random_days = 30 } }
 	CHI = {
 		# NPCSC rules out universal suffrage for the 2007/2008 elections (26 April 2004)
 		country_event = { id = hongkong.10 days = 116 }
 	}
-	HKG = {
-		# 2004 LegCo election (12 September 2004)
-		country_event = { id = hongkong_legco.1 days = 255 }
-	}
-	PER = {
-		country_event = { id = iranian_focus.165 days = 1 random_days = 360 }
-		country_event = { id = iranian_flavor.5 days = 90 random_days = 45 }
-		country_event = { id = iranian_flavor.6 days = 190 random_days = 60 }
-	}
-	PAL = {
-		country_event = { id = palestine.2 days = 320 }
-	}
-	ARM = {
-		if = {
-			limit = {
-				has_government = communism
-			}
-			country_event = { id = arme.193 days = 102 }
-		}
-		country_event = { id = arme.194 days = 19 }
-	}
+	COM = { country_event = { id = comoros.32 days = 30 random_days = 25 } }
+	DEN = { country_event = { id = denmark.23 days = 214 random_days = 5 } }
+	FRA = { country_event = { id = france_md.501 days = 10 random_days = 180 } }
 	GER = {
 		country_event = { id = germany_yearly.3 days = 1 random_days = 360 }
 		country_event = { id = germany.233 days = 1 random_days = 360 }
@@ -936,291 +539,202 @@ trigger_year_2004_events = {
 		country_event = { id = Germany_Mech.9 days = 1 random_days = 360 }
 	}
 	GRE = { country_event = { id = greece_military.01 days = 150 random_days = 50 } }
-	USA = {
-		country_event = { id = USA_econ_event.24 days = 181 random_days = 61 } #Jun 29th, 2004
-		country_event = { id = USA_econ_event.1 days = 328 random_days = 61 } #Nov 23rd, 2004
-		country_event = { id = USA_econ_event.10 days = 4 random_days = 732 }
-
-		if = {
-			limit = {
-				NOT = { has_completed_focus = USA_electoral_rainbow }
-			}
-			country_event = { id = USA_treason_event.2 days = 286 } #Choose to commit Election Fraud
-		}
-		else = {
-			country_event = { id = USA_treason_event.8 days = 280 } #Reformed Republic Election Fraud
-		}
-
-	}
-	TUR = {
-		country_event = { id = Turkish_parties.10 days = 91 }
-	}
-	CAN = {
-		#The Sponsorship Scandal
-		country_event = { id = canada_md_politics.5 days = 40 random_days = 5 }
-	}
-	DEN = {
-		#Thule Airbase
-		country_event = { id = denmark.23 days = 214 random_days = 5 }
-	}
-	UAE = {
-		news_event = { id = uae_royal.1 days = 305 random_days = 90 }
-	}
-	SIN = {
-		# Nicoll Highway Collapses
-		country_event = { id = singapore.109 days = 90 random_days = 90 }
-		# Stepping Down of Goh Chok Tong
-		country_event = { id = singapore.108 days = 120 random_days = 90 }
-	}
-	SPR = {
-		# Constitution Day Bombings
-		country_event = { id = spain.222 days = 340 random_hours = 24 }
-		# 2004 Madrid Train Bombings
-		country_event = { id = spain.255 days = 90 random_days = 7 }
-	}
-	IND = {
-		# Aceh Tsunami and Ceasefire
-		country_event = { id = indonesia.577 days = 359 }
-	}
-	JAP = {
-		country_event = { id = JAP_historical.161023001 days = 296 } # 2004 Chuetsu Earthquake
-		country_event = { id = JAP_historical.20030926 days = 268 }
-	}
-	SOM = {
-		country_event = { id = somalia.8 days = 270 random_days = 10 }
-	}
 	HAI = {
-		# Student Protests Turn Violent!
 		country_event = { id = haiti.13 days = 8 }
-		# The Cannibal Army Seizes Gonaives
 		country_event = { id = haiti.14 days = 34 }
 	}
-	FRA = {
-		# Hotel Attacks in Marseille
-		country_event = { id = france_md.501 days = 10 random_days = 180 }
-	}
-	CAR = {
-		# Allow Patasse Into the Elections
-		country_event = { id = central_africa.10 days = 180 random_days = 30 }
+	HKG = {
+		# 2004 LegCo election (12 September 2004)
+		country_event = { id = hongkong_legco.1 days = 255 }
 	}
 	HOL = {
-		# Geert Wilders friction with the VVD; flashpoint chain rolls toward the historical 2004 split
 		country_event = { id = HOL_politics.78 days = 60 random_days = 20 }
-	}
-	BRA = {
-		country_event = { id = brazil_flavour_events.7 days = 90 random_days = 15 }
-		# Cyclone Catrina
-	}
-	BOS = {
-		country_event = { id = BOS_political.13 days = 240 random_days = 30 }
-		# SFOR hands over to EUFOR (2 December 2004); fires early so the guard beats BOS_SFOR's 1797-day timer expiring the same day
-		country_event = { id = BOS_political.33 days = 334 }
-	}
-	HOL = {
 		country_event = { id = HOL_common_event.11 days = 307 random_days = 32 }
 	}
-	COM = {
-		# Death of Former President Massounde
-		country_event = { id = comoros.32 days = 30 random_days = 25 }
+	IND = { country_event = { id = indonesia.577 days = 359 } }
+	JAP = {
+		country_event = { id = JAP_historical.161023001 days = 296 }
+		country_event = { id = JAP_historical.20030926 days = 268 }
 	}
-	RAJ = {
-		country_event = { id = RAJ_naxal.10 days = 210 random_days = 40 }
+	KOS = { country_event = { id = kosovo.10 days = 76 } }
+	PAL = { country_event = { id = palestine.2 days = 320 } }
+	PER = {
+		country_event = { id = iranian_focus.165 days = 1 random_days = 360 }
+		country_event = { id = iranian_flavor.5 days = 90 random_days = 45 }
+		country_event = { id = iranian_flavor.6 days = 190 random_days = 60 }
 	}
-	TAI = {
-		country_event = { id = taiwan.1 days = 35 random_days = 10 }
-	}
-	ALG = {
-		country_event = { id = ALG_terror.1008 days = 72 }
-		country_event = { id = algeria_gspc.2 days = 183 }
-	}
+	RAJ = { country_event = { id = RAJ_naxal.10 days = 210 random_days = 40 } }
 	SIA = {
-		# Chart Pattana Party absorbed into Thai Rak Thai (Aug 2004)
 		SIA_merge_chart_pattana_into_trt = yes
-		# Tak Bai incident (25 Oct 2004)
 		country_event = { id = thailand.75 days = 301 }
-		# Indian Ocean tsunami (26 Dec 2004)
 		country_event = { id = thailand.52 days = 361 }
+	}
+	SIN = {
+		country_event = { id = singapore.109 days = 90 random_days = 90 }
+		country_event = { id = singapore.108 days = 120 random_days = 90 }
+	}
+	SLV = {
+		country_event = { id = slovenia.9 days = 88 }
+		country_event = { id = slovenia.10 days = 121 }
+	}
+	SOM = { country_event = { id = somalia.8 days = 270 random_days = 10 } }
+	SPR = {
+		country_event = { id = spain.222 days = 340 random_hours = 24 }
+		country_event = { id = spain.255 days = 90 random_days = 7 }
+	}
+	TAI = { country_event = { id = taiwan.1 days = 35 random_days = 10 } }
+	TUR = { country_event = { id = Turkish_parties.10 days = 91 } }
+	UAE = { news_event = { id = uae_royal.1 days = 305 random_days = 90 } }
+	USA = {
+		country_event = { id = USA_econ_event.24 days = 181 random_days = 61 }
+		country_event = { id = USA_econ_event.1 days = 328 random_days = 61 }
+		country_event = { id = USA_econ_event.10 days = 4 random_days = 732 }
+		if = { limit = { NOT = { has_completed_focus = USA_electoral_rainbow } } country_event = { id = USA_treason_event.2 days = 286 } }
+		else = { country_event = { id = USA_treason_event.8 days = 280 } }
 	}
 }
 trigger_year_2005_events = {
-	SIA = {
-		# Deep South onset for anyone who never took SIA_the_southern_question
-		country_event = { id = thailand.150 days = 1 }
-		# The 2005 landslide and the scandals that followed it
-		country_event = { id = thailand.78 days = 39 }
-		country_event = { id = thailand.76 days = 154 }
-		country_event = { id = thailand.77 days = 246 }
-	}
-	CHI = {
-		if = {
-			limit = { check_variable = { CHI_demographic_policy_stage = 1 } }
-			country_event = { id = CHI_political_events.50 days = 30 random_days = 400 }
-		}
-	}
-	PER = {
-		# 2005 Election Notification
-		country_event = { id = PER_election_events.3 days = 90 }
-		country_event = { id = iranian_focus.166 days = 1 random_days = 360 }
-		country_event = { id = iranian_flavor.7 days = 75 random_days = 90 }
-	}
-	ARM = {
-		country_event = { id = arme.196 days = 114 }
-	}
-	GER = {
-		country_event = { id = germany_yearly.4 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.34 days = 1 }
-	}
-	USA = {
-		country_event = { id = USA_econ_event.25 days = 124 random_days = 61 } #May 2nd, 2005
-		country_event = { id = USA_econ_event.2 days = 355 random_days = 61 } #Dec 20th, 2005
-		country_event = { id = usa.999 days = 20 } #Election (AI Only)
-		country_event = { id = USA_econ_event.30 days = 59 }
-	}
-	CAN = {
-		# American Submarines in the Northwest Passage
-		country_event = { id = canada_md_politics.6 days = 333 random_days = 5 }
-	}
-	UZB = {
-		if = { limit = { has_country_leader = { name = "Islam Karimov" ruling_only = yes } }
-			country_event = { id = centraluzb.3 days = 130 }
-		}
-	}
-	KYR = {
-		if = { limit = { has_country_leader = { name = "Askar Akayev" ruling_only = yes } }
-			country_event = { id = centralkyr.8 days = 77 }
-		}
-	}
-	DEN = {
-		#Hans Island
-		country_event = { id = denmark.24 days = 183 random_days = 5 }
-		#Storm Erwin (Gudrun)
-		country_event = { id = denmark.43 days = 7 random_days = 5 }
-	}
-	SAU = {
-		news_event = { id = saudi_royal.1 days = 214 } #Death of King Fahd
-	}
-	POL = {
-		if = { limit = { western_social_democrats_are_in_power = yes }
-			country_event = { id = poland.6 days = 240 random_days = 30 }
-		}
-		else_if = { limit = { western_conservatism_are_in_power = yes }
-			country_event = { id = poland.7 days = 240 random_days = 30 }
-		}
-		country_event = { id = poland.102 days = 315 }
-	}
-	SIN = {
-		# Marina Bay Floating Platform
-		country_event = { id = singapore.110 days = 120 random_days = 90 }
-	}
-	SPR = {
-		# Cidudanos Forms
-		country_event = { id = spain.206 random_days = 280 random_hours = 24 }
-		# Metropol Parasol Project
-		country_event = { id = spain.245 days = 30 random_days = 210 random_hours = 24 }
-		# Another Car Bombing In Madrid
-		country_event = { id = spain.223 random_days = 360 random_hours = 24 }
-	}
-	EST = {
-		country_event = { id = estonia.7 days = 210 random_days = 14 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.4 days = 190 } #Introduction of the new Lira
-	}
-	JAP = {
-		country_event = { id = JAP_historical.170320001 days = 79 } # 2005 Fukuoka Earthquake
-		country_event = { id = JAP_historical.170425001 days = 115 } # Derailment Accident on the Fukuchiyama Line
-		country_event = { id = JAP_historical.20030926 days = 268 }
-		country_event = { id = JAP_ai.1 days = 180 random_days = 30 }
-	}
-	CAR = {
-		# The Presidential Elections
-		country_event = { id = central_africa.12 days = 270 random_days = 15 }
-		# The Central African Republic Bush War
-		country_event = { id = central_africa.13 days = 285 random_days = 15 }
-	}
-	FIJ = {
-		country_event = { id = fiji_news.403 days = 213 } #2005 Coup Start
-	}
-	MAL = {
-		# Agency of Northern Malian Development
-		country_event = { id = mali.3 days = 110 random_days = 15 }
-	}
-	NKO = {
-		# A Report from Kim Jong-Un
-		country_event = { id = kim_jong_il_death.3 days = 108 }
-	}
-	GRE = {
-		# Helios Airways Flight 522 Crash
-		country_event = { id = greece.503 days = 213 random_days = 15 }
-	}
-	BRA = {
-		# Banco Central Burglary
-		country_event = { id = brazil_flavour_events.9 days = 210 random_days = 20 }
-	}
-	NIG = {
-		# 2005 - 1st Africa Movie Academy Awards
-		country_event = { id = nigeria_md.105 days = 120 random_days = 60 }
-	}
-	BOS = {
-		country_event = { id = BOS_political.14 days = 30 random_days = 30 }
-	}
-	CRO = {
-		# EU accession negotiations open
-		country_event = { id = CRO_political.4 days = 276 }
-		# Gotovina arrested in Tenerife
-		country_event = { id = CRO_political.2 days = 341 }
-	}
-	BRA = {
-		country_event = { id = brazil_amazon.27 days = 1 random_days = 360 random_hours = 24 }
-	}
-
-	COM = {
-		country_event = { id = comoros.21 days = 90 random_days = 29 }
-		country_event = { id = comoros.22 days = 304 random_days = 29 }
-	}
-
-	# The 2005 West African Drought
-	random_country = {
-		limit = {
-			OR = {
-				original_tag = MAL
-				original_tag = NGR
-				original_tag = BFA
-			}
-		}
-		country_event = { id = african.0 days = 30 random_days = 280 }
-	}
+	random_country = { limit = { OR = { original_tag = MAL original_tag = NGR original_tag = BFA } } country_event = { id = african.0 days = 30 random_days = 280 } }
 	ALG = {
 		country_event = { id = alg_generals.1 days = 1 }
 		country_event = { id = ALG_terror.1009 days = 210 }
 	}
-
-	# 2005 Czechia begins construction of Antarctic Research Station
-	CZE = {
-		setup_scripted_ai_station = yes
+	ARM = { country_event = { id = arme.196 days = 114 } }
+	BOS = { country_event = { id = BOS_political.14 days = 30 random_days = 30 } }
+	BRA = {
+		country_event = { id = brazil_flavour_events.9 days = 210 random_days = 20 }
+		country_event = { id = brazil_amazon.27 days = 1 random_days = 360 random_hours = 24 }
 	}
-	SWE = {
-		# Alleged sinking of USS Ronald Reagan during a submarine exercise
-		news_event = { id = Sweden.19 days = 240 }
+	CAN = { country_event = { id = canada_md_politics.6 days = 333 random_days = 5 } }
+	CAR = {
+		country_event = { id = central_africa.12 days = 270 random_days = 15 }
+		country_event = { id = central_africa.13 days = 285 random_days = 15 }
 	}
+	CHI = { if = { limit = { check_variable = { CHI_demographic_policy_stage = 1 } } country_event = { id = CHI_political_events.50 days = 30 random_days = 400 } } }
+	COM = {
+		country_event = { id = comoros.21 days = 90 random_days = 29 }
+		country_event = { id = comoros.22 days = 304 random_days = 29 }
+	}
+	CRO = {
+		country_event = { id = CRO_political.4 days = 276 }
+		country_event = { id = CRO_political.2 days = 341 }
+	}
+	CZE = { setup_scripted_ai_station = yes }
+	DEN = {
+		country_event = { id = denmark.24 days = 183 random_days = 5 }
+		country_event = { id = denmark.43 days = 7 random_days = 5 }
+	}
+	EST = { country_event = { id = estonia.7 days = 210 random_days = 14 } }
+	FIJ = { country_event = { id = fiji_news.403 days = 213 } }
+	GER = {
+		country_event = { id = germany_yearly.4 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.34 days = 1 }
+	}
+	GRE = { country_event = { id = greece.503 days = 213 random_days = 15 } }
+	JAP = {
+		country_event = { id = JAP_historical.170320001 days = 79 }
+		country_event = { id = JAP_historical.170425001 days = 115 }
+		country_event = { id = JAP_historical.20030926 days = 268 }
+		country_event = { id = JAP_ai.1 days = 180 random_days = 30 }
+	}
+	KYR = { if = { limit = { has_country_leader = { name = "Askar Akayev" ruling_only = yes } } country_event = { id = centralkyr.8 days = 77 } } }
+	MAL = { country_event = { id = mali.3 days = 110 random_days = 15 } }
+	NIG = { country_event = { id = nigeria_md.105 days = 120 random_days = 60 } }
+	NKO = { country_event = { id = kim_jong_il_death.3 days = 108 } }
+	PER = {
+		country_event = { id = PER_election_events.3 days = 90 }
+		country_event = { id = iranian_focus.166 days = 1 random_days = 360 }
+		country_event = { id = iranian_flavor.7 days = 75 random_days = 90 }
+	}
+	POL = {
+		if = { limit = { western_social_democrats_are_in_power = yes } country_event = { id = poland.6 days = 240 random_days = 30 } }
+		else_if = { limit = { western_conservatism_are_in_power = yes } country_event = { id = poland.7 days = 240 random_days = 30 } }
+		country_event = { id = poland.102 days = 315 }
+	}
+	SAU = { news_event = { id = saudi_royal.1 days = 214 } }
+	SIA = {
+		country_event = { id = thailand.150 days = 1 }
+		country_event = { id = thailand.78 days = 39 }
+		country_event = { id = thailand.76 days = 154 }
+		country_event = { id = thailand.77 days = 246 }
+	}
+	SIN = { country_event = { id = singapore.110 days = 120 random_days = 90 } }
+	SMA = { if = { limit = { has_country_flag = SMA_vatican_union } country_event = { id = SMA.6 days = 92 } } }
+	SPR = {
+		country_event = { id = spain.206 random_days = 280 random_hours = 24 }
+		country_event = { id = spain.245 days = 30 random_days = 210 random_hours = 24 }
+		country_event = { id = spain.223 random_days = 360 random_hours = 24 }
+	}
+	SWE = { news_event = { id = Sweden.19 days = 240 } }
+	TUR = { country_event = { id = TUR_flavor_event.4 days = 190 } }
 	USA = {
+		country_event = { id = USA_econ_event.25 days = 124 random_days = 61 }
+		country_event = { id = USA_econ_event.2 days = 355 random_days = 61 }
+		country_event = { id = usa.999 days = 20 }
+		country_event = { id = USA_econ_event.30 days = 59 }
 		news_event = { id = Sweden.19 days = 240 }
 	}
-	SMA = {
-		# John Paul II dies (2 April 2005)
-		if = {
-			limit = { has_country_flag = SMA_vatican_union }
-			country_event = { id = SMA.6 days = 92 }
-		}
-	}
+	UZB = { if = { limit = { has_country_leader = { name = "Islam Karimov" ruling_only = yes } } country_event = { id = centraluzb.3 days = 130 } } }
 }
 trigger_year_2006_events = {
-	SIA = {
-		# Shin Corp sold to Temasek (23 Jan 2006)
-		country_event = { id = thailand.73 days = 25 }
+	ALG = { country_event = { id = mali.6 days = 181 random_days = 20 } }
+	AZE = { if = { limit = { NOT = { has_country_flag = AZE_hunta_not_possible } } country_event = { id = azeev.10 days = 90 random_days = 20 } } }
+	BOS = {
+		country_event = { id = BOS_political.15 days = 210 random_days = 30 }
+		country_event = { id = BOS_political.43 days = 1 }
+		country_event = { id = BOS_political.44 days = 116 }
 	}
+	BOT = { country_event = { id = Botswana_pulse.14 days = 270 random_days = 30 } }
+	CAM = { country_event = { id = Cameroon.2 days = 60 random_days = 20 } }
+	CAN = {
+		country_event = { id = canada_md_politics.7 days = 38 random_days = 5 }
+		country_event = { id = canada_md_politics.9 days = 332 random_days = 5 }
+	}
+	CZE = { country_event = { id = CZE_political_tree_event.1 days = 182 } }
+	DEN = { country_event = { id = denmark.25 days = 2 random_days = 5 } }
+	EST = { country_event = { id = estonia.106 days = 30 random_days = 180 } }
+	FIJ = { country_event = { id = fiji_news.8 days = 338 } }
+	GER = {
+		country_event = { id = germany_yearly.5 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.6 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.35 days = 1 }
+		news_event = { id = GER_news.10 days = 100 random_days = 90 }
+	}
+	GRE = {
+		country_event = { id = greece.504 days = 90 random_days = 30 }
+		country_event = { id = greece.505 days = 150 random_days = 30 }
+	}
+	HEZ = { if = { limit = { NOT = { OR = { has_war_with = ISR is_ally_with = ISR } } } country_event = { id = hezbollah_events.28 days = 192 } } }
+	IND = { country_event = { id = indonesia.67 days = 102 } }
+	IRQ = { country_event = { id = iraq_md.318 days = 10 } }
+	JAP = {
+		country_event = { id = JAP_historical.180906001 days = 249 }
+		country_event = { id = JAP_historical.20060926 days = 268 }
+		country_event = { id = JAP_historical.20030926 days = 268 }
+	}
+	KUW = { news_event = { id = kuwait_royal.1 days = 16 } }
+	LIT = { country_event = { id = lithuania.1 days = 120 random_days = 90 } }
+	MAL = {
+		country_event = { id = mali.30 days = 60 random_days = 20 }
+		country_event = { id = mali.4 days = 110 random_days = 25 }
+		country_event = { id = mali.31 days = 130 random_days = 5 }
+		country_event = { id = mali.5 days = 120 random_days = 5 }
+		country_event = { id = mali.5 days = 120 random_days = 20 }
+	}
+	NIG = {
+		country_event = { id = nigeria_md.104 days = 180 random_days = 60 }
+		country_event = { id = nigeria_md.107 days = 1 random_days = 30 }
+		country_event = { id = nigeria_md.108 days = 210 random_days = 30 }
+		country_event = { id = nigeria_md.109 days = 230 random_days = 30 }
+		country_event = { id = nigeria_delta.1 days = 15 random_days = 45 }
+	}
+	PAL = { if = { limit = { ISR = { is_ai = no } } country_event = { id = israel.150 days = 28 } } }
+	PER = {
+		country_event = { id = iranian_flavor.8 days = 60 random_days = 60 }
+		country_event = { id = iranian_flavor.9 days = 210 random_days = 60 }
+	}
+	RAJ = { country_event = { id = indian_event.61 days = 31 random_days = 1 } }
 	SER = {
-		# Milosevic dies in custody (11 March 2006)
 		country_event = { id = Serbia.29 days = 69 }
 		# Referendum fallback (21 May 2006): AI Serbia never crushed the arc's separatism
 		if = {
@@ -1238,294 +752,28 @@ trigger_year_2006_events = {
 			country_event = { id = Serbia.15 days = 140 }
 		}
 	}
-	PER = {
-		country_event = { id = iranian_flavor.8 days = 60 random_days = 60 }
-		country_event = { id = iranian_flavor.9 days = 210 random_days = 60 }
-	}
-	GER = {
-		country_event = { id = germany_yearly.5 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.6 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.35 days = 1 }
-		news_event = { id = GER_news.10 days = 100 random_days = 90 }
-	}
-	GRE = {
-		# Kurdish Protests in Athens
-		country_event = { id = greece.504 days = 90 random_days = 30 }
-		# Gaza Crisis Protests
-		country_event = { id = greece.505 days = 150 random_days = 30 }
-	}
-	USA = {
-		country_event = { id = USA_econ_event.26 days = 271 random_days = 61 } #Sep 27th, 2006
-		country_event = { id = USA_econ_event.27 days = 89 random_days = 61 } #Mar 28th, 2006
-		country_event = { id = USA_econ_event.100 days = 31 random_days = 28 }
-		country_event = { id = USA_events_domestic_policies.20 days = 75 } #Iowa & Wisconsin struck from the Naval Vessel Register, Mar 17th, 2006
-		if = {
-			limit = { is_historical_focus_on = no }
-			country_event = { id = USA_crisis_event.4 days = 1 random_days = 90 } #2nd Mini Crisis Chain
-		}
-	}
-	CAN = {
-		#The Toronto 18
-		country_event = { id = canada_md_politics.7 days = 38 random_days = 5 }
-		#Quebecois Nation Motion
-		country_event = { id = canada_md_politics.9 days = 332 random_days = 5 }
-	}
-	DEN = {
-		# Muhammed Drawings
-		country_event = { id = denmark.25 days = 2 random_days = 5 }
-	}
-	KUW = {
-		# Death of Sheikh Jaber
-		news_event = { id = kuwait_royal.1 days = 16 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.61 days = 31 random_days = 1 } #2006 Mumbai train bombings
-	}
+	SIA = { country_event = { id = thailand.73 days = 25 } }
+	SOM = { country_event = { id = somalia.10 days = 30 random_days = 90 } }
+	SOV = { country_event = { id = russia.106 days = 10 } }
 	SPR = {
-		# Visitation of Ceuta & Melilla
 		country_event = { id = spain.266 days = 5 random_days = 10 }
-		# Madrid–Barajas Airport bombing
 		country_event = { id = spain.217 random_days = 360 random_hours = 24 }
-		# Statute of Autonomy of Catalonia
 		country_event = { id = spain.230 random_days = 180 random_hours = 24 }
 	}
-	IND = {
-		# 2006 Papua Refugee Crisis
-		country_event = { id = indonesia.67 days = 102 }
-	}
-	IRQ = {
-		country_event = { id = iraq_md.318 days = 10 }
-	}
-	AZE = {
-		if = {
-			limit = { NOT = { has_country_flag = AZE_hunta_not_possible } }
-
-			country_event = { id = azeev.10 days = 90 random_days = 20 }
-		}
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.20 days = 75 } #Introduction of the new Lira
-	}
-	JAP = {
-		country_event = { id = JAP_historical.180906001 days = 249 } # Prince Hisahito born
-		country_event = { id = JAP_historical.20060926 days = 268 } #Junichiro Koizumi Steps Down, Shinzo Abe Becomes Prime Minister
-		country_event = { id = JAP_historical.20030926 days = 268 }
-	}
-	EST = {
-		country_event = { id = estonia.106 days = 30 random_days = 180 }
-	}
-	# The rise of the Islamic Courts Union
-	SOM = {
-		country_event = { id = somalia.10 days = 30 random_days = 90 }
-	}
-	FIJ = {
-		country_event = { id = fiji_news.8 days = 338 } #2006 Coup Start
-	}
-	MAL = {
-		# Hassan ag Fagaga, of Tuareg origins, defected from his post with a number of his men
-		country_event = { id = mali.30 days = 60 random_days = 20 }
-		# Maouloud Festievel & A Guest
-		country_event = { id = mali.4 days = 110 random_days = 25 }
-		# An attack was launched on the Malian Army at Tin Zawaten
-		country_event = { id = mali.31 days = 130 random_days = 5 }
-		# Attacks on Military Garrison in Kidal and Menaka
-		country_event = { id = mali.5 days = 120 random_days = 5 }
-		# The ADC is Formed
-		country_event = { id = mali.5 days = 120 random_days = 20 }
-	}
-	ALG = {
-		# The Kidal Accords
-		country_event = { id = mali.6 days = 181 random_days = 20 }
-	}
-	BOT = {
-		#Top Gear Botswana Special
-		country_event = { id = Botswana_pulse.14 days = 270 random_days = 30 }
-	}
-	CZE = {
-		# 2006 political rotation
-		country_event = { id = CZE_political_tree_event.1 days = 182 }
-	}
-	PAL = {
-		# Palestinian Elections and Abbas declaring martial law for the result
-		if = { #This is a stop gap
-			limit = {
-				ISR = {
-					is_ai = no
-				}
-			}
-			country_event = { id = israel.150 days = 28 }
-		}
-	}
-	HEZ = {
-		# Hezbollah and Israel's 33 Days War
-		if = {
-			limit = {
-				NOT = {
-					OR = {
-						has_war_with = ISR
-						is_ally_with = ISR
-					}
-				}
-			}
-			country_event = { id = hezbollah_events.28 days = 192 }
-		}
-	}
-	SOV = {
-		# Creation of Just Russia Party
-		country_event = { id = russia.106 days = 10 }
-	}
-	CAM = {
-		# A Boat Capsizes
-		country_event = { id = Cameroon.2 days = 60 random_days = 20 }
-	}
-	NIG = {
-		# Building Collapse in Lagos
-		country_event = { id = nigeria_md.104 days = 180 random_days = 60 }
-		# Nigerian Militants Attack in Port Harcourt
-		country_event = { id = nigeria_md.107 days = 1 random_days = 30 }
-		# Pipeline Explosion in Lagos
-		country_event = { id = nigeria_md.108 days = 210 random_days = 30 }
-		# Collapse of a Dam in Zamfara
-		country_event = { id = nigeria_md.109 days = 230 random_days = 30 }
-		# MEND Formation - Niger Delta Crisis begins (January 2006)
-		country_event = { id = nigeria_delta.1 days = 15 random_days = 45 }
-	}
-	BOS = {
-		country_event = { id = BOS_political.15 days = 210 random_days = 30 }
-		country_event = { id = BOS_political.43 days = 1 } # State-level VAT in force (1 January 2006)
-		country_event = { id = BOS_political.44 days = 116 } # April Package constitutional vote (26 April 2006)
-	}
-	LIT = {
-		country_event = { id = lithuania.1 days = 120 random_days = 90 }
-	}
-	TIM = {
-		country_event = { id = east_timor.1 days = 30 random_days = 120 }
+	TIM = { country_event = { id = east_timor.1 days = 30 random_days = 120 } }
+	TUR = { country_event = { id = TUR_flavor_event.20 days = 75 } }
+	USA = {
+		country_event = { id = USA_econ_event.26 days = 271 random_days = 61 }
+		country_event = { id = USA_econ_event.27 days = 89 random_days = 61 }
+		country_event = { id = USA_econ_event.100 days = 31 random_days = 28 }
+		country_event = { id = USA_events_domestic_policies.20 days = 75 }
+		if = { limit = { is_historical_focus_on = no } country_event = { id = USA_crisis_event.4 days = 1 random_days = 90 } }
 	}
 }
 trigger_year_2007_events = {
-	SIA = {
-		# Thai Rak Thai dissolved by the Constitutional Tribunal (30 May 2007)
-		country_event = { id = thailand.20 days = 149 }
-	}
-	SLV = {
-		country_event = { id = slovenia.8 days = 293 } # Youth Party merges into the United Greens
-		country_event = { id = slovenia.11 days = 1 } # Euro adoption (1 January 2007)
-		country_event = { id = slovenia.12 days = 354 } # Schengen entry (21 December 2007)
-	}
-	PER = {
-		if = {
-			limit = {
-				OR = {
-					emerging_hardline_shiite_are_in_power = yes
-					emerging_moderate_shiite_are_in_power = yes
-				}
-			}
-			country_event = { id = iranian_focus.193 days = 1 random_days = 360 }
-		}
-		country_event = { id = iranian_flavor.10 days = 95 random_days = 90 }
-	}
-	GER = {
-		country_event = { id = germany_yearly.7 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.8 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.36 days = 1 }
-	}
-	USA = {
-		country_event = { id = USA_econ_event.29 days = 58 random_days = 61 } #Feb 28th, 2007
-		country_event = { id = USA_econ_event.28 days = 334 random_days = 61 } #Nov 29th, 2007
-	}
-	CAN = {
-		#Indigenous Day of Action
-		country_event = { id = canada_md_politics.10 days = 181 random_days = 5 }
-	}
-	DEN = {
-		#Pulling out of Iraq
-		news_event = { id = denmark.26 days = 33  random_days = 5 }
-	}
-	PAK = {
-		country_event = { id = pakistani_taliban.1 days = 15 random_days = 80 }
-	}
-	SIN = {
-		# An Execution
-		country_event = { id = singapore.111 days = 120 random_days = 90 }
-	}
-	IND = {
-		# 2006 Papua Independence Organization
-		country_event = { id = indonesia.678 days = 232 }
-	}
-	EST = {
-		country_event = { id = estonia.9 days = 110 random_days = 14 }
-		country_event = { id = estonia.11 days = 300 random_days = 21 }
-	}
-	SOV = {
-		country_event = { id = sov_liberals.31 days = 110 random_days = 14 }
-
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.5 days = 18 } #Hrant Dink Assassination
-	}
-	JAP = {
-		country_event = { id = JAP_historical.20070307 days = 66 } #Matsuoka's Scandal
-		country_event = { id = JAP_historical.20070528 days = 148 } #Matsuoka's suicide
-		country_event = { id = JAP_historical.20070704 days = 182 } #Kyuuma's gaffe
-		country_event = { id = JAP_historical.20070801 days = 213 } #Akagi's Scandal
-		country_event = { id = JAP_historical.20070926 days = 268 } #Abe or Fukuda
-		country_event = { id = JAP_historical.190216001 days = 45 } # Missing Pension Records
-		country_event = { id = JAP_historical.190325001 days = 84 } # 2007 Noto Earthquake
-		country_event = { id = JAP_historical.190716001 days = 196 } # 2007 Chuetsu Offshore Earthquake
-		country_event = { id = JAP_historical.20030926 days = 268 }
-	}
-	ARM = {
-		country_event = { id = TUR_flavor_event.5 days = 18 } #Hrant Dink Assassination
-	}
-	MAL = {
-		# The 2007 Presidential Elections
-		country_event = { id = mali.9 days = 100 random_days = 15 }
-		# Iyad Ag Ghali Joins Malian Consulate in Jeddah
-		country_event = { id = mali.10 days = 304 random_days = 10 }
-		# Tuareg gunmen captured a military convoy 50 km from the town of Tinsawatene
-		country_event = { id = mali.32 days = 213 random_days = 15 }
-	}
-	NGR = {
-		# Additional Garrisons Assaulted
-		country_event = { id = mali.11 days = 120 random_days = 20 }
-		# MNJ Attacks on Outposts
-		country_event = { id = mali.25 days = 31 random_days = 15 }
-		# MNJ Attacked Agadez Airport
-		country_event = { id = mali.26 days = 152 random_days = 15 }
-	}
-	ITA = {
-		country_event = { id = italy_md.42 days = 305 }
-		country_event = { id = italy_md.66 days = 245 }
-	}
-	NKO = {
-		# Who will be the heir to the throne?
-		country_event = { id = kim_jong_il_death.1 days = 328 }
-	}
-	BRA = {
-		# TAM Airlines Flight 3054 Disaster
-		country_event = { id = brazil_flavour_events.11 days = 210 random_days = 15 }
-		# Cristo Redentaor Wonder of the World
-		country_event = { id = brazil_flavour_events.13 days = 180 random_days = 20 }
-		# The Democrats Formed
-		country_event = { id = brazil_flavour_events.14 days = 120 random_days = 80 }
-	}
-	NIG = {
-		# 2007 - Violence Leading into the Elections
-		country_event = { id = nigeria_md.110 days = 120 random_days = 14 }
-		# 2007 - Petrol Spill in Kaduna State
-		country_event = { id = nigeria_md.111 days = 90 random_days = 30 }
-	}
-	GRE = {
-		# 2007 Greek Forest Fires
-		country_event = { id = greece.506 days = 170 random_days = 25 }
-	}
-
-	## PMC Content
-	# B-3-3; w-1-1;A-2-1,C-1-2,M-1-1
 	add_to_variable = { global.merc_capacity^0 = 2 }
 	add_to_variable = { global.merc_capacity^2 = 2 }
 	add_to_variable = { global.merc_upgrade^2 = 1 }
-
 	add_to_variable = { global.merc_capacity^4 = 2 }
 	add_to_variable = { global.merc_upgrade^4 = 1 }
 	if = {
@@ -1538,333 +786,258 @@ trigger_year_2007_events = {
 		country_event = { id = ALG_terror.2 days = 102 }
 		country_event = { id = ALG_terror.3 days = 249 }
 	}
-	LIT = {
-		country_event = { id = lithuania.10 days = 60 random_days = 120 }
+	ARM = { country_event = { id = TUR_flavor_event.5 days = 18 } }
+	BEL = { setup_scripted_ai_station = yes }
+	BRA = {
+		country_event = { id = brazil_flavour_events.11 days = 210 random_days = 15 }
+		country_event = { id = brazil_flavour_events.13 days = 180 random_days = 20 }
+		country_event = { id = brazil_flavour_events.14 days = 120 random_days = 80 }
 	}
-
-	BEL = {
-		setup_scripted_ai_station = yes
+	CAN = { country_event = { id = canada_md_politics.10 days = 181 random_days = 5 } }
+	DEN = { news_event = { id = denmark.26 days = 33 random_days = 5 } }
+	EST = {
+		country_event = { id = estonia.9 days = 110 random_days = 14 }
+		country_event = { id = estonia.11 days = 300 random_days = 21 }
+	}
+	GER = {
+		country_event = { id = germany_yearly.7 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.8 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.36 days = 1 }
+	}
+	GRE = { country_event = { id = greece.506 days = 170 random_days = 25 } }
+	IND = { country_event = { id = indonesia.678 days = 232 } }
+	ITA = {
+		country_event = { id = italy_md.42 days = 305 }
+		country_event = { id = italy_md.66 days = 245 }
+	}
+	JAP = {
+		country_event = { id = JAP_historical.20070307 days = 66 }
+		country_event = { id = JAP_historical.20070528 days = 148 }
+		country_event = { id = JAP_historical.20070704 days = 182 }
+		country_event = { id = JAP_historical.20070801 days = 213 }
+		country_event = { id = JAP_historical.20070926 days = 268 }
+		country_event = { id = JAP_historical.190216001 days = 45 }
+		country_event = { id = JAP_historical.190325001 days = 84 }
+		country_event = { id = JAP_historical.190716001 days = 196 }
+		country_event = { id = JAP_historical.20030926 days = 268 }
+	}
+	LIT = { country_event = { id = lithuania.10 days = 60 random_days = 120 } }
+	MAL = {
+		country_event = { id = mali.9 days = 100 random_days = 15 }
+		country_event = { id = mali.10 days = 304 random_days = 10 }
+		country_event = { id = mali.32 days = 213 random_days = 15 }
+	}
+	NGR = {
+		country_event = { id = mali.11 days = 120 random_days = 20 }
+		country_event = { id = mali.25 days = 31 random_days = 15 }
+		country_event = { id = mali.26 days = 152 random_days = 15 }
+	}
+	NIG = {
+		country_event = { id = nigeria_md.110 days = 120 random_days = 14 }
+		country_event = { id = nigeria_md.111 days = 90 random_days = 30 }
+	}
+	NKO = { country_event = { id = kim_jong_il_death.1 days = 328 } }
+	PAK = { country_event = { id = pakistani_taliban.1 days = 15 random_days = 80 } }
+	PER = {
+		if = { limit = { OR = { emerging_hardline_shiite_are_in_power = yes emerging_moderate_shiite_are_in_power = yes } } country_event = { id = iranian_focus.193 days = 1 random_days = 360 } }
+		country_event = { id = iranian_flavor.10 days = 95 random_days = 90 }
+	}
+	SIA = { country_event = { id = thailand.20 days = 149 } }
+	SIN = { country_event = { id = singapore.111 days = 120 random_days = 90 } }
+	SLV = {
+		country_event = { id = slovenia.8 days = 293 }
+		country_event = { id = slovenia.11 days = 1 }
+		country_event = { id = slovenia.12 days = 354 }
+	}
+	SOV = { country_event = { id = sov_liberals.31 days = 110 random_days = 14 } }
+	TUR = { country_event = { id = TUR_flavor_event.5 days = 18 } }
+	USA = {
+		country_event = { id = USA_econ_event.29 days = 58 random_days = 61 }
+		country_event = { id = USA_econ_event.28 days = 334 random_days = 61 }
 	}
 }
 trigger_year_2008_events = {
-	SIA = {
-		country_event = { id = preah_vihear.110 days = 183 }
-		country_event = { id = thailand.222 days = 261 }
+	ALG = {
+		country_event = { id = alg_generals.2 days = 1 }
+		country_event = { id = ALG_terror.4 days = 231 }
 	}
-	HKG = {
-		country_event = { id = hongkong_legco.1 days = 250 }
-	}
-	SER = {
-		country_event = { id = Serbia.34 days = 51 }
-		country_event = { id = Serbia.31 days = 202 }
-	}
-	CRO = {
-		country_event = { id = CRO_political.5 days = 94 }
-	}
+	ARM = { if = { limit = { emerging_reactionaries_are_in_power = yes } country_event = { id = arme.198 days = 50 } } }
 	BLR = {
 		if = {
 			limit = {
 				is_subject = no
 				NOT = { has_autonomy_state = autonomy_union_state }
 			}
-			# Global financial crisis reaches Belarus (October 2008)
 			country_event = { id = belarus_another.40 days = 273 }
 		}
 	}
-	ARM = {
-		if = {
-			limit = {
-				emerging_reactionaries_are_in_power = yes
-			}
-			country_event = { id = arme.198 days = 50 }
-		}
+	BOS = {
+		country_event = { id = BOS_political.30 days = 204 }
+		country_event = { id = BOS_political.40 days = 48 }
+		country_event = { id = BOS_political.42 days = 168 }
 	}
+	CAN = { country_event = { id = canada_md_politics.11 days = 107 random_days = 5 } }
+	CBD = { country_event = { id = preah_vihear.101 days = 189 random_days = 14 } }
 	CHI = {
 		country_event = { id = CHI_political_events.2 days = 133 random_days = 10 }
-		if = {
-			limit = { NOT = { has_active_mission = CHI_olympic_mission } }
-			country_event = { id = CHI_political_events.3 days = 220 }
-		}
+		if = { limit = { NOT = { has_active_mission = CHI_olympic_mission } } country_event = { id = CHI_political_events.3 days = 220 } }
 	}
+	COL = { country_event = { id = colombia.1 days = 50 random_days = 60 } }
+	CRO = { country_event = { id = CRO_political.5 days = 94 } }
+	DEN = { country_event = { id = denmark.27 days = 33 random_days = 5 } }
+	ETH = { country_event = { id = ethiopia.8 days = 3 random_days = 210 } }
+	FRA = { country_event = { id = france_md.110 days = 270 random_days = 30 random_hours = 24 } }
 	GER = {
 		country_event = { id = germany_yearly.9 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.10 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.37 days = 1 }
 	}
-	USA = {
-		country_event = { id = USA_econ_event.14 days = 8 random_days = 366 }
-
-		if = { limit = { has_completed_focus = USA_electoral_rainbow }
-			country_event = { id = USA_treason_event.11 days = 280 } #Reformed Republic Election Fraud
-		}
-		else = {
-			country_event = { id = USA_treason_event.3 days = 286 } #Choose to commit Election Fraud
-		}
-
+	GRE = {
+		country_event = { id = greece.12 days = 30 random_days = 15 }
+		country_event = { id = greece.507 days = 330 random_days = 20 }
 	}
-	CAN = {
-		#RCMP Raid on Conservative Headquarters
-		country_event = { id = canada_md_politics.11 days = 107 random_days = 5 }
+	GRN = { country_event = { id = greenland_event.1 days = 322 random_days = 15 } }
+	HKG = {
+		country_event = { id = hongkong_legco.1 days = 250 }
 	}
-	GRN = {
-		# Self Government Act Referendum
-		country_event = { id = greenland_event.1 days = 322  random_days = 15 }
-	}
-	DEN = {
-		#Plot to kill Kurt Westergaard
-		country_event = { id = denmark.27 days = 33  random_days = 5 }
-	}
-	SIN = {
-		# An Execution
-		country_event = { id = singapore.112 days = 90 random_days = 90 }
-		# mas Selamat Kastari Escapes
-		country_event = { id = singapore.113 days = 120 random_days = 90 }
-		# JB Jeyaretnam
-		country_event = { id = singapore.129 days = 160 random_days = 80 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.47 days = 330 random_days = 1 } #Terror ravages Mumbai
-	}
-	SPR = {
-		# 2008 Barcelona Terror Plot Thwarted
-		country_event = { id = spain.258 days = 45 random_days = 210 random_hours = 24 }
-		# Funding for the Sagrada Familia
-		country_event = { id = spain.253 days = 90 random_days = 210 random_hours = 24 }
-		# Basque Self-determination Referendum
-		country_event = { id = spain.218 random_days = 360 random_hours = 24 }
-		# Funding Request for Metropol Parasol Project
-		if = { limit = { NOT = { has_country_flag = SPR_metropol_parasol_project_ignored } }
-			country_event = { id = spain.246 random_days = 360 random_hours = 24 }
-		}
-	}
-	EST = {
-		country_event = { id = estonia.16 days = 240 random_days = 14 }
-		country_event = { id = estonia.111 days = 150 random_days = 90 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.6 days = 243 } #2008 Migrant influx
-	}
+	HOL = { country_event = { id = HOL_military.064 days = 73 random_days = 15 } }
 	JAP = {
-		country_event = { id = JAP_historical.20080924 days = 267 } # #Fukuda or Asō?
-		country_event = { id = JAP_historical.200614001 days = 165 } # 2008 Iwate-Miyagi Nairiku Earthquake
+		country_event = { id = JAP_historical.20080924 days = 267 }
+		country_event = { id = JAP_historical.200614001 days = 165 }
 		country_event = { id = JAP_historical.20030926 days = 268 }
 	}
-	MAL = {
-		# Kidnapping of Canadian Diplomats and European Tourists
-		country_event = { id = mali.12 days = 335 random_days = 10 }
-	}
+	MAL = { country_event = { id = mali.12 days = 335 random_days = 10 } }
+	NGR = { country_event = { id = mali.27 days = 152 random_days = 15 } }
+	NIG = { country_event = { id = nigeria_md.112 days = 150 random_days = 30 } }
+	PAK = { country_event = { id = pakistan.1 days = 60 random_days = 120 } }
 	PER = {
 		country_event = { id = iranian_focus.201 days = 300 }
 		country_event = { id = iranian_flavor.11 days = 80 random_days = 90 }
 	}
-	NGR = {
-		# MNJ kidnapped four employees of Areva, the French state nuclear corporation
-		country_event = { id = mali.27 days = 152 random_days = 15 }
-	}
-	GRE = {
-		# Tsipras elected leader of SYRIZA
-		country_event = { id = greece.12 days = 30 random_days = 15 }
-		# Alexandros Grigoropoulos Death - December 2008 Riots
-		country_event = { id = greece.507 days = 330 random_days = 20 }
-	}
-	NIG = {
-		# 2008 - Ijegun Pipeline Explosion
-		country_event = { id = nigeria_md.112 days = 150 random_days = 30 }
-	}
-	HOL = {
-		#Selling of MIO Stork to Rheinmetall
-		country_event = { id = HOL_military.064 days = 73 random_days = 15 }
-	}
-	FRA = {
-		country_event = { id = france_md.110 days = 270 random_days = 30 random_hours = 24 }
-	}
-	SIA = {
-		# UNESCO designates Preah Vihear as World Heritage Site (July 7, 2008)
-		country_event = { id = preah_vihear.100 days = 189 random_days = 14 }
-	}
-	CBD = {
-		# Cambodia celebrates UNESCO designation
-		country_event = { id = preah_vihear.101 days = 189 random_days = 14 }
-	}
-	ETH = {
-		# Ethio-Djibouti Railways stops its operations
-		country_event = { id = ethiopia.8 days = 3 random_days = 210 }
-	}
-	ALG = {
-		country_event = { id = alg_generals.2 days = 1 }
-		country_event = { id = ALG_terror.4 days = 231 }
-	}
-	COL = {
-		country_event = { id = colombia.1 days = 50 random_days = 60 }
-	}
-	PAK = {
-		country_event = { id = pakistan.1 days = 60 random_days = 120 }
-	}
 	RAJ = {
+		country_event = { id = indian_event.47 days = 330 random_days = 1 }
 		country_event = { id = RAJ_regional.19 days = 60 random_days = 30 }
 	}
-	BOS = {
-		# Karadzic arrest, reaction in Sarajevo (21 July 2008, fired 2 days after Serbia.31)
-		country_event = { id = BOS_political.30 days = 204 }
-		country_event = { id = BOS_political.40 days = 48 } # Kosovo declares independence (17 February 2008)
-		country_event = { id = BOS_political.42 days = 168 } # SAA signed with the EU (16 June 2008)
+	SER = {
+		country_event = { id = Serbia.34 days = 51 }
+		country_event = { id = Serbia.31 days = 202 }
+	}
+	SIA = {
+		country_event = { id = preah_vihear.110 days = 183 }
+		country_event = { id = thailand.222 days = 261 }
+		country_event = { id = preah_vihear.100 days = 189 random_days = 14 }
+	}
+	SIN = {
+		country_event = { id = singapore.112 days = 90 random_days = 90 }
+		country_event = { id = singapore.113 days = 120 random_days = 90 }
+		country_event = { id = singapore.129 days = 160 random_days = 80 }
+	}
+	SPR = {
+		country_event = { id = spain.258 days = 45 random_days = 210 random_hours = 24 }
+		country_event = { id = spain.253 days = 90 random_days = 210 random_hours = 24 }
+		country_event = { id = spain.218 random_days = 360 random_hours = 24 }
+		if = { limit = { NOT = { has_country_flag = SPR_metropol_parasol_project_ignored } } country_event = { id = spain.246 random_days = 360 random_hours = 24 } }
+		EST = {
+			country_event = { id = estonia.16 days = 240 random_days = 14 }
+			country_event = { id = estonia.111 days = 150 random_days = 90 }
+		}
+	}
+	TUR = { country_event = { id = TUR_flavor_event.6 days = 243 } }
+	USA = {
+		country_event = { id = USA_econ_event.14 days = 8 random_days = 366 }
+		if = { limit = { has_completed_focus = USA_electoral_rainbow } country_event = { id = USA_treason_event.11 days = 280 } }
+		else = { country_event = { id = USA_treason_event.3 days = 286 } }
 	}
 }
 trigger_year_2009_events = {
-	SIA = {
-		# Thaksin appointed Cambodian economic adviser; ambassadors recalled (Nov 2009)
-		country_event = { id = preah_vihear.111 days = 305 }
+	if = { limit = { MEX = { owns_state = 835 } } MEX = { country_event = { id = pandemic_events.1 days = 120 random_days = 30 } } }
+	else = { random_country = { limit = { owns_state = 835 } country_event = { id = pandemic_events.1 days = 120 random_days = 30 } } }
+	ALG = { if = { limit = { NOT = { has_country_flag = ALG_unlock_fatima_boudouani } } country_event = { id = ALG.2001 days = 182 random_days = 30 } } }
+	AZE = { if = { limit = { NOT = { has_country_flag = AZE_hunta_not_possible } } country_event = { id = azeev.11 days = 20 random_days = 100 } } }
+	BOS = {
+		country_event = { id = BOS_political.32 days = 355 }
+		country_event = { id = BOS_political.45 days = 293 }
+		country_event = { id = BOS_political.47 days = 60 }
 	}
-	GRE = {
-		# 2009 Greek Forest Fires
-		country_event = { id = greece.508 days = 200 random_days = 30 }
+	COM = { country_event = { id = comoros.23 days = 180 } }
+	DEN = {
+		country_event = { id = denmark.28 days = 184 random_days = 5 }
+		country_event = { id = denmark.29 days = 337 random_days = 5 }
 	}
-	EST = {
-		# Unveiling of the Victory Column
-		country_event = { id = estonia.6 days = 173 }
-	}
-	PER = {
-		# 2009 Election Notification
-		country_event = { id = PER_election_events.4 days = 90 }
-		if = {
-			limit = {
-				has_country_leader = { name = "Hossein-Ali Montazeri" ruling_only = yes }
-			}
-			country_event = { id = iranian_focus.168 days = 350 }
-		}
-		country_event = { id = iranian_flavor.12 days = 65 random_days = 60 }
-	}
-	IRQ = {
-		if = {
-			limit = {
-				has_country_leader = { name = "Saddam Hussein" ruling_only = yes }
-			}
-			random = {
-				chance = 10
-
-					set_country_flag = IRQ_alzheimers
-
-			}
-
-			country_event = { id = iraq_md.74 days = 1 random_days = 360 }
-		}
-		country_event = { id = iraq_md.200 days = 1 random_days = 360 }
-	}
-	USA = {
-		country_event = { id = usa.999 days = 20 } #Election (AI Only)
-	}
+	EST = { country_event = { id = estonia.6 days = 173 } }
 	GER = {
 		country_event = { id = germany_yearly.11 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.38 days = 1 }
 		news_event = { id = GER_news.11 days = 40 random_days = 180 }
 		news_event = { id = GER_news.12 days = 120 random_days = 90 }
 	}
-	DEN = {
-		#Arctic Military Command
-		country_event = { id = denmark.28 days = 184  random_days = 5 }
-		#Copenhagen Summit
-		country_event = { id = denmark.29 days = 337  random_days = 5 }
-	}
-	SIN = {
-		# 50 Years of Self Governace
-		country_event = { id = singapore.114 days = 220 random_days = 90 }
-	}
-	SPR = {
-		# Jurdan Martitegi Arrested
-		country_event = { id = spain.219 random_days = 360 random_hours = 24 }
-		# Guardia Civil Bombings
-		country_event = { id = spain.220 random_days = 360 random_hours = 24 }
-	}
-	AZE = {
+	GRE = { country_event = { id = greece.508 days = 200 random_days = 30 } }
+	HOL = { country_event = { id = HOL_common_event.12 days = 120 } }
+	IRQ = {
 		if = {
-			limit = { NOT = { has_country_flag = AZE_hunta_not_possible } }
-
-			country_event = { id = azeev.11 days = 20 random_days = 100 }
+			limit = { has_country_leader = { name = "Saddam Hussein" ruling_only = yes } }
+			random = { chance = 10 set_country_flag = IRQ_alzheimers }
+			country_event = { id = iraq_md.74 days = 1 random_days = 360 }
 		}
+		country_event = { id = iraq_md.200 days = 1 random_days = 360 }
 	}
-	SMA = {
-		# United of parties
-		country_event = { id = SMA.8 days = 60 random_days = 60 }
+	ITA = {
+		country_event = { id = italy_md.16 days = 98 }
+		country_event = { id = italy_md.41 days = 300 }
 	}
-	ALG = {
-		if = {
-			limit = { NOT = { has_country_flag = ALG_unlock_fatima_boudouani } }
-
-			country_event = { id = ALG.2001 days = 182 random_days = 30 }
-		}
+	JAP = {
+		country_event = { id = JAP_historical.210811001 days = 223 }
+		country_event = { id = JAP_historical.20090808 days = 219 }
 	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.7 days = 121 } #2009 Drug rise
-		country_event = { id = TurkeyFocusEvents.53 days = 266 } #Osman V Dies
+	MAL = { country_event = { id = mali.15 days = 31 random_days = 10 } }
+	NIG = {
+		country_event = { id = nigeria_md.113 days = 180 random_days = 60 }
+		country_event = { id = nigeria_md.114 days = 250 random_days = 30 }
+		country_event = { id = nigeria_delta.10 days = 176 random_days = 30 }
+	}
+	PER = {
+		country_event = { id = PER_election_events.4 days = 90 }
+		country_event = { id = iranian_flavor.12 days = 65 random_days = 60 }
+		if = { limit = { has_country_leader = { name = "Hossein-Ali Montazeri" ruling_only = yes } } country_event = { id = iranian_focus.168 days = 350 } }
 	}
 	ROM = {
 		country_event = { id = romania_misc.10 days = 5 }
 		country_event = { id = romania_misc.11 days = 330 }
 		country_event = { id = romania_misc.12 days = 310 }
 	}
-	SOV = {
-		country_event = { id = russia.30 days = 121 }
+	SIA = { country_event = { id = preah_vihear.111 days = 305 } }
+	SIN = { country_event = { id = singapore.114 days = 220 random_days = 90 } }
+	SMA = { country_event = { id = SMA.8 days = 60 random_days = 60 } }
+	SOV = { country_event = { id = russia.30 days = 121 } }
+	SPR = {
+		country_event = { id = spain.219 random_days = 360 random_hours = 24 }
+		country_event = { id = spain.220 random_days = 360 random_hours = 24 }
 	}
-	JAP = {
-		country_event = { id = JAP_historical.210811001 days = 223 } # Shizuoka Earthquake
-		country_event = { id = JAP_historical.20090808 days = 219 }
+	TUR = {
+		country_event = { id = TUR_flavor_event.7 days = 121 }
+		country_event = { id = TurkeyFocusEvents.53 days = 266 }
 	}
-	MAL = {
-		# Kidal Peace Ceremony Includes Surrender of Weapons
-		country_event = { id = mali.15 days = 31 random_days = 10 }
-	}
-	ITA = {
-		country_event = { id = italy_md.16 days = 98 }
-		country_event = { id = italy_md.41 days = 300 }
-	}
-	NIG = {
-		# 2009 - Islamic Extremists Attack in Bauchi State
-		country_event = { id = nigeria_md.113 days = 180 random_days = 60 }
-		# 2009 - Establishment of Afe Babalola University
-		country_event = { id = nigeria_md.114 days = 250 random_days = 30 }
-		# Presidential Amnesty Program Offer - June 25, 2009 (historical)
-		country_event = { id = nigeria_delta.10 days = 176 random_days = 30 }
-	}
-	HOL = {
-		country_event = { id = HOL_common_event.12 days = 120 }
-	}
-	COM = {
-		country_event = { id = comoros.23 days = 180 }
-	}
-	# 2009 Swine Flu Pandemic
-	if = {
-		limit = { MEX = { owns_state = 835 } }
-		MEX = {
-			country_event = { id = pandemic_events.1 days = 120 random_days = 30 }
-		}
-	}
-	else = {
-		random_country = {
-			limit = { owns_state = 835 }
-			country_event = { id = pandemic_events.1 days = 120 random_days = 30 }
-		}
-	}
-	BOS = {
-		# The Sejdic-Finci ruling in Strasbourg (22 December 2009)
-		country_event = { id = BOS_political.32 days = 355 }
-		country_event = { id = BOS_political.45 days = 293 } # Butmir reform talks (October 2009)
-		country_event = { id = BOS_political.47 days = 60 } # Mostar electoral deadlock
-	}
+	USA = { country_event = { id = usa.999 days = 20 } }
 }
-
-# 2010s
 trigger_year_2010_events = {
-	SER = {
-		# Kraljevo earthquake (3 November 2010)
-		country_event = { id = Serbia.5 days = 306 }
+	random_country = { limit = { OR = { original_tag = NGR original_tag = BEN original_tag = GAH original_tag = NIG original_tag = TOG } } country_event = { id = african.3 days = 30 random_days = 280 } }
+	BOS = {
+		country_event = { id = BOS_political.6 days = 300 random_days = 30 }
+		country_event = { id = BOS_political.70 days = 178 }
+		country_event = { id = BOS_political.62 days = 276 }
+		country_event = { id = BOS_political.61 days = 349 }
 	}
-	KOS = {
-		# ICJ advisory opinion (22 July 2010)
-		country_event = { id = kosovo.11 days = 202 }
+	CAN = {
+		country_event = { id = canada_md_politics.13 days = 61 random_days = 5 }
+		country_event = { id = canada_md_politics.14 days = 181 random_days = 5 }
+		country_event = { id = canada_md_politics.15 days = 287 random_days = 5 }
 	}
-	PER = {
-		country_event = { id = iranian_flavor.13 days = 50 random_days = 30 }
-		country_event = { id = iranian_flavor.14 days = 200 random_days = 60 }
+	CDI = { country_event = { id = ivory_coast_md.11 days = 304 random_days = 10 } }
+	CRO = { country_event = { id = CRO_political.6 days = 344 } }
+	CZE = { country_event = { id = CZE_political_tree_event.1 days = 182 } }
+	DEN = {
+		country_event = { id = denmark.30 days = 3 random_days = 5 }
+		country_event = { id = denmark.31 days = 337 random_days = 5 }
 	}
 	GER = {
 		country_event = { id = germany_yearly.12 days = 1 random_days = 360 }
@@ -1872,379 +1045,142 @@ trigger_year_2010_events = {
 		country_event = { id = germany.420 days = 240 }
 		country_event = { id = germany_yearly.39 days = 1 }
 	}
-	CAN = {
-		# The Golden Goal
-		country_event = { id = canada_md_politics.13 days = 61 random_days = 5 }
-		# G20 Summit Riots in Toronto
-		country_event = { id = canada_md_politics.14 days = 181 random_days = 5 }
-		# Withdrawing the Security Council Bid
-		country_event = { id = canada_md_politics.15 days = 287 random_days = 5 }
-	}
-	DEN = {
-		#Axe assault on Kurt Westergaard
-		country_event = { id = denmark.30 days = 3  random_days = 5 }
-		#foiled attack on Jyllandsposten
-		country_event = { id = denmark.31 days = 337  random_days = 5 }
-	}
-	KYR = {
-		if = {
-			limit = {
-				has_country_leader = {
-					name = "Kurmanbek Bakiyev"
-					ruling_only = yes
-				}
-			}
-			country_event = { id = centralkyr.14 days = 94 }
-		}
-	}
-	POL = {
-		if = { limit = { western_conservatism_are_in_power = yes }
-			random_list = {
-				70 = {
-					news_event = { id = poland_news.2 days = 125 random_days = 10 }
-				}
-				30 = {
-					news_event = { id = poland_news.3 days = 125 random_days = 10 }
-				}
-			}
-		}
-	}
-	SIN = {
-		# City Harvest Church CAse
-		country_event = { id = singapore.115 days = 180 random_days = 90 }
-		# Alan Shad
-		country_event = { id = singapore.116 days = 120 random_days = 90 }
-	}
-	SPR = {
-		# Death of Charlie Sheen
-		country_event = { id = spain.205 random_days = 210 random_hours = 24 }
-		# 2010 Bilbao Receives the Nobel Prize
-		country_event = { id = spain.212 random_days = 180 random_hours = 24 }
-		# Spanish Constitutional Court Revises the Statute of Autonomy
-		country_event = { id = spain.231 days = 40 random_days = 20 }
-	}
-	TUR = {
-		# Gaza flotilla raid // removed cuz I added it to be triggered from ISR tree
-		#country_event = { id = TUR_flavor_event.8 days = 180 }
-		# Deniz Baykal Scandal (10 May 2010)
-		country_event = { id = TurkeyRandomEvents.1 days = 129 }
-		# HEPAR Founded (25 November 2010)
-		if = {
-			limit = { NOT = { has_country_flag = TUR_hepar_founded } }
-			country_event = { id = Turkish_parties.11 days = 328 }
-		}
-	}
-	CDI = {
-		# 2010 Presidential Elections
-		country_event = { id = ivory_coast_md.11 days = 304 random_days = 10 }
-	}
-	USA = {
-		# Constellis Forms
-		news_event = { id = pmc_events.7 days = 90 random_days = 180 }
-	}
-	CZE = {
-		# 2010 political rotation
-		country_event = { id = CZE_political_tree_event.1 days = 182 }
-	}
-	NIG = {
-		# 2010 - The Bloodied Golden Jubilee
-		country_event = { id = nigeria_md.116 days = 273 }
-	}
-	BOS = {
-		country_event = { id = BOS_political.6 days = 300 random_days = 30 }
-		# Bugojno police station bombing (27 June 2010)
-		country_event = { id = BOS_political.70 days = 178 }
-		# 2010 general election and the start of the sixteen-month deadlock (3 October 2010)
-		country_event = { id = BOS_political.62 days = 276 }
-		# Visa liberalization with Schengen takes effect (15 December 2010)
-		country_event = { id = BOS_political.61 days = 349 }
-	}
-	CRO = {
-		# Ina-MOL scandal, Sanader arrested
-		country_event = { id = CRO_political.6 days = 344 }
-	}
 	JAP = {
 		country_event = { id = JAP_historical.20090808 days = 219 }
 		country_event = { id = JAP_ai.2 days = 180 random_days = 30 }
 	}
-
-	# The 2010 Nigerien Floods (These are technically called Nigerien but they sprawled to several countries)
-	random_country = {
-		limit = {
-			OR = {
-				original_tag = NGR
-				original_tag = BEN
-				original_tag = GAH
-				original_tag = NIG
-				original_tag = TOG
+	KOS = { country_event = { id = kosovo.11 days = 202 } }
+	KYR = { if = { limit = { has_country_leader = { name = "Kurmanbek Bakiyev" ruling_only = yes } } country_event = { id = centralkyr.14 days = 94 } } }
+	NIG = { country_event = { id = nigeria_md.116 days = 273 } }
+	PER = {
+		country_event = { id = iranian_flavor.13 days = 50 random_days = 30 }
+		country_event = { id = iranian_flavor.14 days = 200 random_days = 60 }
+	}
+	POL = {
+		if = {
+			limit = { western_conservatism_are_in_power = yes }
+			random_list = {
+				70 = { news_event = { id = poland_news.2 days = 125 random_days = 10 } }
+				30 = { news_event = { id = poland_news.3 days = 125 random_days = 10 } }
 			}
 		}
-		country_event = { id = african.3 days = 30 random_days = 280 }
 	}
-	RAJ = {
-		country_event = { id = RAJ_naxal.17 days = 96 random_days = 5 }
+	RAJ = { country_event = { id = RAJ_naxal.17 days = 96 random_days = 5 } }
+	SER = { country_event = { id = Serbia.5 days = 306 } }
+	SIN = {
+		country_event = { id = singapore.115 days = 180 random_days = 90 }
+		country_event = { id = singapore.116 days = 120 random_days = 90 }
 	}
+	SPR = {
+		country_event = { id = spain.205 random_days = 210 random_hours = 24 }
+		country_event = { id = spain.212 random_days = 180 random_hours = 24 }
+		country_event = { id = spain.231 days = 40 random_days = 20 }
+	}
+	TUR = {
+		country_event = { id = TurkeyRandomEvents.1 days = 129 }
+		if = { limit = { NOT = { has_country_flag = TUR_hepar_founded } } country_event = { id = Turkish_parties.11 days = 328 } }
+	}
+	USA = { news_event = { id = pmc_events.7 days = 90 random_days = 180 } }
 }
 trigger_year_2011_events = {
-	SIA = {
-		# Preah Vihear referred to the Security Council (Feb 2011)
-		country_event = { id = preah_vihear.120 days = 32 }
-		# Great Chao Phraya flood (Jul 2011)
-		country_event = { id = thailand.53 days = 183 }
-		# Yingluck's rice-pledging scheme (Aug 2011)
-		country_event = { id = thailand.54 days = 217 }
+	add_to_variable = { global.merc_capacity^3 = 2 }
+	add_to_variable = { global.merc_upgrade^3 = 1 }
+	add_to_variable = { global.merc_capacity^4 = 2 }
+	add_to_variable = { global.merc_upgrade^4 = 1 }
+	AFG = { country_event = { id = Afghanistan.15 days = 260 random_days = 720 } }
+	ALG = { country_event = { id = alg_politics_news.1 days = 212 } }
+	ARM = { if = { limit = { has_government = communism } country_event = { id = arme.203 days = 1 random_days = 30 } } }
+	BOS = {
+		country_event = { id = BOS_political.31 days = 147 }
+		country_event = { id = BOS_political.71 days = 301 }
 	}
-	SER = {
-		# Mladic arrested in Lazarevo (26 May 2011)
-		country_event = { id = Serbia.32 days = 145 }
-	}
-	SLV = {
-		country_event = { id = slovenia.1 days = 295 } # Positive Slovenia founded
-	}
-	ARM = {
-		if = {
-			limit = {
-				has_government = communism
-			}
-			country_event = { id = arme.203 days = 1 random_days = 30 }
-		}
-	}
+	CAN = { country_event = { id = canada_md_politics.16 days = 112 random_days = 5 } }
+	CHI = { country_event = { id = CHI_political_events.51 days = 90 random_days = 30 } }
+	DEN = { country_event = { id = denmark.32 days = 184 random_days = 5 } }
 	GER = {
 		country_event = { id = germany_yearly.15 days = 1 random_days = 360 }
 		country_event = { id = Germany_Mech.45 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.40 days = 1 }
 	}
-	AFG = {
-		country_event = { id = Afghanistan.15 days = 260 random_days = 720 }
-	}
-	CAN = {
-		#A Orange Wave
-		country_event = { id = canada_md_politics.16 days = 112 random_days = 5 }
-	}
-	RAJ = {
-		# Anti-Corruption Movement
-		country_event = { id = indian_event.48 days = 93 random_days = 1 }
-		# Supreme Court ruling against Salwa Judum (5 July 2011)
-		country_event = { id = RAJ_naxal.21 days = 184 random_days = 5 }
-	}
-	DEN = {
-		country_event = { id = denmark.32 days = 184   random_days = 5 }
-	}
-	SPR = {
-		# Permanent Ceasefire With The ETA
-		country_event = { id = spain.221 random_days = 360 random_hours = 24 }
-	}
-	PER = {
-		# Pendar Pazeshkpour dies (Pan Iranist event)
-		country_event = { id = iranian_focus.162 days = 6 }
-		country_event = { id = iranian_flavor.15 days = 85 random_days = 90 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.9 days = 280 } #2011 Van Earthquake
-	}
+	HOL = { country_event = { id = HOL_common_event.13 days = 99 random_days = 14 } }
 	JAP = {
-		country_event = { id = JAP_historical.20110311 days = 69 hours = 15 } #Great East Japan Earthquake
+		country_event = { id = JAP_historical.20110311 days = 69 hours = 15 }
 		country_event = { id = JAP_historical.20090808 days = 219 }
 	}
 	MAL = {
-		# New Security, Economic and Development Programs in Kidal
 		country_event = { id = mali.17 days = 212 random_days = 20 }
-		# Ibrahim AG bahanga Dies in Car Accident
 		country_event = { id = mali.19 days = 212 random_days = 15 }
-		# The MNA is Formed
 		country_event = { id = mali.16 days = 273 random_days = 20 }
-		# MNLA is Formed
 		country_event = { id = mali.16 days = 293 random_days = 20 }
-		# Security in Gao Worsening
 		country_event = { id = mali.21 days = 304 random_days = 20 }
 	}
-	NKO = {
-		news_event = { id = kim_jong_il_death.2 days = 353 }
+	NKO = { news_event = { id = kim_jong_il_death.2 days = 353 } }
+	PER = {
+		country_event = { id = iranian_focus.162 days = 6 }
+		country_event = { id = iranian_flavor.15 days = 85 random_days = 90 }
 	}
-	HOL = {
-		country_event = { id = HOL_common_event.13 days = 99 random_days = 14 }
+	RAJ = {
+		country_event = { id = indian_event.48 days = 93 random_days = 1 }
+		country_event = { id = RAJ_naxal.21 days = 184 random_days = 5 }
 	}
-
-	## PMC Content
-	# B-3-3; w-1-1;A-2-1,C-2-3,M-2-2
-	add_to_variable = { global.merc_capacity^3 = 2 }
-	add_to_variable = { global.merc_upgrade^3 = 1 }
-
-	add_to_variable = { global.merc_capacity^4 = 2 }
-	add_to_variable = { global.merc_upgrade^4 = 1 }
-	ALG = {
-		country_event = { id = alg_politics_news.1 days = 212 }
+	SER = { country_event = { id = Serbia.32 days = 145 } }
+	SIA = {
+		country_event = { id = preah_vihear.120 days = 32 }
+		country_event = { id = thailand.53 days = 183 }
+		country_event = { id = thailand.54 days = 217 }
 	}
-	CHI = { country_event = { id = CHI_political_events.51 days = 90 random_days = 30 } }
-	BOS = {
-		# Mladic arrest, reaction in Sarajevo (26 May 2011, fired 2 days after Serbia.32)
-		country_event = { id = BOS_political.31 days = 147 }
-		# US embassy Sarajevo shooting (28 October 2011)
-		country_event = { id = BOS_political.71 days = 301 }
-	}
+	SLV = { country_event = { id = slovenia.1 days = 295 } }
+	SPR = { country_event = { id = spain.221 random_days = 360 random_hours = 24 } }
+	TUR = { country_event = { id = TUR_flavor_event.9 days = 280 } }
 }
 trigger_year_2012_events = {
-	HKG = {
-		# 2012 LegCo election (9 September 2012)
-		country_event = { id = hongkong_legco.1 days = 252 }
+	if = { limit = { SAU = { owns_state = 176 } } SAU = { country_event = { id = pandemic_events.3 days = 170 random_days = 30 } } }
+	else = { random_country = { limit = { owns_state = 176 } country_event = { id = pandemic_events.3 days = 170 random_days = 30 } } }
+	if = {
+		limit = {
+			has_game_rule = { rule = rule_event_horizon_scenario option = CASUAL }
+			NOT = { has_global_flag = EH_scenario_launched_earlier_flag }
+		}
+		random_country = { EH_convergence_event_chain_effect = yes }
 	}
 	ALG = {
-		if = {
-			limit = { NOT = { has_country_flag = ALG_unlock_fatima_zohra_ardjoune } }
-
-			country_event = { id = ALG.2002 days = 30 random_days = 60 }
-		}
-		if = {
-			limit = { country_exists = GER }
-			# MEKO A-200AN frigate order placed with the German yards
-			country_event = { id = germany.511 days = 90 }
-		}
+		if = { limit = { NOT = { has_country_flag = ALG_unlock_fatima_zohra_ardjoune } } country_event = { id = ALG.2002 days = 30 random_days = 60 } }
+		if = { limit = { country_exists = GER } country_event = { id = germany.511 days = 90 } }
 	}
-	SER = {
-		# EU candidate status granted (1 March 2012)
-		country_event = { id = Serbia.33 days = 60 }
-	}
-	BOS = {
-		# The six-party coalition finally forms, resolving the 2010 deadlock (February 2012)
-		country_event = { id = BOS_political.63 days = 43 }
-	}
-	CRO = {
-		# Gotovina acquitted on appeal
-		country_event = { id = CRO_political.7 days = 321 }
-	}
-	ARM = {
-		if = {
-			limit = {
-				has_government = communism
-			}
-			country_event = { id = arme.204 days = 1 random_days = 30 }
-		}
-	}
+	ARM = { if = { limit = { has_government = communism } country_event = { id = arme.204 days = 1 random_days = 30 } } }
+	BOS = { country_event = { id = BOS_political.63 days = 43 } }
+	CAN = { country_event = { id = canada_md_politics.17 days = 172 random_days = 5 } }
+	CAR = { country_event = { id = central_africa.19 days = 290 random_days = 45 } }
+	CRO = { country_event = { id = CRO_political.7 days = 321 } }
+	CZE = { country_event = { id = CZE_czech.30 days = 270 random_days = 10 } }
+	DEN = { country_event = { id = denmark.33 days = 155 random_days = 5 } }
+	EST = { country_event = { id = estonia.115 days = 90 random_days = 90 } }
 	GER = {
 		country_event = { id = germany.407 days = 1 random_days = 1500 }
 		country_event = { id = germany_yearly.16 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.17 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.41 days = 1 }
 	}
-	GRE = {
-		# Golden Dawn Enters Parliament
-		country_event = { id = greece.509 days = 180 random_days = 30 }
-	}
-	PER = {
-		country_event = { id = iranian_focus.196 days = 1 }
-		country_event = { id = iranian_flavor.16 days = 120 random_days = 60 }
-	}
-	USA = {
-		country_event = { id = USA_econ_event.15 days = 12 random_days = 1098 }
-		country_event = { id = USA_econ_event.16 days = 12 random_days = 732 }
-
-		if = { limit = { has_completed_focus = USA_electoral_rainbow }
-			country_event = { id = USA_treason_event.14 days = 280 } #Reformed Republic Election Fraud
-		}
-		else = {
-			country_event = { id = USA_treason_event.4 days = 286 } #Choose to commit Election Fraud
-		}
-	}
-	CAN = {
-		# War of 1812 Bicentennial
-		country_event = { id = canada_md_politics.17 days = 172 random_days = 5 }
-	}
-	DEN = {
-		#Same-sex marriage
-		country_event = { id = denmark.33 days = 155  random_days = 5 }
-	}
-	SIN = {
-		# Chinese Bus Driver Strike
-		country_event = { id = singapore.117 days = 120 random_days = 90 }
-	}
-	ROM = {
-		country_event = { id = romania_misc.13 days = 49 }
-		country_event = { id = romania_misc.14 days = 96 }
-		country_event = { id = romania_misc.15 days = 150 }
-		country_event = { id = romania_misc.16 days = 162 }
-		if = {
-			limit = {
-				NOT = {
-					has_country_leader = {
-						name = "Adrian Nastase"
-						ruling_only = yes
-					}
-				}
-			}
-			country_event = { id = romania_misc.17 days = 172 }
-		}
-	}
-	SPR = {
-		# Death of Antonio Cubillo
-		country_event = { id = spain.244 random_days = 210 random_hours = 24 }
-		# Catalonia Demands Independence
-		country_event = { id = spain.233 days = 40 random_days = 180 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.10 days = 80 } #Nowruz Protests
-	}
-	EST = {
-		# The EKRE has formed
-		country_event = { id = estonia.115 days = 90 random_days = 90 }
-	}
-	CAR = {
-		# Accusations of Violations
-		# - Start of the Civil War Event Chain
-		country_event = { id = central_africa.19 days = 290 random_days = 45 }
-	}
-	MAL = {
-		# The Second Tuareg Rebellion
-		country_event = { id = mali.22 days = 5 random_days = 10 }
-		# 2012 Malian Coup
-		country_event = { id = mali.23 days = 60 random_days = 10 }
-		# The Islamists Intervene in the Malian War
-		country_event = { id = mali.24 days = 152 random_days = 10 }
-	}
-	CZE = {
-		country_event = { id = CZE_czech.30 days = 270 random_days = 10 }
-	}
-	ISR = {
-		country_event = { id = israel_labour.3 days = 59 }
-	}
-	NIG = {
-		# 2012 - The Nigerian Floods
-		country_event = { id = nigeria_md.115 days = 180 random_days = 60 }
+	GRE = { country_event = { id = greece.509 days = 180 random_days = 30 } }
+	HKG = {
+		# 2012 LegCo election (9 September 2012)
+		country_event = { id = hongkong_legco.1 days = 252 }
 	}
 	HOL = {
-		country_event = { id = HOL_common_event.16 days = 48 } # 17 Feb 2012, Prince Friso's avalanche
-		country_event = { id = HOL_mocro.1 days = 48 random_days = 60 } # Mocro Maffia rises to national prominence
+		country_event = { id = HOL_common_event.16 days = 48 }
+		country_event = { id = HOL_mocro.1 days = 48 random_days = 60 }
 	}
+	ISR = { country_event = { id = israel_labour.3 days = 59 } }
 	JAP = {
 		country_event = { id = JAP_historical.20090808 days = 219 }
 		country_event = { id = JAP_historical.20120928 days = 271 }
 	}
-	# 2012 MERS Outbreak
-	if = {
-		limit = { SAU = { owns_state = 176 } }
-		SAU = {
-			country_event = { id = pandemic_events.3 days = 170 random_days = 30 }
-		}
+	MAL = {
+		country_event = { id = mali.22 days = 5 random_days = 10 }
+		country_event = { id = mali.23 days = 60 random_days = 10 }
+		country_event = { id = mali.24 days = 152 random_days = 10 }
 	}
-	else = {
-		random_country = {
-			limit = { owns_state = 176 }
-			country_event = { id = pandemic_events.3 days = 170 random_days = 30 }
-		}
-	}
-
-	# Event Horizon Casual Mode
-	if = {
-		limit = {
-			has_game_rule = {
-				rule = rule_event_horizon_scenario
-				option = CASUAL
-			}
-			NOT = { has_global_flag = EH_scenario_launched_earlier_flag }
-		}
-		random_country = { EH_convergence_event_chain_effect = yes }
-	}
-
-	# Pakistan joins Antarctic Treaty
+	NIG = { country_event = { id = nigeria_md.115 days = 180 random_days = 60 } }
 	PAK = {
 		if = {
 			limit = {
@@ -2257,12 +1193,32 @@ trigger_year_2012_events = {
 			set_country_flag = antarctica_ccamlr_member
 		}
 	}
+	PER = {
+		country_event = { id = iranian_focus.196 days = 1 }
+		country_event = { id = iranian_flavor.16 days = 120 random_days = 60 }
+	}
+	ROM = {
+		country_event = { id = romania_misc.13 days = 49 }
+		country_event = { id = romania_misc.14 days = 96 }
+		country_event = { id = romania_misc.15 days = 150 }
+		country_event = { id = romania_misc.16 days = 162 }
+		if = { limit = { NOT = { has_country_leader = { name = "Adrian Nastase" ruling_only = yes } } } country_event = { id = romania_misc.17 days = 172 } }
+	}
+	SER = { country_event = { id = Serbia.33 days = 60 } }
+	SIN = { country_event = { id = singapore.117 days = 120 random_days = 90 } }
+	SPR = {
+		country_event = { id = spain.244 random_days = 210 random_hours = 24 }
+		country_event = { id = spain.233 days = 40 random_days = 180 }
+	}
+	TUR = { country_event = { id = TUR_flavor_event.10 days = 80 } }
+	USA = {
+		country_event = { id = USA_econ_event.15 days = 12 random_days = 1098 }
+		country_event = { id = USA_econ_event.16 days = 12 random_days = 732 }
+		if = { limit = { has_completed_focus = USA_electoral_rainbow } country_event = { id = USA_treason_event.14 days = 280 } }
+		else = { country_event = { id = USA_treason_event.4 days = 286 } }
+	}
 }
 trigger_year_2013_events = {
-	CRO = {
-		# EU accession celebrations
-		country_event = { id = CRO_political.8 days = 182 }
-	}
 	if = {
 		limit = {
 			NOT = { has_global_flag = CAR_central_african_republic_civil_war_phase_two }
@@ -2273,10 +1229,25 @@ trigger_year_2013_events = {
 		}
 		CAR = { country_event = { id = central_africa.26 days = 15 } }
 	}
-	CAR = {
-		# The Union for Central African Renewal Forms (URCA)
-		country_event = { id = central_africa.27 days = 330 random_days = 20 }
+	ALG = {
+		country_event = { id = ALG_bouteflika.3 days = 1 }
+		country_event = { id = ALG_terror.13 days = 15 }
+		if = { limit = { NOT = { has_country_flag = ALG_drugs } } country_event = { id = ALG_flavor_event.7 days = 120 random_days = 90 } }
 	}
+	BOS = {
+		country_event = { id = BOS_political.34 days = 273 }
+		country_event = { id = BOS_political.48 days = 100 random_days = 200 }
+		country_event = { id = BOS_political.74 days = 170 }
+		country_event = { id = BOS_political.75 days = 288 }
+	}
+	CAN = { country_event = { id = canada_md_politics.18 days = 136 random_days = 5 } }
+	CAR = { country_event = { id = central_africa.27 days = 330 random_days = 20 } }
+	CRO = { country_event = { id = CRO_political.8 days = 182 } }
+	CZE = {
+		country_event = { id = CZE_political_tree_event.2 days = 122 }
+		country_event = { id = CZE_political_tree_event.1 days = 182 }
+	}
+	DEN = { country_event = { id = denmark.34 days = 94 random_days = 5 } }
 	GER = {
 		country_event = { id = germany_yearly.18 days = 1 random_days = 360 }
 		country_event = { id = germany_yearly.19 days = 1 random_days = 360 }
@@ -2284,97 +1255,40 @@ trigger_year_2013_events = {
 		country_event = { id = germany_party.0 days = 36 }
 	}
 	GRE = {
-		# Greek Solution Party Forms
 		country_event = { id = greece.510 days = 60 random_days = 30 }
-		# Death of Pavlos Fyssas
 		country_event = { id = greece.511 days = 240 random_days = 30 }
 	}
-	USA = {
-		# Election (AI Only)
-		country_event = { id = usa.999 days = 20 }
-	}
-	CAN = {
-		# International Space Station Expedition 35
-		country_event = { id = canada_md_politics.18 days = 136 random_days = 5 }
-	}
-	DEN = {
-		#Teachers union shutting down School
-		country_event = { id = denmark.34 days = 94  random_days = 5 }
-	}
-	SIN = {
-		# Little India Riot
-		country_event = { id = singapore.118 days = 120 random_days = 90 }
-		# Anti-Migrant Worker Demonstrations
-		country_event = { id = singapore.120 days = 90 random_days = 180 }
-	}
-	SPR = {
-		# Vox Forms
-		country_event = { id = spain.207 random_days = 180 random_hours = 72 }
-		# Abdication of Juan Carlos
-		country_event = { id = spain.204 random_days = 450 random_hours = 24 }
-		# Catalan Way 2013
-		country_event = { id = spain.234 random_days = 280 random_hours = 24 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.11 days = 32 } #Attack on Embassy
+	HOL = {
+		if = { limit = { has_idea = HOL_beatrix } country_event = { id = HOL_common_event.1 days = 28 } }
+		country_event = { id = HOL_common_event.17 days = 228 }
 	}
 	ITA = {
 		country_event = { id = italy_md.40 days = 344 }
 		country_event = { id = italy_md.59 days = 255 }
 	}
-	CZE = {
-		# 2013 political rotation
-		country_event = { id = CZE_political_tree_event.2 days = 122 }
-		country_event = { id = CZE_political_tree_event.1 days = 182 }
-	}
-	HOL = {
-		if = {
-			limit = { has_idea = HOL_beatrix }
-			country_event = { id = HOL_common_event.1 days = 28 }
-		}
-		country_event = { id = HOL_common_event.17 days = 228 } # 16 Aug 2013, Prince Friso's funeral
-	}
-	VEN = {
-		# Death of Hugo Chavez
-		country_event = { id = venezuela.24 random_days = 130 random_hours = 24 }
-	}
-	PER = {
-		# 2013 Election Notification
-		country_event = { id = PER_election_events.5 days = 90 }
-		country_event = { id = iranian_flavor.17 days = 105 random_days = 60 }
-	}
-	ALG = {
-		country_event = { id = ALG_bouteflika.3 days = 1 }
-		country_event = { id = ALG_terror.13 days = 15 }
-		if = {
-			limit = { NOT = { has_country_flag = ALG_drugs } }
-
-			country_event = { id = ALG_flavor_event.7 days = 120 random_days = 90 }
-		}
-	}
 	JAP = {
 		country_event = { id = JAP_historical.20090808 days = 219 }
 		country_event = { id = JAP_historical.20120928 days = 271 }
 	}
-	RAJ = {
-		country_event = { id = RAJ_naxal.19 days = 90 random_days = 5 } #2013 Darbha attack
+	PER = {
+		country_event = { id = PER_election_events.5 days = 90 }
+		country_event = { id = iranian_flavor.17 days = 105 random_days = 60 }
 	}
-	BOS = {
-		# First post-war census (1 October 2013)
-		country_event = { id = BOS_political.34 days = 273 }
-		# Mass emigration wave accelerates (2013-2019)
-		country_event = { id = BOS_political.48 days = 100 random_days = 200 }
-		# The JMBG "babylution" protests (June-July 2013)
-		country_event = { id = BOS_political.74 days = 170 }
-		# First-ever World Cup qualification (15 October 2013)
-		country_event = { id = BOS_political.75 days = 288 }
+	RAJ = { country_event = { id = RAJ_naxal.19 days = 90 random_days = 5 } }
+	SIN = {
+		country_event = { id = singapore.118 days = 120 random_days = 90 }
+		country_event = { id = singapore.120 days = 90 random_days = 180 }
 	}
+	SPR = {
+		country_event = { id = spain.207 random_days = 180 random_hours = 72 }
+		country_event = { id = spain.204 random_days = 450 random_hours = 24 }
+		country_event = { id = spain.234 random_days = 280 random_hours = 24 }
+	}
+	TUR = { country_event = { id = TUR_flavor_event.11 days = 32 } }
+	USA = { country_event = { id = usa.999 days = 20 } }
+	VEN = { country_event = { id = venezuela.24 random_days = 130 random_hours = 24 } }
 }
 trigger_year_2014_events = {
-	SER = {
-		# Cyclone Tamara floods (mid-May 2014)
-		country_event = { id = Serbia.6 days = 133 }
-	}
 	if = {
 		limit = {
 			NOT = { has_global_flag = CAR_central_african_republic_civil_war_phase_two }
@@ -2385,64 +1299,8 @@ trigger_year_2014_events = {
 		}
 		CAR = { country_event = { id = central_africa.26 days = 15 } }
 	}
-	GER = {
-		country_event = { id = germany_yearly.20 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.21 days = 1 random_days = 360 }
-		country_event = { id = germany_yearly.43 days = 1 }
-	}
-	USA = {
-		country_event = { id = USA_crisis_event.1000 days = 212 random_days = 25 }
-	}
-	CAN = {
-		# Negotiations with the EU on CETA Conclude
-		country_event = { id = canada_md_politics.19 days = 216 random_days = 5 }
-		# Terror in the Capital
-		country_event = { id = canada_md_politics.20 days = 298 random_days = 5 }
-	}
-	SIN = {
-		# Defamation Around CPF Scheme
-		country_event = { id = singapore.121 days = 90 random_days = 90 }
-		# MRT Line Cosnstruction
-		country_event = { id = singapore.122 days = 120 random_days = 120 }
-	}
-	SPR = {
-		# Catalan Way 2014
-		country_event = { id = spain.235 random_days = 180 random_hours = 24 }
-		# Catalan Self-Determination Referendum
-		country_event = { id = spain.236 days = 190 random_days = 30 }
-		# Charges Brought Against Cristina
-		country_event = { id = spain.265 days = 180 random_hours = 96 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.12 days = 130 } #Soma mine disaster
-	}
-	BOS = {
-		country_event = { id = BOS_political.17 days = 120 random_days = 30 }
-		# Tuzla protests and plenums (4 February 2014)
-		country_event = { id = BOS_political.35 days = 34 }
-		# 2014 general election: return of the nationalists (12 October 2014)
-		country_event = { id = BOS_political.64 days = 285 }
-	}
-	HOL = {
-		if = {
-			limit = {
-				UKR = { has_war_with = SOV }
-			}
-			country_event = { id = HOL_common_event.5 days = 130 random_days = 60 }
-		}
-	}
-	EGY = {
-		if = {
-			limit = { owns_state = 217 }
-			country_event = { id = egypt.163 days = 90 random_days = 45 }
-		}
-	}
-
-	## PMC Content
-	# B-3-3; w-2-2;A-3-2,C-2-3,M-3-3
 	add_to_variable = { global.merc_capacity^2 = 2 }
 	add_to_variable = { global.merc_upgrade^2 = 1 }
-
 	add_to_variable = { global.merc_capacity^4 = 2 }
 	add_to_variable = { global.merc_upgrade^4 = 1 }
 	if = {
@@ -2450,352 +1308,141 @@ trigger_year_2014_events = {
 		add_to_variable = { global.merc_capacity^1 = 2 }
 		add_to_variable = { global.merc_upgrade^1 = 1 }
 	}
-	ALG = {
-		country_event = { id = ALG_2014_oil_crash.1 days = 1 }
+	if = { limit = { GUI = { owns_state = 360 } } GUI = { country_event = { id = pandemic_events.4 days = 60 random_days = 30 } } }
+	else = { random_country = { limit = { owns_state = 360 } country_event = { id = pandemic_events.4 days = 60 random_days = 30 } } }
+	ALG = { country_event = { id = ALG_2014_oil_crash.1 days = 1 } }
+	BLR = {
+		setup_scripted_ai_station = yes
+		if = { limit = { country_exists = LPR } country_event = { id = belarus_ukraine.2 days = 160 } }
 	}
+	BOS = {
+		country_event = { id = BOS_political.17 days = 120 random_days = 30 }
+		country_event = { id = BOS_political.35 days = 34 }
+		country_event = { id = BOS_political.64 days = 285 }
+	}
+	CAN = {
+		country_event = { id = canada_md_politics.19 days = 216 random_days = 5 }
+		country_event = { id = canada_md_politics.20 days = 298 random_days = 5 }
+	}
+	EGY = { if = { limit = { owns_state = 217 } country_event = { id = egypt.163 days = 90 random_days = 45 } } }
+	FRA = { country_event = { id = france_md.507 days = 1 } }
+	GER = {
+		country_event = { id = germany_yearly.20 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.21 days = 1 random_days = 360 }
+		country_event = { id = germany_yearly.43 days = 1 }
+	}
+	HOL = { if = { limit = { UKR = { has_war_with = SOV } } country_event = { id = HOL_common_event.5 days = 130 random_days = 60 } } }
 	JAP = {
 		country_event = { id = JAP_historical.20120928 days = 271 }
 		country_event = { id = JAP_historical.20141128 days = 331 }
-	}
-	# 2014 Ebola Outbreak — West Africa
-	if = {
-		limit = { GUI = { owns_state = 360 } }
-		GUI = {
-			country_event = { id = pandemic_events.4 days = 60 random_days = 30 }
-		}
-	}
-	else = {
-		random_country = {
-			limit = { owns_state = 360 }
-			country_event = { id = pandemic_events.4 days = 60 random_days = 30 }
-		}
-	}
-	FRA = {
-		# Eurocopter Group rebrands as Airbus Helicopters (2 January 2014)
-		country_event = { id = france_md.507 days = 1 }
 	}
 	RAJ = {
 		country_event = { id = RAJ_regional.11 days = 60 random_days = 120 }
 		country_event = { id = RAJ_regional.16 days = 200 random_days = 60 }
 		country_event = { id = RAJ_regional.18 days = 250 random_days = 30 }
 	}
-
-	# 2014 Belarus begins construction of Antarctic Research Station
-	BLR = {
-		setup_scripted_ai_station = yes
-		if = {
-			limit = { country_exists = LPR }
-			# Belarusian volunteers head for the Donbas
-			country_event = { id = belarus_ukraine.2 days = 160 }
-		}
-	}
-}
-trigger_year_2015_events = {
-	GER = {
-		country_event = { id = germany_yearly.44 days = 1 }
-	}
-	BLR = {
-		if = {
-			limit = {
-				country_exists = UKR
-				country_exists = DPR
-			}
-			# Minsk II signed in Minsk (11 February 2015)
-			country_event = { id = belarus_ukraine.3 days = 41 }
-		}
-	}
-	BOS = {
-		# Attack on the Zvornik police station (27 April 2015)
-		country_event = { id = BOS_political.72 days = 117 }
-		# SAA enters into force (1 June 2015)
-		country_event = { id = BOS_political.81 days = 152 }
-		# B&H Airlines liquidated (June 2015)
-		country_event = { id = BOS_political.77 days = 162 }
-		# Buroj Ozone Gulf megaproject announced (2015)
-		country_event = { id = BOS_political.78 days = 200 }
-	}
-	PER = {
-		country_event = { id = iranian_flavor.18 days = 125 random_days = 90 }
-	}
-	ARM = {
-		if = {
-			limit = {
-				NOT = {
-					neutrality_neutral_libertarians_are_in_power = yes
-				}
-			}
-			country_event = { id = arme.206 days = 150 }
-		}
-		country_event = { id = arme.207 days = 171 }
-		if = {
-			limit = {
-				gives_military_access_to = SOV
-			}
-			country_event = { id = arme.208 days = 12 }
-		}
-	}
-	CAN = {
-		# Airstrikes in Syria and Iraq
-		country_event = { id = canada_md_politics.21 days = 139 random_days = 5 }
-	}
-	GRE = {
-		# Trial of Golden Dawn Members
-		country_event = { id = greece.512 days = 180 random_days = 60 }
-	}
-	DEN = {
-		#Islamist Omar El-Hussein
-		country_event = { id = denmark.35 days = 35  random_days = 5 }
-	}
-	ROM = {
-		# Death of Corneliu Vadim Tudor
-		country_event = { id = romania_politics.24 days = 288 }
-	}
+	SER = { country_event = { id = Serbia.6 days = 133 } }
 	SIN = {
-		# Death of Lee Kuan Yew
-		country_event = { id = singapore.123 days = 60 random_days = 30 }
-		# 15 Suspected Militants of Jemaah Islamiyah
-		country_event = { id = singapore.124 days = 120 random_days = 30 }
-		# Reduction of Banned Books
-		country_event = { id = singapore.125 days = 160 random_days = 30 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.13 days = 280 } #Ankara bombings
-	}
-	SOV = {
-		country_event = { id = sov_liberals.29 days = 280 }
+		country_event = { id = singapore.121 days = 90 random_days = 90 }
+		country_event = { id = singapore.122 days = 120 random_days = 120 }
 	}
 	SPR = {
-		# Stripping of Titles
-		country_event = { id = spain.265 days = 170 random_hours = 96 }
+		country_event = { id = spain.235 random_days = 180 random_hours = 24 }
+		country_event = { id = spain.236 days = 190 random_days = 30 }
+		country_event = { id = spain.265 days = 180 random_hours = 96 }
 	}
-	USA = {
-		country_event = { id = USA_crisis_event.1002 days = 150 random_days = 61 }
-	}
+	TUR = { country_event = { id = TUR_flavor_event.12 days = 130 } }
+	USA = { country_event = { id = USA_crisis_event.1000 days = 212 random_days = 25 } }
+}
+trigger_year_2015_events = {
 	ALG = {
 		country_event = { id = alg_generals.3 days = 1 }
-		if = {
-			limit = { NOT = { has_country_flag = ALG_migration_flood } }
-
-			country_event = { id = ALG_flavor_event.6 days = 150 random_days = 120 }
-		}
+		if = { limit = { NOT = { has_country_flag = ALG_migration_flood } } country_event = { id = ALG_flavor_event.6 days = 150 random_days = 120 } }
 	}
+	ARM = {
+		if = { limit = { NOT = { neutrality_neutral_libertarians_are_in_power = yes } } country_event = { id = arme.206 days = 150 } }
+		if = { limit = { gives_military_access_to = SOV } country_event = { id = arme.208 days = 12 } }
+		country_event = { id = arme.207 days = 171 }
+	}
+	BLR = { if = { limit = { country_exists = UKR country_exists = DPR } country_event = { id = belarus_ukraine.3 days = 41 } } }
+	BOS = {
+		country_event = { id = BOS_political.72 days = 117 }
+		country_event = { id = BOS_political.81 days = 152 }
+		country_event = { id = BOS_political.77 days = 162 }
+		country_event = { id = BOS_political.78 days = 200 }
+	}
+	CAN = { country_event = { id = canada_md_politics.21 days = 139 random_days = 5 } }
+	DEN = { country_event = { id = denmark.35 days = 35 random_days = 5 } }
+	FRA = { country_event = { id = france_md.505 days = 210 random_days = 14 } }
+	GER = { country_event = { id = germany_yearly.44 days = 1 } }
+	GRE = { country_event = { id = greece.512 days = 180 random_days = 60 } }
 	JAP = {
 		country_event = { id = JAP_historical.20120928 days = 271 }
 		country_event = { id = JAP_historical.20141128 days = 331 }
 		country_event = { id = JAP_ai.3 days = 180 random_days = 30 }
 	}
-	FRA = {
-		# KANT holding agreement — KMW + Nexter merger (29 July 2015)
-		country_event = { id = france_md.505 days = 210 random_days = 14 }
-	}
+	PER = { country_event = { id = iranian_flavor.18 days = 125 random_days = 90 } }
 	RAJ = {
 		country_event = { id = RAJ_regional.1 days = 160 random_days = 10 }
 		country_event = { id = RAJ_regional.2 days = 170 random_days = 10 }
 		country_event = { id = RAJ_regional.8 days = 230 random_days = 10 }
 		country_event = { id = RAJ_regional.13 days = 260 random_days = 15 }
 	}
+	ROM = { country_event = { id = romania_politics.24 days = 288 } }
+	SIN = {
+		country_event = { id = singapore.123 days = 60 random_days = 30 }
+		country_event = { id = singapore.124 days = 120 random_days = 30 }
+		country_event = { id = singapore.125 days = 160 random_days = 30 }
+	}
+	SOV = { country_event = { id = sov_liberals.29 days = 280 } }
+	SPR = { country_event = { id = spain.265 days = 170 random_hours = 96 } }
+	TUR = { country_event = { id = TUR_flavor_event.13 days = 280 } }
+	USA = { country_event = { id = USA_crisis_event.1002 days = 150 random_days = 61 } }
 }
 trigger_year_2016_events = {
-	GER = {
-		country_event = { id = germany_yearly.45 days = 1 }
+	ARM = { if = { limit = { has_government = communism } country_event = { id = arme.211 days = 195 } } }
+	BOS = {
+		country_event = { id = BOS_political.36 days = 45 }
+		news_event = { id = balkan_news.1 days = 83 }
+		country_event = { id = BOS_political.76 days = 254 }
+		country_event = { id = BOS_political.69 days = 336 }
 	}
-	SIA = {
-		country_event = { id = thailand.14 days = 287 }
-	}
-	HKG = {
-		country_event = { id = hongkong_legco.1 days = 247 }
-	}
-	MNT = {
-		# Election-day coup plot (16 October 2016)
-		country_event = { id = Montenegro.28 days = 289 }
-	}
-	PHI = {
-		country_event = { id = philippines.1 days = 181 } # Partido Federal ng Pilipinas (Duterte era)
-	}
-	MOR = {
-		country_event = { id = morocco.401 days = 152 } # National Unity Collective forms
-	}
-	PER = {
-		country_event = { id = iranian_flavor.19 days = 160 random_days = 90 }
-	}
-	ARM = {
-		if = {
-			limit = {
-				has_government = communism
-			}
-			country_event = { id = arme.211 days = 195 }
-		}
-	}
-	USA = {
-		country_event = { id = USA_econ_event.17 days = 16 random_days = 1464 }
-		country_event = { id = USA_crisis_event.1003 days = 150 random_days = 61 }
-		if = { limit = { has_completed_focus = USA_electoral_rainbow }
-			country_event = { id = USA_treason_event.17 days = 280 } #Reformed Republic Election Fraud
-		}
-		else = {
-			country_event = { id = USA_treason_event.5 days = 286 } #Choose to commit Election Fraud
-		}
-	}
-	CAN = {
-		#The Case of Omar Kadhr
-		country_event = { id = canada_md_politics.22 days = 52 random_days = 5 }
-	}
-	DEN = {
-		#Asylum Seekers Valuables
-		country_event = { id = denmark.36 days = 4  random_days = 5 }
-	}
-	SIN = {
-		# Eight Bangladeshi Arrested
-		country_event = { id = singapore.126 days = 120 random_days = 90 }
-	}
-	SPR = {
-		# Unidos Podemos Forms
-		country_event = { id = spain.210 random_days = 90 random_hours = 24 }
-		# Go Ahead Catalan Republic!
-		country_event = { id = spain.237 random_days = 280 random_hours = 24 }
-	}
-	UZB = {
-		if = {
-			limit = {
-				has_country_leader = {
-					name = "Islam Karimov"
-					ruling_only = yes
-				}
-			}
-			country_event = { id = centraluzb.6 days = 243 }
-		}
-	}
+	CAN = { country_event = { id = canada_md_politics.22 days = 52 random_days = 5 } }
+	DEN = { country_event = { id = denmark.36 days = 4 random_days = 5 } }
+	GER = { country_event = { id = germany_yearly.45 days = 1 } }
+	HKG = { country_event = { id = hongkong_legco.1 days = 247 } }
 	ITA = {
 		country_event = { id = italy_md.15 days = 239 }
 		country_event = { id = italy_md.24 random_days = 180 }
 	}
-	NIG = {
-		# Niger Delta Avengers Emergence - February 2016 (historical)
-		country_event = { id = nigeria_delta.20 days = 45 random_days = 60 }
+	JAP = {
+		country_event = { id = JAP_historical.20120928 days = 271 }
+		country_event = { id = JAP_historical.20141128 days = 331 }
+	}
+	MNT = { country_event = { id = Montenegro.28 days = 289 } }
+	MOR = { country_event = { id = morocco.401 days = 152 } }
+	NIG = { country_event = { id = nigeria_delta.20 days = 45 random_days = 60 } }
+	PER = { country_event = { id = iranian_flavor.19 days = 160 random_days = 90 } }
+	PHI = { country_event = { id = philippines.1 days = 181 } }
+	SIA = { country_event = { id = thailand.14 days = 287 } }
+	SIN = { country_event = { id = singapore.126 days = 120 random_days = 90 } }
+	SPR = {
+		country_event = { id = spain.210 random_days = 90 random_hours = 24 }
+		country_event = { id = spain.237 random_days = 280 random_hours = 24 }
 	}
 	TAI = {
 		country_event = { id = taiwan.13 days = 180 random_days = 35 }
 		country_event = { id = taiwan.16 days = 220 random_days = 35 }
 	}
-	JAP = {
-		country_event = { id = JAP_historical.20120928 days = 271 }
-		country_event = { id = JAP_historical.20141128 days = 331 }
+	USA = {
+		country_event = { id = USA_econ_event.17 days = 16 random_days = 1464 }
+		country_event = { id = USA_crisis_event.1003 days = 150 random_days = 61 }
+		if = { limit = { has_completed_focus = USA_electoral_rainbow } country_event = { id = USA_treason_event.17 days = 280 } }
+		else = { country_event = { id = USA_treason_event.5 days = 286 } }
 	}
-	BOS = {
-		# EU membership application (15 February 2016)
-		country_event = { id = BOS_political.36 days = 45 }
-		# Karadzic convicted at The Hague (24 March 2016)
-		news_event = { id = balkan_news.1 days = 83 }
-		# EFT Stanari thermal plant reaches commercial operation (September 2016)
-		country_event = { id = BOS_political.76 days = 254 }
-		# The Ljubic ruling freezes election-law reform (December 2016)
-		country_event = { id = BOS_political.69 days = 336 }
-	}
+	UZB = { if = { limit = { has_country_leader = { name = "Islam Karimov" ruling_only = yes } } country_event = { id = centraluzb.6 days = 243 } } }
 }
 trigger_year_2017_events = {
-	GER = {
-		country_event = { id = germany_yearly.46 days = 1 }
-	}
-	MNT = {
-		# NATO accession celebrations (5 June 2017)
-		country_event = { id = Montenegro.29 days = 155 }
-	}
-	SLV = {
-		country_event = { id = slovenia.6 days = 175 } # The Left (Levica) forms
-	}
-	CAN = {
-		#Fate of the Bombardier CSeries
-		country_event = { id = canada_md_politics.23 days = 288 random_days = 5 }
-		#Plans to increase military spending
-		country_event = { id = canada_md_politics.25 days = 157 random_days = 5 }
-		#Canada Celebrates 150 years of being around
-		country_event = { id = canada_md_politics.26 days = 181 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.62 days = 31 random_days = 1 } #2016 Uri attack
-		country_event = { id = indian_event.63 days = 335 random_days = 1 } #2016 Demonetization
-		country_event = { id = RAJ_regional.3 days = 240 random_days = 30 }
-		country_event = { id = RAJ_regional.4 days = 100 random_days = 30 }
-		country_event = { id = RAJ_regional.17 days = 200 random_days = 30 }
-	}
-	DEN = {
-		#Banning Hate Speech
-		country_event = { id = denmark.37 days = 125  random_days = 5 }
-		#Ancient Law
-		country_event = { id = denmark.38 days = 156  random_days = 5 }
-	}
-	GRE = {
-		# Major Aegean Earthquake
-		country_event = { id = greece.513 days = 180 random_days = 30 }
-	}
-	ROM = {
-		country_event = { id = romania_politics.20 days = 340 }
-	}
-	BRA = {
-		if = { limit = { has_government = nationalist }
-			country_event = { id = brazil.23 days = 5 random_days = 50 }
-		}
-		if = { limit = { has_government = communism }
-			# 2016 - Protests for Dilma's Impeachment
-			country_event = { id = brazil.40 days = 244 }
-		}
-	}
-	USA = {
-		country_event = { id = usa.999 days = 20 } #Election (AI Only)
-	}
-	FRA = {
-		# DCNS rebrands to Naval Group (28 June 2017)
-		country_event = { id = france_md.508 days = 178 }
-	}
-	KYR = {
-		if = {
-			limit = {
-				OR = {
-					has_country_leader = {
-						name = "Almazbek Atambayev"
-						ruling_only = yes
-					}
-					has_country_leader = {
-						name = "Roza Otunbayeva"
-						ruling_only = yes
-					}
-				}
-			}
-			country_event = { id = centralkyr.28 days = 286 }
-		}
-	}
-	SIN = {
-		# Eight Bangladeshi Arrested
-		country_event = { id = singapore.127 days = 90 random_days = 90 }
-	}
-	SPR = {
-		# Barcelona Terror Attacks
-		country_event = { id = spain.259 days = 120 random_days = 120 random_hours = 24 }
-		country_event = { id = spain.238 days = 120 random_days = 30 }
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.14 days = 200 }
-	}
-	BRA = {
-		# 2017 Carnaval
-		country_event = { id = brazil_flavour_events.12 days = 30 random_days = 15 }
-	}
-	CZE = {
-		# 2017 political rotation
-		country_event = { id = CZE_political_tree_event.1 days = 182 }
-	}
-	PER = {
-		# 2017 Election Notification
-		country_event = { id = PER_election_events.6 days = 90 }
-	}
-	JAP = {
-		country_event = { id = JAP_historical.20120928 days = 271 }
-		country_event = { id = JAP_historical.20141128 days = 331 }
-		country_event = { id = JAP_historical.20170925 days = 267 }
-	}
-
-	### PMC Content
-	# B-3-3; w-3-3;A-3-3,C-3-3,M-3-3
 	add_to_variable = { global.merc_capacity^3 = 2 }
 	add_to_variable = { global.merc_upgrade^2 = 1 }
 	if = {
@@ -2803,170 +1450,113 @@ trigger_year_2017_events = {
 		add_to_variable = { global.merc_capacity^1 = 2 }
 		add_to_variable = { global.merc_upgrade^1 = 1 }
 	}
+	BOS = { news_event = { id = balkan_news.3 days = 325 } }
+	BRA = {
+		if = { limit = { has_government = nationalist } country_event = { id = brazil.23 days = 5 random_days = 50 } }
+		if = { limit = { has_government = communism } country_event = { id = brazil.40 days = 244 } }
+		country_event = { id = brazil_flavour_events.12 days = 30 random_days = 15 }
+	}
+	CAN = {
+		country_event = { id = canada_md_politics.23 days = 288 random_days = 5 }
+		country_event = { id = canada_md_politics.25 days = 157 random_days = 5 }
+		country_event = { id = canada_md_politics.26 days = 181 }
+	}
+	CRO = { news_event = { id = balkan_news.4 days = 332 } }
+	CZE = { country_event = { id = CZE_political_tree_event.1 days = 182 } }
+	DEN = {
+		country_event = { id = denmark.37 days = 125 random_days = 5 }
+		country_event = { id = denmark.38 days = 156 random_days = 5 }
+	}
+	FRA = { country_event = { id = france_md.508 days = 178 } }
+	GER = { country_event = { id = germany_yearly.46 days = 1 } }
+	GRE = { country_event = { id = greece.513 days = 180 random_days = 30 } }
+	JAP = {
+		country_event = { id = JAP_historical.20120928 days = 271 }
+		country_event = { id = JAP_historical.20141128 days = 331 }
+		country_event = { id = JAP_historical.20170925 days = 267 }
+	}
+	KYR = {
+		if = {
+			limit = {
+				OR = {
+					has_country_leader = { name = "Almazbek Atambayev" ruling_only = yes }
+					has_country_leader = { name = "Roza Otunbayeva" ruling_only = yes }
+				}
+			}
+			country_event = { id = centralkyr.28 days = 286 }
+		}
+	}
+	MNT = { country_event = { id = Montenegro.29 days = 155 } }
+	PER = { country_event = { id = PER_election_events.6 days = 90 } }
 	RAJ = {
+		country_event = { id = indian_event.62 days = 31 random_days = 1 }
+		country_event = { id = indian_event.63 days = 335 random_days = 1 }
+		country_event = { id = RAJ_regional.3 days = 240 random_days = 30 }
+		country_event = { id = RAJ_regional.4 days = 100 random_days = 30 }
+		country_event = { id = RAJ_regional.17 days = 200 random_days = 30 }
 		country_event = { id = RAJ_naxal.18 days = 114 random_days = 5 }
-		country_event = { id = RAJ_eastas.6 days = 151 random_days = 1 } #2017 Doklam standoff
+		country_event = { id = RAJ_eastas.6 days = 151 random_days = 1 }
 	}
-	BOS = {
-		# Mladic convicted at The Hague (22 November 2017)
-		news_event = { id = balkan_news.3 days = 325 }
+	ROM = { country_event = { id = romania_politics.20 days = 340 } }
+	SIN = { country_event = { id = singapore.127 days = 90 random_days = 90 } }
+	SLV = { country_event = { id = slovenia.6 days = 175 } }
+	SPR = {
+		country_event = { id = spain.259 days = 120 random_days = 120 random_hours = 24 }
+		country_event = { id = spain.238 days = 120 random_days = 30 }
 	}
-	CRO = {
-		# Praljak courtroom suicide, Prlic verdicts upheld (29 November 2017)
-		news_event = { id = balkan_news.4 days = 332 }
-	}
+	TUR = { country_event = { id = TUR_flavor_event.14 days = 200 } }
+	USA = { country_event = { id = usa.999 days = 20 } }
 }
 trigger_year_2018_events = {
-	GER = {
-		country_event = { id = germany_yearly.47 days = 1 }
-	}
-	BOS = {
-		country_event = { id = BOS_political.41 days = 150 } # Western Balkans migrant route crisis (Una-Sana)
-		country_event = { id = BOS_political.49 days = 280 } # Komsic wins the Croat presidency seat (7 October 2018)
-		country_event = { id = BOS_political.50 days = 290 } # NATO Annual National Programme deadlock begins (October 2018)
-		news_event = { id = balkan_news.8 days = 140 } # Erdogan's Sarajevo rally (20 May 2018)
-	}
-	SER = {
-		# Flash floods hit farmland (June 2018)
-		country_event = { id = Serbia.7 days = 160 random_days = 30 }
-	}
-	SLV = {
-		country_event = { id = slovenia.2 days = 154 } # List of Marjan Šarec enters national politics
-	}
-	FYR = {
-		# Prespa Agreement signed with Greece (17 June 2018)
-		country_event = { id = FYR_political.3 days = 167 }
-	}
+	if = { limit = { DRC = { owns_state = 302 } } DRC = { country_event = { id = pandemic_events.6 days = 210 random_days = 30 } } }
+	else = { random_country = { limit = { owns_state = 302 } country_event = { id = pandemic_events.6 days = 210 random_days = 30 } } }
 	ARM = {
 		if = {
 			limit = {
-				NOT = {
-					neutrality_neutral_libertarians_are_in_power = yes
-				}
+				NOT = { neutrality_neutral_libertarians_are_in_power = yes }
 				has_government = communism
 				has_country_flag = ARM_fashinyan_priskokal
 			}
 			country_event = { id = arme.215 days = 90 }
 		}
 	}
+	BOS = {
+		country_event = { id = BOS_political.41 days = 150 }
+		country_event = { id = BOS_political.49 days = 280 }
+		country_event = { id = BOS_political.50 days = 290 }
+		news_event = { id = balkan_news.8 days = 140 }
+	}
 	BRA = {
 		country_event = { id = brazil.28 days = 120 random_days = 20 }
-		# 2018 - Lula is Arrested
 		country_event = { id = brazil.38 days = 97 }
-		# 2018 - Bolsonaro Stabbed in Juiz de Fora
 		country_event = { id = brazil.41 days = 249 }
 	}
-	GRE = {
-		# 2018 Attica Wildfires
-		country_event = { id = greece.514 days = 200 random_days = 30 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.49 days = 248 random_days = 1 } #Question of LGBT
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.15 days = 15 } #CASA CN Crash
-		# 2018 Turkey setups camp on Antarctica
-		setup_scripted_ai_station = yes
-	}
-	ITA = {
-		country_event = { id = italy_md.61 days = 230 }
-	}
-	ISR = {
-		country_event = { id = israel_labour.4 days = 356 }
-	}
+	FYR = { country_event = { id = FYR_political.3 days = 167 } }
+	GER = { country_event = { id = germany_yearly.47 days = 1 } }
+	GRE = { country_event = { id = greece.514 days = 200 random_days = 30 } }
+	ISR = { country_event = { id = israel_labour.4 days = 356 } }
+	ITA = { country_event = { id = italy_md.61 days = 230 } }
 	JAP = {
 		country_event = { id = JAP_historical.20141128 days = 331 }
 		country_event = { id = JAP_historical.20170925 days = 267 }
 		country_event = { id = JAP_historical.20180507 days = 126 }
 	}
-	# 2018 Ebola Outbreak — DR Congo
-	if = {
-		limit = { DRC = { owns_state = 302 } }
-		DRC = {
-			country_event = { id = pandemic_events.6 days = 210 random_days = 30 }
-		}
-	}
-	else = {
-		random_country = {
-			limit = { owns_state = 302 }
-			country_event = { id = pandemic_events.6 days = 210 random_days = 30 }
-		}
+	RAJ = { country_event = { id = indian_event.49 days = 248 random_days = 1 } }
+	SER = { country_event = { id = Serbia.7 days = 160 random_days = 30 } }
+	SLV = { country_event = { id = slovenia.2 days = 154 } }
+	TUR = {
+		country_event = { id = TUR_flavor_event.15 days = 15 }
+		setup_scripted_ai_station = yes
 	}
 }
 trigger_year_2019_events = {
-	GER = {
-		country_event = { id = germany_yearly.48 days = 1 }
-	}
-	SIA = {
-		# Bhumjaithai enters the post-election coalition (Mar 2019)
-		country_event = { id = thailand.270 days = 85 }
-	}
-	PER = {
-		country_event = { id = iranian_flavor.20 days = 115 random_days = 60 }
-	}
-	ENG = {
-		# Prince Andrew steps back from public duties (20 November 2019)
-		country_event = { id = ENG_inner_circle_andrew.06 days = 324 }
-	}
-	ARM = {
-		if = {
-			limit = {
-				NOT = {
-					western_conservatism_are_in_power = yes
-				}
-			}
-			country_event = { id = arme.219 days = 173 }
-		}
-	}
-	USA = {
-		country_event = { id = USA_econ_event.7 days = 354 random_days = 31 }
-		country_event = { id = USA_crisis_event.1004 days = 250 random_days = 10 }
-	}
-	GRE = {
-		# Another Athenian Earthquake
-		country_event = { id = greece.515 days = 150 random_days = 30 }
-	}
-	RAJ = {
-		country_event = { id = indian_event.50 days = 44 random_days = 1 } #another terrorist attack
-		country_event = { id = indian_event.64 days = 305 random_days = 1 } #2019 Pulwama attack
-		country_event = { id = indian_event.65 days = 274 random_days = 1 } #2019 Article 370 revocation
-		country_event = { id = indian_event.66 days = 274 random_days = 1 } #2019 CAA protests
-		country_event = { id = RAJ_regional.5 days = 240 random_days = 30 }
-	}
-	SPR = {
-		# Unidas Podemos
-		country_event = { id = spain.211 random_days = 180 random_hours = 24 }
-
-		country_event = { id = spain.240 days = 120 random_days = 30 }
-	}
-	KAZ = {
-		if = {
-			limit = {
-				has_country_leader = {
-					name = "Nursultan Nazarbayev"
-					ruling_only = yes
-				}
-			}
-			country_event = { id = centralkaz.4 days = 77 }
-		}
-	}
-	TUR = {
-		country_event = { id = TUR_flavor_event.16 days = 330 } #Antarctica outpost
-	}
-	ROM = {
-		country_event = { id = romania_misc.18 days = 181 }
-	}
-	COM = {
-		country_event = { id = comoros.24 days = 113 }
-	}
-	ALG = {
-		country_event = { id = ALG_bouteflika_resigns.1 days = 120 }
-	}
-	JAP = {
-		country_event = { id = JAP_historical.20141128 days = 331 }
-		country_event = { id = JAP_historical.20170925 days = 267 }
-		country_event = { id = JAP_historical.20180507 days = 126 }
-		country_event = { id = JAP_historical.20190401 days = 90 }
+	ALG = { country_event = { id = ALG_bouteflika_resigns.1 days = 120 } }
+	ARM = { if = { limit = { NOT = { western_conservatism_are_in_power = yes } } country_event = { id = arme.219 days = 173 } } }
+	BOS = {
+		news_event = { id = balkan_news.2 days = 78 }
+		country_event = { id = BOS_political.80 days = 252 }
+		country_event = { id = BOS_political.51 days = 357 }
+		country_event = { id = BOS_political.58 days = 190 }
 	}
 	CHI = {
 		if = {
@@ -2979,201 +1569,128 @@ trigger_year_2019_events = {
 			country_event = { id = CHI_semiconductor_events.1 days = 150 random_days = 30 }
 		}
 	}
-	BOS = {
-		# Karadzic appeal, life sentence (20 March 2019)
-		news_event = { id = balkan_news.2 days = 78 }
-		# First Sarajevo Pride march (9 September 2019)
-		country_event = { id = BOS_political.80 days = 252 }
-		# Council of Ministers finally seated (23 December 2019)
-		country_event = { id = BOS_political.51 days = 357 }
-		# Aluminij Mostar smelter shut down over unpaid power debt (9 July 2019)
-		country_event = { id = BOS_political.58 days = 190 }
-	}
-}
-trigger_year_2020_events = {
-	SIA = {
-		# The student protest wave (Aug 2020)
-		country_event = { id = thailand.71 days = 216 }
-	}
-	BOS = {
-		# Lavrov's Sarajevo visit and the stolen icon (December 2020)
-		news_event = { id = balkan_news.9 days = 350 }
-		# Mostar holds local elections for the first time in twelve years (20 December 2020)
-		country_event = { id = BOS_political.65 days = 354 }
-	}
-	CHI = {
-		if = {
-			limit = { country_exists = RAJ }
-			country_event = { id = sino_indian.22 days = 165 } # Galwan Valley clash
-		}
-	}
-	USA = {
-		country_event = { id = iranian_focus.160 days = 3 random_days = 10 }
-		country_event = { id = USA_crisis_event.1005 days = 59 random_days = 25 }
-		country_event = { id = USA_treason_event.6 days = 286 } #Choose to commit Election Fraud
-	}
-	POL = {
-		if = { limit = { western_conservatism_are_in_power = yes }
-			country_event = { id = poland.10 days = 210 random_days = 30 }
-		}
-	}
-	KYR = {
-		if = {
-			limit = {
-				has_country_leader = {
-					name = "Sooronbay Jeenbekov"
-					ruling_only = yes
-				}
-			}
-			country_event = { id = centralkyr.21 days = 277 }
-		}
-	}
-	SOV = {
-		# Creation of New People Party
-		country_event = { id = russia.107 days = 20 }
-	}
-	OMA = {
-		# Death of Sultan Qaboos
-		country_event = { id = oman_royal.1 days = 1 random_days = 90 }
-	}
+	COM = { country_event = { id = comoros.24 days = 113 } }
+	ENG = { country_event = { id = ENG_inner_circle_andrew.06 days = 324 } }
+	GER = { country_event = { id = germany_yearly.48 days = 1 } }
+	GRE = { country_event = { id = greece.515 days = 150 random_days = 30 } }
 	JAP = {
+		country_event = { id = JAP_historical.20141128 days = 331 }
 		country_event = { id = JAP_historical.20170925 days = 267 }
 		country_event = { id = JAP_historical.20180507 days = 126 }
 		country_event = { id = JAP_historical.20190401 days = 90 }
 	}
+	KAZ = { if = { limit = { has_country_leader = { name = "Nursultan Nazarbayev" ruling_only = yes } } country_event = { id = centralkaz.4 days = 77 } } }
+	PER = { country_event = { id = iranian_flavor.20 days = 115 random_days = 60 } }
 	RAJ = {
-		country_event = { id = RAJ_eastas.7 days = 152 random_days = 1 } #2020 Galwan clash
-		country_event = { id = RAJ_regional.6 days = 280 random_days = 30 }
-		country_event = { id = RAJ_regional.15 days = 140 random_days = 20 }
+		country_event = { id = indian_event.50 days = 44 random_days = 1 }
+		country_event = { id = indian_event.64 days = 305 random_days = 1 }
+		country_event = { id = indian_event.65 days = 274 random_days = 1 }
+		country_event = { id = indian_event.66 days = 274 random_days = 1 }
+		country_event = { id = RAJ_regional.5 days = 240 random_days = 30 }
 	}
-	if = {
-		limit = { CHI = { owns_state = 570 } }
-		CHI = {
-			# Start of the COVID Events
-			country_event = { id = COVID_events.0 days = 300 random_days = 30 }
-		}
+	ROM = { country_event = { id = romania_misc.18 days = 181 } }
+	SIA = { country_event = { id = thailand.270 days = 85 } }
+	SPR = {
+		country_event = { id = spain.211 random_days = 180 random_hours = 24 }
+		country_event = { id = spain.240 days = 120 random_days = 30 }
 	}
-	else = {
-		random_country = {
-			limit = { owns_state = 570 }
-			country_event = { id = COVID_events.0 days = 300 random_days = 30 }
-		}
+	TUR = { country_event = { id = TUR_flavor_event.16 days = 330 } }
+	USA = {
+		country_event = { id = USA_econ_event.7 days = 354 random_days = 31 }
+		country_event = { id = USA_crisis_event.1004 days = 250 random_days = 10 }
 	}
-
-	# Event Horizon Delayed Mode
+}
+trigger_year_2020_events = {
+	if = { limit = { CHI = { owns_state = 570 } } CHI = { country_event = { id = COVID_events.0 days = 300 random_days = 30 } } }
+	else = { random_country = { limit = { owns_state = 570 } country_event = { id = COVID_events.0 days = 300 random_days = 30 } } }
 	if = {
 		limit = {
-			has_game_rule = {
-				rule = rule_event_horizon_scenario
-				option = DELAYED
-			}
+			has_game_rule = { rule = rule_event_horizon_scenario option = DELAYED }
 			NOT = { has_global_flag = EH_scenario_launched_earlier_flag }
 		}
 		random_country = { EH_convergence_event_chain_effect = yes }
 	}
-}
-trigger_year_2021_events = {
-	SLV = {
-		country_event = { id = slovenia.3 days = 26 } # Z.DEJ (Green Action) registered
+	BOS = {
+		news_event = { id = balkan_news.9 days = 350 }
+		country_event = { id = BOS_political.65 days = 354 }
 	}
-	HKG = {
-		# 2021 LegCo election under the revised electoral system (19 December 2021)
-		country_event = { id = hongkong_legco.1 days = 352 }
-	}
-	CHI = {
-		if = {
-			limit = { has_completed_focus = CHI_seventeen_plus_one_mechanism }
-			country_event = { id = chi_bri.94 days = 141 } # Lithuania withdraws from the 17+1
-		}
-	}
-	ARM = {
-		if = {
-			limit = {
-				nationalist_military_junta_are_in_power = no
-			}
-			country_event = { id = arme.220 days = 112 }
-		}
-	}
-	TUR = {
-		country_event = { id = TurkeyFocusEvents.54 days = 7 } #Beyezid III Dies
-	}
-	SPR = {
-		# September 17th Attacks
-		country_event = { id = spain.260 days = 190 random_days = 130 random_hours = 24 }
-
-		country_event = { id = spain.241 days = 120 random_days = 30 }
-	}
-	USA = {
-		country_event = { id = USA_crisis_event.1006 days = 5 random_days = 25 }
-		country_event = { id = usa.999 days = 20 } #Election (AI Only)
-	}
-	CZE = {
-		# 2021 political rotation
-		country_event = { id = CZE_political_tree_event.1 days = 182 }
-		# 2021 tornado
-		country_event = { id = CZE_czech.29 days = 186 random_days = 10 }
-	}
-	EGY = {
-		# Evergreen Ship Stuck
-		country_event = { id = egypt.100 days = 85 random_days = 40 }
-	}
-	HOL = { country_event = { id = HOL_common_event.14 days = 195 random_days = 12 } }
-	GER = { country_event = { id = germany.66 days = 90 random_days = 12 } }
-	PER = {
-		# 2021 Election Notification
-		country_event = { id = PER_election_events.7 days = 90 }
-	}
-	ENG = { country_event = { id = ENG_inner_circle_philip.04 days = 99 } }
+	CHI = { if = { limit = { country_exists = RAJ } country_event = { id = sino_indian.22 days = 165 } } }
 	JAP = {
 		country_event = { id = JAP_historical.20170925 days = 267 }
 		country_event = { id = JAP_historical.20180507 days = 126 }
 		country_event = { id = JAP_historical.20190401 days = 90 }
 	}
+	KYR = { if = { limit = { has_country_leader = { name = "Sooronbay Jeenbekov" ruling_only = yes } } country_event = { id = centralkyr.21 days = 277 } } }
+	OMA = { country_event = { id = oman_royal.1 days = 1 random_days = 90 } }
+	POL = { if = { limit = { western_conservatism_are_in_power = yes } country_event = { id = poland.10 days = 210 random_days = 30 } } }
 	RAJ = {
-		country_event = { id = RAJ_naxal.20 days = 120 random_days = 5 } #2021 Bijapur attack
+		country_event = { id = RAJ_eastas.7 days = 152 random_days = 1 }
+		country_event = { id = RAJ_regional.6 days = 280 random_days = 30 }
+		country_event = { id = RAJ_regional.15 days = 140 random_days = 20 }
+	}
+	SIA = { country_event = { id = thailand.71 days = 216 } }
+	SOV = { country_event = { id = russia.107 days = 20 } }
+	USA = {
+		country_event = { id = iranian_focus.160 days = 3 random_days = 10 }
+		country_event = { id = USA_crisis_event.1005 days = 59 random_days = 25 }
+		country_event = { id = USA_treason_event.6 days = 286 }
+	}
+}
+trigger_year_2021_events = {
+	ARM = { if = { limit = { nationalist_military_junta_are_in_power = no } country_event = { id = arme.220 days = 112 } } }
+	BOS = {
+		news_event = { id = balkan_news.5 days = 158 }
+		country_event = { id = BOS_political.37 days = 203 }
+		country_event = { id = BOS_political.38 days = 343 }
+		country_event = { id = BOS_political.52 days = 182 }
+	}
+	CHI = { if = { limit = { has_completed_focus = CHI_seventeen_plus_one_mechanism } country_event = { id = chi_bri.94 days = 141 } } }
+	CZE = {
+		country_event = { id = CZE_political_tree_event.1 days = 182 }
+		country_event = { id = CZE_czech.29 days = 186 random_days = 10 }
+	}
+	EGY = { country_event = { id = egypt.100 days = 85 random_days = 40 } }
+	ENG = { country_event = { id = ENG_inner_circle_philip.04 days = 99 } }
+	GER = { country_event = { id = germany.66 days = 90 random_days = 12 } }
+	HKG = { country_event = { id = hongkong_legco.1 days = 352 } }
+	HOL = { country_event = { id = HOL_common_event.14 days = 195 random_days = 12 } }
+	JAP = {
+		country_event = { id = JAP_historical.20170925 days = 267 }
+		country_event = { id = JAP_historical.20180507 days = 126 }
+		country_event = { id = JAP_historical.20190401 days = 90 }
+	}
+	PER = { country_event = { id = PER_election_events.7 days = 90 } }
+	RAJ = {
+		country_event = { id = RAJ_naxal.20 days = 120 random_days = 5 }
 		country_event = { id = RAJ_regional.7 days = 50 random_days = 30 }
 	}
-	SWE = {
-		# 2021 government crisis and no-confidence vote
-		country_event = { id = Sweden.20 days = 172 random_days = 15 }
+	SLV = { country_event = { id = slovenia.3 days = 26 } }
+	SPR = {
+		country_event = { id = spain.260 days = 190 random_days = 130 random_hours = 24 }
+		country_event = { id = spain.241 days = 120 random_days = 30 }
 	}
-	BOS = {
-		# Mladic appeal upheld (8 June 2021)
-		news_event = { id = balkan_news.5 days = 158 }
-		# High Representative bans genocide denial (23 July 2021)
-		country_event = { id = BOS_political.37 days = 203 }
-		# Republika Srpska withdrawal laws (10 December 2021)
-		country_event = { id = BOS_political.38 days = 343 }
-		# Schmidt appointed High Representative without a UNSC endorsement (1 August 2021)
-		country_event = { id = BOS_political.52 days = 182 }
+	SWE = { country_event = { id = Sweden.20 days = 172 random_days = 15 } }
+	TUR = { country_event = { id = TurkeyFocusEvents.54 days = 7 } }
+	USA = {
+		country_event = { id = USA_crisis_event.1006 days = 5 random_days = 25 }
+		country_event = { id = usa.999 days = 20 }
 	}
 }
 trigger_year_2022_events = {
-	SLV = {
-		country_event = { id = slovenia.5 days = 27 } # Modern Centre Party rebrands as Konkretno
-		country_event = { id = slovenia.4 days = 114 } # Z.DEJ rebrands as the Freedom Movement
-	}
 	BLR = {
 		if = {
 			limit = {
 				country_exists = UKR
 				UKR = { has_war = yes }
 			}
-			# Kalinovsky Regiment formed from Belarusian volunteers (March 2022)
 			country_event = { id = belarus_ukraine.1 days = 68 }
 		}
 	}
-	KAZ = {
-		if = {
-			limit = {
-				has_country_leader = {
-					name = "Kassym-Jomart Tokayev"
-					ruling_only = yes
-				}
-			}
-			country_event = { id = centralkaz.5 days = 154 }
-			country_event = { id = centralkaz.6 days = 1 }
-		}
+	BOS = {
+		country_event = { id = BOS_political.39 days = 348 }
+		country_event = { id = BOS_political.53 days = 275 }
+		news_event = { id = balkan_news.7 days = 60 }
+		country_event = { id = BOS_political.73 days = 100 }
 	}
 	JAP = {
 		country_event = { id = JAP_historical.20170925 days = 267 }
@@ -3181,56 +1698,48 @@ trigger_year_2022_events = {
 		country_event = { id = JAP_historical.20190401 days = 90 }
 		country_event = { id = JAP_historical.20220710 days = 190 }
 	}
-	BOS = {
-		# AI fallback: EU candidate status historically granted (15 December 2022)
-		country_event = { id = BOS_political.39 days = 348 }
-		# Schmidt imposes election-law and constitutional changes as polls close (2 October 2022)
-		country_event = { id = BOS_political.53 days = 275 }
-		# EUFOR Althea reinforcement after Russia's invasion of Ukraine (February-March 2022)
-		news_event = { id = balkan_news.7 days = 60 }
-		# US sanctions widen against Dodik's patronage network
-		country_event = { id = BOS_political.73 days = 100 }
+	KAZ = {
+		if = {
+			limit = { has_country_leader = { name = "Kassym-Jomart Tokayev" ruling_only = yes } }
+			country_event = { id = centralkaz.5 days = 154 }
+			country_event = { id = centralkaz.6 days = 1 }
+		}
+	}
+	SLV = {
+		country_event = { id = slovenia.5 days = 27 }
+		country_event = { id = slovenia.4 days = 114 }
 	}
 }
 trigger_year_2023_events = {
-	KOS = {
-		# The Banjska attack (24 September 2023)
-		country_event = { id = kosovo.12 days = 266 }
+	BOS = {
+		country_event = { id = BOS_political.54 days = 152 random_days = 30 }
+		country_event = { id = BOS_political.59 days = 315 random_days = 15 }
+		country_event = { id = BOS_political.60 days = 350 }
 	}
-	CRO = {
-		# Schengen and euro entry
-		country_event = { id = CRO_political.9 days = 1 }
-	}
+	CRO = { country_event = { id = CRO_political.9 days = 1 } }
+	HOL = { country_event = { id = HOL_common_event.18 days = 311 } }
 	JAP = {
 		country_event = { id = JAP_historical.20180507 days = 126 }
 		country_event = { id = JAP_historical.20190401 days = 90 }
 		country_event = { id = JAP_historical.20220710 days = 190 }
 	}
+	KOS = { country_event = { id = kosovo.12 days = 266 } }
 	RAJ = {
-		country_event = { id = indian_event.67 days = 213 random_days = 1 } #2023 Manipur violence
+		country_event = { id = indian_event.67 days = 213 random_days = 1 }
 		country_event = { id = RAJ_regional.10 days = 170 random_days = 30 }
-	}
-	HOL = { country_event = { id = HOL_common_event.18 days = 311 } } #7 Nov 2023, Pär Sundström (Sabaton) at the National Military Museum
-	BOS = {
-		# Republika Srpska passes laws voiding Constitutional Court rulings and HR decisions (June-July 2023)
-		country_event = { id = BOS_political.54 days = 152 random_days = 30 }
-		# ArcelorMittal Zenica idles its blast furnace (November 2023)
-		country_event = { id = BOS_political.59 days = 315 random_days = 15 }
-		# Tuzla Block 7 Chinese-financed loan project collapses (December 2023)
-		country_event = { id = BOS_political.60 days = 350 }
 	}
 }
 trigger_year_2024_events = {
-	SIN = {
-		# Stepping Down of Lee Hsien Loong
-		country_event = { id = singapore.128 days = 136 }
+	ALG = { country_event = { id = algeria_elections.2024 days = 335 } }
+	BOS = {
+		country_event = { id = BOS_political.55 days = 81 }
+		country_event = { id = BOS_political.56 days = 81 }
+		news_event = { id = balkan_news.6 days = 161 }
+		country_event = { id = BOS_political.79 days = 277 }
 	}
-	USA = {
-		country_event = { id = USA_crisis_event.1007 days = 22 }
-		country_event = { id = USA_treason_event.7 days = 286 } #Choose to commit Election Fraud
-	}
-	ISR = {
-		country_event = { id = israel_labour.2 days = 180 }
+	COM = {
+		country_event = { id = comoros.25 days = 101 }
+		country_event = { id = comoros.26 days = 257 }
 	}
 	HAM = {
 		if = {
@@ -3242,56 +1751,33 @@ trigger_year_2024_events = {
 			country_event = { id = israel.152 days = 280 }
 		}
 	}
-	COM = {
-		country_event = { id = comoros.25 days = 101 }
-		country_event = { id = comoros.26 days = 257 }
-	}
-	ALG = {
-		country_event = { id = algeria_elections.2024 days = 335 }
-	}
-	JAP = {
-		country_event = { id = JAP_historical.20220710 days = 190 }
-	}
-	BOS = {
-		# EU Council opens accession negotiations (21 March 2024)
-		country_event = { id = BOS_political.55 days = 81 }
-		country_event = { id = BOS_political.56 days = 81 }
-		# The "Serbian World" declaration (June 2024)
-		news_event = { id = balkan_news.6 days = 161 }
-		# Jablanica floods and landslide (3-4 October 2024)
-		country_event = { id = BOS_political.79 days = 277 }
+	ISR = { country_event = { id = israel_labour.2 days = 180 } }
+	JAP = { country_event = { id = JAP_historical.20220710 days = 190 } }
+	SIN = { country_event = { id = singapore.128 days = 136 } }
+	USA = {
+		country_event = { id = USA_crisis_event.1007 days = 22 }
+		country_event = { id = USA_treason_event.7 days = 286 }
 	}
 }
 trigger_year_2025_events = {
-	SIA = {
-		# Ta Muen Thom landmine incident (Jul 2025)
-		country_event = { id = thailand.315 days = 182 }
-		# Paetongtarn removed by the Constitutional Court (Aug 2025)
-		country_event = { id = thailand.320 days = 213 }
-	}
-	country_event = { id = usa.999 days = 20 } #Election (AI Only)
-	PER = {
-		# 2025 Election Notification
-		country_event = { id = PER_election_events.71 days = 90 }
+	country_event = { id = usa.999 days = 20 }
+	BOS = {
+		country_event = { id = BOS_political.57 days = 57 }
+		country_event = { id = BOS_political.66 days = 60 }
+		country_event = { id = BOS_political.67 days = 114 }
+		country_event = { id = BOS_political.68 days = 327 }
 	}
 	ENG = { country_event = { id = ENG_inner_circle_andrew.05 days = 200 random_days = 100 } }
-	JAP = {
-		country_event = { id = JAP_historical.20220710 days = 190 }
-	}
-	HOL = { country_event = { id = HOL_monarchy.40 days = 272 } } #29 Sep 2025, Princess Amalia enters military service
-	BOS = {
-		# Dodik convicted and banned from office (26 February 2025)
-		country_event = { id = BOS_political.57 days = 57 }
-		# Republika Srpska passes a "foreign agents" registry law (27 February - March 2025)
-		country_event = { id = BOS_political.66 days = 60 }
-		# Arrest warrant, flight to Moscow, and the failed SIPA arrest (March-April 2025)
-		country_event = { id = BOS_political.67 days = 114 }
-		# RS snap presidential election: Karan succeeds Dodik (23 November 2025)
-		country_event = { id = BOS_political.68 days = 327 }
+	HOL = { country_event = { id = HOL_monarchy.40 days = 272 } }
+	JAP = { country_event = { id = JAP_historical.20220710 days = 190 } }
+	PER = { country_event = { id = PER_election_events.71 days = 90 } }
+	SIA = {
+		country_event = { id = thailand.315 days = 182 }
+		country_event = { id = thailand.320 days = 213 }
 	}
 }
 trigger_year_2026_events = {
-	HOL = { country_event = { id = HOL_monarchy.41 days = 35 } } #4 Feb 2026, Queen Máxima enters military service
+	HOL = { country_event = { id = HOL_monarchy.41 days = 35 } }
 }
 trigger_year_2027_events = {
 	ALG = {
@@ -3320,7 +1806,7 @@ trigger_year_2036_events = {
 trigger_year_2037_events = {
 }
 trigger_year_2038_events = {
-	HOL = { country_event = { id = HOL_common_event.3 days = 180 random_days = 60 } } # Willem-Alexander's 25th year on the throne
+	HOL = { country_event = { id = HOL_common_event.3 days = 180 random_days = 60 } }
 }
 trigger_year_2039_events = {
 }
@@ -3379,9 +1865,7 @@ trigger_year_2065_events = {
 trigger_year_2066_events = {
 }
 trigger_year_2067_events = {
-	USA = {
-		country_event = { id = USA_crisis_event.8 days = 30 random_days = 336 }
-	}
+	USA = { country_event = { id = USA_crisis_event.8 days = 30 random_days = 336 } }
 }
 trigger_year_2068_events = {
 }

--- a/common/scripted_effects/00_yearly_effects.txt
+++ b/common/scripted_effects/00_yearly_effects.txt
@@ -99,8 +99,6 @@ MD_event_on_startup_events = {
 	}
 	NRY = { country_event = { id = norway.1 days = 3 random_days = 7 } }
 	PER = {
-		set_country_flag = PER_mek_insurgency_active
-		set_variable = { PER_mek_strength = 15 }
 		country_event = { id = iranian_focus.178 days = 1 random_days = 360 }
 		country_event = { id = iranian_focus.179 days = 90 }
 		country_event = { id = iranian_focus.180 days = 12 }


### PR DESCRIPTION
### Changes
- Reformatted the yearly date-based event scheduling into one-line blocks and sorted the contents of every year: untagged effects first, then country tags alphabetically, so a given year's schedule can be scanned at a glance
- Removed a commented-out Gaza flotilla raid scheduling line that the Israeli focus tree already superseded
- Combined duplicate blocks of TAG = {}

No gameplay change. The set of event IDs scheduled by this file is identical to main; the only removed reference was already commented out.