### PR TITLE
Reapply Taliban opinion penalty when the Taliban country is restored

### DIFF
--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2048,7 +2048,6 @@ on_actions = {
 				}
 			}
 		}
-		# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
 		if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 	}
 

--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2048,6 +2048,8 @@ on_actions = {
 				}
 			}
 		}
+		# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
+		if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 	}
 
 	# ROOT = attacker, FROM = defender

--- a/common/on_actions/01_tfv_on_actions.txt
+++ b/common/on_actions/01_tfv_on_actions.txt
@@ -184,6 +184,8 @@ on_actions = {
 					}
 				}
 			}
+			# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
+			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 		}
 	}
 
@@ -274,6 +276,8 @@ on_actions = {
 						set_election_year_60_months = yes
 					}
 					ingame_startup_nations_effect = yes
+					# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
+					if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 				}
 			}
 		}
@@ -285,6 +289,8 @@ on_actions = {
 			FROM = {
 				ROOT = {
 					ingame_startup_nations_effect = yes
+					# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
+					if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 				}
 			}
 			set_temp_variable = { percent_change = 5 }

--- a/common/on_actions/01_tfv_on_actions.txt
+++ b/common/on_actions/01_tfv_on_actions.txt
@@ -184,7 +184,6 @@ on_actions = {
 					}
 				}
 			}
-			# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
 			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 		}
 	}
@@ -276,7 +275,6 @@ on_actions = {
 						set_election_year_60_months = yes
 					}
 					ingame_startup_nations_effect = yes
-					# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
 					if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 				}
 			}
@@ -289,7 +287,6 @@ on_actions = {
 			FROM = {
 				ROOT = {
 					ingame_startup_nations_effect = yes
-					# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
 					if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 				}
 			}

--- a/common/on_actions/07_nsb_on_actions.txt
+++ b/common/on_actions/07_nsb_on_actions.txt
@@ -412,6 +412,8 @@ on_actions = {
 
 	on_release_as_puppet = {
 		effect = {
+			# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
+			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 		}
 	}
 

--- a/common/on_actions/07_nsb_on_actions.txt
+++ b/common/on_actions/07_nsb_on_actions.txt
@@ -412,7 +412,6 @@ on_actions = {
 
 	on_release_as_puppet = {
 		effect = {
-			# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
 			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 		}
 	}

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -315,6 +315,15 @@ on_actions = {
 		}
 	}
 
+	# Weekly backstop: TAL can be revived by paths that fire no on_action (conditional peace
+	# deal state transfer), and a restored TAL skips the fresh-nation startup gate, so re-apply
+	# its Taliban_Are_Terrorists opinion modifiers every week while it exists.
+	on_weekly_TAL = {
+		effect = {
+			AFG_reapply_taliban_opinion_modifiers = yes
+		}
+	}
+
 	#ROOT is winner #FROM gets annexed - For civil wars on_civil_war_end is also fired
 	on_annex = {
 		effect = {

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -315,7 +315,7 @@ on_actions = {
 		}
 	}
 
-	on_weekly_TAL = {
+	on_monthly_TAL = {
 		effect = {
 			AFG_reapply_taliban_opinion_modifiers = yes
 		}

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -315,9 +315,6 @@ on_actions = {
 		}
 	}
 
-	# Weekly backstop: TAL can be revived by paths that fire no on_action (conditional peace
-	# deal state transfer), and a restored TAL skips the fresh-nation startup gate, so re-apply
-	# its Taliban_Are_Terrorists opinion modifiers every week while it exists.
 	on_weekly_TAL = {
 		effect = {
 			AFG_reapply_taliban_opinion_modifiers = yes

--- a/common/scripted_effects/02_peace_deal_effects.txt
+++ b/common/scripted_effects/02_peace_deal_effects.txt
@@ -1041,6 +1041,8 @@ CPD_liberate_in_state_effect = {
 			}
 			var:CPD_liberated_state_owner = { remove_state_core = PREV }
 			transfer_state = var:CPD_liberated_state
+			# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
+			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 		}
 	}
 	else = {

--- a/common/scripted_effects/02_peace_deal_effects.txt
+++ b/common/scripted_effects/02_peace_deal_effects.txt
@@ -1041,7 +1041,6 @@ CPD_liberate_in_state_effect = {
 			}
 			var:CPD_liberated_state_owner = { remove_state_core = PREV }
 			transfer_state = var:CPD_liberated_state
-			# Restored TAL lost its Taliban_Are_Terrorists opinion modifiers when destroyed; re-apply them
 			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 		}
 	}

--- a/common/scripted_effects/99_AFG_scripted_effects.txt
+++ b/common/scripted_effects/99_AFG_scripted_effects.txt
@@ -1,7 +1,7 @@
 #Taliban Insurgency:
 
 AFG_reapply_taliban_opinion_modifiers = {
-	every_country = {
+	every_other_country = {
 		limit = {
 			NOT = { original_tag = TAL }
 			NOT = { original_tag = TTP }


### PR DESCRIPTION
Fixes #2423

**What**
The `Taliban_Are_Terrorists` (−100) and `Taliban_Are_Terrorists_Trade` (−200) opinion modifiers are applied at game start by every country's history file. When the Taliban is destroyed in a war and later revived, those history files do not re-run, so the revived country comes back without the penalty. A previous fix (#2662) only fired for nations the mod's startup test considers fresh (`fresh_nation_temp = 1`), and a restored TAL skips that gate, so the bug persisted.

**Why**
The penalty is applied from the other countries' side, so nothing re-applies it when TAL re-enters the game. The reapply effect (`AFG_reapply_taliban_opinion_modifiers`) is idempotent, so the trigger just needs to fire whenever TAL comes back, not only when it is brand-new.

**How**
Hook `AFG_reapply_taliban_opinion_modifiers = yes` (guarded by `original_tag = TAL`) into every revival path:

- `on_liberate`, `on_release_as_free`, `on_release_as_puppet` (`01_tfv_on_actions.txt` and the empty `07_nsb_on_actions.txt` block) — vanilla peace-conference and release-decision paths
- `on_puppet` (`00_on_actions.txt`) — dead tag puppeted directly
- The conditional peace deal dead-tag revive branch (`CPD_liberate_in_state_effect`, `02_peace_deal_effects.txt`) — revives TAL via `transfer_state`, which fires no on_action
- `on_weekly_TAL` (`MD_on_actions.txt`) — weekly backstop covering any path that fires no on_action (same pattern as the existing `on_weekly_ISR`/etc.), so the penalty returns within a week at worst

`add_opinion_modifier` is idempotent, so repeated re-application cannot stack.