### PR TITLE
Fix Chen Shui-bian unelectable in Taiwan 2000 election

### DIFF
--- a/common/country_leader/TAI_traits.txt
+++ b/common/country_leader/TAI_traits.txt
@@ -1,0 +1,26 @@
+leader_traits = {
+	black_gold_crusader = {
+		random = no
+		stability_factor = 0.05
+		police_cost_multiplier_modifier = -0.05
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	establishment_economist = {
+		random = no
+		stability_factor = 0.05
+		interest_rate_multiplier_modifier = -1
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	grassroots_campaigner = {
+		random = no
+		political_power_factor = 0.10
+		stability_factor = 0.05
+		ai_will_do = {
+			factor = 1
+		}
+	}
+}

--- a/common/scripted_effects/TAI_political_leaders.txt
+++ b/common/scripted_effects/TAI_political_leaders.txt
@@ -13,6 +13,7 @@ set_leader_TAI = {
 				traits = {
 					western_conservatism
 					pro_china
+					establishment_economist
 				}
 			}
 
@@ -119,6 +120,7 @@ set_leader_TAI = {
 				traits = {
 					neutrality_Neutral_conservatism
 					pro_china
+					grassroots_campaigner
 				}
 			}
 
@@ -243,6 +245,7 @@ set_leader_TAI = {
 					rash
 					pro_american
 					pro_independence_taiwan
+					black_gold_crusader
 				}
 			}
 

--- a/events/Taiwan.txt
+++ b/events/Taiwan.txt
@@ -65,32 +65,25 @@ country_event = {
 	option = {
 		name = taiwan.3.a
 		log = "[GetDateText]: [This.GetName]: taiwan.3.a executed"
-		set_politics = {
-			ruling_party = democratic
-			elections_allowed = yes
-		}
+		set_temp_variable = { rul_party_temp = 2 }
+		set_temp_variable = { change_leader_temp = 1 }
+		change_ruling_party_effect = yes
 	}
 
 	option = {
 		name = taiwan.3.b
 		log = "[GetDateText]: [This.GetName]: taiwan.3.b executed"
-		create_country_leader = {
-			name = "Lien Chan"
-			picture = "Lien_Chan.dds"
-			expire = "2055.1.1"
-			ideology = Neutral_conservatism
-		}
+		set_temp_variable = { rul_party_temp = 1 }
+		set_temp_variable = { change_leader_temp = 1 }
+		change_ruling_party_effect = yes
 	}
 
 	option = {
 		name = taiwan.3.c
 		log = "[GetDateText]: [This.GetName]: taiwan.3.c executed"
-		create_country_leader = {
-			name = "James Soong"
-			picture = "James_Soong.dds"
-			expire = "2055.1.1"
-			ideology = Neutral_conservatism
-		}
+		set_temp_variable = { rul_party_temp = 14 }
+		set_temp_variable = { change_leader_temp = 1 }
+		change_ruling_party_effect = yes
 	}
 
 }

--- a/localisation/english/MD_new_traits_l_english.yml
+++ b/localisation/english/MD_new_traits_l_english.yml
@@ -236,3 +236,11 @@
 
  Firefighter: "Background: Firefighter"
  Firefighter_desc: "Has a background as a Firefighter"
+
+ # Taiwan
+ black_gold_crusader: "Black Gold Crusader"
+ black_gold_crusader_desc: "Rose to prominence fighting Taiwan's black gold politics of vote-buying and money. His anti-corruption crusade made him the face of political change."
+ establishment_economist: "Establishment Economist"
+ establishment_economist_desc: "University of Chicago-trained economist and steady hand of the KMT establishment. Cautious and methodical, he steered Taiwan's economy through its boom years."
+ grassroots_campaigner: "Grassroots Campaigner"
+ grassroots_campaigner_desc: "A tireless campaigner with unmatched grassroots appeal. His charisma and common touch made him the most popular politician of his generation."


### PR DESCRIPTION
Fixes #2788

**What**
The DPP option in the Taiwan 2000 presidential election event (`taiwan.3.a`) only ran `set_politics` without creating a leader, so picking Chen Shui-bian left Lee Teng-hui in office and disrupted the election flow. The KMT and independent options worked but hand-rolled `create_country_leader` outside the mod's politics system.

**Why**
`common/scripted_effects/TAI_political_leaders.txt` already defines the canonical TAI leader roster (Lien Chan/conservatism, James Soong/Neutral_conservatism, Chen Shui-bian/liberalism) wired for `change_ruling_party_effect`, but it was never invoked. The event duplicated the roster, dropped the candidate traits, never retired the outgoing leader, and missed the DPP entry entirely.

**How**
All three options now set `rul_party_temp` (2 = liberalism/DPP, 1 = conservatism/KMT, 14 = Neutral_conservatism/Soong) plus `change_leader_temp = 1` and call `change_ruling_party_effect`, matching `singapore_elections.0` and the `MD4_election.3` campaign-result flow. The swap rebuilds the ruling-party array, updates politics/party name, retires the incumbent and creates the proper leader via `set_leader_TAI`.

New flavor traits in `common/country_leader/TAI_traits.txt`, added to the roster:
- `black_gold_crusader` (Chen Shui-bian): stability + police cost, from his anti-corruption campaign against the KMT's black gold politics
- `establishment_economist` (Lien Chan): stability + interest rate, from his University of Chicago training and steady premiership
- `grassroots_campaigner` (James Soong): political power + stability, from his unmatched grassroots appeal as provincial governor