### PR TITLE
Fix war support inverting war refugee outflow

### DIFF
--- a/common/scripted_effects/00_money_system.txt
+++ b/common/scripted_effects/00_money_system.txt
@@ -6450,7 +6450,7 @@ calculate_migration_mechanic_values = {
 				multiply = 0.20
 				multiply = {
 					value = 0.50
-					add = modifier@war_support_factor
+					subtract = modifier@war_support_factor
 					clamp = { min = 0 max = 1 }
 				}
 				multiply = -1


### PR DESCRIPTION
Closes #2760

## What
In `common/scripted_effects/00_money_system.txt` (`personal_war_refugees_display`), flip `add = modifier@war_support_factor` to `subtract = modifier@war_support_factor`.

## Why
The war refugee outflow expression is negative (`... multiply = -1`). With `add`, higher war support `(0.50 + ws)` increased the multiplier and therefore increased outflow, the opposite of the intent. A country whose citizens support the war keeps more people home, so fewer flee. The regression came from the math-expression conversion (#2156), which dropped the old `war_support_modifier = -1 + total_war_support` reduction term.

## How
Neutral support (factor 0) keeps the 0.50 baseline. Higher war support yields a smaller multiplier and less outflow. The existing `clamp = { min = 0 max = 1 }` guards against negatives at very high support. `war_support_factor` deltas are small (\u00b10.05\u20130.10), so sensitivity is mild.