### PR TITLE
Add satellite deorbit controls

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -82,6 +82,7 @@ v2.0.0
     - Orbit view now has filter buttons to make finding and targeting specific satellites easier
     - Nation selection UI has been adjust so that it now displays the name and flag of the country, and not just the flag
     - Production & Payload menus now display what version a satellite is, along with the name.
+  - Added owner-only single and model wide satellite deorbit controls with confirmation, live affected counts, SPYSAT mission safeguards, and stale ASAT target cleanup
   - Russia's "Annexation of Crimea" is made more flexible so as to increase the options available to the Russian player
   - Power Ranking system now is calculated 2 times a year (May and November) for performance-oriented purposes
   - Extended the Generic tree for more economic and military options

--- a/common/scripted_effects/00_missiles_scripted_effects.txt
+++ b/common/scripted_effects/00_missiles_scripted_effects.txt
@@ -2720,20 +2720,26 @@ remove_satellite_from_system = {
 }
 
 remove_deorbited_satellite_target_reference = {
-	set_temp_variable = { MD_deorbit_target_removed = 0 }
 	for_each_loop = {
-		array = sat_target_array
-		value = v
-		index = i
-		break = MD_deorbit_target_removed
-		if = {
-			limit = {
-				check_variable = { v = var_sat_ID }
-				check_variable = { sat_target_TAG_array^i = ROOT.id }
+		array = global.countries
+		value = targeting_country
+		var:targeting_country = {
+			set_temp_variable = { MD_deorbit_target_removed = 0 }
+			for_each_loop = {
+				array = sat_target_array
+				value = v
+				index = i
+				break = MD_deorbit_target_removed
+				if = {
+					limit = {
+						check_variable = { v = ROOT.var_sat_ID }
+						check_variable = { sat_target_TAG_array^i = ROOT.id }
+					}
+					remove_from_array = { array = sat_target_TAG_array index = i }
+					remove_from_array = { array = sat_target_array index = i }
+					set_temp_variable = { MD_deorbit_target_removed = 1 }
+				}
 			}
-			remove_from_array = { array = sat_target_TAG_array index = i }
-			remove_from_array = { array = sat_target_array index = i }
-			set_temp_variable = { MD_deorbit_target_removed = 1 }
 		}
 	}
 }

--- a/common/scripted_effects/00_missiles_scripted_effects.txt
+++ b/common/scripted_effects/00_missiles_scripted_effects.txt
@@ -2322,6 +2322,7 @@ add_satellite_from_payload = {
 	}
 	set_satellites_gui = yes
 	clear_array = payload_array
+	refresh_bulk_deorbit_state = yes
 }
 
 ###################################
@@ -2719,28 +2720,92 @@ remove_satellite_from_system = {
 	}
 }
 
