### PR TITLE
Guard autonomy overlord scopes

### DIFF
--- a/common/autonomous_states/MD_AFG_autonomies.txt
+++ b/common/autonomous_states/MD_AFG_autonomies.txt
@@ -32,8 +32,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = USA
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = USA
+			}
 		}
 		original_tag = AFG
 	}

--- a/common/autonomous_states/MD_HOL_personal_union.txt
+++ b/common/autonomous_states/MD_HOL_personal_union.txt
@@ -36,8 +36,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			tag = HOL
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				tag = HOL
+			}
 		}
 		OR = {
 			original_tag = ENG

--- a/common/autonomous_states/MD_IRQ_autonomies.txt
+++ b/common/autonomous_states/MD_IRQ_autonomies.txt
@@ -32,8 +32,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = USA
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = USA
+			}
 		}
 		original_tag = IRQ
 	}
@@ -75,9 +78,14 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = POL
-			original_tag = ENG
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				OR = {
+					original_tag = POL
+					original_tag = ENG
+				}
+			}
 		}
 		original_tag = IRQ
 	}

--- a/common/autonomous_states/MD_MNT_autonomies.txt
+++ b/common/autonomous_states/MD_MNT_autonomies.txt
@@ -34,21 +34,30 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 		original_tag = MNT
 	}
 
 	can_take_level = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 	}
 
 	can_lose_level = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 	}
 }
@@ -91,21 +100,30 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 		original_tag = MNT
 	}
 
 	can_take_level = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 	}
 
 	can_lose_level = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 	}
 }

--- a/common/autonomous_states/MD_antillean_autonomies.txt
+++ b/common/autonomous_states/MD_antillean_autonomies.txt
@@ -38,8 +38,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = CUB
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = CUB
+			}
 		}
 		OR = {
 		original_tag = HAI

--- a/common/autonomous_states/MD_armenian_autonomies.txt
+++ b/common/autonomous_states/MD_armenian_autonomies.txt
@@ -39,8 +39,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = ARM
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = ARM
+			}
 		}
 		original_tag = NKR
 	}
@@ -93,9 +96,12 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = ARM
-			has_government = democratic
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = ARM
+				has_government = democratic
+			}
 		}
 		OR = {
 			original_tag = CHE

--- a/common/autonomous_states/MD_british_autonomies.txt
+++ b/common/autonomous_states/MD_british_autonomies.txt
@@ -56,9 +56,12 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = ENG
-			NOT = { has_country_flag = ENG_devolution_purged }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = ENG
+				NOT = { has_country_flag = ENG_devolution_purged }
+			}
 		}
 		ENG_constituent_state_check = yes
 	}
@@ -69,7 +72,10 @@ autonomy_state = {
 
 	# Conditions to Annex via Puppet System
 	can_lose_level = {
-		OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		}
 	}
 }
 
@@ -115,7 +121,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = ADS }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = ADS }
+		}
 	}
 
 	can_take_level = {

--- a/common/autonomous_states/MD_caliphate_autonomies.txt
+++ b/common/autonomous_states/MD_caliphate_autonomies.txt
@@ -34,7 +34,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { is_in_array = { ruling_party = 11 } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { is_in_array = { ruling_party = 11 } }
+		}
 	}
 
 	can_take_level = {
@@ -79,7 +82,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { is_in_array = { ruling_party = 11 } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { is_in_array = { ruling_party = 11 } }
+		}
 	}
 
 	can_take_level = {
@@ -124,21 +130,33 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { is_in_array = { ruling_party = 11 } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { is_in_array = { ruling_party = 11 } }
+		}
 	}
 
 	# Annex Requirements
 	can_take_level = {
 		if = { limit = { original_tag = ERI }
-			OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			}
 		}
 	}
 
 	# Conditions to Annex via Puppet System
 	can_lose_level = {
-		OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		}
 		if = { limit = { original_tag = ERI }
-			OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			}
 		}
 	}
 }

--- a/common/autonomous_states/MD_chinese_autonomies.txt
+++ b/common/autonomous_states/MD_chinese_autonomies.txt
@@ -37,7 +37,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = CHI }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = CHI }
+		}
 		original_tag = HKG
 	}
 
