### PR TITLE
Use Event Horizon Models For Walker Tanks (#2792)

### DIFF
--- a/common/special_projects/projects/zz_event_horizon_special_projects.txt
+++ b/common/special_projects/projects/zz_event_horizon_special_projects.txt
@@ -1,12 +1,9 @@
 # Author(s): XCezor, HACS project icon: cyrusjackson, HACS mech design: Muv Luv Team, converted to HoI4: cyrusjackson
 sp_monitor_portal_energy_emissions_project = {
+	allowed = { EH_scenario_enabled = yes }
 	specialization = specialization_land
 	icon = GFX_sp_wireless_power_grid_expansion
 	project_tags = sp_tag_eh_portal_research
-
-	visible = {
-		FROM = { EH_scenario_enabled = yes }
-	}
 
 	available = {
 		FROM = { has_completed_focus = EH_portals_must_be_the_key }
@@ -115,13 +112,10 @@ sp_monitor_portal_energy_emissions_project = {
 }
 
 sp_spies_in_hive_project = {
+	allowed = { EH_scenario_enabled = yes }
 	specialization = specialization_land
 	icon = GFX_sp_naval_swarm_drones
 	project_tags = sp_tag_eh_portal_research
-
-	visible = {
-		FROM = { EH_scenario_enabled = yes }
-	}
 
 	available = {
 		FROM = { has_completed_focus = EH_but_how_does_this_key_work }
@@ -246,13 +240,10 @@ sp_spies_in_hive_project = {
 }
 
 sp_the_tesla_weapon_project = {
+	allowed = { EH_scenario_enabled = yes }
 	specialization = specialization_land
 	icon = GFX_sp_emp_warheads
 	project_tags = sp_tag_eh_portal_research
-
-	visible = {
-		FROM = { EH_scenario_enabled = yes }
-	}
 
 	available = {
 		FROM = { has_completed_focus = EH_project_tesla }
@@ -352,13 +343,10 @@ sp_the_tesla_weapon_project = {
 }
 
 sp_hacs_gen_one_project = {
+	allowed = { EH_scenario_enabled = yes }
 	specialization = specialization_land
 	icon = GFX_sp_HACS
 	project_tags = sp_tag_eh_mech_research
-
-	visible = {
-		FROM = { EH_scenario_enabled = yes }
-	}
 
 	available = {
 		FROM = {
@@ -649,13 +637,10 @@ sp_hacs_gen_one_project = {
 }
 
 sp_hacs_gen_two_project = {
+	allowed = { EH_scenario_enabled = yes }
 	specialization = specialization_land
 	icon = GFX_sp_HACS
 	project_tags = sp_tag_eh_mech_research
-
-	visible = {
-		FROM = { EH_scenario_enabled = yes }
-	}
 
 	available = {
 		FROM = {
@@ -816,13 +801,10 @@ sp_hacs_gen_two_project = {
 }
 
 sp_hacs_gen_three_project = {
+	allowed = { EH_scenario_enabled = yes }
 	specialization = specialization_land
 	icon = GFX_sp_HACS
 	project_tags = sp_tag_eh_mech_research
-
-	visible = {
-		FROM = { EH_scenario_enabled = yes }
-	}
 
 	available = {
 		FROM = {

--- a/gfx/entities/MD_HACS.asset
+++ b/gfx/entities/MD_HACS.asset
@@ -906,6 +906,83 @@ entity = {
 	scale = 0.35
 }
 ############
+############ MIDDLE EAST HACS - MODERNISED
+############
+# This mesh carries no rifle_ or thruster_ locators, so the muzzle and exhaust particles are dropped
+entity = {
+	name = "HACS_SAS32M_entity"
+	pdxmesh = "HACS_SAS32M_mesh"
+
+	state = { name = "idle"				animation = "idle"   animation_blend_time = 0.3 }
+	state = { name = "move"				animation = "move"   animation_blend_time = 0.3
+		event = { trigger_once = yes sound = { soundeffect = "HACS_engine" } }
+	}
+	state = { name = "retreat"				animation = "move"   animation_blend_time = 0.3
+		event = { trigger_once = yes sound = { soundeffect = "HACS_engine" } }
+	}
+	################ RANDOM ATTACK ################
+	state = { name = "attack"			animation = "attack_1" animation_blend_time = 0.3 chance = 1
+		event = { time = 0 sound = { soundeffect = HACS_gun } }
+		event = { time = 1.50 sound = { soundeffect = HACS_gun } }
+		event = { time = 3 sound = { soundeffect = HACS_gun } }
+	}
+	###
+	state = { name = "attack"			animation = "attack_2" animation_blend_time = 0.3 chance = 1
+		event = { time = 1.30 sound = { soundeffect = HACS_gun } }
+		event = { time = 5.60 sound = { soundeffect = HACS_gun } }
+	}
+	###
+	state = { name = "attack"			animation = "attack_3" animation_blend_time = 0.3 chance = 1
+		event = { time = 0 sound = { soundeffect = HACS_gun } }
+		event = { time = 1 sound = { soundeffect = HACS_gun } }
+		event = { time = 1.60 sound = { soundeffect = HACS_gun } }
+		event = { time = 2.10 sound = { soundeffect = HACS_gun } }
+		event = { time = 3.40 sound = { soundeffect = HACS_gun } }
+	}
+	#################
+	state = { name = "defend"			animation = "attack_1" animation_blend_time = 0.3 chance = 1
+		event = { time = 0 sound = { soundeffect = HACS_gun } }
+		event = { time = 1.50 sound = { soundeffect = HACS_gun } }
+		event = { time = 3 sound = { soundeffect = HACS_gun } }
+	}
+	###
+	state = { name = "defend"			animation = "attack_2" animation_blend_time = 0.3 chance = 1
+		event = { time = 1.30 sound = { soundeffect = HACS_gun } }
+		event = { time = 5.60 sound = { soundeffect = HACS_gun } }
+	}
+	###
+	state = { name = "defend"			animation = "attack_3" animation_blend_time = 0.3 chance = 1
+		event = { time = 0 sound = { soundeffect = HACS_gun } }
+		event = { time = 1 sound = { soundeffect = HACS_gun } }
+		event = { time = 1.60 sound = { soundeffect = HACS_gun } }
+		event = { time = 2.10 sound = { soundeffect = HACS_gun } }
+		event = { time = 3.40 sound = { soundeffect = HACS_gun } }
+	}
+	#################
+	state = { name = "support_attack"			animation = "attack_1" animation_blend_time = 0.3 chance = 1
+		event = { time = 0 sound = { soundeffect = HACS_gun } }
+		event = { time = 1.50 sound = { soundeffect = HACS_gun } }
+		event = { time = 3 sound = { soundeffect = HACS_gun } }
+	}
+	###
+	state = { name = "support_attack"			animation = "attack_2" animation_blend_time = 0.3 chance = 1
+		event = { time = 1.30 sound = { soundeffect = HACS_gun } }
+		event = { time = 5.60 sound = { soundeffect = HACS_gun } }
+	}
+	###
+	state = { name = "support_attack"			animation = "attack_3" animation_blend_time = 0.3 chance = 1
+		event = { time = 0 sound = { soundeffect = HACS_gun } }
+		event = { time = 1 sound = { soundeffect = HACS_gun } }
+		event = { time = 1.60 sound = { soundeffect = HACS_gun } }
+		event = { time = 2.10 sound = { soundeffect = HACS_gun } }
+		event = { time = 3.40 sound = { soundeffect = HACS_gun } }
+	}
+	#################
+	state = { name = "training"				animation = "idle" 			animation_blend_time = 0.3 animation_speed = 1.0 }
+
+	scale = 0.35
+}
+############
 ############ MIDDLE EAST HACS
 ############
 entity = {

--- a/gfx/entities/MD_HACS.gfx
+++ b/gfx/entities/MD_HACS.gfx
@@ -29,4 +29,15 @@ objectTypes = {
 		animation = { id = "attack_2"			type = "HACS_SAS32_attack_2_animation" }
 		animation = { id = "attack_3"			type = "HACS_SAS32_attack_3_animation" }
 	}
+	# SAS32M is rigged to the SAS32 skeleton bone-for-bone, so it reuses that animation set
+	pdxmesh = {
+		name = "HACS_SAS32M_mesh"
+		file = "gfx/models/units/HACS/HACS_SAS32M.mesh"
+
+		animation = { id = "idle"			type = "HACS_SAS32_idle_animation" }
+		animation = { id = "move"			type = "HACS_SAS32_move_animation" }
+		animation = { id = "attack_1"			type = "HACS_SAS32_attack_1_animation" }
+		animation = { id = "attack_2"			type = "HACS_SAS32_attack_2_animation" }
+		animation = { id = "attack_3"			type = "HACS_SAS32_attack_3_animation" }
+	}
 }

--- a/gfx/interface/equipmentdesigner/graphic_db/00_tank_icons.txt
+++ b/gfx/interface/equipmentdesigner/graphic_db/00_tank_icons.txt
@@ -37,6 +37,32 @@ default = {
 				"gfx/interface/technologies/0_generic/armor/titan_1_v2.dds"
 				"gfx/interface/technologies/0_generic/armor/titan_1.dds"
 			}
+			models = {
+				"HACS_BF38_entity"
+				"HACS_GSK41_entity"
+				"HACS_SAS32_entity"
+				"HACS_SAS32M_entity"
+			}
+		}
+	}
+	super_heavy_tank_destroyer_chassis = {
+		pool = {
+			models = {
+				"HACS_BF38_entity"
+				"HACS_GSK41_entity"
+				"HACS_SAS32_entity"
+				"HACS_SAS32M_entity"
+			}
+		}
+	}
+	super_heavy_tank_artillery_chassis = {
+		pool = {
+			models = {
+				"HACS_BF38_entity"
+				"HACS_GSK41_entity"
+				"HACS_SAS32_entity"
+				"HACS_SAS32M_entity"
+			}
 		}
 	}
 	medium_tank_chassis_0 = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank.gui
@@ -59,18 +59,6 @@ guiTypes = {
 					position = { x=0 y=0 }
 					size = { width=100% height=100% }
 				}
-
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_bra.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_bra.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_chi.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_chi.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_eng.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_eng.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_fra.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_fra.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_gah.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_gah.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_ger.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_ger.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_isr.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_isr.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_ita.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_ita.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_jap.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_jap.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_pol.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_pol.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_usa.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_artillery_usa.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_bra.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_bra.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_chi.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_chi.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_bra.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_bra.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_chi.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_chi.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_eng.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_eng.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_fra.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_fra.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_gah.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_gah.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_ger.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_ger.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_isr.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_isr.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_ita.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_ita.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_jap.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_jap.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_pol.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_pol.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_usa.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_destroyer_usa.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_eng.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_eng.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_fra.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_fra.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_gah.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_gah.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_ger.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_ger.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_isr.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_isr.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_ita.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_ita.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_jap.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_jap.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_pol.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_pol.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_usa.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_super_heavy_tank_usa.gui
@@ -60,18 +60,6 @@ guiTypes = {
 					size = { width=100% height=100% }
 				}
 
-				containerWindowType = {
-					name = "walker_armament_slot_3@highlight"
-					position = { x=0 y=0 }
-					size = { width=100% height=100% }
-
-					iconType = {
-						name = "blueprint"
-						spriteType = "GFX_TM_heavy_tank_chassis_armament_slot_3"
-						position = { x=0 y=0 }
-					}
-				}
-
 			}
 
 			containerWindowType = {

--- a/interface/subuniticons.gfx
+++ b/interface/subuniticons.gfx
@@ -57,6 +57,11 @@ spriteTypes = {
 	#Tank
 	SpriteType = { name = "GFX_unit_armor_Bat_icon_medium" texturefile = "gfx/interface/counters/divisions_large/armor.dds" noOfFrames = 2 }
 	SpriteType = { name = "GFX_unit_medium_walker_battalion_icon_medium" texturefile = "gfx/interface/counters/divisions_large/Walker.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_walker_tank_battalion_icon_medium" texturefile = "gfx/interface/counters/divisions_large/Walker.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_heavy_walker_tank_battalion_icon_medium" texturefile = "gfx/interface/counters/divisions_large/Walker.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_medium_walker_battalion_icon_medium" texturefile = "gfx/interface/counters/divisions_large/Walker.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_light_walker_tank_battalion_icon_medium" texturefile = "gfx/interface/counters/divisions_large/Walker.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_heavy_walker_tank_battalion_icon_medium" texturefile = "gfx/interface/counters/divisions_large/Walker.dds" noOfFrames = 2 }
 	SpriteType = { name = "GFX_unit_armor_Comp_icon_medium" texturefile = "gfx/interface/counters/divisions_large/armor.dds" noOfFrames = 2 }
 	SpriteType = { name = "GFX_unit_L_arm_Bat_icon_medium" texturefile = "gfx/interface/counters/divisions_large/light_tank.dds" noOfFrames = 2 }
 	SpriteType = { name = "GFX_unit_A_L_arm_Bat_icon_medium" texturefile = "gfx/interface/counters/divisions_large/light_tank.dds" noOfFrames = 2 }
@@ -200,7 +205,12 @@ spriteTypes = {
 	SpriteType = { name = "GFX_unit_armor_Comp_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_armor_bat_icon.dds" noOfFrames = 2 } # Missing
 	SpriteType = { name = "GFX_unit_L_arm_Bat_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_armor_recce_bat_icon.dds" noOfFrames = 2 } # Missing
 	SpriteType = { name = "GFX_unit_A_L_arm_Bat_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_armor_recce_bat_icon.dds" noOfFrames = 2 }
-    SpriteType = { name = "GFX_unit_medium_walker_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_medium_walker_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_walker_tank_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_heavy_walker_tank_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_medium_walker_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_light_walker_tank_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
+	SpriteType = { name = "GFX_unit_light_heavy_walker_tank_battalion_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_walker_icon.dds" noOfFrames = 2 }
 	#Recce
 	SpriteType = { name = "GFX_unit_L_Recce_Bat_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_l_recce_bat_icon.dds" noOfFrames = 2 }
 	SpriteType = { name = "GFX_unit_L_Recce_Comp_icon_medium_white" texturefile = "gfx/interface/counters/divisions_small/onmap_unit_l_recce_bat_icon.dds" noOfFrames = 2 } # Missing


### PR DESCRIPTION
### Changes
- Walker tanks now render on the map and offer a 3D model choice in the tank designer, using the Event Horizon HACS mechs, where before no model could be selected at all
- Added the HACS SAS32M mech, which already shipped as a model but was never wired up, bringing the walker model choices to four
- Added the missing division counter icons for the Light and Heavy Walker Battalions and their understrength variants

Closes #2792