-remove_deorbited_satellite_target_reference = {
+remove_deorbited_satellite_target_references = {
 	for_each_loop = {
 		array = global.countries
 		value = targeting_country
 		var:targeting_country = {
-			set_temp_variable = { MD_deorbit_target_removed = 0 }
-			for_each_loop = {
-				array = sat_target_array
-				value = v
-				index = i
-				break = MD_deorbit_target_removed
+			set_temp_variable = { target_index = sat_target_array^num }
+			subtract_from_temp_variable = { target_index = 1 }
+			while_loop_effect = {
+				limit = { check_variable = { target_index > -1 } }
+				set_temp_variable = { target_slot = sat_target_array^target_index }
 				if = {
 					limit = {
-						check_variable = { v = ROOT.var_sat_ID }
-						check_variable = { sat_target_TAG_array^i = ROOT.id }
+						check_variable = { sat_target_TAG_array^target_index = ROOT.id }
+						OR = {
+							AND = {
+								check_variable = { ROOT.MD_remove_all_zeroed_deorbit_targets = 0 }
+								check_variable = { target_slot = ROOT.var_sat_ID }
+							}
+							AND = {
+								check_variable = { ROOT.MD_remove_all_zeroed_deorbit_targets = 1 }
+								check_variable = { ROOT.orbit_array^target_slot = 0 }
+							}
+						}
 					}
-					remove_from_array = { array = sat_target_TAG_array index = i }
-					remove_from_array = { array = sat_target_array index = i }
-					set_temp_variable = { MD_deorbit_target_removed = 1 }
+					remove_from_array = { array = sat_target_TAG_array index = target_index }
+					remove_from_array = { array = sat_target_array index = target_index }
 				}
+				subtract_from_temp_variable = { target_index = 1 }
 			}
 		}
+	}
+}
+
+remove_deorbited_satellite_target_reference = {
+	set_temp_variable = { MD_remove_all_zeroed_deorbit_targets = 0 }
+	remove_deorbited_satellite_target_references = yes
+}
+
+remove_bulk_deorbited_satellite_target_references = {
+	set_temp_variable = { MD_remove_all_zeroed_deorbit_targets = 1 }
+	remove_deorbited_satellite_target_references = yes
+}
+
+clear_bulk_deorbit_state = {
+	clear_variable = MD_bulk_deorbit_model
+	clear_variable = MD_bulk_deorbit_count
+	clr_country_flag = MD_confirm_bulk_deorbit_satellites
+}
+
+clear_satellite_deorbit_state = {
+	clear_variable = var_deorbit_sat_ID
+	clr_country_flag = MD_confirm_deorbit_satellite
+	clear_bulk_deorbit_state = yes
+	clr_country_flag = MD_satellite_orbit_selection_active
+}
+
+start_satellite_deorbit_selection = {
+	clear_satellite_deorbit_state = yes
+	set_country_flag = MD_satellite_orbit_selection_active
+}
+
+finish_satellite_deorbit = {
+	clear_variable = var_selected_sat
+	clear_satellite_deorbit_state = yes
+	country_event = satellites.9
+}
+
+refresh_bulk_deorbit_state = {
+	if = {
+		limit = { has_country_flag = MD_confirm_bulk_deorbit_satellites }
+		set_variable = { MD_bulk_deorbit_count = 0 }
+		for_each_loop = {
+			array = orbit_array
+			if = {
+				limit = {
+					check_variable = { v = MD_bulk_deorbit_model }
+					check_variable = { v > 0 }
+				}
+				add_to_variable = { MD_bulk_deorbit_count = 1 }
+			}
+		}
+		if = {
+			limit = { check_variable = { MD_bulk_deorbit_count < 1 } }
+			clear_bulk_deorbit_state = yes
+		}
+		international_systems_update = yes
 	}
 }
 
@@ -2750,45 +2815,29 @@ deorbit_selected_satellite = {
 	remove_satellite_from_system = yes
 	remove_satellite_from_orbit = yes
 	remove_deorbited_satellite_target_reference = yes
-	clear_variable = var_selected_sat
-	clear_variable = var_deorbit_sat_ID
-	clr_country_flag = MD_confirm_deorbit_satellite
-	clr_country_flag = MD_satellite_orbit_selection_active
-	country_event = satellites.9
+	finish_satellite_deorbit = yes
 }
 
 stage_bulk_deorbit_selected_model = {
 	set_variable = { MD_bulk_deorbit_model = orbit_array^var_selected_sat }
-	set_variable = { MD_bulk_deorbit_count = 0 }
-	for_each_loop = {
-		array = orbit_array
-		if = {
-			limit = {
-				check_variable = { v = MD_bulk_deorbit_model }
-				check_variable = { v > 0 }
-			}
-			add_to_variable = { MD_bulk_deorbit_count = 1 }
-		}
-	}
 	set_country_flag = MD_confirm_bulk_deorbit_satellites
 	clr_country_flag = MD_confirm_deorbit_satellite
-	international_systems_update = yes
-}
-
-clear_bulk_deorbit_state = {
-	clear_variable = MD_bulk_deorbit_model
-	clear_variable = MD_bulk_deorbit_count
-	clr_country_flag = MD_confirm_bulk_deorbit_satellites
+	refresh_bulk_deorbit_state = yes
 }
 
 bulk_deorbit_selected_model = {
+	refresh_bulk_deorbit_state = yes
 	if = {
 		limit = {
+			check_variable = { MD_bulk_deorbit_count > 0 }
 			OR = {
 				check_variable = { MD_bulk_deorbit_model < 161 }
 				check_variable = { MD_bulk_deorbit_model > 178 }
-				check_variable = { MD_bulk_deorbit_count < var_SPY_mission_num_available }
-				check_variable = { MD_bulk_deorbit_count = var_SPY_mission_num_available }
+				check_variable = {
+					var = MD_bulk_deorbit_count
+					value = var_SPY_mission_num_available
+					compare = less_than_or_equals
+				}
 			}
 		}
 		set_variable = { tempTAG = ROOT.id }
@@ -2802,16 +2851,11 @@ bulk_deorbit_selected_model = {
 				set_variable = { var_sat_ID = i }
 				remove_satellite_from_system = yes
 				remove_satellite_from_orbit = yes
-				remove_deorbited_satellite_target_reference = yes
 			}
 		}
+		remove_bulk_deorbited_satellite_target_references = yes
 	}
-	clear_variable = var_selected_sat
-	clear_variable = var_deorbit_sat_ID
-	clear_bulk_deorbit_state = yes
-	clr_country_flag = MD_confirm_deorbit_satellite
-	clr_country_flag = MD_satellite_orbit_selection_active
-	country_event = satellites.9
+	finish_satellite_deorbit = yes
 }
 
 advanced_filter_effect = {
@@ -3176,6 +3220,7 @@ anti_satellite_weapon_use = {
 			}
 		}
 		var:tempTAG = {
+			refresh_bulk_deorbit_state = yes
 			country_event = satellites.9
 		}
 	}
@@ -3215,6 +3260,7 @@ remove_killsat_used = {
 	}
 	set_satellites_gui = yes
 	set_variable = { var_KILLSAT_orbit = KILL_satellite_array^var_KILLSAT_type }
+	refresh_bulk_deorbit_state = yes
 }
 
 ### right container # sat access arrays

