### PR TITLE
Clean redundant booleans and GFX validation

### DIFF
--- a/common/decisions/Coalition Decisions.txt
+++ b/common/decisions/Coalition Decisions.txt
@@ -3427,10 +3427,8 @@ coalition_decisions = {
 				OR = {
 					has_country_leader_with_trait = western_technocrat
 					has_country_flag = coalition_reshuffling
-					OR = {
-						check_variable = { var = government_coalition_strength_elect value = majority_threshold compare = greater_than_or_equals }
-						is_in_array = { ruling_party = max_index_1 }
-					}
+					check_variable = { var = government_coalition_strength_elect value = majority_threshold compare = greater_than_or_equals }
+					is_in_array = { ruling_party = max_index_1 }
 				}
 			}
 		}
@@ -3452,10 +3450,8 @@ coalition_decisions = {
 				OR = {
 					has_country_leader_with_trait = western_technocrat
 					has_country_flag = coalition_reshuffling
-					OR = {
-						check_variable = { var = government_coalition_strength_elect value = majority_threshold compare = greater_than_or_equals }
-						is_in_array = { ruling_party = max_index_2 }
-					}
+					check_variable = { var = government_coalition_strength_elect value = majority_threshold compare = greater_than_or_equals }
+					is_in_array = { ruling_party = max_index_2 }
 				}
 			}
 		}

--- a/common/decisions/Country Flag Decisions.txt
+++ b/common/decisions/Country Flag Decisions.txt
@@ -34,11 +34,9 @@ different_country_flags_category = {
 									has_cosmetic_tag = [ROOTTAG]
 								}
 								has_civil_war = yes
-								OR = {
-									NOT = { tag = [ROOTTAG] }
-									has_cosmetic_tag = [ROOTTAG]_REB
-									has_cosmetic_tag = [ROOTTAG]_REB_S
-								}
+								NOT = { tag = [ROOTTAG] }
+								has_cosmetic_tag = [ROOTTAG]_REB
+								has_cosmetic_tag = [ROOTTAG]_REB_S
 							}
 						}
 					}
@@ -58,11 +56,9 @@ different_country_flags_category = {
 									has_cosmetic_tag = [ROOTTAG]
 								}
 								has_civil_war = yes
-								OR = {
-									NOT = { tag = [ROOTTAG] }
-									has_cosmetic_tag = [ROOTTAG]_REB
-									has_cosmetic_tag = [ROOTTAG]_REB_S
-								}
+								NOT = { tag = [ROOTTAG] }
+								has_cosmetic_tag = [ROOTTAG]_REB
+								has_cosmetic_tag = [ROOTTAG]_REB_S
 							}
 						}
 					}