@@ -88,7 +91,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = CHI }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = CHI }
+		}
 		original_tag = MAC
 	}
 
@@ -139,7 +145,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = CHI }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = CHI }
+		}
 		original_tag = TAI
 	}
 
@@ -190,7 +199,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = CHI }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = CHI }
+		}
 		original_tag = TIB
 	}
 
@@ -241,7 +253,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = CHI }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = CHI }
+		}
 		original_tag = ETK
 	}
 
@@ -292,7 +307,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = CHI }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = CHI }
+		}
 		original_tag = MON
 	}
 

--- a/common/autonomous_states/MD_colored_autonomies.txt
+++ b/common/autonomous_states/MD_colored_autonomies.txt
@@ -191,15 +191,24 @@ autonomy_state = {
 	# OVERLORD = { } is the overlord nation
 	can_take_level = {
 		if = { limit = { original_tag = ERI }
-			OVERLORD = { NOT = { has_country_flag = ETH_locked_federalisation_FLAG } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_country_flag = ETH_locked_federalisation_FLAG } }
+			}
 		}
 	}
 
 	# Conditions to Annex via Puppet System
 	can_lose_level = {
-		OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		}
 		if = { limit = { original_tag = ERI }
-			OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			}
 		}
 	}
 }

--- a/common/autonomous_states/MD_danish_autonomies.txt
+++ b/common/autonomous_states/MD_danish_autonomies.txt
@@ -37,8 +37,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = DEN
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = DEN
+			}
 		}
 		OR = {
 			original_tag = GRN

--- a/common/autonomous_states/MD_default_autonomies.txt
+++ b/common/autonomous_states/MD_default_autonomies.txt
@@ -173,7 +173,10 @@ autonomy_state = {
 	# OVERLORD = { } is the overlord nation
 	can_take_level = {
 		if = { limit = { original_tag = ERI }
-			OVERLORD = { NOT = { has_country_flag = ETH_locked_federalisation_FLAG } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_country_flag = ETH_locked_federalisation_FLAG } }
+			}
 		}
 		if = {
 			limit = {
@@ -182,15 +185,24 @@ autonomy_state = {
 					original_tag = HUN
 				}
 			}
-			OVERLORD = { NOT = { has_cosmetic_tag = CZE_SLO_czechoslovakia } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_cosmetic_tag = CZE_SLO_czechoslovakia } }
+			}
 		}
 	}
 
 	# Conditions to Annex via Puppet System
 	can_lose_level = {
-		OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { NOT = { has_idea = generic_bureaucratic_drain_idea } }
+		}
 		if = { limit = { original_tag = ERI }
-			OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_idea = ETH_eritrean_constitution } }
+			}
 		}
 		if = {
 			limit = {
@@ -199,7 +211,10 @@ autonomy_state = {
 					original_tag = HUN
 				}
 			}
-			OVERLORD = { NOT = { has_cosmetic_tag = CZE_SLO_czechoslovakia } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_cosmetic_tag = CZE_SLO_czechoslovakia } }
+			}
 		}
 	}
 }

--- a/common/autonomous_states/MD_france_autonomies.txt
+++ b/common/autonomous_states/MD_france_autonomies.txt
@@ -32,12 +32,18 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = { original_tag = FRA }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = FRA }
+		}
 		# INFO: Add an OR statement and every successive tag that needs to be added here
 		OR = {
 			AND = {
 				original_tag = MTE
-				OVERLORD = { has_country_flag = FRA_MTE_overseas_department }
+				if = {
+					limit = { is_subject = yes }
+					OVERLORD = { has_country_flag = FRA_MTE_overseas_department }
+				}
 			}
 			original_tag = COM
 		}

--- a/common/autonomous_states/MD_iran_autonomies.txt
+++ b/common/autonomous_states/MD_iran_autonomies.txt
@@ -37,8 +37,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			has_country_flag = PER_decentralized_nation
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				has_country_flag = PER_decentralized_nation
+			}
 		}
 	}
 
@@ -91,8 +94,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			has_completed_focus = PER_workers_party_of_iraq
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				has_completed_focus = PER_workers_party_of_iraq
+			}
 		}
 		original_tag = IRQ
 	}
@@ -146,8 +152,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			has_country_flag = PER_autonomize_kurds
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				has_country_flag = PER_autonomize_kurds
+			}
 		}
 		original_tag = IKR
 	}