--- a/common/scripted_effects/00_missiles_scripted_effects.txt
+++ b/common/scripted_effects/00_missiles_scripted_effects.txt
@@ -2245,59 +2245,82 @@ add_satellite_from_payload = {
 	resize_array = { COM_satellite_array = 12 }
 	resize_array = { SPY_satellite_array = 12 }
 	resize_array = { KILL_satellite_array = 10 }
+	set_satellites_gui = yes
+	set_temp_variable = {
+		sat_active_total = {
+			value = var_GNSS_sat_total
+			add = var_COM_sat_total
+			add = var_SPY_sat_total
+			add = var_KILL_sat_total
+		}
+	}
+	set_temp_variable = { sat_limit_reported = 0 }
 
 	for_each_loop = {
 		array = payload_array
 		set_temp_variable = { payload_id = payload_array^i }
 		if = {
-			limit = {
-				check_variable = { payload_id > 120 }
-				check_variable = { payload_id < 139 }
+			limit = { check_variable = { sat_active_total < 3000 } }
+			if = {
+				limit = {
+					check_variable = { payload_id > 120 }
+					check_variable = { payload_id < 139 }
+				}
+				set_temp_variable = { sat_idx = { value = payload_id subtract = 121 } }
+				add_to_variable = { GNSS_satellite_array^sat_idx = 1 }
+				add_to_array = { orbit_array = payload_id }
+				set_variable = { var_orbit_display_ID = orbit_array^num }
+				subtract_from_variable = { var_orbit_display_ID = 1 }
+				add_new_satellite_to_orbit = yes
+				add_to_temp_variable = { sat_active_total = 1 }
 			}
-			set_temp_variable = { sat_idx = { value = payload_id subtract = 121 } }
-			add_to_variable = { GNSS_satellite_array^sat_idx = 1 }
-			add_to_array = { orbit_array = payload_id }
-			set_variable = { var_orbit_display_ID = orbit_array^num }
-			subtract_from_variable = { var_orbit_display_ID = 1 }
-			add_new_satellite_to_orbit = yes
+			else_if = {
+				limit = {
+					check_variable = { payload_id > 140 }
+					check_variable = { payload_id < 159 }
+				}
+				set_temp_variable = { sat_idx = { value = payload_id subtract = 141 } }
+				add_to_variable = { COM_satellite_array^sat_idx = 1 }
+				add_to_array = { orbit_array = payload_id }
+				set_variable = { var_orbit_display_ID = orbit_array^num }
+				subtract_from_variable = { var_orbit_display_ID = 1 }
+				add_new_satellite_to_orbit = yes
+				add_to_temp_variable = { sat_active_total = 1 }
+			}
+			else_if = {
+				limit = {
+					check_variable = { payload_id > 160 }
+					check_variable = { payload_id < 179 }
+				}
+				set_temp_variable = { sat_idx = { value = payload_id subtract = 161 } }
+				add_to_variable = { SPY_satellite_array^sat_idx = 1 }
+				add_to_array = { orbit_array = payload_id }
+				set_variable = { var_orbit_display_ID = orbit_array^num }
+				subtract_from_variable = { var_orbit_display_ID = 1 }
+				add_new_satellite_to_orbit = yes
+				add_to_temp_variable = { sat_active_total = 1 }
+			}
+			else_if = {
+				limit = {
+					check_variable = { payload_id > 180 }
+					check_variable = { payload_id < 199 }
+				}
+				set_temp_variable = { sat_idx = { value = payload_id subtract = 181 } }
+				add_to_variable = { KILL_satellite_array^sat_idx = 1 }
+				add_to_array = { orbit_array = payload_id }
+				set_variable = { var_orbit_display_ID = orbit_array^num }
+				subtract_from_variable = { var_orbit_display_ID = 1 }
+				add_new_satellite_to_orbit = yes
+				add_to_temp_variable = { sat_active_total = 1 }
+			}
 		}
 		else_if = {
-			limit = {
-				check_variable = { payload_id > 140 }
-				check_variable = { payload_id < 159 }
-			}
-			set_temp_variable = { sat_idx = { value = payload_id subtract = 141 } }
-			add_to_variable = { COM_satellite_array^sat_idx = 1 }
-			add_to_array = { orbit_array = payload_id }
-			set_variable = { var_orbit_display_ID = orbit_array^num }
-			subtract_from_variable = { var_orbit_display_ID = 1 }
-			add_new_satellite_to_orbit = yes
-		}
-		else_if = {
-			limit = {
-				check_variable = { payload_id > 160 }
-				check_variable = { payload_id < 179 }
-			}
-			set_temp_variable = { sat_idx = { value = payload_id subtract = 161 } }
-			add_to_variable = { SPY_satellite_array^sat_idx = 1 }
-			add_to_array = { orbit_array = payload_id }
-			set_variable = { var_orbit_display_ID = orbit_array^num }
-			subtract_from_variable = { var_orbit_display_ID = 1 }
-			add_new_satellite_to_orbit = yes
-		}
-		else_if = {
-			limit = {
-				check_variable = { payload_id > 180 }
-				check_variable = { payload_id < 199 }
-			}
-			set_temp_variable = { sat_idx = { value = payload_id subtract = 181 } }
-			add_to_variable = { KILL_satellite_array^sat_idx = 1 }
-			add_to_array = { orbit_array = payload_id }
-			set_variable = { var_orbit_display_ID = orbit_array^num }
-			subtract_from_variable = { var_orbit_display_ID = 1 }
-			add_new_satellite_to_orbit = yes
+			limit = { check_variable = { sat_limit_reported = 0 } }
+			ROOT = { news_event = satellites.8 }
+			set_temp_variable = { sat_limit_reported = 1 }
 		}
 	}
+	set_satellites_gui = yes
 	clear_array = payload_array
 }
 
@@ -2694,6 +2717,95 @@ remove_satellite_from_system = {
 			subtract_from_variable = { KILL_satellite_array^sat_idx = 1 }
 		}
 	}
