### PR TITLE
Fix housing collapse tooltip mismatch and sweep the per-branch cycle tooltips (#2824)

### DIFF
--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -52,7 +52,6 @@ country_event = {
 		name = econvent.1.a
 		log = "[GetDateText]: [This.GetName]: econvent.1.a executed"
 		small_expenditure = yes
-
 		random_list = {
 			40 = {
 				modifier = {
@@ -67,8 +66,6 @@ country_event = {
 			}
 			60 = { }
 		}
-
-
 		set_temp_variable = { temp_opinion = -10 }
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
@@ -76,7 +73,6 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -87,7 +83,6 @@ country_event = {
 		name = econvent.1.b
 		log = "[GetDateText]: [This.GetName]: econvent.1.b executed"
 		custom_effect_tooltip = econvent.1.b_tt
-
 		set_country_flag = possible_housing_bubble
 		set_temp_variable = { temp_opinion = 5 }
 		change_wall_street_opinion = yes
@@ -96,11 +91,11 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
-
 		ai_chance = {
 			base = 0
 		}
 	}
+
 }
 
 #### Collapsing housing prices ####
@@ -110,14 +105,6 @@ country_event = {
 	desc = econvent.2.d
 	picture = GFX_news_housing_crash
 	is_triggered_only = yes
-	trigger = {
-		NOT = {
-			OR = {
-				has_country_flag = bank_crisis
-				has_country_flag = stock_market_crash
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -146,133 +133,89 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = {
+			OR = {
+				has_country_flag = bank_crisis
+				has_country_flag = stock_market_crash
+			}
+		}
+	}
+
 	#Lower interest-rates and demand banks increase lending
 	option = {
 		name = econvent.2.a
 		log = "[GetDateText]: [This.GetName]: econvent.2.a executed"
 		set_country_flag = { flag = housing_crash value = 1 days = 180 }
 		clr_country_flag = possible_housing_bubble
-
 		set_country_flag = { flag = voodoo_economics value = 1 days = 365 }
-		custom_effect_tooltip = econvent.from_booming_tt
 		if = { limit = { has_idea = economic_boom }
+			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				70 = {
 					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = economic_boom
-						add_ideas = fast_growth
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
 					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = economic_boom
-						add_ideas = stable_growth
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 				10 = {
 					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = economic_boom
-						add_ideas = stagnation
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
+			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				70 = {
 					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = fast_growth
-						add_ideas = stable_growth
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
 					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = fast_growth
-						add_ideas = stagnation
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 				10 = {
 					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = fast_growth
-						add_ideas = recession
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
+			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				80 = {
 					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stable_growth
-						add_ideas = stagnation
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
 					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stable_growth
-						add_ideas = recession
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			random_list = {
-				50 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
-				}
-				50 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stagnation
-						add_ideas = recession
-					}
-					clr_country_flag = disable_cycle_costs
-				}
+			custom_effect_tooltip = econvent.from_stagnation_tt
+			random = {
+				chance = 50
+				decrease_economic_growth = yes
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			random_list = {
-				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
-				}
-				40 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = recession
-						add_ideas = depression
-					}
-					clr_country_flag = disable_cycle_costs
-				}
+			custom_effect_tooltip = econvent.from_recession_tt
+			random = {
+				chance = 40
+				decrease_economic_growth = yes
 			}
 		}
+		else_if = { limit = { has_idea = depression }
+			custom_effect_tooltip = econvent.list.no_effect_tt
+		}
 		custom_effect_tooltip = econvent.voodoo_economics_tt
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_small_medium_business_owners_opinion = yes
 		change_industrial_conglomerates_opinion = yes
@@ -280,7 +223,6 @@ country_event = {
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
 		change_wall_street_opinion = yes
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -308,117 +250,72 @@ country_event = {
 		name = econvent.2.b
 		log = "[GetDateText]: [This.GetName]: econvent.2.b executed"
 		set_country_flag = { flag = housing_crash value = 2  days = 365 }
-
-		custom_effect_tooltip = econvent.from_booming_tt
 		if = { limit = { has_idea = economic_boom }
+			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				65 = {
 					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = economic_boom
-						add_ideas = fast_growth
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
 					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = economic_boom
-						add_ideas = stable_growth
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 				15 = {
 					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = economic_boom
-						add_ideas = stagnation
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
+			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				65 = {
 					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = fast_growth
-						add_ideas = stable_growth
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				35 = {
 					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = fast_growth
-						add_ideas = stagnation
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
+			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				65 = {
 					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stable_growth
-						add_ideas = stagnation
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				35 = {
 					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stable_growth
-						add_ideas = recession
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
+			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				90 = {
 					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stagnation
-						add_ideas = recession
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
 					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = {
-						remove_ideas = stagnation
-						add_ideas = depression
-					}
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.list.depression_tt
-			set_country_flag = disable_cycle_costs
-			hidden_effect = {
-				remove_ideas = recession
-				add_ideas = depression
-			}
-			clr_country_flag = disable_cycle_costs
-			custom_effect_tooltip = econvent.2.b_tt
+			custom_effect_tooltip = econvent.from_recession_tt
+			decrease_economic_growth = yes
+		}
+		else_if = { limit = { has_idea = depression }
+			custom_effect_tooltip = econvent.list.no_effect_tt
 		}
 		custom_effect_tooltip = econvent.2.b_tt
-
 		set_temp_variable = { temp_opinion = -10 }
 		change_small_medium_business_owners_opinion = yes
 		change_industrial_conglomerates_opinion = yes
@@ -428,11 +325,11 @@ country_event = {
 		change_wall_street_opinion = yes
 		change_farmers_opinion = yes
 		change_landowners_opinion = yes
-
 		ai_chance = {
 			base = 100
 		}
 	}
+
 }
 
 # Stock Market Crash
@@ -442,14 +339,6 @@ country_event = {
 	desc = econvent.3.d
 	picture = GFX_economy_crisis
 	is_triggered_only = yes
-	trigger = {
-		NOT = {
-			OR = {
-				has_country_flag = bank_crisis
-				has_country_flag = housing_crash
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -495,12 +384,20 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = {
+			OR = {
+				has_country_flag = bank_crisis
+				has_country_flag = housing_crash
+			}
+		}
+	}
+
 	# Crash Effects
 	option = {
 		name = econvent.3.a
 		log = "[GetDateText]: [This.GetName]: econvent.3.a executed"
 		set_country_flag = { flag = stock_market_crash value = 1 days = 365 }
-
 		if = { limit = { has_idea = economic_boom }
 			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
@@ -577,7 +474,6 @@ country_event = {
 			hidden_effect = { add_ideas = depression }
 			clr_country_flag = disable_cycle_costs
 		}
-
 		set_temp_variable = { temp_opinion = -15 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
@@ -590,7 +486,6 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_fossil_fuel_industry_opinion = yes
 		change_labour_unions_opinion = yes
-
 		ai_chance = {
 			base = 2.0
 		}
@@ -601,10 +496,8 @@ country_event = {
 		name = econvent.3.b
 		log = "[GetDateText]: [This.GetName]: econvent.3.b executed"
 		set_country_flag = { flag = stock_market_crash value = 1 days = 180 }
-
 		medium_expenditure = yes
 		decrease_economic_growth = yes
-
 		set_temp_variable = { temp_opinion = -10 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
@@ -617,11 +510,11 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_fossil_fuel_industry_opinion = yes
 		change_labour_unions_opinion = yes
-
 		ai_chance = {
 			base = 0.25
 		}
 	}
+
 }
 
 # Bank Crisis
@@ -631,14 +524,6 @@ country_event = {
 	desc = econvent.4.d
 	picture = GFX_world_foreclosure
 	is_triggered_only = yes
-	trigger = {
-		NOT = {
-			OR = {
-				has_country_flag = housing_crash
-				has_country_flag = stock_market_crash
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -657,10 +542,18 @@ country_event = {
 			factor = 0.5
 			has_country_flag = consumption_slowdown
 		}
-
 		modifier = {
 			factor = 1.15
 			has_country_flag = temp_increase_major_hike_in_corp_taxes
+		}
+	}
+
+	trigger = {
+		NOT = {
+			OR = {
+				has_country_flag = housing_crash
+				has_country_flag = stock_market_crash
+			}
 		}
 	}
 
@@ -669,7 +562,6 @@ country_event = {
 		name = econvent.4.a
 		log = "[GetDateText]: [This.GetName]: econvent.4.a executed"
 		set_country_flag = { flag = bank_crisis value = 1 days = 365 }
-
 		small_expenditure = yes
 		if = { limit = { has_idea = economic_boom }
 			custom_effect_tooltip = econvent.from_booming_tt
@@ -741,14 +633,12 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
-
 		ai_chance = {
 			base = 0
 		}
@@ -759,7 +649,6 @@ country_event = {
 		name = econvent.4.b
 		log = "[GetDateText]: [This.GetName]: econvent.4.b executed"
 		set_country_flag = { flag = bank_crisis value = 2 days = 365 }
-
 		add_political_power = -75
 		if = { limit = { has_idea = economic_boom }
 			custom_effect_tooltip = econvent.from_booming_tt
@@ -846,7 +735,6 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
@@ -854,7 +742,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -10 }
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
-
 		ai_chance = {
 			base = 0
 		}
@@ -865,7 +752,6 @@ country_event = {
 		name = econvent.4.c
 		log = "[GetDateText]: [This.GetName]: econvent.4.c executed"
 		set_country_flag = { flag = bank_crisis value = 2 days = 365 }
-
 		if = { limit = { has_idea = economic_boom }
 			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
@@ -942,18 +828,17 @@ country_event = {
 			clr_country_flag = disable_cycle_costs
 			ingame_update_setup = yes
 		}
-
 		set_temp_variable = { temp_opinion = -10 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
-
 		ai_chance = {
 			base = 1
 		}
 	}
+
 }
 
 
@@ -1083,7 +968,6 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
@@ -1095,7 +979,6 @@ country_event = {
 		name = econvent.5.b
 		log = "[GetDateText]: [This.GetName]: econvent.5.b executed"
 		set_country_flag = { flag = consumption_slowdown value = 1 days = 365 }
-
 		if = { limit = { has_idea = economic_boom }
 			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
@@ -1181,12 +1064,12 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
 	}
+
 }
 
 ### Lower demand for our goods in int. markets
@@ -1317,6 +1200,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 #### Things for poor countries ####
@@ -1328,11 +1212,6 @@ country_event = {
 	title = econvent.7.t
 	desc = econvent.7.d
 	is_triggered_only = yes
-
-	trigger = {
-		has_country_flag = arid_nation_flag
-		NOT = { has_country_flag = drought }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1352,6 +1231,11 @@ country_event = {
 			factor = 0.8
 			check_variable = { gdp_per_capita > 3.999 }
 		}
+	}
+
+	trigger = {
+		has_country_flag = arid_nation_flag
+		NOT = { has_country_flag = drought }
 	}
 
 	#Not much to do about this
@@ -1442,6 +1326,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 ### Drought causes famine
@@ -1450,10 +1335,6 @@ country_event = {
 	title = econvent.8.t
 	desc = econvent.8.d
 	is_triggered_only = yes
-	trigger = {
-		has_country_flag = drought
-		NOT = { has_idea = depression }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1469,6 +1350,11 @@ country_event = {
 			factor = 0.8
 			check_variable = { gdp_per_capita > 3.999 }
 		}
+	}
+
+	trigger = {
+		has_country_flag = drought
+		NOT = { has_idea = depression }
 	}
 
 	#Not much to do about this
@@ -1558,10 +1444,10 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { temp_opinion = -15 }
 		change_farmers_opinion = yes
 	}
+
 }
 
 ##Positive Economic Events
@@ -1572,19 +1458,6 @@ country_event = {
 	desc = econvent.9.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
-	trigger = {
-		NOT = {
-			OR = {
-				has_country_flag = increased_consumer_confidence
-				has_idea = economic_boom
-				has_active_mission = debt_default_main_mission
-				#JAP
-				has_idea = JAP_entrenched_demand_shortfall_idea_1
-				has_idea = JAP_entrenched_demand_shortfall_idea_2
-				has_idea = JAP_entrenched_demand_shortfall_idea_3
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		# Economically Liberal trying to spurn economic growth
@@ -1630,6 +1503,20 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = {
+			OR = {
+				has_country_flag = increased_consumer_confidence
+				has_idea = economic_boom
+				has_active_mission = debt_default_main_mission
+				#JAP
+				has_idea = JAP_entrenched_demand_shortfall_idea_1
+				has_idea = JAP_entrenched_demand_shortfall_idea_2
+				has_idea = JAP_entrenched_demand_shortfall_idea_3
+			}
+		}
+	}
+
 	option = {
 		name = econvent.9.a
 		log = "[GetDateText]: [Root.GetName]: event econvent.9.a"
@@ -1647,9 +1534,9 @@ country_event = {
 		change_international_bankers_opinion = yes
 		change_wall_street_opinion = yes
 		change_maritime_industry_opinion = yes
-
 		set_country_flag = { flag = increased_consumer_confidence value = 1 days = 180 }
 	}
+
 }
 
 #Stock Market Boom
@@ -1658,24 +1545,6 @@ country_event = {
 	title = econvent.10.t
 	desc = econvent.10.d
 	is_triggered_only = yes
-	trigger = {
-		NOT = {
-			OR = {
-				has_idea = economic_boom
-				has_active_mission = debt_default_main_mission
-				has_country_flag = stock_market_boom_accelerate
-				has_country_flag = stock_market_boom_slowed
-				has_country_flag = stock_market_boom
-				#JAP
-				has_idea = JAP_entrenched_demand_shortfall_idea_1
-				has_idea = JAP_entrenched_demand_shortfall_idea_2
-				has_idea = JAP_entrenched_demand_shortfall_idea_3
-
-				# Communists cannot get stock market boom...
-				has_communist_government_or_in_coalition = yes
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1723,6 +1592,23 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = {
+			OR = {
+				has_idea = economic_boom
+				has_active_mission = debt_default_main_mission
+				has_country_flag = stock_market_boom_accelerate
+				has_country_flag = stock_market_boom_slowed
+				has_country_flag = stock_market_boom
+				#JAP
+				has_idea = JAP_entrenched_demand_shortfall_idea_1
+				has_idea = JAP_entrenched_demand_shortfall_idea_2
+				has_idea = JAP_entrenched_demand_shortfall_idea_3
+				# Communists cannot get stock market boom...
+				has_communist_government_or_in_coalition = yes
+			}
+		}
+	}
 
 	option = {
 		name = econvent.10.a
@@ -1738,6 +1624,7 @@ country_event = {
 			base = 0
 		}
 	}
+
 	option = {
 		name = econvent.10.b
 		log = "[GetDateText]: [Root.GetName]: event econvent.10.b"
@@ -1751,6 +1638,7 @@ country_event = {
 			base = 1
 		}
 	}
+
 	option = {
 		name = econvent.10.c
 		log = "[GetDateText]: [Root.GetName]: event econvent.10.c"
@@ -1763,6 +1651,7 @@ country_event = {
 			base = 0
 		}
 	}
+
 }
 
 # Major Financial Institution Requires a Bailout
@@ -1770,16 +1659,8 @@ country_event = {
 	id = econvent.11
 	title = econvent.11.t
 	desc = econvent.11.d
-	is_triggered_only = yes
 	picture = GFX_banking_crisis
-	trigger = {
-		NOT = { has_country_flag = ECON_recent_financial_institution_crash }
-		OR = {
-			has_idea = economic_boom
-			has_idea = fast_growth
-			has_idea = stable_growth
-		}
-	}
+	is_triggered_only = yes
 
 	mean_time_to_happen = {
 		# Communists Lower Chances -- Sim more market economy control
@@ -1806,15 +1687,22 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = { has_country_flag = ECON_recent_financial_institution_crash }
+		OR = {
+			has_idea = economic_boom
+			has_idea = fast_growth
+			has_idea = stable_growth
+		}
+	}
+
 	# Too Big to Fail
 	option = {
 		name = econvent.11.a
 		log = "[GetDateText]: [Root.GetName]: event econvent.11.a"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_international_bankers_opinion = yes
 		change_wall_street_opinion = yes
@@ -1828,11 +1716,9 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		# Reduce only one level
 		decrease_economic_growth = yes
 		every_country = {
@@ -1890,7 +1776,6 @@ country_event = {
 				}
 			}
 		}
-
 		set_country_flag = { flag = ECON_recent_financial_institution_crash days = 365 value = 1 }
 		ai_chance = {
 			base = 1
@@ -1901,7 +1786,6 @@ country_event = {
 	option = {
 		name = econvent.11.b
 		log = "[GetDateText]: [Root.GetName]: event econvent.11.b"
-
 		set_temp_variable = { temp_opinion = -15 }
 		change_international_bankers_opinion = yes
 		change_wall_street_opinion = yes
@@ -1915,11 +1799,9 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		hidden_effect = {
 			remove_ideas = {
 				economic_boom
@@ -1969,12 +1851,12 @@ country_event = {
 			}
 		}
 		clr_country_flag = disable_cycle_costs
-
 		set_country_flag = { flag = ECON_recent_financial_institution_crash days = 365 value = 1 }
 		ai_chance = {
 			base = 0
 		}
 	}
+
 }
 
 # [FROM.GetName] Recent Economic Crisis has rippled through our nation
@@ -1988,11 +1870,9 @@ country_event = {
 	option = {
 		name = econvent.12.a
 		log = "[GetDateText]: [This.GetName]: econvent.12.a executed"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_international_bankers_opinion = yes
 		set_temp_variable = { temp_opinion = -3 }
@@ -2008,7 +1888,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		decrease_economic_growth = yes
 		ai_chance = {
 			base = 1
@@ -2018,7 +1897,6 @@ country_event = {
 	option = {
 		name = econvent.12.b
 		log = "[GetDateText]: [This.GetName]: econvent.12.b executed"
-
 		set_temp_variable = { temp_opinion = -15 }
 		change_international_bankers_opinion = yes
 		set_temp_variable = { temp_opinion = -10 }
@@ -2031,16 +1909,15 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		decrease_economic_growth = yes
 		ai_chance = {
 			base = 0
 		}
 	}
+
 }
 
 # High Debt Causes Companies to Leave
@@ -2050,15 +1927,6 @@ country_event = {
 	desc = econvent.13.d
 	picture = GFX_banking_crisis
 	is_triggered_only = yes
-	immediate = {
-		set_country_flag = { flag = high_debt_company_closure value = 1 days = 180 }
-	}
-
-	trigger = {
-		check_variable = { industrial_complex_total > 1 }
-		gdp_debt_ratio_higher_125 = yes
-		NOT = { has_country_flag = high_debt_company_closure }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2091,12 +1959,20 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { industrial_complex_total > 1 }
+		gdp_debt_ratio_higher_125 = yes
+		NOT = { has_country_flag = high_debt_company_closure }
+	}
+
+	immediate = {
+		set_country_flag = { flag = high_debt_company_closure value = 1 days = 180 }
+	}
 
 	# Allow the Loss
 	option = {
 		name = econvent.13.a
 		log = "[GetDateText]: [This.GetName]: econvent.13.a executed"
-
 		random_owned_controlled_state = {
 			limit = {
 				check_variable = { building_level@industrial_complex > 0 }
@@ -2106,7 +1982,6 @@ country_event = {
 				level = -1
 			}
 		}
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_international_bankers_opinion = yes
 		change_small_medium_business_owners_opinion = yes
@@ -2118,7 +1993,6 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -2135,7 +2009,6 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.025 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_international_bankers_opinion = yes
 		change_small_medium_business_owners_opinion = yes
@@ -2147,7 +2020,6 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_defense_industry_opinion = yes
 		change_maritime_industry_opinion = yes
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -2156,6 +2028,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 # Private Investors Invest Civilian Industry
@@ -2165,17 +2038,6 @@ country_event = {
 	desc = econvent.14.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_idea = non_state_actor }
-		NOT = { has_country_flag = private_investor_civilian_industry }
-		any_owned_state = {
-			free_building_slots = {
-				building = industrial_complex
-				size > 0
-				include_locked = yes
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2226,13 +2088,24 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = private_investor_civilian_industry }
+		any_owned_state = {
+			free_building_slots = {
+				building = industrial_complex
+				size > 0
+				include_locked = yes
+			}
+		}
+	}
+
 	option = {
 		name = econvent.14.a
 		log = "[GetDateText]: [This.GetName]: econvent.14.a executed"
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		# Free Industrial Complex
 		random_owned_controlled_state = {
 			limit = { free_shared_building_slots = yes }
@@ -2243,9 +2116,9 @@ country_event = {
 				instant_build = yes
 			}
 		}
-
 		set_country_flag = { flag = private_investor_civilian_industry value = 1 days = 365 }
 	}
+
 }
 
 # Private Investors Invest in Office Park
@@ -2255,17 +2128,6 @@ country_event = {
 	desc = econvent.15.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_idea = non_state_actor }
-		NOT = { has_country_flag = private_investor_office_park }
-		any_owned_state = {
-			free_building_slots = {
-				building = offices
-				size > 0
-				include_locked = yes
-			}
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2319,13 +2181,24 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = private_investor_office_park }
+		any_owned_state = {
+			free_building_slots = {
+				building = offices
+				size > 0
+				include_locked = yes
+			}
+		}
+	}
+
 	option = {
 		name = econvent.15.a
 		log = "[GetDateText]: [This.GetName]: econvent.15.a executed"
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		# Free Industrial Complex
 		random_owned_controlled_state = {
 			limit = { free_shared_building_slots = yes }
@@ -2336,9 +2209,9 @@ country_event = {
 				instant_build = yes
 			}
 		}
-
 		set_country_flag = { flag = private_investor_office_park value = 1 days = 365 }
 	}
+
 }
 
 # Bailout Requested
@@ -2372,7 +2245,6 @@ country_event = {
 		else = {
 			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
 		}
-
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2451,6 +2323,7 @@ country_event = {
 			}
 		}
 	}
+
 	# We have no help to offer
 	option = {
 		name = bankruptcy.1.b
@@ -2458,7 +2331,6 @@ country_event = {
 		FROM = {
 			country_event = { id = bankruptcy.4 hours = 3 }
 		}
-
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -2511,6 +2383,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 ##Bailout Requested from 2nd biggest influencer###
@@ -2518,8 +2391,8 @@ country_event = {
 	id = bankruptcy.2
 	title = bankruptcy.2.t
 	desc = bankruptcy.2.d
-	is_triggered_only = yes
 	picture = GFX_stock_market
+	is_triggered_only = yes
 
 	#Give it
 	option = {
@@ -2545,7 +2418,6 @@ country_event = {
 		else = {
 			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
 		}
-
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2590,12 +2462,12 @@ country_event = {
 			}
 		}
 	}
+
 	#We have no help to offer
 	option = {
 		name = bankruptcy.2.b
 		log = "[GetDateText]: [This.GetName]: bankruptcy.2.b executed"
 		FROM = { country_event = { id = bankruptcy.4 hours = 3 } }
-
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -2609,6 +2481,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 ##Bailout Requested from neigbhour###
@@ -2616,8 +2489,8 @@ country_event = {
 	id = bankruptcy.3
 	title = bankruptcy.3.t
 	desc = bankruptcy.3.d
-	is_triggered_only = yes
 	picture = GFX_stock_market
+	is_triggered_only = yes
 
 	#Give it
 	option = {
@@ -2643,7 +2516,6 @@ country_event = {
 		else = {
 			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
 		}
-
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2688,6 +2560,7 @@ country_event = {
 			}
 		}
 	}
+
 	#We have no help to offer
 	option = {
 		name = bankruptcy.3.b
@@ -2706,6 +2579,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 #We were denied the bailout
@@ -2713,8 +2587,8 @@ country_event = {
 	id = bankruptcy.4
 	title = bankruptcy.4.t
 	desc = bankruptcy.4.d
-	is_triggered_only = yes
 	picture = GFX_banking_crisis
+	is_triggered_only = yes
 
 	#We were denied our bailout
 	option = {
@@ -2723,6 +2597,7 @@ country_event = {
 		add_opinion_modifier = { modifier = did_not_support_us target = FROM }
 		clear_variable = debt_bailout
 	}
+
 }
 
 ##Bailout Requested from overlord###
@@ -2730,8 +2605,8 @@ country_event = {
 	id = bankruptcy.5
 	title = bankruptcy.5.t
 	desc = bankruptcy.5.d
-	is_triggered_only = yes
 	picture = GFX_stock_market
+	is_triggered_only = yes
 
 	#Give it
 	option = {
@@ -2764,7 +2639,6 @@ country_event = {
 		else = {
 			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
 		}
-
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2804,6 +2678,7 @@ country_event = {
 			}
 		}
 	}
+
 	#We have no help to offer
 	option = {
 		name = bankruptcy.5.b
@@ -2822,6 +2697,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 ### Financial Collapse ###
@@ -2830,8 +2706,8 @@ country_event = {
 	id = bankruptcy.10
 	title = bankruptcy.10.t
 	desc = bankruptcy.10.d
-	is_triggered_only = yes
 	picture = GFX_election_rally
+	is_triggered_only = yes
 
 	#Allow new elections
 	option = {
@@ -2861,6 +2737,7 @@ country_event = {
 			base = 95
 		}
 	}
+
 	#Block new elections
 	option = {
 		name = bankruptcy.10.b
@@ -2878,8 +2755,8 @@ country_event = {
 	id = bankruptcy.11
 	title = bankruptcy.11.t
 	desc = bankruptcy.11.d
-	is_triggered_only = yes
 	picture = GFX_election_rally
+	is_triggered_only = yes
 
 	#Side with the coup
 	option = {
@@ -2903,6 +2780,7 @@ country_event = {
 		}
 		ai_chance = { base = 50 }
 	}
+
 	#Against the coup
 	option = {
 		name = bankruptcy.11.b
@@ -2930,8 +2808,8 @@ country_event = {
 	id = bankruptcy.12
 	title = bankruptcy.12.t
 	desc = bankruptcy.12.d
-	is_triggered_only = yes
 	picture = GFX_election_rally
+	is_triggered_only = yes
 
 	#Relinquish power
 	option = {
@@ -2959,6 +2837,7 @@ country_event = {
 			base = 95
 		}
 	}
+
 	#Block new elections
 	option = {
 		name = bankruptcy.12.b
@@ -3103,12 +2982,10 @@ country_event = {
 				OR = {
 					any_state_in = {
 						ai_area = 12 # Mediterranean Sea
-
 						is_controlled_by = PREV
 					}
 					any_state_in = {
 						ai_area = 15 # Exit to Atlantic Ocean
-
 						is_controlled_by = PREV
 					}
 				}
@@ -3120,7 +2997,6 @@ country_event = {
 	option = {
 		name = bankruptcy.13.b
 		log = "[GetDateText]: [This.GetName]: bankruptcy.13.b executed"
-
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -3137,6 +3013,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 # Subject fails to pay on defaulted debt
@@ -3160,6 +3037,7 @@ country_event = {
 			}
 		}
 	}
+
 }
 
 
@@ -3207,6 +3085,7 @@ country_event = {
 		change_oligarchs_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 
 #downsize military
@@ -3235,6 +3114,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.101.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.101.b executed"
@@ -3243,6 +3123,7 @@ country_event = {
 		change_the_military_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #downsize police
 country_event = {
@@ -3270,6 +3151,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.102.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.102.b executed"
@@ -3278,6 +3160,7 @@ country_event = {
 		change_intelligence_community_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #cut education spending
 country_event = {
@@ -3307,6 +3190,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.103.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.103.b executed"
@@ -3317,6 +3201,7 @@ country_event = {
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #cut health spending
 country_event = {
@@ -3345,6 +3230,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.104.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.104.b executed"
@@ -3354,6 +3240,7 @@ country_event = {
 		change_labour_unions_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #cut social spending
 country_event = {
@@ -3382,6 +3269,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.105.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.105.b executed"
@@ -3391,6 +3279,7 @@ country_event = {
 		change_labour_unions_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #increase resource exports
 country_event = {
@@ -3420,6 +3309,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.106.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.106.b executed"
@@ -3430,6 +3320,7 @@ country_event = {
 		change_oligarchs_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 # Corruption
 country_event = {
@@ -3448,12 +3339,14 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.107.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.107.b executed"
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #land reform
 country_event = {
@@ -3511,6 +3404,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.108.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.108.b executed"
@@ -3521,6 +3415,7 @@ country_event = {
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #bankers in government
 country_event = {
@@ -3549,6 +3444,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.109.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.109.b executed"
@@ -3557,6 +3453,7 @@ country_event = {
 		change_international_bankers_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #confiscate church funds
 country_event = {
@@ -3577,6 +3474,7 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.110.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.110.b executed"
@@ -3588,6 +3486,7 @@ country_event = {
 		change_the_wahabi_ulema_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #dismantle military factories
 country_event = {
@@ -3622,16 +3521,15 @@ country_event = {
 				}
 			}
 		}
-
 		# Internal Faction Effect
 		set_temp_variable = { temp_opinion = -10 }
 		change_the_military_opinion = yes
 		change_defense_industry_opinion = yes
-
 		# Economic Stuff
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.111.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.111.b executed"
@@ -3641,6 +3539,7 @@ country_event = {
 		change_defense_industry_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #dismantle naval dockyards
 country_event = {
@@ -3653,7 +3552,6 @@ country_event = {
 	option = {
 		name = bankruptcy.112.a	#Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.112.a executed"
-
 		# Dismantles the Dockyards
 		if = { limit = { check_variable = { gdp_per_capita < 5 } }
 			random_owned_state = {
@@ -3677,15 +3575,14 @@ country_event = {
 				}
 			}
 		}
-
 		# Maritime Industry No likey
 		set_temp_variable = { temp_opinion = -10 }
 		change_maritime_industry_opinion = yes
-
 		# Economic Effects
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.112.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.112.b executed"
@@ -3694,6 +3591,7 @@ country_event = {
 		change_maritime_industry_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 #raise taxes
 country_event = {
@@ -3738,7 +3636,6 @@ country_event = {
 		}
 		calculate_tax_rate = yes
 		imf_debt_relief_accepted_effect = yes
-
 		#Internal Faction Effects
 		set_temp_variable = { temp_opinion = -5 }
 		change_wall_street_opinion = yes
@@ -3751,9 +3648,9 @@ country_event = {
 		change_landowners_opinion = yes
 		change_farmers_opinion = yes
 		change_labour_unions_opinion = yes
-
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.113.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.113.b executed"
@@ -3769,9 +3666,9 @@ country_event = {
 		change_landowners_opinion = yes
 		change_farmers_opinion = yes
 		change_labour_unions_opinion = yes
-
 		ai_chance = { base = 10 }
 	}
+
 }
 #sell international investments
 country_event = {
@@ -3780,9 +3677,8 @@ country_event = {
 	desc = bankruptcy.114.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
-	trigger = {
-		check_variable = { int_investments > 0 }
-	}
+
+	trigger = { check_variable = { int_investments > 0 } }
 
 	option = {
 		name = bankruptcy.114.a	#Agree
@@ -3821,6 +3717,7 @@ country_event = {
 		ingame_update_setup = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.114.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.114.b executed"
@@ -3829,6 +3726,7 @@ country_event = {
 		change_international_bankers_opinion = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 # Dismantle State Owned industry
 country_event = {
@@ -3866,12 +3764,14 @@ country_event = {
 		imf_debt_relief_accepted_effect = yes
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = bankruptcy.115.b	#Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.115.b executed"
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
+
 }
 
 ##Financial collapse stuff
@@ -3882,12 +3782,6 @@ country_event = {
 	desc = bankruptcy.200.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 0 } }
-		NOT = { is_in_array = { gov_coalition_array = 0 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3904,6 +3798,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 0 } }
+		NOT = { is_in_array = { gov_coalition_array = 0 } }
+	}
+
 	option = {
 		name = bankruptcy.200.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.200.a executed"
@@ -3913,6 +3813,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.200.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.200.b executed"
@@ -3923,6 +3824,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #conservatism makes a speech
 country_event = {
@@ -3931,12 +3833,6 @@ country_event = {
 	desc = bankruptcy.201.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 1 } }
-		NOT = { is_in_array = { gov_coalition_array = 1 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3953,6 +3849,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 1 } }
+		NOT = { is_in_array = { gov_coalition_array = 1 } }
+	}
+
 	option = {
 		name = bankruptcy.201.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.201.a executed"
@@ -3962,6 +3864,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.201.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.201.b executed"
@@ -3972,6 +3875,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #liberalism makes a speech
 country_event = {
@@ -3980,12 +3884,6 @@ country_event = {
 	desc = bankruptcy.202.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 2 } }
-		NOT = { is_in_array = { gov_coalition_array = 2 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4002,6 +3900,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 2 } }
+		NOT = { is_in_array = { gov_coalition_array = 2 } }
+	}
+
 	option = {
 		name = bankruptcy.202.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.202.a executed"
@@ -4011,6 +3915,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.202.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.202.b executed"
@@ -4021,6 +3926,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #socialism makes a speech
 country_event = {
@@ -4029,12 +3935,6 @@ country_event = {
 	desc = bankruptcy.203.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 3 } }
-		NOT = { is_in_array = { gov_coalition_array = 3 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4051,6 +3951,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 3 } }
+		NOT = { is_in_array = { gov_coalition_array = 3 } }
+	}
+
 	option = {
 		name = bankruptcy.203.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.203.a executed"
@@ -4060,6 +3966,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.203.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.203.b executed"
@@ -4070,6 +3977,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Communist-State makes a speech
 country_event = {
@@ -4078,12 +3986,6 @@ country_event = {
 	desc = bankruptcy.204.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 4 } }
-		NOT = { is_in_array = { gov_coalition_array = 4 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4100,6 +4002,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 4 } }
+		NOT = { is_in_array = { gov_coalition_array = 4 } }
+	}
+
 	option = {
 		name = bankruptcy.204.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.204.a executed"
@@ -4109,6 +4017,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.204.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.204.b executed"
@@ -4119,6 +4028,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #anarchist_communism makes a speech
 country_event = {
@@ -4127,12 +4037,6 @@ country_event = {
 	desc = bankruptcy.205.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 5 } }
-		NOT = { is_in_array = { gov_coalition_array = 5 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4149,6 +4053,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 5 } }
+		NOT = { is_in_array = { gov_coalition_array = 5 } }
+	}
+
 	option = {
 		name = bankruptcy.205.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.205.a executed"
@@ -4158,6 +4068,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.205.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.205.b executed"
@@ -4168,6 +4079,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Conservative makes a speech
 country_event = {
@@ -4176,12 +4088,6 @@ country_event = {
 	desc = bankruptcy.206.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 6 } }
-		NOT = { is_in_array = { gov_coalition_array = 6 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4198,6 +4104,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 6 } }
+		NOT = { is_in_array = { gov_coalition_array = 6 } }
+	}
+
 	option = {
 		name = bankruptcy.206.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.206.a executed"
@@ -4207,6 +4119,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.206.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.206.b executed"
@@ -4217,6 +4130,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Autocracy makes a speech
 country_event = {
@@ -4225,12 +4139,6 @@ country_event = {
 	desc = bankruptcy.207.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 7 } }
-		NOT = { is_in_array = { gov_coalition_array = 7 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4247,6 +4155,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 7 } }
+		NOT = { is_in_array = { gov_coalition_array = 7 } }
+	}
+
 	option = {
 		name = bankruptcy.207.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.207.a executed"
@@ -4256,6 +4170,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.207.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.207.b executed"
@@ -4266,6 +4181,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Mod_Vilayat_e_Faqih makes a speech
 country_event = {
@@ -4274,6 +4190,21 @@ country_event = {
 	desc = bankruptcy.208.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 0.25
+			has_country_flag = party9_banned
+		}
+		modifier = {
+			factor = 2
+			has_active_mission = bankruptcy_incoming_collapse
+		}
+		modifier = {
+			factor = 0.25
+			check_variable = { party_pop_array^8 < 0.01 }
+		}
+	}
 
 	trigger = {
 		OR = {
@@ -4305,21 +4236,6 @@ country_event = {
 		NOT = { is_in_array = { gov_coalition_array = 8 } }
 	}
 
-	mean_time_to_happen = {
-		modifier = {
-			factor = 0.25
-			has_country_flag = party9_banned
-		}
-		modifier = {
-			factor = 2
-			has_active_mission = bankruptcy_incoming_collapse
-		}
-		modifier = {
-			factor = 0.25
-			check_variable = { party_pop_array^8 < 0.01 }
-		}
-	}
-
 	option = {
 		name = bankruptcy.208.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.208.a executed"
@@ -4329,6 +4245,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.208.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.208.b executed"
@@ -4339,6 +4256,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Vilayat_e_Faqih makes a speech
 country_event = {
@@ -4347,6 +4265,21 @@ country_event = {
 	desc = bankruptcy.209.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 0.25
+			has_country_flag = party10_banned
+		}
+		modifier = {
+			factor = 2
+			has_active_mission = bankruptcy_incoming_collapse
+		}
+		modifier = {
+			factor = 0.25
+			check_variable = { party_pop_array^9 < 0.01 }
+		}
+	}
 
 	trigger = {
 		OR = {
@@ -4378,21 +4311,6 @@ country_event = {
 		NOT = { is_in_array = { gov_coalition_array = 9 } }
 	}
 
-	mean_time_to_happen = {
-		modifier = {
-			factor = 0.25
-			has_country_flag = party10_banned
-		}
-		modifier = {
-			factor = 2
-			has_active_mission = bankruptcy_incoming_collapse
-		}
-		modifier = {
-			factor = 0.25
-			check_variable = { party_pop_array^9 < 0.01 }
-		}
-	}
-
 	option = {
 		name = bankruptcy.209.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.209.a executed"
@@ -4402,6 +4320,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.209.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.209.b executed"
@@ -4412,6 +4331,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Kingdom makes a speech
 country_event = {
@@ -4420,19 +4340,6 @@ country_event = {
 	desc = bankruptcy.210.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		OR = {
-			has_idea = sunni
-			has_idea = sufi_islam
-			has_idea = ibadi
-			has_idea = shia
-			has_idea = pluralist
-		}
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 10 } }
-		NOT = { is_in_array = { gov_coalition_array = 10 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4449,6 +4356,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		OR = {
+			has_idea = sunni
+			has_idea = sufi_islam
+			has_idea = ibadi
+			has_idea = shia
+			has_idea = pluralist
+		}
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 10 } }
+		NOT = { is_in_array = { gov_coalition_array = 10 } }
+	}
+
 	option = {
 		name = bankruptcy.210.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.210.a executed"
@@ -4458,6 +4378,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.210.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.210.b executed"
@@ -4468,6 +4389,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Caliphate makes a speech
 country_event = {
@@ -4476,19 +4398,6 @@ country_event = {
 	desc = bankruptcy.211.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		OR = {
-			has_idea = sunni
-			has_idea = sufi_islam
-			has_idea = ibadi
-			has_idea = shia
-			has_idea = pluralist
-		}
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 11 } }
-		NOT = { is_in_array = { gov_coalition_array = 11 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4505,6 +4414,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		OR = {
+			has_idea = sunni
+			has_idea = sufi_islam
+			has_idea = ibadi
+			has_idea = shia
+			has_idea = pluralist
+		}
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 11 } }
+		NOT = { is_in_array = { gov_coalition_array = 11 } }
+	}
+
 	option = {
 		name = bankruptcy.211.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.211.a executed"
@@ -4514,6 +4436,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.211.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.211.b executed"
@@ -4524,6 +4447,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Neutral_Muslim_Brotherhood makes a speech
 country_event = {
@@ -4532,19 +4456,6 @@ country_event = {
 	desc = bankruptcy.212.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		OR = {
-			has_idea = sunni
-			has_idea = sufi_islam
-			has_idea = ibadi
-			has_idea = shia
-			has_idea = pluralist
-		}
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 12 } }
-		NOT = { is_in_array = { gov_coalition_array = 12 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4561,6 +4472,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		OR = {
+			has_idea = sunni
+			has_idea = sufi_islam
+			has_idea = ibadi
+			has_idea = shia
+			has_idea = pluralist
+		}
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 12 } }
+		NOT = { is_in_array = { gov_coalition_array = 12 } }
+	}
+
 	option = {
 		name = bankruptcy.212.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.212.a executed"
@@ -4570,6 +4494,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.212.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.212.b executed"
@@ -4580,6 +4505,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Neutral_Autocracy makes a speech
 country_event = {
@@ -4588,12 +4514,6 @@ country_event = {
 	desc = bankruptcy.213.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 13 } }
-		NOT = { is_in_array = { gov_coalition_array = 13 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4610,6 +4530,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 13 } }
+		NOT = { is_in_array = { gov_coalition_array = 13 } }
+	}
+
 	option = {
 		name = bankruptcy.213.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.213.a executed"
@@ -4619,6 +4545,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.213.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.213.b executed"
@@ -4629,6 +4556,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Neutral_conservatism makes a speech
 country_event = {
@@ -4637,12 +4565,6 @@ country_event = {
 	desc = bankruptcy.214.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 14 } }
-		NOT = { is_in_array = { gov_coalition_array = 14 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4659,6 +4581,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 14 } }
+		NOT = { is_in_array = { gov_coalition_array = 14 } }
+	}
+
 	option = {
 		name = bankruptcy.214.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.214.a executed"
@@ -4668,6 +4596,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.214.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.214.b executed"
@@ -4678,6 +4607,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #oligarchism makes a speech
 country_event = {
@@ -4686,12 +4616,6 @@ country_event = {
 	desc = bankruptcy.215.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 15 } }
-		NOT = { is_in_array = { gov_coalition_array = 15 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4708,6 +4632,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 15 } }
+		NOT = { is_in_array = { gov_coalition_array = 15 } }
+	}
+
 	option = {
 		name = bankruptcy.215.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.215.a executed"
@@ -4717,6 +4647,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.215.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.215.b executed"
@@ -4727,6 +4658,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Neutral_Libertarian makes a speech
 country_event = {
@@ -4735,12 +4667,6 @@ country_event = {
 	desc = bankruptcy.216.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 16 } }
-		NOT = { is_in_array = { gov_coalition_array = 16 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4757,6 +4683,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 16 } }
+		NOT = { is_in_array = { gov_coalition_array = 16 } }
+	}
+
 	option = {
 		name = bankruptcy.216.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.216.a executed"
@@ -4766,6 +4698,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.216.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.216.b executed"
@@ -4776,6 +4709,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Neutral_green makes a speech
 country_event = {
@@ -4784,12 +4718,6 @@ country_event = {
 	desc = bankruptcy.217.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 17 } }
-		NOT = { is_in_array = { gov_coalition_array = 17 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4806,6 +4734,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 17 } }
+		NOT = { is_in_array = { gov_coalition_array = 17 } }
+	}
+
 	option = {
 		name = bankruptcy.217.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.217.a executed"
@@ -4815,6 +4749,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.217.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.217.b executed"
@@ -4825,6 +4760,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #neutral_Social makes a speech
 country_event = {
@@ -4833,12 +4769,6 @@ country_event = {
 	desc = bankruptcy.218.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 18 } }
-		NOT = { is_in_array = { gov_coalition_array = 18 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4855,6 +4785,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 18 } }
+		NOT = { is_in_array = { gov_coalition_array = 18 } }
+	}
+
 	option = {
 		name = bankruptcy.218.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.218.a executed"
@@ -4864,6 +4800,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.218.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.218.b executed"
@@ -4874,6 +4811,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Neutral_Communism makes a speech
 country_event = {
@@ -4882,12 +4820,6 @@ country_event = {
 	desc = bankruptcy.219.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 19 } }
-		NOT = { is_in_array = { gov_coalition_array = 19 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4904,6 +4836,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 19 } }
+		NOT = { is_in_array = { gov_coalition_array = 19 } }
+	}
+
 	option = {
 		name = bankruptcy.219.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.219.a executed"
@@ -4913,6 +4851,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.219.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.219.b executed"
@@ -4923,6 +4862,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Nat_Populism makes a speech
 country_event = {
@@ -4931,12 +4871,6 @@ country_event = {
 	desc = bankruptcy.220.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 20 } }
-		NOT = { is_in_array = { gov_coalition_array = 20 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4953,6 +4887,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 20 } }
+		NOT = { is_in_array = { gov_coalition_array = 20 } }
+	}
+
 	option = {
 		name = bankruptcy.220.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.220.a executed"
@@ -4962,6 +4902,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.220.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.220.b executed"
@@ -4972,6 +4913,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Nat_Fascism makes a speech
 country_event = {
@@ -4980,12 +4922,6 @@ country_event = {
 	desc = bankruptcy.221.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 21 } }
-		NOT = { is_in_array = { gov_coalition_array = 21 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -5002,6 +4938,12 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 21 } }
+		NOT = { is_in_array = { gov_coalition_array = 21 } }
+	}
+
 	option = {
 		name = bankruptcy.221.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.221.a executed"
@@ -5011,6 +4953,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.221.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.221.b executed"
@@ -5021,6 +4964,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Nat_Autocracy makes a speech
 country_event = {
@@ -5029,13 +4973,6 @@ country_event = {
 	desc = bankruptcy.222.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		NOT = { has_idea = no_military }
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 22 } }
-		NOT = { is_in_array = { gov_coalition_array = 22 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -5052,6 +4989,13 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = { has_idea = no_military }
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 22 } }
+		NOT = { is_in_array = { gov_coalition_array = 22 } }
+	}
+
 	option = {
 		name = bankruptcy.222.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.222.a executed"
@@ -5061,6 +5005,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.222.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.222.b executed"
@@ -5071,6 +5016,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 #Monarchist makes a speech
 country_event = {
@@ -5079,13 +5025,6 @@ country_event = {
 	desc = bankruptcy.223.d
 	picture = GFX_election_rally
 	is_triggered_only = yes
-
-	trigger = {
-		NOT = { has_idea = no_military }
-		check_variable = { interest_rate > 14.999 }
-		NOT = { is_in_array = { ruling_party = 23 } }
-		NOT = { is_in_array = { gov_coalition_array = 23 } }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -5102,6 +5041,13 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		NOT = { has_idea = no_military }
+		check_variable = { interest_rate > 14.999 }
+		NOT = { is_in_array = { ruling_party = 23 } }
+		NOT = { is_in_array = { gov_coalition_array = 23 } }
+	}
+
 	option = {
 		name = bankruptcy.223.a	#Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.223.a executed"
@@ -5111,6 +5057,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = bankruptcy.223.b	#Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.223.b executed"
@@ -5121,6 +5068,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
+
 }
 
 ### we got the bailout - biggest influencer
@@ -5129,12 +5077,10 @@ news_event = {
 	title = News_bankruptcy.1.t
 	desc = News_bankruptcy.1.d
 	picture = GFX_world_stockmarket
-
 	is_triggered_only = yes
 
-	option = {
-		name = News_bankruptcy.1.a
-	}
+	option = { name = News_bankruptcy.1.a }
+
 }
 
 ### we got the bailout - 2nd biggest influencer
@@ -5143,12 +5089,10 @@ news_event = {
 	title = News_bankruptcy.2.t
 	desc = News_bankruptcy.2.d
 	picture = GFX_world_stockmarket
-
 	is_triggered_only = yes
 
-	option = {
-		name = News_bankruptcy.2.a
-	}
+	option = { name = News_bankruptcy.2.a }
+
 }
 ### we got the bailout - neighbour
 news_event = {
@@ -5156,12 +5100,10 @@ news_event = {
 	title = News_bankruptcy.3.t
 	desc = News_bankruptcy.3.d
 	picture = GFX_world_stockmarket
-
 	is_triggered_only = yes
 
-	option = {
-		name = News_bankruptcy.3.a
-	}
+	option = { name = News_bankruptcy.3.a }
+
 }
 ###[FROM.GetNameDef] Prepares for New Elections
 news_event = {
@@ -5169,12 +5111,10 @@ news_event = {
 	title = News_bankruptcy.4.t
 	desc = News_bankruptcy.4.d
 	picture = GFX_news_press_conference
-
 	is_triggered_only = yes
 
-	option = {
-		name = News_bankruptcy.4.a
-	}
+	option = { name = News_bankruptcy.4.a }
+
 }
 ###Radical Political Shift in [FROM.GetNameDef]
 news_event = {
@@ -5184,9 +5124,8 @@ news_event = {
 	picture = GFX_news_press_conference
 	is_triggered_only = yes
 
-	option = {
-		name = News_bankruptcy.5.a
-	}
+	option = { name = News_bankruptcy.5.a }
+
 }
 ###Financial Collapse Leads to Conflict in [FROM.GetNameDef]
 news_event = {
@@ -5196,7 +5135,6 @@ news_event = {
 	picture = GFX_news_press_conference
 	is_triggered_only = yes
 
-	option = {
-		name = News_bankruptcy.6.a
-	}
+	option = { name = News_bankruptcy.6.a }
+
 }

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -124,9 +124,8 @@ country_event = {
 			has_country_flag = possible_housing_bubble
 		}
 		modifier = {
-			factor = 0
+			factor = 0.5
 			OR = {
-				has_idea = depression
 				has_idea = recession
 				has_idea = stagnation
 			}
@@ -140,6 +139,7 @@ country_event = {
 				has_country_flag = stock_market_crash
 			}
 		}
+		NOT = { has_idea = depression }
 	}
 
 	#Lower interest-rates and demand banks increase lending
@@ -172,7 +172,7 @@ country_event = {
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
 				50 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				40 = {
 					decrease_economic_growth = yes
@@ -185,7 +185,7 @@ country_event = {
 		else_if = { limit = { has_idea = recession }
 			random_list = {
 				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				40 = {
 					decrease_economic_growth = yes
@@ -345,80 +345,47 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: econvent.3.a executed"
 		set_country_flag = { flag = stock_market_crash value = 1 days = 365 }
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				70 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				30 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				75 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				25 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				80 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				90 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_stagnation_tt
-			custom_effect_tooltip = econvent.from_recession2_tt
-			custom_effect_tooltip = econvent.list.depression_tt
-			set_country_flag = disable_cycle_costs
-			hidden_effect = { add_ideas = depression }
-			clr_country_flag = disable_cycle_costs
+			decrease_economic_growth = yes
 		}
 		set_temp_variable = { temp_opinion = -15 }
 		change_small_medium_business_owners_opinion = yes
@@ -510,72 +477,52 @@ country_event = {
 		set_country_flag = { flag = bank_crisis value = 1 days = 365 }
 		small_expenditure = yes
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				40 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				40 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				70 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				30 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				80 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				20 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random_list = {
 				90 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
@@ -597,87 +544,55 @@ country_event = {
 		set_country_flag = { flag = bank_crisis value = 2 days = 365 }
 		add_political_power = -75
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				80 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				85 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				15 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				90 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				70 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random_list = {
 				30 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				70 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
@@ -699,79 +614,47 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: econvent.4.c executed"
 		set_country_flag = { flag = bank_crisis value = 2 days = 365 }
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				60 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				40 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				65 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				35 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				70 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				30 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				80 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession2_tt
-			custom_effect_tooltip = econvent.list.depression_tt
-			set_country_flag = disable_cycle_costs
-			hidden_effect = { add_ideas = depression }
-			clr_country_flag = disable_cycle_costs
+			decrease_economic_growth = yes
 			ingame_update_setup = yes
 		}
 		set_temp_variable = { temp_opinion = -10 }
@@ -844,73 +727,13 @@ country_event = {
 		name = econvent.5.a
 		log = "[GetDateText]: [This.GetName]: econvent.5.a executed"
 		set_country_flag = { flag = consumption_slowdown value = 1 days = 365 }
-		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
+		if = { limit = { NOT = { has_idea = depression } }
 			random_list = {
 				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				40 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
-				}
-			}
-		}
-		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
-			random_list = {
-				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
-				}
-				40 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
-				}
-			}
-		}
-		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
-			random_list = {
-				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
-				}
-				40 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
-				}
-			}
-		}
-		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
-			random_list = {
-				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
-				}
-				40 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
-				}
-			}
-		}
-		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
-			random_list = {
-				60 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
-				}
-				40 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
@@ -926,87 +749,55 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: econvent.5.b executed"
 		set_country_flag = { flag = consumption_slowdown value = 1 days = 365 }
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				80 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				20 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				85 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				15 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				90 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-				custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				10 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				80 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				80 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
@@ -1064,84 +855,58 @@ country_event = {
 		name = econvent.6.a
 		log = "[GetDateText]: [This.GetName]: econvent.6.a executed"
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				70 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				75 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				5 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				80 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				25 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				75 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random_list = {
 				50 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				50 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
@@ -1190,84 +955,58 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: econvent.7.a executed"
 		set_country_flag = { flag = drought value = 1 days = 120 }
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				70 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				75 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				5 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				80 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				25 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				75 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random_list = {
 				50 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				50 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
@@ -1309,84 +1048,58 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: econvent.8.a executed"
 		set_country_flag = { flag = famine value = 1 days = 200 }
 		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				70 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = fast_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				10 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				75 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stable_growth }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 				5 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
 			random_list = {
 				20 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				80 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = stagnation }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
 				25 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				75 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = recession }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random_list = {
 				50 = {
-					custom_effect_tooltip = econvent.list.no_effect_tt
+					custom_effect_tooltip = NO_EFFECT_TT
 				}
 				50 = {
-					custom_effect_tooltip = econvent.list.depression_tt
-					set_country_flag = disable_cycle_costs
-					hidden_effect = { add_ideas = depression }
-					clr_country_flag = disable_cycle_costs
+					decrease_economic_growth = yes
 				}
 			}
 		}

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -149,71 +149,44 @@ country_event = {
 		set_country_flag = { flag = housing_crash value = 1 days = 180 }
 		clr_country_flag = possible_housing_bubble
 		set_country_flag = { flag = voodoo_economics value = 1 days = 365 }
-		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
+		if = { limit = { OR = { has_idea = economic_boom has_idea = fast_growth has_idea = stable_growth } }
 			random_list = {
 				70 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
+					modifier = {
+						factor = 0.5
+						has_country_flag = possible_housing_bubble
+					}
+					modifier = {
+						factor = 0.5
+						has_country_flag = voodoo_economics
+					}
+					modifier = {
+						factor = 0.5
+						has_country_flag = consumption_slowdown
+					}
 					decrease_economic_growth = yes
 				}
-				20 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					decrease_two_level_economic_growth = yes
-				}
-				10 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					decrease_two_level_economic_growth = yes
-					decrease_economic_growth = yes
-				}
-			}
-		}
-		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
-			random_list = {
-				70 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					decrease_economic_growth = yes
-				}
-				20 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					decrease_two_level_economic_growth = yes
-				}
-				10 = {
-					custom_effect_tooltip = econvent.list.recession_tt
-					decrease_two_level_economic_growth = yes
-					decrease_economic_growth = yes
-				}
-			}
-		}
-		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
-			random_list = {
-				80 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					decrease_economic_growth = yes
-				}
-				20 = {
-					custom_effect_tooltip = econvent.list.recession_tt
+				30 = {
 					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
-			random = {
-				chance = 50
-				decrease_economic_growth = yes
+			random_list = {
+				50 = { }
+				40 = {
+					decrease_economic_growth = yes
+				}
+				10 = {
+					decrease_two_level_economic_growth = yes
+				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			random = {
 				chance = 40
 				decrease_economic_growth = yes
 			}
-		}
-		else_if = { limit = { has_idea = depression }
-			custom_effect_tooltip = econvent.list.no_effect_tt
 		}
 		custom_effect_tooltip = econvent.voodoo_economics_tt
 		set_temp_variable = { temp_opinion = -5 }
@@ -250,70 +223,36 @@ country_event = {
 		name = econvent.2.b
 		log = "[GetDateText]: [This.GetName]: econvent.2.b executed"
 		set_country_flag = { flag = housing_crash value = 2  days = 365 }
-		if = { limit = { has_idea = economic_boom }
-			custom_effect_tooltip = econvent.from_booming_tt
+		if = { limit = { OR = { has_idea = economic_boom has_idea = fast_growth has_idea = stable_growth } }
 			random_list = {
-				65 = {
-					custom_effect_tooltip = econvent.list.fast_growth_tt
+				50 = {
+					modifier = {
+						factor = 1.5
+						has_country_flag = voodoo_economics
+					}
+					modifier = {
+						factor = 1.5
+						has_country_flag = possible_housing_bubble
+					}
 					decrease_economic_growth = yes
 				}
-				20 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					decrease_two_level_economic_growth = yes
-				}
-				15 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					decrease_two_level_economic_growth = yes
-					decrease_economic_growth = yes
-				}
-			}
-		}
-		else_if = { limit = { has_idea = fast_growth }
-			custom_effect_tooltip = econvent.from_fast_growth_tt
-			random_list = {
-				65 = {
-					custom_effect_tooltip = econvent.list.stable_growth_tt
-					decrease_economic_growth = yes
-				}
-				35 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					decrease_two_level_economic_growth = yes
-				}
-			}
-		}
-		else_if = { limit = { has_idea = stable_growth }
-			custom_effect_tooltip = econvent.from_stable_growth_tt
-			random_list = {
-				65 = {
-					custom_effect_tooltip = econvent.list.stagnation_tt
-					decrease_economic_growth = yes
-				}
-				35 = {
-					custom_effect_tooltip = econvent.list.recession_tt
+				50 = {
 					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
-			custom_effect_tooltip = econvent.from_stagnation_tt
 			random_list = {
-				90 = {
-					custom_effect_tooltip = econvent.list.recession_tt
+				70 = {
 					decrease_economic_growth = yes
 				}
-				10 = {
-					custom_effect_tooltip = econvent.list.depression_tt
+				30 = {
 					decrease_two_level_economic_growth = yes
-					decrease_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			custom_effect_tooltip = econvent.from_recession_tt
 			decrease_economic_growth = yes
-		}
-		else_if = { limit = { has_idea = depression }
-			custom_effect_tooltip = econvent.list.no_effect_tt
 		}
 		custom_effect_tooltip = econvent.2.b_tt
 		set_temp_variable = { temp_opinion = -10 }

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -147,33 +147,33 @@ country_event = {
 		name = econvent.2.a
 		log = "[GetDateText]: [This.GetName]: econvent.2.a executed"
 		set_country_flag = { flag = housing_crash value = 1 days = 180 }
-		clr_country_flag = possible_housing_bubble
-		set_country_flag = { flag = voodoo_economics value = 1 days = 365 }
 		if = { limit = { OR = { has_idea = economic_boom has_idea = fast_growth has_idea = stable_growth } }
 			random_list = {
 				70 = {
-					modifier = {
-						factor = 0.5
-						has_country_flag = possible_housing_bubble
-					}
-					modifier = {
-						factor = 0.5
-						has_country_flag = voodoo_economics
-					}
-					modifier = {
-						factor = 0.5
-						has_country_flag = consumption_slowdown
-					}
 					decrease_economic_growth = yes
 				}
 				30 = {
+					modifier = {
+						factor = 1.5
+						has_country_flag = possible_housing_bubble
+					}
+					modifier = {
+						factor = 1.5
+						has_country_flag = voodoo_economics
+					}
+					modifier = {
+						factor = 1.5
+						has_country_flag = consumption_slowdown
+					}
 					decrease_two_level_economic_growth = yes
 				}
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				50 = { }
+				50 = {
+					custom_effect_tooltip = econvent.list.no_effect_tt
+				}
 				40 = {
 					decrease_economic_growth = yes
 				}
@@ -183,11 +183,17 @@ country_event = {
 			}
 		}
 		else_if = { limit = { has_idea = recession }
-			random = {
-				chance = 40
-				decrease_economic_growth = yes
+			random_list = {
+				60 = {
+					custom_effect_tooltip = econvent.list.no_effect_tt
+				}
+				40 = {
+					decrease_economic_growth = yes
+				}
 			}
 		}
+		clr_country_flag = possible_housing_bubble
+		set_country_flag = { flag = voodoo_economics value = 1 days = 365 }
 		custom_effect_tooltip = econvent.voodoo_economics_tt
 		set_temp_variable = { temp_opinion = -5 }
 		change_small_medium_business_owners_opinion = yes
@@ -226,6 +232,9 @@ country_event = {
 		if = { limit = { OR = { has_idea = economic_boom has_idea = fast_growth has_idea = stable_growth } }
 			random_list = {
 				50 = {
+					decrease_economic_growth = yes
+				}
+				50 = {
 					modifier = {
 						factor = 1.5
 						has_country_flag = voodoo_economics
@@ -234,9 +243,6 @@ country_event = {
 						factor = 1.5
 						has_country_flag = possible_housing_bubble
 					}
-					decrease_economic_growth = yes
-				}
-				50 = {
 					decrease_two_level_economic_growth = yes
 				}
 			}
@@ -254,6 +260,7 @@ country_event = {
 		else_if = { limit = { has_idea = recession }
 			decrease_economic_growth = yes
 		}
+		clr_country_flag = possible_housing_bubble
 		custom_effect_tooltip = econvent.2.b_tt
 		set_temp_variable = { temp_opinion = -10 }
 		change_small_medium_business_owners_opinion = yes

--- a/localisation/english/MD_tooltips_l_english.yml
+++ b/localisation/english/MD_tooltips_l_english.yml
@@ -1,6 +1,7 @@
 ﻿l_english:
  special_forces_training_time_factor_tt: "$MODIFIER_SPECIAL_FORCES_TRAINING_TIME_FACTOR$: $RIGHT|-=%1$"
  # Custom tooltips
+ NO_EFFECT_TT: "§HNo change§!"
  variable_above_tt: "§Y$VAR_NAME$§! must be above §Y$THRESHOLD$§!"
  variable_below_tt: "§Y$VAR_NAME$§! must be below §Y$THRESHOLD$§!"
  dynamic_modifier_above_tt: "§Y$VAR_NAME$§! in $MODIFIER|Y$ must be above §Y$THRESHOLD$§!"
@@ -338,18 +339,6 @@
  neutral_conservatisms_have_less_than_14_tt: "§Y[Neutral_conservatism_L]§! Have Less Than §Y14%§! Popularity (Current: [?party_pop_array^14|2%Y])\n"
 
   #Economy
- econvent.from_booming_tt: "Will §Rlower§! our economic growth from §HBooming§!\n"
- econvent.from_fast_growth_tt: "Will §Rlower§! our economic growth from §HFast growth§!\n"
- econvent.from_stable_growth_tt: "Will §Rlower§! our economic growth from §HStable Growth§!\n"
- econvent.from_stagnation_tt: "Will §Rlower§! our economic growth from §HStagnation§!\n"
- econvent.from_recession_tt: "Will §Rlower§! our economic growth from §HRecession§!\n"
- econvent.from_recession2_tt: "Will §Rlower§! our economic growth from §HRecession§! to:\n"
- econvent.list.fast_growth_tt: "§HFast growth§!"
- econvent.list.stable_growth_tt: "§HStable Growth§!"
- econvent.list.stagnation_tt: "§HStagnation§!"
- econvent.list.recession_tt: "§HRecession§!"
- econvent.list.depression_tt: "§HDepression§!"
- econvent.list.no_effect_tt: "§HNo change§!"
  MD_has_met_all_spending_demands_TT: "Our budget meets every §YSpending Demand§! (administration, police, education, healthcare, welfare, and military)"
  econvent.voodoo_economics_tt: "By lowering interest rates, pushing banks to take greater risks and expanding the money supply we make it easier to get loans so the fall will be limited. This is called §H'Voodoo Economics'§! by critics, as it will cushion the blow to a collapsing market, but not fix the underlying issues\n"
  econvent.2.b_tt: "By doing nothing the crash will be much worse. However, the road to recovery may be faster - as the underlying cause of the crash in the first place was too much money flowing into the housing market\n"


### PR DESCRIPTION
Closes #2824

## What

Fix the housing collapse event (`econvent.2`), where the 'Will lower our economic growth from Booming' tooltip showed no matter what the economy was actually doing. The `econvent.from_booming_tt` line sat above the `if/else_if` chain, so the option announced 'from Booming' even in recession.

The fix then grew to cover how every economic event reports a cycle change. Instead of hand-writing a tooltip per branch and hiding the idea swap behind it, these events now call the existing scripted effects and let the engine render the change. That removes the whole class of bug #2824 belongs to, along with the 117 hand-written tooltip lines that carried it.

## Why

The screenshot in #2824 shows the option announcing 'Booming' while the economy is in recession. `econvent.2` was the worst case, but not the only one: `econvent.3.a`'s recession branch printed `econvent.from_stagnation_tt`, telling a country in recession its growth would fall 'from Stagnation'.

Hand-written per-branch tooltips are the cause. Every branch restated in prose the transition its `hidden_effect` was about to make, and nothing kept the two in step. `decrease_economic_growth` and `decrease_two_level_economic_growth` already exist, already wrap the swap in `disable_cycle_costs`, and already cover every transition these events perform. Calling them lets the swap run unhidden and tooltip itself, so there is one source of truth instead of two.

Separately, `econvent.2`'s exclusion for the low cycles lived only in a `mean_time_to_happen` `factor = 0`. The event fires from the `random_events` pool in `on_monthly`, and whether MTTH gates anything there is ambiguous: `validate_events.py` documents it both ways in a single docstring, and this branch's first commit assumed the opposite of its second. A `trigger` holds either way, so the gate moved there.

## How

### `econvent.2` gating

- `NOT = { has_idea = depression }` added to `trigger`. Depression is the floor, so the event has nothing to do there.
- The MTTH `factor = 0` for recession and stagnation becomes `factor = 0.5`. Those branches stay reachable (they carry real weights) but a housing crash is half as likely in an already weak economy.

### `econvent.2` outcomes

- Every downturn capped at 2 levels. The old 3-step drops (boom to stagnation at 10 % in 2.a, fast_growth to recession at 10 % in 2.a, boom to stagnation at 15 % in 2.b) are gone.
- The upper three cycles collapse into one branch per option, since the scripted effects translate each starting cycle on their own.
- Weights:
  - 2.a upper cycles: 70 % one-step / 30 % two-step
  - 2.a stagnation: 50 % no change / 40 % one-step / 10 % two-step
  - 2.a recession: 60 % no change / 40 % one-step
  - 2.b upper cycles: 50 % one-step / 50 % two-step
  - 2.b stagnation: 70 % one-step / 30 % two-step
  - 2.b recession: 100 % one-step (depression is the floor)
- The housing flags raise the two-step weight, so an ignored warning or a previous soft response makes the crash worse:
  - 2.a: `possible_housing_bubble`, `voodoo_economics` and `consumption_slowdown` each multiply the two-step bucket by 1.5. All three set gives 70 vs 101.25, a 59 % chance of the two-step drop.
  - 2.b: `voodoo_economics` and `possible_housing_bubble` each multiply the two-step bucket by 1.5. Both set gives 50 vs 112.5, 69 %.
- Both options now clear `possible_housing_bubble`. Previously only 2.a did.

### Tooltip sweep

`econvent.3.a`, `4.a`, `4.b`, `4.c`, `5.a`, `5.b`, `6.a`, `7.a` and `8.a` convert from `custom_effect_tooltip` + `hidden_effect = { add_ideas }` to the scripted effects. Every weight and cycle transition is unchanged, verified by call-site count (52 one-step, 26 two-step) against the original per-branch table. Buckets that genuinely do nothing keep a tooltip, since there is no effect for the engine to render.

`econvent.5.a` collapses from five branches to one: all five reduced to the same 60 % no change / 40 % one-step roll. It is guarded by `NOT = { has_idea = depression }`, because `econvent.5` has no `trigger` and depression countries previously fell through the chain with no effect.

`econvent.11.b` is left alone. It sets an absolute cycle (stagnation / recession / depression at 40/40/20) regardless of where the country started, which the relative-step effects cannot express. It carries no per-branch tooltips either, so there is nothing to remove.

### Localisation

`econvent.list.no_effect_tt` becomes a generic `NO_EFFECT_TT` in the shared tooltip block so other systems can reuse it. The eleven keys the sweep orphaned (`econvent.from_*_tt` and `econvent.list.<cycle>_tt`) are deleted from English. Non-English files are left alone, per AGENTS.md.

## Scope note on the standardizer

The pre-commit `md-standardize` hook rewrites the whole staged file, so this PR also carries its layout fixes to unrelated events in `Econ_events.txt` (mostly repositioning `trigger` blocks per the documented event layout, and tightening blank lines). They can be split out if preferred.

## Validation

- `python -m pytest`: 1138 passed, 2 skipped.
- `validate_events.py`, `validate_style.py`, `validate_simplifications.py`, `validate_on_actions.py`, `validate_set_variables.py`, `check_common_mistakes.py`: no findings.
- `validate_localisation.py` and `validate_variables.py`: output identical to the pre-branch baseline (pre-existing backlogs in unrelated files only). The orphaned-tooltip-key and custom-tooltip-reference checks are clean.
- Pre-commit passes on both changed files.

## Known follow-up

`econvent.1` has the same contradiction `econvent.2` just lost: its MTTH zeroes on recession and depression while `econvent.1.a`'s `random_list` carries weight modifiers keyed on those exact ideas. Out of scope here.