--- a/common/autonomous_states/MD_israeli_autonomies.txt
+++ b/common/autonomous_states/MD_israeli_autonomies.txt
@@ -40,8 +40,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = ISR
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = ISR
+			}
 		}
 		original_tag = PAL
 	}
@@ -94,8 +97,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = ISR
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = ISR
+			}
 		}
 		original_tag = PAL
 	}
@@ -148,8 +154,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = ISR
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = ISR
+			}
 		}
 		original_tag = PAL
 	}
@@ -203,8 +212,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = PAL
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = PAL
+			}
 		}
 		original_tag = HAM
 	}

--- a/common/autonomous_states/MD_korea_autonomies.txt
+++ b/common/autonomous_states/MD_korea_autonomies.txt
@@ -50,8 +50,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = NKO
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = NKO
+			}
 		}
 		original_tag = KOR
 	}

--- a/common/autonomous_states/MD_russian_autonomies.txt
+++ b/common/autonomous_states/MD_russian_autonomies.txt
@@ -39,8 +39,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = KHM
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = KHM
+			}
 		}
 		OR = {
 			original_tag = CHE
@@ -125,9 +128,12 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
-			emerging_communist_state_are_in_power = yes
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+				emerging_communist_state_are_in_power = yes
+			}
 		}
 		has_idea = faction_warsaw_pact_idea
 	}
@@ -180,8 +186,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		OR = {
 			original_tag = CHE
@@ -276,7 +285,10 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = { original_tag = SOV }
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = { original_tag = SOV }
+		}
 		has_country_flag = SOV_subject_republic
 		OR = {
 			original_tag = CHE
@@ -370,8 +382,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		has_country_flag = SOV_subject_kray
 		OR = {
@@ -466,8 +481,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		OR = {
 			original_tag = CHE
@@ -562,8 +580,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		OR = {
 			original_tag = CHE
@@ -658,8 +679,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		SOV = {
 			OR = {
@@ -750,8 +774,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		OR = {
 			original_tag = ARM

--- a/common/autonomous_states/MD_serbian_autonomies.txt
+++ b/common/autonomous_states/MD_serbian_autonomies.txt
@@ -40,8 +40,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 		original_tag = VOJ
 	}
@@ -94,11 +97,16 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
-		original_tag = VOJ
-		original_tag = MNT
+		OR = {
+			original_tag = VOJ
+			original_tag = MNT
+		}
 	}
 
 	can_take_level = {
@@ -150,8 +158,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SER
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SER
+			}
 		}
 		OR = {
 			original_tag = CRO

--- a/common/autonomous_states/MD_tajik_autonomies.txt
+++ b/common/autonomous_states/MD_tajik_autonomies.txt
@@ -38,8 +38,11 @@ autonomy_state = {
 
 	allowed = {
 		is_iranian_nation = yes
-		OVERLORD = {
-			has_country_flag = iranic_confederation_member
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				has_country_flag = iranic_confederation_member
+			}
 		}
 	}
 
@@ -85,8 +88,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = TAJ
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = TAJ
+			}
 		}
 		original_tag = BDA
 	}

--- a/common/autonomous_states/MD_turkish_autonomies.txt
+++ b/common/autonomous_states/MD_turkish_autonomies.txt
@@ -31,8 +31,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = TUR
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = TUR
+			}
 		}
 		original_tag = PKK
 	}