+}
+
+remove_deorbited_satellite_target_reference = {
+	set_temp_variable = { MD_deorbit_target_removed = 0 }
+	for_each_loop = {
+		array = sat_target_array
+		value = v
+		index = i
+		break = MD_deorbit_target_removed
+		if = {
+			limit = {
+				check_variable = { v = var_sat_ID }
+				check_variable = { sat_target_TAG_array^i = ROOT.id }
+			}
+			remove_from_array = { array = sat_target_TAG_array index = i }
+			remove_from_array = { array = sat_target_array index = i }
+			set_temp_variable = { MD_deorbit_target_removed = 1 }
+		}
+	}
+}
+
+deorbit_selected_satellite = {
+	set_variable = { tempTAG = ROOT.id }
+	set_variable = { var_sat_ID = var_deorbit_sat_ID }
+	remove_satellite_from_system = yes
+	remove_satellite_from_orbit = yes
+	remove_deorbited_satellite_target_reference = yes
+	clear_variable = var_selected_sat
+	clear_variable = var_deorbit_sat_ID
+	clr_country_flag = MD_confirm_deorbit_satellite
+	clr_country_flag = MD_satellite_orbit_selection_active
+	country_event = satellites.9
+}
+
+stage_bulk_deorbit_selected_model = {
+	set_variable = { MD_bulk_deorbit_model = orbit_array^var_selected_sat }
+	set_variable = { MD_bulk_deorbit_count = 0 }
+	for_each_loop = {
+		array = orbit_array
+		if = {
+			limit = {
+				check_variable = { v = MD_bulk_deorbit_model }
+				check_variable = { v > 0 }
+			}
+			add_to_variable = { MD_bulk_deorbit_count = 1 }
+		}
+	}
+	set_country_flag = MD_confirm_bulk_deorbit_satellites
+	clr_country_flag = MD_confirm_deorbit_satellite
+	international_systems_update = yes
+}
+
+clear_bulk_deorbit_state = {
+	clear_variable = MD_bulk_deorbit_model
+	clear_variable = MD_bulk_deorbit_count
+	clr_country_flag = MD_confirm_bulk_deorbit_satellites
+}
+
+bulk_deorbit_selected_model = {
+	if = {
+		limit = {
+			OR = {
+				check_variable = { MD_bulk_deorbit_model < 161 }
+				check_variable = { MD_bulk_deorbit_model > 178 }
+				check_variable = { MD_bulk_deorbit_count < var_SPY_mission_num_available }
+				check_variable = { MD_bulk_deorbit_count = var_SPY_mission_num_available }
+			}
+		}
+		set_variable = { tempTAG = ROOT.id }
+		for_each_loop = {
+			array = orbit_array
+			if = {
+				limit = {
+					check_variable = { v = MD_bulk_deorbit_model }
+					check_variable = { v > 0 }
+				}
+				set_variable = { var_sat_ID = i }
+				remove_satellite_from_system = yes
+				remove_satellite_from_orbit = yes
+				remove_deorbited_satellite_target_reference = yes
+			}
+		}
+	}
+	clear_variable = var_selected_sat
+	clear_variable = var_deorbit_sat_ID
+	clear_bulk_deorbit_state = yes
+	clr_country_flag = MD_confirm_deorbit_satellite
+	clr_country_flag = MD_satellite_orbit_selection_active
+	country_event = satellites.9
 }
 
 advanced_filter_effect = {

--- a/common/scripted_guis/00_missiles_scripted_guis.txt
+++ b/common/scripted_guis/00_missiles_scripted_guis.txt
@@ -2483,9 +2483,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_1_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				set_country_flag = MD_satellite_orbit_selection_active
+				start_satellite_deorbit_selection = yes
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_1_array^i }
 				}
@@ -2499,9 +2497,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_2_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				set_country_flag = MD_satellite_orbit_selection_active
+				start_satellite_deorbit_selection = yes
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_2_array^i }
 				}
@@ -2515,9 +2511,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_3_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				set_country_flag = MD_satellite_orbit_selection_active
+				start_satellite_deorbit_selection = yes
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_3_array^i }
 				}
