### PR TITLE
Fix #2599: Christian Lindner belongs to FDP, not LKR (Germany)

### DIFF
--- a/common/scripted_effects/GER_political_leaders.txt
+++ b/common/scripted_effects/GER_political_leaders.txt
@@ -76,22 +76,6 @@ set_leader_GER = {
 			set_temp_variable = { b = 1 }
 		}
 	}
-	else_if = { limit = { has_country_flag = set_liberalism }
-
-		if = { limit = { check_variable = { liberalism_leader = 0 } NOT = { check_variable = { b = 1 } } }
-			add_to_variable = { liberalism_leader = 1 }
-			hidden_effect = { kill_country_leader = yes }
-
-			create_country_leader = {
-				name = "Christian Lindner"
-				picture = "lib_Christian_Lindner.dds"
-				ideology = liberalism
-			}
-
-			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { liberalism_leader = 1 } }
-			set_temp_variable = { b = 1 }
-		}
-	}
 	else_if = { limit = { has_country_flag = set_socialism }
 
 		if = { limit = { check_variable = { socialism_leader = 0 } }
@@ -289,6 +273,48 @@ set_leader_GER = {
 			create_country_leader = {
 				name = "Wolfgang Gerhardt"
 				picture = "Wolfgang_Gerhardt.dds"
+				ideology = Neutral_Libertarian
+			}
+
+			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Neutral_Libertarian_leader = 1 } }
+			if = { limit = { date < 2001.6.1 } set_temp_variable = { b = 1 } } #Gerhardt chaired FDP until 2001
+		}
+
+		if = { limit = { check_variable = { Neutral_Libertarian_leader = 1 } NOT = { check_variable = { b = 1 } } }
+			add_to_variable = { Neutral_Libertarian_leader = 1 }
+			hidden_effect = { kill_country_leader = yes }
+
+			create_country_leader = {
+				name = "Guido Westerwelle"
+				picture = "generic.dds" # TODO: graphics - portrait needed
+				ideology = Neutral_Libertarian
+			}
+
+			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Neutral_Libertarian_leader = 1 } }
+			if = { limit = { date < 2011.5.14 } set_temp_variable = { b = 1 } } #Westerwelle chaired FDP until 2011
+		}
+
+		if = { limit = { check_variable = { Neutral_Libertarian_leader = 2 } NOT = { check_variable = { b = 1 } } }
+			add_to_variable = { Neutral_Libertarian_leader = 1 }
+			hidden_effect = { kill_country_leader = yes }
+
+			create_country_leader = {
+				name = "Philipp Rosler"
+				picture = "generic.dds" # TODO: graphics - portrait needed
+				ideology = Neutral_Libertarian
+			}
+
+			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Neutral_Libertarian_leader = 1 } }
+			if = { limit = { date < 2013.12.7 } set_temp_variable = { b = 1 } } #Rosler chaired FDP until 2013
+		}
+
+		if = { limit = { check_variable = { Neutral_Libertarian_leader = 3 } NOT = { check_variable = { b = 1 } } }
+			add_to_variable = { Neutral_Libertarian_leader = 1 }
+			hidden_effect = { kill_country_leader = yes }
+
+			create_country_leader = {
+				name = "Christian Lindner"
+				picture = "lib_Christian_Lindner.dds"
 				ideology = Neutral_Libertarian
 			}
 


### PR DESCRIPTION
## What

Christian Lindner was the only scripted leader for Germany's `set_liberalism` slot (Liberal-Konservative Reformer, a fictional MD Western-aligned party). In real life Lindner has been chairman of the Freie Demokraten (FDP) since 2013, so he belongs to the `set_Neutral_Libertarian` slot instead.

## Why

In 2009 a German election would show Christian Lindner as the LKR leader. The screenshot in #2599 demonstrates exactly this — Lindner's portrait appears under the LKR party instead of the FDP. The LKR and the FDP are distinct parties and Lindner has never been associated with the LKR.

## How

- Removed the entire `set_liberalism` branch from `common/scripted_effects/GER_political_leaders.txt`. The LKR (a fictional MD-only party) has no scripted leader; the game falls back to its default flow.
- Expanded the `set_Neutral_Libertarian` branch from a single leader to the actual FDP chair timeline:
  - Wolfgang Gerhardt (until 2001) — uses existing `Wolfgang_Gerhardt.dds`
  - Guido Westerwelle (2001-2011) — uses `generic.dds` with `# TODO: graphics - portrait needed`
  - Philipp Rosler (2011-2013) — uses `generic.dds` with `# TODO: graphics - portrait needed`
  - Christian Lindner (2013+) — uses existing `lib_Christian_Lindner.dds`, ideology changed from `liberalism` to `Neutral_Libertarian`
- Each earlier leader is gated with the project's standard `date < YYYY.M.D set_temp_variable = { b = 1 }` skip idiom, matching the pattern already used in the GER conservatism block.
- No localisation, idea, focus, or event references to Lindner existed outside this file, so no downstream changes were required.

## Out of scope

Westerwelle and Rosler dedicated portraits. They will display the vanilla generic placeholder until art lands; the bug is fully fixed without them.

Closes #2599