--- a/common/autonomous_states/MD_uar_autonomies.txt
+++ b/common/autonomous_states/MD_uar_autonomies.txt
@@ -39,12 +39,15 @@ autonomy_state = {
 
 	allowed = {
 		is_arabic_nation = yes
-		OVERLORD = {
-			OR = {
-				has_country_flag = formed_baathist_uar
-				has_country_flag = united_baathist_uar
-				has_country_flag = formed_neo_baathist_uar
-				has_country_flag = united_neo_baathist_uar
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				OR = {
+					has_country_flag = formed_baathist_uar
+					has_country_flag = united_baathist_uar
+					has_country_flag = formed_neo_baathist_uar
+					has_country_flag = united_neo_baathist_uar
+				}
 			}
 		}
 	}
@@ -97,12 +100,15 @@ autonomy_state = {
 
 	allowed = {
 		is_arabic_nation = yes
-		OVERLORD = {
-			OR = {
-				has_country_flag = formed_baathist_uar
-				has_country_flag = united_baathist_uar
-				has_country_flag = formed_neo_baathist_uar
-				has_country_flag = united_neo_baathist_uar
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				OR = {
+					has_country_flag = formed_baathist_uar
+					has_country_flag = united_baathist_uar
+					has_country_flag = formed_neo_baathist_uar
+					has_country_flag = united_neo_baathist_uar
+				}
 			}
 		}
 	}
@@ -157,12 +163,15 @@ autonomy_state = {
 
 	allowed = {
 		is_arabic_nation = yes
-		OVERLORD = {
-			OR = {
-				has_country_flag = formed_baathist_uar
-				has_country_flag = united_baathist_uar
-				has_country_flag = formed_neo_baathist_uar
-				has_country_flag = united_neo_baathist_uar
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				OR = {
+					has_country_flag = formed_baathist_uar
+					has_country_flag = united_baathist_uar
+					has_country_flag = formed_neo_baathist_uar
+					has_country_flag = united_neo_baathist_uar
+				}
 			}
 		}
 	}

--- a/common/autonomous_states/MD_ukrainian_autonomies.txt
+++ b/common/autonomous_states/MD_ukrainian_autonomies.txt
@@ -40,8 +40,11 @@ autonomy_state = {
 	}
 
 	allowed = {
-		OVERLORD = {
-			original_tag = UKR
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = UKR
+			}
 		}
 		OR = {
 			original_tag = CRM

--- a/common/autonomous_states/MD_union_state.txt
+++ b/common/autonomous_states/MD_union_state.txt
@@ -37,8 +37,11 @@ autonomy_state = {
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
-		OVERLORD = {
-			original_tag = SOV
+		if = {
+			limit = { is_subject = yes }
+			OVERLORD = {
+				original_tag = SOV
+			}
 		}
 		OR = {
 			original_tag = BLR

--- a/common/scripted_triggers/00_diplomacy_triggers.txt
+++ b/common/scripted_triggers/00_diplomacy_triggers.txt
@@ -10,7 +10,10 @@ check_opinion_calculation = {
 
 # Autonomy States
 disabled_default_autonomy_states = {
-	OVERLORD = { NOT = { is_in_array = { ruling_party = 11 } } }
+	if = {
+		limit = { is_subject = yes }
+		OVERLORD = { NOT = { is_in_array = { ruling_party = 11 } } }
+	}
 	#Disabled for Russian custom subjects
 	NOT = {
 		OR = {
@@ -22,10 +25,13 @@ disabled_default_autonomy_states = {
 	OR = {
 		is_arabic_nation = no
 		AND = {
-			OVERLORD = { NOT = { has_country_flag = formed_neo_baathist_uar } }
-			OVERLORD = { NOT = { has_country_flag = united_neo_baathist_uar } }
-			OVERLORD = { NOT = { has_country_flag = formed_baathist_uar } }
-			OVERLORD = { NOT = { has_country_flag = united_baathist_uar } }
+			if = {
+				limit = { is_subject = yes }
+				OVERLORD = { NOT = { has_country_flag = formed_neo_baathist_uar } }
+				OVERLORD = { NOT = { has_country_flag = united_neo_baathist_uar } }
+				OVERLORD = { NOT = { has_country_flag = formed_baathist_uar } }
+				OVERLORD = { NOT = { has_country_flag = united_baathist_uar } }
+			}
 			is_arabic_nation = yes
 		}
 	}


### PR DESCRIPTION
Closes #2720

## What

- Guard all `OVERLORD` accesses in autonomy-state triggers behind subject checks.
- Cover `allowed`, `can_take_level`, `can_lose_level`, and the shared default-autonomy trigger.
- Group two existing multi-tag checks with `OR` so the staged validator accepts the touched files and either intended tag can match.

## Why

Autonomy triggers can be evaluated for independent countries. Directly entering the `OVERLORD` dual scope in that context has no target and repeatedly logs `invalid event target: OVERLORD`.

## How

Each affected scope is evaluated inside `if = { limit = { is_subject = yes } ... }`, preserving subject behavior while skipping invalid lookups for independent countries.