### PR TITLE
Fix AI accepting full annexation of tiny nations in peace deals

### DIFF
--- a/common/scripted_diplomatic_actions/01_peace_deal_diplomatic_actions.txt
+++ b/common/scripted_diplomatic_actions/01_peace_deal_diplomatic_actions.txt
@@ -231,7 +231,7 @@ scripted_diplomatic_actions = {
 							multiply = 100
 							round = yes
 							subtract = 100
-							clamp = { min = -500 max = 1000 }
+							clamp = { min = -500 max = 200 }
 						}
 					}
 					# Dampen when ROOT has no faction — engine metric includes all
@@ -467,6 +467,19 @@ scripted_diplomatic_actions = {
 					add = 100
 					ROOT = { has_country_flag = CPD_full_puppet_demand }
 					is_subject = yes
+				}
+			}
+			# Full annexation — receiver refuses to sign away its entire country.
+			# Blocks the superpower-annexes-tiny-nation exploit (issue #2733).
+			CPD_full_annexation_aversion = {
+				base = 0
+				modifier = {
+					set_temp_variable = { CPD_receiver_controlled_states = num_of_controlled_states }
+				}
+				modifier = {
+					add = -200
+					ROOT = { check_variable = { CPD_annex_state_DEMANDS^num > 0 } }
+					NOT = { check_variable = { ROOT.CPD_annex_state_DEMANDS^num < CPD_receiver_controlled_states } }
 				}
 			}
 			CPD_regime_change_aversion = {

--- a/common/scripted_triggers/00_peace_deal_triggers.txt
+++ b/common/scripted_triggers/00_peace_deal_triggers.txt
@@ -109,7 +109,7 @@
 						multiply = 100
 						round = yes
 						subtract = 100
-						clamp = { min = -500 max = 1000 }
+						clamp = { min = -500 max = 200 }
 					}
 				}
 				# Dampen when ROOT has no faction — engine metric includes all
@@ -318,6 +318,17 @@
 						add_to_temp_variable = { CPD_FP_aversion_temp = 100 }
 					}
 				}
+				# Full annexation — receiver refuses to sign away its entire country.
+				# Mirrors CPD_full_annexation_aversion in 01_peace_deal_diplomatic_actions.txt.
+				set_temp_variable = { CPD_receiver_controlled_states = THIS.num_of_controlled_states }
+				set_temp_variable = { CPD_FA_aversion_temp = 0 }
+				if = {
+					limit = {
+						ROOT = { check_variable = { CPD_annex_state_DEMANDS^num > 0 } }
+						NOT = { check_variable = { ROOT.CPD_annex_state_DEMANDS^num < CPD_receiver_controlled_states } }
+					}
+					set_temp_variable = { CPD_FA_aversion_temp = -200 }
+				}
 				set_temp_variable = { CPD_RC_aversion_temp = 0 }
 				if = {
 					limit = { ROOT = { has_country_flag = CPD_regime_change_demand } }
@@ -384,6 +395,7 @@
 						add = v
 						add = CPD_DF_temp
 						add = CPD_FP_aversion_temp
+						add = CPD_FA_aversion_temp
 						add = CPD_RC_aversion_temp
 						add = CPD_FN_aversion_temp
 						add = CPD_MB_aversion_temp


### PR DESCRIPTION
Closes #2733

## What
Two changes to the Conditional Peace Deal AI acceptance logic:

1. **Cap the relative-strength bonus** at 200 (was 1000) in both the
   `ai_acceptance` block (`01_peace_deal_diplomatic_actions.txt`) and the
   mirrored `CPD_AI_will_accept_calculation` trigger
   (`00_peace_deal_triggers.txt`). A strength disparity can no longer
   overwhelm the deal-fairness and term-aversion penalties.

2. **Add a full-annexation aversion** (`-200`) that fires when a deal
   demands annexation of all of the receiver's states, mirroring the
   existing `CPD_full_puppet_aversion`. It triggers when
   `CPD_annex_state_DEMANDS^num` is not less than the receiver's
   `num_of_controlled_states`.

## Why
As a superpower (e.g. USA), a player could declare war on a tiny nation
(Jamaica, Haiti), demand total annexation, and the AI would accept. The
relative-strength term alone contributed up to +1000 acceptance for a
huge strength disparity, dwarfing the base reluctance (-100), deal
fairness (max -100), and cost penalty. Annexing a tiny nation is cheap,
so the fairness penalty was near zero and nothing stopped the AI from
signing away its entire country.

## How
- `clamp = { min = -500 max = 1000 }` → `max = 200` in both files.
- New `CPD_full_annexation_aversion` term in the diplomatic action, and a
  matching `CPD_FA_aversion_temp` in the scripted trigger, both added to
  the consolidated acceptance accumulation.
- The `>=` comparison is written as `NOT { ... < ... }` to match the
  file's existing `<` usage and pass the style validator (which counts
  `=` characters and flags `>=`).