@@ -2531,9 +2525,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_4_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				set_country_flag = MD_satellite_orbit_selection_active
+				start_satellite_deorbit_selection = yes
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_4_array^i }
 				}
@@ -2547,9 +2539,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_5_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				set_country_flag = MD_satellite_orbit_selection_active
+				start_satellite_deorbit_selection = yes
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_5_array^i }
 				}
@@ -2563,9 +2553,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_6_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				set_country_flag = MD_satellite_orbit_selection_active
+				start_satellite_deorbit_selection = yes
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_6_array^i }
 				}
@@ -2651,9 +2639,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			country_view_flag_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_country_flag = open_MD_satellite_orbit_country_selection
 				clear_array = temp_countries
 				every_country = {
@@ -2662,9 +2648,7 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			country_view_flag_button_right_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = ROOT.id }
 				set_sat_access_arrays_selected_TAG = yes
 				set_satellites_gui = yes
@@ -2672,57 +2656,43 @@ scripted_gui = {
 			}
 			### sat access buttons
 			GNSS_mil_access_flags_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = selected_TAG_GNSS_mil_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			GNSS_civ_access_flags_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = selected_TAG_GNSS_civ_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			COM_mil_access_flags_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = selected_TAG_COM_mil_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			COM_civ_access_flags_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = selected_TAG_COM_civ_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			SPY_mil_access_flags_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = selected_TAG_SPY_mil_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			SPY_civ_access_flags_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				set_variable = { orbit_selected_TAG = selected_TAG_SPY_civ_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			close_button_click = {
-				clr_country_flag = MD_confirm_deorbit_satellite
-				clear_bulk_deorbit_state = yes
-				clr_country_flag = MD_satellite_orbit_selection_active
+				clear_satellite_deorbit_state = yes
 				if = {
 					limit = {
 						NOT = { has_country_flag = rods_search_target }
@@ -2826,7 +2796,6 @@ scripted_gui = {
 				has_country_flag = MD_confirm_bulk_deorbit_satellites
 				has_country_flag = MD_satellite_orbit_selection_active
 				check_variable = { orbit_selected_TAG = ROOT.id }
-				check_variable = { orbit_array^var_selected_sat = MD_bulk_deorbit_model }
 				check_variable = { MD_bulk_deorbit_count > 0 }
 			}
 			bulk_deorbit_model_button_click_enabled = {
@@ -2843,8 +2812,11 @@ scripted_gui = {
 					OR = {
 						check_variable = { MD_bulk_deorbit_model < 161 }
 						check_variable = { MD_bulk_deorbit_model > 178 }
-						check_variable = { MD_bulk_deorbit_count < var_SPY_mission_num_available }
-						check_variable = { MD_bulk_deorbit_count = var_SPY_mission_num_available }
+						check_variable = {
+							var = MD_bulk_deorbit_count
+							value = var_SPY_mission_num_available
+							compare = less_than_or_equals
+						}
 					}
 				}
 			}

--- a/common/scripted_guis/00_missiles_scripted_guis.txt
+++ b/common/scripted_guis/00_missiles_scripted_guis.txt
@@ -2483,6 +2483,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_1_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				set_country_flag = MD_satellite_orbit_selection_active
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_1_array^i }
 				}
@@ -2496,6 +2499,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_2_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				set_country_flag = MD_satellite_orbit_selection_active
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_2_array^i }
 				}
@@ -2509,6 +2515,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_3_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				set_country_flag = MD_satellite_orbit_selection_active
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_3_array^i }
 				}
@@ -2522,6 +2531,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_4_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				set_country_flag = MD_satellite_orbit_selection_active
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_4_array^i }
 				}
@@ -2535,6 +2547,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_5_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				set_country_flag = MD_satellite_orbit_selection_active
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_5_array^i }
 				}
@@ -2548,6 +2563,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			sat_6_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				set_country_flag = MD_satellite_orbit_selection_active
 				var:orbit_selected_TAG = {
 					set_variable = { ROOT.var_selected_sat = sat_6_array^i }
 				}
