### PR TITLE
Gate cyber and PMC mission decisions with allowed = always no

### DIFF
--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -226,7 +226,9 @@ jobs:
               - 'common/resistance_compliance_modifiers/**'
               - 'common/scripted_guis/**'
             decisions:
-              - 'common/decisions/**'
+              - 'common/**/*.txt'
+              - 'events/**/*.txt'
+              - 'history/**/*.txt'
             scripted-loc:
               - 'common/scripted_localisation/**'
             scripted-guis:

--- a/common/decisions/00_cyberwarfare_decisions.txt
+++ b/common/decisions/00_cyberwarfare_decisions.txt
@@ -12,6 +12,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -38,6 +39,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -64,6 +66,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -90,6 +93,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -116,6 +120,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -146,6 +151,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -172,6 +178,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -198,6 +205,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -224,6 +232,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -250,6 +259,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -280,6 +290,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -306,6 +317,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -332,6 +344,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -358,6 +371,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -384,6 +398,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -414,6 +429,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -440,6 +456,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -466,6 +483,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -492,6 +510,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -518,6 +537,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -548,6 +568,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -574,6 +595,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -600,6 +622,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -626,6 +649,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -652,6 +676,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -682,6 +707,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -708,6 +734,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -734,6 +761,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -760,6 +788,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -786,6 +815,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -816,6 +846,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -842,6 +873,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -868,6 +900,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -894,6 +927,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -920,6 +954,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -950,6 +985,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -976,6 +1012,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1002,6 +1039,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1028,6 +1066,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1054,6 +1093,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1084,6 +1124,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1110,6 +1151,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1136,6 +1178,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1162,6 +1205,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1188,6 +1232,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1218,6 +1263,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1244,6 +1290,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1270,6 +1317,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1296,6 +1344,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1322,6 +1371,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1352,6 +1402,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1378,6 +1429,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1404,6 +1456,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1430,6 +1483,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1456,6 +1510,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1482,6 +1537,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1508,6 +1564,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1534,6 +1591,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1560,6 +1618,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1586,6 +1645,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1616,6 +1676,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1642,6 +1703,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1668,6 +1730,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1694,6 +1757,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1720,6 +1784,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1746,6 +1811,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1772,6 +1838,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1798,6 +1865,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1824,6 +1892,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1850,6 +1919,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1880,6 +1950,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1906,6 +1977,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1932,6 +2004,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1958,6 +2031,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -1984,6 +2058,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2010,6 +2085,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2036,6 +2112,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2062,6 +2139,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2088,6 +2166,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2114,6 +2193,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2144,6 +2224,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2170,6 +2251,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2196,6 +2278,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2222,6 +2305,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2248,6 +2332,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2274,6 +2359,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2300,6 +2386,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2326,6 +2413,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2352,6 +2440,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2378,6 +2467,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2408,6 +2498,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2434,6 +2525,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2460,6 +2552,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2486,6 +2579,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2512,6 +2606,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2538,6 +2633,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2564,6 +2660,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2590,6 +2687,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2616,6 +2714,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2642,6 +2741,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2672,6 +2772,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2698,6 +2799,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2724,6 +2826,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2750,6 +2853,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2776,6 +2880,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2802,6 +2907,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2828,6 +2934,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2854,6 +2961,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2880,6 +2988,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2906,6 +3015,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2936,6 +3046,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2962,6 +3073,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -2988,6 +3100,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3014,6 +3127,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3040,6 +3154,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3066,6 +3181,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3092,6 +3208,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3118,6 +3235,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3144,6 +3262,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3170,6 +3289,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3200,6 +3320,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3226,6 +3347,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3252,6 +3374,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3278,6 +3401,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3304,6 +3428,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3330,6 +3455,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3356,6 +3482,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3382,6 +3509,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3408,6 +3536,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3434,6 +3563,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3464,6 +3594,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3490,6 +3621,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3516,6 +3648,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3542,6 +3675,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3568,6 +3702,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3594,6 +3729,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3620,6 +3756,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3646,6 +3783,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3672,6 +3810,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3698,6 +3837,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3728,6 +3868,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3754,6 +3895,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3780,6 +3922,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3806,6 +3949,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3832,6 +3976,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3858,6 +4003,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3884,6 +4030,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3910,6 +4057,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3936,6 +4084,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3962,6 +4111,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -3992,6 +4142,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4017,6 +4168,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4065,6 +4217,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4090,6 +4243,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4115,6 +4269,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4163,6 +4318,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4188,6 +4344,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4213,6 +4370,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4261,6 +4419,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4286,6 +4445,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4311,6 +4471,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4359,6 +4520,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4384,6 +4546,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4409,6 +4572,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4457,6 +4621,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4482,6 +4647,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4507,6 +4673,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4555,6 +4722,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4580,6 +4748,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4605,6 +4774,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4653,6 +4823,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4678,6 +4849,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4703,6 +4875,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4751,6 +4924,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4776,6 +4950,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4801,6 +4976,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4849,6 +5025,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4874,6 +5051,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4899,6 +5077,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {
@@ -4947,6 +5126,7 @@ cyber_operations = {
 		activation = { always = no }
 		selectable_mission = no
 
+		allowed = { always = no }
 		available = { always = no }
 
 		timeout_effect = {

--- a/common/decisions/01_pmc_decisions.txt
+++ b/common/decisions/01_pmc_decisions.txt
@@ -18,6 +18,7 @@
 pmc_category = {
 	# Blackwater
 	get_blackwater_light_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -105,6 +106,7 @@ pmc_category = {
 	}
 
 	get_blackwater_mot_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -191,6 +193,7 @@ pmc_category = {
 	}
 
 	get_blackwater_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -275,6 +278,7 @@ pmc_category = {
 	}
 
 	get_blackwater_heavy_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -359,6 +363,7 @@ pmc_category = {
 	}
 
 	get_blackwater_special_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -452,6 +457,7 @@ pmc_category = {
 	}
 
 	get_blackwater_tank = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -540,6 +546,7 @@ pmc_category = {
 	}
 
 	get_blackwater_specops = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -632,6 +639,7 @@ pmc_category = {
 
 	# Wagner
 	get_wagner_light_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -732,6 +740,7 @@ pmc_category = {
 	}
 
 	get_wagner_mot_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -833,6 +842,7 @@ pmc_category = {
 	}
 
 	get_wagner_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -931,6 +941,7 @@ pmc_category = {
 	}
 
 	get_wagner_heavy_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1029,6 +1040,7 @@ pmc_category = {
 	}
 
 	get_wagner_special_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1136,6 +1148,7 @@ pmc_category = {
 	}
 
 	get_wagner_tank = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1238,6 +1251,7 @@ pmc_category = {
 	}
 
 	get_wagner_specops = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1344,6 +1358,7 @@ pmc_category = {
 
 	# Aegis
 	get_aegis_light_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1430,6 +1445,7 @@ pmc_category = {
 	}
 
 	get_aegis_mot_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1517,6 +1533,7 @@ pmc_category = {
 	}
 
 	get_aegis_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1601,6 +1618,7 @@ pmc_category = {
 	}
 
 	get_aegis_heavy_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1685,6 +1703,7 @@ pmc_category = {
 	}
 
 	get_aegis_special_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1778,6 +1797,7 @@ pmc_category = {
 	}
 
 	get_aegis_tank = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1866,6 +1886,7 @@ pmc_category = {
 	}
 
 	get_aegis_specops = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -1959,6 +1980,7 @@ pmc_category = {
 	# Constellis
 
 	get_constellis_light_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2032,6 +2054,7 @@ pmc_category = {
 	}
 
 	get_constellis_mot_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2106,6 +2129,7 @@ pmc_category = {
 	}
 
 	get_constellis_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2177,6 +2201,7 @@ pmc_category = {
 	}
 
 	get_constellis_heavy_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2248,6 +2273,7 @@ pmc_category = {
 	}
 
 	get_constellis_special_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2328,6 +2354,7 @@ pmc_category = {
 	}
 
 	get_constellis_tank = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2403,6 +2430,7 @@ pmc_category = {
 	}
 
 	get_constellis_specops = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2482,6 +2510,7 @@ pmc_category = {
 
 	# MD
 	get_md_light_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2555,6 +2584,7 @@ pmc_category = {
 	}
 
 	get_md_mot_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2629,6 +2659,7 @@ pmc_category = {
 	}
 
 	get_md_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2700,6 +2731,7 @@ pmc_category = {
 	}
 
 	get_md_heavy_mech_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2771,6 +2803,7 @@ pmc_category = {
 	}
 
 	get_md_special_infantry = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2851,6 +2884,7 @@ pmc_category = {
 	}
 
 	get_md_tank = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -2926,6 +2960,7 @@ pmc_category = {
 	}
 
 	get_md_specops = {
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3006,6 +3041,7 @@ pmc_category = {
 # Other
 	pmc_asgard = {
 		icon = GFX_decision_asgaarg_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3039,6 +3075,7 @@ pmc_category = {
 	}
 	pmc_mpri = {
 		icon = GFX_decision_mpri_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3072,6 +3109,7 @@ pmc_category = {
 	}
 	pmc_itt = {
 		icon = GFX_decision_g4s_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3102,6 +3140,7 @@ pmc_category = {
 	}
 	pmc_sadat = {
 		icon = GFX_decision_sadat_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3135,6 +3174,7 @@ pmc_category = {
 	}
 	pmc_rsb = {
 		icon = GFX_decision_rsb_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3167,6 +3207,7 @@ pmc_category = {
 	}
 	pmc_sadline = {
 		icon = GFX_decision_sandline_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3194,6 +3235,7 @@ pmc_category = {
 	}
 	pmc_kbr = {
 		icon = GFX_decision_kbr_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3227,6 +3269,7 @@ pmc_category = {
 	}
 	pmc_nirtal = {
 		icon = GFX_decision_nirtal_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3264,6 +3307,7 @@ pmc_category = {
 	}
 	pmc_halo = {
 		icon = GFX_decision_hamo_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3297,6 +3341,7 @@ pmc_category = {
 
 	pmc_dci = {
 		icon = GFX_decision_dci_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3331,6 +3376,7 @@ pmc_category = {
 
 	pmc_garda = {
 		icon = GFX_decision_garda_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3360,6 +3406,7 @@ pmc_category = {
 
 	pmc_sinai = {
 		icon = GFX_decision_union_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3389,6 +3436,7 @@ pmc_category = {
 
 	pmc_gard = {
 		icon = GFX_decision_gard_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3418,6 +3466,7 @@ pmc_category = {
 
 	pmc_patriot = {
 		icon = GFX_decision_patriot_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3447,6 +3496,7 @@ pmc_category = {
 
 	pmc_dewe = {
 		icon = GFX_decision_dewe_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3476,6 +3526,7 @@ pmc_category = {
 
 	pmc_over = {
 		icon = GFX_decision_over_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3509,6 +3560,7 @@ pmc_category = {
 	}
 	pmc_front = {
 		icon = GFX_decision_front_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3541,6 +3593,7 @@ pmc_category = {
 	}
 	pmc_redut = {
 		icon = GFX_decision_redut_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3569,6 +3622,7 @@ pmc_category = {
 	}
 	pmc_gazprom = {
 		icon = GFX_decision_gaz_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3610,6 +3664,7 @@ pmc_category = {
 	}
 	pmc_iron = {
 		icon = GFX_decision_iron_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3638,6 +3693,7 @@ pmc_category = {
 	}
 	pmc_eu = {
 		icon = GFX_decision_eu_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3671,6 +3727,7 @@ pmc_category = {
 	}
 	pmc_sheriff = {
 		icon = GFX_decision_sheriff_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3699,6 +3756,7 @@ pmc_category = {
 	}
 	pmc_lukoil = {
 		icon = GFX_decision_lukoil_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3740,6 +3798,7 @@ pmc_category = {
 	}
 	pmc_rosneft = {
 		icon = GFX_decision_rosneft_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3781,6 +3840,7 @@ pmc_category = {
 	}
 	pmc_sberbank = {
 		icon = GFX_decision_sberbank_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 
@@ -3822,6 +3882,7 @@ pmc_category = {
 	}
 	pmc_vtb = {
 		icon = GFX_decision_vtb_button
+		allowed = { always = no }
 		available = { always = yes }
 		activation = { always = no }
 

--- a/common/decisions/05_CHI_decisions.txt
+++ b/common/decisions/05_CHI_decisions.txt
@@ -177,10 +177,7 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_develp_button
 
-		visible = {
-			FROM = { is_sco = yes }
-			is_sco = yes
-		}
+		target_root_trigger = { is_sco = yes }
 
 		available = {
 			FROM = {
@@ -195,6 +192,7 @@ CHI_sco_category = {
 		target_trigger = {
 			country_exists = FROM
 			FROM = {
+				is_sco = yes
 				NOT = { OR = { original_tag = CHI original_tag = SOV } }
 			}
 			if = {
@@ -265,10 +263,7 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_develp_button
 
-		visible = {
-			is_sco = yes
-			FROM = { is_sco = yes }
-		}
+		target_root_trigger = { is_sco = yes }
 
 		available = {
 			NOT = { has_war = yes }
@@ -283,7 +278,10 @@ CHI_sco_category = {
 
 		target_trigger = {
 			country_exists = FROM
-			FROM = { NOT = { tag = ROOT } }
+			FROM = {
+				is_sco = yes
+				NOT = { tag = ROOT }
+			}
 		}
 
 		cost = 50
@@ -322,10 +320,7 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_exersises_button
 
-		visible = {
-			is_sco = yes
-			FROM = { is_sco = yes }
-		}
+		target_root_trigger = { is_sco = yes }
 
 		available = {
 			NOT = { has_war = yes }
@@ -337,7 +332,10 @@ CHI_sco_category = {
 
 		target_trigger = {
 			country_exists = FROM
-			FROM = { NOT = { tag = ROOT } }
+			FROM = {
+				is_sco = yes
+				NOT = { tag = ROOT }
+			}
 			any_neighbor_country = { tag = FROM }
 		}
 
@@ -367,10 +365,7 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_develp_button
 
-		visible = {
-			is_sco = yes
-			FROM = { is_sco = yes }
-		}
+		target_root_trigger = { is_sco = yes }
 
 		available = { NOT = { has_war = yes } }
 
@@ -378,7 +373,10 @@ CHI_sco_category = {
 
 		target_trigger = {
 			country_exists = FROM
-			FROM = { NOT = { tag = ROOT } }
+			FROM = {
+				is_sco = yes
+				NOT = { tag = ROOT }
+			}
 		}
 
 		cost = 30
@@ -414,9 +412,8 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_exersises_button
 
-		visible = {
+		target_root_trigger = {
 			is_sco = yes
-			FROM = { is_sco = yes }
 			CHI = { has_completed_focus = CHI_Counter_Terrorism_Cooperation }
 		}
 
@@ -429,7 +426,10 @@ CHI_sco_category = {
 
 		target_trigger = {
 			country_exists = FROM
-			FROM = { NOT = { tag = ROOT } }
+			FROM = {
+				is_sco = yes
+				NOT = { tag = ROOT }
+			}
 		}
 
 		cost = 40
@@ -465,10 +465,7 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_develp_button
 
-		visible = {
-			is_sco = yes
-			FROM = { is_sco = yes }
-		}
+		target_root_trigger = { is_sco = yes }
 
 		available = {
 			NOT = { has_war = yes }
@@ -483,7 +480,10 @@ CHI_sco_category = {
 
 		target_trigger = {
 			country_exists = FROM
-			FROM = { NOT = { tag = ROOT } }
+			FROM = {
+				is_sco = yes
+				NOT = { tag = ROOT }
+			}
 		}
 
 		cost = 75
@@ -1684,14 +1684,14 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_exersises_button
 
-		visible = {
-			is_sco = yes
-			FROM = { is_sco = yes }
-		}
+		target_root_trigger = { is_sco = yes }
 
 		target_array = global.sco_members
 
-		target_trigger = { country_exists = FROM }
+		target_trigger = {
+			country_exists = FROM
+			FROM = { is_sco = yes }
+		}
 
 		available = {
 			has_war = no
@@ -1742,7 +1742,7 @@ CHI_sco_category = {
 
 		icon = GFX_decision_sco_exersises_button
 
-		visible = {
+		target_root_trigger = {
 			is_sco = yes
 			has_country_flag = CHI_sco_joint_exercises_offered
 		}
@@ -3401,14 +3401,14 @@ CHI_national_commitee_decisions_category = {
 			highlight_color_while_active = 2
 		}
 
-		target_trigger = { FROM = { is_core_of = CHI } }
-
-		visible = {
-			has_completed_focus = CHI_public_rental_housing_drive
+		target_trigger = {
 			FROM = {
+				is_core_of = CHI
 				NOT = { has_state_flag = CHI_housing_project_complete }
 			}
 		}
+
+		target_root_trigger = { has_completed_focus = CHI_public_rental_housing_drive }
 
 		available = {
 			num_of_civilian_factories_available_for_projects > 14
@@ -11444,7 +11444,7 @@ CHI_military_decisions_category = {
 
 		icon = SWI_isolate_switzerland
 
-		visible = { has_completed_focus = CHI_rare_earth_leverage }
+		target_root_trigger = { has_completed_focus = CHI_rare_earth_leverage }
 
 		target_array = global.majors
 
@@ -12014,7 +12014,7 @@ CHI_megaprojects = {
 			}
 		}
 
-		visible = {
+		target_root_trigger = {
 			has_completed_focus = CHI_four_trillion_stimulus
 			custom_trigger_tooltip = {
 				tooltip = CHI_mega_rail_hub_cap_tt

--- a/common/decisions/05_muslim_brotherhood_decisions.txt
+++ b/common/decisions/05_muslim_brotherhood_decisions.txt
@@ -5,6 +5,7 @@
 muslim_brotherhood_sponsor = {
 
 	MB_build_network_hub = {
+
 		icon = GFX_decision_secur_brotheryes_button
 
 		cost = 150
@@ -15,9 +16,7 @@ muslim_brotherhood_sponsor = {
 			NOT = { has_idea = muslim_brotherhood_faction_member }
 		}
 
-		visible = {
-			NOT = { has_idea = muslim_brotherhood_faction_member }
-		}
+		visible = { NOT = { has_idea = muslim_brotherhood_faction_member } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision MB_build_network_hub"
@@ -38,12 +37,13 @@ muslim_brotherhood_sponsor = {
 	}
 
 	MB_fund_affiliates = {
+
 		icon = GFX_decision_secur_brother_button
 
 		target_array = global.possible_muslim_brotherhood_nation
-		target_root_trigger = {
-			has_idea = muslim_brotherhood_faction_member
-		}
+
+		target_root_trigger = { has_idea = muslim_brotherhood_faction_member }
+
 		target_trigger = {
 			FROM = {
 				mb_eligible_brotherhood_target = yes
@@ -52,6 +52,7 @@ muslim_brotherhood_sponsor = {
 		}
 
 		cost = 75
+
 		days_re_enable = 90
 
 		available = {
@@ -109,14 +110,14 @@ muslim_brotherhood_sponsor = {
 	}
 
 	MB_diplomatic_solidarity = {
+
 		icon = generic_political_discourse
 
 		cost = 50
+
 		days_re_enable = 365
 
-		available = {
-			is_muslim_brotherhood = yes
-		}
+		available = { is_muslim_brotherhood = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision MB_diplomatic_solidarity"
@@ -138,22 +139,20 @@ muslim_brotherhood_sponsor = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 }
 
 muslim_brotherhood_suppressor = {
 
 	MB_bankroll_crackdown = {
+
 		icon = GFX_decision_oppression
 
 		target_array = global.possible_muslim_brotherhood_nation
-		target_root_trigger = {
-			is_in_array = { global.possible_muslim_brotherhood_nation = THIS.id }
-			NOT = { is_muslim_brotherhood = yes }
-		}
+
+		target_root_trigger = { is_muslim_brotherhood = no }
+
 		target_trigger = {
 			FROM = {
 				mb_eligible_brotherhood_target = yes
@@ -162,14 +161,8 @@ muslim_brotherhood_suppressor = {
 		}
 
 		cost = 75
-		days_re_enable = 90
 
-		available = {
-			FROM = {
-				mb_eligible_brotherhood_target = yes
-				NOT = { has_idea = muslim_brotherhood_crackdown }
-			}
-		}
+		days_re_enable = 90
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision MB_bankroll_crackdown on [FROM.GetName]"
@@ -208,13 +201,12 @@ muslim_brotherhood_suppressor = {
 	}
 
 	MB_designate_terrorist_organization = {
+
 		icon = GFX_decision_oppression
 
 		cost = 100
 
-		visible = {
-			NOT = { has_country_flag = mb_designated_terrorist }
-		}
+		visible = { NOT = { has_country_flag = mb_designated_terrorist } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision MB_designate_terrorist_organization"
@@ -251,14 +243,14 @@ muslim_brotherhood_suppressor = {
 	}
 
 	MB_rescind_terrorist_designation = {
+
 		icon = generic_political_discourse
 
 		cost = 50
+
 		days_re_enable = 365
 
-		visible = {
-			has_country_flag = mb_designated_terrorist
-		}
+		visible = { has_country_flag = mb_designated_terrorist }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision MB_rescind_terrorist_designation"
@@ -295,13 +287,16 @@ muslim_brotherhood_suppressor = {
 	}
 
 	MB_counter_sponsor_influence = {
+
 		icon = generic_political_discourse
 
 		target_array = global.possible_muslim_brotherhood_nation
+
 		target_root_trigger = {
 			is_in_array = { global.possible_muslim_brotherhood_nation = THIS.id }
 			NOT = { is_muslim_brotherhood = yes }
 		}
+
 		target_trigger = {
 			FROM = {
 				mb_eligible_brotherhood_target = yes
@@ -310,6 +305,7 @@ muslim_brotherhood_suppressor = {
 		}
 
 		cost = 60
+
 		days_re_enable = 60
 
 		available = {

--- a/common/decisions/EH_decisions.txt
+++ b/common/decisions/EH_decisions.txt
@@ -1,13 +1,17 @@
 @DEFENSE_WALLS_RENDER_DISTANCE = 300.0
 
 EH_electric_traps_category = {
+
 	EH_set_up_electric_trap = {
+
 		icon = GFX_decision_fixes_button
+
 		days_remove = 7
 
 		state_target = yes
 
 		on_map_mode = map_only
+
 		highlight_states = {
 			highlight_states_trigger = {
 				is_controlled_by = ROOT
@@ -16,10 +20,12 @@ EH_electric_traps_category = {
 			highlight_color_before_active = 3
 			highlight_color_while_active = 2
 		}
+
 		target_trigger = {
 			FROM = {
 				is_controlled_by = ROOT
 				has_state_flag = EH_electric_trap_enabled_flag
+				NOT = { has_state_flag = EH_electric_trap_set_up_flag }
 			}
 		}
 
@@ -27,12 +33,6 @@ EH_electric_traps_category = {
 			has_resources_in_country = {
 				resource = tungsten
 				amount > 0
-			}
-		}
-
-		visible = {
-			FROM = {
-				NOT = { has_state_flag = EH_electric_trap_set_up_flag }
 			}
 		}
 
@@ -47,8 +47,11 @@ EH_electric_traps_category = {
 
 		ai_will_do = { base = 0 }
 	}
+
 	EH_remove_electric_trap = {
+
 		icon = GFX_decision_fixes_button_blocked
+
 		days_remove = 7
 
 		state_target = yes
@@ -71,19 +74,7 @@ EH_electric_traps_category = {
 			}
 		}
 
-		visible = {
-			FROM = {
-				has_state_flag = EH_electric_trap_set_up_flag
-			}
-		}
-
-		available = {
-			FROM = {
-				NOT = {
-					has_state_flag = EH_electric_trap_active_flag
-				}
-			}
-		}
+		available = { FROM = { NOT = { has_state_flag = EH_electric_trap_active_flag } } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_remove_electric_trap"
@@ -104,8 +95,11 @@ EH_electric_traps_category = {
 
 		ai_will_do = { base = 0 }
 	}
+
 	EH_activate_electric_trap = {
+
 		icon = GFX_decision_influence
+
 		days_remove = 10
 
 		state_target = yes
@@ -124,12 +118,6 @@ EH_electric_traps_category = {
 		target_trigger = {
 			FROM = {
 				is_controlled_by = ROOT
-				has_state_flag = EH_electric_trap_set_up_flag
-			}
-		}
-
-		visible = {
-			FROM = {
 				has_state_flag = EH_electric_trap_set_up_flag
 			}
 		}
@@ -191,8 +179,11 @@ EH_electric_traps_category = {
 }
 
 EH_research_sites_category = {
+
 	EH_setup_research_site = {
+
 		icon = GFX_decision_generic_research
+
 		days_remove = var:EH_research_sites_prep_time_var
 
 		available = {
@@ -244,8 +235,11 @@ EH_research_sites_category = {
 	}
 
 	EH_install_anti_air_weapons = {
+
 		icon = GFX_decision_shoot_bird
+
 		days_remove = 60
+
 		fire_only_once = yes
 
 		available = {
@@ -276,8 +270,11 @@ EH_research_sites_category = {
 	}
 
 	EH_panic_shelters_and_land_turrets = {
+
 		icon = GFX_decision_conter_raid_button
+
 		days_remove = 60
+
 		fire_only_once = yes
 
 		available = {
@@ -309,8 +306,11 @@ EH_research_sites_category = {
 	}
 
 	EH_hire_additional_security_for_scientists = {
+
 		icon = GFX_decision_recruit_operative
+
 		days_remove = 40
+
 		fire_only_once = yes
 
 		available = {
@@ -340,12 +340,12 @@ EH_research_sites_category = {
 	}
 
 	EH_disable_site_notifications = {
+
 		icon = GFX_decision_message_decline_button
+
 		days_remove = 0
 
-		visible = {
-			NOT = { has_country_flag = EH_research_sites_disable_notifications_flag }
-		}
+		visible = { NOT = { has_country_flag = EH_research_sites_disable_notifications_flag } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_disable_site_notifications"
@@ -357,12 +357,12 @@ EH_research_sites_category = {
 	}
 
 	EH_enable_site_notifications = {
+
 		icon = GFX_decision_message_accept_button
+
 		days_remove = 0
 
-		visible = {
-			has_country_flag = EH_research_sites_disable_notifications_flag
-		}
+		visible = { has_country_flag = EH_research_sites_disable_notifications_flag }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_enable_site_notifications"
@@ -374,6 +374,7 @@ EH_research_sites_category = {
 	}
 
 	EH_doudna_or_charpentier_project_mission = {
+
 		activation = {
 			has_country_flag = EH_hired_jennifer_doudna_flag
 			has_country_flag = EH_hired_emmanuelle_charpentier_flag
@@ -397,7 +398,9 @@ EH_research_sites_category = {
 		}
 
 		icon = GFX_decision_jennifer_emmanuelle
+
 		is_good = yes
+
 		days_mission_timeout = 280
 
 		timeout_effect = {
@@ -408,9 +411,13 @@ EH_research_sites_category = {
 }
 
 EH_find_new_veins_category = {
+
 	EH_search_for_randallite_veins = {
+
 		icon = GFX_decision_search_for_randallite
+
 		days_remove = var:EH_search_for_randallite_veins_time_var
+
 		days_re_enable = 10
 
 		fixed_random_seed = no
@@ -427,7 +434,6 @@ EH_find_new_veins_category = {
 				tooltip = EH_randallite_limit_TT
 				check_variable = { EH_randallite_stockpile < 300 }
 			}
-
 			OR = {
 				NOT = {
 					has_active_mission = EH_set_up_mine_mission
@@ -478,17 +484,16 @@ EH_find_new_veins_category = {
 	}
 
 	EH_set_up_mine_mission = {
+
 		icon = GFX_decision_search_for_randallite
+
 		is_good = yes
+
 		days_mission_timeout = var:EH_set_up_mine_time_var
 
-		activation = {
-			always = no
-		}
+		activation = { always = no }
 
-		available = {
-			always = no
-		}
+		available = { always = no }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_set_up_mine_mission"
@@ -530,7 +535,9 @@ EH_find_new_veins_category = {
 	}
 
 	EH_large_company_seeks_for_randallite_mission = {
+
 		icon = GFX_decision_gre_investment_decisions
+
 		days_mission_timeout = 100
 
 		fixed_random_seed = no
@@ -542,9 +549,7 @@ EH_find_new_veins_category = {
 			has_completed_focus = EH_find_new_veins
 		}
 
-		available = {
-			has_country_flag = EH_outlawed_randallite_extraction_flag
-		}
+		available = { has_country_flag = EH_outlawed_randallite_extraction_flag }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_large_company_seeks_for_randallite_mission"
@@ -555,7 +560,6 @@ EH_find_new_veins_category = {
 				add_to_variable = { EH_non_state_mines_var = 1 }
 				add_to_variable = { EH_total_mines = 1 }
 				multiply_variable = { EH_non_state_mines_corporate_tax_income_var = EH_non_state_mines_var }
-
 				if = {
 					limit = {
 						NOT = {
@@ -581,7 +585,9 @@ EH_find_new_veins_category = {
 	}
 
 	EH_outlaw_randallite_extraction = {
+
 		icon = GFX_decision_randallite_outlawed
+
 		days_remove = 30
 
 		visible = {
@@ -591,35 +597,26 @@ EH_find_new_veins_category = {
 			check_variable = { EH_non_state_mines_var > 0 }
 		}
 
-		modifier = {
-			political_power_gain = -1
-		}
+		modifier = { political_power_gain = -1 }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_outlaw_randallite_extraction"
 			set_temp_variable = { EH_outlaw_randallite_stability_penalty = -0.04 }
 			set_temp_variable = { EH_outlaw_randallite_pp_penalty = -50 }
 			set_temp_variable = { EH_outlaw_randallite_randallite_gain = 2 }
-
 			multiply_temp_variable = { EH_outlaw_randallite_stability_penalty = EH_non_state_mines_var }
 			multiply_temp_variable = { EH_outlaw_randallite_pp_penalty = EH_non_state_mines_var }
 			multiply_temp_variable = { EH_outlaw_randallite_randallite_gain = EH_non_state_mines_var }
-
 			add_stability = EH_outlaw_randallite_stability_penalty
 			add_political_power = EH_outlaw_randallite_pp_penalty
 			set_temp_variable = { add_randallite = EH_outlaw_randallite_randallite_gain }
 			EH_add_randallite_effect = yes
-
 			add_to_variable = { EH_randallite_mines_set_up_var = EH_non_state_mines_var }
 			set_variable = { EH_non_state_mines_var = 0 }
-
 			newline = yes
-
 			set_country_flag = EH_outlawed_randallite_extraction_flag
 			custom_effect_tooltip = EH_outlaw_randallite_extraction_TT
-
 			newline = yes
-
 			increase_corruption = yes
 		}
 
@@ -627,16 +624,14 @@ EH_find_new_veins_category = {
 	}
 
 	EH_legalize_randallite_extraction = {
+
 		icon = GFX_decision_randallite_allowed
+
 		days_remove = 30
 
-		visible = {
-			has_country_flag = EH_outlawed_randallite_extraction_flag
-		}
+		visible = { has_country_flag = EH_outlawed_randallite_extraction_flag }
 
-		modifier = {
-			political_power_gain = -0.5
-		}
+		modifier = { political_power_gain = -0.5 }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EH_legalize_randallite_extraction"
@@ -649,9 +644,13 @@ EH_find_new_veins_category = {
 }
 
 EH_nile_defense_line_category = {
+
 	EH_construct_southern_zenobia_defense_line = {
+
 		icon = GFX_decision_fortification
+
 		days_remove = 30
+
 		fire_only_once = yes
 
 		available = {
@@ -747,8 +746,11 @@ EH_nile_defense_line_category = {
 
 		ai_will_do = { base = 100 }
 	}
+
 	EH_southern_zenobia_defense_line_destruction = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -814,8 +816,11 @@ EH_nile_defense_line_category = {
 	}
 
 	EH_construct_western_zenobia_defense_line = {
+
 		icon = GFX_decision_fortification
+
 		days_remove = 30
+
 		fire_only_once = yes
 
 		available = {
@@ -902,7 +907,9 @@ EH_nile_defense_line_category = {
 	}
 
 	EH_western_zenobia_defense_line_destruction = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -956,8 +963,11 @@ EH_nile_defense_line_category = {
 	}
 
 	EH_construct_inner_saladin_defense_line = {
+
 		icon = GFX_decision_fortification
+
 		days_remove = 45
+
 		fire_only_once = yes
 
 		available = {
@@ -1107,7 +1117,9 @@ EH_nile_defense_line_category = {
 	}
 
 	EH_inner_saladin_defense_line_destruction = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -1210,8 +1222,11 @@ EH_nile_defense_line_category = {
 	}
 
 	EH_construct_outer_saladin_defense_line = {
+
 		icon = GFX_decision_fortification
+
 		days_remove = 45
+
 		fire_only_once = yes
 
 		available = {
@@ -1284,7 +1299,9 @@ EH_nile_defense_line_category = {
 	}
 
 	EH_outer_saladin_defense_line_destruction = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -1336,9 +1353,13 @@ EH_nile_defense_line_category = {
 }
 
 EH_bosporus_defense_line_category = {
+
 	EH_construct_bosphorus_defense_line = {
+
 		icon = GFX_decision_fortification
+
 		days_remove = 30
+
 		fire_only_once = yes
 
 		available = {
@@ -1444,8 +1465,11 @@ EH_bosporus_defense_line_category = {
 
 		ai_will_do = { base = 100 }
 	}
+
 	EH_bosphorus_defense_line_destruction = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -1515,9 +1539,13 @@ EH_bosporus_defense_line_category = {
 }
 
 EH_caucasus_defense_line_category = {
+
 	EH_construct_caucasus_defense_line = {
+
 		icon = GFX_decision_fortification
+
 		days_remove = 30
+
 		fire_only_once = yes
 
 		available = {
@@ -1824,8 +1852,11 @@ EH_caucasus_defense_line_category = {
 
 		ai_will_do = { base = 100 }
 	}
+
 	EH_caucasus_defense_line_destruction_1 = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -1910,8 +1941,11 @@ EH_caucasus_defense_line_category = {
 			custom_effect_tooltip = EH_defense_line_will_be_destroyed_TT
 		}
 	}
+
 	EH_caucasus_defense_line_destruction_2 = {
+
 		icon = GFX_decision_fire
+
 		days_mission_timeout = 15
 
 		activation = {
@@ -2010,7 +2044,9 @@ EH_caucasus_defense_line_category = {
 }
 
 EH_start_scenario_cheat_category = {
+
 	EH_start_scenario_decision = {
+
 		icon = GFX_decision_generic_research
 
 		fire_only_once = yes

--- a/common/decisions/EU_POTEF_decisions.txt
+++ b/common/decisions/EU_POTEF_decisions.txt
@@ -1,15 +1,21 @@
 ### Environmental Imperialism
 EU_environmental_imperialism_category = {
+
 	EU_POTEF_environmental_imperialism_decision = {
+
 		cost = 100
+
 		target_root_trigger = {
 			has_idea = EU_president
 			has_country_flag = environmental_imperialism
 		}
+
 		target_trigger = {
 			FROM = {
 				NOT = { has_country_flag = EU_POTEF_environmental_imperialism_target }
 				NOT = { has_idea = USoE_environmental_sanctions }
+				NOT = { has_country_flag = fossil_energy_pact }
+				NOT = { has_country_flag = break_environmental_sanctions }
 				renewable_energy_infra < num_owned_states
 				OR = {
 					AND = {
@@ -82,15 +88,6 @@ EU_environmental_imperialism_category = {
 
 		target_array = global.PR_regional_or_greater_powers
 
-		visible = {
-			FROM = {
-				NOT = { has_country_flag = EU_POTEF_environmental_imperialism_target }
-				NOT = { has_idea = USoE_environmental_sanctions }
-				NOT = { has_country_flag = fossil_energy_pact }
-				NOT = { has_country_flag = break_environmental_sanctions }
-			}
-		}
-
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_decision"
 			FROM = {
@@ -100,25 +97,25 @@ EU_environmental_imperialism_category = {
 				show_ideas_tooltip = USoE_environmental_sanctions
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_POTEF_environmental_imperialism_mission = {
-		allowed = {
-			always = yes
-		}
+
+		allowed = { always = yes }
+
 		available = {
 			set_temp_variable = { var = a value = { value = num_owned_states subtract = 1 } }
 			renewable_energy_infra > a
 		}
-		activation = {
-			always = no
-		}
+
+		activation = { always = no }
 
 		days_mission_timeout = 30
+
 		is_good = no
+
 		selectable_mission = yes
 
 		fire_only_once = yes
@@ -134,6 +131,7 @@ EU_environmental_imperialism_category = {
 			}
 			clr_country_flag = EU_POTEF_environmental_imperialism_target
 		}
+
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_mission"
 			add_ideas = USoE_environmental_sanctions
@@ -142,17 +140,16 @@ EU_environmental_imperialism_category = {
 				country_event = USoEevent.6
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	#Green Energy Reconstruction
 	EU_POTEF_environmental_imperialism_restructure_industry_decision = {
+
 		cost = 100
-		available = {
-			has_country_flag = EU_POTEF_environmental_imperialism_target
-		}
+
+		available = { has_country_flag = EU_POTEF_environmental_imperialism_target }
 
 		visible = {
 			has_country_flag = EU_POTEF_environmental_imperialism_target
@@ -161,6 +158,7 @@ EU_environmental_imperialism_category = {
 				industrial_complex > 0
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_environmental_imperialism_restructure_industry_decision"
 			set_temp_variable = { temp1 = 0 }
@@ -195,23 +193,20 @@ EU_environmental_imperialism_category = {
 				}
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_POTEF_break_environmental_sanctions_decision = {
+
 		cost = 100
 
 		target_array = global.EU_member
-		target_root_trigger = {
-			has_idea = USoE_environmental_sanctions
-		}
-		target_trigger = {
-			FROM = {
-				has_idea = EU_president
-			}
-		}
+
+		target_root_trigger = { has_idea = USoE_environmental_sanctions }
+
+		target_trigger = { FROM = { has_idea = EU_president } }
+
 		war_with_on_complete = ROOT
 
 		complete_effect = {
@@ -221,7 +216,6 @@ EU_environmental_imperialism_category = {
 			FROM = {
 				add_opinion_modifier = { target = ROOT modifier = betrayed_our_cause }
 				reverse_add_opinion_modifier = { target = ROOT modifier = betrayed_our_cause }
-
 				set_temp_variable = { wargoal_on = ROOT }
 				set_temp_variable = { wargoal_type = 1 }
 				add_threat_from_wargoal_effect = yes
@@ -234,7 +228,7 @@ EU_environmental_imperialism_category = {
 			if = {
 				limit = {
 					NOT = { has_global_flag = fossil_energy_pact }
-					NOT = {	is_in_faction = yes }
+					NOT = { is_in_faction = yes }
 				}
 				create_faction_from_template = faction_template_fep
 				set_global_flag = fossil_energy_pact
@@ -243,7 +237,7 @@ EU_environmental_imperialism_category = {
 			else_if = {
 				limit = {
 					has_global_flag = fossil_energy_pact
-					NOT = {	is_in_faction = yes }
+					NOT = { is_in_faction = yes }
 				}
 				random_country = {
 					limit = {
@@ -255,6 +249,7 @@ EU_environmental_imperialism_category = {
 				set_country_flag = fossil_energy_pact
 			}
 		}
+
 		ai_will_do = {
 			base = 0
 			modifier = {
@@ -302,6 +297,7 @@ EU_environmental_imperialism_category = {
 EU_office_category = {
 
 	EU_POTEF_call_election = {
+
 		available = {
 			NOT = {
 				any_of = {
@@ -323,12 +319,16 @@ EU_office_category = {
 			election_POTEF_in_member_state = yes
 			set_global_flag = ongoing_potef_election
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_POTEF_election_campaign = {
+
 		allowed = { always = no }
+
 		available = { tag = EUU }
+
 		activation = { always = no }
 
 		days_mission_timeout = 90
@@ -347,8 +347,11 @@ EU_office_category = {
 	}
 
 	EU_POTEF_term = {
+
 		allowed = { always = no }
+
 		available = { tag = EUU }
+
 		activation = { always = no }
 
 		days_mission_timeout = POTEF_time_to_camp
@@ -364,7 +367,6 @@ EU_office_category = {
 
 		ai_will_do = { base = 0 }
 	}
-
 
 	EU_POTEF_nominee = {
 
@@ -465,12 +467,11 @@ EU_office_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	EU_POTEF_show_election_polls = {
+
 		visible = {
 			has_global_flag = european_federation
 			NOT = { has_country_flag = POTEF_polls }
@@ -480,10 +481,12 @@ EU_office_category = {
 			log = "[GetDateText]: [Root.GetName]: decision EU_POTEF_show_election_polls"
 			set_country_flag = POTEF_polls
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_POTEF_hide_election_polls = {
+
 		visible = {
 			has_global_flag = european_federation
 			has_country_flag = POTEF_polls
@@ -493,17 +496,23 @@ EU_office_category = {
 			log = "[GetDateText]: [Root.GetName]: decision EU_POTEF_hide_election_polls"
 			clr_country_flag = POTEF_polls
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_POTEF_campaign_in_member_state = {
+
 		allowed = { EU_is_potential = yes }
+
 		target_root_trigger = {
 			has_idea = EU_member
 			has_country_flag = POTEF_has_nominated
 		}
+
 		target_array = global.EU_member
+
 		cost = 200
+
 		days_remove = 30
 
 		fixed_random_seed = no
@@ -514,6 +523,7 @@ EU_office_category = {
 				has_active_mission = EU_POTEF_election_campaign
 			}
 		}
+
 		complete_effect = {
 			custom_effect_tooltip = tooltip_EU_POTEF_campaign_in_member_state_effect
 			hidden_effect = {
@@ -595,10 +605,8 @@ EU_office_category = {
 				}
 			}
 		}
-		ai_will_do = {
-			base = 1
 
-		}
+		ai_will_do = { base = 1 }
 	}
 }
 
@@ -614,9 +622,7 @@ EU_defense_category = {
 
 	EU_POTEF_call_all_major_non_EU_ally = {
 
-		available = {
-			has_defensive_war = yes
-		}
+		available = { has_defensive_war = yes }
 
 		visible = {
 			has_global_flag = EDU
@@ -632,29 +638,33 @@ EU_defense_category = {
 				add_ai_strategy = { type = alliance id = ROOT value = 200 }
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_POTEF_call_major_non_EU_ally = {
+
 		allowed = { EU_is_potential = yes }
+
 		target_root_trigger = {
 			has_idea = EU_member
 			has_global_flag = EDU
 			is_faction_leader = yes
 		}
-		target_trigger = {
-			FROM = {
-				has_idea = EDU_major_non_EU_ally
-			}
-		}
+
+		target_trigger = { FROM = { has_idea = EDU_major_non_EU_ally } }
+
 		target_array = global.non_EU_EDU_ally
+
 		cost = 100
+
 		available = {
 			is_faction_leader = yes
 			FROM = {
 				influence_higher_5 = yes
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_POTEF_call_major_non_EU_ally"
 			ROOT = {
@@ -667,8 +677,6 @@ EU_defense_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 }

--- a/common/decisions/EU_USoE_decisions.txt
+++ b/common/decisions/EU_USoE_decisions.txt
@@ -1,9 +1,10 @@
 EU_USoE_category = {
 
 	### USoE Decisions ###
-
 	EU_USoE_capital_of_europe = {
+
 		cost = 100
+
 		available = {
 			owns_state = 51
 			hidden_trigger = {
@@ -19,29 +20,26 @@ EU_USoE_category = {
 				has_country_flag = USoE_capital_moved
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_capital_of_europe"
 			set_country_flag = USoE_capital_moved
 			set_capital = { state = 51 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_USoE_westernize_decision = {
-		allowed = {
-			EU_is_potential = yes
-		}
+
+		allowed = { EU_is_potential = yes }
+
 		targets = { ALG BHR CHI EGY HKG IRQ JAP JOR KOR KUR KUW LBA MOR OMA PAK PER QAT RAJ SAU SIN TAI TUN UAE YEM }
-		target_root_trigger = {
-			has_country_flag = USoE
-		}
-		target_trigger = {
-			FROM = {
-				has_country_flag = USoE_westernize_THIS
-			}
-		}
+
+		target_root_trigger = { has_country_flag = USoE }
+
+		target_trigger = { FROM = { has_country_flag = USoE_westernize_THIS } }
+
 		war_with_target_on_complete = yes
 
 		complete_effect = {
@@ -55,7 +53,6 @@ EU_USoE_category = {
 						}
 					}
 				}
-
 				set_temp_variable = { wargoal_on = FROM }
 				add_threat_from_wargoal_effect = yes
 				create_wargoal = {
@@ -82,12 +79,12 @@ EU_USoE_category = {
 				}
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_USoE_create_eurosphere_decision = {
+
 		cost = 200
 
 		visible = {
@@ -116,14 +113,14 @@ EU_USoE_category = {
 				change_influence_percentage = yes
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	USoE_integrate_new_members = {
 
 		cost = 1500
+
 		available = {
 			EU_influence_on_all_other_members_25_percent = yes
 			custom_trigger_tooltip = {
@@ -138,7 +135,6 @@ EU_USoE_category = {
 		}
 
 		#fire_only_once = yes # Will not re-enable after being removed
-
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision USoE_integrate_new_members"
 			custom_effect_tooltip = tooltip_USoE_part_of_usoe
@@ -179,6 +175,7 @@ EU_USoE_category = {
 				}
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 }
@@ -187,30 +184,28 @@ EU_USoE_category = {
 EU_environmental_imperialism_category = {
 
 	EU_USoE_environmental_imperialism_show_europe = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_europe
 			NOT = { has_country_flag = environmental_imperialism_europe }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_europe"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_europe
 			set_country_flag = environmental_imperialism_europe
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_europe = {
 
+		visible = { has_country_flag = environmental_imperialism_europe }
 
-		visible = {
-			has_country_flag = environmental_imperialism_europe
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_europe"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_europe
@@ -221,30 +216,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_north_america = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_north_america
 			NOT = { has_country_flag = environmental_imperialism_north_america }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_north_america"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_na
 			set_country_flag = environmental_imperialism_north_america
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_north_america = {
 
+		visible = { has_country_flag = environmental_imperialism_north_america }
 
-		visible = {
-			has_country_flag = environmental_imperialism_north_america
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_north_america"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_na
@@ -255,30 +248,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_south_america = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_south_america
 			NOT = { has_country_flag = environmental_imperialism_south_america }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_south_america"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_sa
 			set_country_flag = environmental_imperialism_south_america
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_south_america = {
 
+		visible = { has_country_flag = environmental_imperialism_south_america }
 
-		visible = {
-			has_country_flag = environmental_imperialism_south_america
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_south_america"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_sa
@@ -289,30 +280,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_africa = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_africa
 			NOT = { has_country_flag = environmental_imperialism_africa }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_africa"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_africa
 			set_country_flag = environmental_imperialism_africa
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_africa = {
 
+		visible = { has_country_flag = environmental_imperialism_africa }
 
-		visible = {
-			has_country_flag = environmental_imperialism_africa
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_africa"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_africa
@@ -323,30 +312,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_asia = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_asia
 			NOT = { has_country_flag = environmental_imperialism_asia }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_asia"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_asia
 			set_country_flag = environmental_imperialism_asia
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_asia = {
 
+		visible = { has_country_flag = environmental_imperialism_asia }
 
-		visible = {
-			has_country_flag = environmental_imperialism_asia
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_asia"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_asia
@@ -357,30 +344,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_middle_east = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_middle_east
 			NOT = { has_country_flag = environmental_imperialism_middle_east }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_middle_east"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_me
 			set_country_flag = environmental_imperialism_middle_east
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_middle_east = {
 
+		visible = { has_country_flag = environmental_imperialism_middle_east }
 
-		visible = {
-			has_country_flag = environmental_imperialism_middle_east
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_middle_east"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_me
@@ -391,30 +376,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_pacific = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_pacific
 			NOT = { has_country_flag = environmental_imperialism_pacific }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_pacific"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_pac
 			set_country_flag = environmental_imperialism_pacific
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_pacific = {
 
+		visible = { has_country_flag = environmental_imperialism_pacific }
 
-		visible = {
-			has_country_flag = environmental_imperialism_pacific
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_pacific"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_pac
@@ -425,30 +408,28 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_show_oceania = {
-		available = {
-			has_country_flag = environmental_imperialism
-		}
+
+		available = { has_country_flag = environmental_imperialism }
 
 		visible = {
 			has_country_flag = environmental_imperialism
 			has_global_flag = environmental_imperialism_oceania
 			NOT = { has_country_flag = environmental_imperialism_oceania }
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_show_oceania"
 			custom_effect_tooltip = tooltip_USoE_show_envir_imper_ocea
 			set_country_flag = environmental_imperialism_oceania
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	EU_USoE_environmental_imperialism_hide_oceania = {
 
+		visible = { has_country_flag = environmental_imperialism_oceania }
 
-		visible = {
-			has_country_flag = environmental_imperialism_oceania
-		}
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_hide_oceania"
 			custom_effect_tooltip = tooltip_USoE_hide_envir_imper_ocea
@@ -459,18 +440,24 @@ EU_environmental_imperialism_category = {
 	}
 
 	EU_USoE_environmental_imperialism_decision = {
-		allowed = {
-			EU_is_potential = yes
-		}
+
+		allowed = { EU_is_potential = yes }
+
 		target_array = global.majors
+
 		target_root_trigger = {
 			has_country_flag = environmental_imperialism
+			has_country_flag = USoE
 		}
+
 		cost = 100
+
 		target_trigger = {
 			FROM = {
 				NOT = { has_country_flag = EU_USoE_environmental_imperialism_target }
 				NOT = { has_idea = USoE_environmental_sanctions }
+				NOT = { has_country_flag = fossil_energy_pact }
+				NOT = { has_country_flag = break_environmental_sanctions }
 				OR = {
 					has_idea = regional_power
 					has_idea = large_power
@@ -547,17 +534,6 @@ EU_environmental_imperialism_category = {
 			}
 		}
 
-		visible = {
-			has_country_flag = environmental_imperialism
-			has_country_flag = USoE
-			FROM = {
-				NOT = { has_country_flag = EU_USoE_environmental_imperialism_target }
-				NOT = { has_idea = USoE_environmental_sanctions }
-				NOT = { has_country_flag = fossil_energy_pact }
-				NOT = { has_country_flag = break_environmental_sanctions }
-			}
-		}
-
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_decision"
 			FROM = {
@@ -567,26 +543,26 @@ EU_environmental_imperialism_category = {
 				show_ideas_tooltip = USoE_environmental_sanctions
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_USoE_environmental_imperialism_mission = {
-		allowed = {
-			always = yes
-		}
+
+		allowed = { always = yes }
+
 		available = {
 			set_temp_variable = { a = num_owned_states }
 			subtract_from_temp_variable = { a = 1 }
 			renewable_energy_infra > a
 		}
-		activation = {
-			always = no
-		}
+
+		activation = { always = no }
 
 		days_mission_timeout = 30
+
 		is_good = no
+
 		selectable_mission = yes
 
 		fire_only_once = yes
@@ -602,6 +578,7 @@ EU_environmental_imperialism_category = {
 			}
 			clr_country_flag = EU_USoE_environmental_imperialism_target
 		}
+
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_mission"
 			add_ideas = USoE_environmental_sanctions
@@ -610,17 +587,16 @@ EU_environmental_imperialism_category = {
 				country_event = USoEevent.6
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	# Green Energy Reconstruction
 	EU_USoE_environmental_imperialism_restructure_industry_decision = {
+
 		cost = 100
-		available = {
-			has_country_flag = EU_USoE_environmental_imperialism_target
-		}
+
+		available = { has_country_flag = EU_USoE_environmental_imperialism_target }
 
 		visible = {
 			has_country_flag = EU_USoE_environmental_imperialism_target
@@ -629,6 +605,7 @@ EU_environmental_imperialism_category = {
 				industrial_complex > 0
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_USoE_environmental_imperialism_restructure_industry_decision"
 			set_temp_variable = { temp1 = 0 }
@@ -663,22 +640,20 @@ EU_environmental_imperialism_category = {
 				}
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_USoE_break_environmental_sanctions_decision = {
-		target_root_trigger = {
-			has_idea = USoE_environmental_sanctions
-		}
-		target_trigger = {
-			FROM = {
-				has_country_flag = USoE
-			}
-		}
+
+		target_root_trigger = { has_idea = USoE_environmental_sanctions }
+
+		target_trigger = { FROM = { has_country_flag = USoE } }
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		war_with_on_complete = ROOT
 
 		complete_effect = {
@@ -700,7 +675,7 @@ EU_environmental_imperialism_category = {
 			if = {
 				limit = {
 					NOT = { has_global_flag = fossil_energy_pact }
-					NOT = {	is_in_faction = yes }
+					NOT = { is_in_faction = yes }
 				}
 				create_faction_from_template = faction_template_fep
 				set_global_flag = fossil_energy_pact
@@ -709,7 +684,7 @@ EU_environmental_imperialism_category = {
 			else_if = {
 				limit = {
 					has_global_flag = fossil_energy_pact
-					NOT = {	is_in_faction = yes }
+					NOT = { is_in_faction = yes }
 				}
 				random_country = {
 					limit = {
@@ -721,6 +696,7 @@ EU_environmental_imperialism_category = {
 				set_country_flag = fossil_energy_pact
 			}
 		}
+
 		ai_will_do = {
 			base = 0
 			modifier = {

--- a/common/decisions/EU_voting_decisions.txt
+++ b/common/decisions/EU_voting_decisions.txt
@@ -1,9 +1,13 @@
 EU_voting_category = {
 
 	EU_election_5_years = {
+
 		allowed = { always = no }
+
 		available = { tag = EUU }
+
 		activation = { always = no }
+
 		is_good = yes
 
 		days_mission_timeout = 1825
@@ -19,19 +23,23 @@ EU_voting_category = {
 
 		ai_will_do = { base = 0 }
 	}
+
 	#############
 	### EUXXX ###
 	#############
-
 	EU_parliament_focus_EUXXX_approve = {
+
 		allowed = { always = yes }
+
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = EU_parliament_vote_passed_tt
 				check_variable = { global.pass_vote_mission_ender = 1 }
 			}
 		}
+
 		activation = { always = no }
+
 		is_good = yes
 
 		days_mission_timeout = 14
@@ -56,6 +64,7 @@ EU_voting_category = {
 				EU_finalize_passed_agenda = yes
 			}
 		}
+
 		timeout_effect = {
 			if = {
 				limit = {
@@ -84,7 +93,6 @@ EU_voting_category = {
 						reset_MEP_support_party_x = yes
 						set_variable = { global.active_MEP_Support = 0 }
 						set_variable = { global.pass_vote_mission_ender = 0 }
-
 						if = {
 							limit = {
 								NOT = { has_global_flag = EU_ongoing_budget_draft }
@@ -128,17 +136,26 @@ EU_voting_category = {
 	}
 
 	EU_council_determine_serious_breach_of_EU_values = {
+
 		allowed = { EU_is_potential = yes }
-		target_root_trigger = { has_idea = EU_member }
+
+		target_root_trigger = {
+			EU_council_has_breach_authority = yes
+			has_idea = EU_member
+		}
+
 		target_trigger = {
 			FROM = {
-				NOT = {
-					has_country_flag = serious_breach_of_EU_values
-				}
+				NOT = { has_country_flag = serious_breach_of_EU_values }
+				NOT = { has_idea = EUU_voting_rights_suspended }
+				check_variable = { THIS.breach_of_EU_value > 3 }
 			}
 		}
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		available = {
 			FROM = {
 				custom_trigger_tooltip = {
@@ -146,16 +163,8 @@ EU_voting_category = {
 					check_variable = { THIS.breach_of_EU_value > 3 }
 				}
 			}
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			EU_council_has_breach_authority = yes
 		}
-		visible = {
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			FROM = {
-				check_variable = { THIS.breach_of_EU_value > 3 }
-				NOT = { has_country_flag = serious_breach_of_EU_values }
-			}
-		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_council_determine_serious_breach_of_EU_values"
 			FROM = {
@@ -166,33 +175,39 @@ EU_voting_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	EU_council_revoke_determination_of_serious_breach_of_EU_values = {
+
 		allowed = { EU_is_potential = yes }
-		target_root_trigger = { has_idea = EU_member }
-		target_trigger = {
-			FROM = { has_country_flag = serious_breach_of_EU_values }
+
+		target_root_trigger = {
+			has_idea = EU_member
+			NOT = { has_idea = EUU_voting_rights_suspended }
 		}
+
+		target_trigger = {
+			FROM = {
+				has_country_flag = serious_breach_of_EU_values
+				NOT = { has_idea = EUU_voting_rights_suspended }
+			}
+		}
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		available = {
 			FROM = {
 				custom_trigger_tooltip = {
 					tooltip = "Level of breach of EU values < 4."
 					check_variable = { THIS.breach_of_EU_value < 4 }
 				}
-				NOT = { has_idea = EUU_voting_rights_suspended }
 			}
 			NOT = { has_idea = EUU_voting_rights_suspended }
 		}
-		visible = {
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			FROM = { has_country_flag = serious_breach_of_EU_values }
-		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_council_revoke_determination_of_serious_breach_of_EU_values"
 			FROM = {
@@ -203,22 +218,29 @@ EU_voting_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	EU_council_suspend_voting_rights = {
+
 		allowed = { EU_is_potential = yes }
-		target_root_trigger = { has_idea = EU_member }
+
+		target_root_trigger = {
+			has_idea = EU_member
+			NOT = { has_idea = EUU_voting_rights_suspended }
+		}
+
 		target_trigger = {
 			FROM = {
 				has_country_flag = serious_breach_of_EU_values
 				NOT = { has_idea = EUU_voting_rights_suspended }
 			}
 		}
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		available = {
 			FROM = {
 				custom_trigger_tooltip = {
@@ -229,13 +251,7 @@ EU_voting_category = {
 			NOT = { has_idea = EUU_voting_rights_suspended }
 			EU_council_has_breach_authority = yes
 		}
-		visible = {
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			FROM = {
-				has_country_flag = serious_breach_of_EU_values
-				NOT = { has_idea = EUU_voting_rights_suspended }
-			}
-		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_council_suspend_voting_rights"
 			FROM = {
@@ -246,19 +262,24 @@ EU_voting_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	EU_council_revoke_voting_rights_suspension = {
+
 		allowed = { EU_is_potential = yes }
-		target_root_trigger = { has_idea = EU_member }
-		target_trigger = {
-			FROM = { has_idea = EUU_voting_rights_suspended }
+
+		target_root_trigger = {
+			has_idea = EU_member
+			NOT = { has_idea = EUU_voting_rights_suspended }
 		}
+
+		target_trigger = { FROM = { has_idea = EUU_voting_rights_suspended } }
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		available = {
 			FROM = {
 				custom_trigger_tooltip = {
@@ -285,10 +306,7 @@ EU_voting_category = {
 				}
 			}
 		}
-		visible = {
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			FROM = { has_idea = EUU_voting_rights_suspended }
-		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_council_revoke_voting_rights_suspension"
 			FROM = {
@@ -299,18 +317,19 @@ EU_voting_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	### budget rights
-
 	EU_council_suspend_subsidies = {
+
 		allowed = { EU_is_potential = yes }
+
 		target_root_trigger = {
 			has_idea = EU_member
+			NOT = { has_idea = EUU_voting_rights_suspended }
 		}
+
 		target_trigger = {
 			FROM = {
 				has_country_flag = serious_breach_of_EU_values
@@ -319,8 +338,11 @@ EU_voting_category = {
 				}
 			}
 		}
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		available = {
 			FROM = {
 				custom_trigger_tooltip = {
@@ -333,13 +355,7 @@ EU_voting_category = {
 			}
 			EU_council_has_breach_authority = yes
 		}
-		visible = {
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			FROM = {
-				has_country_flag = serious_breach_of_EU_values
-				NOT = { has_idea = EUU_subsidies_suspended }
-			}
-		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_council_suspend_subsidies"
 			FROM = {
@@ -349,19 +365,25 @@ EU_voting_category = {
 				europeanism_change = yes
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 
 	EU_council_revoke_subsidies_suspension = {
+
 		allowed = { EU_is_potential = yes }
-		target_root_trigger = { has_idea = EU_member }
-		target_trigger = {
-			FROM = { has_idea = EUU_subsidies_suspended }
+
+		target_root_trigger = {
+			has_idea = EU_member
+			NOT = { has_idea = EUU_voting_rights_suspended }
 		}
+
+		target_trigger = { FROM = { has_idea = EUU_subsidies_suspended } }
+
 		target_array = global.EU_member
+
 		cost = 100
+
 		available = {
 			FROM = {
 				custom_trigger_tooltip = {
@@ -374,10 +396,7 @@ EU_voting_category = {
 				has_idea = EUU_voting_rights_suspended
 			}
 		}
-		visible = {
-			NOT = { has_idea = EUU_voting_rights_suspended }
-			FROM = { has_idea = EUU_subsidies_suspended }
-		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_council_revoke_subsidies_suspension"
 			FROM = {
@@ -387,28 +406,32 @@ EU_voting_category = {
 				europeanism_change = yes
 			}
 		}
-		ai_will_do = {
-			base = 1
 
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	##################################
 	### 1.1.8 New Voting Decisions ###
 	##################################
-
 	### Unified Result Mission QMV ###
-
 	# Held by every member as a shared countdown; only the commission president applies the result, on timeout.
 	EU_voting_mission_focus_EUXXX_QMV_result = {
+
 		#icon = EU_voting_decision
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
+
 		is_good = yes
+
 		days_mission_timeout = 14
+
 		selectable_mission = yes
+
 		fire_only_once = yes
+
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_voting_mission_focus_EUXXX_QMV_result"
 			if = {
@@ -424,18 +447,23 @@ EU_voting_category = {
 				apply_EU_QMV_result = yes
 			}
 		}
+
 		ai_will_do = { base = -1000 }
 	}
 
 	### Budget and MFF missions
-
 	EU_budget_yearly_timer = {
+
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
 
 		days_mission_timeout = 344
+
 		selectable_mission = yes
+
 		is_good = yes
 
 		timeout_effect = {
@@ -451,12 +479,17 @@ EU_voting_category = {
 	}
 
 	EU_budget_draft_preparations = {
+
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
+
 		is_good = yes
 
 		days_mission_timeout = 7
+
 		selectable_mission = yes
 
 		timeout_effect = {
@@ -480,12 +513,17 @@ EU_voting_category = {
 	}
 
 	EU_budget_draft_ongoing = {
+
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
 
 		days_mission_timeout = 14
+
 		selectable_mission = yes
+
 		is_good = yes
 
 		timeout_effect = {
@@ -539,12 +577,17 @@ EU_voting_category = {
 	}
 
 	EU_mff_yearly_timer = {
+
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
+
 		is_good = yes
 
 		days_mission_timeout = 1237
+
 		selectable_mission = yes
 
 		timeout_effect = {
@@ -560,12 +603,17 @@ EU_voting_category = {
 	}
 
 	EU_mff_draft_preparations = {
+
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
+
 		is_good = yes
 
 		days_mission_timeout = 14
+
 		selectable_mission = yes
 
 		timeout_effect = {
@@ -589,12 +637,17 @@ EU_voting_category = {
 	}
 
 	EU_mff_draft_ongoing = {
+
 		allowed = { always = yes }
+
 		available = { always = no }
+
 		activation = { always = no }
 
 		days_mission_timeout = 28
+
 		selectable_mission = yes
+
 		is_good = yes
 
 		timeout_effect = {
@@ -650,9 +703,13 @@ EU_voting_category = {
 
 
 EU_fiscal_category = {
+
 	invest_in_FRA = {
+
 		allowed = { always = no }
+
 		available = { NOT = { has_idea = EU_member } }
+
 		activation = { always = no }
 
 		days_mission_timeout = 1
@@ -672,8 +729,11 @@ EU_fiscal_category = {
 	}
 
 	eurozone_reforms = {
+
 		allowed = { always = no }
+
 		activation = { always = no }
+
 		available = {
 			# European Banking Union
 			is_in_array = { array = global.EU_passed_votes value = 202 }
@@ -706,7 +766,6 @@ EU_fiscal_category = {
 				random_scope_in_array = {
 					array = global.EU_member
 					limit = { is_ai = no }
-
 					country_event = EUevent.5
 				}
 			}
@@ -718,9 +777,7 @@ EU_fiscal_category = {
 			}
 		}
 
-		cancel_trigger = {
-			has_global_flag = eurozone_reforms
-		}
+		cancel_trigger = { has_global_flag = eurozone_reforms }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision eurozone_reforms"
@@ -817,31 +874,23 @@ EU_fiscal_category = {
 			}
 		}
 
-		activation = {
-			always = no
-		}
+		activation = { always = no }
 
 		days_mission_timeout = 730
 
 		selectable_mission = yes
 
-		ai_will_do = {
-			base = 100
-		}
+		ai_will_do = { base = 100 }
 
-		cancel_trigger = {
-			ROOT = {
-				NOT = {
-					has_idea = EUU_national_dept_crisis_eu
-				}
-			}
-		}
+		cancel_trigger = { ROOT = { NOT = { has_idea = EUU_national_dept_crisis_eu } } }
+
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision troika_reforms"
 			ROOT = {
 				country_event = EUevent.9
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision troika_reforms"
 			ROOT = {
@@ -853,7 +902,9 @@ EU_fiscal_category = {
 
 
 EU_exit_category = {
+
 	EU_Revoke_Article_50 = {
+
 		visible = {
 			has_idea = EU_member
 			has_country_flag = Article_50
@@ -903,7 +954,9 @@ EU_exit_category = {
 	}
 
 	EU_exit = {
+
 		allowed = { always = no }
+
 		activation = { always = no }
 
 		available = {
@@ -941,7 +994,6 @@ EU_exit_category = {
 				leaving_EU = yes
 				clr_country_flag = Article_50
 			}
-
 			# One Member State Leaves
 			news_event = EU_news.21
 		}
@@ -957,6 +1009,7 @@ EU_exit_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_exit"
 			news_event = EU_news.22 ### Article 50 is revoked
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_exit"
 			add_ideas = withdrawal_treaty
@@ -1046,11 +1099,14 @@ EU_exit_category = {
 			activate_mission = EU_exit_three_month
 			news_event = EU_news.24 ### Article 50 Extension
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_exit_three_month = {
+
 		activation = { always = no }
+
 		allowed = { always = no }
 
 		available = {
@@ -1113,6 +1169,7 @@ EU_exit_category = {
 				news_event = EU_news.22 ### Article 50 is revoked
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_exit_three_month"
 			ROOT = {
@@ -1122,6 +1179,7 @@ EU_exit_category = {
 			}
 			news_event = EU_news.23
 		}
+
 		### AI Withdrawal Treaty
 		ai_will_do = {
 			base = 60
@@ -1181,9 +1239,7 @@ EU_exit_category = {
 
 	EU_withdrawal_treaty = {
 
-		available = {
-			EU_influence_on_leader_of_foreign_policy_25_percent = yes
-		}
+		available = { EU_influence_on_leader_of_foreign_policy_25_percent = yes }
 
 		visible = {
 			has_idea = EU_member
@@ -1305,7 +1361,9 @@ EU_exit_category = {
 }
 
 EU_defense_category = {
+
 	EU_Frontex_take_control = {
+
 		visible = {
 			has_idea = EU_member
 			has_idea = frontex_ExDir
@@ -1345,10 +1403,12 @@ EU_defense_category = {
 			set_country_flag = control_frontex_force
 			set_variable = { global.EU_frontex_controller = ROOT }
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_EuroNavy_take_control = {
+
 		visible = {
 			has_idea = EU_member
 			has_idea = EUU_euronavy_sc
@@ -1371,10 +1431,12 @@ EU_defense_category = {
 				country_event = EUevent.10
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_EuroArmy_take_control = {
+
 		visible = {
 			has_idea = EU_member
 			has_idea = EUU_euroarmy_sc
@@ -1406,6 +1468,7 @@ EU_defense_category = {
 			set_country_flag = control_euroarmy_force
 			set_variable = { global.EU_euroarmy_controller = ROOT }
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -1456,25 +1519,26 @@ EU_defense_category = {
 			### non-EU NATO members notification of EDU
 			news_event = EU_news.48
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	EU_military_exercise = {
-		allowed = {
-			EU_is_potential = yes
-		}
+
+		allowed = { EU_is_potential = yes }
+
 		target_array = neighbors
+
 		target_root_trigger = {
 			has_idea = European_Security_Council
 			has_idea = EU_member
 		}
+
 		icon = GFX_decision_infiltrate_state
 
 		days_remove = 90
 
-		custom_cost_trigger = {
-			command_power > 40
-		}
+		custom_cost_trigger = { command_power > 40 }
 
 		custom_cost_text = command_power_more_than_40
 
@@ -1500,13 +1564,12 @@ EU_defense_category = {
 					is_major = yes
 					is_in_faction = yes
 				}
-
 			}
 		}
 
 		available = {
 			all_of_scopes = {
-			array = global.EU_member
+				array = global.EU_member
 				NOT = {
 					has_country_flag = EU_military_exercise_prep
 				}
@@ -1532,19 +1595,21 @@ EU_defense_category = {
 			}
 			set_country_flag = { flag = EU_military_exercise_prep value = 1 days = 450 }
 		}
-		ai_will_do = { base = 0 }
 
+		ai_will_do = { base = 0 }
 	}
 
 	EU_ask_to_host_military_exercise = {
-		allowed = {
-			EU_is_potential = yes
-		}
+
+		allowed = { EU_is_potential = yes }
+
 		target_array = global.EU_member
+
 		target_root_trigger = {
 			has_idea = European_Security_Council
 			has_idea = EU_member
 		}
+
 		days_remove = 365
 
 		target_trigger = {
@@ -1569,22 +1634,14 @@ EU_defense_category = {
 			has_idea = EU_member
 		}
 
-		visible = {
-			FROM = {
-				any_neighbor_country = {
-					has_country_flag = EU_military_exercise_at_border_from@ROOT
-				}
-			}
-		}
-
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_ask_to_host_military_exercise"
 			FROM = {
 				country_event = EUevent.18
 			}
 		}
-		ai_will_do = { base = 0 }
 
+		ai_will_do = { base = 0 }
 	}
 
 	EU_military_exercise_mission = {
@@ -1598,9 +1655,7 @@ EU_defense_category = {
 			}
 		}
 
-		activation = {
-			always = no
-		}
+		activation = { always = no }
 
 		is_good = yes
 
@@ -1610,9 +1665,7 @@ EU_defense_category = {
 
 		selectable_mission = yes
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 
 		fire_only_once = yes
 
@@ -1621,6 +1674,7 @@ EU_defense_category = {
 			add_command_power = -40
 			EU_military_exercise_cleanup = yes
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect EU_military_exercise_mission"
 			### mission reward
@@ -1702,6 +1756,7 @@ EU_defense_category = {
 				}
 			}
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_military_exercise_mission"
 			EU_military_exercise_cleanup = yes
@@ -1709,7 +1764,7 @@ EU_defense_category = {
 	}
 }
 
-generic_coalition_politics_decisions = { ### temp category
+generic_coalition_politics_decisions = {
 
 	counter_military_exercise_mission = {
 
@@ -1722,10 +1777,7 @@ generic_coalition_politics_decisions = { ### temp category
 			}
 		}
 
-		activation = {
-			always = no
-		}
-
+		activation = { always = no }
 
 		is_good = yes
 
@@ -1735,9 +1787,7 @@ generic_coalition_politics_decisions = { ### temp category
 
 		selectable_mission = yes
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 
 		fire_only_once = yes
 
@@ -1745,6 +1795,7 @@ generic_coalition_politics_decisions = { ### temp category
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect counter_military_exercise_mission"
 			add_command_power = -40
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect counter_military_exercise_mission"
 			if = {
@@ -1783,7 +1834,6 @@ generic_coalition_politics_decisions = { ### temp category
 				army_experience = 10
 				add_command_power = 10
 			}
-
 			### diplo: the countered nation sours the originator of the border exercise on it
 			if = { limit = { check_variable = { ROOT.var_counter_military_exercise_originator > 0 } }
 				var:ROOT.var_counter_military_exercise_originator = {
@@ -1795,18 +1845,21 @@ generic_coalition_politics_decisions = { ### temp category
 				news_event = EU_news.51
 			}
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision counter_military_exercise_mission"
 			clear_variable = ROOT.var_counter_military_exercise_state
 			clear_variable = ROOT.var_counter_military_exercise_originator
 		}
 	}
-
 }
 
 EU_apply_for_membership_category = {
+
 	EU_apply_for_membership = {
+
 		cost = 50
+
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = EU_level_of_breaches_less_than_3_tt
@@ -1850,9 +1903,7 @@ EU_apply_for_membership_category = {
 			}
 		}
 
-		visible = {
-			NOT = { has_idea = EU_member }
-		}
+		visible = { NOT = { has_idea = EU_member } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete EU_apply_for_membership"
@@ -1986,7 +2037,9 @@ EU_apply_for_membership_category = {
 	}
 
 	EU_join_the_euro_decision = {
+
 		cost = 100
+
 		available = {
 			if = { limit = { original_tag = DEN }
 				has_country_flag = DEN_accept
@@ -2057,7 +2110,9 @@ EU_apply_for_membership_category = {
 	}
 
 	pre_accession_assistance_program = {
+
 		allowed = { always = no }
+
 		available = {
 			OR = {
 				has_idea = corruption_level_03
@@ -2065,22 +2120,27 @@ EU_apply_for_membership_category = {
 				has_idea = corruption_level_01
 			}
 		}
-		activation = { always = no 	}
+
+		activation = { always = no }
+
 		days_mission_timeout = 5 #180
+
 		selectable_mission = yes
+
 		fire_only_once = yes
+
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision pre_accession_assistance_program"
 			var:var_IPA = {
 				country_event = EUevent.20
 			}
 		}
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision pre_accession_assistance_program"
 			add_political_power = 400
 		}
-		ai_will_do = {
-			base = 100
-		}
+
+		ai_will_do = { base = 100 }
 	}
 }

--- a/common/decisions/Gulf.txt
+++ b/common/decisions/Gulf.txt
@@ -1,4 +1,5 @@
 gulf_society = {
+
 	GCC_crack_down_on_muslim_broterhood = {
 
 		icon = GFX_decision_secur_brother_button
@@ -22,6 +23,7 @@ gulf_society = {
 			log = "[GetDateText]: [Root.GetName]: Decision GCC_crack_down_on_muslim_broterhood"
 			add_ideas = muslim_brotherhood_crackdown
 		}
+
 		ai_will_do = {
 			base = 1
 			modifier = {
@@ -51,11 +53,7 @@ gulf_society = {
 
 		icon = GFX_decision_secur_brotheryes_button
 
-
-
-		visible = {
-			has_idea = muslim_brotherhood_crackdown
-		}
+		visible = { has_idea = muslim_brotherhood_crackdown }
 
 		cost = 50
 
@@ -63,6 +61,7 @@ gulf_society = {
 			log = "[GetDateText]: [Root.GetName]: Decision GCC_stop_crackdowns"
 			remove_ideas = muslim_brotherhood_crackdown
 		}
+
 		ai_will_do = {
 			base = 1
 			modifier = {
@@ -76,15 +75,9 @@ gulf_society = {
 
 		icon = GFX_decision_secur_algjaban_button
 
-
-
 		fire_only_once = yes
 
-
-
-		visible = {
-			has_idea = al_jazeera_allowed
-		}
+		visible = { has_idea = al_jazeera_allowed }
 
 		cost = 75
 
@@ -96,6 +89,7 @@ gulf_society = {
 				add_idea = al_jazeera_banned
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -103,13 +97,9 @@ gulf_society = {
 
 		icon = GFX_decision_secur_algjaagree_button
 
-
-
 		fire_only_once = yes
 
-		visible = {
-			has_idea = al_jazeera_banned
-		}
+		visible = { has_idea = al_jazeera_banned }
 
 		cost = 50
 
@@ -121,6 +111,7 @@ gulf_society = {
 				add_idea = al_jazeera_allowed
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -130,15 +121,9 @@ gulf_society = {
 
 		name = GEN_remove_saudi_aid
 
-
-
 		fire_only_once = yes
 
-
-
-		visible = {
-			has_idea = saudi_aid
-		}
+		visible = { has_idea = saudi_aid }
 
 		cost = 50
 
@@ -150,6 +135,7 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			SAU = { add_opinion_modifier = { target = ROOT modifier = GEN_banned_saudi_mosques } }
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -165,9 +151,7 @@ gulf_society = {
 			}
 		}
 
-		custom_cost_trigger = {
-			check_variable = { treasury > 1.4 }
-		}
+		custom_cost_trigger = { check_variable = { treasury > 1.4 } }
 
 		custom_cost_text = cost_1_5
 
@@ -189,6 +173,7 @@ gulf_society = {
 			}
 			recalculate_party = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -203,9 +188,7 @@ gulf_society = {
 			}
 		}
 
-		custom_cost_trigger = {
-			check_variable = { treasury > 1.4 }
-		}
+		custom_cost_trigger = { check_variable = { treasury > 1.4 } }
 
 		custom_cost_text = cost_1_5
 
@@ -227,6 +210,7 @@ gulf_society = {
 			}
 			recalculate_party = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -322,6 +306,7 @@ gulf_society = {
 			set_temp_variable = { temp_modify_social_con_government = 2 }
 			modify_social_conservatism_government = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -417,6 +402,7 @@ gulf_society = {
 			set_temp_variable = { temp_modify_social_con_government = 2 }
 			modify_social_conservatism_government = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -424,9 +410,7 @@ gulf_society = {
 
 		icon = GFX_decision_secur_alcohol_button
 
-		visible = {
-			NOT = { has_country_flag = limited_alcohol }
-		}
+		visible = { NOT = { has_country_flag = limited_alcohol } }
 
 		available = {
 			OR = {
@@ -462,9 +446,7 @@ gulf_society = {
 
 	GCC_reverse_limited_alcohol_legalization = {
 
-		visible = {
-			has_country_flag = limited_alcohol
-		}
+		visible = { has_country_flag = limited_alcohol }
 
 		icon = GFX_decision_secur_alcoholban_button
 
@@ -483,14 +465,13 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			clr_country_flag = limited_alcohol
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_legalize_alcohol = {
 
-		visible = {
-			NOT = { has_country_flag = alcohol }
-		}
+		visible = { NOT = { has_country_flag = alcohol } }
 
 		icon = GFX_decision_secur_alcohol_button
 
@@ -529,9 +510,7 @@ gulf_society = {
 
 	GCC_ban_alcohol = {
 
-		visible = {
-			has_country_flag = alcohol
-		}
+		visible = { has_country_flag = alcohol }
 
 		icon = GFX_decision_secur_alcoholban_button
 
@@ -550,14 +529,13 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			clr_country_flag = alcohol
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_relax_dress_code = {
 
-		visible = {
-			NOT = { has_country_flag = relaxed_dress_code }
-		}
+		visible = { NOT = { has_country_flag = relaxed_dress_code } }
 
 		icon = GFX_decision_secur_dressyes_button
 
@@ -595,9 +573,7 @@ gulf_society = {
 
 	GCC_reimpose_dress_code = {
 
-		visible = {
-			has_country_flag = relaxed_dress_code
-		}
+		visible = { has_country_flag = relaxed_dress_code }
 
 		icon = GFX_decision_secur_dress_button
 
@@ -616,10 +592,12 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			clr_country_flag = relaxed_dress_code
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_ban_burqa = {
+
 		visible = { NOT = { has_country_flag = banned_burqa } }
 
 		icon = GFX_decision_secur_burqaban_button
@@ -658,6 +636,7 @@ gulf_society = {
 	}
 
 	GCC_unban_burqa = {
+
 		visible = { has_country_flag = banned_burqa }
 
 		icon = GFX_decision_secur_burqayes_button
@@ -677,10 +656,12 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			clr_country_flag = banned_burqa
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_head_scarves = {
+
 		visible = { NOT = { has_country_flag = banned_head_scarf } }
 
 		icon = GFX_decision_secur_scavesno_button
@@ -719,6 +700,7 @@ gulf_society = {
 	}
 
 	GCC_unban_head_scarves = {
+
 		visible = { has_country_flag = banned_head_scarf }
 
 		icon = GFX_decision_secur_scavesyes_button
@@ -738,11 +720,14 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			clr_country_flag = banned_head_scarf
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_decriminalize_same_sex_relations = {
+
 		icon = GFX_decision_secur_18_button
+
 		visible = { NOT = { has_country_flag = same_sex_decriminalized } }
 
 		available = {
@@ -778,9 +763,7 @@ gulf_society = {
 
 		icon = GFX_decision_secur_18plus_button
 
-		visible = {
-			has_country_flag = same_sex_decriminalized
-		}
+		visible = { has_country_flag = same_sex_decriminalized }
 
 		available = {
 			custom_trigger_tooltip = {
@@ -797,11 +780,14 @@ gulf_society = {
 			modify_social_conservatism_government = yes
 			clr_country_flag = same_sex_decriminalized
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_secularize_the_state = {
+
 		icon = GFX_decision_secur_secur_button
+
 		visible = { NOT = { has_country_flag = secularized } }
 
 		available = {
@@ -847,19 +833,19 @@ gulf_society = {
 				}
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 }
 
 
 shia_decisions = {
+
 	encourage_shia_immigration = {
 
 		icon = GFX_decision_infiltrate_state
 
-		visible = {
-			check_variable = { shia_population < 100 }
-		}
+		visible = { check_variable = { shia_population < 100 } }
 
 		available = {
 			NOT = { has_completed_focus = GCC_impose_quotas }
@@ -923,9 +909,7 @@ shia_decisions = {
 
 		icon = GFX_decision_infiltrate_state
 
-		visible = {
-			check_variable = { shia_population > 0 }
-		}
+		visible = { check_variable = { shia_population > 0 } }
 
 		available = {
 			NOT = { has_completed_focus = GCC_impose_quotas }
@@ -976,9 +960,7 @@ shia_decisions = {
 
 		icon = GFX_decision_generic_break_treaty
 
-		visible = {
-			check_variable = { shia_population > 0 }
-		}
+		visible = { check_variable = { shia_population > 0 } }
 
 		available = {
 			NOT = { has_decision = encourage_shia_immigration }
@@ -998,6 +980,7 @@ shia_decisions = {
 			add_ruling_outlook_popularity = yes
 			decrease_pop_gulf = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -1005,9 +988,7 @@ shia_decisions = {
 
 		icon = GFX_decision_generic_break_treaty
 
-		visible = {
-			check_variable = { shia_population < 100 }
-		}
+		visible = { check_variable = { shia_population < 100 } }
 
 		available = {
 			NOT = { has_decision = encourage_sunni_immigration }
@@ -1064,6 +1045,7 @@ gcc_decisions = {
 			set_temp_variable = { temp_modify_gcc_unity = 1 }
 			modify_gcc_unity = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -1098,6 +1080,7 @@ gcc_decisions = {
 				}
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
@@ -1152,9 +1135,7 @@ gcc_decisions = {
 			clr_global_flag = GCC_joint_exercises_offered
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	GCC_request_bloc_arms_sales = {
@@ -1237,9 +1218,7 @@ gcc_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	GCC_expel = {
@@ -1253,7 +1232,14 @@ gcc_decisions = {
 			NOT = { any_of_scopes = { array = global.gcc_member_state has_country_flag = being_expelled } }
 		}
 
-		target_trigger = { country_exists = FROM }
+		target_trigger = {
+			country_exists = FROM
+			FROM = {
+				NOT = { has_country_flag = gcc_membership_secure }
+				NOT = { has_country_flag = being_expelled }
+				NOT = { has_country_flag = recently_expelled_from_gcc }
+			}
+		}
 
 		available = {
 			FROM = {
@@ -1264,14 +1250,6 @@ gcc_decisions = {
 					jihadist_government = yes
 					NOT = { has_idea = saudi_royal_family }
 				}
-			}
-		}
-
-		visible = {
-			FROM = {
-				NOT = { has_country_flag = gcc_membership_secure }
-				NOT = { has_country_flag = being_expelled }
-				NOT = { has_country_flag = recently_expelled_from_gcc }
 			}
 		}
 
@@ -1310,9 +1288,7 @@ gcc_decisions = {
 
 		target_array = global.gcc_member_state
 
-		target_root_trigger = {
-			has_idea = idea_gcc_member_state
-		}
+		target_root_trigger = { has_idea = idea_gcc_member_state }
 
 		target_trigger = {
 			country_exists = FROM
@@ -2206,9 +2182,7 @@ gcc_decisions = {
 			custom_effect_tooltip = become_gcc_dominant_member_tt
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	GCC_blockade = {
@@ -2217,14 +2191,14 @@ gcc_decisions = {
 
 		target_array = global.gcc_member_state
 
-		target_root_trigger = {
-			has_idea = idea_gcc_member_state
-		}
+		target_root_trigger = { has_idea = idea_gcc_member_state }
 
-		target_trigger = { country_exists = FROM }
-
-		visible = {
-			NOT = { any_of_scopes = { array = global.gcc_member_state has_country_flag = blockade_@FROM } }
+		target_trigger = {
+			country_exists = FROM
+			FROM = {
+				has_completed_focus = GCC_improve_relations_with_iran
+				NOT = { has_country_flag = accepted_blockade_demands }
+			}
 			OR = {
 				AND = {
 					FROM = { tag = QAT }
@@ -2233,10 +2207,10 @@ gcc_decisions = {
 				}
 				has_completed_focus = GCC_confront_iranian_partners
 			}
-			FROM = {
-				has_completed_focus = GCC_improve_relations_with_iran
-				NOT = { has_country_flag = accepted_blockade_demands }
-			}
+		}
+
+		visible = {
+			NOT = { any_of_scopes = { array = global.gcc_member_state has_country_flag = blockade_@FROM } }
 		}
 
 		cost = 100
@@ -2289,21 +2263,21 @@ gcc_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	GCC_drop_the_blockade = {
+
 		icon = GFX_decision_gulf_agree_button
+
 		target_array = global.gcc_member_state
 
-		target_trigger = { country_exists = FROM }
-
-		visible = {
-			has_country_flag = initiated_blockade_@FROM
+		target_trigger = {
+			country_exists = FROM
 			FROM = { has_country_flag = rejected_blockade_demands }
 		}
+
+		visible = { has_country_flag = initiated_blockade_@FROM }
 
 		cost = 50
 
@@ -2350,6 +2324,7 @@ gcc_decisions = {
 	}
 
 	GCC_accept_blockade_demands = {
+
 		icon = GFX_decision_gulf_agree1_button
 
 		visible = { has_country_flag = rejected_blockade_demands }
@@ -2455,22 +2430,20 @@ gcc_decisions = {
 				modify_gcc_unity = yes
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_support_gcc_membership = {
+
 		icon = GFX_decision_gulf_support_member_button
 
 		target_array = global.possible_gcc_members
 
-		target_root_trigger = {
-			has_idea = idea_gcc_member_state
-		}
+		target_root_trigger = { has_idea = idea_gcc_member_state }
 
-		target_trigger = { country_exists = FROM }
-
-		visible = {
-			NOT = { has_country_flag = supports_membership_@FROM }
+		target_trigger = {
+			country_exists = FROM
 			FROM = {
 				NOT = {
 					OR = {
@@ -2480,6 +2453,8 @@ gcc_decisions = {
 				}
 			}
 		}
+
+		visible = { NOT = { has_country_flag = supports_membership_@FROM } }
 
 		cost = 25
 
@@ -2569,22 +2544,15 @@ gcc_decisions = {
 	}
 
 	GCC_pressure_countries_to_support = {
+
 		icon = GFX_decision_gulf_pressure_button
 
 		target_array = global.possible_gcc_members
 
-		target_root_trigger = {
-			has_idea = idea_gcc_member_state
-		}
+		target_root_trigger = { has_idea = idea_gcc_member_state }
 
-		target_trigger = { country_exists = FROM }
-
-		visible = {
-			has_country_flag = supports_membership_@FROM
-			any_of_scopes = {
-				array = global.gcc_member_state
-				NOT = { has_country_flag = supports_membership_@FROM }
-			}
+		target_trigger = {
+			country_exists = FROM
 			FROM = {
 				NOT = {
 					OR = {
@@ -2592,6 +2560,14 @@ gcc_decisions = {
 						jihadist_government = yes
 					}
 				}
+			}
+		}
+
+		visible = {
+			has_country_flag = supports_membership_@FROM
+			any_of_scopes = {
+				array = global.gcc_member_state
+				NOT = { has_country_flag = supports_membership_@FROM }
 			}
 		}
 
@@ -2636,6 +2612,7 @@ gcc_decisions = {
 	}
 
 	GCC_show_supporters = {
+
 		icon = GFX_decision_gulf_list_button
 
 		visible = {
@@ -2656,16 +2633,17 @@ gcc_decisions = {
 					has_country_flag = supports_membership_@ROOT
 				}
 				display_individual_scopes = yes
-
 				set_temp_variable = { selected_tag = THIS.id }
 				TAG_get_name_with_flag = yes
 				newline = yes
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	GCC_begin_accession_process = {
+
 		icon = GFX_decision_gulf_agree_button
 
 		visible = {
@@ -2701,12 +2679,11 @@ gcc_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	GCC_complete_accession_plan = {
+
 		icon = GFX_decision_gulf_agree1_button
 
 		visible = {
@@ -2714,9 +2691,7 @@ gcc_decisions = {
 			has_country_flag = gcc_accession_process
 		}
 
-		available = {
-			gdp_per_capita_greater_than_10 = yes
-		}
+		available = { gdp_per_capita_greater_than_10 = yes }
 
 		cost = 100
 
@@ -2989,16 +2964,18 @@ gcc_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 }
 
 subversive_activities = {
+
 	send_support_to_hamas = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = { has_completed_focus = GCC_support_hamas }
+
 		available = {
 			OR = {
 				country_exists = HAM
@@ -3015,13 +2992,12 @@ subversive_activities = {
 			has_equipment = { util_vehicle_type > 4 }
 		}
 
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 209
-			}
-		}
+		highlight_states = { highlight_states_trigger = { state = 209 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hamas"
 			if = {
@@ -3072,15 +3048,16 @@ subversive_activities = {
 				PAL = { country_event = gulf.36 }
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_hezbollah = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
-		visible = {
-			has_completed_focus = GCC_non_aggression_pact
-		}
+
+		visible = { has_completed_focus = GCC_non_aggression_pact }
+
 		available = {
 			country_exists = HEZ
 			has_equipment = { infantry_weapons_type > 99 }
@@ -3088,13 +3065,13 @@ subversive_activities = {
 			has_equipment = { AA_Equipment > 9 }
 			has_equipment = { util_vehicle_type > 4 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 201
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 201 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hezbollah"
 			send_equipment = {
@@ -3119,13 +3096,16 @@ subversive_activities = {
 			}
 			HEZ = { country_event = gulf.36 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_pmu = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = { has_completed_focus = GCC_non_aggression_pact }
+
 		available = {
 			country_exists = IRQ
 			IRQ = { has_government = communism }
@@ -3134,13 +3114,13 @@ subversive_activities = {
 			has_equipment = { AA_Equipment > 9 }
 			has_equipment = { util_vehicle_type > 4 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 557
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 557 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_pmu"
 			send_equipment = {
@@ -3169,13 +3149,16 @@ subversive_activities = {
 				change_influence_percentage = yes
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_pro_government_forces = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = { has_completed_focus = GCC_non_aggression_pact }
+
 		available = {
 			country_exists = SYR
 			SYR = { has_government = communism }
@@ -3184,13 +3167,13 @@ subversive_activities = {
 			has_equipment = { AA_Equipment > 9 }
 			has_equipment = { util_vehicle_type > 4 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 186
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 186 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_pro_government_forces"
 			send_equipment = {
@@ -3219,13 +3202,16 @@ subversive_activities = {
 				change_influence_percentage = yes
 			}
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_the_syrian_opposition = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = { has_completed_focus = GCC_back_the_syrian_opposition }
+
 		available = {
 			has_equipment = { infantry_weapons_type > 99 }
 			has_equipment = { L_AT_Equipment > 9 }
@@ -3234,13 +3220,12 @@ subversive_activities = {
 			country_exists = FSA
 		}
 
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 188
-			}
-		}
+		highlight_states = { highlight_states_trigger = { state = 188 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_the_syrian_opposition"
 			send_equipment = {
@@ -3265,24 +3250,27 @@ subversive_activities = {
 			}
 			FSA = { country_event = gulf.36 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_arabs = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = { has_completed_focus = GCC_support_iranian_separatists }
+
 		available = {
 			has_equipment = { infantry_weapons_type > 99 }
 			PER = { owns_state = 399 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 399
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 399 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_arabs"
 			add_equipment_to_stockpile = {
@@ -3290,29 +3278,33 @@ subversive_activities = {
 				amount = -100
 			}
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_arabs"
 			custom_effect_tooltip = arab_rebels_strengthened_tt
 			add_to_variable = { global.arab_rebels_strength = 1 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_balochis = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = { has_completed_focus = GCC_support_iranian_separatists }
+
 		available = {
 			has_equipment = { infantry_weapons_type > 99 }
 			PER = { owns_state = 401 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 401
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 401 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_balochis"
 			add_equipment_to_stockpile = {
@@ -3320,35 +3312,39 @@ subversive_activities = {
 				amount = -100
 			}
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_balochis"
 			custom_effect_tooltip = balochi_rebels_strengthened_tt
 			add_to_variable = { global.balochi_rebels_strength = 1 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_gna = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = {
 			has_completed_focus = GCC_back_the_brotherhood
 			has_completed_focus = GCC_war_in_libya
 			country_exists = GNA
 		}
+
 		available = {
 			has_equipment = { infantry_weapons_type > 99 }
 			has_equipment = { L_AT_Equipment > 9 }
 			has_equipment = { AA_Equipment > 9 }
 			has_equipment = { util_vehicle_type > 4 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 391
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 391 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_gna"
 			send_equipment = {
@@ -3373,31 +3369,34 @@ subversive_activities = {
 			}
 			GNA = { country_event = gulf.36 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_gnc = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = {
 			has_completed_focus = GCC_back_the_brotherhood
 			has_completed_focus = GCC_war_in_libya
 			country_exists = GNC
 			NOT = { country_exists = GNA }
 		}
+
 		available = {
 			has_equipment = { infantry_weapons_type > 99 }
 			has_equipment = { L_AT_Equipment > 9 }
 			has_equipment = { AA_Equipment > 9 }
 			has_equipment = { util_vehicle_type > 4 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 391
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 391 } }
+
 		cost = 20
+
 		days_remove = 50
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_gnc"
 			send_equipment = {
@@ -3422,30 +3421,33 @@ subversive_activities = {
 			}
 			GNC = { country_event = gulf.36 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
+
 	send_support_to_hor = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		visible = {
 			has_completed_focus = GCC_back_the_strongman
 			has_completed_focus = GCC_war_in_libya
 			country_exists = HOR
 		}
+
 		available = {
 			has_equipment = { infantry_weapons_type > 99 }
 			has_equipment = { L_AT_Equipment > 9 }
 			has_equipment = { AA_Equipment > 9 }
 			has_equipment = { util_vehicle_type > 4 }
 		}
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 396
-			}
-		}
+
+		highlight_states = { highlight_states_trigger = { state = 396 } }
+
 		cost = 20
+
 		days_remove = 60
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision send_support_to_hor"
 			send_equipment = {
@@ -3470,14 +3472,14 @@ subversive_activities = {
 			}
 			HOR = { country_event = gulf.36 }
 		}
-		ai_will_do = {
-			base = 1
-		}
+
+		ai_will_do = { base = 1 }
 	}
 }
 
 
 JOR_oil_shale = {
+
 	JOR_renegotiate_terms = {
 
 		icon = oil
@@ -3545,7 +3547,6 @@ JOR_oil_shale = {
 			log = "[GetDateText]: [Root.GetName]: Decision JOR_back_out_of_contract"
 			PER = {
 				country_event = iranian_focus.18
-
 				remove_resource_rights = 210
 			}
 			JOR = {

--- a/common/decisions/India.txt
+++ b/common/decisions/India.txt
@@ -1,6 +1,9 @@
 RAJ_religious_groups = {
+
 	RAJ_appease_hindus = {
+
 		icon = GFX_decision_generic_political_discourse
+
 		cost = 25
 
 		days_remove = 30
@@ -29,7 +32,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_appease_sikhs = {
+
 		icon = GFX_decision_generic_political_discourse
+
 		cost = 25
 
 		days_remove = 30
@@ -58,8 +63,11 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_appease_buddhists = {
+
 		icon = GFX_decision_generic_political_discourse
+
 		cost = 25
+
 		days_remove = 30
 
 		remove_effect = {
@@ -86,7 +94,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_appease_christians = {
+
 		icon = GFX_decision_generic_political_discourse
+
 		cost = 25
 
 		days_remove = 30
@@ -115,7 +125,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_appease_muslims = {
+
 		icon = GFX_decision_generic_political_discourse
+
 		cost = 25
 
 		days_remove = 30
@@ -144,16 +156,16 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_interfaith_dialogue = {
+
 		icon = GFX_decision_generic_political_discourse
+
 		cost = 100
 
 		days_remove = 180
 
 		fire_only_once = no
 
-		available = {
-			NOT = { has_civil_war = yes }
-		}
+		available = { NOT = { has_civil_war = yes } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_interfaith_dialogue"
@@ -187,7 +199,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_ladakh_crisis = {
+
 		icon = GFX_decision_crisis
+
 		activation = {
 			owns_state = 993
 			check_variable = { RAJ_muslim_opinion < 20 }
@@ -201,13 +215,14 @@ RAJ_religious_groups = {
 			}
 		}
 
-		cancel_trigger = {
-			NOT = { owns_state = 993 }
-		}
+		cancel_trigger = { NOT = { owns_state = 993 } }
 
 		days_mission_timeout = 180
+
 		is_good = no
+
 		selectable_mission = no
+
 		fire_only_once = yes
 
 		complete_effect = {
@@ -225,7 +240,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_meghalaya_crisis = {
+
 		icon = GFX_decision_crisis
+
 		activation = {
 			owns_state = 980
 			check_variable = { RAJ_christians_opinion < 20 }
@@ -239,13 +256,14 @@ RAJ_religious_groups = {
 			}
 		}
 
-		cancel_trigger = {
-			NOT = { owns_state = 980 }
-		}
+		cancel_trigger = { NOT = { owns_state = 980 } }
 
 		days_mission_timeout = 180
+
 		is_good = no
+
 		selectable_mission = no
+
 		fire_only_once = yes
 
 		complete_effect = {
@@ -263,7 +281,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_manipur_crisis = {
+
 		icon = GFX_decision_crisis
+
 		activation = {
 			owns_state = 477
 			check_variable = { RAJ_christians_opinion < 20 }
@@ -277,13 +297,14 @@ RAJ_religious_groups = {
 			}
 		}
 
-		cancel_trigger = {
-			NOT = { owns_state = 477 }
-		}
+		cancel_trigger = { NOT = { owns_state = 477 } }
 
 		days_mission_timeout = 180
+
 		is_good = no
+
 		selectable_mission = no
+
 		fire_only_once = yes
 
 		complete_effect = {
@@ -301,7 +322,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_sikkim_crisis = {
+
 		icon = GFX_decision_crisis
+
 		activation = {
 			owns_state = 982
 			check_variable = { RAJ_buddhist_opinion < 20 }
@@ -315,13 +338,14 @@ RAJ_religious_groups = {
 			}
 		}
 
-		cancel_trigger = {
-			NOT = { owns_state = 982 }
-		}
+		cancel_trigger = { NOT = { owns_state = 982 } }
 
 		days_mission_timeout = 180
+
 		is_good = no
+
 		selectable_mission = no
+
 		fire_only_once = yes
 
 		complete_effect = {
@@ -339,7 +363,9 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_punjab_crisis = {
+
 		icon = GFX_decision_crisis
+
 		activation = {
 			owns_state = 429
 			check_variable = { RAJ_sikh_opinion < 15 }
@@ -353,13 +379,14 @@ RAJ_religious_groups = {
 			}
 		}
 
-		cancel_trigger = {
-			NOT = { owns_state = 429 }
-		}
+		cancel_trigger = { NOT = { owns_state = 429 } }
 
 		days_mission_timeout = 180
+
 		is_good = no
+
 		selectable_mission = no
+
 		fire_only_once = yes
 
 		complete_effect = {
@@ -377,6 +404,7 @@ RAJ_religious_groups = {
 	}
 
 	RAJ_settle_gujarat_unrest = {
+
 		icon = GFX_decision_generic_political_discourse
 
 		available = {
@@ -384,14 +412,13 @@ RAJ_religious_groups = {
 				tooltip = RAJ_settle_gujarat_unrest_TT
 				check_variable = { RAJ_muslim_opinion > 50 }
 				check_variable = { RAJ_hindus_opinion > 50 }
-
 			}
 		}
-		visible = {
-			has_idea = RAJ_gujarat_trouble_idea
-		}
+
+		visible = { has_idea = RAJ_gujarat_trouble_idea }
 
 		cost = 75
+
 		days_remove = 60
 
 		remove_effect = {
@@ -403,21 +430,20 @@ RAJ_religious_groups = {
 			add_stability = 0.02
 		}
 
-		ai_will_do = {
-			base = 10
-		}
+		ai_will_do = { base = 10 }
 	}
 }
 
 RAJ_Export_category = {
+
 	RAJ_ita_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = ITA
 			NOT = { has_war_with = ITA }
@@ -448,6 +474,7 @@ RAJ_Export_category = {
 				modify_treasury_effect = yes
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -458,13 +485,13 @@ RAJ_Export_category = {
 	}
 
 	RAJ_shri_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = SRI
 			NOT = { has_war_with = SRI }
@@ -493,6 +520,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -503,13 +531,13 @@ RAJ_Export_category = {
 	}
 
 	RAJ_isr_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = ISR
 			NOT = { has_war_with = ISR }
@@ -538,6 +566,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -546,14 +575,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_sau_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = SAU
 			NOT = { has_war_with = SAU }
@@ -582,6 +612,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -590,14 +621,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_arm_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = ARM
 			NOT = { has_war_with = ARM }
@@ -626,6 +658,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -634,14 +667,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_eth_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = ETH
 			NOT = { has_war_with = ETH }
@@ -670,6 +704,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -678,14 +713,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_nep_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = NEP
 			NOT = { has_war_with = NEP }
@@ -714,6 +750,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -722,14 +759,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_fra_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = FRA
 			NOT = { has_war_with = FRA }
@@ -758,6 +796,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -766,14 +805,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_sov_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = SOV
 			NOT = { has_war_with = SOV }
@@ -802,6 +842,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -810,14 +851,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_mld_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = MLD
 			NOT = { has_war_with = MLD }
@@ -846,6 +888,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -854,14 +897,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_mrt_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = MRT
 			NOT = { has_war_with = MRT }
@@ -890,6 +934,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -898,14 +943,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_egy_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = EGY
 			NOT = { has_war_with = EGY }
@@ -934,6 +980,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -942,14 +989,15 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_uae_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
 
 		days_remove = 300
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		available = {
 			country_exists = UAE
 			NOT = { has_war_with = UAE }
@@ -978,6 +1026,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -986,8 +1035,11 @@ RAJ_Export_category = {
 			}
 		}
 	}
+
 	RAJ_bhu_export = {
+
 		icon = GFX_decision_desicion_cat_weapon
+
 		days_remove = 300
 
 		available = {
@@ -995,9 +1047,8 @@ RAJ_Export_category = {
 			NOT = { has_war_with = BHU }
 		}
 
-		visible = {
-			has_completed_focus = RAJ_indian_arms_exports
-		}
+		visible = { has_completed_focus = RAJ_indian_arms_exports }
+
 		cost = 65
 
 		complete_effect = {
@@ -1021,6 +1072,7 @@ RAJ_Export_category = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 10
 			modifier = {
@@ -1032,13 +1084,16 @@ RAJ_Export_category = {
 }
 
 RAJ_brics_alliance_decisions = {
+
 	# Self-application to join (non-leader BRICS-potential nations)
 	BRICS_apply_to_join_brics = {
+
 		icon = emerging_button # TODO: Replace with a better icon
 
 		cost = 100
 
 		days_remove = 30
+
 		days_re_enable = 90
 
 		visible = {
@@ -1048,9 +1103,8 @@ RAJ_brics_alliance_decisions = {
 			NOT = { has_idea = RAJ_BRICS }
 			BRICS_focus_requirement_met = yes
 		}
-		available = {
-			NOT = { has_country_flag = BRICS_application_pending }
-		}
+
+		available = { NOT = { has_country_flag = BRICS_application_pending } }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision BRICS_apply_to_join_brics"
@@ -1062,28 +1116,28 @@ RAJ_brics_alliance_decisions = {
 
 	# Tier 2: Full Member Invite
 	RAJ_brics_invite_full_member = {
+
 		icon = GFX_decision_faction_targeted
+
 		target_array = global.BRICS_potential
 
-		target_root_trigger = {
-			has_dynamic_modifier = { modifier = RAJ_brics_leadership }
-		}
-
-		visible = {
-			country_exists = FROM
-			FROM = { NOT = { tag = ROOT } }
-		}
+		target_root_trigger = { has_dynamic_modifier = { modifier = RAJ_brics_leadership } }
 
 		target_trigger = {
+			country_exists = FROM
 			FROM = {
+				NOT = { tag = ROOT }
 				BRICS_valid_invite_target = yes
 				BRICS_can_full_member = yes
 			}
 		}
 
 		days_remove = 60
+
 		fire_only_once = no
+
 		days_re_enable = 270
+
 		cost = 100
 
 		remove_effect = {
@@ -1109,30 +1163,28 @@ RAJ_brics_alliance_decisions = {
 
 	# Tier 3: Associate Member Invite
 	RAJ_brics_invite_associate_member = {
+
 		icon = GFX_decision_faction_targeted
+
 		target_array = global.BRICS_potential
 
-		target_root_trigger = {
-			has_dynamic_modifier = { modifier = RAJ_brics_leadership }
-		}
+		target_root_trigger = { has_dynamic_modifier = { modifier = RAJ_brics_leadership } }
 
-		visible = {
+		target_trigger = {
 			country_exists = FROM
 			FROM = {
 				NOT = { tag = ROOT }
-			}
-		}
-
-		target_trigger = {
-			FROM = {
 				BRICS_valid_invite_target = yes
 				BRICS_can_associate_member = yes
 			}
 		}
 
 		days_remove = 45
+
 		fire_only_once = no
+
 		days_re_enable = 180
+
 		cost = 75
 
 		remove_effect = {
@@ -1155,30 +1207,28 @@ RAJ_brics_alliance_decisions = {
 
 	# Tier 4: Observer State Invite
 	RAJ_brics_invite_observer = {
+
 		icon = GFX_decision_faction_targeted
+
 		target_array = global.BRICS_potential
 
-		target_root_trigger = {
-			has_dynamic_modifier = { modifier = RAJ_brics_leadership }
-		}
+		target_root_trigger = { has_dynamic_modifier = { modifier = RAJ_brics_leadership } }
 
-		visible = {
+		target_trigger = {
 			country_exists = FROM
 			FROM = {
 				NOT = { tag = ROOT }
-			}
-		}
-
-		target_trigger = {
-			FROM = {
 				BRICS_valid_invite_target = yes
 				BRICS_can_observer = yes
 			}
 		}
 
 		days_remove = 30
+
 		fire_only_once = no
+
 		days_re_enable = 90
+
 		cost = 40
 
 		remove_effect = {
@@ -1203,12 +1253,12 @@ RAJ_brics_alliance_decisions = {
 
 	# Tier Promotion: Observer → Associate
 	RAJ_brics_promote_to_associate = {
+
 		icon = GFX_decision_faction_targeted
+
 		target_array = global.BRICS_observers
 
-		target_root_trigger = {
-			has_dynamic_modifier = { modifier = RAJ_brics_leadership }
-		}
+		target_root_trigger = { has_dynamic_modifier = { modifier = RAJ_brics_leadership } }
 
 		target_trigger = {
 			country_exists = FROM
@@ -1221,8 +1271,11 @@ RAJ_brics_alliance_decisions = {
 		}
 
 		days_remove = 45
+
 		fire_only_once = no
+
 		days_re_enable = 90
+
 		cost = 50
 
 		remove_effect = {
@@ -1236,19 +1289,17 @@ RAJ_brics_alliance_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
+		ai_will_do = { base = 10 }
 	}
 
 	# Tier Promotion: Associate → Full Member
 	RAJ_brics_promote_to_full = {
+
 		icon = GFX_decision_faction_targeted
+
 		target_array = global.BRICS_associates
 
-		target_root_trigger = {
-			has_dynamic_modifier = { modifier = RAJ_brics_leadership }
-		}
+		target_root_trigger = { has_dynamic_modifier = { modifier = RAJ_brics_leadership } }
 
 		target_trigger = {
 			country_exists = FROM
@@ -1260,8 +1311,11 @@ RAJ_brics_alliance_decisions = {
 		}
 
 		days_remove = 60
+
 		fire_only_once = no
+
 		days_re_enable = 90
+
 		cost = 75
 
 		remove_effect = {
@@ -1276,17 +1330,20 @@ RAJ_brics_alliance_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
+		ai_will_do = { base = 10 }
 	}
 }
 
 maoist_decision_category = {
+
 	RAJ_MAO_rebellion = {
+
 		priority = 100
+
 		icon = GFX_decision_generic_nationalism
+
 		days_mission_timeout = 365
+
 		fire_only_once = no
 
 		activation = {
@@ -1298,9 +1355,7 @@ maoist_decision_category = {
 			}
 		}
 
-		available = {
-			always = no
-		}
+		available = { always = no }
 
 		on_map_mode = map_only
 
@@ -1332,16 +1387,16 @@ maoist_decision_category = {
 	}
 
 	RAJ_MAO_rebellion_armed = {
+
 		priority = 100
+
 		icon = GFX_decision_generic_nationalism
+
 		days_mission_timeout = 365
+
 		fire_only_once = yes
 
-		activation = {
-			hidden_trigger = {
-				always = no
-			}
-		}
+		activation = { hidden_trigger = { always = no } }
 
 		on_map_mode = map_only
 
@@ -1367,47 +1422,51 @@ maoist_decision_category = {
 	}
 
 	RAJ_maoist_suppression = {
+
 		icon = {
 			key = GFX_decision_com_rebel_highest
 			trigger = { FROM = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency } } }
 		}
+
 		icon = {
 			key = GFX_decision_com_rebel_high
 			trigger = { FROM = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_1 } } }
 		}
+
 		icon = {
 			key = GFX_decision_com_rebel_medium
 			trigger = { FROM = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_2 } } }
 		}
+
 		icon = {
 			key = GFX_decision_com_rebel_moderat
 			trigger = { FROM = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_3 } } }
 		}
+
 		icon = {
 			key = GFX_decision_com_rebel_weak
 			trigger = { FROM = { has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency_4 } } }
 		}
 
 		state_target = yes
+
 		on_map_mode = map_and_decisions_view
+
 		targets = { 456 459 991 989 451 452 447 458 988 470 }
 
-		target_trigger = {
-			FROM = { RAJ_state_has_any_naxalite = yes }
-		}
+		target_trigger = { FROM = { RAJ_state_has_any_naxalite = yes } }
 
-		target_root_trigger = {
-			RAJ_country_has_any_naxalite_states = yes
-		}
+		target_root_trigger = { RAJ_country_has_any_naxalite_states = yes }
 
 		cost = 60
+
 		fixed_random_seed = no
+
 		fire_only_once = no
+
 		days_remove = 15
 
-		available = {
-			NOT = { has_country_flag = RAJ_suppression_active }
-		}
+		available = { NOT = { has_country_flag = RAJ_suppression_active } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_maoist_suppression"
@@ -1459,11 +1518,15 @@ maoist_decision_category = {
 	}
 
 	RAJ_integrated_development_initiative = {
+
 		icon = GFX_decision_generic_construction
 
 		cost = 75
+
 		fire_only_once = no
+
 		days_remove = 60
+
 		fixed_random_seed = no
 
 		available = {
@@ -1473,9 +1536,7 @@ maoist_decision_category = {
 			RAJ_country_has_any_naxalite_states = yes
 		}
 
-		visible = {
-			RAJ_country_has_any_naxalite_states = yes
-		}
+		visible = { RAJ_country_has_any_naxalite_states = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_integrated_development_initiative"
@@ -1521,22 +1582,20 @@ maoist_decision_category = {
 	}
 
 	RAJ_surrender_rehabilitation_program = {
+
 		icon = GFX_decision_generic_political_discourse
 
 		cost = 50
+
 		fire_only_once = no
+
 		days_remove = 30
+
 		fixed_random_seed = no
 
-		available = {
-			NOT = {
-				has_country_flag = RAJ_rehabilitation_in_progress
-			}
-		}
+		available = { NOT = { has_country_flag = RAJ_rehabilitation_in_progress } }
 
-		visible = {
-			RAJ_country_has_any_naxalite_states = yes
-		}
+		visible = { RAJ_country_has_any_naxalite_states = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_surrender_rehabilitation_program"
@@ -1568,17 +1627,19 @@ maoist_decision_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 40
-		}
+		ai_will_do = { base = 40 }
 	}
 
 	RAJ_operation_green_hunt = {
+
 		icon = GFX_decision_generic_military_support
 
 		cost = 100
+
 		fire_only_once = no
+
 		days_remove = 90
+
 		fixed_random_seed = no
 
 		available = {
@@ -1589,9 +1650,7 @@ maoist_decision_category = {
 			}
 		}
 
-		visible = {
-			RAJ_has_severe_naxalite_states_trigger = yes
-		}
+		visible = { RAJ_has_severe_naxalite_states_trigger = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_operation_green_hunt"
@@ -1633,9 +1692,11 @@ maoist_decision_category = {
 	}
 
 	RAJ_samadhan_doctrine = {
+
 		icon = GFX_decision_generic_intelligence_agency
 
 		cost = 75
+
 		fire_only_once = yes
 
 		available = {
@@ -1655,17 +1716,18 @@ maoist_decision_category = {
 			add_ideas = RAJ_samadhan_doctrine_idea
 		}
 
-		ai_will_do = {
-			base = 100
-		}
+		ai_will_do = { base = 100 }
 	}
 
 	# Salwa Judum - Controversial civilian militia program (2005-2011)
 	RAJ_salwa_judum = {
+
 		fixed_random_seed = no
+
 		icon = GFX_decision_generic_prepare_civil_war_new
 
 		cost = 40
+
 		days_remove = 180
 
 		available = {
@@ -1709,25 +1771,22 @@ maoist_decision_category = {
 			remove_ideas = RAJ_salwa_judum_active
 		}
 
-		ai_will_do = {
-			base = 50
-		}
+		ai_will_do = { base = 50 }
 	}
 
 	RAJ_road_connectivity_program = {
+
 		icon = GFX_decision_generic_construction
 
 		cost = 60
+
 		days_remove = 120
+
 		fixed_random_seed = no
 
-		available = {
-			num_of_civilian_factories > 30
-		}
+		available = { num_of_civilian_factories > 30 }
 
-		visible = {
-			RAJ_country_has_any_naxalite_states = yes
-		}
+		visible = { RAJ_country_has_any_naxalite_states = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision RAJ_road_connectivity_program"
@@ -1760,24 +1819,26 @@ maoist_decision_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 30
-		}
+		ai_will_do = { base = 30 }
 	}
 }
 
 RAJ_central_asian_salaf_revolution = {
+
 	RAJ_central_asian_revolution = {
+
 		icon = GFX_decision_generic_prepare_civil_war_new
+
 		targets = { KAZ UZB TAJ KYR }
+
 		target_root_trigger = { tag = RAJ }
-		target_trigger = {
-			FROM = {
-				NOT = { has_government = fascism }
-			}
-		}
+
+		target_trigger = { FROM = { NOT = { has_government = fascism } } }
+
 		fire_only_once = yes
+
 		cost = 200
+
 		days_remove = 70
 
 		available = {
@@ -1803,12 +1864,10 @@ RAJ_central_asian_salaf_revolution = {
 				set_temp_variable = { rul_party_temp = 11 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-
 				set_temp_variable = { party_index = 11 }
 				set_temp_variable = { party_popularity_increase = 0.25 }
 				set_temp_variable = { temp_outlook_increase = 0.25 }
 				change_relative_party_popularity = yes
-
 				start_civil_war = {
 					ideology = democratic
 					size = 0.3
@@ -1823,13 +1882,17 @@ RAJ_central_asian_salaf_revolution = {
 RAJ_greater_hindustan_decisions_category = {
 
 	RAJ_expanding_sphere_of_influence = {
+
 		icon = GFX_decision_afghanistan
 
 		cost = 500
+
 		days_remove = 120
+
 		fire_only_once = yes
 
 		war_with_on_remove = AFG
+
 		war_with_on_remove = TAL
 
 		remove_effect = {
@@ -1839,14 +1902,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = TAL.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_demand_sri_lanka = {
+
 		icon = GFX_decision_eng_trade_unions_demand
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		war_with_on_remove = SRI
@@ -1856,14 +1923,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = SRI.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_demand_myanma = {
+
 		icon = GFX_decision_spr_political_assassination
 
 		cost = 500
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		war_with_on_remove = BRM
@@ -1873,20 +1944,28 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = BRM.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_burn_down_the_separatist_sentiments = {
+
 		icon = GFX_decision_oppression
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		war_with_on_remove = BRM
+
 		war_with_on_remove = WAA
+
 		war_with_on_remove = SHN
+
 		war_with_on_remove = NHN
+
 		war_with_on_remove = KAR
 
 		remove_effect = {
@@ -1903,14 +1982,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = KAR.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_land_of_freedom = {
+
 		icon = GFX_decision_hol_war_on_pacifism
 
 		cost = 500
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		war_with_on_remove = SIA
@@ -1920,14 +2003,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = SIA.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_laotian_resorts = {
+
 		icon = GFX_decision_3si_dec
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		war_with_on_remove = LAO
@@ -1937,14 +2024,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = LAO.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_vietnamese_intervention = {
+
 		icon = GFX_decision_kavkaz_revol
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		remove_effect = {
@@ -1952,14 +2043,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = VIE.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_cambodian_natural_resources = {
+
 		icon = GFX_decision_generic_construction
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		remove_effect = {
@@ -1967,14 +2062,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = CBD.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_change_the_malaysian_constitution = {
+
 		icon = GFX_decision_generic_construction
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		remove_effect = {
@@ -1982,14 +2081,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = MAY.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_demand_singapore = {
+
 		icon = GFX_decision_singapore
 
 		cost = 250
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		remove_effect = {
@@ -1997,14 +2100,18 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = SIN.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	RAJ_bring_hinduism_back_to_indonesia = {
+
 		icon = GFX_decision_indonesia_export
 
 		cost = 500
 
 		days_remove = 120
+
 		fire_only_once = yes
 
 		remove_effect = {
@@ -2014,6 +2121,7 @@ RAJ_greater_hindustan_decisions_category = {
 			set_temp_variable = { demand_annex_target = ACE.id }
 			RAJ_demand_annex_target = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 }

--- a/common/decisions/Singapore.txt
+++ b/common/decisions/Singapore.txt
@@ -8,66 +8,68 @@
 # © Millenium Dawn 2016-2026
 
 SIN_government_of_singapore = {
+
 	# ---- Decisions ----- #
 	SIN_repeal_centralized_education_system = {
+
 		icon = jap_conquer_china
+
 		visible = {
 			has_completed_focus = SIN_centralized_education
 			has_idea = SIN_centralized_education_idea
 		}
 
-		available = {
-			has_idea = SIN_centralized_education_idea
-		}
+		available = { has_idea = SIN_centralized_education_idea }
+
 		cost = 100
 
 		days_re_enable = 10
+
 		days_remove = 180
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: decisions SIN_repeal_centralized_education_system"
 			remove_ideas = SIN_centralized_education_idea
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	SIN_replace_centralized_education_system = {
+
 		icon = jap_conquer_china
+
 		visible = {
 			has_completed_focus = SIN_centralized_education
 			NOT = { has_idea = SIN_centralized_education_idea }
 		}
 
-		available = {
-			NOT = { has_idea = SIN_centralized_education_idea }
-		}
+		available = { NOT = { has_idea = SIN_centralized_education_idea } }
+
 		cost = 100
 
 		days_re_enable = 10
+
 		days_remove = 180
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: decisions SIN_repeal_centralized_education_system"
 			add_ideas = SIN_centralized_education_idea
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	SIN_extend_finance_western_projects = {
-		icon = decision
-		visible = {
-			has_idea = SIN_finance_western_projects_idea
-		}
 
-		available = {
-			NOT = {
-				any_enemy_country = {
-					has_government = democratic
-				}
-			}
-		}
+		icon = decision
+
+		visible = { has_idea = SIN_finance_western_projects_idea }
+
+		available = { NOT = { any_enemy_country = { has_government = democratic } } }
 
 		days_re_enable = 120
+
 		days_remove = 10
 
 		remove_effect = {
@@ -80,55 +82,64 @@ SIN_government_of_singapore = {
 				days = 90
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	SIN_repeal_decentralization_protocol_decision = {
+
 		icon = jap_conquer_china
+
 		visible = {
 			has_completed_focus = SIN_decentralize_the_government
 			has_idea = SIN_decentralize_the_government_idea
 		}
 
-		available = {
-			40_percent_government_popularity = yes
-		}
+		available = { 40_percent_government_popularity = yes }
+
 		cost = 100
 
 		days_re_enable = 10
+
 		days_remove = 180
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: decisions SIN_repeal_centralized_education_system"
 			remove_ideas = SIN_decentralize_the_government_idea
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	SIN_enact_decentralization_protocol_decision = {
+
 		icon = jap_conquer_china
+
 		visible = {
 			has_completed_focus = SIN_decentralize_the_government
 			NOT = { has_idea = SIN_decentralize_the_government_idea }
 		}
 
-		available = {
-			40_percent_government_popularity = yes
-		}
+		available = { 40_percent_government_popularity = yes }
+
 		cost = 100
 
 		days_re_enable = 10
+
 		days_remove = 180
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: decisions SIN_repeal_centralized_education_system"
 			add_ideas = SIN_decentralize_the_government_idea
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	SIN_repeal_the_migrant_worker_policy = {
+
 		icon = jap_conquer_china
+
 		visible = {
 			OR = {
 				has_idea = SIN_migrant_workers
@@ -137,13 +148,12 @@ SIN_government_of_singapore = {
 			}
 		}
 
-		available = {
-			40_percent_government_popularity = yes
-		}
+		available = { 40_percent_government_popularity = yes }
 
 		cost = 100
 
 		days_re_enable = 10
+
 		days_remove = 180
 
 		remove_effect = {
@@ -158,33 +168,32 @@ SIN_government_of_singapore = {
 				remove_ideas = SIN_migrant_workers_encouraged_two_idea
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
 
 	# ---- Missions ----- #
 	SIN_riau_islands_crisis_mission = {
-		activation = {
-			owns_state = 627
-		}
 
-		highlight_states = {
-			highlight_states_trigger = {
-				state = 627
-			}
-		}
+		activation = { owns_state = 627 }
+
+		highlight_states = { highlight_states_trigger = { state = 627 } }
 
 		war_with_on_remove = IND
+
 		days_mission_timeout = 180
+
 		fire_only_once = yes
+
 		selectable_mission = yes
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission complete_effect SIN_riau_islands_crisis_mission"
 			add_war_support = -0.05
 		}
+
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: mission timeout_effect SIN_riau_islands_crisis_mission"
-
 			set_temp_variable = { wargoal_on = IND }
 			add_threat_from_wargoal_effect = yes
 			create_wargoal = {
@@ -201,11 +210,13 @@ SIN_government_of_singapore = {
 	# ---- Targeted Decisions ----- #
 	# Trade Agreements
 	SIN_singaporean_foreign_aid_target_decisions = {
+
 		icon = decision
-		available = {
-			is_subject = no
-		}
+
+		available = { is_subject = no }
+
 		target_array = SIN_singaporean_trade_agreement
+
 		target_trigger = {
 			FROM = {
 				has_opinion = {
@@ -214,11 +225,11 @@ SIN_government_of_singapore = {
 				}
 			}
 		}
-		target_root_trigger = {
-			has_completed_focus = SIN_singaporean_foreign_aid
-		}
+
+		target_root_trigger = { has_completed_focus = SIN_singaporean_foreign_aid }
 
 		days_remove = 30
+
 		days_re_enable = 60
 
 		remove_effect = {
@@ -230,33 +241,38 @@ SIN_government_of_singapore = {
 			FROM = {
 				modify_treasury_effect = yes
 			}
-
 			set_temp_variable = { influence_target = FROM.id }
 			set_temp_variable = { percent_change = 5 }
 			change_influence_percentage = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
 }
 
 SIN_expand_the_entreport_decision_categories = {
+
 	SIN_facilitate_trade_expansion = {
+
 		icon = jap_conquer_china
+
 		targets = { HKG CHI IND MAC MAY VIE RAJ BRM LAO CBD JAP PHI BAN SIA FIJ SAM MIC PAU MAR KIR TUL VAN TON NAU }
+
 		targets_dynamic = yes
 
-		visible = {
-			NOT = { has_war_with = ROOT }
+		target_root_trigger = {
 			NOT = { has_idea = SIN_expanded_freight_transport }
 			NOT = { has_country_flag = SIN_facilitate_trade_expansion_flag }
 		}
-		available = {
-			NOT = { has_idea = SIN_expanded_freight_transport }
-		}
+
+		target_trigger = { NOT = { has_war_with = FROM } }
+
+		available = { NOT = { has_idea = SIN_expanded_freight_transport } }
 
 		cost = 75
 
 		days_remove = 180
+
 		days_re_enable = 90
 
 		complete_effect = {
@@ -288,16 +304,18 @@ SIN_expand_the_entreport_decision_categories = {
 ## Singapore Balance of Power (BOP) Mechanic ##
 ###############################################
 SIN_balance_of_power_category = {
+
 	### BOP Singapore World Dominance LEFT (MINUS)
 	#### Promote Singapore Asian Value
 	SIN_BOP_promote_singapore_asian_value = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 110
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_promote_singapore_asian_value"
@@ -325,13 +343,14 @@ SIN_balance_of_power_category = {
 
 	#### Establish ASEAN Innovation Hub
 	SIN_BOP_establish_asean_innovation_hub = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 65
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_establish_asean_innovation_hub"
@@ -358,13 +377,14 @@ SIN_balance_of_power_category = {
 
 	#### Expand Global Diplomatic Footprint
 	SIN_BOP_expand_global_diplomatic_footprint = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 115
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_expand_global_diplomatic_footprint"
@@ -390,13 +410,14 @@ SIN_balance_of_power_category = {
 
 	#### Maintenance No.1 Strongest World Passport
 	SIN_BOP_maintenance_no1_strongest_world_passport = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 730
+
 		cost = 250
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_maintenance_no1_strongest_world_passport"
@@ -433,13 +454,14 @@ SIN_balance_of_power_category = {
 
 	#### Found Singapore Strategic Investment Authority (SSIA)
 	SIN_BOP_found_singapore_strategic_investment_authority = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 65
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_found_singapore_strategic_investment_authority"
@@ -468,13 +490,14 @@ SIN_balance_of_power_category = {
 
 	#### Establish Singapore Armed Forces Training Partnerships
 	SIN_BOP_establish_singapore_armed_forces_training_partnerships = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 135
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_establish_singapore_armed_forces_training_partnerships"
@@ -504,13 +527,14 @@ SIN_balance_of_power_category = {
 
 	#### Build Global Tech Corridor
 	SIN_BOP_build_global_tech_corridor = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 100
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_build_global_tech_corridor"
@@ -538,16 +562,16 @@ SIN_balance_of_power_category = {
 
 	#### Host Asia Global Security Summit
 	SIN_BOP_host_asia_global_security_summit = {
+
 		icon = GFX_decision_zsr_propaganda
 
 		cost = 120
 
 		days_remove = 120
+
 		fire_only_once = yes
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_host_asia_global_security_summit"
@@ -576,13 +600,14 @@ SIN_balance_of_power_category = {
 
 	#### Launch “Smart Southeast Asia” Initiative
 	SIN_BOP_launch_smart_southeast_asia_initiative = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 75
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_launch_smart_southeast_asia_initiative"
@@ -593,9 +618,9 @@ SIN_balance_of_power_category = {
 		}
 
 		modifier = {
-			education_cost_multiplier_modifier = 0.05				#Education Spending Multiplier
-			research_speed_factor = 0.075							#Research Speed
-			special_project_speed_factor = 0.075						#Special Project Speed
+			education_cost_multiplier_modifier = 0.05 #Education Spending Multiplier
+			research_speed_factor = 0.075 #Research Speed
+			special_project_speed_factor = 0.075 #Special Project Speed
 		}
 
 		ai_will_do = {
@@ -609,13 +634,14 @@ SIN_balance_of_power_category = {
 
 	#### Initiate Maritime Silk Reconnect
 	SIN_BOP_initiate_maritime_silk_reconnect = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 95
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_initiate_maritime_silk_reconnect"
@@ -642,13 +668,14 @@ SIN_balance_of_power_category = {
 
 	#### Fund Regional Think Tanks
 	SIN_BOP_fund_regional_think_tanks = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 100
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_fund_regional_think_tanks"
@@ -675,13 +702,14 @@ SIN_balance_of_power_category = {
 
 	#### Establish Singaporean Cultural Institutes Abroad
 	SIN_BOP_establish_singaporean_cultural_institutes_abroad = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 70
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_establish_singaporean_cultural_institutes_abroad"
@@ -707,13 +735,14 @@ SIN_balance_of_power_category = {
 
 	#### Secure Overseas Port Access Agreements
 	SIN_BOP_secure_overseas_port_access_agreements = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 65
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_secure_overseas_port_access_agreements"
@@ -741,13 +770,14 @@ SIN_balance_of_power_category = {
 
 	#### Launch Global Green Finance Diplomacy
 	SIN_BOP_launch_global_green_finance_diplomacy = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 85
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_launch_global_green_finance_diplomacy"
@@ -777,13 +807,14 @@ SIN_balance_of_power_category = {
 
 	#### Singapore Citizenship Journey Program
 	SIN_BOP_singapore_citizenship_journey_program = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 70
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_singapore_citizenship_journey_program"
@@ -809,13 +840,14 @@ SIN_balance_of_power_category = {
 
 	#### Reclaim Throne Tiger of the Peninsula
 	SIN_BOP_reclaim_throne_tiger_of_the_peninsula = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 730
+
 		cost = 500
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_reclaim_throne_tiger_of_the_peninsula"
@@ -845,13 +877,14 @@ SIN_balance_of_power_category = {
 
 	#### Gold Card Visas for Billionaire Program
 	SIN_BOP_gold_card_visas_for_billionaire_program = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 365
+
 		cost = 100
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_gold_card_visas_for_billionaire_program"
@@ -863,9 +896,7 @@ SIN_balance_of_power_category = {
 			}
 		}
 
-		modifier = {
-			monthly_population = 0.02
-		}
+		modifier = { monthly_population = 0.02 }
 
 		ai_will_do = {
 			base = 1
@@ -878,14 +909,16 @@ SIN_balance_of_power_category = {
 
 	#### Boost Overseas Intelligence Activity
 	SIN_BOP_overseas_intelligence_activity = {
+
 		allowed = { has_dlc = "La Resistance" }
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 365
+
 		cost = 350
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_overseas_intelligence_activity"
@@ -919,13 +952,14 @@ SIN_balance_of_power_category = {
 
 	#### Promote Singapore Business Environment
 	SIN_BOP_promote_singapore_business_environment = {
+
 		icon = GFX_decision_zsr_propaganda
+
 		days_remove = 120
+
 		cost = 85
 
-		available = {
-			is_subject = no
-		}
+		available = { is_subject = no }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_promote_singapore_business_environment"
@@ -955,11 +989,13 @@ SIN_balance_of_power_category = {
 	}
 
 	### BOP Singapore First RIGHT (PLUS)
-
 	#### Scholarship for Bachelor, Master, and Doctoral Education
 	SIN_BOP_scholarship_for_bachelor_master_and_doctoral_education = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 90
 
 		remove_effect = {
@@ -988,8 +1024,11 @@ SIN_balance_of_power_category = {
 
 	#### National Skills Future Movement
 	SIN_BOP_national_skills_future_movement = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 85
 
 		remove_effect = {
@@ -1017,8 +1056,11 @@ SIN_balance_of_power_category = {
 
 	#### Enhance CPF and Housing Grants
 	SIN_BOP_enhance_cpf_and_housing_grants = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 70
 
 		remove_effect = {
@@ -1046,8 +1088,11 @@ SIN_balance_of_power_category = {
 
 	#### Local Enterprise Growth Scheme
 	SIN_BOP_local_enterprise_growth_scheme = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 90
 
 		remove_effect = {
@@ -1076,8 +1121,11 @@ SIN_balance_of_power_category = {
 
 	#### Boost Birth Rate Incentive Package
 	SIN_BOP_boost_birth_rate_incentive_package = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 100
 
 		remove_effect = {
@@ -1106,8 +1154,11 @@ SIN_balance_of_power_category = {
 
 	#### Green Singapore Movement
 	SIN_BOP_green_singapore_movement = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 75
 
 		remove_effect = {
@@ -1138,8 +1189,11 @@ SIN_balance_of_power_category = {
 
 	#### Public Transport Excellence Scheme
 	SIN_BOP_public_transport_excellence_scheme = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 50
 
 		remove_effect = {
@@ -1167,8 +1221,11 @@ SIN_balance_of_power_category = {
 
 	#### National Food Resilience Strategy
 	SIN_BOP_national_food_resilience_strategy = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 70
 
 		remove_effect = {
@@ -1197,8 +1254,11 @@ SIN_balance_of_power_category = {
 
 	#### Cybersecurity for Citizens Initiative
 	SIN_BOP_cybersecurity_for_citizens_initiative = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 75
 
 		remove_effect = {
@@ -1226,8 +1286,11 @@ SIN_balance_of_power_category = {
 
 	#### Support Local Talent First Act
 	SIN_BOP_support_local_talent_first_act = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 80
 
 		remove_effect = {
@@ -1255,8 +1318,11 @@ SIN_balance_of_power_category = {
 
 	#### Singaporean Culture Preservation Fund
 	SIN_BOP_singaporean_culture_preservation_fund = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 75
 
 		remove_effect = {
@@ -1283,8 +1349,11 @@ SIN_balance_of_power_category = {
 
 	#### Financial Wellness National Campaign
 	SIN_BOP_financial_wellness_national_campaign = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 80
 
 		remove_effect = {
@@ -1314,8 +1383,11 @@ SIN_balance_of_power_category = {
 
 	#### Give Incentives for Domestic Companies
 	SIN_BOP_give_incentives_for_domestic_companies = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 85
 
 		remove_effect = {
@@ -1343,8 +1415,11 @@ SIN_balance_of_power_category = {
 
 	#### Fight Foreign Influece
 	SIN_BOP_fight_foreign_influence = {
+
 		icon = GFX_decision_fist
+
 		days_remove = 120
+
 		cost = 100
 
 		remove_effect = {
@@ -1371,13 +1446,14 @@ SIN_balance_of_power_category = {
 
 	#### Masterplan for Land Allocation
 	SIN_BOP_masterplan_for_land_allocation = {
+
 		icon = GFX_decision_generic_factory
+
 		days_remove = 1825
+
 		cost = 100
 
-		available = {
-			has_idea = SIN_singapore_masterplan_idea
-		}
+		available = { has_idea = SIN_singapore_masterplan_idea }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_masterplan_for_land_allocation"
@@ -1408,7 +1484,6 @@ SIN_balance_of_power_category = {
 			}
 			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
-
 			add_power_balance_value = {
 				id = SIN_power_balance
 				value = 0.01
@@ -1426,13 +1501,14 @@ SIN_balance_of_power_category = {
 
 	#### Masterplan for Civilian Industry Development
 	SIN_BOP_masterplan_for_civilian_industry_development = {
+
 		icon = GFX_decision_generic_factory
+
 		days_remove = 1825
+
 		cost = 100
 
-		available = {
-			has_idea = SIN_singapore_masterplan_idea
-		}
+		available = { has_idea = SIN_singapore_masterplan_idea }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_masterplan_for_civilian_industry_development"
@@ -1454,13 +1530,14 @@ SIN_balance_of_power_category = {
 
 	#### Masterplan for Miliatary Industry Development
 	SIN_BOP_masterplan_for_miliatary_industry_development = {
+
 		icon = GFX_decision_generic_factory
+
 		days_remove = 1825
+
 		cost = 100
 
-		available = {
-			has_idea = SIN_singapore_masterplan_idea
-		}
+		available = { has_idea = SIN_singapore_masterplan_idea }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_masterplan_for_miliatary_industry_development"
@@ -1482,13 +1559,14 @@ SIN_balance_of_power_category = {
 
 	#### Masterplan for Naval Yard Development
 	SIN_BOP_masterplan_for_naval_yard_development = {
+
 		icon = GFX_decision_generic_factory
+
 		days_remove = 1825
+
 		cost = 100
 
-		available = {
-			has_idea = SIN_singapore_masterplan_idea
-		}
+		available = { has_idea = SIN_singapore_masterplan_idea }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_masterplan_for_naval_yard_development"
@@ -1510,13 +1588,14 @@ SIN_balance_of_power_category = {
 
 	#### Masterplan for Offices Development
 	SIN_BOP_masterplan_for_offices_development = {
+
 		icon = GFX_decision_generic_factory
+
 		days_remove = 1825
+
 		cost = 100
 
-		available = {
-			has_idea = SIN_singapore_masterplan_idea
-		}
+		available = { has_idea = SIN_singapore_masterplan_idea }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision SIN_BOP_masterplan_for_offices_development"

--- a/common/decisions/Yugoslavia.txt
+++ b/common/decisions/Yugoslavia.txt
@@ -6,22 +6,15 @@ yugo_bloc = {
 
 		target_array = global.yugo_members
 
-		target_root_trigger = {
-			NOT = { has_idea = formed_yugoslavia }
-		}
+		target_root_trigger = { NOT = { has_idea = formed_yugoslavia } }
 
 		target_trigger = {
 			country_exists = FROM
 			NOT = { FROM = { tag = ROOT } }
-		}
-
-		visible = {
 			FROM = { check_variable = { yugo_nostalgia < 75 } }
 		}
 
-		available = {
-			FROM = { influence_higher_15 = yes }
-		}
+		available = { FROM = { influence_higher_15 = yes } }
 
 		days_remove = 5
 

--- a/common/decisions/bankruptcy_decisions.txt
+++ b/common/decisions/bankruptcy_decisions.txt
@@ -4,8 +4,8 @@ bankruptcy_decisions = {
 	#Always use cheap loans from IMF first, only ask for bailout if interest > 15%
 	#First ask bailout from IMF, then neighbours, then 2nd influencer, then 1st influencer to do the least damage
 	#Default if interest > 25% and not at war
-
 	bankruptcy_cheap_loans_from_imf = {
+
 		icon = GFX_decision_bancru_imf_button
 
 		cost = 50
@@ -18,6 +18,7 @@ bankruptcy_decisions = {
 				}
 			}
 		}
+
 		available = {
 			is_full_state = yes
 			has_added_tension_amount < 5
@@ -42,7 +43,6 @@ bankruptcy_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_cheap_loans_from_imf"
 			custom_effect_tooltip = cheap_loans_from_imf_tt
 			ingame_update_setup = yes
-
 			activate_mission = cheap_loan_from_the_imf_mission
 		}
 
@@ -53,11 +53,12 @@ bankruptcy_decisions = {
 				has_political_power < 0
 			}
 		}
-
 	}
 
 	bankruptcy_cheap_loans_from_african_investment_fund = {
+
 		allowed = { is_african_nation = yes }
+
 		icon = GFX_decision_bancru_ask_button
 
 		available = {
@@ -67,9 +68,7 @@ bankruptcy_decisions = {
 			interest_rate_lower_than_15 = yes
 		}
 
-		modifier = {
-			interest_rate_multiplier_modifier = -3
-		}
+		modifier = { interest_rate_multiplier_modifier = -3 }
 
 		days_remove = 360
 
@@ -98,15 +97,17 @@ bankruptcy_decisions = {
 				has_political_power < 0
 			}
 		}
-
 	}
 
 	bankruptcy_seek_bailout_from_biggest_influencer = {
+
 		icon = GFX_decision_bancru_ask_button
+
 		visible = {
 			check_variable = { influence_array^0 > 0 }
 			NOT = { check_variable = { influence_array^0 > ROOT.id } }
 		}
+
 		available = {
 			is_subject = no
 			custom_trigger_tooltip = {
@@ -159,15 +160,17 @@ bankruptcy_decisions = {
 				has_political_power < 0
 			}
 		}
-
 	}
 
 	bankruptcy_seek_bailout_from_second_biggest_influencer = {
+
 		icon = GFX_decision_bancru_ask_button
+
 		visible = {
 			check_variable = { influence_array^0 > 0 }
 			NOT = { check_variable = { influence_array^1 > ROOT.id } }
 		}
+
 		available = {
 			is_subject = no
 			custom_trigger_tooltip = {
@@ -223,6 +226,7 @@ bankruptcy_decisions = {
 	}
 
 	bankruptcy_seek_bailout_from_neighbour = {
+
 		icon = GFX_decision_bancru_ask_button
 
 		target_array = neighbors
@@ -234,7 +238,7 @@ bankruptcy_decisions = {
 				NOT = { original_tag = var:ROOT.influence_array^0 }
 				NOT = { original_tag = var:ROOT.influence_array^1 }
 				check_variable = { FROM.gdp_total > ROOT.gdp_total }
-				FROM = { is_full_state = yes }
+				is_full_state = yes
 			}
 		}
 
@@ -254,7 +258,6 @@ bankruptcy_decisions = {
 			NOT = { has_decision = bankruptcy_seek_bailout_from_imf }
 		}
 
-
 		days_re_enable = 360
 
 		days_remove = 7
@@ -267,7 +270,6 @@ bankruptcy_decisions = {
 			else = {
 				add_political_power = -100
 			}
-
 			set_variable = {
 				debt_bailout = {
 					value = debt
@@ -293,10 +295,11 @@ bankruptcy_decisions = {
 	}
 
 	bankruptcy_seek_bailout_from_overlord = {
-		visible = {
-			is_subject = yes
-		}
+
+		visible = { is_subject = yes }
+
 		icon = GFX_decision_bancru_ask_overlord_button
+
 		available = {
 			if = {
 				limit = { is_ai = no }
@@ -306,8 +309,11 @@ bankruptcy_decisions = {
 			NOT = { has_decision = bankruptcy_seek_bailout_from_imf }
 			overlord = { NOT = { has_dynamic_modifier = { modifier = very_high_interest_country_modifiers } } }
 		}
+
 		days_re_enable = 360
+
 		days_remove = 7
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_seek_bailout_from_overlord"
 			if = { limit = { is_ai = yes }
@@ -316,7 +322,6 @@ bankruptcy_decisions = {
 			else = {
 				add_political_power = -100
 			}
-
 			set_variable = {
 				debt_bailout = {
 					value = debt
@@ -328,6 +333,7 @@ bankruptcy_decisions = {
 			custom_effect_tooltip = bankruptcy_seek_bailout_from_overlord_tt
 			overlord = { country_event = { id = bankruptcy.5 hours = 3 } }
 		}
+
 		ai_will_do = {
 			base = 800
 			modifier = {
@@ -341,7 +347,9 @@ bankruptcy_decisions = {
 	}
 
 	bankruptcy_seek_bailout_from_imf = {
+
 		icon = GFX_decision_bancru_ass_imf_button
+
 		available = {
 			is_full_state = yes
 			has_added_tension_amount < 5
@@ -359,9 +367,13 @@ bankruptcy_decisions = {
 			NOT = { has_decision = bankruptcy_seek_bailout_from_neighbour }
 			NOT = { has_decision = bankruptcy_seek_bailout_from_overlord }
 		}
+
 		fixed_random_seed = no
+
 		days_re_enable = 180
+
 		days_remove = 7
+
 		cost = 50
 
 		complete_effect = {
@@ -771,6 +783,7 @@ bankruptcy_decisions = {
 				}
 			}
 		}
+
 		ai_will_do = {
 			base = 900
 			modifier = {
@@ -785,7 +798,9 @@ bankruptcy_decisions = {
 	}
 
 	bankruptcy_seek_bailout_from_african_monetary_fund = {
+
 		allowed = { is_african_nation = yes }
+
 		icon = GFX_decision_bancru_ask_button
 
 		available = {
@@ -804,9 +819,13 @@ bankruptcy_decisions = {
 			NOT = { has_decision = bankruptcy_seek_bailout_from_neighbour }
 			NOT = { has_decision = bankruptcy_seek_bailout_from_overlord }
 		}
+
 		fixed_random_seed = no
+
 		days_re_enable = 360
+
 		days_remove = 7
+
 		cost = 100
 
 		complete_effect = {
@@ -841,6 +860,7 @@ bankruptcy_decisions = {
 			set_temp_variable = { percent_change = 10 }
 			change_influence_percentage = yes
 		}
+
 		ai_will_do = {
 			base = 950
 			modifier = {
@@ -855,7 +875,9 @@ bankruptcy_decisions = {
 	}
 
 	bankruptcy_incoming_collapse = {
+
 		icon = GFX_decision_bancru_collapse_button
+
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = bankruptcy_incoming_collapse_complete_trigger
@@ -898,14 +920,14 @@ bankruptcy_decisions = {
 			log = "[GetDateText]: [Root.GetName]: Decision bankruptcy_incoming_collapse"
 			add_political_power = 150
 		}
-
 	}
 
 	bankruptcy_default_on_debts = {
-		visible = {
-			interest_rate_higher_than_15 = yes
-		}
+
+		visible = { interest_rate_higher_than_15 = yes }
+
 		icon = GFX_decision_bancru_depts_button
+
 		available = {
 			is_subject = no
 			interest_rate_higher_than_15 = yes
@@ -923,7 +945,6 @@ bankruptcy_decisions = {
 				set_temp_variable = { cart_influence_change = 20 }
 				modify_treasury_effect = yes
 			}
-
 			set_variable = { debt_default_left = debt }
 			multiply_variable = { debt_default_left = 0.5 }
 			round_variable = debt_default_left
@@ -955,8 +976,11 @@ bankruptcy_decisions = {
 	}
 
 	cheap_loan_from_the_imf_mission = {
+
 		fixed_random_seed = no
+
 		icon = GFX_decision_bancru_collapse_button
+
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = potential_expenses_lower_than_potential_income_tt
@@ -964,9 +988,7 @@ bankruptcy_decisions = {
 			}
 		}
 
-		activation = {
-			always = no
-		}
+		activation = { always = no }
 
 		is_good = no
 
@@ -1018,9 +1040,7 @@ bankruptcy_decisions = {
 					}
 				}
 			}
-
 			activate_mission = cheap_loan_from_the_imf_mission
-
 			if = { limit = { has_idea = IMF_failed_to_balance_budget }
 				hidden_effect = {
 					remove_ideas = IMF_failed_to_balance_budget
@@ -1072,9 +1092,10 @@ debt_default_decisions = {
 	#3. Sell factories unless GDP is < 80% of pre-default GDP (sell order NIC -> MIC -> Offices -> CIC)
 	#4. Political concessions to 2nd and 1st influencer
 	#Default if interest > 25% and not at war
-
 	debt_default_main_mission = {
+
 		icon = GFX_decision_bancru_collapse_button
+
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = debt_default_main_mission_complete_trigger
@@ -1082,11 +1103,10 @@ debt_default_decisions = {
 			}
 		}
 
-		activation = {
-			always = no
-		}
+		activation = { always = no }
 
 		is_good = no
+
 		selectable_mission = no
 
 		days_mission_timeout = 360
@@ -1198,15 +1218,15 @@ debt_default_decisions = {
 	}
 
 	debt_default_pay_10_from_treasury = {
+
 		icon = GFX_decision_bancru_ask_button
+
 		visible = {
 			has_active_mission = debt_default_main_mission
 			check_variable = { gdp_total < 100 }
 		}
 
-		available = {
-			interest_rate_lower_than_5 = yes
-		}
+		available = { interest_rate_lower_than_5 = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision debt_default_pay_10_from_treasury"
@@ -1220,22 +1240,19 @@ debt_default_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	debt_default_pay_50_from_treasury = {
+
 		icon = GFX_decision_bancru_ask_button
+
 		visible = {
 			has_active_mission = debt_default_main_mission
 			check_variable = { gdp_total > 100 }
 		}
 
-		available = {
-			interest_rate_lower_than_5 = yes
-		}
+		available = { interest_rate_lower_than_5 = yes }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision debt_default_pay_50_from_treasury"
@@ -1249,19 +1266,14 @@ debt_default_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	debt_default_concessions_to_the_imf = {
+
 		icon = GFX_decision_bancru_ass_imf_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
 
-
+		visible = { has_active_mission = debt_default_main_mission }
 
 		days_re_enable = 180
 
@@ -1355,17 +1367,14 @@ debt_default_decisions = {
 			}
 		}
 
-		ai_will_do = {
-			base = 900
-		}
-
+		ai_will_do = { base = 900 }
 	}
 
 	debt_default_political_concessions_to_biggest_influencer = {
+
 		icon = GFX_decision_bancru_ask_overlord_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
+
+		visible = { has_active_mission = debt_default_main_mission }
 
 		available = {
 			custom_trigger_tooltip = {
@@ -1420,14 +1429,13 @@ debt_default_decisions = {
 				}
 			}
 		}
-
 	}
 
 	debt_default_political_concessions_to_second_biggest_influencer = {
+
 		icon = GFX_decision_bancru_ask_overlord_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
+
+		visible = { has_active_mission = debt_default_main_mission }
 
 		available = {
 			custom_trigger_tooltip = {
@@ -1482,14 +1490,13 @@ debt_default_decisions = {
 				}
 			}
 		}
-
 	}
 
 	debt_default_sell_civilian_factories = {
+
 		icon = GFX_decision_bancru_ask_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
+
+		visible = { has_active_mission = debt_default_main_mission }
 
 		available = {
 			num_of_civilian_factories > 0
@@ -1529,14 +1536,13 @@ debt_default_decisions = {
 				}
 			}
 		}
-
 	}
 
 	debt_default_dismantle_military_factories = {
+
 		icon = GFX_decision_bancru_ask_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
+
+		visible = { has_active_mission = debt_default_main_mission }
 
 		available = {
 			any_owned_state = {
@@ -1578,14 +1584,13 @@ debt_default_decisions = {
 				}
 			}
 		}
-
 	}
 
 	debt_default_scrap_dockyard = {
+
 		icon = GFX_decision_bancru_ask_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
+
+		visible = { has_active_mission = debt_default_main_mission }
 
 		available = {
 			num_of_naval_factories > 0
@@ -1625,14 +1630,13 @@ debt_default_decisions = {
 				}
 			}
 		}
-
 	}
 
 	debt_default_cut_down_government_services = {
+
 		icon = GFX_decision_bancru_ask_button
-		visible = {
-			has_active_mission = debt_default_main_mission
-		}
+
+		visible = { has_active_mission = debt_default_main_mission }
 
 		available = {
 			custom_trigger_tooltip = {
@@ -1675,7 +1679,5 @@ debt_default_decisions = {
 				}
 			}
 		}
-
 	}
-
 }

--- a/common/decisions/libya.txt
+++ b/common/decisions/libya.txt
@@ -7,6 +7,7 @@ libya_oil_nationalisation = {
 		cost = 50
 
 		days_remove = 30
+
 		days_re_enable = 45
 
 		visible = {
@@ -14,9 +15,7 @@ libya_oil_nationalisation = {
 			NOT = { has_country_flag = libya_noc_dismantled }
 		}
 
-		available = {
-			NOT = { has_decision = libya_sell_oil_fields }
-		}
+		available = { NOT = { has_decision = libya_sell_oil_fields } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_nationalise_oil_fields"
@@ -73,6 +72,7 @@ libya_oil_nationalisation = {
 		cost = 50
 
 		days_remove = 30
+
 		days_re_enable = 45
 
 		visible = {
@@ -80,9 +80,7 @@ libya_oil_nationalisation = {
 			NOT = { has_country_flag = libya_noc_dismantled }
 		}
 
-		available = {
-			NOT = { has_decision = libya_nationalise_oil_fields }
-		}
+		available = { NOT = { has_decision = libya_nationalise_oil_fields } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_sell_oil_fields"
@@ -142,6 +140,7 @@ libya_oil_nationalisation = {
 	libya_develop_el_sahara_fields_1 = {
 
 		name = libya_develop_el_sahara_fields
+
 		desc = libya_develop_el_sahara_fields_desc
 
 		icon = oil
@@ -152,9 +151,7 @@ libya_oil_nationalisation = {
 
 		fire_only_once = yes
 
-		visible = {
-			NOT = { has_completed_focus = LBA_attract_private_oil_companies }
-		}
+		visible = { NOT = { has_completed_focus = LBA_attract_private_oil_companies } }
 
 		available = {
 			owns_state = 391
@@ -165,11 +162,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation1
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 392
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 392 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_el_sahara_fields_1"
@@ -207,12 +200,12 @@ libya_oil_nationalisation = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_develop_el_sahara_fields_2 = {
 
 		name = libya_develop_el_sahara_fields
+
 		desc = libya_develop_el_sahara_fields_desc
 
 		icon = oil
@@ -237,11 +230,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation2
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 392
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 392 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_el_sahara_fields_2"
@@ -279,12 +268,12 @@ libya_oil_nationalisation = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_develop_el_sahara_fields_3 = {
 
 		name = libya_develop_el_sahara_fields
+
 		desc = libya_develop_el_sahara_fields_desc
 
 		icon = oil
@@ -309,11 +298,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation3
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 392
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 392 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_el_sahara_fields_3"
@@ -351,12 +336,12 @@ libya_oil_nationalisation = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_develop_el_sahara_fields_4 = {
 
 		name = libya_develop_el_sahara_fields
+
 		desc = libya_develop_el_sahara_fields_desc
 
 		icon = oil
@@ -381,11 +366,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation4
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 392
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 392 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_el_sahara_fields_4"
@@ -423,12 +404,12 @@ libya_oil_nationalisation = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_develop_el_sahara_fields_5 = {
 
 		name = libya_develop_el_sahara_fields
+
 		desc = libya_develop_el_sahara_fields_desc
 
 		icon = oil
@@ -453,11 +434,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation5
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 392
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 392 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_el_sahara_fields_5"
@@ -494,12 +471,12 @@ libya_oil_nationalisation = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_develop_west_waha_fields_1 = {
 
 		name = libya_develop_west_waha_fields
+
 		desc = libya_develop_west_waha_fields_desc
 
 		icon = oil
@@ -510,9 +487,7 @@ libya_oil_nationalisation = {
 
 		fire_only_once = yes
 
-		visible = {
-			NOT = { has_completed_focus = LBA_attract_private_oil_companies }
-		}
+		visible = { NOT = { has_completed_focus = LBA_attract_private_oil_companies } }
 
 		available = {
 			owns_state = 919
@@ -523,11 +498,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation1
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 919
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 919 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_west_waha_fields_1"
@@ -580,12 +551,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_west_waha_fields_2 = {
 
 		name = libya_develop_west_waha_fields
+
 		desc = libya_develop_west_waha_fields_desc
 
 		icon = oil
@@ -610,11 +581,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation2
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 919
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 919 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_west_waha_fields_2"
@@ -667,12 +634,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_west_waha_fields_3 = {
 
 		name = libya_develop_west_waha_fields
+
 		desc = libya_develop_west_waha_fields_desc
 
 		icon = oil
@@ -697,11 +664,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation3
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 919
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 919 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_west_waha_fields_3"
@@ -754,12 +717,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_west_waha_fields_4 = {
 
 		name = libya_develop_west_waha_fields
+
 		desc = libya_develop_west_waha_fields_desc
 
 		icon = oil
@@ -784,11 +747,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation4
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 919
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 919 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_west_waha_fields_4"
@@ -841,12 +800,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_west_waha_fields_5 = {
 
 		name = libya_develop_west_waha_fields
+
 		desc = libya_develop_west_waha_fields_desc
 
 		icon = oil
@@ -871,11 +830,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation5
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 919
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 919 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_west_waha_fields_5"
@@ -927,12 +882,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_east_waha_fields_1 = {
 
 		name = libya_develop_east_waha_fields
+
 		desc = libya_develop_east_waha_fields_desc
 
 		icon = oil
@@ -943,9 +898,7 @@ libya_oil_nationalisation = {
 
 		fire_only_once = yes
 
-		visible = {
-			NOT = { has_completed_focus = LBA_attract_private_oil_companies }
-		}
+		visible = { NOT = { has_completed_focus = LBA_attract_private_oil_companies } }
 
 		available = {
 			owns_state = 397
@@ -956,11 +909,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation1
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 397
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 397 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_east_waha_fields_1"
@@ -1013,12 +962,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_east_waha_fields_2 = {
 
 		name = libya_develop_east_waha_fields
+
 		desc = libya_develop_east_waha_fields_desc
 
 		icon = oil
@@ -1043,11 +992,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation2
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 397
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 397 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_east_waha_fields_2"
@@ -1100,12 +1045,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_east_waha_fields_3 = {
 
 		name = libya_develop_east_waha_fields
+
 		desc = libya_develop_east_waha_fields_desc
 
 		icon = oil
@@ -1130,11 +1075,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation3
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 397
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 397 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_east_waha_fields_3"
@@ -1187,12 +1128,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_east_waha_fields_4 = {
 
 		name = libya_develop_east_waha_fields
+
 		desc = libya_develop_east_waha_fields_desc
 
 		icon = oil
@@ -1217,11 +1158,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation4
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 397
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 397 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_east_waha_fields_4"
@@ -1274,12 +1211,12 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_east_waha_fields_5 = {
 
 		name = libya_develop_east_waha_fields
+
 		desc = libya_develop_east_waha_fields_desc
 
 		icon = oil
@@ -1304,11 +1241,7 @@ libya_oil_nationalisation = {
 			has_tech = excavation5
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 397
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 397 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_east_waha_fields_5"
@@ -1360,7 +1293,6 @@ libya_oil_nationalisation = {
 				}
 			}
 		}
-
 	}
 
 	libya_develop_oil_fields_with_foreign_aid = {
@@ -1373,9 +1305,7 @@ libya_oil_nationalisation = {
 
 		days_re_enable = 360
 
-		visible = {
-			has_completed_focus = LBA_attract_private_oil_companies
-		}
+		visible = { has_completed_focus = LBA_attract_private_oil_companies }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_develop_oil_fields_with_foreign_aid"
@@ -1397,7 +1327,7 @@ libya_oil_nationalisation = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove libya_develop_oil_fields_with_foreign_aid"
 			random_owned_state = {
 				limit = {
-					NOT = {	has_state_category = state_inhospitable	}
+					NOT = { has_state_category = state_inhospitable }
 				}
 				add_resource = {
 					type = oil
@@ -1414,7 +1344,6 @@ libya_oil_nationalisation = {
 				check_variable = { domestic_influence_amount < 30 }
 			}
 		}
-
 	}
 
 	libya_dig_wadi_ash_shati = {
@@ -1443,11 +1372,7 @@ libya_oil_nationalisation = {
 			}
 		}
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 392
-			}
-		}
+		highlight_states = { highlight_state_targets = { state = 392 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_dig_wadi_ash_shati"
@@ -1525,7 +1450,6 @@ libya_oil_nationalisation = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 }
 
@@ -1567,10 +1491,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_muhammad_muammar = {
@@ -1609,10 +1530,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_father_to_son_talk_muhammad_muammar = {
@@ -1685,7 +1603,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_sensor_internet_muhammad_muammar = {
@@ -1748,7 +1665,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_saif_al_islam = {
@@ -1786,10 +1702,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_saif_al_islam = {
@@ -1834,7 +1747,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_showcase_art_saif_al_islam = {
@@ -1906,7 +1818,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_discuss_succession_saif_al_islam = {
@@ -1982,7 +1893,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_sue_sunday_telegraph_saif_al_islam = {
@@ -2055,7 +1965,6 @@ libya_gaddafi_family = {
 				check_variable = { gaddafi_family_instability > 60 }
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_al_saadi = {
@@ -2093,10 +2002,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_al_saadi = {
@@ -2134,10 +2040,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_improve_football_career_al_saadi = {
@@ -2209,7 +2112,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_create_new_city_al_saadi = {
@@ -2276,7 +2178,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_send_to_rehab_al_saadi = {
@@ -2347,7 +2248,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_mutassim = {
@@ -2406,7 +2306,6 @@ libya_gaddafi_family = {
 				has_stability < 0.30
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_recall_mutassim = {
@@ -2451,7 +2350,6 @@ libya_gaddafi_family = {
 				has_stability < 0.30
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_national_security_advisor_mutassim = {
@@ -2506,7 +2404,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_additional_equipment_mutassim = {
@@ -2578,7 +2475,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_hannibal = {
@@ -2616,10 +2512,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_hannibal = {
@@ -2657,10 +2550,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_civilian_education_hannibal = {
@@ -2748,7 +2638,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_military_education_hannibal = {
@@ -2826,7 +2715,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_ayesha = {
@@ -2864,10 +2752,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_ayesha = {
@@ -2905,10 +2790,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_send_legal_aid_ayesha = {
@@ -2981,7 +2863,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_military_training_aid_ayesha = {
@@ -3052,7 +2933,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_saif_al_arab = {
@@ -3090,10 +2970,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_saif_al_arab = {
@@ -3131,10 +3008,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_business_trip_saif_al_arab = {
@@ -3200,7 +3074,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_tech_seminar_saif_al_arab = {
@@ -3272,7 +3145,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_military_expo_saif_al_arab = {
@@ -3335,7 +3207,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_exile_khamis = {
@@ -3380,10 +3251,7 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_recall_khamis = {
@@ -3421,13 +3289,11 @@ libya_gaddafi_family = {
 			}
 		}
 
-		ai_will_do = {
-			base = 0
-		}
-
+		ai_will_do = { base = 0 }
 	}
 
 	libya_gaddafi_family_give_military_command_khamis = {
+
 		fixed_random_seed = no
 
 		icon = GFX_zsr_parlament
@@ -3522,7 +3388,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_khamis_brigade_khamis = {
@@ -3594,10 +3459,10 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_aecom_khamis = {
+
 		fixed_random_seed = no
 
 		icon = GFX_zsr_parlament
@@ -3669,7 +3534,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_hold_un_speech_gaddafi = {
@@ -3743,7 +3607,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_throw_money_gaddafi = {
@@ -3815,7 +3678,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_design_car_gaddafi = {
@@ -3891,7 +3753,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_state_visit_gaddafi = {
@@ -3976,7 +3837,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_do_black_magic_gaddafi = {
@@ -4055,7 +3915,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_meet_women_gaddafi = {
@@ -4132,7 +3991,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_hold_tv_speech_gaddafi = {
@@ -4194,7 +4052,6 @@ libya_gaddafi_family = {
 				has_stability < 0.30
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_abolish_switzerland_gaddafi = {
@@ -4271,7 +4128,6 @@ libya_gaddafi_family = {
 				has_stability < 0.25
 			}
 		}
-
 	}
 
 	libya_gaddafi_family_anti_government_protests = {
@@ -4296,16 +4152,13 @@ libya_gaddafi_family = {
 			}
 		}
 
-		available = {
-			has_stability > 0.199
-		}
+		available = { has_stability > 0.199 }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout libya_gaddafi_family_anti_government_protests"
 			custom_effect_tooltip = libya_gaddafi_family_anti_government_protests_tt
 			country_event = LibyaCivilWar.15
 		}
-
 	}
 
 	libya_gaddafi_family_deploy_military = {
@@ -4329,12 +4182,8 @@ libya_gaddafi_family = {
 			custom_effect_tooltip = libya_gaddafi_family_deploy_military_tt
 		}
 
-		ai_will_do = {
-			base = 5
-		}
-
+		ai_will_do = { base = 5 }
 	}
-
 }
 
 libya_libyan_tribalism = {
@@ -4347,9 +4196,7 @@ libya_libyan_tribalism = {
 
 		days_re_enable = 180
 
-		available = {
-			NOT = { has_idea = bureau_01 }
-		}
+		available = { NOT = { has_idea = bureau_01 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_tribalism_decentralise_state"
@@ -4389,7 +4236,6 @@ libya_libyan_tribalism = {
 				check_variable = { fezzan_loyalty < 0.35 }
 			}
 		}
-
 	}
 
 	libya_tribalism_placate_tripolitanians = {
@@ -4465,7 +4311,6 @@ libya_libyan_tribalism = {
 				}
 			}
 		}
-
 	}
 
 	libya_tribalism_placate_cyrenaicans = {
@@ -4542,7 +4387,6 @@ libya_libyan_tribalism = {
 				}
 			}
 		}
-
 	}
 
 	libya_tribalism_placate_fezzans = {
@@ -4618,7 +4462,6 @@ libya_libyan_tribalism = {
 				}
 			}
 		}
-
 	}
 
 	libya_tribalism_military_crackdown = {
@@ -4629,13 +4472,12 @@ libya_libyan_tribalism = {
 
 		targets = { 391 918 395 }
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
 		days_re_enable = 360
+
 		days_remove = 360
 
 		target_root_trigger = {
@@ -4647,13 +4489,9 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		target_trigger = {
-			FROM = { NOT = { is_core_of = ROOT } }
-		}
+		target_trigger = { FROM = { NOT = { is_core_of = ROOT } } }
 
-		modifier = {
-			personnel_cost_multiplier_modifier = 0.075
-		}
+		modifier = { personnel_cost_multiplier_modifier = 0.075 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_tribalism_military_crackdown"
@@ -4689,10 +4527,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
 
 	libya_tribalism_use_military_as_workforce = {
@@ -4703,13 +4538,12 @@ libya_libyan_tribalism = {
 
 		targets = { 391 918 395 }
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
 		days_re_enable = 360
+
 		days_remove = 360
 
 		target_root_trigger = {
@@ -4776,10 +4610,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
 
 	libya_tribalism_use_military_as_security = {
@@ -4790,23 +4621,15 @@ libya_libyan_tribalism = {
 
 		targets = { 391 918 395 }
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
 		days_re_enable = 360
+
 		days_remove = 360
 
-		target_root_trigger = {
-			has_completed_focus = LBA_establish_military_zones
-			owns_any_state_of = {
-				391
-				918
-				395
-			}
-		}
+		target_root_trigger = { has_completed_focus = LBA_establish_military_zones owns_any_state_of = { 391 918 395 } }
 
 		available = {
 			OR = {
@@ -4815,9 +4638,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		modifier = {
-			personnel_cost_multiplier_modifier = 0.10
-		}
+		modifier = { personnel_cost_multiplier_modifier = 0.10 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_tribalism_use_military_as_security"
@@ -4853,10 +4674,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
 
 	libya_tribalism_demobilise_soldiers = {
@@ -4867,9 +4685,7 @@ libya_libyan_tribalism = {
 
 		targets = { 391 918 395 }
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
@@ -4927,10 +4743,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
 
 	libya_tribalism_end_tribalism = {
@@ -4961,10 +4774,7 @@ libya_libyan_tribalism = {
 			set_country_flag = LBA_tribalism_disabled
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
 
 	libya_tribalism_tripolitanian_revolt = {
@@ -4996,9 +4806,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		cancel_trigger = {
-			country_exists = TRP
-		}
+		cancel_trigger = { country_exists = TRP }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout libya_tribalism_tripolitanian_revolt"
@@ -5026,7 +4834,6 @@ libya_libyan_tribalism = {
 			}
 			country_event = LibyaFocus.95
 		}
-
 	}
 
 	libya_tribalism_cyrenaica_revolt = {
@@ -5058,9 +4865,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		cancel_trigger = {
-			country_exists = CYR
-		}
+		cancel_trigger = { country_exists = CYR }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout libya_tribalism_cyrenaica_revolt"
@@ -5087,7 +4892,6 @@ libya_libyan_tribalism = {
 			}
 			country_event = LibyaFocus.96
 		}
-
 	}
 
 	libya_tribalism_fezzan_revolt = {
@@ -5119,9 +4923,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		cancel_trigger = {
-			country_exists = FEZ
-		}
+		cancel_trigger = { country_exists = FEZ }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout libya_tribalism_fezzan_revolt"
@@ -5147,7 +4949,6 @@ libya_libyan_tribalism = {
 			}
 			country_event = LibyaFocus.97
 		}
-
 	}
 
 	libya_tribalism_dismantle_libya = {
@@ -5171,9 +4972,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		available = {
-			has_war = no
-		}
+		available = { has_war = no }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_tribalism_dismantle_libya"
@@ -5235,10 +5034,7 @@ libya_libyan_tribalism = {
 			}
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 }
 
@@ -5254,9 +5050,7 @@ libya_libyan_foreign_policy = {
 
 		fire_only_once = yes
 
-		visible = {
-			has_completed_focus = LBA_islamic_state_of_sahel
-		}
+		visible = { has_completed_focus = LBA_islamic_state_of_sahel }
 
 		available = {
 			has_completed_focus = LBA_topple_chad
@@ -5285,7 +5079,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_core_northern_niger = {
@@ -5298,9 +5091,7 @@ libya_libyan_foreign_policy = {
 
 		fire_only_once = yes
 
-		visible = {
-			has_completed_focus = LBA_islamic_state_of_sahel
-		}
+		visible = { has_completed_focus = LBA_islamic_state_of_sahel }
 
 		available = {
 			has_completed_focus = LBA_topple_niger
@@ -5331,7 +5122,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_core_algerian_sahara = {
@@ -5344,9 +5134,7 @@ libya_libyan_foreign_policy = {
 
 		fire_only_once = yes
 
-		visible = {
-			has_completed_focus = LBA_islamic_state_of_sahel
-		}
+		visible = { has_completed_focus = LBA_islamic_state_of_sahel }
 
 		available = {
 			has_completed_focus = LBA_topple_algeria
@@ -5379,7 +5167,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_core_northern_mali = {
@@ -5392,9 +5179,7 @@ libya_libyan_foreign_policy = {
 
 		fire_only_once = yes
 
-		visible = {
-			has_completed_focus = LBA_islamic_state_of_sahel
-		}
+		visible = { has_completed_focus = LBA_islamic_state_of_sahel }
 
 		available = {
 			has_completed_focus = LBA_infiltrate_mali
@@ -5431,7 +5216,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_core_mauritanian_sahara = {
@@ -5444,9 +5228,7 @@ libya_libyan_foreign_policy = {
 
 		fire_only_once = yes
 
-		visible = {
-			has_completed_focus = LBA_islamic_state_of_sahel
-		}
+		visible = { has_completed_focus = LBA_islamic_state_of_sahel }
 
 		available = {
 			has_completed_focus = LBA_expand_to_mauritania
@@ -5487,9 +5269,7 @@ libya_libyan_foreign_policy = {
 
 		fire_only_once = yes
 
-		visible = {
-			has_completed_focus = LBA_claim_jerusalem_for_arabs
-		}
+		visible = { has_completed_focus = LBA_claim_jerusalem_for_arabs }
 
 		available = {
 			any_owned_state = {
@@ -5520,7 +5300,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_pacify_cyrenaica = {
@@ -5560,10 +5339,7 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	libya_pacify_tripolitania = {
@@ -5611,10 +5387,7 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	libya_pacify_fezzan = {
@@ -5654,10 +5427,7 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	libya_pacify_tuaregs = {
@@ -5669,9 +5439,7 @@ libya_libyan_foreign_policy = {
 			918 = { NOT = { is_core_of = ROOT } }
 		}
 
-		available = {
-			918 = {	compliance > 30 }
-		}
+		available = { 918 = { compliance > 30 } }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision complete libya_pacify_tuaregs"
@@ -5680,10 +5448,7 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	libya_pacify_toubou = {
@@ -5717,28 +5482,28 @@ libya_libyan_foreign_policy = {
 					owns_state = 920
 					920 = { NOT = { is_core_of = ROOT } }
 				}
-				920 = {	compliance > 30	}
+				920 = { compliance > 30 }
 			}
 			if = {
 				limit = {
 					owns_state = 1100
 					1100 = { NOT = { is_core_of = ROOT } }
 				}
-				1100 = { compliance > 30	}
+				1100 = { compliance > 30 }
 			}
 			if = {
 				limit = {
 					owns_state = 1101
 					1101 = { NOT = { is_core_of = ROOT } }
 				}
-				1101 = { compliance > 30	}
+				1101 = { compliance > 30 }
 			}
 			if = {
 				limit = {
 					owns_state = 580
 					580 = { NOT = { is_core_of = ROOT } }
 				}
-				580 = {	compliance > 30	}
+				580 = { compliance > 30 }
 			}
 		}
 
@@ -5774,10 +5539,7 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1000
-		}
-
+		ai_will_do = { base = 1000 }
 	}
 
 	libya_liberate_minorities = {
@@ -5792,19 +5554,12 @@ libya_libyan_foreign_policy = {
 
 		war_with_target_on_remove = yes
 
-		target_root_trigger = {
-			has_completed_focus = LBA_protect_toubou_and_tuaregs
-		}
+		target_root_trigger = { has_completed_focus = LBA_protect_toubou_and_tuaregs }
 
 		target_trigger = {
 			FROM = {
 				NOT = { is_subject_of = ROOT }
 				NOT = { is_in_faction_with = ROOT }
-			}
-		}
-
-		visible = {
-			FROM = {
 				any_owned_state = {
 					OR = {
 						is_core_of = TUA
@@ -5925,7 +5680,6 @@ libya_libyan_foreign_policy = {
 				is_subject = yes
 			}
 		}
-
 	}
 
 	libya_launch_oef = {
@@ -5940,19 +5694,12 @@ libya_libyan_foreign_policy = {
 
 		war_with_target_on_remove = yes
 
-		target_root_trigger = {
-			has_completed_focus = LBA_oef_trans_sahara
-		}
+		target_root_trigger = { has_completed_focus = LBA_oef_trans_sahara }
 
 		target_trigger = {
 			FROM = {
 				NOT = { is_subject_of = ROOT }
 				NOT = { is_in_faction_with = ROOT }
-			}
-		}
-
-		visible = {
-			FROM = {
 				NOT = { has_war_with = ROOT }
 				OR = {
 					salafist_caliphate_are_in_power = yes
@@ -5999,7 +5746,6 @@ libya_libyan_foreign_policy = {
 				is_subject = yes
 			}
 		}
-
 	}
 
 	libya_build_rail_to_tunisia = {
@@ -6049,7 +5795,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_build_rail_to_egypt = {
@@ -6099,7 +5844,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_build_rail_to_niger = {
@@ -6150,7 +5894,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_build_rail_to_chad = {
@@ -6197,7 +5940,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_negotiations_with_un = {
@@ -6210,26 +5952,18 @@ libya_libyan_foreign_policy = {
 
 		is_good = yes
 
-		allowed = {
-			always = no
-		}
-		activation = {
-			has_completed_focus = LBA_negotiations_with_un
-		}
+		allowed = { always = no }
 
-		available = {
-			always = no
-		}
+		activation = { has_completed_focus = LBA_negotiations_with_un }
+
+		available = { always = no }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision timeout libya_negotiations_with_un"
 			custom_effect_tooltip = libya_negotiations_with_un_tt
 		}
 
-		ai_will_do = {
-			base = 5
-		}
-
+		ai_will_do = { base = 5 }
 	}
 
 	libya_casablanca_accords = {
@@ -6242,13 +5976,9 @@ libya_libyan_foreign_policy = {
 
 		selectable_mission = yes
 
-		allowed = {
-			always = no
-		}
+		allowed = { always = no }
 
-		activation = {
-			has_completed_focus = LBA_casablanca_accords
-		}
+		activation = { has_completed_focus = LBA_casablanca_accords }
 
 		available = {
 			custom_trigger_tooltip = {
@@ -6423,10 +6153,7 @@ libya_libyan_foreign_policy = {
 			hidden_effect = { news_event = { id = LibyaFocusNews.18 hours = 12 } }
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_casablanca_accords_draft_solution = {
@@ -6445,10 +6172,7 @@ libya_libyan_foreign_policy = {
 			country_event = LibyaFocus.59
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_casablanca_accords_hold_negotiations = {
@@ -6484,13 +6208,11 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_casablanca_accords_convince_morocco = {
+
 		fixed_random_seed = no
 
 		icon = political_discourse
@@ -6539,13 +6261,11 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_casablanca_accords_convince_sahrawi = {
+
 		fixed_random_seed = no
 
 		icon = political_discourse
@@ -6594,13 +6314,11 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_casablanca_accords_convince_algeria = {
+
 		fixed_random_seed = no
 
 		icon = political_discourse
@@ -6649,13 +6367,11 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_casablanca_accords_convince_mauritania = {
+
 		fixed_random_seed = no
 
 		icon = political_discourse
@@ -6704,10 +6420,7 @@ libya_libyan_foreign_policy = {
 			}
 		}
 
-		ai_will_do = {
-			base = 100
-		}
-
+		ai_will_do = { base = 100 }
 	}
 
 	libya_anti_colonial_start_revolution = {
@@ -6789,7 +6502,6 @@ libya_libyan_foreign_policy = {
 				check_variable = { interest_rate > 8 }
 			}
 		}
-
 	}
 
 	libya_demand_tuareg_territory = {
@@ -6804,19 +6516,12 @@ libya_libyan_foreign_policy = {
 
 		war_with_target_on_remove = yes
 
-		target_root_trigger = {
-			has_completed_focus = LBA_liberate_tuareg
-		}
+		target_root_trigger = { has_completed_focus = LBA_liberate_tuareg }
 
 		target_trigger = {
 			FROM = {
 				NOT = { is_subject_of = ROOT }
 				NOT = { is_in_faction_with = ROOT }
-			}
-		}
-
-		visible = {
-			FROM = {
 				any_owned_state = {
 					is_core_of = TUA
 				}
@@ -6864,7 +6569,6 @@ libya_libyan_foreign_policy = {
 				is_subject = yes
 			}
 		}
-
 	}
 
 	libya_demand_toubou_territory = {
@@ -6879,19 +6583,12 @@ libya_libyan_foreign_policy = {
 
 		war_with_target_on_remove = yes
 
-		target_root_trigger = {
-			has_completed_focus = LBA_liberate_toubou
-		}
+		target_root_trigger = { has_completed_focus = LBA_liberate_toubou }
 
 		target_trigger = {
 			FROM = {
 				NOT = { is_subject_of = ROOT }
 				NOT = { is_in_faction_with = ROOT }
-			}
-		}
-
-		visible = {
-			FROM = {
 				any_owned_state = {
 					is_core_of = TIE
 				}
@@ -6939,9 +6636,7 @@ libya_libyan_foreign_policy = {
 				is_subject = yes
 			}
 		}
-
 	}
-
 }
 
 aozou_strip_occupation_decisions = {
@@ -7003,14 +6698,13 @@ aozou_strip_occupation_decisions = {
 				has_war = yes
 			}
 		}
-
 	}
-
 }
 
 libya_aftermath_of_civil_war = {
 
 	libya_integrate_militias_mission = {
+
 		fixed_random_seed = no
 
 		activation = {
@@ -7025,15 +6719,9 @@ libya_aftermath_of_civil_war = {
 			has_war = no
 		}
 
-		available = {
-			hidden_trigger = {
-				always = no
-			}
-		}
+		available = { hidden_trigger = { always = no } }
 
-		cancel_trigger = {
-			has_war = yes
-		}
+		cancel_trigger = { has_war = yes }
 
 		is_good = yes
 
@@ -7094,12 +6782,9 @@ libya_aftermath_of_civil_war = {
 
 		days_remove = 14
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
-
 
 		visible = {
 			ASL = { owns_state = 395 }
@@ -7157,7 +6842,7 @@ libya_aftermath_of_civil_war = {
 			}
 			else = {
 				start_border_war = {
-					   change_state_after_war = yes
+					change_state_after_war = yes
 					attacker = {
 						state = 397
 						num_of_provinces = 2
@@ -7175,6 +6860,7 @@ libya_aftermath_of_civil_war = {
 	}
 
 	libya_attack_ansar_al_sharia_in_derna = {
+
 		fixed_random_seed = no
 
 		icon = military_plan
@@ -7183,18 +6869,11 @@ libya_aftermath_of_civil_war = {
 
 		days_remove = 14
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 396
-			}
-		}
-
+		highlight_states = { highlight_state_targets = { state = 396 } }
 
 		visible = {
 			396 = { has_dynamic_modifier = { modifier = LBA_shura_council_of_derna } }
@@ -7249,6 +6928,7 @@ libya_aftermath_of_civil_war = {
 	}
 
 	libya_attack_ansar_al_sharia_in_ajdabiya = {
+
 		fixed_random_seed = no
 
 		icon = military_plan
@@ -7257,18 +6937,11 @@ libya_aftermath_of_civil_war = {
 
 		days_remove = 14
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 397
-			}
-		}
-
+		highlight_states = { highlight_state_targets = { state = 397 } }
 
 		visible = {
 			397 = { has_dynamic_modifier = { modifier = LBA_shura_council_of_ajdabiya } }
@@ -7332,18 +7005,11 @@ libya_aftermath_of_civil_war = {
 
 		days_remove = 90
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
 
-		highlight_states = {
-			highlight_state_targets = {
-				state = 1100
-			}
-		}
-
+		highlight_states = { highlight_state_targets = { state = 1100 } }
 
 		visible = {
 			1100 = { has_dynamic_modifier = { modifier = LBA_southern_insurgency } }
@@ -7359,9 +7025,7 @@ libya_aftermath_of_civil_war = {
 			397 = { NOT = { has_dynamic_modifier = { modifier = LBA_shura_council_of_ajdabiya } } }
 		}
 
-		modifier = {
-			personnel_cost_multiplier_modifier = 0.10
-		}
+		modifier = { personnel_cost_multiplier_modifier = 0.10 }
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision remove libya_attack_ansar_al_sharia_in_kufra [FROM.GetName]"
@@ -7383,12 +7047,9 @@ libya_aftermath_of_civil_war = {
 
 		days_remove = 14
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
-
 
 		visible = {
 			ASL = { owns_state = 919 }
@@ -7494,6 +7155,7 @@ libya_aftermath_of_civil_war = {
 	}
 
 	libya_attack_ansar_al_sharia_in_sabha = {
+
 		fixed_random_seed = no
 
 		icon = military_plan
@@ -7502,12 +7164,9 @@ libya_aftermath_of_civil_war = {
 
 		days_remove = 14
 
-		custom_cost_trigger = {
-			command_power > 50
-		}
+		custom_cost_trigger = { command_power > 50 }
 
 		custom_cost_text = command_power_more_than_50
-
 
 		visible = {
 			392 = { is_demilitarized_zone = yes }
@@ -7583,13 +7242,9 @@ libya_aftermath_of_civil_war = {
 
 	libya_operation_dignity_mission = {
 
-		activation = {
-			always = no
-		}
+		activation = { always = no }
 
-		available = {
-			NOT = { country_exists = ASL }
-		}
+		available = { NOT = { country_exists = ASL } }
 
 		cancel_trigger = {
 			OR = {
@@ -7602,6 +7257,7 @@ libya_aftermath_of_civil_war = {
 		}
 
 		is_good = no
+
 		war_with_on_timeout = ASL
 
 		days_mission_timeout = 600
@@ -7649,7 +7305,6 @@ libya_aftermath_of_civil_war = {
 							state = 579
 						}
 					}
-
 					set_country_flag = LBA_this_is_LNA
 					set_cosmetic_tag = LBA_LIBYAN_NATIONAL_ARMY
 					clr_country_flag = dynamic_flag
@@ -7663,7 +7318,6 @@ libya_aftermath_of_civil_war = {
 						LBA_saqr_geroushi = { set_nationality = PREV.PREV }
 						LBA_faraj_al_mahdawi = { set_nationality = PREV.PREV }
 					}
-
 					if = {
 						limit = { ROOT = { has_completed_focus = LBA_libyan_national_army } }
 						unlock_national_focus = LBA_libyan_national_army
@@ -7686,7 +7340,6 @@ libya_aftermath_of_civil_war = {
 					type = civil_war
 				}
 				add_civil_war_target = ASL
-
 				if = {
 					limit = {
 						ASL = { NOT = { has_template = "Liwa al-Shuhada" } }

--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -1,21 +1,23 @@
 MER_mercosur_diplomacy = {
 
 	MER_invite_CHL_full_member = {
+
 		allowed = { NOT = { original_tag = CHL } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			CHL = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_chl_accession_pending }
 			}
 		}
@@ -29,7 +31,7 @@ MER_mercosur_diplomacy = {
 			CHL = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_chl_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -64,22 +66,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_PRU_associate = {
+
 		allowed = { NOT = { original_tag = PRU } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			PRU = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -92,7 +96,7 @@ MER_mercosur_diplomacy = {
 			PRU = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -126,21 +130,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_PRU_full_member = {
+
 		allowed = { NOT = { original_tag = PRU } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			PRU = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_pru_accession_pending }
 			}
 		}
@@ -154,7 +160,7 @@ MER_mercosur_diplomacy = {
 			PRU = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_pru_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -189,22 +195,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_COL_associate = {
+
 		allowed = { NOT = { original_tag = COL } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			COL = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -217,7 +225,7 @@ MER_mercosur_diplomacy = {
 			COL = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -251,21 +259,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_COL_full_member = {
+
 		allowed = { NOT = { original_tag = COL } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			COL = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_col_accession_pending }
 			}
 		}
@@ -279,7 +289,7 @@ MER_mercosur_diplomacy = {
 			COL = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_col_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -314,22 +324,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_ECU_associate = {
+
 		allowed = { NOT = { original_tag = ECU } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			ECU = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -342,7 +354,7 @@ MER_mercosur_diplomacy = {
 			ECU = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -376,21 +388,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_ECU_full_member = {
+
 		allowed = { NOT = { original_tag = ECU } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			ECU = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_ecu_accession_pending }
 			}
 		}
@@ -404,7 +418,7 @@ MER_mercosur_diplomacy = {
 			ECU = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_ecu_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -439,22 +453,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_VEN_associate = {
+
 		allowed = { NOT = { original_tag = VEN } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			VEN = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -467,7 +483,7 @@ MER_mercosur_diplomacy = {
 			VEN = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -501,21 +517,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_VEN_full_member = {
+
 		allowed = { NOT = { original_tag = VEN } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			VEN = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_ven_accession_pending }
 			}
 		}
@@ -529,7 +547,7 @@ MER_mercosur_diplomacy = {
 			VEN = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_ven_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -564,21 +582,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_BOL_full_member = {
+
 		allowed = { NOT = { original_tag = BOL } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			BOL = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_bol_accession_pending }
 			}
 		}
@@ -592,7 +612,7 @@ MER_mercosur_diplomacy = {
 			BOL = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_bol_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -627,22 +647,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_GUY_associate = {
+
 		allowed = { NOT = { original_tag = GUY } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			GUY = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -655,7 +677,7 @@ MER_mercosur_diplomacy = {
 			GUY = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -689,21 +711,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_GUY_full_member = {
+
 		allowed = { NOT = { original_tag = GUY } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			GUY = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_guy_accession_pending }
 			}
 		}
@@ -717,7 +741,7 @@ MER_mercosur_diplomacy = {
 			GUY = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_guy_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -752,22 +776,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_SUR_associate = {
+
 		allowed = { NOT = { original_tag = SUR } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			SUR = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -780,7 +806,7 @@ MER_mercosur_diplomacy = {
 			SUR = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -814,21 +840,23 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_SUR_full_member = {
+
 		allowed = { NOT = { original_tag = SUR } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_dynamic_modifier = mercosur_member_state_modifier
 			SUR = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_sur_accession_pending }
 			}
 		}
@@ -842,7 +870,7 @@ MER_mercosur_diplomacy = {
 			SUR = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_sur_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -877,23 +905,25 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_MEX_associate = {
+
 		allowed = { NOT = { original_tag = MEX } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_global_flag = mercosur_latin_america_invites_unlocked
 			has_dynamic_modifier = mercosur_member_state_modifier
 			MEX = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -907,7 +937,7 @@ MER_mercosur_diplomacy = {
 			MEX = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -941,22 +971,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_MEX_full_member = {
+
 		allowed = { NOT = { original_tag = MEX } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_global_flag = mercosur_latin_america_invites_unlocked
 			has_dynamic_modifier = mercosur_member_state_modifier
 			MEX = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_mex_accession_pending }
 			}
 		}
@@ -971,7 +1003,7 @@ MER_mercosur_diplomacy = {
 			MEX = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_mex_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -1006,23 +1038,25 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_PAN_associate = {
+
 		allowed = { NOT = { original_tag = PAN } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 30
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_global_flag = mercosur_latin_america_invites_unlocked
 			has_dynamic_modifier = mercosur_member_state_modifier
 			PAN = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			}
 		}
 
@@ -1036,7 +1070,7 @@ MER_mercosur_diplomacy = {
 			PAN = {
 				exists = yes
 				NOT = { has_idea = BRA_idea_associate_states }
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 				has_elections = yes
 				NOT = { has_country_flag = partyall_banned }
@@ -1070,22 +1104,24 @@ MER_mercosur_diplomacy = {
 	}
 
 	MER_invite_PAN_full_member = {
+
 		allowed = { NOT = { original_tag = PAN } }
 
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
+
 		days_remove = 45
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_mercosur_requests_enabled
 			has_global_flag = mercosur_latin_america_invites_unlocked
 			has_dynamic_modifier = mercosur_member_state_modifier
 			PAN = {
 				exists = yes
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_pan_accession_pending }
 			}
 		}
@@ -1100,7 +1136,7 @@ MER_mercosur_diplomacy = {
 			PAN = {
 				exists = yes
 				has_idea = BRA_idea_associate_states
-				NOT = {	has_dynamic_modifier = mercosur_member_state_modifier }
+				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				NOT = { has_country_flag = mercosur_pan_accession_pending }
 				is_subject = no
 				has_elections = yes
@@ -1134,7 +1170,8 @@ MER_mercosur_diplomacy = {
 		}
 	}
 
-MER_request_mercosur_associate_membership = {
+	MER_request_mercosur_associate_membership = {
+
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
@@ -1189,7 +1226,8 @@ MER_request_mercosur_associate_membership = {
 		ai_will_do = { base = 0 }
 	}
 
-MER_request_mercosur_full_membership = {
+	MER_request_mercosur_full_membership = {
+
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
@@ -1273,7 +1311,8 @@ MER_request_mercosur_full_membership = {
 		ai_will_do = { base = 0 }
 	}
 
-MER_request_unasul_membership = {
+	MER_request_unasul_membership = {
+
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
@@ -1355,8 +1394,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_CHL_tariff_alignment = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 35
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1387,7 +1429,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_CHL_tariff_alignment"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
-
 			CHL = {
 				set_country_flag = mercosur_chl_accession_mission_1_done
 				country_event = mercosur.27
@@ -1399,8 +1440,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_CHL_customs_system_modernization = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 45
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1431,7 +1475,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_CHL_customs_system_modernization"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			CHL = {
 				set_country_flag = mercosur_chl_accession_mission_2_done
 				country_event = mercosur.27
@@ -1443,8 +1486,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_CHL_common_standards = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 50
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1475,7 +1521,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_CHL_common_standards"
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
-
 			CHL = {
 				set_country_flag = mercosur_chl_accession_mission_3_done
 				country_event = mercosur.27
@@ -1487,8 +1532,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_COL_tariff_alignment = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 35
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1519,7 +1567,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_COL_tariff_alignment"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
-
 			COL = {
 				set_country_flag = mercosur_col_accession_mission_1_done
 				country_event = mercosur.27
@@ -1531,8 +1578,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_COL_customs_system_modernization = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 45
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1563,7 +1613,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_COL_customs_system_modernization"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			COL = {
 				set_country_flag = mercosur_col_accession_mission_2_done
 				country_event = mercosur.27
@@ -1575,8 +1624,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_COL_common_standards = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 50
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1607,7 +1659,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_COL_common_standards"
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
-
 			COL = {
 				set_country_flag = mercosur_col_accession_mission_3_done
 				country_event = mercosur.27
@@ -1619,8 +1670,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_VEN_tariff_alignment = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 35
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1651,7 +1705,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_VEN_tariff_alignment"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
-
 			VEN = {
 				set_country_flag = mercosur_ven_accession_mission_1_done
 				country_event = mercosur.27
@@ -1663,8 +1716,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_VEN_customs_system_modernization = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 45
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1695,7 +1751,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_VEN_customs_system_modernization"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			VEN = {
 				set_country_flag = mercosur_ven_accession_mission_2_done
 				country_event = mercosur.27
@@ -1707,8 +1762,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_VEN_common_standards = {
+
 		icon = GFX_decision_generic_diplomacy
+
 		cost = 50
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1739,7 +1797,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_VEN_common_standards"
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
-
 			VEN = {
 				set_country_flag = mercosur_ven_accession_mission_3_done
 				country_event = mercosur.27
@@ -1751,8 +1808,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_PRU_logistics_corridor = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 25
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1783,7 +1843,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_PRU_logistics_corridor"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			PRU = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -1811,8 +1870,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_PRU_cross_border_transport = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1843,7 +1905,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_PRU_cross_border_transport"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			PRU = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -1871,8 +1932,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_PRU_port_connectivity = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1903,7 +1967,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_PRU_port_connectivity"
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
-
 			PRU = {
 				random_owned_controlled_state = {
 					limit = { network_infrastructure_random_build_loc = yes }
@@ -1931,8 +1994,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_BOL_logistics_corridor = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 25
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -1963,7 +2029,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_BOL_logistics_corridor"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			BOL = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -1991,8 +2056,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_BOL_overland_transport = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2023,7 +2091,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_BOL_overland_transport"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			BOL = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -2051,8 +2118,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_BOL_border_connectivity = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2083,7 +2153,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_BOL_border_connectivity"
 			set_temp_variable = { treasury_change = -6.0 }
 			modify_treasury_effect = yes
-
 			BOL = {
 				random_owned_controlled_state = {
 					limit = { network_infrastructure_random_build_loc = yes }
@@ -2111,8 +2180,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_PAN_logistics_corridor = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 25
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2143,7 +2215,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_PAN_logistics_corridor"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			PAN = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -2171,8 +2242,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_PAN_port_transport = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2203,7 +2277,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_PAN_port_transport"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			PAN = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -2231,8 +2304,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_PAN_trade_connectivity = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2263,7 +2339,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_PAN_trade_connectivity"
 			set_temp_variable = { treasury_change = -6.0 }
 			modify_treasury_effect = yes
-
 			PAN = {
 				random_owned_controlled_state = {
 					limit = { network_infrastructure_random_build_loc = yes }
@@ -2291,8 +2366,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_ECU_development_funds = {
+
 		icon = GFX_decision_money_dec
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2323,11 +2401,9 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_ECU_development_funds"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			ECU = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
-
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
 						type = offices
@@ -2345,8 +2421,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_ECU_civilian_industry = {
+
 		icon = GFX_decision_generic_factory
+
 		cost = 25
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2377,7 +2456,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_ECU_civilian_industry"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
-
 			ECU = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
@@ -2398,8 +2476,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_ECU_infrastructure_development = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2430,7 +2511,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_ECU_infrastructure_development"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			ECU = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -2458,8 +2538,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_GUY_development_funds = {
+
 		icon = GFX_decision_money_dec
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2490,11 +2573,9 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_GUY_development_funds"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			GUY = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
-
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
 						type = offices
@@ -2517,8 +2598,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_GUY_civilian_industry = {
+
 		icon = GFX_decision_generic_factory
+
 		cost = 25
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2549,7 +2633,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_GUY_civilian_industry"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
-
 			GUY = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
@@ -2570,8 +2653,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_GUY_infrastructure_development = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2602,7 +2688,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_GUY_infrastructure_development"
 			set_temp_variable = { treasury_change = -7.0 }
 			modify_treasury_effect = yes
-
 			GUY = {
 				random_owned_controlled_state = {
 					limit = { infrastructure_random_build_loc = yes }
@@ -2630,8 +2715,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_SUR_development_funds = {
+
 		icon = GFX_decision_money_dec
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2662,11 +2750,9 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_SUR_development_funds"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			SUR = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
-
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
 						type = offices
@@ -2684,8 +2770,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_SUR_civilian_industry = {
+
 		icon = GFX_decision_generic_factory
+
 		cost = 25
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2716,7 +2805,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_SUR_civilian_industry"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
-
 			SUR = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
@@ -2737,8 +2825,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_SUR_commercial_infrastructure = {
+
 		icon = GFX_decision_generic_construction
+
 		cost = 20
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2769,11 +2860,9 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_SUR_commercial_infrastructure"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			SUR = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
-
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
 						type = offices
@@ -2791,8 +2880,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_MEX_industrial_investment_agreement = {
+
 		icon = GFX_decision_generic_factory
+
 		cost = 35
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2823,7 +2915,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_MEX_industrial_investment_agreement"
 			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
-
 			MEX = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
@@ -2844,8 +2935,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_MEX_commercial_investment_framework = {
+
 		icon = GFX_decision_money_dec
+
 		cost = 30
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2876,11 +2970,9 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_MEX_commercial_investment_framework"
 			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-
 			MEX = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
-
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
 						type = offices
@@ -2898,8 +2990,11 @@ MER_request_unasul_membership = {
 	}
 
 	MER_MEX_financial_cooperation_package = {
+
 		icon = GFX_decision_money_dec
+
 		cost = 45
+
 		fire_only_once = yes
 
 		days_remove = 30
@@ -2930,11 +3025,9 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_MEX_financial_cooperation_package"
 			set_temp_variable = { treasury_change = -19.5 }
 			modify_treasury_effect = yes
-
 			MEX = {
 				random_owned_controlled_state = {
 					limit = { free_shared_building_slots = yes }
-
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
 						type = offices
@@ -2961,7 +3054,9 @@ MER_request_unasul_membership = {
 	}
 
 	MER_release_development_fund_round = {
+
 		icon = GFX_decision_money_dec
+
 		visible = {
 			OR = {
 				has_completed_focus = MER_development_fund
@@ -2983,6 +3078,7 @@ MER_request_unasul_membership = {
 		}
 
 		days_re_enable = 365
+
 		cost = 75
 
 		complete_effect = {
@@ -2990,7 +3086,6 @@ MER_request_unasul_membership = {
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 			set_global_flag = MER_release_development_fund_round_cooldown
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				tooltip = TT_ALL_MERCOSUR_POTENTIAL_NATIONS_GAIN
@@ -3003,14 +3098,12 @@ MER_request_unasul_membership = {
 					country_event = mercosur.108
 				}
 			}
-
 			effect_tooltip = {
 				add_timed_idea = {
 					idea = MER_development_fund_round_modifier
 					days = 180
 				}
 			}
-
 			country_event = { id = mercosur.34 days = 365 }
 		}
 
@@ -3024,6 +3117,7 @@ MER_request_unasul_membership = {
 	}
 
 	MER_invite_to_unasul = {
+
 		icon = GFX_decision_generic_diplomacy
 
 		cost = 75
@@ -3032,14 +3126,12 @@ MER_request_unasul_membership = {
 
 		days_re_enable = 180
 
-		visible = {
+		target_root_trigger = {
 			has_global_flag = MER_unasul_established
 			has_dynamic_modifier = unasul_member_state_modifier
 		}
 
 		available = {
-			has_global_flag = MER_unasul_expansion_enabled
-			has_dynamic_modifier = unasul_member_state_modifier
 			is_subject = no
 			FROM = {
 				has_elections = yes
@@ -3087,10 +3179,10 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_integrated_corridor_plan = {
+
 		icon = GFX_decision_crossrail
 
 		cost = 75
-
 
 		visible = {
 			has_completed_focus = MER_sa_corridor_development
@@ -3109,7 +3201,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_unasul_integrated_corridor_plan"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				tooltip = TT_ALL_MERCOSUR_POTENTIAL_NATIONS_GAIN
@@ -3122,14 +3213,12 @@ MER_request_unasul_membership = {
 					country_event = mercosur.50
 				}
 			}
-
 			effect_tooltip = {
 				add_timed_idea = {
 					idea = MER_unasul_integrated_corridor_plan_modifier
 					days = 180
 				}
 			}
-
 			set_global_flag = MER_unasul_integrated_corridor_plan_cooldown
 			country_event = { id = mercosur.71 days = 365 }
 		}
@@ -3144,10 +3233,10 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_counter_cartel_operation = {
+
 		icon = GFX_decision_category_cartel
 
 		cost = 75
-
 
 		visible = {
 			has_completed_focus = MER_counter_cartel
@@ -3171,7 +3260,6 @@ MER_request_unasul_membership = {
 			custom_effect_tooltip = MER_unasul_counter_cartel_operation_tt
 			set_variable = { global.MER_unasul_counter_cartel_high_commitment = 0 }
 			set_variable = { global.MER_unasul_counter_cartel_participants = 0 }
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {
@@ -3184,7 +3272,6 @@ MER_request_unasul_membership = {
 					country_event = { id = mercosur.60 days = 1 }
 				}
 			}
-
 			set_global_flag = MER_unasul_counter_cartel_operation_cooldown
 			country_event = { id = mercosur.63 days = 7 }
 			country_event = { id = mercosur.74 days = 180 }
@@ -3194,10 +3281,10 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_energy_security_reinforcement = {
+
 		icon = GFX_decision_energy_build_button
 
 		cost = 75
-
 
 		visible = {
 			has_completed_focus = MER_sa_energy_council
@@ -3216,7 +3303,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_unasul_energy_security_reinforcement"
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				tooltip = TT_ALL_MERCOSUR_POTENTIAL_NATIONS_GAIN
@@ -3229,14 +3315,12 @@ MER_request_unasul_membership = {
 					country_event = mercosur.53
 				}
 			}
-
 			effect_tooltip = {
 				add_timed_idea = {
 					idea = MER_unasul_energy_security_modifier
 					days = 180
 				}
 			}
-
 			set_global_flag = MER_unasul_energy_security_reinforcement_cooldown
 			country_event = { id = mercosur.72 days = 365 }
 		}
@@ -3251,6 +3335,7 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_joint_health_improvement_project = {
+
 		icon = GFX_decision_ISR_healthcare_button
 
 		cost = 75
@@ -3278,7 +3363,6 @@ MER_request_unasul_membership = {
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			set_global_flag = MER_unasul_joint_health_improvement_project_active
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {
@@ -3297,7 +3381,6 @@ MER_request_unasul_membership = {
 			}
 			add_to_variable = { global.MER_unasul_joint_health_improvement_project_rounds = 1 }
 			add_to_variable = { global.MER_unasul_monthly_population = 0.02 tooltip = monthly_population_tt }
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {
@@ -3311,6 +3394,7 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_supply_chain_strengthening = {
+
 		icon = GFX_decision_generic_factory
 
 		cost = 75
@@ -3338,7 +3422,6 @@ MER_request_unasul_membership = {
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 			set_global_flag = MER_unasul_supply_chain_strengthening_active
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {
@@ -3357,7 +3440,6 @@ MER_request_unasul_membership = {
 			}
 			add_to_variable = { global.MER_unasul_supply_chain_strengthening_rounds = 1 }
 			add_to_variable = { global.MER_unasul_production_speed_industrial_complex_factor = 0.03 tooltip = civilian_factories_productivity_tt }
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {
@@ -3371,10 +3453,10 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_joint_exercises = {
+
 		icon = GFX_decision_jet_transport
 
 		cost = 75
-
 
 		visible = {
 			has_completed_focus = MER_sa_defense_council
@@ -3393,7 +3475,6 @@ MER_request_unasul_membership = {
 			log = "[GetDateText]: [Root.GetName]: Decision MER_unasul_joint_exercises"
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				tooltip = TT_ALL_MERCOSUR_POTENTIAL_NATIONS_GAIN
@@ -3406,14 +3487,12 @@ MER_request_unasul_membership = {
 					country_event = mercosur.56
 				}
 			}
-
 			effect_tooltip = {
 				add_timed_idea = {
 					idea = MER_unasul_joint_exercises_modifier
 					days = 180
 				}
 			}
-
 			set_global_flag = MER_unasul_joint_exercises_cooldown
 			country_event = { id = mercosur.73 days = 365 }
 		}
@@ -3428,6 +3507,7 @@ MER_request_unasul_membership = {
 	}
 
 	MER_unasul_joint_research_exchange_project = {
+
 		icon = GFX_decision_generic_research
 
 		cost = 75
@@ -3455,7 +3535,6 @@ MER_request_unasul_membership = {
 			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 			set_global_flag = MER_unasul_joint_research_exchange_project_active
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {
@@ -3474,7 +3553,6 @@ MER_request_unasul_membership = {
 			}
 			add_to_variable = { global.MER_unasul_joint_research_exchange_project_rounds = 1 }
 			add_to_variable = { global.MER_unasul_research_speed_factor = 0.02 tooltip = research_speed_factor_tt }
-
 			for_each_scope_loop = {
 				array = global.mercosur_potential
 				if = {

--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -1218,7 +1218,7 @@ MER_mercosur_diplomacy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove_effect"
+			log = "[GetDateText]: [Root.GetName]: Decision remove_effect MER_request_mercosur_associate_membership"
 			country_event = mercosur.104
 			custom_effect_tooltip = MER_request_mercosur_associate_membership_tt
 		}
@@ -1302,7 +1302,7 @@ MER_mercosur_diplomacy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove_effect"
+			log = "[GetDateText]: [Root.GetName]: Decision remove_effect MER_request_mercosur_full_membership"
 			country_event = mercosur.92
 			country_event = mercosur.94
 			custom_effect_tooltip = MER_request_mercosur_full_membership_tt
@@ -1385,7 +1385,7 @@ MER_mercosur_diplomacy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove_effect"
+			log = "[GetDateText]: [Root.GetName]: Decision remove_effect MER_request_unasul_membership"
 			country_event = mercosur.106
 			custom_effect_tooltip = MER_request_unasul_membership_tt
 		}

--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -1218,7 +1218,7 @@ MER_mercosur_diplomacy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove_effect MER_request_mercosur_associate_membership"
+			log = "[GetDateText]: [Root.GetName]: Decision MER_request_mercosur_associate_membership"
 			country_event = mercosur.104
 			custom_effect_tooltip = MER_request_mercosur_associate_membership_tt
 		}
@@ -1302,7 +1302,7 @@ MER_mercosur_diplomacy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove_effect MER_request_mercosur_full_membership"
+			log = "[GetDateText]: [Root.GetName]: Decision MER_request_mercosur_full_membership"
 			country_event = mercosur.92
 			country_event = mercosur.94
 			custom_effect_tooltip = MER_request_mercosur_full_membership_tt
@@ -1385,7 +1385,7 @@ MER_mercosur_diplomacy = {
 		}
 
 		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision remove_effect MER_request_unasul_membership"
+			log = "[GetDateText]: [Root.GetName]: Decision MER_request_unasul_membership"
 			country_event = mercosur.106
 			custom_effect_tooltip = MER_request_unasul_membership_tt
 		}

--- a/common/decisions/netherlands.txt
+++ b/common/decisions/netherlands.txt
@@ -1,5 +1,7 @@
 HOL_ing_group_strategy_category = {
+
 	HOL_ing_group_strategies_expansion_GER = {
+
 		priority = 50
 
 		icon = GFX_decision_germany
@@ -34,15 +36,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_GER"
@@ -68,7 +66,9 @@ HOL_ing_group_strategy_category = {
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_POL = {
+
 		priority = 50
 
 		icon = GFX_decision_poland
@@ -103,15 +103,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_POL"
@@ -125,19 +121,21 @@ HOL_ing_group_strategy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_POL"
-				custom_effect_tooltip = {
-					localization_key = modifies_dynamic_modifier_tt
-					MODIFIER = HOL_economy
-				}
-				add_to_variable = { HOL_economy_consumer_goods_factor = -0.10 tooltip = consumer_goods_factor_tt }
-				set_temp_variable = { percent_change = 5 }
-				set_temp_variable = { influence_target = POL }
-				change_influence_percentage = yes
-				add_to_variable = { HOL_ing_group_upgrades = 1 }
-				clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
+			custom_effect_tooltip = {
+				localization_key = modifies_dynamic_modifier_tt
+				MODIFIER = HOL_economy
+			}
+			add_to_variable = { HOL_economy_consumer_goods_factor = -0.10 tooltip = consumer_goods_factor_tt }
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { influence_target = POL }
+			change_influence_percentage = yes
+			add_to_variable = { HOL_ing_group_upgrades = 1 }
+			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_AST = {
+
 		priority = 50
 
 		icon = GFX_decision_australia
@@ -172,15 +170,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_AST"
@@ -194,19 +188,21 @@ HOL_ing_group_strategy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_AST"
-				custom_effect_tooltip = {
-					localization_key = modifies_dynamic_modifier_tt
-					MODIFIER = HOL_economy
-				}
-				add_to_variable = { HOL_economy_research_speed_factor = 0.05 tooltip = research_speed_factor_tt }
-				set_temp_variable = { percent_change = 5 }
-				set_temp_variable = { influence_target = AST }
-				change_influence_percentage = yes
-				add_to_variable = { HOL_ing_group_upgrades = 1 }
-				clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
+			custom_effect_tooltip = {
+				localization_key = modifies_dynamic_modifier_tt
+				MODIFIER = HOL_economy
+			}
+			add_to_variable = { HOL_economy_research_speed_factor = 0.05 tooltip = research_speed_factor_tt }
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { influence_target = AST }
+			change_influence_percentage = yes
+			add_to_variable = { HOL_ing_group_upgrades = 1 }
+			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_SPR = {
+
 		priority = 50
 
 		icon = GFX_decision_spain2
@@ -241,15 +237,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_SPR"
@@ -263,19 +255,21 @@ HOL_ing_group_strategy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_SPR"
-				custom_effect_tooltip = {
-					localization_key = modifies_dynamic_modifier_tt
-					MODIFIER = HOL_economy
-				}
-				add_to_variable = { HOL_economy_production_speed_buildings_factor = 0.10 tooltip = production_speed_buildings_factor_tt }
-				set_temp_variable = { percent_change = 5 }
-				set_temp_variable = { influence_target = SPR }
-				change_influence_percentage = yes
-				add_to_variable = { HOL_ing_group_upgrades = 1 }
-				clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
+			custom_effect_tooltip = {
+				localization_key = modifies_dynamic_modifier_tt
+				MODIFIER = HOL_economy
+			}
+			add_to_variable = { HOL_economy_production_speed_buildings_factor = 0.10 tooltip = production_speed_buildings_factor_tt }
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { influence_target = SPR }
+			change_influence_percentage = yes
+			add_to_variable = { HOL_ing_group_upgrades = 1 }
+			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_ITA = {
+
 		priority = 50
 
 		icon = GFX_decision_italy
@@ -310,15 +304,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA"
@@ -332,19 +322,21 @@ HOL_ing_group_strategy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ITA"
-				custom_effect_tooltip = {
-					localization_key = modifies_dynamic_modifier_tt
-					MODIFIER = HOL_economy
-				}
-				add_to_variable = { HOL_economy_offices_productivity = 0.05 tooltip = offices_productivity_tt }
-				set_temp_variable = { percent_change = 5 }
-				set_temp_variable = { influence_target = ITA }
-				change_influence_percentage = yes
-				add_to_variable = { HOL_ing_group_upgrades = 1 }
-				clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
+			custom_effect_tooltip = {
+				localization_key = modifies_dynamic_modifier_tt
+				MODIFIER = HOL_economy
+			}
+			add_to_variable = { HOL_economy_offices_productivity = 0.05 tooltip = offices_productivity_tt }
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { influence_target = ITA }
+			change_influence_percentage = yes
+			add_to_variable = { HOL_ing_group_upgrades = 1 }
+			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_TUR = {
+
 		priority = 50
 
 		icon = GFX_decision_turkey
@@ -379,15 +371,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_TUR"
@@ -401,19 +389,21 @@ HOL_ing_group_strategy_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_TUR"
-				custom_effect_tooltip = {
-					localization_key = modifies_dynamic_modifier_tt
-					MODIFIER = HOL_economy
-				}
-				add_to_variable = { HOL_economy_trade_opinion_factor = 0.20 tooltip = trade_opinion_factor_tt }
-				set_temp_variable = { percent_change = 5 }
-				set_temp_variable = { influence_target = TUR }
-				change_influence_percentage = yes
-				add_to_variable = { HOL_ing_group_upgrades = 1 }
-				clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
+			custom_effect_tooltip = {
+				localization_key = modifies_dynamic_modifier_tt
+				MODIFIER = HOL_economy
+			}
+			add_to_variable = { HOL_economy_trade_opinion_factor = 0.20 tooltip = trade_opinion_factor_tt }
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { influence_target = TUR }
+			change_influence_percentage = yes
+			add_to_variable = { HOL_ing_group_upgrades = 1 }
+			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_USA = {
+
 		priority = 50
 
 		icon = GFX_decision_usa
@@ -448,15 +438,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_USA"
@@ -482,7 +468,9 @@ HOL_ing_group_strategy_category = {
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_ROM = {
+
 		priority = 50
 
 		icon = GFX_decision_romania
@@ -517,15 +505,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades < 3 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades < 3 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 6
-		}
+		modifier = { civilian_factory_use = 6 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_ROM"
@@ -551,15 +535,14 @@ HOL_ing_group_strategy_category = {
 			clr_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_speciality1 = {
+
 		priority = 13
 
 		icon = GFX_decision_syr_burecrats_button
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			NOT = { has_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag }
@@ -570,15 +553,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades > 2 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades > 2 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 12
-		}
+		modifier = { civilian_factory_use = 12 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality1"
@@ -589,6 +568,7 @@ HOL_ing_group_strategy_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality1"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality1"
 			custom_effect_tooltip = {
@@ -603,15 +583,14 @@ HOL_ing_group_strategy_category = {
 			set_country_flag = HOL_ing_fully_upgraded
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_speciality2 = {
+
 		priority = 13
 
 		icon = GFX_decision_syr_burecrats_button
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			NOT = { has_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag }
@@ -622,15 +601,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades > 2 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades > 2 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 12
-		}
+		modifier = { civilian_factory_use = 12 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality2"
@@ -641,6 +616,7 @@ HOL_ing_group_strategy_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality2"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality2"
 			custom_effect_tooltip = {
@@ -655,15 +631,14 @@ HOL_ing_group_strategy_category = {
 			set_country_flag = HOL_ing_fully_upgraded
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_speciality3 = {
+
 		priority = 13
 
 		icon = GFX_decision_syr_burecrats_button
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			NOT = { has_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag }
@@ -674,15 +649,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades > 2 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades > 2 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 12
-		}
+		modifier = { civilian_factory_use = 12 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality3"
@@ -693,6 +664,7 @@ HOL_ing_group_strategy_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality3"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality3"
 			custom_effect_tooltip = {
@@ -707,15 +679,14 @@ HOL_ing_group_strategy_category = {
 			set_country_flag = HOL_ing_fully_upgraded
 		}
 	}
+
 	HOL_ing_group_strategies_expansion_speciality4 = {
+
 		priority = 13
 
 		icon = GFX_decision_syr_burecrats_button
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			NOT = { has_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag }
@@ -726,15 +697,11 @@ HOL_ing_group_strategy_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			check_variable = { HOL_ing_group_upgrades > 2 }
-		}
+		visible = { check_variable = { HOL_ing_group_upgrades > 2 } }
 
 		cost = 75
 
-		modifier = {
-			civilian_factory_use = 12
-		}
+		modifier = { civilian_factory_use = 12 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality4"
@@ -745,6 +712,7 @@ HOL_ing_group_strategy_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality4"
 			set_country_flag = HOL_ING_Group_Strategy_upgrade_in_progress_flag
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_ing_group_strategies_expansion_speciality4"
 			custom_effect_tooltip = {
@@ -759,16 +727,20 @@ HOL_ing_group_strategy_category = {
 			set_country_flag = HOL_ing_fully_upgraded
 		}
 	}
-
 }
 HOL_carrier_production = {
+
 	HOL_request_carrier_production_USA = {
+
 		icon = GFX_devision_HOL_air_carrier
+
 		targets = { USA }
+
 		target_root_trigger = {
 			NOT = { has_country_flag = HOL_Carrier_Production_in_progress_flag_USA }
 			NOT = { has_country_flag = HOL_Carrier_Production_Completed_USA }
 		}
+
 		available = {
 			has_opinion = {
 				target = USA
@@ -810,13 +782,18 @@ HOL_carrier_production = {
 
 		ai_will_do = { base = 50 }
 	}
+
 	HOL_request_carrier_production_uk = {
+
 		icon = GFX_devision_HOL_air_carrier
+
 		targets = { ENG }
+
 		target_root_trigger = {
 			NOT = { has_country_flag = HOL_Carrier_Production_in_progress_flag_UK }
 			NOT = { has_country_flag = HOL_Carrier_Production_Completed_UK }
 		}
+
 		available = {
 			NOT = { has_country_flag = HOL_accepted_FRA_carrier }
 			has_opinion = {
@@ -849,21 +826,29 @@ HOL_carrier_production = {
 				has_country_flag = HOL_Carrier_Production_Available_UK
 			}
 		}
+
 		cost = 75
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_uk"
 			ENG = { country_event = HOL_military.052 }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_UK
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_request_carrier_production_FRA = {
+
 		icon = GFX_devision_HOL_air_carrier
+
 		targets = { FRA }
+
 		target_root_trigger = {
 			NOT = { has_country_flag = HOL_Carrier_Production_in_progress_flag_FRA }
 			NOT = { has_country_flag = HOL_Carrier_Production_Completed_FRA }
 		}
+
 		available = {
 			has_opinion = {
 				target = FRA
@@ -895,22 +880,30 @@ HOL_carrier_production = {
 				has_country_flag = HOL_Carrier_Production_Available_FRA
 			}
 		}
+
 		cost = 75
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_FRA"
 			FRA = { country_event = { id = HOL_military.055 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_FRA
 			set_country_flag = HOL_accepted_FRA_carrier
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_request_carrier_production_RUS = {
+
 		icon = GFX_devision_HOL_air_carrier
+
 		targets = { SOV }
+
 		target_root_trigger = {
 			NOT = { has_country_flag = HOL_Carrier_Production_in_progress_flag_RUS }
 			NOT = { has_country_flag = HOL_Carrier_Production_Completed_RUS }
 		}
+
 		available = {
 			has_navy_size = {
 				size > 3
@@ -934,28 +927,35 @@ HOL_carrier_production = {
 				target = SOV
 				value > 80
 			}
-
 			SOV = { is_top5_influencer = yes }
 			NOT = { has_country_flag = HOL_Carrier_Production_Completed_HOL }
 			hidden_trigger = {
 				has_country_flag = HOL_Carrier_Production_Available_RUS
 			}
 		}
+
 		cost = 75
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_RUS"
 			SOV = { country_event = { id = HOL_military.058 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_RUS
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_request_carrier_production_chn = {
+
 		icon = GFX_devision_HOL_air_carrier
+
 		targets = { CHI }
+
 		target_root_trigger = {
 			NOT = { has_country_flag = HOL_Carrier_Production_in_progress_flag_CHN }
 			NOT = { has_country_flag = HOL_Carrier_Production_Completed_CHN }
 		}
+
 		available = {
 			has_opinion = {
 				target = CHI
@@ -967,17 +967,24 @@ HOL_carrier_production = {
 				has_country_flag = HOL_Carrier_Production_Available_CHN
 			}
 		}
+
 		cost = 75
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_chn"
 			CHI = { country_event = { id = HOL_military.061 days = 1 } }
 			set_country_flag = HOL_Carrier_Production_in_progress_flag_CHN
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_request_carrier_production_dutch = {
+
 		icon = GFX_decision_generic_construction
+
 		targets = { HOL }
+
 		available = {
 			NOT = {
 				OR = {
@@ -1002,7 +1009,9 @@ HOL_carrier_production = {
 				has_completed_focus = HOL_maritiem_masterplan
 			}
 		}
+
 		cost = 75
+
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_carrier_production_dutch"
 			create_equipment_variant = {
@@ -1041,7 +1050,9 @@ HOL_carrier_production = {
 	}
 }
 HOL_future_air_defender_program = {
+
 	HOL_FAD_construction = {
+
 		icon = GFX_decision_navy
 
 		allowed = {
@@ -1056,10 +1067,13 @@ HOL_future_air_defender_program = {
 		}
 
 		is_good = yes
+
 		selectable_mission = no
+
 		fire_only_once = no
 
 		activation = { always = no }
+
 		available = { always = no }
 
 		days_mission_timeout = 1825
@@ -1090,12 +1104,15 @@ HOL_future_air_defender_program = {
 			}
 		}
 	}
+
 	HOL_FAD_invite_partner = {
+
 		icon = GFX_decision_generic_form_nation
 
 		allowed = { original_tag = HOL }
 
 		targets = { SWE DEN NRY FIN }
+
 		target_trigger = {
 			FROM = {
 				exists = yes
@@ -1106,7 +1123,7 @@ HOL_future_air_defender_program = {
 			}
 		}
 
-		visible = {
+		target_root_trigger = {
 			has_active_mission = HOL_FAD_construction
 			OR = {
 				has_country_flag = HOL_FAD_GER_declined
@@ -1128,26 +1145,22 @@ HOL_future_air_defender_program = {
 	}
 }
 HOL_influence_flanders = {
+
 	BEL_counter_influence_flanders = {
+
 		icon = GFX_decision_boost
 
-		allowed = {
-			original_tag = BEL
-		}
+		allowed = { original_tag = BEL }
 
 		targets = { BEL }
 
-		target_root_trigger = {
-			HOL = { has_completed_focus = HOL_increase_corporation_vlaanderen }
-		}
+		target_root_trigger = { HOL = { has_completed_focus = HOL_increase_corporation_vlaanderen } }
 
 		cost = 200
 
 		fire_only_once = no
 
-		ai_will_do = {
-			base = 10
-		}
+		ai_will_do = { base = 10 }
 
 		days_remove = 30
 
@@ -1157,12 +1170,12 @@ HOL_influence_flanders = {
 			custom_effect_tooltip = HOL_influence_decreased10
 		}
 	}
+
 	HOL_flanders_high_productivity = {
+
 		icon = GFX_decision_civ_fac
 
-		allowed = {
-			original_tag = HOL
-		}
+		allowed = { original_tag = HOL }
 
 		targets = { BEL }
 
@@ -1178,6 +1191,7 @@ HOL_influence_flanders = {
 		}
 
 		selectable_mission = no
+
 		priority = 100
 
 		activation = {
@@ -1185,12 +1199,12 @@ HOL_influence_flanders = {
 			HOL = { has_completed_focus = HOL_increase_corporation_vlaanderen }
 		}
 	}
+
 	HOL_high_influence_belgium = {
+
 		icon = GFX_decision_hol_radio_oranje
 
-		allowed = {
-			original_tag = HOL
-		}
+		allowed = { original_tag = HOL }
 
 		days_mission_timeout = 80
 
@@ -1204,6 +1218,7 @@ HOL_influence_flanders = {
 		}
 
 		selectable_mission = no
+
 		priority = 100
 
 		activation = {
@@ -1211,12 +1226,12 @@ HOL_influence_flanders = {
 			HOL = { has_completed_focus = HOL_increase_corporation_vlaanderen }
 		}
 	}
+
 	HOL_pro_dutch_in_power = {
+
 		icon = GFX_decision_generic_nationalism
 
-		allowed = {
-			original_tag = HOL
-		}
+		allowed = { original_tag = HOL }
 
 		days_mission_timeout = 80
 
@@ -1230,6 +1245,7 @@ HOL_influence_flanders = {
 		}
 
 		selectable_mission = no
+
 		priority = 100
 
 		activation = {
@@ -1237,12 +1253,12 @@ HOL_influence_flanders = {
 			HOL = { has_completed_focus = HOL_increase_corporation_vlaanderen }
 		}
 	}
+
 	HOL_pro_dutch_coalition = {
+
 		icon = GFX_decision_generic_nationalism
 
-		allowed = {
-			original_tag = HOL
-		}
+		allowed = { original_tag = HOL }
 
 		days_mission_timeout = 80
 
@@ -1256,6 +1272,7 @@ HOL_influence_flanders = {
 		}
 
 		selectable_mission = no
+
 		priority = 100
 
 		activation = {
@@ -1265,8 +1282,11 @@ HOL_influence_flanders = {
 	}
 }
 BEL_referendum_category = {
+
 	BEL_referendum_mission = {
+
 		fixed_random_seed = no
+
 		icon = GFX_decision_generic_political_rally
 
 		allowed = {
@@ -1305,21 +1325,26 @@ BEL_referendum_category = {
 		}
 
 		selectable_mission = no
+
 		priority = 100
 
-		activation = {
-			has_country_flag = HOL_belgium_pressured_annexation
-		}
+		activation = { has_country_flag = HOL_belgium_pressured_annexation }
 	}
 }
 HOL_voc_category_ind = {
+
 	HOL_voc_indonesia_counter_voc = {
+
 		fixed_random_seed = no
+
 		icon = GFX_decision_generic_army_support
 
 		is_good = yes
+
 		days_mission_timeout = 60
+
 		selectable_mission = no
+
 		priority = 100
 
 		activation = {
@@ -1681,9 +1706,10 @@ HOL_voc_category_ind = {
 	}
 }
 HOL_voc_category = {
-	HOL_voc_india_mission1 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_india_mission1 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -1700,9 +1726,7 @@ HOL_voc_category = {
 			RAJ = { is_top3_influencer = yes }
 		}
 
-		activation = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		activation = { has_completed_focus = HOL_financial_influence_india }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_india_mission1"
@@ -1714,9 +1738,10 @@ HOL_voc_category = {
 			}
 		}
 	}
-	HOL_voc_india_mission2 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_india_mission2 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -1746,9 +1771,7 @@ HOL_voc_category = {
 			}
 		}
 
-		activation = {
-			has_completed_focus = HOL_gujurat_trade_port
-		}
+		activation = { has_completed_focus = HOL_gujurat_trade_port }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_india_mission2"
@@ -1775,20 +1798,22 @@ HOL_voc_category = {
 			}
 		}
 	}
+
 	HOL_voc_india_water = {
+
 		icon = GFX_decision_generic_naval
 
 		cost = 150
 
 		days_remove = 90
+
 		days_re_enable = 180
+
 		fire_only_once = no
 
 		targets = { RAJ }
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		available = {
 			RAJ = {
@@ -1807,14 +1832,12 @@ HOL_voc_category = {
 			change_influence_percentage = yes
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
-	HOL_voc_india_christian = {
-		icon = GFX_decision_generic_nationalism
 
+	HOL_voc_india_christian = {
+
+		icon = GFX_decision_generic_nationalism
 
 		targets = { RAJ }
 
@@ -1835,9 +1858,7 @@ HOL_voc_category = {
 
 		days_re_enable = 180
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 100
 
@@ -1847,11 +1868,13 @@ HOL_voc_category = {
 			set_temp_variable = { influence_target = RAJ }
 			change_influence_percentage = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_civilwar = {
-		icon = GFX_decision_generic_nationalism
 
+	HOL_voc_india_civilwar = {
+
+		icon = GFX_decision_generic_nationalism
 
 		targets = { RAJ }
 
@@ -1869,9 +1892,7 @@ HOL_voc_category = {
 
 		days_re_enable = 180
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 100
 
@@ -1879,16 +1900,17 @@ HOL_voc_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_india_civilwar"
 			RAJ = { country_event = HOL_voc.1 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_gujurat_rebellion1 = {
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_gujurat_rebellion1 = {
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
 		available = {
-
 			436 = {
 				OR = {
 					has_dynamic_modifier = { modifier = RAJ_naxalite_insurgency }
@@ -1908,9 +1930,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -1928,12 +1948,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_gujurat_port_patrol_lvl1
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_gujurat_rebellion2 = {
-		name = HOL_voc_india_gujurat_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_gujurat_rebellion2 = {
+
+		name = HOL_voc_india_gujurat_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -1958,9 +1981,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -1973,12 +1994,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_gujurat_port_patrol_lvl2
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_gujurat_rebellion3 = {
-		name = HOL_voc_india_gujurat_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_gujurat_rebellion3 = {
+
+		name = HOL_voc_india_gujurat_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2003,9 +2027,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2026,12 +2048,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_gujurat_port_patrol_lvl3
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_gujurat_rebellion4 = {
-		name = HOL_voc_india_gujurat_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_gujurat_rebellion4 = {
+
+		name = HOL_voc_india_gujurat_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2056,9 +2081,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2079,12 +2102,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_gujurat_port_patrol_lvl4
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_gujurat_rebellion5 = {
-		name = HOL_voc_india_gujurat_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_gujurat_rebellion5 = {
+
+		name = HOL_voc_india_gujurat_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2109,9 +2135,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2128,11 +2152,13 @@ HOL_voc_category = {
 				set_country_flag = HOL_gujurat_port_patrol_lvl5
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_bengal_rebellion1 = {
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_bengal_rebellion1 = {
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2156,9 +2182,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2176,12 +2200,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_bengal_patrol_lvl1
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_bengal_rebellion2 = {
-		name = HOL_voc_india_bengal_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_bengal_rebellion2 = {
+
+		name = HOL_voc_india_bengal_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2206,9 +2233,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2221,12 +2246,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_bengal_patrol_lvl2
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_bengal_rebellion3 = {
-		name = HOL_voc_india_bengal_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_bengal_rebellion3 = {
+
+		name = HOL_voc_india_bengal_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2245,16 +2273,13 @@ HOL_voc_category = {
 				NOT = { has_country_flag = HOL_bengal_patrol_lvl3 }
 				has_country_flag = HOL_bengal_patrol_lvl2
 			}
-
 		}
 
 		days_remove = 90
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2275,12 +2300,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_bengal_patrol_lvl3
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_bengal_rebellion4 = {
-		name = HOL_voc_india_bengal_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_bengal_rebellion4 = {
+
+		name = HOL_voc_india_bengal_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2305,9 +2333,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2328,12 +2354,15 @@ HOL_voc_category = {
 				set_country_flag = HOL_bengal_patrol_lvl4
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_bengal_rebellion5 = {
-		name = HOL_voc_india_bengal_rebellion1
-		icon = GFX_decision_oppression
 
+	HOL_voc_india_bengal_rebellion5 = {
+
+		name = HOL_voc_india_bengal_rebellion1
+
+		icon = GFX_decision_oppression
 
 		targets = { RAJ }
 
@@ -2358,9 +2387,7 @@ HOL_voc_category = {
 
 		fire_only_once = yes
 
-		target_root_trigger = {
-			has_completed_focus = HOL_financial_influence_india
-		}
+		target_root_trigger = { has_completed_focus = HOL_financial_influence_india }
 
 		cost = 150
 
@@ -2377,11 +2404,13 @@ HOL_voc_category = {
 				set_country_flag = HOL_bengal_patrol_lvl5
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_east_gujurat = {
-		icon = GFX_decision_generic_army_support
 
+	HOL_voc_india_east_gujurat = {
+
+		icon = GFX_decision_generic_army_support
 
 		targets = { RAJ }
 
@@ -2389,7 +2418,6 @@ HOL_voc_category = {
 			RAJ = { influence_higher_90 = yes }
 			NOT = {
 				owns_state = 436
-
 			}
 		}
 
@@ -2415,11 +2443,13 @@ HOL_voc_category = {
 			436 = { transfer_state_to = HOL }
 			RAJ = { country_event = HOL_voc.2 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_west_bengal = {
-		icon = GFX_decision_generic_army_support
 
+	HOL_voc_india_west_bengal = {
+
+		icon = GFX_decision_generic_army_support
 
 		targets = { RAJ }
 
@@ -2427,7 +2457,6 @@ HOL_voc_category = {
 			RAJ = { influence_higher_90 = yes }
 			NOT = {
 				owns_state = 452
-
 			}
 		}
 
@@ -2453,11 +2482,13 @@ HOL_voc_category = {
 			452 = { transfer_state_to = HOL }
 			RAJ = { country_event = HOL_voc.3 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_kerala = {
-		icon = GFX_decision_generic_army_support
 
+	HOL_voc_india_kerala = {
+
+		icon = GFX_decision_generic_army_support
 
 		targets = { RAJ }
 
@@ -2465,7 +2496,6 @@ HOL_voc_category = {
 			RAJ = { influence_higher_90 = yes }
 			NOT = {
 				owns_state = 465
-
 			}
 		}
 
@@ -2491,11 +2521,13 @@ HOL_voc_category = {
 			465 = { transfer_state_to = HOL }
 			RAJ = { country_event = HOL_voc.4 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_india_tamil = {
-		icon = GFX_decision_generic_army_support
 
+	HOL_voc_india_tamil = {
+
+		icon = GFX_decision_generic_army_support
 
 		targets = { RAJ }
 
@@ -2503,7 +2535,6 @@ HOL_voc_category = {
 			RAJ = { influence_higher_90 = yes }
 			NOT = {
 				owns_state = 462
-
 			}
 		}
 
@@ -2529,11 +2560,13 @@ HOL_voc_category = {
 			462 = { transfer_state_to = HOL }
 			RAJ = { country_event = HOL_voc.5 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_taiwan_mission1 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_taiwan_mission1 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -2566,9 +2599,10 @@ HOL_voc_category = {
 			}
 		}
 	}
-	HOL_voc_taiwan_mission2 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_taiwan_mission2 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -2613,9 +2647,10 @@ HOL_voc_category = {
 			}
 		}
 	}
-	HOL_voc_taiwan_agreement_USA = {
-		icon = GFX_decision_eng_trade_unions_support
 
+	HOL_voc_taiwan_agreement_USA = {
+
+		icon = GFX_decision_eng_trade_unions_support
 
 		targets = { USA }
 
@@ -2630,7 +2665,6 @@ HOL_voc_category = {
 					owns_state = 1157
 				}
 			}
-
 		}
 
 		days_remove = 7
@@ -2655,11 +2689,13 @@ HOL_voc_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_taiwan_agreement_USA"
 			USA = { country_event = HOL_voc.6 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_srilanka_mission1 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_srilanka_mission1 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -2692,9 +2728,10 @@ HOL_voc_category = {
 			}
 		}
 	}
-	HOL_voc_srilanka_mission2 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_srilanka_mission2 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -2739,17 +2776,14 @@ HOL_voc_category = {
 			}
 		}
 	}
-	HOL_voc_agriculture_agreement_srilanka = {
-		icon = GFX_decision_generic_construction
 
+	HOL_voc_agriculture_agreement_srilanka = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { SRI }
 
-		available = {
-			NOT = {
-				SRI = { has_idea = HOL_sri_dutch_agriculture_benefits }
-			}
-		}
+		available = { NOT = { SRI = { has_idea = HOL_sri_dutch_agriculture_benefits } } }
 
 		fire_only_once = no
 
@@ -2768,17 +2802,17 @@ HOL_voc_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_agriculture_agreement_srilanka"
 			SRI = { country_event = HOL_voc.17 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_investment_agreement_srilanka = {
-		icon = GFX_decision_generic_construction
 
+	HOL_voc_investment_agreement_srilanka = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { SRI }
 
-		available = {
-			has_country_flag = HOL_refused_investment_sri_lanka
-		}
+		available = { has_country_flag = HOL_refused_investment_sri_lanka }
 
 		target_root_trigger = {
 			has_country_flag = HOL_refused_investment_sri_lanka
@@ -2798,11 +2832,13 @@ HOL_voc_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_investment_agreement_srilanka"
 			SRI = { country_event = HOL_voc.20 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_small_reinvestment_sri_lanka = {
-		icon = GFX_decision_generic_construction
 
+	HOL_voc_small_reinvestment_sri_lanka = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { SRI }
 
@@ -2832,14 +2868,13 @@ HOL_voc_category = {
 
 		cost = 150
 
-		modifier = {
-			civilian_factory_use = 2
-		}
+		modifier = { civilian_factory_use = 2 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_small_reinvestment_sri_lanka"
 			set_country_flag = no_active_sri_lanka_investment
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_small_reinvestment_sri_lanka"
 			SRI = {
@@ -2857,11 +2892,13 @@ HOL_voc_category = {
 			change_influence_percentage = yes
 			clr_country_flag = no_active_sri_lanka_investment
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_medium_reinvestment_sri_lanka = {
-		icon = GFX_decision_generic_construction
 
+	HOL_voc_medium_reinvestment_sri_lanka = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { SRI }
 
@@ -2891,14 +2928,13 @@ HOL_voc_category = {
 
 		cost = 150
 
-		modifier = {
-			civilian_factory_use = 5
-		}
+		modifier = { civilian_factory_use = 5 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_medium_reinvestment_sri_lanka"
 			set_country_flag = no_active_sri_lanka_investment
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_medium_reinvestment_sri_lanka"
 			SRI = {
@@ -2924,11 +2960,13 @@ HOL_voc_category = {
 			change_influence_percentage = yes
 			clr_country_flag = no_active_sri_lanka_investment
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_heavy_reinvestment_sri_lanka = {
-		icon = GFX_decision_generic_construction
 
+	HOL_voc_heavy_reinvestment_sri_lanka = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { SRI }
 
@@ -2952,14 +2990,13 @@ HOL_voc_category = {
 
 		cost = 150
 
-		modifier = {
-			civilian_factory_use = 10
-		}
+		modifier = { civilian_factory_use = 10 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_heavy_reinvestment_sri_lanka"
 			set_country_flag = no_active_sri_lanka_investment
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_heavy_reinvestment_sri_lanka"
 			SRI = {
@@ -2993,11 +3030,13 @@ HOL_voc_category = {
 			change_influence_percentage = yes
 			clr_country_flag = no_active_sri_lanka_investment
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_voc_saf_mission1 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_saf_mission1 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -3037,14 +3076,12 @@ HOL_voc_category = {
 			}
 		}
 
-		ai_will_do = {
-			base = 10
-		}
-
+		ai_will_do = { base = 10 }
 	}
-	HOL_voc_saf_mission2 = {
-		icon = GFX_decision_influence
 
+	HOL_voc_saf_mission2 = {
+
+		icon = GFX_decision_influence
 
 		days_mission_timeout = 90
 
@@ -3101,9 +3138,10 @@ HOL_voc_category = {
 			}
 		}
 	}
-	HOL_voc_saf_aids_support = {
-		icon = GFX_decision_generic_research
 
+	HOL_voc_saf_aids_support = {
+
+		icon = GFX_decision_generic_research
 
 		targets = { SAF }
 
@@ -3141,6 +3179,7 @@ HOL_voc_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_saf_aids_support"
 			SAF = { country_event = HOL_voc.29 }
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_voc_saf_aids_support"
 			SAF = {
@@ -3178,20 +3217,21 @@ HOL_voc_category = {
 			change_influence_percentage = yes
 			clr_country_flag = no_active_sri_lanka_investment
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_voc_indonesia_attack_mission = {
+
 		icon = GFX_decision_eng_puppet_usa
 
 		days_remove = 90
+
 		fire_only_once = no
+
 		days_re_enable = 180
 
-		visible = {
-			has_completed_focus = HOL_reclaim_crown_colony
-		}
-
-
+		visible = { has_completed_focus = HOL_reclaim_crown_colony }
 
 		war_with_on_complete = IND
 
@@ -3205,9 +3245,12 @@ HOL_voc_category = {
 			}
 			HOL = { country_event = HOL_voc.36 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_request_military_access_australia = {
+
 		icon = GFX_decision_generic_army_support
 
 		cost = 50
@@ -3217,21 +3260,26 @@ HOL_voc_category = {
 			country_exists = AST
 			has_military_access_to = AST
 		}
+
 		available = {
 			AST = {
 				is_subject = no
 				NOT = { has_war_with = FROM }
 			}
 		}
+
 		targets = { AST }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_request_military_access_australia"
 			AST = { country_event = HOL_voc.39 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_reduce_java_detection = {
+
 		icon = GFX_decision_recruit_operative
 
 		available = {
@@ -3245,6 +3293,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 30
 
 		custom_cost_trigger = {
@@ -3253,6 +3302,7 @@ HOL_voc_category = {
 		}
 
 		custom_cost_text = army_xp_20
+
 		custom_cost_text = command_power_more_than_20
 
 		target_root_trigger = {
@@ -3275,10 +3325,13 @@ HOL_voc_category = {
 
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_increase_java_strength = {
+
 		icon = GFX_decision_generic_army_support
 
 		targets = { IND }
+
 		available = {
 			has_completed_focus = HOL_reclaim_batavia
 			hidden_trigger = {
@@ -3295,6 +3348,7 @@ HOL_voc_category = {
 		custom_cost_text = HOL_army_cp_pp50_cost
 
 		days_re_enable = 30
+
 		days_remove = 60
 
 		target_root_trigger = {
@@ -3313,6 +3367,7 @@ HOL_voc_category = {
 			add_command_power = -20
 			add_political_power = -50
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_java_strength"
 			add_to_variable = {
@@ -3320,12 +3375,16 @@ HOL_voc_category = {
 			}
 			HOL_increase_voc_java_strength_effect = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_increase_convoy = {
+
 		icon = GFX_decision_generic_naval
 
 		targets = { IND }
+
 		available = {
 			OR = {
 				has_completed_focus = HOL_reclaim_batavia
@@ -3333,6 +3392,7 @@ HOL_voc_category = {
 			}
 			NOT = { has_country_flag = HOL_dutch_indies_conquest }
 		}
+
 		target_root_trigger = {
 			OR = {
 				has_completed_focus = HOL_reclaim_batavia
@@ -3350,11 +3410,10 @@ HOL_voc_category = {
 		custom_cost_text = HOL_navy_cp_pp50_cost
 
 		days_re_enable = 30
+
 		days_remove = 60
 
-		modifier = {
-			industrial_capacity_dockyard = 0.10
-		}
+		modifier = { industrial_capacity_dockyard = 0.10 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_convoy"
@@ -3365,6 +3424,7 @@ HOL_voc_category = {
 			multiply_temp_variable = { treasury_change = -0.02 }
 			modify_treasury_effect = yes
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_convoy"
 			if = {
@@ -3385,22 +3445,21 @@ HOL_voc_category = {
 				}
 				HOL_increase_voc_kalimantan_strength_effect = yes
 			}
-
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_deploy_java_commando = {
-		icon = GFX_decision_generic_intelligence_operation
 
+	HOL_deploy_java_commando = {
+
+		icon = GFX_decision_generic_intelligence_operation
 
 		available = {
 			has_war_with = IND
 			has_country_flag = HOL_dutch_indies_conquest
 		}
 
-		target_root_trigger = {
-			has_completed_focus = HOL_reclaim_batavia
-		}
+		target_root_trigger = { has_completed_focus = HOL_reclaim_batavia }
 
 		targets = { IND }
 
@@ -3419,26 +3478,25 @@ HOL_voc_category = {
 			if = {
 				limit = { check_variable = { HOL_java_strength > 70 } }
 				#load_oob = HOL_VOC_nonnsbhigh
-				}
+			}
 			HOL = { set_state_controller = 1113 }
 			country_event = { id = HOL_voc.42 days = 3 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
-	HOL_deploy_islands_commando = {
-		icon = GFX_decision_generic_intelligence_operation
 
+	HOL_deploy_islands_commando = {
+
+		icon = GFX_decision_generic_intelligence_operation
 
 		available = {
 			has_war_with = IND
 			has_completed_focus = HOL_reclaim_outer_islands
-
 			has_country_flag = HOL_dutch_indies_conquest
 		}
 
-		visible = {
-			has_completed_focus = HOL_reclaim_outer_islands
-		}
+		visible = { has_completed_focus = HOL_reclaim_outer_islands }
 
 		fire_only_once = yes
 
@@ -3455,7 +3513,7 @@ HOL_voc_category = {
 			if = {
 				limit = { check_variable = { HOL_sumatra_strength > 70 } }
 				##load_oob = x
-				}
+			}
 			if = {
 				limit = { check_variable = { HOL_kalimantan_strength < 30 } }
 				##load_oob = x
@@ -3467,16 +3525,19 @@ HOL_voc_category = {
 			if = {
 				limit = { check_variable = { HOL_kalimantan_strength > 70 } }
 				##load_oob = x
-				}
+			}
 			HOL = {
 				set_province_controller = 6111
 				set_province_controller = 4279
 			}
 			country_event = { id = HOL_voc.42 days = 3 }
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_reduce_sumatra_detection = {
+
 		icon = GFX_decision_recruit_operative
 
 		available = {
@@ -3490,6 +3551,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 30
 
 		custom_cost_trigger = {
@@ -3498,6 +3560,7 @@ HOL_voc_category = {
 		}
 
 		custom_cost_text = army_xp_20
+
 		custom_cost_text = command_power_more_than_20
 
 		target_root_trigger = {
@@ -3520,7 +3583,9 @@ HOL_voc_category = {
 
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_reduce_kalimantan_detection = {
+
 		icon = GFX_decision_recruit_operative
 
 		available = {
@@ -3534,6 +3599,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 30
 
 		custom_cost_trigger = {
@@ -3542,6 +3608,7 @@ HOL_voc_category = {
 		}
 
 		custom_cost_text = army_xp_20
+
 		custom_cost_text = command_power_more_than_20
 
 		target_root_trigger = {
@@ -3561,12 +3628,16 @@ HOL_voc_category = {
 				set_country_flag = HOL_voc_counter_discover_chance
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_increase_sumatra_strength = {
+
 		icon = GFX_decision_generic_army_support
 
 		targets = { IND }
+
 		available = {
 			has_completed_focus = HOL_reclaim_outer_islands
 			hidden_trigger = {
@@ -3583,6 +3654,7 @@ HOL_voc_category = {
 		custom_cost_text = HOL_army_cp_pp20_cost
 
 		days_re_enable = 30
+
 		days_remove = 60
 
 		target_root_trigger = {
@@ -3600,8 +3672,8 @@ HOL_voc_category = {
 			army_experience = -20
 			add_command_power = -20
 			add_political_power = -20
-
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_sumatra_strength"
 			add_to_variable = {
@@ -3609,12 +3681,16 @@ HOL_voc_category = {
 			}
 			HOL_increase_voc_sumatra_strength_effect = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_increase_kalimantan_strength = {
+
 		icon = GFX_decision_generic_army_support
 
 		targets = { IND }
+
 		available = {
 			has_completed_focus = HOL_reclaim_outer_islands
 			hidden_trigger = {
@@ -3631,6 +3707,7 @@ HOL_voc_category = {
 		custom_cost_text = HOL_army_cp_pp20_cost
 
 		days_re_enable = 30
+
 		days_remove = 60
 
 		target_root_trigger = {
@@ -3648,8 +3725,8 @@ HOL_voc_category = {
 			army_experience = -20
 			add_command_power = -20
 			add_political_power = -20
-
 		}
+
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_increase_kalimantan_strength"
 			add_to_variable = {
@@ -3657,9 +3734,12 @@ HOL_voc_category = {
 			}
 			HOL_increase_voc_kalimantan_strength_effect = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_reduce_sumatra_detection_corruption = {
+
 		icon = GFX_decision_generic_political_discourse
 
 		available = {
@@ -3682,6 +3762,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 1
 
 		cost = 150
@@ -3698,9 +3779,12 @@ HOL_voc_category = {
 			}
 			HOL_sumatra_detection_chance_effect = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_reduce_kalimantan_detection_corruption = {
+
 		icon = GFX_decision_generic_political_discourse
 
 		available = {
@@ -3723,6 +3807,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 1
 
 		cost = 150
@@ -3739,9 +3824,12 @@ HOL_voc_category = {
 			}
 			HOL_kalimantan_detection_chance_effect = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_reduce_java_detection_corruption = {
+
 		icon = GFX_decision_generic_political_discourse
 
 		available = {
@@ -3764,6 +3852,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 1
 
 		cost = 150
@@ -3780,10 +3869,14 @@ HOL_voc_category = {
 			}
 			HOL_java_detection_chance_effect = yes
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_contact_christian_resistance_ind = {
+
 		fixed_random_seed = no
+
 		icon = GFX_decision_generic_nationalism
 
 		available = {
@@ -3793,10 +3886,10 @@ HOL_voc_category = {
 			}
 			638 = {
 				OR = {
-				has_dynamic_modifier = { modifier = IND_papua_resist }
-				has_dynamic_modifier = { modifier = IND_papua_resist2 }
-				has_dynamic_modifier = { modifier = IND_papua_resist3 }
-				has_dynamic_modifier = { modifier = IND_papua_resist4 }
+					has_dynamic_modifier = { modifier = IND_papua_resist }
+					has_dynamic_modifier = { modifier = IND_papua_resist2 }
+					has_dynamic_modifier = { modifier = IND_papua_resist3 }
+					has_dynamic_modifier = { modifier = IND_papua_resist4 }
 				}
 			}
 			hidden_trigger = {
@@ -3807,6 +3900,7 @@ HOL_voc_category = {
 		targets = { IND }
 
 		days_remove = 60
+
 		days_re_enable = 1
 
 		cost = 150
@@ -3851,19 +3945,17 @@ HOL_voc_category = {
 				}
 			}
 		}
+
 		ai_will_do = { base = 0 }
 	}
+
 	HOL_voc_prepare_for_war_mission1 = {
+
 		icon = GFX_decision_generic_speech
 
+		available = { has_completed_focus = HOL_reclaim_voc_territories }
 
-		available = {
-			has_completed_focus = HOL_reclaim_voc_territories
-		}
-
-		activation = {
-			has_completed_focus = HOL_reclaim_voc_territories
-		}
+		activation = { has_completed_focus = HOL_reclaim_voc_territories }
 
 		days_mission_timeout = 30
 
@@ -3913,9 +4005,10 @@ HOL_voc_category = {
 			set_country_flag = HOL_failed_declaring_war_voc
 		}
 	}
-	HOL_voc_prepare_for_war_mission2 = {
-		icon = GFX_decision_generic_speech
 
+	HOL_voc_prepare_for_war_mission2 = {
+
+		icon = GFX_decision_generic_speech
 
 		available = {
 			has_completed_focus = HOL_reclaim_voc_territories
@@ -3969,15 +4062,14 @@ HOL_voc_category = {
 	}
 }
 HOL_pvda_balance_of_power_category = {
+
 	HOL_pvda_modernize_party_policies = {
+
 		priority = 50
 
 		icon = GFX_decision_eng_trade_unions_support
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 50
 
@@ -3985,9 +4077,7 @@ HOL_pvda_balance_of_power_category = {
 
 		days_re_enable = 180
 
-		modifier = {
-			political_power_factor = -0.05
-		}
+		modifier = { political_power_factor = -0.05 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies"
@@ -3997,19 +4087,16 @@ HOL_pvda_balance_of_power_category = {
 			}
 		}
 
-		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies"
-		}
+		remove_effect = { log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies" }
 	}
+
 	HOL_pvda_promote_urban_investments = {
+
 		priority = 50
 
 		icon = GFX_decision_generic_construction
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 50
 
@@ -4037,15 +4124,14 @@ HOL_pvda_balance_of_power_category = {
 			}
 		}
 	}
+
 	HOL_pvda_focus_climate_policy = {
+
 		priority = 50
 
 		icon = GFX_Decision_tree_smol
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 50
 
@@ -4077,15 +4163,14 @@ HOL_pvda_balance_of_power_category = {
 			}
 		}
 	}
+
 	HOL_pvda_strengthen_union_influence = {
+
 		priority = 50
 
 		icon = GFX_decision_generic_civil_support
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 100
 
@@ -4119,15 +4204,14 @@ HOL_pvda_balance_of_power_category = {
 			change_industrial_conglomerates_opinion = yes
 		}
 	}
+
 	HOL_pvda_promote_rural_investments = {
+
 		priority = 50
 
 		icon = GFX_decision_eng_trade_unions_demand
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 50
 
@@ -4160,15 +4244,14 @@ HOL_pvda_balance_of_power_category = {
 			}
 		}
 	}
+
 	HOL_pvda_climate_action_plan = {
+
 		priority = 50
 
 		icon = GFX_Decision_tree_smol
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 50
 
@@ -4190,19 +4273,16 @@ HOL_pvda_balance_of_power_category = {
 			}
 		}
 
-		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_climate_action_plan"
-		}
+		remove_effect = { log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_climate_action_plan" }
 	}
+
 	HOL_pvda_social_housing_initiative = {
+
 		priority = 50
 
 		icon = GFX_decision_generic_construction
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 50
 
@@ -4233,15 +4313,14 @@ HOL_pvda_balance_of_power_category = {
 			}
 		}
 	}
+
 	HOL_pvda_private_energy_investments = {
+
 		priority = 50
 
 		icon = GFX_decision_generic_construction
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		days_remove = 60
 
@@ -4249,9 +4328,7 @@ HOL_pvda_balance_of_power_category = {
 
 		days_re_enable = 180
 
-		modifier = {
-			stability_weekly_factor = -0.002
-		}
+		modifier = { stability_weekly_factor = -0.002 }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_private_energy_investments"
@@ -4274,15 +4351,14 @@ HOL_pvda_balance_of_power_category = {
 	}
 }
 HOL_grey_society_category = {
+
 	HOL_grey_pvda1 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4290,9 +4366,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_social_democrats_are_in_power = no
-		}
+		cancel_trigger = { western_social_democrats_are_in_power = no }
 
 		days_remove = 360
 
@@ -4341,15 +4415,14 @@ HOL_grey_society_category = {
 			}
 		}
 	}
+
 	HOL_grey_pvda2 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4359,9 +4432,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_social_democrats_are_in_power = no
-		}
+		cancel_trigger = { western_social_democrats_are_in_power = no }
 
 		days_remove = 360
 
@@ -4400,15 +4471,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvda3 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4417,9 +4487,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_social_democrats_are_in_power = no
-		}
+		cancel_trigger = { western_social_democrats_are_in_power = no }
 
 		days_remove = 360
 
@@ -4456,15 +4524,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvda4 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4472,9 +4539,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_social_democrats_are_in_power = no
-		}
+		cancel_trigger = { western_social_democrats_are_in_power = no }
 
 		days_remove = 360
 
@@ -4511,16 +4576,16 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvda5 = {
+
 		fixed_random_seed = no
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4529,9 +4594,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_social_democrats_are_in_power = no
-		}
+		cancel_trigger = { western_social_democrats_are_in_power = no }
 
 		days_remove = 360
 
@@ -4622,15 +4685,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_cda1 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_cda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4638,9 +4700,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_conservatism_are_in_power = no
-		}
+		cancel_trigger = { western_conservatism_are_in_power = no }
 
 		days_remove = 360
 
@@ -4678,15 +4738,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_cda2 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_cda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4694,9 +4753,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_conservatism_are_in_power = no
-		}
+		cancel_trigger = { western_conservatism_are_in_power = no }
 
 		days_remove = 360
 
@@ -4735,15 +4792,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_cda3 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_cda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4753,9 +4809,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_conservatism_are_in_power = no
-		}
+		cancel_trigger = { western_conservatism_are_in_power = no }
 
 		days_remove = 360
 
@@ -4794,15 +4848,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_cda4 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_cda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4811,9 +4864,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_conservatism_are_in_power = no
-		}
+		cancel_trigger = { western_conservatism_are_in_power = no }
 
 		days_remove = 360
 
@@ -4852,15 +4903,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_cda5 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_cda_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4869,9 +4919,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_conservatism_are_in_power = no
-		}
+		cancel_trigger = { western_conservatism_are_in_power = no }
 
 		days_remove = 360
 
@@ -4907,15 +4955,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_vvd1 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_vvd_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4925,9 +4972,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_liberals_are_in_power = no
-		}
+		cancel_trigger = { western_liberals_are_in_power = no }
 
 		days_remove = 360
 
@@ -4964,15 +5009,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_vvd2 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_vvd_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -4982,9 +5026,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_liberals_are_in_power = no
-		}
+		cancel_trigger = { western_liberals_are_in_power = no }
 
 		days_remove = 360
 
@@ -5022,15 +5064,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_vvd3 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_vvd_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5040,9 +5081,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_liberals_are_in_power = no
-		}
+		cancel_trigger = { western_liberals_are_in_power = no }
 
 		days_remove = 360
 
@@ -5080,15 +5119,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_vvd4 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_vvd_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5096,9 +5134,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_liberals_are_in_power = no
-		}
+		cancel_trigger = { western_liberals_are_in_power = no }
 
 		days_remove = 360
 
@@ -5136,15 +5172,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_vvd5 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_vvd_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5153,9 +5188,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			western_liberals_are_in_power = no
-		}
+		cancel_trigger = { western_liberals_are_in_power = no }
 
 		days_remove = 360
 
@@ -5191,15 +5224,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvv1 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvv_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5208,9 +5240,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_right_wing_populists_are_in_power = no
-		}
+		cancel_trigger = { nationalist_right_wing_populists_are_in_power = no }
 
 		days_remove = 360
 
@@ -5249,15 +5279,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvv2 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvv_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5265,9 +5294,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_right_wing_populists_are_in_power = no
-		}
+		cancel_trigger = { nationalist_right_wing_populists_are_in_power = no }
 
 		days_remove = 360
 
@@ -5306,15 +5333,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvv3 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvv_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5324,9 +5350,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_right_wing_populists_are_in_power = no
-		}
+		cancel_trigger = { nationalist_right_wing_populists_are_in_power = no }
 
 		days_remove = 360
 
@@ -5365,15 +5389,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvv4 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvv_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5382,9 +5405,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_right_wing_populists_are_in_power = no
-		}
+		cancel_trigger = { nationalist_right_wing_populists_are_in_power = no }
 
 		days_remove = 360
 
@@ -5421,15 +5442,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_pvv5 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_pvv_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5437,9 +5457,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_right_wing_populists_are_in_power = no
-		}
+		cancel_trigger = { nationalist_right_wing_populists_are_in_power = no }
 
 		days_remove = 360
 
@@ -5476,15 +5494,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_monarchy1 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_oranje_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			OR = {
@@ -5536,15 +5553,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_monarchy2 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_oranje_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5597,15 +5613,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_monarchy3 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_oranje_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5656,16 +5671,16 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_monarchy4 = {
+
 		fixed_random_seed = no
+
 		priority = 50
 
 		icon = GFX_decision_HOL_oranje_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5692,9 +5707,7 @@ HOL_grey_society_category = {
 
 		cost = 100
 
-		modifier = {
-			stability_weekly = -0.001
-		}
+		modifier = { stability_weekly = -0.001 }
 
 		cancel_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_grey_monarchy4"
@@ -5771,15 +5784,14 @@ HOL_grey_society_category = {
 			}
 		}
 	}
+
 	HOL_grey_monarchy5 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_oranje_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5830,15 +5842,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_nvu1 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_nvu_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5846,9 +5857,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_fascist_are_in_power = no
-		}
+		cancel_trigger = { nationalist_fascist_are_in_power = no }
 
 		days_remove = 360
 
@@ -5886,15 +5895,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_nvu2 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_nvu_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5902,9 +5910,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_fascist_are_in_power = no
-		}
+		cancel_trigger = { nationalist_fascist_are_in_power = no }
 
 		days_remove = 360
 
@@ -5942,15 +5948,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_nvu3 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_nvu_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -5958,9 +5963,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_fascist_are_in_power = no
-		}
+		cancel_trigger = { nationalist_fascist_are_in_power = no }
 
 		days_remove = 360
 
@@ -5999,15 +6002,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_nvu4 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_nvu_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -6015,9 +6017,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_fascist_are_in_power = no
-		}
+		cancel_trigger = { nationalist_fascist_are_in_power = no }
 
 		days_remove = 360
 
@@ -6059,15 +6059,14 @@ HOL_grey_society_category = {
 			clr_country_flag = HOL_grey_society_flag_improvement
 		}
 	}
+
 	HOL_grey_nvu5 = {
+
 		priority = 50
 
 		icon = GFX_decision_HOL_nvu_icon
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_country_flag = HOL_grey_society_flag
@@ -6075,9 +6074,7 @@ HOL_grey_society_category = {
 			NOT = { has_country_flag = HOL_grey_society_flag_improvement }
 		}
 
-		cancel_trigger = {
-			nationalist_fascist_are_in_power = no
-		}
+		cancel_trigger = { nationalist_fascist_are_in_power = no }
 
 		days_remove = 360
 
@@ -6117,12 +6114,17 @@ HOL_grey_society_category = {
 	}
 }
 HOL_foreign_policy_category = {
+
 	HOL_annual_naval_deployment = {
+
 		icon = GFX_decision_navy
 
 		is_good = yes
+
 		selectable_mission = no
+
 		fire_only_once = no
+
 		priority = 100
 
 		days_mission_timeout = 365
@@ -6151,15 +6153,14 @@ HOL_foreign_policy_category = {
 			}
 		}
 	}
+
 	HOL_antilles_expand_civilian_industry = {
+
 		priority = 50
 
 		icon = GFX_decision_generic_factory
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_completed_focus = HOL_economic_development_antilles
@@ -6168,7 +6169,7 @@ HOL_foreign_policy_category = {
 			NOT = { has_country_flag = HOL_antilles_investment_active }
 		}
 
-		targets = {	NLA }
+		targets = { NLA }
 
 		target_non_existing = yes
 
@@ -6178,9 +6179,7 @@ HOL_foreign_policy_category = {
 
 		cost = 100
 
-		target_root_trigger = {
-			has_completed_focus = HOL_economic_development_antilles
-		}
+		target_root_trigger = { has_completed_focus = HOL_economic_development_antilles }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_civilian_industry"
@@ -6203,15 +6202,14 @@ HOL_foreign_policy_category = {
 			clr_country_flag = HOL_antilles_investment_active
 		}
 	}
+
 	HOL_antilles_expand_office_industry = {
+
 		priority = 50
 
 		icon = GFX_attract_foreign_investor
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_completed_focus = HOL_economic_development_antilles
@@ -6220,7 +6218,7 @@ HOL_foreign_policy_category = {
 			NOT = { has_country_flag = HOL_antilles_investment_active }
 		}
 
-		targets = {	NLA }
+		targets = { NLA }
 
 		target_non_existing = yes
 
@@ -6230,9 +6228,7 @@ HOL_foreign_policy_category = {
 
 		cost = 100
 
-		target_root_trigger = {
-			has_completed_focus = HOL_economic_development_antilles
-		}
+		target_root_trigger = { has_completed_focus = HOL_economic_development_antilles }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_office_industry"
@@ -6255,15 +6251,14 @@ HOL_foreign_policy_category = {
 			clr_country_flag = HOL_antilles_investment_active
 		}
 	}
+
 	HOL_antilles_expand_mil_industry = {
+
 		priority = 50
 
 		icon = GFX_arms_industry
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_completed_focus = HOL_economic_development_antilles
@@ -6272,7 +6267,7 @@ HOL_foreign_policy_category = {
 			NOT = { has_country_flag = HOL_antilles_investment_active }
 		}
 
-		targets = {	NLA }
+		targets = { NLA }
 
 		target_non_existing = yes
 
@@ -6282,9 +6277,7 @@ HOL_foreign_policy_category = {
 
 		cost = 100
 
-		target_root_trigger = {
-			has_completed_focus = HOL_economic_development_antilles
-		}
+		target_root_trigger = { has_completed_focus = HOL_economic_development_antilles }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_mil_industry"
@@ -6307,13 +6300,12 @@ HOL_foreign_policy_category = {
 			clr_country_flag = HOL_antilles_investment_active
 		}
 	}
+
 	HOL_antilles_expand_agriculture = {
+
 		icon = GFX_decision_generic_construction
 
-		ai_will_do = {
-			base = 0.75
-		}
-
+		ai_will_do = { base = 0.75 }
 
 		available = {
 			has_completed_focus = HOL_economic_development_antilles
@@ -6322,7 +6314,7 @@ HOL_foreign_policy_category = {
 			NOT = { has_country_flag = HOL_antilles_investment_active }
 		}
 
-		targets = {	NLA }
+		targets = { NLA }
 
 		target_non_existing = yes
 
@@ -6332,9 +6324,7 @@ HOL_foreign_policy_category = {
 
 		cost = 100
 
-		target_root_trigger = {
-			has_completed_focus = HOL_economic_development_antilles
-		}
+		target_root_trigger = { has_completed_focus = HOL_economic_development_antilles }
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_antilles_expand_agriculture"
@@ -6357,9 +6347,10 @@ HOL_foreign_policy_category = {
 			clr_country_flag = HOL_antilles_investment_active
 		}
 	}
-	HOL_dutch_venezuela_offshore_gas = {
-		icon = GFX_oil
 
+	HOL_dutch_venezuela_offshore_gas = {
+
+		icon = GFX_oil
 
 		targets = { VEN }
 
@@ -6380,14 +6371,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_venezuela_offshore_gas"
-		   VEN = { country_event = HOL_politics.30 }
+			VEN = { country_event = HOL_politics.30 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_dutch_argentina_lng_trade = {
-		icon = GFX_oil
 
+	HOL_dutch_argentina_lng_trade = {
+
+		icon = GFX_oil
 
 		targets = { ARG }
 
@@ -6408,14 +6400,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_argentina_lng_trade"
-		   ARG = { country_event = HOL_politics.33 }
+			ARG = { country_event = HOL_politics.33 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_dutch_mexico_naval_cooperation = {
-		icon = GFX_decision_generic_naval
 
+	HOL_dutch_mexico_naval_cooperation = {
+
+		icon = GFX_decision_generic_naval
 
 		targets = { MEX }
 
@@ -6436,14 +6429,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_mexico_naval_cooperation"
-		   MEX = { country_event = HOL_politics.36 }
+			MEX = { country_event = HOL_politics.36 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_dutch_colombia_port_investment = {
-		icon = GFX_decision_generic_construction
 
+	HOL_dutch_colombia_port_investment = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { COL }
 
@@ -6464,14 +6458,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_colombia_port_investment"
-		   COL = { country_event = HOL_politics.39 }
+			COL = { country_event = HOL_politics.39 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_dutch_paraguay_green_hydrogen = {
-		icon = GFX_oil
 
+	HOL_dutch_paraguay_green_hydrogen = {
+
+		icon = GFX_oil
 
 		targets = { PAR }
 
@@ -6492,14 +6487,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_paraguay_green_hydrogen"
-		   PAR = { country_event = HOL_politics.42 }
+			PAR = { country_event = HOL_politics.42 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_dutch_peru_wind_energy = {
-		icon = GFX_decision_generic_construction
 
+	HOL_dutch_peru_wind_energy = {
+
+		icon = GFX_decision_generic_construction
 
 		targets = { PRU }
 
@@ -6507,6 +6503,7 @@ HOL_foreign_policy_category = {
 			NOT = { has_country_flag = HOL_PRU_accepted_deal }
 			has_completed_focus = HOL_dutch_latin_energy_cooperation
 		}
+
 		available = {
 			has_opinion = {
 				target = PRU
@@ -6519,15 +6516,17 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_dutch_peru_wind_energy"
-		   PRU = { country_event = HOL_politics.45 }
+			PRU = { country_event = HOL_politics.45 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_usa_operation_market_vision = {
-		fixed_random_seed = no
-		icon = GFX_decision_gre_investment_decisions
 
+	HOL_usa_operation_market_vision = {
+
+		fixed_random_seed = no
+
+		icon = GFX_decision_gre_investment_decisions
 
 		targets = { USA }
 
@@ -6542,10 +6541,10 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_usa_operation_market_vision"
-		   ROOT = { country_event = HOL_politics.48 }
-		   set_temp_variable = { treasury_change = -25 }
-		   modify_treasury_effect = yes
-		   effect_tooltip = {
+			ROOT = { country_event = HOL_politics.48 }
+			set_temp_variable = { treasury_change = -25 }
+			modify_treasury_effect = yes
+			effect_tooltip = {
 				random_owned_state = {
 					add_building_construction = {
 						type = arms_factory
@@ -6606,14 +6605,15 @@ HOL_foreign_policy_category = {
 						}
 					}
 				}
-		 }
+			}
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_sur_agreement = {
-		icon = GFX_decision_eng_trade_unions_support
 
+	HOL_sur_agreement = {
+
+		icon = GFX_decision_eng_trade_unions_support
 
 		targets = { SUR }
 
@@ -6628,14 +6628,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_agreement"
-		   SUR = { country_event = HOL_politics.51 }
+			SUR = { country_event = HOL_politics.51 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_sur_infrastructure_agreement = {
-		icon = GFX_decision_eng_trade_unions_support
 
+	HOL_sur_infrastructure_agreement = {
+
+		icon = GFX_decision_eng_trade_unions_support
 
 		targets = { SUR }
 
@@ -6650,14 +6651,15 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_infrastructure_agreement"
-		   SUR = { country_event = HOL_politics.54 }
+			SUR = { country_event = HOL_politics.54 }
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_sur_maritime_agreement = {
-		icon = GFX_decision_generic_naval
 
+	HOL_sur_maritime_agreement = {
+
+		icon = GFX_decision_generic_naval
 
 		targets = { SUR }
 
@@ -6672,17 +6674,18 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_maritime_agreement"
-		   SUR = { country_event = HOL_politics.63 }
-		   set_temp_variable = { treasury_change = gdp_per_capita }
-		   multiply_temp_variable = { treasury_change = -0.15 }
-		   modify_treasury_effect = yes
+			SUR = { country_event = HOL_politics.63 }
+			set_temp_variable = { treasury_change = gdp_per_capita }
+			multiply_temp_variable = { treasury_change = -0.15 }
+			modify_treasury_effect = yes
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_sur_training_agreement = {
-		icon = decision_hol_draw_up_staff_plans
 
+	HOL_sur_training_agreement = {
+
+		icon = decision_hol_draw_up_staff_plans
 
 		targets = { SUR }
 
@@ -6697,17 +6700,18 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_training_agreement"
-		   SUR = { country_event = HOL_politics.66 }
-		   set_temp_variable = { treasury_change = gdp_per_capita }
-		   multiply_temp_variable = { treasury_change = -0.10 }
-		   modify_treasury_effect = yes
+			SUR = { country_event = HOL_politics.66 }
+			set_temp_variable = { treasury_change = gdp_per_capita }
+			multiply_temp_variable = { treasury_change = -0.10 }
+			modify_treasury_effect = yes
 		}
 
 		ai_will_do = { base = 50 }
 	}
-	HOL_sur_resources_agreement = {
-		icon = GFX_aluminium
 
+	HOL_sur_resources_agreement = {
+
+		icon = GFX_aluminium
 
 		targets = { SUR }
 
@@ -6722,17 +6726,19 @@ HOL_foreign_policy_category = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_sur_resources_agreement"
-		   SUR = { country_event = HOL_politics.69 }
-		   set_temp_variable = { treasury_change = gdp_per_capita }
-		   multiply_temp_variable = { treasury_change = -0.10 }
-		   modify_treasury_effect = yes
+			SUR = { country_event = HOL_politics.69 }
+			set_temp_variable = { treasury_change = gdp_per_capita }
+			multiply_temp_variable = { treasury_change = -0.10 }
+			modify_treasury_effect = yes
 		}
 
 		ai_will_do = { base = 50 }
 	}
 }
 HOL_fourth_reich_category = {
-		HOL_core_german_state_schleswig_holstein = {
+
+	HOL_core_german_state_schleswig_holstein = {
+
 		icon = gfx_decision_generic_form_nation
 
 		available = {
@@ -6742,9 +6748,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6759,8 +6763,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_niedersachsen = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			38 = {
@@ -6769,9 +6773,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6786,8 +6788,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_nordrhein_westfalen = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			39 = {
@@ -6796,9 +6798,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6813,8 +6813,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_rheinland_pfalz = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			40 = {
@@ -6823,9 +6823,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6840,8 +6838,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_hessen = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			41 = {
@@ -6850,9 +6848,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6867,8 +6863,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_baden_wurttemberg = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			42 = {
@@ -6877,9 +6873,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6894,8 +6888,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_bayern = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			43 = {
@@ -6904,9 +6898,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6921,8 +6913,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_sachsen = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			44 = {
@@ -6931,9 +6923,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6948,8 +6938,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_berlin = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			45 = {
@@ -6958,9 +6948,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -6975,8 +6963,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_steiermark = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			75 = {
@@ -6985,9 +6973,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7002,8 +6988,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_austria_proper = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			76 = {
@@ -7012,9 +6998,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7029,8 +7013,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_tirol = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			286 = {
@@ -7039,9 +7023,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7056,8 +7038,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_mecklenburg = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			539 = {
@@ -7066,9 +7048,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7083,8 +7063,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_thuringen = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			545 = {
@@ -7093,9 +7073,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7110,8 +7088,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_franken = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			964 = {
@@ -7120,9 +7098,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7137,8 +7113,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_koln_bonn = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			966 = {
@@ -7147,9 +7123,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7164,8 +7138,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_saarland = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			967 = {
@@ -7174,9 +7148,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7191,8 +7163,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_sachsen_anhalt = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			972 = {
@@ -7201,9 +7173,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7218,8 +7188,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_brandenburg = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			1079 = {
@@ -7228,9 +7198,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7245,8 +7213,8 @@ HOL_fourth_reich_category = {
 	}
 
 	HOL_core_german_state_hamburg = {
-		icon = gfx_decision_generic_form_nation
 
+		icon = gfx_decision_generic_form_nation
 
 		available = {
 			1080 = {
@@ -7255,9 +7223,7 @@ HOL_fourth_reich_category = {
 			}
 		}
 
-		visible = {
-			has_completed_focus = HOL_fourth_reich
-		}
+		visible = { has_completed_focus = HOL_fourth_reich }
 
 		cost = 75
 
@@ -7272,19 +7238,22 @@ HOL_fourth_reich_category = {
 	}
 }
 HOL_megaproject_category = {
+
 	HOL_ijstad_mission = {
+
 		icon = GFX_decision_generic_construction
 
 		selectable_mission = no
+
 		fire_only_once = yes
+
 		is_good = yes
+
 		priority = 100
 
 		days_mission_timeout = 1095
 
-		available = {
-			hidden_trigger = { always = no }
-		}
+		available = { hidden_trigger = { always = no } }
 
 		activation = {
 			has_completed_focus = HOL_global_land_reclamation
@@ -7311,23 +7280,24 @@ HOL_megaproject_category = {
 	}
 }
 HOL_space_program_category = {
+
 	HOL_mars_colony_mission = {
+
 		icon = GFX_decision_generic_construction
 
 		selectable_mission = no
+
 		fire_only_once = yes
+
 		is_good = yes
+
 		priority = 100
 
 		days_mission_timeout = 1500
 
-		available = {
-			hidden_trigger = { always = no }
-		}
+		available = { hidden_trigger = { always = no } }
 
-		activation = {
-			has_completed_focus = HOL_mars_one
-		}
+		activation = { has_completed_focus = HOL_mars_one }
 
 		timeout_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_mars_colony_mission"

--- a/common/scripted_effects/00_microchip_effects.txt
+++ b/common/scripted_effects/00_microchip_effects.txt
@@ -200,7 +200,7 @@ microchip_update = {
 			}
 		}
 
-		//if we have no production or import of a required material (none avaiabile at all), then halt production
+		# if we have no production or import of a required material (none avaiabile at all), then halt production
 		if = {
 			limit = {
 				OR = {

--- a/common/scripted_guis/00_missiles_scripted_guis.txt
+++ b/common/scripted_guis/00_missiles_scripted_guis.txt
@@ -7007,6 +7007,7 @@ scripted_gui = {
 					has_country_flag = aegis_sel
 					has_country_flag = wagner_sel
 					has_country_flag = constellis_sel
+					has_country_flag = md_sel
 				}
 
 				OR = {
@@ -7112,6 +7113,10 @@ scripted_gui = {
 						set_country_flag = inf_hire
 						activate_mission = get_wagner_light_infantry
 					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = inf_hire
+						activate_mission = get_md_light_infantry
+					}
 				}
 				if = { limit = { check_variable = { v = 002 } }
 					if = { limit = { has_country_flag = blackwater_sel }
@@ -7129,6 +7134,10 @@ scripted_gui = {
 					else_if = { limit = { has_country_flag = wagner_sel }
 						set_country_flag = mot_inf_hire
 						activate_mission = get_wagner_mot_infantry
+					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = mot_inf_hire
+						activate_mission = get_md_mot_infantry
 					}
 				}
 				if = { limit = { check_variable = { v = 003 } }
@@ -7148,6 +7157,10 @@ scripted_gui = {
 						set_country_flag = mech_inf_hire
 						activate_mission = get_wagner_mech_infantry
 					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = mech_inf_hire
+						activate_mission = get_md_mech_infantry
+					}
 				}
 				if = { limit = { check_variable = { v = 004 } }
 					if = { limit = { has_country_flag = blackwater_sel }
@@ -7165,6 +7178,10 @@ scripted_gui = {
 					else_if = { limit = { has_country_flag = wagner_sel }
 						set_country_flag = hvy_inf_hire
 						activate_mission = get_wagner_heavy_mech_infantry
+					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = hvy_inf_hire
+						activate_mission = get_md_heavy_mech_infantry
 					}
 				}
 				if = { limit = { check_variable = { v = 005 } }
@@ -7184,6 +7201,10 @@ scripted_gui = {
 						set_country_flag = spec_inf_hire
 						activate_mission = get_wagner_special_infantry
 					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = spec_inf_hire
+						activate_mission = get_md_special_infantry
+					}
 				}
 				if = { limit = { check_variable = { v = 006 } }
 					if = { limit = { has_country_flag = blackwater_sel }
@@ -7202,6 +7223,10 @@ scripted_gui = {
 						set_country_flag = tank_hire
 						activate_mission = get_wagner_tank
 					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = tank_hire
+						activate_mission = get_md_tank
+					}
 				}
 				if = { limit = { check_variable = { v = 007 } }
 					if = { limit = { has_country_flag = blackwater_sel }
@@ -7219,6 +7244,10 @@ scripted_gui = {
 					else_if = { limit = { has_country_flag = wagner_sel }
 						set_country_flag = sf_hire
 						activate_mission = get_wagner_specops
+					}
+					else_if = { limit = { has_country_flag = md_sel }
+						set_country_flag = sf_hire
+						activate_mission = get_md_specops
 					}
 				}
 				if = { limit = { is_ai = yes }

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -283,9 +283,9 @@ def test_precommit_exempt_entries_are_current(disk, precommit):
 
 def test_strict_mismatch_allowlist_is_current(disk, precommit, ci):
     gone = sorted(STRICT_MISMATCH_ALLOWED - disk)
-    assert (
-        not gone
-    ), f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
+    assert not gone, (
+        f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
+    )
     resolved = sorted(
         s
         for s in STRICT_MISMATCH_ALLOWED
@@ -333,9 +333,9 @@ def test_validator_cache_restore_is_source_hash_scoped():
                     restore_steps.extend(
                         step.get("with", {}).get("restore-keys", "").splitlines()
                     )
-        assert (
-            restore_steps
-        ), f"No validator cache restore keys found in {workflow.name}"
+        assert restore_steps, (
+            f"No validator cache restore keys found in {workflow.name}"
+        )
         assert all(key.startswith(expected_prefix) for key in restore_steps), (
             f"{workflow.name} has a validator cache fallback outside the current "
             "validator source-hash generation"
@@ -356,12 +356,12 @@ def test_nightly_keys_the_bundle_on_the_live_base_tip():
     script = "\n".join(
         line for line in step["run"].splitlines() if not line.lstrip().startswith("#")
     )
-    assert (
-        "commits/main" in script
-    ), "the nightly must resolve main's live head for base_sha"
-    assert (
-        ".base.sha" not in script
-    ), "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    assert "commits/main" in script, (
+        "the nightly must resolve main's live head for base_sha"
+    )
+    assert ".base.sha" not in script, (
+        "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    )
 
 
 def test_mio_validator_runs_for_localisation_changes():
@@ -479,9 +479,9 @@ def test_ci_run_steps_default_to_strict():
             for step in workflow["jobs"][job]["steps"]
             if step.get("name") == "Run validation"
         )
-        assert (
-            'matrix.validator.strict }}" != "false"' in run
-        ), f"{job}'s Run step must default to --strict when `strict:` is absent."
+        assert 'matrix.validator.strict }}" != "false"' in run, (
+            f"{job}'s Run step must default to --strict when `strict:` is absent."
+        )
 
 
 def test_oob_routes_cover_every_create_unit_source():

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -283,9 +283,9 @@ def test_precommit_exempt_entries_are_current(disk, precommit):
 
 def test_strict_mismatch_allowlist_is_current(disk, precommit, ci):
     gone = sorted(STRICT_MISMATCH_ALLOWED - disk)
-    assert not gone, (
-        f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
-    )
+    assert (
+        not gone
+    ), f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
     resolved = sorted(
         s
         for s in STRICT_MISMATCH_ALLOWED
@@ -333,9 +333,9 @@ def test_validator_cache_restore_is_source_hash_scoped():
                     restore_steps.extend(
                         step.get("with", {}).get("restore-keys", "").splitlines()
                     )
-        assert restore_steps, (
-            f"No validator cache restore keys found in {workflow.name}"
-        )
+        assert (
+            restore_steps
+        ), f"No validator cache restore keys found in {workflow.name}"
         assert all(key.startswith(expected_prefix) for key in restore_steps), (
             f"{workflow.name} has a validator cache fallback outside the current "
             "validator source-hash generation"
@@ -356,12 +356,12 @@ def test_nightly_keys_the_bundle_on_the_live_base_tip():
     script = "\n".join(
         line for line in step["run"].splitlines() if not line.lstrip().startswith("#")
     )
-    assert "commits/main" in script, (
-        "the nightly must resolve main's live head for base_sha"
-    )
-    assert ".base.sha" not in script, (
-        "the PR list's .base.sha does not track main, so it cannot key the bundle"
-    )
+    assert (
+        "commits/main" in script
+    ), "the nightly must resolve main's live head for base_sha"
+    assert (
+        ".base.sha" not in script
+    ), "the PR list's .base.sha does not track main, so it cannot key the bundle"
 
 
 def test_mio_validator_runs_for_localisation_changes():
@@ -479,9 +479,9 @@ def test_ci_run_steps_default_to_strict():
             for step in workflow["jobs"][job]["steps"]
             if step.get("name") == "Run validation"
         )
-        assert 'matrix.validator.strict }}" != "false"' in run, (
-            f"{job}'s Run step must default to --strict when `strict:` is absent."
-        )
+        assert (
+            'matrix.validator.strict }}" != "false"' in run
+        ), f"{job}'s Run step must default to --strict when `strict:` is absent."
 
 
 def test_oob_routes_cover_every_create_unit_source():

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pytest
 import yaml
 from precommit_validate import _REGISTRY
+from validate_decisions import _DECISION_REFERENCE_SOURCE_PATTERNS
 from validate_oob_units import _CREATE_UNIT_SOURCE_PATTERNS
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -282,9 +283,9 @@ def test_precommit_exempt_entries_are_current(disk, precommit):
 
 def test_strict_mismatch_allowlist_is_current(disk, precommit, ci):
     gone = sorted(STRICT_MISMATCH_ALLOWED - disk)
-    assert (
-        not gone
-    ), f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
+    assert not gone, (
+        f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
+    )
     resolved = sorted(
         s
         for s in STRICT_MISMATCH_ALLOWED
@@ -332,9 +333,9 @@ def test_validator_cache_restore_is_source_hash_scoped():
                     restore_steps.extend(
                         step.get("with", {}).get("restore-keys", "").splitlines()
                     )
-        assert (
-            restore_steps
-        ), f"No validator cache restore keys found in {workflow.name}"
+        assert restore_steps, (
+            f"No validator cache restore keys found in {workflow.name}"
+        )
         assert all(key.startswith(expected_prefix) for key in restore_steps), (
             f"{workflow.name} has a validator cache fallback outside the current "
             "validator source-hash generation"
@@ -355,12 +356,12 @@ def test_nightly_keys_the_bundle_on_the_live_base_tip():
     script = "\n".join(
         line for line in step["run"].splitlines() if not line.lstrip().startswith("#")
     )
-    assert (
-        "commits/main" in script
-    ), "the nightly must resolve main's live head for base_sha"
-    assert (
-        ".base.sha" not in script
-    ), "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    assert "commits/main" in script, (
+        "the nightly must resolve main's live head for base_sha"
+    )
+    assert ".base.sha" not in script, (
+        "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    )
 
 
 def test_mio_validator_runs_for_localisation_changes():
@@ -478,9 +479,9 @@ def test_ci_run_steps_default_to_strict():
             for step in workflow["jobs"][job]["steps"]
             if step.get("name") == "Run validation"
         )
-        assert (
-            'matrix.validator.strict }}" != "false"' in run
-        ), f"{job}'s Run step must default to --strict when `strict:` is absent."
+        assert 'matrix.validator.strict }}" != "false"' in run, (
+            f"{job}'s Run step must default to --strict when `strict:` is absent."
+        )
 
 
 def test_oob_routes_cover_every_create_unit_source():
@@ -491,6 +492,11 @@ def test_oob_routes_cover_every_create_unit_source():
     assert {d + "**" for d in dirs} <= set(filters["oob"])
     spec = next(s for s in _REGISTRY if s.script == "validate_oob_units")
     assert dirs <= {prefix for prefix, _ in spec.rules}
+
+
+def test_decision_filter_covers_every_reference_source():
+    _, filters = _filter_definitions()
+    assert set(_DECISION_REFERENCE_SOURCE_PATTERNS) <= set(filters["decisions"])
 
 
 def test_gfx_reference_validator_runs_for_all_reference_sources():

--- a/tools/validation/tests/validate_decisions_meta_activation_test.py
+++ b/tools/validation/tests/validate_decisions_meta_activation_test.py
@@ -40,7 +40,7 @@ def _unused(tokens, activated_decisions, activated_missions, monkeypatch):
 def test_placeholder_name_covers_matching_tokens(monkeypatch):
     assert (
         _unused(
-            ["cyber_op_slot_0_gps_tracking", "cyber_op_slot_11_infra_tracking"],
+            ["cyber_op_slot_0_gps_tracking", "cyber_op_slot_9_infra_tracking"],
             set(),
             {"cyber_op_slot_[SLOT]_[TYPE]"},
             monkeypatch,
@@ -49,7 +49,7 @@ def test_placeholder_name_covers_matching_tokens(monkeypatch):
     )
 
 
-def test_placeholder_name_respects_prefix_and_suffix(monkeypatch):
+def test_investment_placeholder_covers_defined_slots(monkeypatch):
     assert _unused(
         ["investments_project_0_target_decision", "unrelated_target_decision"],
         {"investments_project_[INDEX]_target_decision"},
@@ -58,15 +58,31 @@ def test_placeholder_name_respects_prefix_and_suffix(monkeypatch):
     ) == ["unrelated_target_decision"]
 
 
-def test_placeholder_needs_something_in_the_gap(monkeypatch):
-    # A placeholder always substitutes to something, so the bare prefix+suffix
-    # concatenation is not one of the names the template can build.
+def test_cyber_placeholder_rejects_out_of_domain_slot_and_type(monkeypatch):
     assert _unused(
-        ["cyber_op_slot_tracking"],
+        ["cyber_op_slot_10_gps_tracking", "cyber_op_slot_0_typo_tracking"],
         set(),
-        {"cyber_op_slot_[TYPE]tracking"},
+        {"cyber_op_slot_[SLOT]_[TYPE]"},
         monkeypatch,
-    ) == ["cyber_op_slot_tracking"]
+    ) == ["cyber_op_slot_0_typo_tracking", "cyber_op_slot_10_gps_tracking"]
+
+
+def test_investment_placeholder_rejects_out_of_domain_slot(monkeypatch):
+    assert _unused(
+        ["investments_project_15_target_decision"],
+        {"investments_project_[INDEX]_target_decision"},
+        set(),
+        monkeypatch,
+    ) == ["investments_project_15_target_decision"]
+
+
+def test_unknown_placeholder_template_does_not_match(monkeypatch):
+    assert _unused(
+        ["custom_slot_0_mission"],
+        set(),
+        {"custom_slot_[SLOT]_mission"},
+        monkeypatch,
+    ) == ["custom_slot_0_mission"]
 
 
 def test_targeted_mission_matches_the_decision_scan(monkeypatch):
@@ -90,3 +106,21 @@ def test_unactivated_decision_still_flagged(monkeypatch):
         {"get_wagner_light_infantry"},
         monkeypatch,
     ) == ["get_md_light_infantry"]
+
+
+def test_activation_scan_uses_only_shipped_content_roots(tmp_path):
+    shipped = tmp_path / "common" / "scripted_effects" / "effects.txt"
+    shipped.parent.mkdir(parents=True)
+    shipped.write_text("activate_mission = shipped_mission\n", encoding="utf-8")
+
+    archived = tmp_path / "resources" / "archive.txt"
+    archived.parent.mkdir()
+    archived.write_text("activate_mission = archived_mission\n", encoding="utf-8")
+
+    decisions, missions, removals = V.Validator(
+        str(tmp_path), workers=1
+    )._get_activation_removal_scan()
+
+    assert decisions == set()
+    assert missions == {"shipped_mission"}
+    assert removals == set()

--- a/tools/validation/tests/validate_decisions_meta_activation_test.py
+++ b/tools/validation/tests/validate_decisions_meta_activation_test.py
@@ -1,0 +1,92 @@
+"""Regressions for meta_effect-constructed decision activations.
+
+`activate_mission = cyber_op_slot_[SLOT]_[TYPE]` reaches the activation scan
+with its placeholders intact, so the unused-decision check has to match on the
+constant text around each `[...]` instead of literally.
+"""
+
+import validate_decisions as V
+
+
+class _FakeValidator(V.Validator):
+    """Validator whose _report collects results instead of rendering."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.collected = []
+
+    def _report(self, results, ok_msg, fail_msg, severity=None, category=""):
+        self.collected.extend(results)
+
+
+def _unused(tokens, activated_decisions, activated_missions, monkeypatch):
+    factories = [
+        V.DecisionFactory(
+            f"{token} = {{\n\tallowed = {{ always = no }}\n}}", source_basename="X.txt"
+        )
+        for token in tokens
+    ]
+    validator = _FakeValidator("/tmp")
+    monkeypatch.setattr(V, "parse_all_decision_factories", lambda mod_path: factories)
+    monkeypatch.setattr(
+        validator,
+        "_get_activation_removal_scan",
+        lambda: (activated_decisions, activated_missions, set()),
+    )
+    validator.validate_unused_decisions()
+    return validator.collected
+
+
+def test_placeholder_name_covers_matching_tokens(monkeypatch):
+    assert (
+        _unused(
+            ["cyber_op_slot_0_gps_tracking", "cyber_op_slot_11_infra_tracking"],
+            set(),
+            {"cyber_op_slot_[SLOT]_[TYPE]"},
+            monkeypatch,
+        )
+        == []
+    )
+
+
+def test_placeholder_name_respects_prefix_and_suffix(monkeypatch):
+    assert _unused(
+        ["investments_project_0_target_decision", "unrelated_target_decision"],
+        {"investments_project_[INDEX]_target_decision"},
+        set(),
+        monkeypatch,
+    ) == ["unrelated_target_decision"]
+
+
+def test_placeholder_needs_something_in_the_gap(monkeypatch):
+    # A placeholder always substitutes to something, so the bare prefix+suffix
+    # concatenation is not one of the names the template can build.
+    assert _unused(
+        ["cyber_op_slot_tracking"],
+        set(),
+        {"cyber_op_slot_[TYPE]tracking"},
+        monkeypatch,
+    ) == ["cyber_op_slot_tracking"]
+
+
+def test_targeted_mission_matches_the_decision_scan(monkeypatch):
+    # A mission with a target is activated by activate_targeted_decision, which
+    # lands in the decision set rather than the mission set.
+    assert (
+        _unused(
+            ["investments_project_3_target_decision"],
+            {"investments_project_3_target_decision"},
+            set(),
+            monkeypatch,
+        )
+        == []
+    )
+
+
+def test_unactivated_decision_still_flagged(monkeypatch):
+    assert _unused(
+        ["get_md_light_infantry"],
+        {"get_blackwater_light_infantry"},
+        {"get_wagner_light_infantry"},
+        monkeypatch,
+    ) == ["get_md_light_infantry"]

--- a/tools/validation/tests/validate_targeted_trigger_placement_test.py
+++ b/tools/validation/tests/validate_targeted_trigger_placement_test.py
@@ -1,0 +1,169 @@
+"""Tests for the targeted-decision trigger-placement performance checks."""
+
+import validate_decisions as V
+
+
+class _FakeValidator(V.Validator):
+    """Validator whose _report collects results instead of rendering."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.collected = []
+
+    def _report(self, results, ok_msg, fail_msg, severity=None, category=""):
+        self.collected.extend(results)
+
+
+def _results_for(factories, monkeypatch, check):
+    validator = _FakeValidator("/tmp")
+    monkeypatch.setattr(V, "parse_all_decision_factories", lambda mod_path: factories)
+    getattr(validator, check)()
+    return validator.collected
+
+
+def _factory(body):
+    return V.DecisionFactory(body, source_basename="X.txt")
+
+
+TARGETS_BLOCK = "\ttargets = {\n\t\tTAG\n\t}\n"
+TARGET_ROOT_TRIGGER_BLOCK = "\ttarget_root_trigger = {\n\t\thas_capital = yes\n\t}\n"
+ALLOWED_ALWAYS_NO = "\tallowed = {\n\t\talways = no\n\t}\n"
+STATE_TARGET_YES = "\tstate_target = yes\n"
+
+VISIBLE_ROOT_ONLY = "\tvisible = {\n\t\thas_capital = yes\n\t}\n"
+VISIBLE_WITH_FROM = (
+    "\tvisible = {\n\t\tFROM = {\n\t\t\tis_in_faction_with = ROOT\n\t\t}\n\t}\n"
+)
+
+TARGET_TRIGGER_NO_FROM = "\ttarget_trigger = {\n\t\thas_capital = yes\n\t}\n"
+TARGET_TRIGGER_WITH_FROM = (
+    "\ttarget_trigger = {\n\t\tFROM = {\n\t\t\tis_in_faction_with = ROOT\n\t\t}\n\t}\n"
+)
+
+
+def _dec(token, *field_blocks):
+    return f"{token} = {{\n" + "".join(field_blocks) + "}"
+
+
+# --- validate_root_only_visible_on_targeted ---
+
+
+def test_root_only_check_skips_visible_referencing_from(monkeypatch):
+    factory = _factory(_dec("dec_c1_clean", TARGETS_BLOCK, VISIBLE_WITH_FROM))
+    assert (
+        _results_for([factory], monkeypatch, "validate_root_only_visible_on_targeted")
+        == []
+    )
+
+
+def test_root_only_visible_flagged(monkeypatch):
+    factory = _factory(_dec("dec_c1_violation", TARGETS_BLOCK, VISIBLE_ROOT_ONLY))
+    results = _results_for(
+        [factory], monkeypatch, "validate_root_only_visible_on_targeted"
+    )
+    assert len(results) == 1
+    assert "dec_c1_violation" in results[0]
+    assert "target_root_trigger" in results[0]
+
+
+def test_root_only_check_exempts_allowed_always_no(monkeypatch):
+    factory = _factory(
+        _dec("dec_c1_alwaysno", TARGETS_BLOCK, VISIBLE_ROOT_ONLY, ALLOWED_ALWAYS_NO)
+    )
+    assert (
+        _results_for([factory], monkeypatch, "validate_root_only_visible_on_targeted")
+        == []
+    )
+
+
+def test_root_only_check_exempts_state_target(monkeypatch):
+    factory = _factory(
+        _dec("dec_c1_statetarget", TARGETS_BLOCK, VISIBLE_ROOT_ONLY, STATE_TARGET_YES)
+    )
+    assert (
+        _results_for([factory], monkeypatch, "validate_root_only_visible_on_targeted")
+        == []
+    )
+
+
+def test_root_only_check_ignores_non_targeted_decision(monkeypatch):
+    factory = _factory(_dec("dec_c1_nontargeted", VISIBLE_ROOT_ONLY))
+    assert (
+        _results_for([factory], monkeypatch, "validate_root_only_visible_on_targeted")
+        == []
+    )
+
+
+def test_root_only_check_skips_when_target_root_trigger_present(monkeypatch):
+    factory = _factory(
+        _dec(
+            "dec_c1_hastarget_root",
+            TARGETS_BLOCK,
+            TARGET_ROOT_TRIGGER_BLOCK,
+            VISIBLE_ROOT_ONLY,
+        )
+    )
+    assert (
+        _results_for([factory], monkeypatch, "validate_root_only_visible_on_targeted")
+        == []
+    )
+
+
+# --- validate_from_checks_in_visible ---
+
+
+def test_from_in_visible_check_skips_visible_without_from(monkeypatch):
+    factory = _factory(_dec("dec_c2_clean", TARGET_TRIGGER_NO_FROM, VISIBLE_ROOT_ONLY))
+    assert _results_for([factory], monkeypatch, "validate_from_checks_in_visible") == []
+
+
+def test_from_in_visible_flagged_with_move_advice(monkeypatch):
+    factory = _factory(
+        _dec("dec_c2_violation", TARGET_TRIGGER_NO_FROM, VISIBLE_WITH_FROM)
+    )
+    results = _results_for([factory], monkeypatch, "validate_from_checks_in_visible")
+    assert len(results) == 1
+    assert "dec_c2_violation" in results[0]
+    assert "move" in results[0]
+
+
+def test_from_in_visible_check_exempts_allowed_always_no(monkeypatch):
+    factory = _factory(
+        _dec(
+            "dec_c2_alwaysno",
+            TARGET_TRIGGER_NO_FROM,
+            VISIBLE_WITH_FROM,
+            ALLOWED_ALWAYS_NO,
+        )
+    )
+    assert _results_for([factory], monkeypatch, "validate_from_checks_in_visible") == []
+
+
+def test_from_in_visible_check_exempts_state_target(monkeypatch):
+    factory = _factory(
+        _dec(
+            "dec_c2_statetarget",
+            TARGET_TRIGGER_NO_FROM,
+            VISIBLE_WITH_FROM,
+            STATE_TARGET_YES,
+        )
+    )
+    assert _results_for([factory], monkeypatch, "validate_from_checks_in_visible") == []
+
+
+def test_from_in_visible_check_ignores_decision_without_target_trigger(monkeypatch):
+    factory = _factory(_dec("dec_c2_nontargeted", VISIBLE_WITH_FROM))
+    assert _results_for([factory], monkeypatch, "validate_from_checks_in_visible") == []
+
+
+def test_from_in_visible_identical_to_target_trigger_gets_deletion_advice(
+    monkeypatch,
+):
+    factory = _factory(
+        _dec("dec_c2_duplicate", TARGET_TRIGGER_WITH_FROM, VISIBLE_WITH_FROM)
+    )
+    results = _results_for([factory], monkeypatch, "validate_from_checks_in_visible")
+    assert len(results) == 1
+    assert "dec_c2_duplicate" in results[0]
+    assert "delete" in results[0]
+    assert "identical" in results[0]

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -27,13 +27,6 @@ from validator_common import (
 
 EXTRA_SKIP_PATTERNS = DEFAULT_EXTRA_SKIP_PATTERNS
 
-# Decisions activated dynamically (e.g. via variable-constructed IDs) that
-# cannot be detected by static analysis and should be excluded from the
-# unused-decision check.
-DYNAMICALLY_ACTIVATED_DECISIONS = [
-    f"AC_project_{i}_target_decision" for i in range(15)
-] + [f"investments_project_{i}_target_decision" for i in range(15)]
-
 
 def _should_skip(filename: str) -> bool:
     return should_skip_file(filename, extra_skip_patterns=EXTRA_SKIP_PATTERNS)
@@ -44,6 +37,7 @@ _TARGETED_BLOCK_RE = re.compile(
 )
 _DECISION_NAME_RE = re.compile(r"\bdecision\s*=\s*(\S+)")
 _MISSION_NAME_RE = re.compile(r"\bactivate_mission\s*=\s*(\S+)")
+_META_PLACEHOLDER_RE = re.compile(r"\[[^\]]+\]")
 _BRACKETED_LOC_RE = re.compile(r"^\[([A-Za-z0-9_]+)\]$")
 _SCRIPTED_LOC_RE = re.compile(r"\bname\s*=\s*([A-Za-z0-9_]+)")
 
@@ -92,7 +86,37 @@ _REMOVE_DECISION_RE = re.compile(r"\bremove_decision\s*=\s*(\w+)")
 _REMOVE_TARGETED_BLOCK_RE = re.compile(
     r"\bremove_targeted_decision\s*=\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}"
 )
-_REMOVE_DECISION_NAME_RE = re.compile(r"\bdecision\s*=\s*(\w+)")
+_REMOVE_DECISION_NAME_RE = re.compile(r"\bdecision\s*=\s*(\S+)")
+
+
+def _unactivated(candidates: set, activated: set) -> list:
+    """Sorted *candidates* with no matching entry in *activated*.
+
+    Names assembled by ``meta_effect`` substitution reach the scan with their
+    placeholders intact (``cyber_op_slot_[SLOT]_[TYPE]``), so they never match
+    a token literally — those are matched on the constant text surrounding
+    each ``[...]`` instead.
+    """
+    remaining = candidates - activated
+    for name in activated:
+        if not remaining:
+            break
+        if "[" not in name:
+            continue
+        parts = _META_PLACEHOLDER_RE.split(name)
+        prefix, suffix = parts[0], parts[-1]
+        if not prefix and not suffix:
+            continue
+        remaining = {
+            token
+            for token in remaining
+            if not (
+                token.startswith(prefix)
+                and token.endswith(suffix)
+                and len(token) > len(prefix) + len(suffix)
+            )
+        }
+    return sorted(remaining)
 
 
 def _scan_activations_and_removals(filename: str) -> Tuple[set, set, set]:
@@ -877,16 +901,11 @@ class Validator(BaseValidator):
             "Checking for unused decisions (always=no but never activated)..."
         )
 
-        factories = parse_all_decision_factories(self.mod_path)
-        manual_decisions: set = set()
-        manual_missions: set = set()
-
-        for d in factories:
-            if d.allowed and "always = no" in d.allowed:
-                if d.mission_subtype:
-                    manual_missions.add(d.token)
-                else:
-                    manual_decisions.add(d.token)
+        manual = {
+            d.token
+            for d in parse_all_decision_factories(self.mod_path)
+            if d.allowed and "always = no" in d.allowed
+        }
 
         # The worker extracts `decision = X` only from inside an
         # `activate_targeted_decision = { ... }` block; the bare keyword
@@ -894,14 +913,9 @@ class Validator(BaseValidator):
         # and matching them would hide genuinely unused decisions.
         activated_decisions, activated_missions, _ = self._get_activation_removal_scan()
 
-        results = sorted(
-            (manual_decisions - activated_decisions)
-            - set(DYNAMICALLY_ACTIVATED_DECISIONS)
-        )
-        results += sorted(
-            (manual_missions - activated_missions)
-            - set(DYNAMICALLY_ACTIVATED_DECISIONS)
-        )
+        # A mission with a target is activated by activate_targeted_decision, so
+        # neither set alone covers every activation mechanism.
+        results = _unactivated(manual, activated_decisions | activated_missions)
         self._report(
             results,
             "✓ No unused decisions",

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -27,6 +27,12 @@ from validator_common import (
 
 EXTRA_SKIP_PATTERNS = DEFAULT_EXTRA_SKIP_PATTERNS
 
+_DECISION_REFERENCE_SOURCE_PATTERNS = (
+    "common/**/*.txt",
+    "events/**/*.txt",
+    "history/**/*.txt",
+)
+
 
 def _should_skip(filename: str) -> bool:
     return should_skip_file(filename, extra_skip_patterns=EXTRA_SKIP_PATTERNS)
@@ -37,7 +43,6 @@ _TARGETED_BLOCK_RE = re.compile(
 )
 _DECISION_NAME_RE = re.compile(r"\bdecision\s*=\s*(\S+)")
 _MISSION_NAME_RE = re.compile(r"\bactivate_mission\s*=\s*(\S+)")
-_META_PLACEHOLDER_RE = re.compile(r"\[[^\]]+\]")
 _BRACKETED_LOC_RE = re.compile(r"^\[([A-Za-z0-9_]+)\]$")
 _SCRIPTED_LOC_RE = re.compile(r"\bname\s*=\s*([A-Za-z0-9_]+)")
 
@@ -88,34 +93,43 @@ _REMOVE_TARGETED_BLOCK_RE = re.compile(
 )
 _REMOVE_DECISION_NAME_RE = re.compile(r"\bdecision\s*=\s*(\S+)")
 
+_CYBER_OPERATION_TYPES = (
+    "gps_tracking",
+    "economic_tracking",
+    "propaganda_tracking",
+    "infra_tracking",
+    "crit_tracking",
+    "sigint_surveillance_tracking",
+    "radar_spoofing_tracking",
+    "election_interference_tracking",
+    "industrial_espionage_tracking",
+    "comms_intercept_tracking",
+    "financial_system_attack_tracking",
+    "logistics_disruption_tracking",
+    "sleeper_network_tracking",
+    "deception_campaign_tracking",
+    "zero_day_strike_tracking",
+    "network_hardening_tracking",
+    "counter_intrusion_tracking",
+    "attribution_hunt_tracking",
+)
+_DYNAMIC_ACTIVATION_EXPANSIONS = {
+    "cyber_op_slot_[SLOT]_[TYPE]": {
+        f"cyber_op_slot_{slot}_{operation_type}"
+        for slot in range(10)
+        for operation_type in _CYBER_OPERATION_TYPES
+    },
+    "investments_project_[INDEX]_target_decision": {
+        f"investments_project_{index}_target_decision" for index in range(15)
+    },
+}
+
 
 def _unactivated(candidates: set, activated: set) -> list:
-    """Sorted *candidates* with no matching entry in *activated*.
-
-    Names assembled by ``meta_effect`` substitution reach the scan with their
-    placeholders intact (``cyber_op_slot_[SLOT]_[TYPE]``), so they never match
-    a token literally — those are matched on the constant text surrounding
-    each ``[...]`` instead.
-    """
+    """Sorted *candidates* with no literal or finite meta-effect activation."""
     remaining = candidates - activated
     for name in activated:
-        if not remaining:
-            break
-        if "[" not in name:
-            continue
-        parts = _META_PLACEHOLDER_RE.split(name)
-        prefix, suffix = parts[0], parts[-1]
-        if not prefix and not suffix:
-            continue
-        remaining = {
-            token
-            for token in remaining
-            if not (
-                token.startswith(prefix)
-                and token.endswith(suffix)
-                and len(token) > len(prefix) + len(suffix)
-            )
-        }
+        remaining.difference_update(_DYNAMIC_ACTIVATION_EXPANSIONS.get(name, ()))
     return sorted(remaining)
 
 
@@ -483,7 +497,7 @@ def _find_category_redundant_rows(
 def extract_value_single_line(obj: str, s: str) -> str:
     pattern = r"\t+" + s + r" = (\S*)"
     matches = re.findall(pattern, obj)
-    return matches[0] if f"\t{s} =" in obj and matches else False
+    return matches[0] if f"\t{s} =" in obj and matches else ""
 
 
 def _top_level_field_value(raw: str, field: str):
@@ -531,9 +545,9 @@ def _top_level_field_value(raw: str, field: str):
 def extract_value_multi_line(obj: str, s: str) -> str:
     pattern = r"(\t+)" + s + r" = (\{([^\n]*|.*?^\1)\})"
     if f"\t{s} =" not in obj:
-        return False
+        return ""
     matches = re.findall(pattern, obj, flags=re.DOTALL | re.MULTILINE)
-    return matches[0][1] if matches else False
+    return matches[0][1] if matches else ""
 
 
 class DecisionFactory:
@@ -840,16 +854,16 @@ class Validator(BaseValidator):
             _set_cache_enabled(False)
 
     def _get_activation_removal_scan(self) -> Tuple[set, set, set]:
-        """Full-repo scan for decision activations and external removals.
-
-        One .txt sweep shared by validate_unused_decisions and
-        validate_orphaned_remove_effect (was two separate full-repo passes).
-        """
+        """Scan shipped content for decision activations and external removals."""
         if self._activation_removal_cache is not None:
             return self._activation_removal_cache
-        all_files = list(
-            glob.iglob(os.path.join(self.mod_path, "**", "*.txt"), recursive=True)
-        )
+        all_files = [
+            filename
+            for pattern in _DECISION_REFERENCE_SOURCE_PATTERNS
+            for filename in glob.iglob(
+                os.path.join(self.mod_path, pattern), recursive=True
+            )
+        ]
         activated_decisions: set = set()
         activated_missions: set = set()
         externally_removed: set = set()

--- a/tools/validation/validate_decisions.py
+++ b/tools/validation/validate_decisions.py
@@ -180,6 +180,39 @@ _CATEGORY_DECISION_TOKEN_RE = re.compile(r"^[ \t]+(\S+) = \{", flags=re.MULTILIN
 _FROM_BLOCK_RE = re.compile(r"\bFROM\s*=\s*\{")
 _FROM_WORD_RE = re.compile(r"\bFROM\b")
 
+
+def _is_targeted_decision(d: "DecisionFactory") -> bool:
+    """True if targets/target_array/target_trigger/target_root_trigger is present."""
+    return bool(
+        d.targets or d.target_array or d.target_trigger or d.target_root_trigger
+    )
+
+
+def _extract_from_blocks(block: str) -> List[str]:
+    """Return the brace-balanced body text of every ``FROM = { ... }`` in *block*.
+
+    ``_FROM_BLOCK_RE`` only matches the opening ``FROM = {``; this walks
+    forward to the matching close so callers get the full block body, not
+    just the header.
+    """
+    if not block:
+        return []
+    bodies = []
+    for m in _FROM_BLOCK_RE.finditer(block):
+        depth = 1
+        i = m.end()
+        n = len(block)
+        while i < n and depth > 0:
+            if block[i] == "{":
+                depth += 1
+            elif block[i] == "}":
+                depth -= 1
+            i += 1
+        if depth == 0:
+            bodies.append(block[m.end() : i - 1])
+    return bodies
+
+
 # Bare trigger names needing a has_ prefix (hoisted from validate_bare_trigger_names).
 _BARE_TRIGGERS = {
     "political_power": "has_political_power",
@@ -1110,6 +1143,118 @@ class Validator(BaseValidator):
             results,
             "✓ No decisions with FROM checks needing target_trigger",
             "Decisions with FROM checks in visible/available but no target_trigger (move FROM into target_trigger for perf):",
+        )
+
+    def validate_root_only_visible_on_targeted(self):
+        """Flag targeted decisions whose visible block is entirely ROOT-only.
+
+        A targeted decision (targets/target_array/target_trigger/
+        target_root_trigger present) evaluates visible every tick, once per
+        surviving target with FROM bound. If visible never references FROM
+        and there's no target_root_trigger already carrying the ROOT-only
+        checks, the whole block is redundant per-target work for something
+        that only needs to run once per ROOT per day. Rename it to
+        target_root_trigger.
+
+        Exempts:
+        - ``allowed = { always = no }`` (decision is script-activated, never
+          auto-visible)
+        - ``state_target = yes`` / ``on_map_mode = map_only`` (player-driven
+          map click, not a daily per-target loop)
+        """
+        self._log_section(
+            "Checking targeted decisions for a ROOT-only visible block (performance)..."
+        )
+
+        factories = parse_all_decision_factories(self.mod_path)
+        results = []
+
+        for d in factories:
+            if not _is_targeted_decision(d):
+                continue
+            if d.target_root_trigger:
+                continue
+            if not d.visible:
+                continue
+            if d.allowed and "always = no" in d.allowed:
+                continue
+            if d.state_target or d.map_only:
+                continue
+            if _FROM_WORD_RE.search(d.visible):
+                continue
+            results.append(
+                f"{d.token:<55}{d.source_basename} - visible is ROOT-only and "
+                f"re-evaluated every tick per target; rename to target_root_trigger"
+            )
+
+        self._report(
+            results,
+            "✓ No targeted decisions with a ROOT-only visible block",
+            "Targeted decisions with a ROOT-only visible and no target_root_trigger (rename visible to target_root_trigger, evaluated daily instead of every tick per target):",
+        )
+
+    def validate_from_checks_in_visible(self):
+        """Flag targeted decisions with FROM checks in visible when a
+        target_trigger already exists.
+
+        visible is evaluated every tick with FROM bound to each surviving
+        target; target_trigger runs the same predicate once per (ROOT, FROM)
+        pair per day. Moving a FROM check from visible into an existing
+        target_trigger is safe with no player-facing change: a failing
+        visible hides the entry and renders no tooltip, exactly like a
+        failing target_trigger.
+
+        Deliberately out of scope: FROM checks in ``available`` are NOT
+        flagged here and must stay put. ``available`` is what renders the
+        red blocked-reason tooltip; moving those into target_trigger would
+        silently drop targets from the list instead of explaining why
+        they're blocked. ``validate_targets_no_trigger`` already covers the
+        case where target_trigger is genuinely missing.
+
+        Exempts:
+        - ``allowed = { always = no }``
+        - ``state_target = yes`` / ``on_map_mode = map_only``
+        """
+        self._log_section(
+            "Checking targeted decisions for FROM checks in visible duplicating target_trigger (performance)..."
+        )
+
+        factories = parse_all_decision_factories(self.mod_path)
+        results = []
+
+        for d in factories:
+            if not d.target_trigger:
+                continue
+            if d.allowed and "always = no" in d.allowed:
+                continue
+            if d.state_target or d.map_only:
+                continue
+            if not d.visible:
+                continue
+
+            visible_from_bodies = _extract_from_blocks(d.visible)
+            if not visible_from_bodies:
+                continue
+
+            normalized_visible = {self._normalize_block(b) for b in visible_from_bodies}
+            normalized_trigger = {
+                self._normalize_block(b) for b in _extract_from_blocks(d.target_trigger)
+            }
+
+            if normalized_visible <= normalized_trigger:
+                advice = (
+                    "identical to the FROM check already in target_trigger; "
+                    "delete it from visible instead of moving it"
+                )
+            else:
+                advice = "move the FROM check into target_trigger (daily) instead of visible (every tick)"
+
+            results.append(f"{d.token:<55}{d.source_basename} - {advice}")
+
+        self._report(
+            results,
+            "✓ No targeted decisions with FROM checks in visible duplicating target_trigger",
+            "Targeted decisions with FROM checks in visible while target_trigger exists:",
         )
 
     def validate_from_without_targets(self):
@@ -2076,6 +2221,8 @@ class Validator(BaseValidator):
         self.validate_custom_cost_trigger()
         self.validate_targeted_without_target()
         self.validate_targets_no_trigger()
+        self.validate_root_only_visible_on_targeted()
+        self.validate_from_checks_in_visible()
         self.validate_from_without_targets()
         self.validate_without_allowed_check()
         self.validate_random_seed()


### PR DESCRIPTION
## What
- Extend decision validation to resolve literal and finite dynamically constructed script activations, with regression coverage and CI routing for every reference source.
- Keep script-activated cyber tracking and PMC missions out of the normal decision menu, and wire MD PMC selections to their hire missions.
- Move selected targeted-decision checks from visible to target_root_trigger or target_trigger, where they run at the required scope rather than once per target every tick.
- Track terrorist-menace modifier holders and use the maintained NATO member array instead of global country scans.
- Remove scripted diplomatic-action logging, correct three Mercosur decision log IDs, and standardize one legacy comment delimiter.

## Why
Script-only missions must remain available to their effects and GUIs without becoming player-selectable decisions. The validator must recognize those activations instead of treating valid content as unused. Targeted decisions and War on Terror cleanup should not repeat work across every possible country when the relevant scope is known.

## How
- Scan common/, events/, and history/ for decision activation and removal references, expanding supported finite meta-effect IDs.
- Gate the affected cyber and PMC missions with allowed = { always = no }; their existing script paths continue to activate them.
- Add validator tests for dynamic activation, target-trigger placement, and CI path coverage.
- Maintain wot_terrorist_menace_holders when modifiers are applied, clear tracked holders on government change, and iterate global.nato_members for NATO responses.