### PR TITLE
Remove Muslim Brotherhood crackdown when MB comes to power

### DIFF
--- a/common/ideas/arab_spirits.txt
+++ b/common/ideas/arab_spirits.txt
@@ -64,6 +64,9 @@ ideas = {
 			on_remove = {
 				mb_remove_crackdown_opinions_effect = yes
 			}
+			cancel = {
+				is_muslim_brotherhood = yes
+			}
 			modifier = {
 				stability_factor = -0.05
 				neutrality_drift = -0.04

--- a/common/scripted_effects/00_middle_east_scripted_effects.txt
+++ b/common/scripted_effects/00_middle_east_scripted_effects.txt
@@ -1460,6 +1460,14 @@ mb_refresh_relations_effect = {
 		if = {
 			limit = {
 				is_muslim_brotherhood = yes
+				has_idea = muslim_brotherhood_crackdown
+			}
+			# A Brotherhood government cannot ban itself; on_remove clears the crackdown opinion web
+			remove_ideas = muslim_brotherhood_crackdown
+		}
+		if = {
+			limit = {
+				is_muslim_brotherhood = yes
 				has_country_flag = mb_designated_terrorist
 			}
 			clr_country_flag = mb_designated_terrorist

--- a/common/scripted_effects/00_middle_east_scripted_effects.txt
+++ b/common/scripted_effects/00_middle_east_scripted_effects.txt
@@ -1460,14 +1460,6 @@ mb_refresh_relations_effect = {
 		if = {
 			limit = {
 				is_muslim_brotherhood = yes
-				has_idea = muslim_brotherhood_crackdown
-			}
-			# A Brotherhood government cannot ban itself; on_remove clears the crackdown opinion web
-			remove_ideas = muslim_brotherhood_crackdown
-		}
-		if = {
-			limit = {
-				is_muslim_brotherhood = yes
 				has_country_flag = mb_designated_terrorist
 			}
 			clr_country_flag = mb_designated_terrorist


### PR DESCRIPTION
Closes #2833

## Summary

A Muslim Brotherhood government cannot ban itself, but the `muslim_brotherhood_crackdown` national spirit was only ever removed via the `brotherhood.6` option b (enable-elections) path. Any other route to a Brotherhood government — coup, civil war, election — left the country with the crackdown spirit while the Brotherhood was in power, cracking down on itself.

## Fix

`mb_refresh_relations_effect` (fired on `on_government_change`) already strips stale anti-MB state when a country becomes MB. Added a block that removes `muslim_brotherhood_crackdown` when `is_muslim_brotherhood = yes` and the idea is present. The idea's `on_remove` hook already calls `mb_remove_crackdown_opinions_effect`, so the crackdown opinion web is cleaned up automatically.

The two add sites (`brotherhood.6`, `brotherhood.11`) both gate on `NOT = { is_muslim_brotherhood = yes }`, so the idea cannot be re-added while MB is in power.