@@ -2569,6 +2587,21 @@ scripted_gui = {
 				clear_array = ROOT.sat_target_array
 				clear_array = ROOT.sat_target_TAG_array
 				international_systems_update = yes
+			}
+			deorbit_satellite_button_click = {
+				clear_bulk_deorbit_state = yes
+				set_variable = { var_deorbit_sat_ID = var_selected_sat }
+				set_country_flag = MD_confirm_deorbit_satellite
+				international_systems_update = yes
+			}
+			confirm_deorbit_satellite_button_click = {
+				deorbit_selected_satellite = yes
+			}
+			bulk_deorbit_model_button_click = {
+				stage_bulk_deorbit_selected_model = yes
+			}
+			confirm_bulk_deorbit_model_button_click = {
+				bulk_deorbit_selected_model = yes
 			}
 			#
 			spy_mission_start_button_click = {
@@ -2618,6 +2651,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			country_view_flag_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_country_flag = open_MD_satellite_orbit_country_selection
 				clear_array = temp_countries
 				every_country = {
@@ -2626,6 +2662,9 @@ scripted_gui = {
 				international_systems_update = yes
 			}
 			country_view_flag_button_right_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = ROOT.id }
 				set_sat_access_arrays_selected_TAG = yes
 				set_satellites_gui = yes
@@ -2633,36 +2672,57 @@ scripted_gui = {
 			}
 			### sat access buttons
 			GNSS_mil_access_flags_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = selected_TAG_GNSS_mil_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			GNSS_civ_access_flags_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = selected_TAG_GNSS_civ_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			COM_mil_access_flags_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = selected_TAG_COM_mil_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			COM_civ_access_flags_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = selected_TAG_COM_civ_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			SPY_mil_access_flags_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = selected_TAG_SPY_mil_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			SPY_civ_access_flags_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				set_variable = { orbit_selected_TAG = selected_TAG_SPY_civ_access_array^i.id }
 				set_sat_access_arrays_selected_TAG = yes
 				international_systems_update = yes
 			}
 			close_button_click = {
+				clr_country_flag = MD_confirm_deorbit_satellite
+				clear_bulk_deorbit_state = yes
+				clr_country_flag = MD_satellite_orbit_selection_active
 				if = {
 					limit = {
 						NOT = { has_country_flag = rods_search_target }
@@ -2722,6 +2782,70 @@ scripted_gui = {
 					check_variable = { sat_6_array^i > 0 }
 					NOT = { check_variable = { sat_6_array^i < 1 } }
 					is_filtered_type = yes
+				}
+			}
+			deorbit_satellite_button_visible = {
+				NOT = { has_country_flag = MD_confirm_deorbit_satellite }
+				check_variable = { orbit_selected_TAG = ROOT.id }
+			}
+			confirm_deorbit_satellite_button_visible = {
+				has_country_flag = MD_confirm_deorbit_satellite
+				has_country_flag = MD_satellite_orbit_selection_active
+				check_variable = { orbit_selected_TAG = ROOT.id }
+				check_variable = { var_deorbit_sat_ID = var_selected_sat }
+				check_variable = { orbit_array^var_deorbit_sat_ID > 0 }
+			}
+			deorbit_satellite_button_click_enabled = {
+				custom_trigger_tooltip = {
+					tooltip = DEORBIT_SATELLITE_SELECTION_TT
+					has_country_flag = MD_satellite_orbit_selection_active
+					check_variable = { var_selected_sat > -1 }
+					check_variable = { orbit_array^var_selected_sat > 0 }
+				}
+				custom_trigger_tooltip = {
+					tooltip = DEORBIT_SATELLITE_SPY_MISSION_TT
+					OR = {
+						check_variable = { orbit_array^var_selected_sat < 161 }
+						check_variable = { orbit_array^var_selected_sat > 178 }
+						check_variable = { var_SPY_mission_num_available > 0 }
+					}
+				}
+			}
+			confirm_deorbit_satellite_button_click_enabled = {
+				OR = {
+					check_variable = { orbit_array^var_deorbit_sat_ID < 161 }
+					check_variable = { orbit_array^var_deorbit_sat_ID > 178 }
+					check_variable = { var_SPY_mission_num_available > 0 }
+				}
+			}
+			bulk_deorbit_model_button_visible = {
+				NOT = { has_country_flag = MD_confirm_bulk_deorbit_satellites }
+				check_variable = { orbit_selected_TAG = ROOT.id }
+			}
+			confirm_bulk_deorbit_model_button_visible = {
+				has_country_flag = MD_confirm_bulk_deorbit_satellites
+				has_country_flag = MD_satellite_orbit_selection_active
+				check_variable = { orbit_selected_TAG = ROOT.id }
+				check_variable = { orbit_array^var_selected_sat = MD_bulk_deorbit_model }
+				check_variable = { MD_bulk_deorbit_count > 0 }
+			}
+			bulk_deorbit_model_button_click_enabled = {
+				custom_trigger_tooltip = {
+					tooltip = BULK_DEORBIT_MODEL_SELECTION_TT
+					has_country_flag = MD_satellite_orbit_selection_active
+					check_variable = { var_selected_sat > -1 }
+					check_variable = { orbit_array^var_selected_sat > 0 }
+				}
+			}
+			confirm_bulk_deorbit_model_button_click_enabled = {
+				custom_trigger_tooltip = {
+					tooltip = BULK_DEORBIT_SPY_MISSION_TT
+					OR = {
+						check_variable = { MD_bulk_deorbit_model < 161 }
+						check_variable = { MD_bulk_deorbit_model > 178 }
+						check_variable = { MD_bulk_deorbit_count < var_SPY_mission_num_available }
+						check_variable = { MD_bulk_deorbit_count = var_SPY_mission_num_available }
+					}
 				}
 			}
 			####################

--- a/interface/MD_countrymissilesview.gui
+++ b/interface/MD_countrymissilesview.gui
@@ -4049,9 +4049,53 @@ guiTypes = {
 				clicksound = click_default
 			}
 
+			buttonType = {
+				name = "deorbit_satellite_button"
+				position = { x = 95 y = 310 }
+				quadTextureSprite = "GFX_small_button_71x26"
+				buttonFont = "hoi_16mbs"
+				buttonText = "DEORBIT_SATELLITE_BUTTON"
+				pdx_tooltip = "DEORBIT_SATELLITE_TT"
+				pdx_tooltip_delayed = "DEORBIT_SATELLITE_TT_DELAYED"
+				clicksound = click_default
+			}
+
+			buttonType = {
+				name = "confirm_deorbit_satellite_button"
+				position = { x = 95 y = 310 }
+				quadTextureSprite = "GFX_small_button_71x26"
+				buttonFont = "hoi_16mbs"
+				buttonText = "CONFIRM_DEORBIT_SATELLITE_BUTTON"
+				pdx_tooltip = "CONFIRM_DEORBIT_SATELLITE_TT"
+				pdx_tooltip_delayed = "DEORBIT_SATELLITE_TT_DELAYED"
+				clicksound = click_default
+			}
+
+			buttonType = {
+				name = "bulk_deorbit_model_button"
+				position = { x = 10 y = 340 }
+				quadTextureSprite = "GFX_button_148x34"
+				buttonFont = "hoi_16mbs"
+				buttonText = "BULK_DEORBIT_MODEL_BUTTON"
+				pdx_tooltip = "BULK_DEORBIT_MODEL_TT"
+				pdx_tooltip_delayed = "BULK_DEORBIT_MODEL_TT_DELAYED"
+				clicksound = click_default
+			}
+
+			buttonType = {
+				name = "confirm_bulk_deorbit_model_button"
+				position = { x = 10 y = 340 }
+				quadTextureSprite = "GFX_button_148x34"
+				buttonFont = "hoi_16mbs"
+				buttonText = "CONFIRM_BULK_DEORBIT_MODEL_BUTTON"
+				pdx_tooltip = "CONFIRM_BULK_DEORBIT_MODEL_TT"
+				pdx_tooltip_delayed = "BULK_DEORBIT_MODEL_TT_DELAYED"
+				clicksound = click_default
+			}
+
 			instantTextboxType = {
 				name = "sat_target_header"
-				position = { x = 0 y = 350 }
+				position = { x = 0 y = 380 }
 				font = "hoi_18mbs"
 				borderSize = {x = 0 y = 0}
 				text = "SAT_TARGET_HEADER"
@@ -4062,8 +4106,8 @@ guiTypes = {
 
 			containerWindowType = {
 				name = "sat_target_gridbox_container"
-				position = { x=-10 y=370 } #position = { x=38 y=180 }
-				size = { width = 175 height = 150 }
+				position = { x=-10 y=400 } #position = { x=38 y=180 }
+				size = { width = 175 height = 110 }
 				clipping = yes
 				verticalScrollbar = "right_vertical_slider"
 				#verticalScrollbar = "left_vertical_slider"

--- a/localisation/english/MD_missiles_l_english.yml
+++ b/localisation/english/MD_missiles_l_english.yml
@@ -405,7 +405,7 @@
 
  TOTAL_SAT_NUM: "£GFX_Satellite_texticon  [total_sat_num_loc]"
  TOTAL_SAT_NUM_TT: "Total number of satellites in orbit."
- TOTAL_SAT_NUM_TT_DELAYED: "There is a total limit of 3000 satellites in orbit. Deorbit one of your satellites to free capacity before launching another."
+ TOTAL_SAT_NUM_TT_DELAYED: "There is a total limit of 3,000 satellites in orbit. Deorbit one of your satellites to free capacity before launching another."
  DEORBIT_SATELLITE_TT: "Deorbit the selected satellite"
  DEORBIT_SATELLITE_TT_DELAYED: "Only satellites belonging to your country can be deliberately deorbited. Removing a satellite may reduce constellation coverage or service level."
  DEORBIT_SATELLITE_BUTTON: "Deorbit"

--- a/localisation/english/MD_missiles_l_english.yml
+++ b/localisation/english/MD_missiles_l_english.yml
@@ -88,7 +88,7 @@
  satellites.7.a: "Okay"
 
  satellites.8.t: "Satellite Limit Reached"
- satellites.8.d: "We have to much satellites in Orbit, we can't launch more at the moment. The limit is 3000."
+ satellites.8.d: "We have too many satellites in orbit and cannot launch more at the moment. The limit is 3,000 active satellites. Deliberately deorbiting one of our satellites frees a slot."
  satellites.8.a: "Okay"
 
  ### MISSILE TECH TREE TOOLTIPS ###
@@ -405,7 +405,21 @@
 
  TOTAL_SAT_NUM: "£GFX_Satellite_texticon  [total_sat_num_loc]"
  TOTAL_SAT_NUM_TT: "Total number of satellites in orbit."
- TOTAL_SAT_NUM_TT_DELAYED: "There is a total limit of 3000 satellites in orbit. If that limit is reached no new satellites can be launched, before others are destroyed."
+ TOTAL_SAT_NUM_TT_DELAYED: "There is a total limit of 3000 satellites in orbit. Deorbit one of your satellites to free capacity before launching another."
+ DEORBIT_SATELLITE_TT: "Deorbit the selected satellite"
+ DEORBIT_SATELLITE_TT_DELAYED: "Only satellites belonging to your country can be deliberately deorbited. Removing a satellite may reduce constellation coverage or service level."
+ DEORBIT_SATELLITE_BUTTON: "Deorbit"
+ DEORBIT_SATELLITE_SELECTION_TT: "Select one of our satellites in the orbit display"
+ CONFIRM_DEORBIT_SATELLITE_TT: "§RClick again to confirm deorbiting§!"
+ CONFIRM_DEORBIT_SATELLITE_BUTTON: "Confirm"
+ DEORBIT_SATELLITE_SPY_MISSION_TT: "Has a spare £GFX_SPY_satellite_texticon  satellite not committed to an active mission"
+ BULK_DEORBIT_MODEL_BUTTON: "Deorbit Selected Model"
+ BULK_DEORBIT_MODEL_TT: "Deorbit every [selected_sat_type_loc] satellite of the selected model"
+ BULK_DEORBIT_MODEL_TT_DELAYED: "Only the selected model in your own orbit is affected. The confirmation shows the exact number of satellites that will be removed."
+ BULK_DEORBIT_MODEL_SELECTION_TT: "Select one of our satellites to choose its model"
+ CONFIRM_BULK_DEORBIT_MODEL_BUTTON: "Confirm ([?MD_bulk_deorbit_count|0])"
+ CONFIRM_BULK_DEORBIT_MODEL_TT: "§RDeorbit all [?MD_bulk_deorbit_count|0] [selected_sat_type_loc] satellites§!"
+ BULK_DEORBIT_SPY_MISSION_TT: "Has enough spare £GFX_SPY_satellite_texticon  satellites to preserve every active mission"
 
  GNSS_SATELLITES_ORBIT: "£GFX_GNSS_satellite_texticon  [GNSS_sat_total]"
  GNSS_SATELLITES_ORBIT_TT: "§Y[GNSS1_model_sat_orbit_loc] - GNSS 5 m -§! [GNSS_SATELLITES_ORBIT_TT0_loc]\n§Y[GNSS2_model_sat_orbit_loc] - GNSS 2.5 m - §! [GNSS_SATELLITES_ORBIT_TT1_loc]\n§Y[GNSS3_model_sat_orbit_loc] - GNSS 1.5 m - §! [GNSS_SATELLITES_ORBIT_TT2_loc]\n§Y[GNSS4_model_sat_orbit_loc] - GNSS 1 m - §! [GNSS_SATELLITES_ORBIT_TT3_loc]\n§Y[GNSS5_model_sat_orbit_loc] - GNSS 0.5 m - §! [GNSS_SATELLITES_ORBIT_TT4_loc]\n§Y[GNSS6_model_sat_orbit_loc] - GNSS 0.25 m - §! [GNSS_SATELLITES_ORBIT_TT5_loc]\n§Y[GNSS7_model_sat_orbit_loc] - GNSS 0.03 m - §! [GNSS_SATELLITES_ORBIT_TT6_loc]\n§Y[GNSS8_model_sat_orbit_loc] - GNSS 0.01 m - §! [GNSS_SATELLITES_ORBIT_TT7_loc]\n§Y[GNSS9_model_sat_orbit_loc] - GNSS 0.007 m - §! [GNSS_SATELLITES_ORBIT_TT8_loc]\n§Y[GNSS10_model_sat_orbit_loc] - GNSS 0.004 m - §! [GNSS_SATELLITES_ORBIT_TT9_loc]\n§Y[GNSS11_model_sat_orbit_loc] - GNSS 0.002 m - §! [GNSS_SATELLITES_ORBIT_TT10_loc]\n§Y[GNSS12_model_sat_orbit_loc] - GNSS 0.001 m - §! [GNSS_SATELLITES_ORBIT_TT11_loc]\n"


### PR DESCRIPTION
## Summary

- add owner-only single-satellite deorbiting with a confirmation click
- add bulk deorbiting for the selected satellite model, showing the affected count before confirmation
- reuse the existing satellite removal and system-refresh paths, including SPYSAT mission safeguards
- enforce the 3,000 active-satellite limit from live constellation totals so deorbiting frees launch capacity

Closes #2643.

## Validation

- [x] staged diff contains only four missile/orbit files
- [x] scripted GUI bindings and localisation references validate
- [x] brace/style, localisation, variable-use, common-mistake, and commit-stage content validators pass
- [x] English localisation remains UTF-8 with BOM
- [x] in-game: deorbit an owned GNSS/COMSAT/SPYSAT/KILLSAT satellite and confirm counts/system values refresh
- [x] in-game: bulk-deorbit one model and confirm only that model is removed
- [x] in-game: verify foreign satellites cannot be deorbited and active SPYSAT missions remain protected
- [ ] in-game: reach the 3,000 active-satellite limit, deorbit one satellite, and launch its replacement
<img width="1845" height="1084" alt="image" src="https://github.com/user-attachments/assets/5236801a-3607-4371-a5c9-7602c6972120" />
