### PR TITLE
Reapply trade/investment agreement opinion bonuses after puppeting

### DIFF
--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2048,7 +2048,6 @@ on_actions = {
 				}
 			}
 		}
-		# Puppeting clears bilateral opinion modifiers; restore any active trade/investment agreement bonuses
 		reapply_agreement_opinion_modifiers = yes
 	}
 

--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2048,6 +2048,8 @@ on_actions = {
 				}
 			}
 		}
+		# Puppeting clears bilateral opinion modifiers; restore any active trade/investment agreement bonuses
+		reapply_agreement_opinion_modifiers = yes
 	}
 
 	# ROOT = attacker, FROM = defender

--- a/common/scripted_effects/00_economic_effects.txt
+++ b/common/scripted_effects/00_economic_effects.txt
@@ -143,6 +143,25 @@ set_improved_trade_agreement = {
 	}
 }
 
+# Re-apply trade/investment agreement opinion modifiers after puppeting clears them.
+# ROOT = the country that was just puppeted, FROM = its new overlord.
+reapply_agreement_opinion_modifiers = {
+	if = {
+		limit = { has_country_flag = trade_agreement@FROM }
+		add_opinion_modifier = { target = FROM modifier = mutual_trade_agreement }
+		add_opinion_modifier = { target = FROM modifier = mutual_trade_opinion }
+		reverse_add_opinion_modifier = { target = FROM modifier = mutual_trade_opinion }
+		reverse_add_opinion_modifier = { target = FROM modifier = mutual_trade_agreement }
+	}
+	if = {
+		limit = { has_country_flag = mutual_investment_treaty_@FROM }
+		add_opinion_modifier = { target = FROM modifier = mutual_investment_treaty_opinion }
+		add_opinion_modifier = { target = FROM modifier = mutual_investment_treaty_trade_opinion }
+		reverse_add_opinion_modifier = { target = FROM modifier = mutual_investment_treaty_opinion }
+		reverse_add_opinion_modifier = { target = FROM modifier = mutual_investment_treaty_trade_opinion }
+	}
+}
+
 quarterly_inflation_calculation = {
 	#Get and set the basic civilian economic growth for this quarter, and grab our old inflation rate
 	set_temp_variable = { last_inflation_rate = inflation_rate_var }

--- a/common/scripted_effects/00_economic_effects.txt
+++ b/common/scripted_effects/00_economic_effects.txt
@@ -143,7 +143,6 @@ set_improved_trade_agreement = {
 	}
 }
 
-# Re-apply trade/investment agreement opinion modifiers after puppeting clears them.
 # ROOT = the country that was just puppeted, FROM = its new overlord.
 reapply_agreement_opinion_modifiers = {
 	if = {


### PR DESCRIPTION
Fixes #2863

**What**
Puppeting a country clears the bilateral opinion modifiers between the puppet and its overlord. The trade agreement (`mutual_trade_agreement` +100, `mutual_trade_opinion` +25) and mutual investment treaty (`mutual_investment_treaty_opinion` +30, `mutual_investment_treaty_trade_opinion` +30) kept their country flags, so the agreements still showed active but the relations bonus was gone until the player cancelled and re-signed them.

**Why**
The country flags survive puppeting but opinion modifiers do not, leaving the agreement UI and the actual effect out of sync.

**How**
Added a `reapply_agreement_opinion_modifiers` scripted effect (`common/scripted_effects/00_economic_effects.txt`) that checks the `trade_agreement@FROM` and `mutual_investment_treaty_@FROM` flags and re-applies the four opinion modifiers in both directions. It is called from `on_puppet` (`common/on_actions/00_on_actions.txt`), where ROOT is the new puppet and FROM the overlord. `add_opinion_modifier` is idempotent, so re-application cannot stack.