@@ -254,16 +250,14 @@ different_country_flags_category = {
 			NOT = {
 				OR = {
 					has_civil_war = yes
-					OR = {
-						nationalist_military_junta_are_in_power = yes
-						AND = {
-							NOT = { tag = var:temp_var }
-							var:temp_var = {
-								OR = {
-									western_autocrats_are_in_power = yes
-									emerging_autocracy_are_in_power = yes
-									neutrality_neutral_autocracy_are_in_power = yes
-								}
+					nationalist_military_junta_are_in_power = yes
+					AND = {
+						NOT = { tag = var:temp_var }
+						var:temp_var = {
+							OR = {
+								western_autocrats_are_in_power = yes
+								emerging_autocracy_are_in_power = yes
+								neutrality_neutral_autocracy_are_in_power = yes
 							}
 						}
 					}

--- a/common/decisions/Czech_Republic.txt
+++ b/common/decisions/Czech_Republic.txt
@@ -5151,13 +5151,11 @@ CZE_SLO_czechoslovakia_category = {
 			NOT = {
 				OR = {
 					has_completed_focus = CZE_SLO_regional_dominance
-					OR = {
-						SLO = {
-							has_country_flag = CZE_SLO_completed_decision_1
-						}
-						CZE = {
-							has_country_flag = CZE_SLO_completed_decision_1
-						}
+					SLO = {
+						has_country_flag = CZE_SLO_completed_decision_1
+					}
+					CZE = {
+						has_country_flag = CZE_SLO_completed_decision_1
 					}
 				}
 			}
@@ -5223,13 +5221,11 @@ CZE_SLO_czechoslovakia_category = {
 			NOT = {
 				OR = {
 					has_completed_focus = CZE_SLO_regional_dominance
-					OR = {
-						SLO = {
-							has_country_flag = CZE_SLO_completed_decision_2
-						}
-						CZE = {
-							has_country_flag = CZE_SLO_completed_decision_2
-						}
+					SLO = {
+						has_country_flag = CZE_SLO_completed_decision_2
+					}
+					CZE = {
+						has_country_flag = CZE_SLO_completed_decision_2
 					}
 				}
 			}
@@ -5295,13 +5291,11 @@ CZE_SLO_czechoslovakia_category = {
 			NOT = {
 				OR = {
 					has_completed_focus = CZE_SLO_regional_dominance
-					OR = {
-						SLO = {
-							has_country_flag = CZE_SLO_completed_decision_3
-						}
-						CZE = {
-							has_country_flag = CZE_SLO_completed_decision_3
-						}
+					SLO = {
+						has_country_flag = CZE_SLO_completed_decision_3
+					}
+					CZE = {
+						has_country_flag = CZE_SLO_completed_decision_3
 					}
 				}
 			}
@@ -5367,13 +5361,11 @@ CZE_SLO_czechoslovakia_category = {
 			NOT = {
 				OR = {
 					has_completed_focus = CZE_SLO_regional_dominance
-					OR = {
-						SLO = {
-							has_country_flag = CZE_SLO_completed_decision_4
-						}
-						CZE = {
-							has_country_flag = CZE_SLO_completed_decision_4
-						}
+					SLO = {
+						has_country_flag = CZE_SLO_completed_decision_4
+					}
+					CZE = {
+						has_country_flag = CZE_SLO_completed_decision_4
 					}
 				}
 			}

--- a/common/decisions/France.txt
+++ b/common/decisions/France.txt
@@ -209,10 +209,8 @@ FRA_invest_LEB_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -242,10 +240,8 @@ FRA_invest_LEB_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -274,10 +270,8 @@ FRA_invest_LEB_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -310,10 +304,8 @@ FRA_invest_LEB_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -367,10 +359,8 @@ FRA_french_africa_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -422,10 +412,8 @@ FRA_french_africa_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -477,10 +465,8 @@ FRA_french_africa_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}
@@ -531,10 +517,8 @@ FRA_french_africa_decision_category = {
 				NOT = {
 					OR = {
 						has_global_flag = FRA_CHAOS_PATH
-						OR = {
-							has_government = communism
-							has_government = nationalist
-						}
+						has_government = communism
+						has_government = nationalist
 					}
 				}
 			}

--- a/common/decisions/Iraq.txt
+++ b/common/decisions/Iraq.txt
@@ -3877,11 +3877,9 @@ IRQ_spring_of_islam = {
 			AFG = {
 				NOT = {
 					OR = {
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-							is_subject_of = IRQ
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
+						is_subject_of = IRQ
 						has_war_with = TAL
 					}
 				}

--- a/common/decisions/Poland.txt
+++ b/common/decisions/Poland.txt
@@ -5923,11 +5923,9 @@ POL_cua_category = {
 			}
 			NOT = {
 				OR = {
-					OR = {
-						has_decision = POL_ban_on_leaving_the_country_during_strikes
-						has_decision = POL_restoration_of_the_old_penal_system
-						has_decision = POL_limiting_activities_at_night
-					}
+					has_decision = POL_ban_on_leaving_the_country_during_strikes
+					has_decision = POL_restoration_of_the_old_penal_system
+					has_decision = POL_limiting_activities_at_night
 					has_idea = POL_economy_status7_idea
 				}
 			}
@@ -5964,11 +5962,9 @@ POL_cua_category = {
 			}
 			NOT = {
 				OR = {
-					OR = {
-						has_decision = POL_ban_on_leaving_the_country_during_strikes
-						has_decision = POL_restoration_of_the_old_penal_system
-						has_decision = POL_hunt_the_new_solidarity_politicians
-					}
+					has_decision = POL_ban_on_leaving_the_country_during_strikes
+					has_decision = POL_restoration_of_the_old_penal_system
+					has_decision = POL_hunt_the_new_solidarity_politicians
 					has_idea = POL_economy_status7_idea
 				}
 			}
@@ -6007,11 +6003,9 @@ POL_cua_category = {
 			}
 			NOT = {
 				OR = {
-					OR = {
-						has_decision = POL_ban_on_leaving_the_country_during_strikes
-						has_decision = POL_limiting_activities_at_night
-						has_decision = POL_hunt_the_new_solidarity_politicians
-					}
+					has_decision = POL_ban_on_leaving_the_country_during_strikes
+					has_decision = POL_limiting_activities_at_night
+					has_decision = POL_hunt_the_new_solidarity_politicians
 					has_idea = POL_economy_status7_idea
 				}
 			}
@@ -6048,11 +6042,9 @@ POL_cua_category = {
 			}
 			NOT = {
 				OR = {
-					OR = {
-						has_decision = POL_restoration_of_the_old_penal_system
-						has_decision = POL_limiting_activities_at_night
-						has_decision = POL_hunt_the_new_solidarity_politicians
-					}
+					has_decision = POL_restoration_of_the_old_penal_system
+					has_decision = POL_limiting_activities_at_night
+					has_decision = POL_hunt_the_new_solidarity_politicians
 					has_idea = POL_economy_status7_idea
 				}
 			}
@@ -6567,21 +6559,15 @@ POL_department_of_foreign_influence_category = {
 		visible = {
 			NOT = {
 				OR = {
-					OR = {
-						CZE = { is_in_faction_with = POL }
-						CZE = { is_subject_of = POL }
-						CZE = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						SLO = { is_in_faction_with = POL }
-						SLO = { is_subject_of = POL }
-						SLO = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						HUN = { is_in_faction_with = POL }
-						HUN = { is_subject_of = POL }
-						HUN = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					CZE = { is_in_faction_with = POL }
+					CZE = { is_subject_of = POL }
+					CZE = { all_core_state = { is_fully_controlled_by = POL } }
+					SLO = { is_in_faction_with = POL }
+					SLO = { is_subject_of = POL }
+					SLO = { all_core_state = { is_fully_controlled_by = POL } }
+					HUN = { is_in_faction_with = POL }
+					HUN = { is_subject_of = POL }
+					HUN = { all_core_state = { is_fully_controlled_by = POL } }
 				}
 			}
 		}
@@ -6630,21 +6616,15 @@ POL_department_of_foreign_influence_category = {
 			has_country_flag = POL_start_visegrad_plans_flag
 			NOT = {
 				OR = {
-					OR = {
-						CZE = { is_in_faction_with = POL }
-						CZE = { is_subject_of = POL }
-						CZE = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						SLO = { is_in_faction_with = POL }
-						SLO = { is_subject_of = POL }
-						SLO = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						HUN = { is_in_faction_with = POL }
-						HUN = { is_subject_of = POL }
-						HUN = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					CZE = { is_in_faction_with = POL }
+					CZE = { is_subject_of = POL }
+					CZE = { all_core_state = { is_fully_controlled_by = POL } }
+					SLO = { is_in_faction_with = POL }
+					SLO = { is_subject_of = POL }
+					SLO = { all_core_state = { is_fully_controlled_by = POL } }
+					HUN = { is_in_faction_with = POL }
+					HUN = { is_subject_of = POL }
+					HUN = { all_core_state = { is_fully_controlled_by = POL } }
 				}
 			}
 		}
@@ -6703,21 +6683,15 @@ POL_department_of_foreign_influence_category = {
 			has_country_flag = POL_start_visegrad_plans_flag
 			NOT = {
 				OR = {
-					OR = {
-						CZE = { is_in_faction_with = POL }
-						CZE = { is_subject_of = POL }
-						CZE = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						SLO = { is_in_faction_with = POL }
-						SLO = { is_subject_of = POL }
-						SLO = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						HUN = { is_in_faction_with = POL }
-						HUN = { is_subject_of = POL }
-						HUN = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					CZE = { is_in_faction_with = POL }
+					CZE = { is_subject_of = POL }
+					CZE = { all_core_state = { is_fully_controlled_by = POL } }
+					SLO = { is_in_faction_with = POL }
+					SLO = { is_subject_of = POL }
+					SLO = { all_core_state = { is_fully_controlled_by = POL } }
+					HUN = { is_in_faction_with = POL }
+					HUN = { is_subject_of = POL }
+					HUN = { all_core_state = { is_fully_controlled_by = POL } }
 				}
 			}
 		}
@@ -7491,11 +7465,9 @@ POL_department_of_foreign_influence_category = {
 			}
 			NOT = {
 				OR = {
-					OR = {
-						HUN = { is_in_faction_with = POL }
-						HUN = { is_subject_of = POL }
-						HUN = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					HUN = { is_in_faction_with = POL }
+					HUN = { is_subject_of = POL }
+					HUN = { all_core_state = { is_fully_controlled_by = POL } }
 					has_country_flag = POL_invites_country_to_rep_flag
 				}
 			}
@@ -7567,21 +7539,15 @@ POL_department_of_foreign_influence_category = {
 		visible = {
 			NOT = {
 				OR = {
-					OR = {
-						LIT = { is_in_faction_with = POL }
-						LIT = { is_subject_of = POL }
-						LIT = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						LAT = { is_in_faction_with = POL }
-						LAT = { is_subject_of = POL }
-						LAT = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						EST = { is_in_faction_with = POL }
-						EST = { is_subject_of = POL }
-						EST = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					LIT = { is_in_faction_with = POL }
+					LIT = { is_subject_of = POL }
+					LIT = { all_core_state = { is_fully_controlled_by = POL } }
+					LAT = { is_in_faction_with = POL }
+					LAT = { is_subject_of = POL }
+					LAT = { all_core_state = { is_fully_controlled_by = POL } }
+					EST = { is_in_faction_with = POL }
+					EST = { is_subject_of = POL }
+					EST = { all_core_state = { is_fully_controlled_by = POL } }
 				}
 			}
 		}
@@ -7994,24 +7960,22 @@ POL_department_of_foreign_influence_category = {
 			has_country_flag = POL_start_baltic_plans_flag
 			NOT = {
 				OR = {
-					OR = {
-						has_country_flag = POL_baltic_plans_failed_flag
-						AND = {
-							OR = {
-								LIT = { is_in_faction_with = POL }
-								LIT = { is_subject_of = POL }
-								LIT = { all_core_state = { is_fully_controlled_by = POL } }
-							}
-							OR = {
-								LAT = { is_in_faction_with = POL }
-								LAT = { is_subject_of = POL }
-								LAT = { all_core_state = { is_fully_controlled_by = POL } }
-							}
-							OR = {
-								EST = { is_in_faction_with = POL }
-								EST = { is_subject_of = POL }
-								EST = { all_core_state = { is_fully_controlled_by = POL } }
-							}
+					has_country_flag = POL_baltic_plans_failed_flag
+					AND = {
+						OR = {
+							LIT = { is_in_faction_with = POL }
+							LIT = { is_subject_of = POL }
+							LIT = { all_core_state = { is_fully_controlled_by = POL } }
+						}
+						OR = {
+							LAT = { is_in_faction_with = POL }
+							LAT = { is_subject_of = POL }
+							LAT = { all_core_state = { is_fully_controlled_by = POL } }
+						}
+						OR = {
+							EST = { is_in_faction_with = POL }
+							EST = { is_subject_of = POL }
+							EST = { all_core_state = { is_fully_controlled_by = POL } }
 						}
 					}
 					has_country_flag = POL_estonian_railway_built
@@ -8535,16 +8499,12 @@ POL_department_of_foreign_influence_category = {
 		visible = {
 			NOT = {
 				OR = {
-					OR = {
-						ROM = { is_in_faction_with = POL }
-						ROM = { is_subject_of = POL }
-						ROM = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						BUL = { is_in_faction_with = POL }
-						BUL = { is_subject_of = POL }
-						BUL = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					ROM = { is_in_faction_with = POL }
+					ROM = { is_subject_of = POL }
+					ROM = { all_core_state = { is_fully_controlled_by = POL } }
+					BUL = { is_in_faction_with = POL }
+					BUL = { is_subject_of = POL }
+					BUL = { all_core_state = { is_fully_controlled_by = POL } }
 				}
 			}
 			OR = {
@@ -9223,16 +9183,12 @@ POL_department_of_foreign_influence_category = {
 		visible = {
 			NOT = {
 				OR = {
-					OR = {
-						SWE = { is_in_faction_with = POL }
-						SWE = { is_subject_of = POL }
-						SWE = { all_core_state = { is_fully_controlled_by = POL } }
-					}
-					OR = {
-						FIN = { is_in_faction_with = POL }
-						FIN = { is_subject_of = POL }
-						FIN = { all_core_state = { is_fully_controlled_by = POL } }
-					}
+					SWE = { is_in_faction_with = POL }
+					SWE = { is_subject_of = POL }
+					SWE = { all_core_state = { is_fully_controlled_by = POL } }
+					FIN = { is_in_faction_with = POL }
+					FIN = { is_subject_of = POL }
+					FIN = { all_core_state = { is_fully_controlled_by = POL } }
 				}
 			}
 			OR = {

--- a/common/decisions/Union State.txt
+++ b/common/decisions/Union State.txt
@@ -174,11 +174,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_parlament_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -226,11 +224,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_gos_sovet_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -278,11 +274,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_council_ministers_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -330,11 +324,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_money_palata_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -381,11 +373,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_eternal_commitie_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -438,11 +428,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_valute_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -495,11 +483,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_civils_idea
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 
@@ -550,11 +536,9 @@ USR_Union_state_category = {
 					has_war_with = SOV
 					has_idea = USR_economic_space_idea
 					has_autonomy_state = autonomy_union_state
-					OR = {
-						nationalist_right_wing_populists_are_in_power = yes
-						nationalist_monarchists_are_in_power = yes
-						has_government = democratic
-					}
+					nationalist_right_wing_populists_are_in_power = yes
+					nationalist_monarchists_are_in_power = yes
+					has_government = democratic
 				}
 			}
 		}
@@ -1034,10 +1018,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_parlament_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1085,10 +1067,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_gos_sovet_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1136,10 +1116,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_council_ministers_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1187,10 +1165,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_money_palata_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1236,10 +1212,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_eternal_commitie_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1292,10 +1266,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_valute_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1347,10 +1319,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_civils_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1400,10 +1370,8 @@ USR_Union_state_category = {
 				OR = {
 					has_idea = USR_economic_space_idea
 					has_autonomy_state = autonomy_union_state
-					OR = {
-						has_government = democratic
-						neutrality_neutral_social_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_social_are_in_power = yes
 				}
 			}
 		}
@@ -1638,11 +1606,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_parlament_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -1692,11 +1658,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_gos_sovet_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -1745,11 +1709,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_council_ministers_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -1798,11 +1760,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_money_palata_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -1851,11 +1811,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_eternal_commitie_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -1910,11 +1868,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_valute_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -1968,11 +1924,9 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_civils_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -2024,11 +1978,9 @@ USR_Union_state_category = {
 				OR = {
 					has_idea = USR_economic_space_idea
 					has_autonomy_state = autonomy_union_state
-					OR = {
-						has_government = democratic
-						neutrality_neutral_libertarians_are_in_power = yes
-						nationalist_fascist_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_libertarians_are_in_power = yes
+					nationalist_fascist_are_in_power = yes
 				}
 			}
 		}
@@ -2275,10 +2227,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_parlament_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2323,10 +2273,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_gos_sovet_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2371,10 +2319,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_council_ministers_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2418,10 +2364,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_money_palata_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2465,10 +2409,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_eternal_commitie_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2517,10 +2459,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_valute_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2570,10 +2510,8 @@ USR_Union_state_category = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
 					has_idea = USR_civils_idea
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 
@@ -2620,10 +2558,8 @@ USR_Union_state_category = {
 				OR = {
 					has_idea = USR_economic_space_idea
 					has_autonomy_state = autonomy_union_state
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 		}
@@ -2792,10 +2728,8 @@ USR_Union_state_category = {
 			NOT = {
 				OR = {
 					has_autonomy_state = autonomy_union_state
-					OR = {
-						has_government = democratic
-						neutrality_neutral_oligarch_are_in_power = yes
-					}
+					has_government = democratic
+					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
 			has_country_flag = USR_armenia_create_union_state

--- a/common/decisions/categories/99_POL_decision_categories.txt
+++ b/common/decisions/categories/99_POL_decision_categories.txt
@@ -284,10 +284,8 @@ POL_cua_category = {
 		has_country_flag = POL_communism_uprising_again_activation
 		NOT = {
 			OR = {
-				OR = {
-					has_idea = POL_solidarity_strength5_idea
-					has_idea = POL_communism_domination5_idea
-				}
+				has_idea = POL_solidarity_strength5_idea
+				has_idea = POL_communism_domination5_idea
 				is_ai = yes
 			}
 		}

--- a/common/decisions/categories/99_SMA_decision_categories.txt
+++ b/common/decisions/categories/99_SMA_decision_categories.txt
@@ -19,19 +19,13 @@ SMA_change_textbooks = {
 		has_completed_focus = SMA_change_history_in_textbooks
 		NOT = {
 			OR = {
-				OR = {
-					has_country_flag = change_texbooks_lang_romanian
-					has_country_flag = change_texbooks_lang_ita
-				}
-				OR = {
-					has_country_flag = change_texbooks_hist_peace
-					has_country_flag = change_texbooks_hist_mil
-				}
-				OR = {
-					has_country_flag = change_texbooks_ed_work
-					has_country_flag = change_texbooks_ed_res
-					has_country_flag = change_texbooks_ed_mil
-				}
+				has_country_flag = change_texbooks_lang_romanian
+				has_country_flag = change_texbooks_lang_ita
+				has_country_flag = change_texbooks_hist_peace
+				has_country_flag = change_texbooks_hist_mil
+				has_country_flag = change_texbooks_ed_work
+				has_country_flag = change_texbooks_ed_res
+				has_country_flag = change_texbooks_ed_mil
 			}
 		}
 	}

--- a/common/ideas/05_united_kingdom.txt
+++ b/common/ideas/05_united_kingdom.txt
@@ -1341,14 +1341,12 @@ ideas = {
 			cancel = {
 				OR = {
 					COL = {
-						AND = {
-							has_idea = corruption_level_01
-							check_variable = {
-								cartel_political_influence < 1
-							}
-							check_variable = {
-								cartel_political_influence < 1
-							}
+						has_idea = corruption_level_01
+						check_variable = {
+							cartel_political_influence < 1
+						}
+						check_variable = {
+							cartel_political_influence < 1
 						}
 					}
 					ENG = {

--- a/common/ideas/AA_law_expanded_economics.txt
+++ b/common/ideas/AA_law_expanded_economics.txt
@@ -789,11 +789,9 @@ ideas = {
 						NOT = {
 							OR = {
 								has_idea = us_dollar
-								OR = {
-									has_idea = chinese_yuan
-									has_idea = chinese_yuan_2
-									has_idea = chinese_yuan_3
-								}
+								has_idea = chinese_yuan
+								has_idea = chinese_yuan_2
+								has_idea = chinese_yuan_3
 								has_idea = japanese_yen
 								has_idea = russia_rouble
 								has_idea = british_pound
@@ -906,10 +904,8 @@ ideas = {
 					NOT = { tag = CHI }
 					NOT = {
 						OR = {
-							OR = {
-								has_government = communism
-								has_government = neutrality
-							}
+							has_government = communism
+							has_government = neutrality
 							NOT = { is_in_faction_with = USA }
 						}
 					}
@@ -986,10 +982,8 @@ ideas = {
 					NOT = { tag = CHI }
 					NOT = {
 						OR = {
-							OR = {
-								has_government = communism
-								has_government = neutrality
-							}
+							has_government = communism
+							has_government = neutrality
 							NOT = { is_in_faction_with = USA }
 						}
 					}
@@ -1066,10 +1060,8 @@ ideas = {
 					NOT = { tag = CHI }
 					NOT = {
 						OR = {
-							OR = {
-								has_government = communism
-								has_government = neutrality
-							}
+							has_government = communism
+							has_government = neutrality
 							NOT = { is_in_faction_with = USA }
 						}
 					}

--- a/common/ideas/Iranian.txt
+++ b/common/ideas/Iranian.txt
@@ -638,10 +638,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_ghalibaf
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -672,10 +670,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_hemmati
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -708,10 +704,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_khatami
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -743,10 +737,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_yazdi
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -773,10 +765,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_kavakebian
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -803,10 +793,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_karroubi
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -833,10 +821,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_mashaei
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -863,10 +849,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_bayadi
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -893,10 +877,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_haghshenas
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -924,10 +906,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_ahmadinejad
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -960,10 +940,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_mousavi
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -996,10 +974,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_rafsanjani
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -1032,10 +1008,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_raisi
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -1070,10 +1044,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_pezeshkian
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -1106,10 +1078,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_rezaee
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -1153,10 +1123,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_rouhani
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}
@@ -1279,10 +1247,8 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_president_tavakoli
-						OR = {
-							emerging_hardline_shiite_are_in_power = yes
-							emerging_moderate_shiite_are_in_power = yes
-						}
+						emerging_hardline_shiite_are_in_power = yes
+						emerging_moderate_shiite_are_in_power = yes
 					}
 				}
 			}

--- a/common/ideas/Russian.txt
+++ b/common/ideas/Russian.txt
@@ -1591,11 +1591,9 @@ ideas = {
 				NOT = {
 					OR = {
 						has_country_flag = SOV_borya_ded
-						OR = {
-							western_liberals_are_in_power = yes
-							western_conservatism_are_in_power = yes
-							western_social_democrats_are_in_power = yes
-						}
+						western_liberals_are_in_power = yes
+						western_conservatism_are_in_power = yes
+						western_social_democrats_are_in_power = yes
 					}
 				}
 			}

--- a/common/national_focus/05_ethiopia.txt
+++ b/common/national_focus/05_ethiopia.txt
@@ -329,14 +329,10 @@ focus_tree = {
 		cancel = {
 			NOT = {
 				OR = {
-					OR = {
-						is_subject = no
-						is_subject_of = USA
-					}
-					OR = {
-						has_elections = yes
-						has_opinion = { target = USA value > 25 }
-					}
+					is_subject = no
+					is_subject_of = USA
+					has_elections = yes
+					has_opinion = { target = USA value > 25 }
 				}
 			}
 			has_war_with = USA

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -26603,13 +26603,11 @@ focus_tree = {
 			}
 			NOT = {
 				OR = {
-					OR = {
-						has_country_leader = {
-							name = "Benjamin Netanyahu"
-							ruling_only = yes
-						}
-						has_government = democratic
+					has_country_leader = {
+						name = "Benjamin Netanyahu"
+						ruling_only = yes
 					}
+					has_government = democratic
 					has_country_flag = pal_rejected_conter
 				}
 			}

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -10090,7 +10090,6 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_special_forces_helicopter"
 			if = {
-				limit = { }
 				create_equipment_variant = {
 					name = "AH-1W SuperCobra"
 					type = heavy_tank_chassis_3

--- a/common/on_actions/99_POL_on_actions.txt
+++ b/common/on_actions/99_POL_on_actions.txt
@@ -105,18 +105,12 @@ on_actions = {
 					has_country_flag = POL_start_visegrad_plans_flag
 					NOT = {
 						OR = {
-							OR = {
-								CZE = { is_in_faction_with = POL }
-								CZE = { is_subject_of = POL }
-							}
-							OR = {
-								SLO = { is_in_faction_with = POL }
-								SLO = { is_subject_of = POL }
-							}
-							OR = {
-								HUN = { is_in_faction_with = POL }
-								HUN = { is_subject_of = POL }
-							}
+							CZE = { is_in_faction_with = POL }
+							CZE = { is_subject_of = POL }
+							SLO = { is_in_faction_with = POL }
+							SLO = { is_subject_of = POL }
+							HUN = { is_in_faction_with = POL }
+							HUN = { is_subject_of = POL }
 							has_country_flag = POL_start_visegrad_plans_flag_event_happened
 						}
 					}
@@ -129,18 +123,12 @@ on_actions = {
 					has_country_flag = POL_start_baltic_plans_flag
 					NOT = {
 						OR = {
-							OR = {
-								LIT = { is_in_faction_with = POL }
-								LIT = { is_subject_of = POL }
-							}
-							OR = {
-								LAT = { is_in_faction_with = POL }
-								LAT = { is_subject_of = POL }
-							}
-							OR = {
-								EST = { is_in_faction_with = POL }
-								EST = { is_subject_of = POL }
-							}
+							LIT = { is_in_faction_with = POL }
+							LIT = { is_subject_of = POL }
+							LAT = { is_in_faction_with = POL }
+							LAT = { is_subject_of = POL }
+							EST = { is_in_faction_with = POL }
+							EST = { is_subject_of = POL }
 							has_country_flag = POL_start_baltic_plans_flag_event_happened
 						}
 					}
@@ -153,14 +141,10 @@ on_actions = {
 					has_country_flag = POL_start_balkan_plans_flag
 					NOT = {
 						OR = {
-							OR = {
-								ROM = { is_in_faction_with = POL }
-								ROM = { is_subject_of = POL }
-							}
-							OR = {
-								BUL = { is_in_faction_with = POL }
-								BUL = { is_subject_of = POL }
-							}
+							ROM = { is_in_faction_with = POL }
+							ROM = { is_subject_of = POL }
+							BUL = { is_in_faction_with = POL }
+							BUL = { is_subject_of = POL }
 							has_country_flag = POL_start_balkan_plans_flag_event_happened
 						}
 					}
@@ -173,14 +157,10 @@ on_actions = {
 					has_country_flag = POL_start_scandinavia_plans_flag
 					NOT = {
 						OR = {
-							OR = {
-								SWE = { is_in_faction_with = POL }
-								SWE = { is_subject_of = POL }
-							}
-							OR = {
-								FIN = { is_in_faction_with = POL }
-								FIN = { is_subject_of = POL }
-							}
+							SWE = { is_in_faction_with = POL }
+							SWE = { is_subject_of = POL }
+							FIN = { is_in_faction_with = POL }
+							FIN = { is_subject_of = POL }
 							has_country_flag = POL_start_scandinavia_plans_flag_event_happened
 						}
 					}

--- a/common/scripted_effects/99_ARM_scripted_effects.txt
+++ b/common/scripted_effects/99_ARM_scripted_effects.txt
@@ -888,11 +888,9 @@ ARM_kob_russia_script = {
 				NOT = {
 					OR = {
 						has_idea = SOV_omon_idea
-						OR = {
-							has_idea = SOV_inner_army_idea
-							has_idea = SOV_rosguard_idea
-							has_idea = SOV_rosguard_idea1
-						}
+						has_idea = SOV_inner_army_idea
+						has_idea = SOV_rosguard_idea
+						has_idea = SOV_rosguard_idea1
 					}
 				}
 				influence_higher_40 = yes
@@ -921,11 +919,9 @@ ARM_kob_russia_script = {
 					NOT = {
 						OR = {
 							has_idea = SOV_omon_idea
-							OR = {
-								has_idea = SOV_inner_army_idea
-								has_idea = SOV_rosguard_idea
-								has_idea = SOV_rosguard_idea1
-							}
+							has_idea = SOV_inner_army_idea
+							has_idea = SOV_rosguard_idea
+							has_idea = SOV_rosguard_idea1
 						}
 					}
 				}
@@ -934,11 +930,9 @@ ARM_kob_russia_script = {
 						OR = {
 							has_idea = SOV_fsb_idea2
 							has_idea = SOV_omon_idea
-							OR = {
-								has_idea = SOV_inner_army_idea
-								has_idea = SOV_rosguard_idea
-								has_idea = SOV_rosguard_idea1
-							}
+							has_idea = SOV_inner_army_idea
+							has_idea = SOV_rosguard_idea
+							has_idea = SOV_rosguard_idea1
 						}
 					}
 					influence_higher_40 = yes
@@ -967,11 +961,9 @@ ARM_kob_russia_script = {
 					OR = {
 						has_idea = SOV_fsb_idea2
 						has_idea = SOV_omon_idea
-						OR = {
-							has_idea = SOV_inner_army_idea
-							has_idea = SOV_rosguard_idea
-							has_idea = SOV_rosguard_idea1
-						}
+						has_idea = SOV_inner_army_idea
+						has_idea = SOV_rosguard_idea
+						has_idea = SOV_rosguard_idea1
 					}
 				}
 			}

--- a/events/Iran.txt
+++ b/events/Iran.txt
@@ -3993,11 +3993,9 @@ country_event = {
 				NOT = {
 					OR = {
 						has_idea = economic_boom
-						OR = {
-							has_idea = corruption_level_03
-							has_idea = corruption_level_02
-							has_idea = corruption_level_01
-						}
+						has_idea = corruption_level_03
+						has_idea = corruption_level_02
+						has_idea = corruption_level_01
 					}
 				}
 				NOT = {
@@ -4114,10 +4112,8 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_mcon_1
-						OR = {
-							has_idea = heavily_regulated_immigration
-							has_idea = closed_borders
-						}
+						has_idea = heavily_regulated_immigration
+						has_idea = closed_borders
 						401 = {
 							any_province_building_level = {
 								province = {
@@ -4201,10 +4197,8 @@ country_event = {
 					OR = {
 						has_country_flag = PER_did_mcon_3
 						has_stability > 0.64
-						OR = {
-							has_idea = police_04
-							has_idea = police_05
-						}
+						has_idea = police_04
+						has_idea = police_05
 					}
 				}
 			}
@@ -4302,11 +4296,9 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_soc_2
-						OR = {
-							has_idea = social_04
-							has_idea = social_05
-							has_idea = social_06
-						}
+						has_idea = social_04
+						has_idea = social_05
+						has_idea = social_06
 						has_idea = open_borders
 						1151 = {
 							infrastructure > 2
@@ -4649,14 +4641,10 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_moderates_1
-						OR = {
-							has_idea = police_04
-							has_idea = police_05
-						}
-						OR = {
-							has_idea = corruption_level_02
-							has_idea = corruption_level_01
-						}
+						has_idea = police_04
+						has_idea = police_05
+						has_idea = corruption_level_02
+						has_idea = corruption_level_01
 					}
 				}
 			}
@@ -4667,11 +4655,9 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_moderates_2
-						OR = {
-							has_country_flag = PER_iraq_accepted_to_pay_half_billion_weekly
-							has_country_flag = PER_iraq_accepted_to_pay_one_billion_weekly
-							has_country_flag = PER_iraq_accepted_to_pay_two_billion_weekly
-						}
+						has_country_flag = PER_iraq_accepted_to_pay_half_billion_weekly
+						has_country_flag = PER_iraq_accepted_to_pay_one_billion_weekly
+						has_country_flag = PER_iraq_accepted_to_pay_two_billion_weekly
 					}
 				}
 			}
@@ -4791,10 +4777,8 @@ country_event = {
 						has_equipment = {
 							infantry_weapons_type > 30000
 						}
-						OR = {
-							has_idea = police_01
-							has_idea = police_02
-						}
+						has_idea = police_01
+						has_idea = police_02
 					}
 				}
 			}
@@ -4805,11 +4789,9 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_libertarian_5
-						OR = {
-							IRQ = { has_idea = tribute_idea_PER	}
-							SYR = { has_idea = tribute_idea_PER	}
-							AFG = { has_idea = tribute_idea_PER	}
-						}
+						IRQ = { has_idea = tribute_idea_PER	}
+						SYR = { has_idea = tribute_idea_PER	}
+						AFG = { has_idea = tribute_idea_PER	}
 					}
 				}
 			}
@@ -4820,12 +4802,10 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_libertarian_6
-						OR = {
-							SAU = { is_subject_of = PER }
-							UAE = { is_subject_of = PER }
-							KUW = { is_subject_of = PER }
-							QAT = { is_subject_of = PER }
-						}
+						SAU = { is_subject_of = PER }
+						UAE = { is_subject_of = PER }
+						KUW = { is_subject_of = PER }
+						QAT = { is_subject_of = PER }
 					}
 				}
 			}
@@ -5091,13 +5071,11 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_monarch_6
-						OR = {
-							BHR = {
-								is_subject_of = PER
-							}
-							423 = {
-								is_controlled_by = PER
-							}
+						BHR = {
+							is_subject_of = PER
+						}
+						423 = {
+							is_controlled_by = PER
 						}
 					}
 				}
@@ -5408,11 +5386,9 @@ country_event = {
 							industrial_complex > 0
 						}
 						has_idea = open_borders
-						OR = {
-							has_idea = social_04
-							has_idea = social_05
-							has_idea = social_06
-						}
+						has_idea = social_04
+						has_idea = social_05
+						has_idea = social_06
 					}
 				}
 			}
@@ -5436,10 +5412,8 @@ country_event = {
 					OR = {
 						has_country_flag = PER_did_reformists_11
 						has_idea = bureau_05
-						OR = {
-							has_idea = corruption_level_02
-							has_idea = corruption_level_01
-						}
+						has_idea = corruption_level_02
+						has_idea = corruption_level_01
 					}
 				}
 			}
@@ -5450,10 +5424,8 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_reformists_12
-						OR = {
-							check_variable = { population_tax_rate < 16 }
-							check_variable = { corporate_tax_rate > 14 }
-						}
+						check_variable = { population_tax_rate < 16 }
+						check_variable = { corporate_tax_rate > 14 }
 					}
 				}
 			}
@@ -5651,13 +5623,11 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_principalists_6
-						OR = {
-							has_country_flag = PER_iraq_accepted_to_pay_half_billion_weekly
-							has_country_flag = PER_iraq_accepted_to_pay_one_billion_weekly
-							has_country_flag = PER_iraq_accepted_to_pay_two_billion_weekly
-							IRQ = {
-								influence_higher_50 = yes
-							}
+						has_country_flag = PER_iraq_accepted_to_pay_half_billion_weekly
+						has_country_flag = PER_iraq_accepted_to_pay_one_billion_weekly
+						has_country_flag = PER_iraq_accepted_to_pay_two_billion_weekly
+						IRQ = {
+							influence_higher_50 = yes
 						}
 					}
 				}
@@ -5669,12 +5639,10 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_principalists_7
-						OR = {
-							SAU = { is_subject_of = PER }
-							UAE = { is_subject_of = PER }
-							KUW = { is_subject_of = PER }
-							QAT = { is_subject_of = PER }
-						}
+						SAU = { is_subject_of = PER }
+						UAE = { is_subject_of = PER }
+						KUW = { is_subject_of = PER }
+						QAT = { is_subject_of = PER }
 					}
 				}
 			}
@@ -5761,10 +5729,8 @@ country_event = {
 					OR = {
 						has_country_flag = PER_did_principalists_13
 						has_stability > 0.74
-						OR = {
-							has_idea = police_04
-							has_idea = police_05
-						}
+						has_idea = police_04
+						has_idea = police_05
 					}
 				}
 			}
@@ -5791,11 +5757,9 @@ country_event = {
 				NOT = {
 					OR = {
 						has_country_flag = PER_did_principalists_15
-						OR = {
-							IRQ = { has_idea = tribute_idea_PER	}
-							SYR = { has_idea = tribute_idea_PER	}
-							LEB = { has_idea = tribute_idea_PER	}
-						}
+						IRQ = { has_idea = tribute_idea_PER	}
+						SYR = { has_idea = tribute_idea_PER	}
+						LEB = { has_idea = tribute_idea_PER	}
 					}
 				}
 			}

--- a/gfx/army_icons/army_icons.txt
+++ b/gfx/army_icons/army_icons.txt
@@ -327,11 +327,13 @@
 		name = "I. Army"
 		available = {
 			NOT = {
-				tag = FRA
-				tag = GER
-				tag = ENG
-				tag = USA
-				tag = SOV
+				OR = {
+					tag = FRA
+					tag = GER
+					tag = ENG
+					tag = USA
+					tag = SOV
+				}
 			}
 		}
 	}
@@ -340,11 +342,13 @@
 		name = "II. Army"
 		available = {
 			NOT = {
-				tag = FRA
-				tag = GER
-				tag = ENG
-				tag = USA
-				tag = SOV
+				OR = {
+					tag = FRA
+					tag = GER
+					tag = ENG
+					tag = USA
+					tag = SOV
+				}
 			}
 		}
 	}
@@ -353,11 +357,13 @@
 		name = "III. Army"
 		available = {
 			NOT = {
-				tag = FRA
-				tag = GER
-				tag = ENG
-				tag = USA
-				tag = SOV
+				OR = {
+					tag = FRA
+					tag = GER
+					tag = ENG
+					tag = USA
+					tag = SOV
+				}
 			}
 		}
 	}
@@ -380,11 +386,13 @@
 		name = "IV. Army"
 		available = {
 			NOT = {
-				tag = FRA
-				tag = GER
-				tag = ENG
-				tag = USA
-				tag = SOV
+				OR = {
+					tag = FRA
+					tag = GER
+					tag = ENG
+					tag = USA
+					tag = SOV
+				}
 			}
 		}
 	}
@@ -393,11 +401,13 @@
 		name = "V. Army"
 		available = {
 			NOT = {
-				tag = FRA
-				tag = GER
-				tag = ENG
-				tag = USA
-				tag = SOV
+				OR = {
+					tag = FRA
+					tag = GER
+					tag = ENG
+					tag = USA
+					tag = SOV
+				}
 			}
 		}
 	}

--- a/interface/countrydecisionview.gui
+++ b/interface/countrydecisionview.gui
@@ -325,11 +325,6 @@ guiTypes = {
 		size = {width=3 height=20}
 		clipping = no
 
-		iconType = {
-			name = "icon_end_bg"
-			position = {x=0 y=0}
-			spriteType = "GFX_category_end_bg"
-		}
 	}
 
 ###########################################

--- a/interface/equipmentdesigner/tanks/tank_chassis_heavy_tank_amphibious_jap.gui
+++ b/interface/equipmentdesigner/tanks/tank_chassis_heavy_tank_amphibious_jap.gui
@@ -9,7 +9,7 @@ guiTypes = { #Japan
 
 		iconType = {
 			name = "equipment_image_overlay"
-			spriteType = "GFX_TC_heavy_tank_amphibious_chassis"
+			spriteType = "GFX_TC_heavy_tank_chassis_jap"
 			position = { x=0 y=0 }
 		}
 

--- a/tools/validation/sprite_index.py
+++ b/tools/validation/sprite_index.py
@@ -24,7 +24,9 @@ from validate_gfx_references import (
     _vanilla_gfx_files,
 )
 
-_NAME_IN_BLOCK = re.compile(r'\bname\s*=\s*"([^"]+)"')
+_NAME_IN_BLOCK = re.compile(
+    r'\bname\s*=\s*(?:"([^"]+)"|([^\s}]+))'
+)
 
 
 def _parse_names(raw: str) -> List[str]:
@@ -38,7 +40,7 @@ def _parse_names(raw: str) -> List[str]:
             block = text[m.end() : line_end if line_end != -1 else m.end() + 200]
         nm = _NAME_IN_BLOCK.search(block)
         if nm:
-            names.append(nm.group(1))
+            names.append(nm.group(1) or nm.group(2))
     return names
 
 

--- a/tools/validation/sprite_index.py
+++ b/tools/validation/sprite_index.py
@@ -24,9 +24,7 @@ from validate_gfx_references import (
     _vanilla_gfx_files,
 )
 
-_NAME_IN_BLOCK = re.compile(
-    r'\bname\s*=\s*(?:"([^"]+)"|([^\s}]+))'
-)
+_NAME_IN_BLOCK = re.compile(r'\bname\s*=\s*(?:"([^"]+)"|([^\s}]+))')
 
 
 def _parse_names(raw: str) -> List[str]:

--- a/tools/validation/tests/sprite_reference_test.py
+++ b/tools/validation/tests/sprite_reference_test.py
@@ -28,7 +28,7 @@ def test_names_in_file_block_scoped_and_comment_safe(tmp_path):
         "spriteTypes = {\n"
         '  spriteType = { name = "GFX_one" texturefile = "a.dds" } // a comment\n'
         "  # another comment\n"
-        '  spriteType = { name = "bare_two" texturefile = "b.dds" }\n'
+        '  spriteType = { name = bare_two texturefile = "b.dds" }\n'
         "}\n",
     )
     names = set(_names_in_file(f))

--- a/tools/validation/tests/validate_scripted_localisation_test.py
+++ b/tools/validation/tests/validate_scripted_localisation_test.py
@@ -27,9 +27,7 @@ def test_gfx_icon_check_accepts_bare_sprite_names(tmp_path):
     interface = tmp_path / "interface"
     interface.mkdir()
     (interface / "icons.gfx").write_text(
-        "spriteTypes = {\n"
-        "\tspriteType = { name = GFX_bare_icon }\n"
-        "}\n"
+        "spriteTypes = {\n\tspriteType = { name = GFX_bare_icon }\n}\n"
     )
     loc_dir = tmp_path / "common" / "scripted_localisation"
     loc_dir.mkdir(parents=True)

--- a/tools/validation/tests/validate_scripted_localisation_test.py
+++ b/tools/validation/tests/validate_scripted_localisation_test.py
@@ -23,6 +23,24 @@ def test_scripted_loc_keeps_and_reports_undefined_bracketed_invocation(tmp_path)
     assert "missingnestedloc" in validator._issues[0].message.lower()
 
 
+def test_gfx_icon_check_accepts_bare_sprite_names(tmp_path):
+    interface = tmp_path / "interface"
+    interface.mkdir()
+    (interface / "icons.gfx").write_text(
+        "spriteTypes = {\n"
+        "\tspriteType = { name = GFX_bare_icon }\n"
+        "}\n"
+    )
+    loc_dir = tmp_path / "common" / "scripted_localisation"
+    loc_dir.mkdir(parents=True)
+    (loc_dir / "icons.txt").write_text("localization_key = GFX_bare_icon\n")
+
+    validator = V.Validator(mod_path=str(tmp_path), use_colors=False, workers=1)
+    validator.validate_gfx_icons()
+
+    assert validator._issues == []
+
+
 def test_digit_prefixed_defined_loc_is_tracked_via_gui(tmp_path):
     gui_dir = tmp_path / "interface"
     gui_dir.mkdir()

--- a/tools/validation/tests/vanilla_sprite_manifest_test.py
+++ b/tools/validation/tests/vanilla_sprite_manifest_test.py
@@ -45,12 +45,12 @@ def test_sprite_names_from_gfx_text():
 def test_sprite_names_accept_bare_names_and_chart_types():
     text = (
         "spriteTypes = {\n"
-        "\tspriteType = { name = GFX_bare_sprite texturefile = \"a.dds\" }\n"
-        "\tpieChartType = { name = \"GFX_chart\" size = 10 }\n"
+        '\tspriteType = { name = GFX_bare_sprite texturefile = "a.dds" }\n'
+        '\tpieChartType = { name = "GFX_chart" size = 10 }\n'
         "\tLineChartType = { name = GFX_line_chart size = { x = 1 y = 1 } }\n"
-        "\tcircularProgressBarType = { name = \"GFX_circular\" }\n"
+        '\tcircularProgressBarType = { name = "GFX_circular" }\n'
         "\tprogressBarType = { name = GFX_progress }\n"
-        "\tspriteType = { name = \"GFX_terrain_riviere-koksoak_1\" }\n"
+        '\tspriteType = { name = "GFX_terrain_riviere-koksoak_1" }\n'
         "}\n"
     )
     assert vg.sprite_names_from_gfx_text(text) == {

--- a/tools/validation/tests/vanilla_sprite_manifest_test.py
+++ b/tools/validation/tests/vanilla_sprite_manifest_test.py
@@ -42,6 +42,25 @@ def test_sprite_names_from_gfx_text():
     assert vg.sprite_names_from_gfx_text(text) == {"GFX_manifest_probe"}
 
 
+def test_sprite_names_accept_bare_names_and_chart_types():
+    text = (
+        "spriteTypes = {\n"
+        "\tspriteType = { name = GFX_bare_sprite texturefile = \"a.dds\" }\n"
+        "\tpieChartType = { name = \"GFX_chart\" size = 10 }\n"
+        "\tLineChartType = { name = GFX_line_chart size = { x = 1 y = 1 } }\n"
+        "\tcircularProgressBarType = { name = \"GFX_circular\" }\n"
+        "\tprogressBarType = { name = GFX_progress }\n"
+        "}\n"
+    )
+    assert vg.sprite_names_from_gfx_text(text) == {
+        "GFX_bare_sprite",
+        "GFX_chart",
+        "GFX_line_chart",
+        "GFX_circular",
+        "GFX_progress",
+    }
+
+
 def test_sprite_names_double_slash_in_quoted_texturefile():
     # `//` inside a quoted texturefile path is not a comment. Stripping it
     # blindly leaves an unterminated quote that drops the sprite definition.

--- a/tools/validation/tests/vanilla_sprite_manifest_test.py
+++ b/tools/validation/tests/vanilla_sprite_manifest_test.py
@@ -50,6 +50,7 @@ def test_sprite_names_accept_bare_names_and_chart_types():
         "\tLineChartType = { name = GFX_line_chart size = { x = 1 y = 1 } }\n"
         "\tcircularProgressBarType = { name = \"GFX_circular\" }\n"
         "\tprogressBarType = { name = GFX_progress }\n"
+        "\tspriteType = { name = \"GFX_terrain_riviere-koksoak_1\" }\n"
         "}\n"
     )
     assert vg.sprite_names_from_gfx_text(text) == {
@@ -58,6 +59,7 @@ def test_sprite_names_accept_bare_names_and_chart_types():
         "GFX_line_chart",
         "GFX_circular",
         "GFX_progress",
+        "GFX_terrain_riviere-koksoak_1",
     }
 
 

--- a/tools/validation/validate_gfx_references.py
+++ b/tools/validation/validate_gfx_references.py
@@ -108,17 +108,19 @@ def _strip_comments(text: str) -> str:
     return text
 
 
-# All sprite type block openers in .gfx files; all use `name = "GFX_xxx"`.
-# We collect any `name = "GFX_xxx"` inside any of these blocks.
+# Renderable GFX block openers in .gfx files. Names may be quoted or bare.
 _GFX_SPRITE_TYPES = re.compile(
     r"\b(?:spriteType|frameAnimatedSpriteType|corneredTileSpriteType|"
-    r"maskedShieldType|progressbartype|textSpriteType)\s*=\s*\{",
+    r"maskedShieldType|progressbartype|textSpriteType|pieChartType|"
+    r"lineChartType|circularProgressBarType)\s*=\s*\{",
     re.IGNORECASE,
 )
 
-# name = "GFX_xxx" inside a block
-# `@` appears in engine frame-variant names (e.g. GFX_x@highlight).
-_GFX_NAME = re.compile(r'\bname\s*=\s*"(GFX_[A-Za-z0-9_@]+)"')
+# name = GFX_xxx or name = "GFX_xxx" inside a block. `@` appears in engine
+# frame-variant names (e.g. GFX_x@highlight); `.` and `-` occur in mod sprites.
+_GFX_NAME = re.compile(
+    r'\bname\s*=\s*(?:"(GFX_[A-Za-z0-9_.@-]+)"|(GFX_[A-Za-z0-9_.@-]+))'
+)
 
 # GUI references — spriteType / quadTextureSprite / background
 _GUI_REF = re.compile(
@@ -348,7 +350,7 @@ def sprite_names_from_gfx_text(raw: str) -> Set[str]:
             ]
         nm = _GFX_NAME.search(snippet)
         if nm:
-            names.add(nm.group(1))
+            names.add(nm.group(1) or nm.group(2))
     return names
 
 
@@ -540,7 +542,7 @@ class Validator(BaseValidator):
         else:
             manifest = _load_vanilla_sprite_manifest()
             if manifest:
-                new = manifest - defined
+                new = set(manifest) - defined
                 defined.update(manifest)
                 self._vanilla_defs_loaded = True
                 self.log(
@@ -787,7 +789,9 @@ class Validator(BaseValidator):
             if stem in equipment:
                 return True
             tagged = _EQUIPMENT_ICON_TAG_RE.match(stem)
-            return bool(tagged) and tagged.group(1) in equipment
+            if tagged is None:
+                return False
+            return tagged.group(1) in equipment
 
         unused = sorted(
             s

--- a/tools/validation/validate_scripted_localisation.py
+++ b/tools/validation/validate_scripted_localisation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
 import disk_cache
+from validate_gfx_references import sprite_names_from_gfx_text
 from validator_common import (
     BaseValidator,
     Colors,
@@ -426,11 +427,9 @@ class Validator(BaseValidator):
         defined_gfx = set()
         for filename in glob.iglob(gfx_path + "**/*.gfx", recursive=True):
             text_file = FileOpener.open_text_file(
-                filename, lowercase=False, strip_comments_flag=True
+                filename, lowercase=False, strip_comments_flag=False
             )
-            matches = re.findall(r'name\s*=\s*"(GFX_[^"]+)"', text_file)
-            for m in matches:
-                defined_gfx.add(m)
+            defined_gfx.update(sprite_names_from_gfx_text(text_file))
 
         # Collect all GFX_ references from scripted localisation files
         if self.staged_files:

--- a/tools/validation/vanilla_sprites.txt
+++ b/tools/validation/vanilla_sprites.txt
@@ -20447,6 +20447,7 @@ GFX_intel_header_bg
 GFX_intel_ledger_air_icon
 GFX_intel_ledger_armor_icon
 GFX_intel_ledger_capital_icon
+GFX_intel_ledger_chart
 GFX_intel_ledger_chart_grid_bg
 GFX_intel_ledger_civ_graph_types
 GFX_intel_ledger_entry
@@ -20723,6 +20724,7 @@ GFX_locked
 GFX_locked_icon
 GFX_log_bg
 GFX_logistics_air_equipment_entry_bg
+GFX_logistics_details_linechart
 GFX_logistics_details_linechart_bg
 GFX_logistics_entry_bg
 GFX_logistics_equipment_entry_bg
@@ -22285,6 +22287,7 @@ GFX_phase_targeted_sabotage_plant_explosives
 GFX_phase_targeted_sabotage_plant_explosives_small
 GFX_phase_targeted_sabotage_remove_roadsigns
 GFX_phase_targeted_sabotage_remove_roadsigns_small
+GFX_phase_circular_progress_pie_chart
 GFX_phase_title_bg
 GFX_phased_array_medium
 GFX_photo_reconnaisance_medium
@@ -22359,6 +22362,9 @@ GFX_pol_view_bg
 GFX_pol_view_bg_no_dlc
 GFX_pol_violence
 GFX_pol_win_idea_header
+GFX_political_chart
+GFX_political_chart_big
+GFX_political_chart_small
 GFX_pops
 GFX_pops_login_blocker
 GFX_population_icon
@@ -26567,6 +26573,7 @@ GFX_project_history_cabinet_scroll_arrow_up
 GFX_project_history_cabinet_scrollbar
 GFX_project_history_scroll_drager
 GFX_project_output_bg
+GFX_project_phase_progress_circular_chart
 GFX_project_paper_clip
 GFX_project_paper_pile
 GFX_project_progress_info_bg
@@ -28612,6 +28619,7 @@ GFX_trade_header
 GFX_trade_import_bg
 GFX_trade_interdiction_bg
 GFX_trade_offer_popup_win
+GFX_trade_resource_chart
 GFX_trade_resource_bg
 GFX_trade_resource_button
 GFX_traded_factories_icon


### PR DESCRIPTION
## Summary

- Flatten redundant same-operator boolean nesting across game script files.
- Fix GFX validation parsing for quoted and bare sprite names plus chart/progress definition types.
- Remove one stale undefined GUI reference and correct the Japanese amphibious tank overlay reference.
- Preserve the existing condition logic, including the Iran script changes.

## Validation

- CWTools targeted validation for CW223, CW251, CW280, CW281, and CW282: 0 errors, 0 warnings.
- GFX reference validation: no undefined sprite findings with or without a local HOI4 install.
- Scripted localisation validation: no issues.
- `python3 -m pytest`: 1167 passed, 2 skipped.
- `git diff --check` passed.