### PR TITLE
Validation baseline: nightly main diff + NEW/EXISTING PR annotation

### DIFF
--- a/.github/workflows/coding-pipeline.yml
+++ b/.github/workflows/coding-pipeline.yml
@@ -859,8 +859,9 @@ jobs:
         needs.validate-targeted.result == 'success' &&
         needs.validate-paths.result == 'success' && 'full' || 'partial' }}
     steps:
-      # Checkout the report generator + the report_lib package it imports.
-      # Stays much smaller than a full checkout — we skip everything else.
+      # Checkout the report generator + the report_lib package it imports,
+      # plus tools/validation for the hashFiles baseline key below. Stays
+      # much smaller than a full checkout — we skip everything else.
       - name: Checkout report tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -869,7 +870,34 @@ jobs:
           sparse-checkout: |
             tools/generate_validation_report.py
             tools/report_lib
+            tools/validation
+            tools/shared_utils.py
           sparse-checkout-cone-mode: false
+
+      # Same source hash as prepare-workspace: the baseline cache entry is
+      # keyed on it, so a report can only restore a baseline built by the
+      # current validator generation.
+      - name: Compute validator code hash
+        id: toolshash
+        run: >-
+          echo "hash=${{ hashFiles('tools/validation/**',
+          'tools/shared_utils.py') }}" >> "$GITHUB_OUTPUT"
+
+      # Latest main-side validation baseline (saved nightly by
+      # validator-cache.yml's check-baseline job). A miss (cold cache,
+      # validator generation changed) only drops the NEW/EXISTING annotation
+      # in the report — never a failure.
+      - name: Restore validation baseline
+        # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .validation_baseline
+          key: >-
+            md-baseline-v1-${{ runner.os }}-${{
+            steps.toolshash.outputs.hash }}-${{
+            inputs.base_sha || github.event.pull_request.base.sha }}
+          restore-keys: |
+            md-baseline-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
@@ -899,6 +927,13 @@ jobs:
             --checks-api
             --print
           )
+          # Missing/stale baseline just renders without NEW/EXISTING tags.
+          if [ -f .validation_baseline/baseline-meta.json ]; then
+            args+=(
+              --baseline-dir .validation_baseline
+              --baseline-toolshash "${{ steps.toolshash.outputs.hash }}"
+            )
+          fi
           if [ -n "$PR_NUMBER" ]; then
             args+=(--post-comment)
           fi

--- a/.github/workflows/validator-cache.yml
+++ b/.github/workflows/validator-cache.yml
@@ -187,6 +187,9 @@ jobs:
 
       # The warm cache build-cache saved for THIS run (run_id-suffixed exact
       # key) — a miss here is a real failure, not a graceful cold fallback.
+      # Same-sha fallback keeps "Re-run failed jobs" recoverable: build-cache
+      # may not re-run with the same run_id, but a same sha + same toolshash
+      # entry holds identical content.
       - name: Restore validator disk cache
         # v6.1.0
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -196,6 +199,8 @@ jobs:
             md-valcache-v1-${{ runner.os }}-${{
             steps.toolshash.outputs.hash }}-${{ github.sha }}-${{
             github.run_id }}
+          restore-keys: |
+            md-valcache-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-${{ github.sha }}-
           fail-on-cache-miss: true
 
       - name: Set up Python
@@ -238,3 +243,25 @@ jobs:
             md-baseline-v1-${{ runner.os }}-${{
             steps.toolshash.outputs.hash }}-${{ github.sha }}-${{
             github.run_id }}
+
+      # cache/save only warns on failure; without this check a failed save
+      # leaves the job green while PRs silently keep annotating against the
+      # previous baseline (which may never advance). Mirrors build-cache's
+      # verify step.
+      - name: Verify this run's baseline entry exists
+        if: steps.diff.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_KEY: >-
+            md-baseline-v1-${{ runner.os }}-${{
+            steps.toolshash.outputs.hash }}-${{ github.sha }}-${{
+            github.run_id }}
+        run: |
+          cache_url="repos/${{ github.repository }}/actions/caches"
+          cache_url="${cache_url}?key=$EXPECTED_KEY&per_page=1"
+          count=$(gh api "$cache_url" --jq '.total_count')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Baseline entry ${EXPECTED_KEY} was not saved"
+            exit 1
+          fi
+          echo "Baseline entry ${EXPECTED_KEY} confirmed"

--- a/.github/workflows/validator-cache.yml
+++ b/.github/workflows/validator-cache.yml
@@ -74,7 +74,8 @@ jobs:
       # a run_id suffix); the restore-keys prefixes do the real matching,
       # newest entry first.
       - name: Restore previous validator disk cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .validation_cache
           key: >-
@@ -99,7 +100,8 @@ jobs:
       # on an unchanged sha — without it the rebuild could never save. PR
       # restores prefix-match the newest entry via restore-keys.
       - name: Save validator disk cache
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: .validation_cache
           key: >-
@@ -126,3 +128,113 @@ jobs:
             exit 1
           fi
           echo "Cache entry ${EXPECTED_KEY} confirmed"
+
+  # ───────────────────────────────────────────────────────────────
+  # Validation baseline — the nightly regression alarm for main itself.
+  # Re-runs the suite (warm, against the cache build-cache just saved) and
+  # diffs the findings against the previous night's baseline. New errors
+  # fail the job and leave the old baseline in place, so the run stays red
+  # every night until the regression is fixed. A validator-code change moves
+  # the toolshash, which instead establishes a fresh baseline. The baseline
+  # entry is what PR validation-report jobs restore to annotate NEW vs
+  # EXISTING findings.
+  # ───────────────────────────────────────────────────────────────
+  check-baseline:
+    name: Check validation baseline
+    needs: [build-cache]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      # Same union as build-cache: validators only see what is on disk, so a
+      # narrower checkout would produce a baseline missing whole namespaces.
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            common
+            events
+            history
+            localisation
+            interface
+            gfx/flags
+            tools
+            resources/documentation
+            .claude
+
+      - name: Compute validator code hash
+        id: toolshash
+        run: >-
+          echo "hash=${{ hashFiles('tools/validation/**',
+          'tools/shared_utils.py') }}" >> "$GITHUB_OUTPUT"
+
+      # Previous night's baseline for the current validator generation. A
+      # validator change moves the toolshash and the restore misses, which is
+      # the re-establish signal: comparing across generations would report
+      # every moved finding as new.
+      - name: Restore previous validation baseline
+        # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .validation_baseline
+          key: >-
+            md-baseline-v1-${{ runner.os }}-${{
+            steps.toolshash.outputs.hash }}-${{ github.sha }}
+          restore-keys: |
+            md-baseline-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-
+
+      # The warm cache build-cache saved for THIS run (run_id-suffixed exact
+      # key) — a miss here is a real failure, not a graceful cold fallback.
+      - name: Restore validator disk cache
+        # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .validation_cache
+          key: >-
+            md-valcache-v1-${{ runner.os }}-${{
+            steps.toolshash.outputs.hash }}-${{ github.sha }}-${{
+            github.run_id }}
+          fail-on-cache-miss: true
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6
+        with:
+          python-version: "3.x"
+
+      # Non-strict: findings never fail this step — the diff below decides.
+      # A validator crash exits 1 and skips the diff, so a broken night
+      # keeps the previous baseline instead of promoting partial results.
+      - name: Run validators and persist results
+        run: >-
+          python3 tools/validation/run_all_validators.py --no-color
+          --persist-results .validation_baseline_candidate
+
+      - name: Diff against previous baseline
+        id: diff
+        run: |
+          workflow_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          workflow_url="$workflow_url/actions/runs/$GITHUB_RUN_ID"
+          python3 tools/baseline_check.py \
+            --previous .validation_baseline \
+            --current .validation_baseline_candidate \
+            --output .validation_baseline \
+            --toolshash "${{ steps.toolshash.outputs.hash }}" \
+            --commit-sha "${{ github.sha }}" \
+            --workflow-run-url "$workflow_url" \
+            --github-repository "${{ github.repository }}"
+
+      # Only a clean diff reaches this step: baseline_check exits 1 on new
+      # errors, so a red night saves nothing and the previous baseline stays
+      # the one PRs compare against.
+      - name: Save validation baseline
+        if: steps.diff.outcome == 'success'
+        # v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .validation_baseline
+          key: >-
+            md-baseline-v1-${{ runner.os }}-${{
+            steps.toolshash.outputs.hash }}-${{ github.sha }}-${{
+            github.run_id }}

--- a/tools/baseline_check.py
+++ b/tools/baseline_check.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Nightly baseline check: diff fresh main-side results against the baseline.
+
+Run by validator-cache.yml's check-baseline job after
+`run_all_validators.py --persist-results` has left the per-validator JSON
+sidecars of a full main run on disk. Exit codes:
+
+  0 — no new errors on main (baseline promoted to tonight's results), or no
+      previous baseline to compare against (a fresh one is established).
+  1 — new errors on main: the workflow goes red and the previous baseline is
+      kept, so the alarm repeats every night until the regression is fixed.
+      A validator-code change moves the toolshash, which re-establishes the
+      baseline instead of comparing against stale output.
+
+New warnings are reported but never fail the job: warnings are advisory
+everywhere else in the pipeline, so the nightly alarm tracks errors only.
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# report_lib imports need tools/ on sys.path (same bootstrap as
+# generate_validation_report.py).
+_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+from report_lib import (  # noqa: E402
+    Baseline,
+    Issue,
+    Severity,
+    issue_key,
+    load_baseline,
+    load_issues,
+    write_baseline,
+)
+
+# How many new findings the step summary lists before folding into a count.
+MAX_LISTED = 50
+
+
+def _split_new_findings(
+    current: Sequence[Issue], previous: Baseline
+) -> Tuple[List[Issue], List[Issue]]:
+    """Split current issues into (new errors, new warnings).
+
+    Findings whose key also exists in the previous baseline are existing.
+    Findings without a file/line can never match a key and count as new —
+    the alarm direction for the nightly check.
+    """
+    new_errors: List[Issue] = []
+    new_warnings: List[Issue] = []
+    for issue in current:
+        key = issue_key(issue)
+        if key is not None and key in previous.keys:
+            continue
+        if issue.severity == Severity.ERROR:
+            new_errors.append(issue)
+        else:
+            new_warnings.append(issue)
+    return new_errors, new_warnings
+
+
+def _current_keys(current: Sequence[Issue]) -> set:
+    keys = set()
+    for issue in current:
+        key = issue_key(issue)
+        if key is not None:
+            keys.add(key)
+    return keys
+
+
+def _fixed_counts(current: Sequence[Issue], previous: Baseline) -> Tuple[int, int]:
+    """(errors, warnings) present in the previous baseline but gone tonight."""
+    fixed = previous.keys - _current_keys(current)
+    fixed_errors = sum(1 for key in fixed if key[0] == Severity.ERROR)
+    return fixed_errors, len(fixed) - fixed_errors
+
+
+def _issue_line(issue: Issue) -> str:
+    marker = "❌" if issue.severity == Severity.ERROR else "⚠️"
+    if issue.file and issue.line:
+        ref = f"`{issue.file}:{issue.line}`"
+    elif issue.file:
+        ref = f"`{issue.file}`"
+    else:
+        ref = "_(no location)_"
+    return f"- {marker} {ref} — {issue.message}"
+
+
+def _write_step_summary(lines: Sequence[str]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    try:
+        with open(path, "a", encoding="utf-8") as stream:
+            stream.write("\n".join(lines) + "\n")
+    except OSError:
+        # The step summary is a nicety; the exit code and stdout are the
+        # real signal for the workflow.
+        print("Warning: could not write step summary", file=sys.stderr)
+
+
+def _build_meta(args) -> Dict[str, str]:
+    return {
+        "toolshash": args.toolshash,
+        "commit_sha": args.commit_sha,
+        "date_utc": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "repo": args.github_repository,
+    }
+
+
+def _header_lines(args) -> List[str]:
+    lines = ["## Validation baseline check", ""]
+    if args.commit_sha:
+        lines.append(f"**Commit:** `{args.commit_sha[:7]}`")
+    if args.workflow_run_url:
+        lines.append(f"**Run:** [{args.workflow_run_url}]({args.workflow_run_url})")
+    lines.append("")
+    return lines
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diff a main-side validation run against the stored baseline"
+    )
+    parser.add_argument(
+        "--previous",
+        required=True,
+        help="Directory holding the previous baseline (restored cache entry)",
+    )
+    parser.add_argument(
+        "--current",
+        required=True,
+        help="Directory holding tonight's per-validator JSON sidecars",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Directory to write the new baseline into on a clean diff",
+    )
+    parser.add_argument(
+        "--toolshash",
+        default="",
+        help="Validator source hash the previous baseline must match",
+    )
+    parser.add_argument("--commit-sha", default="")
+    parser.add_argument("--workflow-run-url", default="")
+    parser.add_argument(
+        "--github-repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+    )
+    args = parser.parse_args(argv)
+
+    # An empty sidecar dir is a legitimate all-clean run: validators only
+    # write a JSON sidecar when they have findings. A missing directory is
+    # a wiring error (the persist step never ran), so that alone fails fast.
+    current_dir = Path(args.current)
+    if not current_dir.is_dir():
+        print("--current directory does not exist", file=sys.stderr)
+        return 1
+    current = load_issues(args.current)
+
+    previous = load_baseline(args.previous, args.toolshash or None)
+    meta = _build_meta(args)
+
+    if previous is None:
+        write_baseline(args.current, args.output, meta)
+        print(
+            "No previous baseline for this validator generation; established "
+            f"a new baseline from {len(current)} issue(s)."
+        )
+        _write_step_summary(
+            _header_lines(args)
+            + [
+                f"**Established a new baseline** from {len(current)} issue(s).",
+                "",
+                "No previous baseline existed for the current validator code "
+                "(first run or a validator change moved the toolshash).",
+            ]
+        )
+        return 0
+
+    new_errors, new_warnings = _split_new_findings(current, previous)
+    fixed_errors, fixed_warnings = _fixed_counts(current, previous)
+
+    summary = _header_lines(args)
+    summary.extend(
+        [
+            f"- **New errors:** {len(new_errors)}",
+            f"- **New warnings:** {len(new_warnings)}",
+            f"- **Fixed since last baseline:** {fixed_errors} error(s), "
+            f"{fixed_warnings} warning(s)",
+        ]
+    )
+
+    if new_errors:
+        summary.append("")
+        summary.append("❌ **New errors on main — baseline not updated.**")
+        summary.append("")
+        summary.append(f"<details><summary>New errors ({len(new_errors)})</summary>")
+        summary.append("")
+        shown = new_errors[:MAX_LISTED]
+        summary.extend(_issue_line(issue) for issue in shown)
+        if len(new_errors) > len(shown):
+            summary.append(f"_…and {len(new_errors) - len(shown):,} more._")
+        summary.extend(["", "</details>"])
+        _write_step_summary(summary)
+        print(
+            f"✗ {len(new_errors)} new error(s) on main; baseline not updated.",
+            file=sys.stderr,
+        )
+        return 1
+
+    write_baseline(args.current, args.output, meta)
+    if new_warnings:
+        summary.append("")
+        summary.append(
+            f"<details><summary>New warnings ({len(new_warnings)})</summary>"
+        )
+        summary.append("")
+        shown = new_warnings[:MAX_LISTED]
+        summary.extend(_issue_line(issue) for issue in shown)
+        if len(new_warnings) > len(shown):
+            summary.append(f"_…and {len(new_warnings) - len(shown):,} more._")
+        summary.extend(["", "</details>"])
+    summary.append("")
+    summary.append("✅ No new errors — baseline updated to tonight's results.")
+    _write_step_summary(summary)
+    print(
+        f"✓ no new errors; baseline updated ({len(new_warnings)} new "
+        f"warning(s), {fixed_errors} error(s), {fixed_warnings} warning(s) fixed)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/generate_validation_report.py
+++ b/tools/generate_validation_report.py
@@ -19,6 +19,7 @@ import argparse
 import os
 import sys
 from datetime import datetime, timezone
+from typing import List, Optional
 
 # Add tools/ to path so the report_lib package imports cleanly when this
 # script is invoked directly (e.g. `python3 tools/generate_validation_report.py`).
@@ -94,7 +95,7 @@ def should_delete_comment(runs, deduped, validation_scope: str) -> bool:
     )
 
 
-def main() -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Generate the Millennium Dawn validation PR report",
     )
@@ -148,7 +149,7 @@ def main() -> int:
         help="owner/repo (defaults to $GITHUB_REPOSITORY)",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     ctx = ReportContext(
         pr_number=args.pr_number,

--- a/tools/generate_validation_report.py
+++ b/tools/generate_validation_report.py
@@ -5,10 +5,12 @@ Generate the Millennium Dawn validation PR report.
 Pipeline:
   1. Load per-validator JSON sidecars (falls back to parsing `.log` text).
   2. Dedupe issues that multiple validators surface about the same line.
-  3. Render two bodies: a concise PR comment (summary table + step-summary
+  3. Classify NEW vs EXISTING against the main-side baseline when one was
+     restored (otherwise render as before the baseline existed).
+  4. Render two bodies: a concise PR comment (summary table + step-summary
      pointer) and a detailed step summary (full per-validator issue list).
-  4. Truncate the comment if over GitHub's 65 536-byte limit.
-  5. Optionally post the comment as a PR comment and/or emit Checks API annotations.
+  5. Truncate the comment if over GitHub's 65 536-byte limit.
+  6. Optionally post the comment as a PR comment and/or emit Checks API annotations.
 
 All heavy lifting lives in `tools/report_lib/`; this file is just a CLI.
 """
@@ -27,9 +29,11 @@ if _TOOLS_DIR not in sys.path:
 from report_lib import (  # noqa: E402
     MAX_ISSUES_STEP_SUMMARY,
     ReportContext,
+    classify,
     dedupe,
     delete_comment,
     load_all,
+    load_baseline,
     post_checks,
     post_comment,
     render,
@@ -37,11 +41,16 @@ from report_lib import (  # noqa: E402
 )
 
 
-def build_report(results_dir: str, ctx: ReportContext):
-    """Return (body, step_summary_body, runs, deduped_issues, truncated)."""
+def build_report(results_dir: str, ctx: ReportContext, baseline=None):
+    """Return (body, step_summary_body, runs, deduped_issues, truncated, stats)."""
     runs = load_all(results_dir)
     flat_issues = [i for run in runs for i in run.issues]
     deduped = dedupe(flat_issues)
+
+    # NEW vs EXISTING classification against the main-side baseline, when
+    # one was restored. None keeps rendering exactly as before the baseline
+    # existed (cold cache, validator generation change).
+    baseline_stats = classify(deduped, baseline) if baseline is not None else None
 
     # PR comment — concise: verdict, summary-table counts, and a pointer to the
     # step summary. The full per-validator issue list is dropped here so the
@@ -52,6 +61,7 @@ def build_report(results_dir: str, ctx: ReportContext):
         ctx,
         include_raw_logs=False,
         include_validator_sections=False,
+        baseline_stats=baseline_stats,
     )
     body, truncated = truncate_if_needed(
         body,
@@ -63,10 +73,15 @@ def build_report(results_dir: str, ctx: ReportContext):
     # skip raw logs (large and redundant with the structured list; omitting them
     # keeps the summary under 1 MB).
     step_body = render(
-        runs, deduped, ctx, max_visible=MAX_ISSUES_STEP_SUMMARY, include_raw_logs=False
+        runs,
+        deduped,
+        ctx,
+        max_visible=MAX_ISSUES_STEP_SUMMARY,
+        include_raw_logs=False,
+        baseline_stats=baseline_stats,
     )
 
-    return body, step_body, runs, deduped, truncated
+    return body, step_body, runs, deduped, truncated, baseline_stats
 
 
 def should_delete_comment(runs, deduped, validation_scope: str) -> bool:
@@ -106,6 +121,24 @@ def main() -> int:
         help="Emit one Check Run per validator with inline annotations",
     )
     parser.add_argument(
+        "--baseline-dir",
+        default=None,
+        help=(
+            "Directory holding the main-side validation baseline (restored "
+            "cache entry, .validation_baseline). Findings are tagged NEW vs "
+            "EXISTING when it loads; a missing/stale baseline only drops the "
+            "annotation."
+        ),
+    )
+    parser.add_argument(
+        "--baseline-toolshash",
+        default=None,
+        help=(
+            "Validator source hash the baseline must have been built with; "
+            "a mismatch ignores the baseline instead of comparing stale output."
+        ),
+    )
+    parser.add_argument(
         "--github-token",
         default=os.environ.get("GITHUB_TOKEN"),
     )
@@ -127,7 +160,18 @@ def main() -> int:
         validation_scope=args.validation_scope,
     )
 
-    body, step_body, runs, deduped, truncated = build_report(args.results_dir, ctx)
+    # None on a cold cache or stale toolshash: classification (and the
+    # NEW/EXISTING rendering) is skipped instead of comparing against output
+    # from a different validator generation.
+    baseline = (
+        load_baseline(args.baseline_dir, args.baseline_toolshash)
+        if args.baseline_dir
+        else None
+    )
+
+    body, step_body, runs, deduped, truncated, baseline_stats = build_report(
+        args.results_dir, ctx, baseline
+    )
 
     try:
         with open(args.output, "w", encoding="utf-8") as f:
@@ -162,6 +206,14 @@ def main() -> int:
         f"({len(deduped)} unique issue(s) after dedupe)",
         file=sys.stderr,
     )
+    if baseline_stats is not None:
+        print(
+            f"vs main baseline: {baseline_stats.new_errors} new error(s), "
+            f"{baseline_stats.new_warnings} new warning(s), "
+            f"{baseline_stats.existing_errors + baseline_stats.existing_warnings} existing, "
+            f"{baseline_stats.unclassified} unclassified",
+            file=sys.stderr,
+        )
 
     if args.post_comment or args.checks_api:
         if not args.github_repository:

--- a/tools/report_lib/__init__.py
+++ b/tools/report_lib/__init__.py
@@ -14,6 +14,16 @@ Public entry points:
 The CLI is `tools/generate_validation_report.py`.
 """
 
+from .baseline import (
+    META_FILENAME,
+    Baseline,
+    BaselineStats,
+    classify,
+    issue_key,
+    load_baseline,
+    load_issues,
+    write_baseline,
+)
 from .checks_api import post_checks
 from .comment import REPORT_MARKER, delete_comment, find_existing_comment, post_comment
 from .dedupe import dedupe
@@ -24,12 +34,20 @@ from .truncation import MAX_COMMENT_BYTES, truncate_if_needed
 
 __all__ = [
     "MAX_ISSUES_STEP_SUMMARY",
+    "META_FILENAME",
     "Issue",
     "Severity",
     "ValidatorRun",
     "ReportContext",
+    "Baseline",
+    "BaselineStats",
     "load_all",
     "discover_validator_runs",
+    "load_baseline",
+    "load_issues",
+    "write_baseline",
+    "issue_key",
+    "classify",
     "dedupe",
     "render",
     "truncate_if_needed",

--- a/tools/report_lib/baseline.py
+++ b/tools/report_lib/baseline.py
@@ -10,8 +10,11 @@ Fingerprint: (severity, category, file, line, message) — the report_lib
 dedupe key plus severity, computed after the same cross-validator dedupe
 runs on both sides. Severity is part of the key so an existing warning that
 escalates to an error reads as a new error (the alarm direction). Known
-limitation: an unrelated edit that shifts lines makes existing findings
-look NEW.
+limitations:
+  - an unrelated edit that shifts lines makes existing findings look NEW;
+  - a PR that runs only a subset of validators can tag an existing finding
+    NEW when main's cross-validator dedupe escalated its severity but the
+    PR's subset didn't (see classify).
 """
 
 import json
@@ -53,9 +56,10 @@ def issue_key(issue: Issue) -> Optional[BaselineKey]:
     """The comparison key for one issue.
 
     None when the issue cannot be keyed: text-fallback issues carry no
-    file/line, so they can never be proven to match a baseline entry.
+    file/line, so they can never be proven to match a baseline entry. Line
+    must be positive to agree with Issue.has_location.
     """
-    if not issue.category or not issue.file or not issue.line or not issue.message:
+    if not issue.category or not issue.file or issue.line <= 0 or not issue.message:
         return None
     return (issue.severity, issue.category, issue.file, issue.line, issue.message)
 
@@ -79,7 +83,9 @@ def load_issues(sidecar_dir: str) -> List[Issue]:
             continue
         if not isinstance(data, list):
             continue
-        issues.extend(Issue.from_dict(d, validator=path.stem) for d in data)
+        issues.extend(
+            Issue.from_dict(d, validator=path.stem) for d in data if isinstance(d, dict)
+        )
     return dedupe(issues)
 
 
@@ -121,6 +127,12 @@ def classify(issues: List[Issue], baseline: Baseline) -> BaselineStats:
     Unkeyable issues (no file/line) are left untagged and counted as
     unclassified. Rendering only adds a NEW tag when the field is set, so a
     missing baseline needs no special case at render time.
+
+    Severity is part of the key on purpose: an existing warning escalated to
+    an error must read as a new error (the alarm direction). The accepted
+    asymmetry is de-escalation — a PR that runs only the validator reporting
+    a warning while main's cross-validator dedupe recorded the same finding
+    as an error tags it NEW even though it exists on main.
     """
     stats = BaselineStats()
     for issue in issues:

--- a/tools/report_lib/baseline.py
+++ b/tools/report_lib/baseline.py
@@ -1,0 +1,167 @@
+"""Validation baseline: store main-side findings, classify PR findings.
+
+The nightly `check-baseline` job in validator-cache.yml persists the
+per-validator JSON sidecars of a full main run as the shared baseline. PR
+report jobs restore that entry (keyed on the validator source hash) and use
+the key set here to tag every finding NEW (not on the latest main run) or
+EXISTING (also present there).
+
+Fingerprint: (severity, category, file, line, message) — the report_lib
+dedupe key plus severity, computed after the same cross-validator dedupe
+runs on both sides. Severity is part of the key so an existing warning that
+escalates to an error reads as a new error (the alarm direction). Known
+limitation: an unrelated edit that shifts lines makes existing findings
+look NEW.
+"""
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from .dedupe import dedupe
+from .models import Issue, Severity
+
+META_FILENAME = "baseline-meta.json"
+
+# (severity, category, file, line, message)
+BaselineKey = Tuple[str, str, str, int, str]
+
+
+@dataclass
+class Baseline:
+    """A loaded baseline: its meta plus the deduped key set."""
+
+    meta: Dict[str, str]
+    keys: Set[BaselineKey]
+
+
+@dataclass
+class BaselineStats:
+    """NEW/EXISTING breakdown of one run against a baseline."""
+
+    new_errors: int = 0
+    new_warnings: int = 0
+    existing_errors: int = 0
+    existing_warnings: int = 0
+    unclassified: int = 0
+    new_issues: List[Issue] = field(default_factory=list)
+
+
+def issue_key(issue: Issue) -> Optional[BaselineKey]:
+    """The comparison key for one issue.
+
+    None when the issue cannot be keyed: text-fallback issues carry no
+    file/line, so they can never be proven to match a baseline entry.
+    """
+    if not issue.category or not issue.file or not issue.line or not issue.message:
+        return None
+    return (issue.severity, issue.category, issue.file, issue.line, issue.message)
+
+
+def load_issues(sidecar_dir: str) -> List[Issue]:
+    """Load and cross-validator dedupe every `<slug>.json` sidecar in a dir.
+
+    The dir layout is the one `run_all_validators.py --persist-results`
+    produces: one flat JSON list of issue dicts per validator. A validator
+    that passed clean writes no sidecar at all, which is exactly the empty
+    findings set the baseline wants.
+    """
+    issues: List[Issue] = []
+    base = Path(sidecar_dir)
+    for path in sorted(base.glob("*.json")):
+        if path.name == META_FILENAME:
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, list):
+            continue
+        issues.extend(Issue.from_dict(d, validator=path.stem) for d in data)
+    return dedupe(issues)
+
+
+def load_baseline(
+    baseline_dir: str, expected_toolshash: Optional[str] = None
+) -> Optional[Baseline]:
+    """Load the stored baseline, or None when missing or stale.
+
+    A toolshash mismatch means the baseline was produced by a different
+    validator generation; comparing against it would report every finding
+    whose output shape moved as NEW, so the caller falls back to rendering
+    without baseline annotation (or, nightly-side, establishing a fresh one).
+    """
+    base = Path(baseline_dir)
+    meta_path = base / META_FILENAME
+    if not meta_path.is_file():
+        return None
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    if expected_toolshash and meta.get("toolshash") != expected_toolshash:
+        return None
+
+    deduped = load_issues(baseline_dir)
+    keys: Set[BaselineKey] = set()
+    for issue in deduped:
+        key = issue_key(issue)
+        if key is not None:
+            keys.add(key)
+    return Baseline(meta=meta, keys=keys)
+
+
+def classify(issues: List[Issue], baseline: Baseline) -> BaselineStats:
+    """Tag each issue's `baseline_status` ("new"/"existing") in place.
+
+    Unkeyable issues (no file/line) are left untagged and counted as
+    unclassified. Rendering only adds a NEW tag when the field is set, so a
+    missing baseline needs no special case at render time.
+    """
+    stats = BaselineStats()
+    for issue in issues:
+        key = issue_key(issue)
+        if key is None:
+            stats.unclassified += 1
+            continue
+        if key in baseline.keys:
+            issue.baseline_status = "existing"
+            if issue.severity == Severity.ERROR:
+                stats.existing_errors += 1
+            else:
+                stats.existing_warnings += 1
+        else:
+            issue.baseline_status = "new"
+            stats.new_issues.append(issue)
+            if issue.severity == Severity.ERROR:
+                stats.new_errors += 1
+            else:
+                stats.new_warnings += 1
+    return stats
+
+
+def write_baseline(sidecar_dir: str, baseline_dir: str, meta: Dict[str, str]) -> None:
+    """Persist a baseline: one JSON per validator sidecar plus a meta file.
+
+    Stale validator files (removed from the suite since the previous save)
+    are dropped so the baseline can never keep reporting issues for a
+    validator that no longer runs. All-json deletion is bounded to
+    `baseline_dir` and skips the meta file.
+    """
+    source = Path(sidecar_dir)
+    target = Path(baseline_dir)
+    target.mkdir(parents=True, exist_ok=True)
+
+    sidecars = sorted(p for p in source.glob("*.json") if p.is_file())
+    keep = {p.name for p in sidecars} | {META_FILENAME}
+    for stale in sorted(p for p in target.glob("*.json") if p.name not in keep):
+        stale.unlink()
+    for path in sidecars:
+        shutil.copyfile(path, target / path.name)
+    (target / META_FILENAME).write_text(
+        json.dumps(meta, indent=2, sort_keys=True), encoding="utf-8"
+    )

--- a/tools/report_lib/markdown.py
+++ b/tools/report_lib/markdown.py
@@ -12,11 +12,14 @@ Two renderings come out of the same builder:
 """
 
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 from .comment import REPORT_MARKER
 from .models import Issue, ReportContext, Severity, ValidatorRun
+
+if TYPE_CHECKING:
+    from .baseline import BaselineStats
 
 # PR comment cap — keeps comment inside GitHub's 65 536-byte limit.
 MAX_ISSUES_COMMENT = 200
@@ -36,6 +39,7 @@ def render(
     max_visible: int = MAX_ISSUES_COMMENT,
     include_raw_logs: bool = True,
     include_validator_sections: bool = True,
+    baseline_stats: Optional["BaselineStats"] = None,
 ) -> str:
     """Render the report body.
 
@@ -43,19 +47,31 @@ def render(
     sections and raw logs are dropped in favour of a one-line pointer to the
     step summary — that's the concise PR comment. The default renders the full
     detail for the step summary.
+
+    ``baseline_stats`` (from ``baseline.classify``) adds the new-vs-existing
+    annotation: NEW/EXISTING counts in the verdict and, in the step summary,
+    a dedicated section listing new findings. ``Issue.baseline_status`` drives
+    the per-bullet NEW tag. Omit it (no baseline restored) and the report
+    renders as before.
     """
     parts: List[str] = []
     parts.append(REPORT_MARKER)
     parts.append("# Validation Report")
     parts.append("")
 
-    verdict = _render_verdict(runs, ctx.validation_scope)
+    verdict = _render_verdict(runs, ctx.validation_scope, baseline_stats)
     if verdict:
         parts.append(verdict)
         parts.append("")
 
     parts.append(_render_metadata_strip(ctx))
     parts.append("")
+
+    if baseline_stats is not None and include_validator_sections:
+        baseline_section = _render_baseline_section(baseline_stats, ctx, max_visible)
+        if baseline_section:
+            parts.append(baseline_section)
+            parts.append("")
 
     # Concise comment hides passing validators (count note only); the step
     # summary lists the full roster alongside the per-validator sections.
@@ -137,7 +153,11 @@ def _severity_icon(errors: int, warnings: int) -> str:
 # ── Verdict banner ─────────────────────────────────────────────────────────────
 
 
-def _render_verdict(runs: List[ValidatorRun], validation_scope: str = "full") -> str:
+def _render_verdict(
+    runs: List[ValidatorRun],
+    validation_scope: str = "full",
+    baseline_stats: Optional["BaselineStats"] = None,
+) -> str:
     """A GitHub alert callout giving an at-a-glance pass/fail verdict."""
     if not runs:
         return ""
@@ -145,12 +165,24 @@ def _render_verdict(runs: List[ValidatorRun], validation_scope: str = "full") ->
 
     if total_errors:
         line = f"{_plural(total_errors, 'error')} must be fixed before merge."
+        if baseline_stats is not None:
+            if baseline_stats.new_errors:
+                line += f" ({baseline_stats.new_errors} new against the main baseline.)"
+            else:
+                line += " (none new against the main baseline.)"
         if total_warnings:
             line += f" ({_plural(total_warnings, 'warning')}, advisory.)"
         return f"> [!CAUTION]\n> ❌ {line}"
 
     if total_warnings:
         line = f"{_plural(total_warnings, 'warning')} to review. None block merge."
+        if baseline_stats is not None:
+            if baseline_stats.new_warnings:
+                line += (
+                    f" ({baseline_stats.new_warnings} new against the main baseline.)"
+                )
+            else:
+                line += " (none new against the main baseline.)"
         return f"> [!WARNING]\n> ⚠️ {line}"
 
     tail = (
@@ -223,6 +255,45 @@ def _render_summary_table(runs: List[ValidatorRun], show_passing: bool = True) -
 
 
 # ── Issues section ─────────────────────────────────────────────────────────────
+
+
+def _render_baseline_section(
+    stats: "BaselineStats", ctx: ReportContext, max_visible: int
+) -> str:
+    """The step-summary 'New findings vs main baseline' section."""
+    lines: List[str] = ["## New findings vs main baseline", ""]
+
+    if not stats.new_issues:
+        lines.append("✅ No new findings against the main baseline.")
+        if stats.unclassified:
+            lines.append(
+                f"_{stats.unclassified} finding(s) could not be compared "
+                "(no file/line)._"
+            )
+        return "\n".join(lines)
+
+    label = _count_label(stats.new_errors, stats.new_warnings)
+    lines.append(f"{label} not present on the latest main run:")
+    lines.append("")
+    sorted_new = sorted(
+        stats.new_issues,
+        key=lambda i: (
+            0 if i.severity == Severity.ERROR else 1,
+            i.file,
+            i.line,
+            i.message,
+        ),
+    )
+    shown = sorted_new[:max_visible]
+    lines.extend(_render_bullet(i, ctx) for i in shown)
+    overflow = len(sorted_new) - len(shown)
+    if overflow:
+        lines.append(f"_…and {overflow:,} more new findings._")
+    if stats.unclassified:
+        lines.append(
+            f"_{stats.unclassified} finding(s) could not be compared (no file/line)._"
+        )
+    return "\n".join(lines)
 
 
 def _render_details_pointer(ctx: ReportContext) -> str:
@@ -366,11 +437,12 @@ def _file_ref(issue: Issue, ctx: ReportContext) -> str:
 
 def _render_bullet(issue: Issue, ctx: ReportContext) -> str:
     marker = "❌" if issue.severity == Severity.ERROR else "⚠️"
+    new_tag = " **NEW**" if issue.baseline_status == "new" else ""
     also = f" _(also: {', '.join(issue.detected_by)})_" if issue.detected_by else ""
 
     if issue.file:
-        return f"- {marker} {_file_ref(issue, ctx)} — {issue.message}{also}"
-    return f"- {marker} {issue.message}{also}"
+        return f"- {marker}{new_tag} {_file_ref(issue, ctx)} — {issue.message}{also}"
+    return f"- {marker}{new_tag} {issue.message}{also}"
 
 
 # ── Raw logs ───────────────────────────────────────────────────────────────────

--- a/tools/report_lib/models.py
+++ b/tools/report_lib/models.py
@@ -23,15 +23,22 @@ class Issue:
     line: int = 0
     validator: str = ""
     detected_by: List[str] = field(default_factory=list)
+    # Set by baseline.classify(): "new" / "existing" when a baseline was
+    # available and the issue could be keyed; None otherwise.
+    baseline_status: Optional[str] = None
 
     @classmethod
     def from_dict(cls, d: dict, validator: str = "") -> "Issue":
+        try:
+            line = int(d.get("line", 0) or 0)
+        except (TypeError, ValueError):
+            line = 0
         return cls(
             severity=d.get("severity", Severity.ERROR),
             category=d.get("category", ""),
             message=d.get("message", ""),
             file=d.get("file", ""),
-            line=int(d.get("line", 0) or 0),
+            line=line,
             validator=d.get("validator", validator),
         )
 

--- a/tools/report_lib/tests/baseline_check_test.py
+++ b/tools/report_lib/tests/baseline_check_test.py
@@ -1,0 +1,185 @@
+"""Tests for the nightly `baseline_check` CLI."""
+
+import json
+
+import baseline_check
+
+from report_lib import load_baseline
+from report_lib.baseline import META_FILENAME
+
+
+def _issue_dict(severity, file="a.txt", line=1, message="m", category="c"):
+    return {
+        "severity": severity,
+        "category": category,
+        "message": message,
+        "file": file,
+        "line": line,
+    }
+
+
+def _write_sidecar(base, slug, issues):
+    base.mkdir(parents=True, exist_ok=True)
+    (base / f"{slug}.json").write_text(json.dumps(issues), encoding="utf-8")
+
+
+def _write_meta(base, toolshash="h"):
+    base.mkdir(parents=True, exist_ok=True)
+    (base / META_FILENAME).write_text(
+        json.dumps({"toolshash": toolshash}), encoding="utf-8"
+    )
+
+
+def _run(tmp_path, previous, current, toolshash="h", monkeypatch=None):
+    if monkeypatch is not None:
+        monkeypatch.setattr(baseline_check, "_write_step_summary", lambda lines: None)
+        monkeypatch.setattr(
+            baseline_check, "_build_meta", lambda args: {"toolshash": args.toolshash}
+        )
+    argv = [
+        "--previous",
+        str(previous),
+        "--current",
+        str(current),
+        "--output",
+        str(tmp_path / "baseline"),
+        "--toolshash",
+        toolshash,
+        "--commit-sha",
+        "abc1234deadbeef",  # pragma: allowlist secret
+    ]
+    return baseline_check.main(argv)
+
+
+def test_establishing_baseline_when_previous_missing(tmp_path, monkeypatch, capsys):
+    current = tmp_path / "current"
+    _write_sidecar(current, "events", [_issue_dict("error")])
+
+    code = _run(
+        tmp_path, tmp_path / "no-such-baseline", current, monkeypatch=monkeypatch
+    )
+
+    assert code == 0
+    assert "established" in capsys.readouterr().out
+    assert (tmp_path / "baseline" / META_FILENAME).is_file()
+    assert (tmp_path / "baseline" / "events.json").is_file()
+
+
+def test_new_errors_fail_and_keep_old_baseline(tmp_path, monkeypatch, capsys):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    _write_sidecar(previous, "events", [_issue_dict("error", message="old")])
+    current = tmp_path / "current"
+    _write_sidecar(
+        current,
+        "events",
+        [
+            _issue_dict("error", message="old"),
+            _issue_dict("error", message="brand new", file="b.txt", line=2),
+        ],
+    )
+
+    code = _run(tmp_path, previous, current, monkeypatch=monkeypatch)
+
+    assert code == 1
+    assert "1 new error(s)" in capsys.readouterr().err
+    # Red night: the old baseline stays; nothing is written to --output.
+    assert not (tmp_path / "baseline" / META_FILENAME).exists()
+
+
+def test_clean_diff_promotes_baseline(tmp_path, monkeypatch, capsys):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    _write_sidecar(previous, "events", [_issue_dict("error", message="old")])
+    current = tmp_path / "current"
+    _write_sidecar(current, "events", [_issue_dict("error", message="old")])
+
+    code = _run(tmp_path, previous, current, monkeypatch=monkeypatch)
+
+    assert code == 0
+    assert (tmp_path / "baseline" / META_FILENAME).is_file()
+    assert "baseline updated" in capsys.readouterr().out
+
+
+def test_fixed_errors_still_promote(tmp_path, monkeypatch, capsys):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    _write_sidecar(
+        previous,
+        "events",
+        [_issue_dict("error", message="old"), _issue_dict("error", message="fixed")],
+    )
+    current = tmp_path / "current"
+    _write_sidecar(current, "events", [_issue_dict("error", message="old")])
+
+    code = _run(tmp_path, previous, current, monkeypatch=monkeypatch)
+
+    assert code == 0
+    assert "fixed" in capsys.readouterr().out
+    assert (tmp_path / "baseline" / META_FILENAME).is_file()
+
+
+def test_new_warnings_do_not_fail(tmp_path, monkeypatch, capsys):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    current = tmp_path / "current"
+    _write_sidecar(current, "events", [_issue_dict("warning", message="new warn")])
+
+    code = _run(tmp_path, previous, current, monkeypatch=monkeypatch)
+
+    assert code == 0
+    assert "1 new warning(s)" in capsys.readouterr().out
+    assert (tmp_path / "baseline" / META_FILENAME).is_file()
+
+
+def test_toolshash_mismatch_reestablishes(tmp_path, monkeypatch, capsys):
+    previous = tmp_path / "prev"
+    _write_meta(previous, toolshash="old-generation")
+    current = tmp_path / "current"
+    _write_sidecar(current, "events", [_issue_dict("error", message="old")])
+
+    code = _run(
+        tmp_path, previous, current, toolshash="new-gen", monkeypatch=monkeypatch
+    )
+
+    assert code == 0
+    assert "established" in capsys.readouterr().out
+
+
+def test_missing_current_dir_fails(tmp_path, monkeypatch, capsys):
+    code = _run(tmp_path, tmp_path / "prev", tmp_path / "no-such-dir")
+    assert code == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_split_new_findings(tmp_path):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    _write_sidecar(previous, "events", [_issue_dict("error", message="old")])
+    baseline = load_baseline(str(previous), "h")
+    assert baseline is not None
+
+    current = [
+        baseline_check.Issue.from_dict(_issue_dict("error", message="old")),
+        baseline_check.Issue.from_dict(_issue_dict("error", message="new")),
+        baseline_check.Issue.from_dict(_issue_dict("warning", message="new warning")),
+    ]
+    new_errors, new_warnings = baseline_check._split_new_findings(current, baseline)
+    assert [i.message for i in new_errors] == ["new"]
+    assert [i.message for i in new_warnings] == ["new warning"]
+
+
+def test_unkeyable_findings_count_as_new(tmp_path):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    baseline = load_baseline(str(previous), "h")
+    assert baseline is not None
+
+    current = [
+        baseline_check.Issue.from_dict(
+            {"severity": "error", "category": "c", "message": "no location"}
+        )
+    ]
+    new_errors, new_warnings = baseline_check._split_new_findings(current, baseline)
+    assert len(new_errors) == 1
+    assert new_warnings == []

--- a/tools/report_lib/tests/baseline_check_test.py
+++ b/tools/report_lib/tests/baseline_check_test.py
@@ -1,5 +1,6 @@
 """Tests for the nightly `baseline_check` CLI."""
 
+import builtins
 import json
 
 import baseline_check
@@ -30,12 +31,18 @@ def _write_meta(base, toolshash="h"):
     )
 
 
-def _run(tmp_path, previous, current, toolshash="h", monkeypatch=None):
+def _run(
+    tmp_path, previous, current, toolshash="h", monkeypatch=None, summary_path=None
+):
     if monkeypatch is not None:
-        monkeypatch.setattr(baseline_check, "_write_step_summary", lambda lines: None)
-        monkeypatch.setattr(
-            baseline_check, "_build_meta", lambda args: {"toolshash": args.toolshash}
-        )
+        if summary_path is None:
+            # No summary requested: exercise the real no-op path rather
+            # than mocking the writer away.
+            monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        else:
+            # Keep the real writer: the step summary is the nightly alarm's
+            # only human-readable output, so tests assert its content.
+            monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
     argv = [
         "--previous",
         str(previous),
@@ -63,6 +70,12 @@ def test_establishing_baseline_when_previous_missing(tmp_path, monkeypatch, caps
     assert "established" in capsys.readouterr().out
     assert (tmp_path / "baseline" / META_FILENAME).is_file()
     assert (tmp_path / "baseline" / "events.json").is_file()
+    # The real _build_meta ran: the persisted meta carries the hash the
+    # PR-side load_baseline will later verify against.
+    meta = json.loads(
+        (tmp_path / "baseline" / META_FILENAME).read_text(encoding="utf-8")
+    )
+    assert meta["toolshash"] == "h"
 
 
 def test_new_errors_fail_and_keep_old_baseline(tmp_path, monkeypatch, capsys):
@@ -115,8 +128,91 @@ def test_fixed_errors_still_promote(tmp_path, monkeypatch, capsys):
     code = _run(tmp_path, previous, current, monkeypatch=monkeypatch)
 
     assert code == 0
-    assert "fixed" in capsys.readouterr().out
+    assert "1 error(s), 0 warning(s) fixed" in capsys.readouterr().out
     assert (tmp_path / "baseline" / META_FILENAME).is_file()
+
+
+def test_red_night_step_summary_reports_new_errors(tmp_path, monkeypatch):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    current = tmp_path / "current"
+    _write_sidecar(
+        current,
+        "events",
+        [_issue_dict("error", file="b.txt", line=2, message="brand new")],
+    )
+    summary_path = tmp_path / "summary.md"
+
+    code = _run(
+        tmp_path,
+        previous,
+        current,
+        monkeypatch=monkeypatch,
+        summary_path=summary_path,
+    )
+
+    assert code == 1
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "New errors on main — baseline not updated." in summary
+    assert "`b.txt:2` — brand new" in summary
+
+
+def test_clean_night_step_summary_confirms_update(tmp_path, monkeypatch):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    _write_sidecar(previous, "events", [_issue_dict("error", message="old")])
+    current = tmp_path / "current"
+    _write_sidecar(current, "events", [_issue_dict("error", message="old")])
+    summary_path = tmp_path / "summary.md"
+
+    code = _run(
+        tmp_path,
+        previous,
+        current,
+        monkeypatch=monkeypatch,
+        summary_path=summary_path,
+    )
+
+    assert code == 0
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "✅ No new errors — baseline updated to tonight's results." in summary
+
+
+def test_step_summary_caps_new_findings_lists(tmp_path, monkeypatch):
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    current = tmp_path / "current"
+    issues = [
+        _issue_dict("warning", file="w.txt", line=n, message=f"warning {n}")
+        for n in range(1, baseline_check.MAX_LISTED + 2)
+    ]
+    _write_sidecar(current, "events", issues)
+    summary_path = tmp_path / "summary.md"
+
+    code = _run(
+        tmp_path,
+        previous,
+        current,
+        monkeypatch=monkeypatch,
+        summary_path=summary_path,
+    )
+
+    assert code == 0
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "_…and 1 more._" in summary
+    assert summary.count("- ⚠️ `w.txt:") == baseline_check.MAX_LISTED
+
+
+def test_issue_line_renders_fallback_locations():
+    no_line = baseline_check.Issue.from_dict(
+        {"severity": "error", "category": "c", "message": "m", "file": "f.txt"}
+    )
+    assert baseline_check._issue_line(no_line) == "- ❌ `f.txt` — m"
+
+    no_file = baseline_check.Issue.from_dict(
+        {"severity": "warning", "category": "c", "message": "m"}
+    )
+    assert baseline_check._issue_line(no_file) == "- ⚠️ _(no location)_ — m"
 
 
 def test_new_warnings_do_not_fail(tmp_path, monkeypatch, capsys):
@@ -183,3 +279,22 @@ def test_unkeyable_findings_count_as_new(tmp_path):
     new_errors, new_warnings = baseline_check._split_new_findings(current, baseline)
     assert len(new_errors) == 1
     assert new_warnings == []
+
+    # The fixed-counts side also skips unkeyable findings instead of
+    # treating them as keyed matches.
+    fixed_errors, fixed_warnings = baseline_check._fixed_counts(current, baseline)
+    assert fixed_errors == 0
+    assert fixed_warnings == 0
+
+
+def test_step_summary_write_failure_is_non_fatal(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
+
+    def broken_open(_path, _mode, encoding="utf-8"):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(builtins, "open", broken_open)
+
+    baseline_check._write_step_summary(["line"])
+
+    assert "could not write step summary" in capsys.readouterr().err

--- a/tools/report_lib/tests/baseline_check_test.py
+++ b/tools/report_lib/tests/baseline_check_test.py
@@ -114,6 +114,24 @@ def test_clean_diff_promotes_baseline(tmp_path, monkeypatch, capsys):
     assert "baseline updated" in capsys.readouterr().out
 
 
+def test_all_clean_night_promotes_empty_baseline(tmp_path, monkeypatch, capsys):
+    # A fully clean suite writes no sidecars at all. That is the empty
+    # findings set, not a crash: the previous baseline (with findings)
+    # collapses to meta-only and the fixed counts are reported.
+    previous = tmp_path / "prev"
+    _write_meta(previous)
+    _write_sidecar(previous, "events", [_issue_dict("error", message="old")])
+    current = tmp_path / "current"
+    current.mkdir()
+
+    code = _run(tmp_path, previous, current, monkeypatch=monkeypatch)
+
+    assert code == 0
+    assert (tmp_path / "baseline" / META_FILENAME).is_file()
+    assert not (tmp_path / "baseline" / "events.json").exists()
+    assert "1 error(s), 0 warning(s) fixed" in capsys.readouterr().out
+
+
 def test_fixed_errors_still_promote(tmp_path, monkeypatch, capsys):
     previous = tmp_path / "prev"
     _write_meta(previous)

--- a/tools/report_lib/tests/baseline_test.py
+++ b/tools/report_lib/tests/baseline_test.py
@@ -69,6 +69,7 @@ def test_load_baseline_loads_and_dedupes_sidecars(tmp_path):
 def test_issue_key_requires_location():
     assert issue_key(_issue()) is not None
     assert issue_key(_issue(file="", line=0)) is None
+    assert issue_key(_issue(line=-3)) is None
 
 
 def test_classify_tags_new_and_existing(tmp_path):
@@ -163,6 +164,42 @@ def test_load_issues_skips_unparseable_sidecars(tmp_path):
     # The broken sidecar is skipped, not fatal: one validator with a
     # truncated upload must not crash the PR report or the nightly diff.
     assert len(issues) == 1
+
+
+def test_load_issues_skips_non_dict_entries(tmp_path):
+    (tmp_path / "events.json").write_text(
+        json.dumps(
+            [
+                _issue_dict("error"),
+                None,
+                "garbage",
+                42,
+                _issue_dict("warning", file="b.txt", line=2, message="second"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    issues = load_issues(str(tmp_path))
+    # Non-dict entries are dropped, not fatal: a malformed sidecar element
+    # must not kill the whole report job via AttributeError.
+    assert [i.file for i in issues] == ["a.txt", "b.txt"]
+    assert [i.severity for i in issues] == ["error", "warning"]
+
+
+def test_from_dict_coerces_non_numeric_line_to_zero(tmp_path):
+    from report_lib import Issue
+
+    issue = Issue.from_dict(
+        {
+            "severity": "error",
+            "category": "c",
+            "message": "m",
+            "file": "f.txt",
+            "line": "abc",
+        }
+    )
+    assert issue.line == 0
+    assert issue.has_location is False
 
 
 def test_load_baseline_returns_none_when_meta_not_a_dict(tmp_path):

--- a/tools/report_lib/tests/baseline_test.py
+++ b/tools/report_lib/tests/baseline_test.py
@@ -1,0 +1,227 @@
+"""Tests for `report_lib.baseline`."""
+
+import json
+
+from report_lib import (
+    Issue,
+    Severity,
+    classify,
+    load_baseline,
+    load_issues,
+    write_baseline,
+)
+from report_lib.baseline import META_FILENAME, issue_key
+
+
+def _issue(**overrides):
+    fields = {
+        "severity": Severity.ERROR,
+        "category": "missing_key",
+        "message": "key FOO not found",
+        "file": "events/MD_x.txt",
+        "line": 212,
+        "validator": "events",
+    }
+    fields.update(overrides)
+    return Issue(**fields)
+
+
+def _write_sidecar(base, slug, issues):
+    (base / f"{slug}.json").write_text(json.dumps(issues), encoding="utf-8")
+
+
+def _issue_dict(severity, file="a.txt", line=1, message="m", category="missing_key"):
+    return {
+        "severity": severity,
+        "category": category,
+        "message": message,
+        "file": file,
+        "line": line,
+    }
+
+
+def test_load_baseline_returns_none_without_meta(tmp_path):
+    _write_sidecar(tmp_path, "events", [_issue_dict("error")])
+    assert load_baseline(str(tmp_path)) is None
+
+
+def test_load_baseline_returns_none_on_toolshash_mismatch(tmp_path):
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "old-hash"}), encoding="utf-8"
+    )
+    assert load_baseline(str(tmp_path), "new-hash") is None
+
+
+def test_load_baseline_loads_and_dedupes_sidecars(tmp_path):
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    dup = _issue_dict("error")
+    _write_sidecar(tmp_path, "events", [dup])
+    _write_sidecar(tmp_path, "localisation", [dup])
+    baseline = load_baseline(str(tmp_path), "h")
+    assert baseline is not None
+    # Cross-validator duplicates collapse before keys are built.
+    assert len(baseline.keys) == 1
+    assert baseline.meta["toolshash"] == "h"
+
+
+def test_issue_key_requires_location():
+    assert issue_key(_issue()) is not None
+    assert issue_key(_issue(file="", line=0)) is None
+
+
+def test_classify_tags_new_and_existing(tmp_path):
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    existing = _issue_dict("error", file="old.txt", line=1, message="old finding")
+    _write_sidecar(tmp_path, "events", [existing])
+    baseline = load_baseline(str(tmp_path), "h")
+
+    issues = [
+        _issue(file="old.txt", line=1, message="old finding"),
+        _issue(file="new.txt", line=1, message="new finding"),
+        _issue(
+            severity=Severity.WARNING,
+            file="new.txt",
+            line=2,
+            message="new warning",
+        ),
+    ]
+    stats = classify(issues, baseline)
+
+    assert [i.baseline_status for i in issues] == ["existing", "new", "new"]
+    assert stats.new_errors == 1
+    assert stats.new_warnings == 1
+    assert stats.existing_errors == 1
+    assert stats.existing_warnings == 0
+    assert stats.unclassified == 0
+    assert stats.new_issues == issues[1:]
+
+
+def test_classify_escalated_severity_counts_as_new(tmp_path):
+    # Severity is part of the key: a warning on main that a PR escalates to
+    # an error must alarm as a new error, not read as existing.
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    _write_sidecar(
+        tmp_path,
+        "events",
+        [_issue_dict("warning", file="a.txt", line=1, message="escalated")],
+    )
+    baseline = load_baseline(str(tmp_path), "h")
+
+    stats = classify([_issue(file="a.txt", line=1, message="escalated")], baseline)
+    assert stats.new_errors == 1
+    assert stats.existing_errors == 0
+
+
+def test_classify_leaves_unkeyable_issues_untagged(tmp_path):
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    baseline = load_baseline(str(tmp_path), "h")
+    assert baseline is not None
+
+    unkeyable = _issue(file="", line=0, message="no location")
+    stats = classify([unkeyable], baseline)
+
+    assert unkeyable.baseline_status is None
+    assert stats.unclassified == 1
+
+
+def test_load_issues_ignores_non_list_json(tmp_path):
+    (tmp_path / "notes.json").write_text('{"not": "a list"}', encoding="utf-8")
+    assert load_issues(str(tmp_path)) == []
+
+
+def test_write_baseline_copies_sidecars_writes_meta_and_prunes(tmp_path):
+    current = tmp_path / "current"
+    current.mkdir()
+    _write_sidecar(current, "events", [_issue_dict("error")])
+
+    output = tmp_path / "baseline"
+    output.mkdir()
+    # A stale sidecar from a validator that no longer runs.
+    _write_sidecar(output, "removed-validator", [_issue_dict("error")])
+
+    write_baseline(str(current), str(output), {"toolshash": "h"})
+
+    assert (output / "events.json").is_file()
+    assert not (output / "removed-validator.json").exists()
+    meta = json.loads((output / META_FILENAME).read_text(encoding="utf-8"))
+    assert meta["toolshash"] == "h"
+
+
+def test_write_baseline_over_empty_sidecar_dir_prunes_all(tmp_path):
+    current = tmp_path / "current"
+    current.mkdir()
+    output = tmp_path / "baseline"
+    output.mkdir()
+    _write_sidecar(output, "events", [_issue_dict("error")])
+
+    # All-clean run: no sidecars at all, so the baseline collapses to the
+    # meta file only — the empty findings set.
+    write_baseline(str(current), str(output), {"toolshash": "h"})
+
+    assert not (output / "events.json").exists()
+    assert (output / META_FILENAME).is_file()
+    baseline = load_baseline(str(output), "h")
+    assert baseline is not None
+    assert baseline.keys == set()
+
+
+def test_build_report_annotates_new_vs_existing(tmp_path):
+    # End-to-end wiring: the report generator classifies against a restored
+    # baseline and both bodies carry the NEW/EXISTING signal.
+    import generate_validation_report
+
+    from report_lib import ReportContext
+
+    results = tmp_path / "validation-results" / "validation-events-results"
+    results.mkdir(parents=True)
+    (results / "validation-events.log").write_text(
+        "VALIDATION COMPLETE", encoding="utf-8"
+    )
+    (results / "validation-events.json").write_text(
+        json.dumps(
+            [
+                _issue_dict("error", file="old.txt", message="old finding"),
+                _issue_dict("error", file="new.txt", message="new finding"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    baseline_dir = tmp_path / "baseline"
+    baseline_dir.mkdir()
+    (baseline_dir / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    _write_sidecar(
+        baseline_dir,
+        "events",
+        [_issue_dict("error", file="old.txt", message="old finding")],
+    )
+    baseline = load_baseline(str(baseline_dir), "h")
+    assert baseline is not None
+
+    ctx = ReportContext(
+        pr_number="42",
+        commit_sha="abc1234deadbeef",  # pragma: allowlist secret
+        repo="MillenniumDawn/Millennium-Dawn",
+    )
+    body, step_body, _runs, deduped, _trunc, stats = (
+        generate_validation_report.build_report(
+            str(tmp_path / "validation-results"), ctx, baseline
+        )
+    )
+
+    assert stats is not None
+    assert stats.new_errors == 1
+    assert stats.existing_errors == 1
+    assert "1 new against the main baseline." in body
+    assert "## New findings vs main baseline" in step_body
+    assert len(deduped) == 2

--- a/tools/report_lib/tests/baseline_test.py
+++ b/tools/report_lib/tests/baseline_test.py
@@ -75,8 +75,14 @@ def test_classify_tags_new_and_existing(tmp_path):
     (tmp_path / META_FILENAME).write_text(
         json.dumps({"toolshash": "h"}), encoding="utf-8"
     )
-    existing = _issue_dict("error", file="old.txt", line=1, message="old finding")
-    _write_sidecar(tmp_path, "events", [existing])
+    _write_sidecar(
+        tmp_path,
+        "events",
+        [
+            _issue_dict("error", file="old.txt", line=1, message="old finding"),
+            _issue_dict("warning", file="warn.txt", line=3, message="known warning"),
+        ],
+    )
     baseline = load_baseline(str(tmp_path), "h")
 
     issues = [
@@ -88,16 +94,27 @@ def test_classify_tags_new_and_existing(tmp_path):
             line=2,
             message="new warning",
         ),
+        _issue(
+            severity=Severity.WARNING,
+            file="warn.txt",
+            line=3,
+            message="known warning",
+        ),
     ]
     stats = classify(issues, baseline)
 
-    assert [i.baseline_status for i in issues] == ["existing", "new", "new"]
+    assert [i.baseline_status for i in issues] == [
+        "existing",
+        "new",
+        "new",
+        "existing",
+    ]
     assert stats.new_errors == 1
     assert stats.new_warnings == 1
     assert stats.existing_errors == 1
-    assert stats.existing_warnings == 0
+    assert stats.existing_warnings == 1
     assert stats.unclassified == 0
-    assert stats.new_issues == issues[1:]
+    assert stats.new_issues == issues[1:3]
 
 
 def test_classify_escalated_severity_counts_as_new(tmp_path):
@@ -135,6 +152,75 @@ def test_classify_leaves_unkeyable_issues_untagged(tmp_path):
 def test_load_issues_ignores_non_list_json(tmp_path):
     (tmp_path / "notes.json").write_text('{"not": "a list"}', encoding="utf-8")
     assert load_issues(str(tmp_path)) == []
+
+
+def test_load_issues_skips_unparseable_sidecars(tmp_path):
+    (tmp_path / "broken.json").write_text("not json", encoding="utf-8")
+    (tmp_path / "events.json").write_text(
+        json.dumps([_issue_dict("error")]), encoding="utf-8"
+    )
+    issues = load_issues(str(tmp_path))
+    # The broken sidecar is skipped, not fatal: one validator with a
+    # truncated upload must not crash the PR report or the nightly diff.
+    assert len(issues) == 1
+
+
+def test_load_baseline_returns_none_when_meta_not_a_dict(tmp_path):
+    (tmp_path / META_FILENAME).write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_baseline(str(tmp_path), "h") is None
+
+
+def test_load_baseline_returns_none_on_unreadable_meta(tmp_path):
+    (tmp_path / META_FILENAME).write_text("{broken", encoding="utf-8")
+    assert load_baseline(str(tmp_path), "h") is None
+
+
+def test_classify_with_empty_baseline_marks_everything_new(tmp_path):
+    # An all-clean main run stores only meta (no sidecars): any PR finding
+    # is new by definition.
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    baseline = load_baseline(str(tmp_path), "h")
+    assert baseline is not None
+
+    stats = classify(
+        [
+            _issue(file="a.txt", line=1, message="first"),
+            _issue(
+                severity=Severity.WARNING,
+                file="b.txt",
+                line=2,
+                message="second",
+            ),
+        ],
+        baseline,
+    )
+
+    assert stats.new_errors == 1
+    assert stats.new_warnings == 1
+    assert stats.existing_errors == 0
+    assert stats.unclassified == 0
+
+
+def test_classify_counts_mixed_unclassified_and_new(tmp_path):
+    (tmp_path / META_FILENAME).write_text(
+        json.dumps({"toolshash": "h"}), encoding="utf-8"
+    )
+    baseline = load_baseline(str(tmp_path), "h")
+    assert baseline is not None
+
+    stats = classify(
+        [
+            _issue(file="a.txt", line=1, message="keyed"),
+            _issue(file="", line=0, message="no location"),
+        ],
+        baseline,
+    )
+
+    assert stats.new_errors == 1
+    assert stats.unclassified == 1
+    assert len(stats.new_issues) == 1
 
 
 def test_write_baseline_copies_sidecars_writes_meta_and_prunes(tmp_path):

--- a/tools/report_lib/tests/generate_validation_report_test.py
+++ b/tools/report_lib/tests/generate_validation_report_test.py
@@ -1,0 +1,135 @@
+"""CLI contract tests for `generate_validation_report` — the production
+entry point the workflow invokes. Covers the baseline flag wiring that the
+unit tests of `build_report` cannot see (argparse → load_baseline →
+build_report)."""
+
+import json
+
+import generate_validation_report
+
+from report_lib.baseline import META_FILENAME
+
+from .conftest import make_results_tree
+
+
+def _issue_dict(severity, file="a.txt", line=1, message="m", category="c"):
+    return {
+        "severity": severity,
+        "category": category,
+        "message": message,
+        "file": file,
+        "line": line,
+    }
+
+
+def _write_baseline(base, toolshash, issues):
+    base.mkdir(parents=True, exist_ok=True)
+    (base / META_FILENAME).write_text(
+        json.dumps({"toolshash": toolshash}), encoding="utf-8"
+    )
+    (base / "events.json").write_text(json.dumps(issues), encoding="utf-8")
+
+
+def _argv(tmp_path, baseline_dir=None, baseline_toolshash=None):
+    argv = [
+        "--results-dir",
+        str(tmp_path / "validation-results"),
+        "--output",
+        str(tmp_path / "report.md"),
+        "--commit-sha",
+        "abc1234deadbeef",  # pragma: allowlist secret
+        "--validation-scope",
+        "partial",
+        "--github-repository",
+        "MillenniumDawn/Millennium-Dawn",
+    ]
+    if baseline_dir is not None:
+        argv += ["--baseline-dir", str(baseline_dir)]
+    if baseline_toolshash is not None:
+        argv += ["--baseline-toolshash", baseline_toolshash]
+    return argv
+
+
+def test_main_annotates_new_vs_existing_from_baseline(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    make_results_tree(
+        tmp_path,
+        {
+            "events": {
+                "log": "VALIDATION COMPLETE",
+                "issues": [
+                    _issue_dict("error", file="old.txt", message="old finding"),
+                    _issue_dict("error", file="new.txt", message="new finding"),
+                ],
+            }
+        },
+    )
+    _write_baseline(
+        tmp_path / "baseline",
+        "h",
+        [_issue_dict("error", file="old.txt", message="old finding")],
+    )
+
+    code = generate_validation_report.main(
+        _argv(tmp_path, baseline_dir=tmp_path / "baseline", baseline_toolshash="h")
+    )
+
+    assert code == 0
+    report = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert "1 new against the main baseline." in report
+    err = capsys.readouterr().err
+    assert "vs main baseline: 1 new error(s), 0 new warning(s)" in err
+
+
+def test_main_ignores_stale_baseline(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    make_results_tree(
+        tmp_path,
+        {
+            "events": {
+                "log": "VALIDATION COMPLETE",
+                "issues": [_issue_dict("error", file="new.txt", message="finding")],
+            }
+        },
+    )
+    _write_baseline(
+        tmp_path / "baseline",
+        "old-generation",
+        [_issue_dict("error", file="old.txt", message="old finding")],
+    )
+
+    code = generate_validation_report.main(
+        _argv(
+            tmp_path,
+            baseline_dir=tmp_path / "baseline",
+            baseline_toolshash="new-generation",
+        )
+    )
+
+    assert code == 0
+    report = (tmp_path / "report.md").read_text(encoding="utf-8")
+    # A baseline from a different validator generation must be ignored, not
+    # compared: no NEW/EXISTING annotation anywhere.
+    assert "main baseline" not in report
+
+
+def test_main_renders_without_baseline_when_dir_missing(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    make_results_tree(
+        tmp_path,
+        {
+            "events": {
+                "log": "VALIDATION COMPLETE",
+                "issues": [_issue_dict("error", file="new.txt", message="finding")],
+            }
+        },
+    )
+
+    code = generate_validation_report.main(
+        _argv(tmp_path, baseline_dir=tmp_path / "no-such-baseline")
+    )
+
+    assert code == 0
+    report = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert "1 error must be fixed before merge." in report
+    assert "main baseline" not in report

--- a/tools/report_lib/tests/generate_validation_report_test.py
+++ b/tools/report_lib/tests/generate_validation_report_test.py
@@ -50,6 +50,19 @@ def _argv(tmp_path, baseline_dir=None, baseline_toolshash=None):
     return argv
 
 
+def _post_argv(tmp_path, *extra):
+    argv = _argv(tmp_path)
+    argv += [
+        "--pr-number",
+        "42",
+        "--github-token",
+        "token",
+        "--post-comment",
+    ]
+    argv += list(extra)
+    return argv
+
+
 def test_main_annotates_new_vs_existing_from_baseline(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
     make_results_tree(
@@ -133,3 +146,165 @@ def test_main_renders_without_baseline_when_dir_missing(tmp_path, monkeypatch):
     report = (tmp_path / "report.md").read_text(encoding="utf-8")
     assert "1 error must be fixed before merge." in report
     assert "main baseline" not in report
+
+
+def _findings_tree(tmp_path):
+    return make_results_tree(
+        tmp_path,
+        {
+            "events": {
+                "log": "VALIDATION COMPLETE",
+                "issues": [_issue_dict("error", file="new.txt", message="finding")],
+            }
+        },
+    )
+
+
+def _passing_tree(tmp_path):
+    return make_results_tree(
+        tmp_path,
+        {"events": {"log": "✓ VALIDATION COMPLETE"}},
+    )
+
+
+def test_main_posts_comment_for_new_findings(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    _findings_tree(tmp_path)
+    calls = []
+
+    def fake_post(owner, repo, pr_number, body, token, update_only):
+        calls.append(
+            {
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "body": body,
+                "token": token,
+                "update_only": update_only,
+            }
+        )
+        return True, "posted"
+
+    monkeypatch.setattr(generate_validation_report, "post_comment", fake_post)
+
+    code = generate_validation_report.main(_post_argv(tmp_path))
+
+    assert code == 0
+    assert len(calls) == 1
+    assert calls[0]["update_only"] is False
+    assert calls[0]["pr_number"] == "42"
+
+
+def test_main_updates_existing_comment_on_clean_partial_run(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    _passing_tree(tmp_path)
+    calls = []
+
+    def fake_post(owner, repo, pr_number, body, token, update_only):
+        calls.append(update_only)
+        return True, "posted"
+
+    def fake_delete(*_args, **_kwargs):
+        raise AssertionError("delete_comment must not be called on a clean partial run")
+
+    monkeypatch.setattr(generate_validation_report, "post_comment", fake_post)
+    monkeypatch.setattr(generate_validation_report, "delete_comment", fake_delete)
+
+    code = generate_validation_report.main(_post_argv(tmp_path))
+
+    assert code == 0
+    # A clean partial run refreshes the existing comment but never opens a
+    # new one (it cannot clear findings an unrun validator would report).
+    assert calls == [True]
+
+
+def test_main_deletes_comment_on_full_clean_run(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    _passing_tree(tmp_path)
+    calls = []
+
+    def fake_delete(owner, repo, pr_number, token):
+        calls.append((owner, repo, pr_number, token))
+        return True, "deleted"
+
+    def fake_post(*args, **kwargs):
+        raise AssertionError("post_comment must not be called on a full clean run")
+
+    monkeypatch.setattr(generate_validation_report, "delete_comment", fake_delete)
+    monkeypatch.setattr(generate_validation_report, "post_comment", fake_post)
+
+    code = generate_validation_report.main(
+        _post_argv(tmp_path, "--validation-scope", "full")
+    )
+
+    assert code == 0
+    assert calls == [("MillenniumDawn", "Millennium-Dawn", "42", "token")]
+
+
+def test_main_checks_api_failure_is_non_fatal(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    _findings_tree(tmp_path)
+    calls = []
+
+    def fake_checks(owner, repo, commit_sha, runs, token):
+        calls.append((commit_sha, token))
+        return [("Events", False, "boom")]
+
+    monkeypatch.setattr(generate_validation_report, "post_checks", fake_checks)
+
+    code = generate_validation_report.main(
+        _argv(tmp_path)
+        + [
+            "--checks-api",
+            "--github-token",
+            "token",
+        ]
+    )
+
+    assert code == 0
+    assert calls == [("abc1234deadbeef", "token")]
+
+
+def test_main_post_comment_requires_repository(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    # GITHUB_REPOSITORY/GITHUB_TOKEN are always set in Actions; without this
+    # the env fallback would bypass the guard and hit the real API.
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    def never_call(*_args, **_kwargs):
+        raise AssertionError("API must not be called when the repository guard fails")
+
+    monkeypatch.setattr(generate_validation_report, "post_comment", never_call)
+    monkeypatch.setattr(generate_validation_report, "delete_comment", never_call)
+
+    _findings_tree(tmp_path)
+    argv = _post_argv(tmp_path)
+    # Drop --github-repository (and its value): the flag must be rejected
+    # before any API call is attempted.
+    idx = argv.index("--github-repository")
+    argv = argv[:idx] + argv[idx + 2 :]
+
+    code = generate_validation_report.main(argv)
+
+    assert code == 1
+
+
+def test_main_post_comment_requires_pr_number(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    def never_call(*_args, **_kwargs):
+        raise AssertionError("API must not be called when the pr-number guard fails")
+
+    monkeypatch.setattr(generate_validation_report, "post_comment", never_call)
+    monkeypatch.setattr(generate_validation_report, "delete_comment", never_call)
+
+    _findings_tree(tmp_path)
+    argv = _post_argv(tmp_path)
+    idx = argv.index("--pr-number")
+    argv = argv[:idx] + argv[idx + 2 :]
+
+    code = generate_validation_report.main(argv)
+
+    assert code == 1

--- a/tools/report_lib/tests/markdown_test.py
+++ b/tools/report_lib/tests/markdown_test.py
@@ -303,17 +303,74 @@ def test_step_summary_lists_new_findings():
         validator="events",
         baseline_status="new",
     )
-    stats = _stats(new_issues=[issue])
+    stats = _stats(new_issues=[issue], unclassified=1)
     body = render([runs[0]], [issue], _ctx(), baseline_stats=stats)
     assert "## New findings vs main baseline" in body
     assert "1 error, 1 warning not present on the latest main run:" in body
     assert "**NEW**" in body
+    assert "1 finding(s) could not be compared (no file/line)." in body
 
 
 def test_step_summary_baseline_section_when_nothing_new():
     runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
     body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0))
     assert "✅ No new findings against the main baseline." in body
+
+
+def test_warning_verdict_counts_new_against_baseline():
+    runs = [
+        ValidatorRun(
+            name="events", title="Events", status="warnings", errors=0, warnings=5
+        )
+    ]
+    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_warnings=3))
+    assert "5 warnings to review. None block merge." in body
+    assert "(3 new against the main baseline.)" in body
+
+
+def test_warning_verdict_says_none_new():
+    runs = [
+        ValidatorRun(
+            name="events", title="Events", status="warnings", errors=0, warnings=5
+        )
+    ]
+    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_warnings=0))
+    assert "(none new against the main baseline.)" in body
+
+
+def test_baseline_section_caps_new_findings():
+    runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
+    issues = [
+        Issue(
+            severity=Severity.ERROR,
+            category="missing_key",
+            message=f"key {n} not found",
+            file="events/MD_x.txt",
+            line=n,
+            validator="events",
+            baseline_status="new",
+        )
+        for n in range(1, 6)
+    ]
+    stats = _stats(new_issues=issues)
+
+    body = render([runs[0]], issues, _ctx(), max_visible=3, baseline_stats=stats)
+
+    assert "_…and 2 more new findings._" in body
+    assert "key 3 not found" in body
+    assert "key 4 not found" not in body
+
+
+def test_baseline_section_notes_unclassified_findings():
+    runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
+    body = render(
+        [runs[0]],
+        [],
+        _ctx(),
+        baseline_stats=_stats(new_errors=0, unclassified=2),
+    )
+    assert "✅ No new findings against the main baseline." in body
+    assert "2 finding(s) could not be compared (no file/line)." in body
 
 
 def test_concise_comment_omits_baseline_section():

--- a/tools/report_lib/tests/markdown_test.py
+++ b/tools/report_lib/tests/markdown_test.py
@@ -1,6 +1,13 @@
 """Tests for `report_lib.markdown`."""
 
-from report_lib import Issue, ReportContext, Severity, ValidatorRun, render
+from report_lib import (
+    Issue,
+    ReportContext,
+    Severity,
+    ValidatorRun,
+    render,
+)
+from report_lib.baseline import BaselineStats
 from report_lib.comment import REPORT_MARKER
 
 
@@ -249,3 +256,90 @@ def test_concise_comment_no_pointer_when_clean():
     assert "## Validators" not in body
     assert "full issue list" not in body
     assert "All 1 validator passed" in body
+
+
+def _stats(**overrides):
+    fields = {
+        "new_errors": 1,
+        "new_warnings": 1,
+        "existing_errors": 4,
+        "existing_warnings": 2,
+        "unclassified": 0,
+    }
+    fields.update(overrides)
+    stats = BaselineStats()
+    for key, value in fields.items():
+        setattr(stats, key, value)
+    return stats
+
+
+def test_verdict_counts_new_against_baseline():
+    runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
+    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=2))
+    assert (
+        "2 errors must be fixed before merge. (2 new against the main baseline.)"
+        in body
+    )
+
+
+def test_verdict_says_none_new_when_all_existing():
+    runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
+    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0))
+    assert "(none new against the main baseline.)" in body
+
+
+def test_step_summary_lists_new_findings():
+    runs = [
+        ValidatorRun(
+            name="events", title="Events", status="failed", errors=1, warnings=1
+        )
+    ]
+    issue = Issue(
+        severity=Severity.ERROR,
+        category="missing_key",
+        message="key FOO not found",
+        file="events/MD_x.txt",
+        line=212,
+        validator="events",
+        baseline_status="new",
+    )
+    stats = _stats(new_issues=[issue])
+    body = render([runs[0]], [issue], _ctx(), baseline_stats=stats)
+    assert "## New findings vs main baseline" in body
+    assert "1 error, 1 warning not present on the latest main run:" in body
+    assert "**NEW**" in body
+
+
+def test_step_summary_baseline_section_when_nothing_new():
+    runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
+    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0))
+    assert "✅ No new findings against the main baseline." in body
+
+
+def test_concise_comment_omits_baseline_section():
+    runs = [
+        ValidatorRun(
+            name="events", title="Events", status="failed", errors=1, warnings=1
+        )
+    ]
+    issue = Issue(
+        severity=Severity.ERROR,
+        category="missing_key",
+        message="key FOO not found",
+        file="events/MD_x.txt",
+        line=212,
+        validator="events",
+        baseline_status="new",
+    )
+    stats = _stats(new_issues=[issue])
+    body = render(
+        [runs[0]],
+        [issue],
+        _ctx(),
+        include_validator_sections=False,
+        baseline_stats=stats,
+    )
+    # The concise PR comment carries the counts in the verdict, not the
+    # per-finding section that lives in the step summary.
+    assert "## New findings vs main baseline" not in body
+    assert "(1 new against the main baseline.)" in body

--- a/tools/validation/run_all_validators.py
+++ b/tools/validation/run_all_validators.py
@@ -6,6 +6,7 @@ import glob
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -261,6 +262,34 @@ def generate_combined_report(
     return "\n".join(lines)
 
 
+def _persist_sidecars(output_dir: str, persist_dir: str) -> None:
+    """Copy every validator's JSON sidecar into persist_dir.
+
+    The suite runs inside a TemporaryDirectory that is deleted on exit; the
+    copies are the only per-validator results that survive. A validator that
+    passed clean writes no sidecar, which is exactly the empty findings set a
+    baseline wants from it. Copy errors raise: a silent partial persist would
+    save a truncated baseline under a valid-looking meta.
+    """
+    try:
+        os.makedirs(persist_dir, exist_ok=True)
+    except OSError:
+        raise
+    copied = 0
+    for json_path in glob.glob(os.path.join(output_dir, "*.json")):
+        try:
+            shutil.copyfile(
+                json_path, os.path.join(persist_dir, os.path.basename(json_path))
+            )
+        except OSError:
+            raise
+        copied += 1
+    print(
+        f"Persisted {copied} validator result sidecar(s) to {persist_dir}",
+        file=sys.stderr,
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run all MD validators in parallel")
     parser.add_argument("--staged", action="store_true")
@@ -302,6 +331,17 @@ def main():
         type=str,
         default=".",
         help="Path to the mod folder (default: current directory)",
+    )
+    parser.add_argument(
+        "--persist-results",
+        type=str,
+        default=None,
+        help=(
+            "Copy each validator's JSON sidecar into this directory before "
+            "the run's temporary output is deleted. Used by the nightly "
+            "baseline job to keep the per-validator results after the suite "
+            "completes."
+        ),
     )
     args = parser.parse_args()
 
@@ -459,6 +499,15 @@ def _run_suite(args, extra_flags, output_dir, VALIDATORS, mod_path) -> int:
             )
         else:
             print(f"\n{report}")
+
+    # Persist before the TemporaryDirectory cleanup in main() reclaims the
+    # sidecars. Runs even when validators crashed so a failing night still
+    # leaves the partial results to inspect (the nightly baseline job gates
+    # its diff on this step's exit code, so a partial persist never becomes
+    # the baseline).
+    persist_dir = getattr(args, "persist_results", None)
+    if persist_dir:
+        _persist_sidecars(output_dir, persist_dir)
 
     if total_errors == 0 and total_warnings == 0:
         print(f"{Colors.GREEN}✓ ALL VALIDATIONS PASSED{Colors.ENDC}", file=human_stream)

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -324,29 +324,36 @@ def test_validator_cache_restore_is_source_hash_scoped():
     # Both shared cache entries (the disk cache and the validation baseline)
     # are keyed on the validator source hash: a validator change must
     # invalidate every restore, never hand a PR cache or baseline output from
-    # a different validator generation.
-    expected_prefixes = (
-        "md-valcache-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-",
-        "md-baseline-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-",
-    )
+    # a different validator generation. Scoped by restore path so a swapped
+    # prefix can't hide behind the other entry's.
+    expected_prefix = {
+        ".validation_cache": (
+            "md-valcache-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-"
+        ),
+        ".validation_baseline": (
+            "md-baseline-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-"
+        ),
+    }
+    restores = {path: [] for path in expected_prefix}
     for workflow in (CI_WORKFLOW, VALIDATOR_CACHE_WORKFLOW):
         config = yaml.safe_load(workflow.read_text(encoding="utf-8"))
-        restore_steps = []
         for job in config["jobs"].values():
             for step in job.get("steps", []):
-                if "actions/cache/restore@" in step.get("uses", ""):
-                    restore_steps.extend(
-                        step.get("with", {}).get("restore-keys", "").splitlines()
-                    )
-        assert (
-            restore_steps
-        ), f"No validator cache restore keys found in {workflow.name}"
-        assert all(
-            any(key.startswith(prefix) for prefix in expected_prefixes)
-            for key in restore_steps
-        ), (
-            f"{workflow.name} has a validator cache fallback outside the current "
-            "validator source-hash generation"
+                if "actions/cache/restore@" not in step.get("uses", ""):
+                    continue
+                path = step.get("with", {}).get("path", "")
+                if path not in restores:
+                    # Workspace-bundle restores key on the merge tree, not the
+                    # validator source hash — out of scope for this guard.
+                    continue
+                restores[path].extend(
+                    step.get("with", {}).get("restore-keys", "").splitlines()
+                )
+    for path, expected in expected_prefix.items():
+        assert restores[path], f"No {path} restores found across the two workflows"
+        assert all(key.startswith(expected) for key in restores[path]), (
+            f"{path} is restored with a key outside the current validator "
+            "source-hash generation"
         )
 
 

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -283,9 +283,9 @@ def test_precommit_exempt_entries_are_current(disk, precommit):
 
 def test_strict_mismatch_allowlist_is_current(disk, precommit, ci):
     gone = sorted(STRICT_MISMATCH_ALLOWED - disk)
-    assert not gone, (
-        f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
-    )
+    assert (
+        not gone
+    ), f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
     resolved = sorted(
         s
         for s in STRICT_MISMATCH_ALLOWED
@@ -321,8 +321,13 @@ def test_targeted_parent_reaches_every_matrix_entry():
 
 
 def test_validator_cache_restore_is_source_hash_scoped():
-    expected_prefix = (
-        "md-valcache-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-"
+    # Both shared cache entries (the disk cache and the validation baseline)
+    # are keyed on the validator source hash: a validator change must
+    # invalidate every restore, never hand a PR cache or baseline output from
+    # a different validator generation.
+    expected_prefixes = (
+        "md-valcache-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-",
+        "md-baseline-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-",
     )
     for workflow in (CI_WORKFLOW, VALIDATOR_CACHE_WORKFLOW):
         config = yaml.safe_load(workflow.read_text(encoding="utf-8"))
@@ -333,10 +338,13 @@ def test_validator_cache_restore_is_source_hash_scoped():
                     restore_steps.extend(
                         step.get("with", {}).get("restore-keys", "").splitlines()
                     )
-        assert restore_steps, (
-            f"No validator cache restore keys found in {workflow.name}"
-        )
-        assert all(key.startswith(expected_prefix) for key in restore_steps), (
+        assert (
+            restore_steps
+        ), f"No validator cache restore keys found in {workflow.name}"
+        assert all(
+            any(key.startswith(prefix) for prefix in expected_prefixes)
+            for key in restore_steps
+        ), (
             f"{workflow.name} has a validator cache fallback outside the current "
             "validator source-hash generation"
         )
@@ -356,12 +364,12 @@ def test_nightly_keys_the_bundle_on_the_live_base_tip():
     script = "\n".join(
         line for line in step["run"].splitlines() if not line.lstrip().startswith("#")
     )
-    assert "commits/main" in script, (
-        "the nightly must resolve main's live head for base_sha"
-    )
-    assert ".base.sha" not in script, (
-        "the PR list's .base.sha does not track main, so it cannot key the bundle"
-    )
+    assert (
+        "commits/main" in script
+    ), "the nightly must resolve main's live head for base_sha"
+    assert (
+        ".base.sha" not in script
+    ), "the PR list's .base.sha does not track main, so it cannot key the bundle"
 
 
 def test_mio_validator_runs_for_localisation_changes():
@@ -479,9 +487,9 @@ def test_ci_run_steps_default_to_strict():
             for step in workflow["jobs"][job]["steps"]
             if step.get("name") == "Run validation"
         )
-        assert 'matrix.validator.strict }}" != "false"' in run, (
-            f"{job}'s Run step must default to --strict when `strict:` is absent."
-        )
+        assert (
+            'matrix.validator.strict }}" != "false"' in run
+        ), f"{job}'s Run step must default to --strict when `strict:` is absent."
 
 
 def test_oob_routes_cover_every_create_unit_source():

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -283,9 +283,9 @@ def test_precommit_exempt_entries_are_current(disk, precommit):
 
 def test_strict_mismatch_allowlist_is_current(disk, precommit, ci):
     gone = sorted(STRICT_MISMATCH_ALLOWED - disk)
-    assert (
-        not gone
-    ), f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
+    assert not gone, (
+        f"STRICT_MISMATCH_ALLOWED names validators that no longer exist: {gone}."
+    )
     resolved = sorted(
         s
         for s in STRICT_MISMATCH_ALLOWED
@@ -371,12 +371,12 @@ def test_nightly_keys_the_bundle_on_the_live_base_tip():
     script = "\n".join(
         line for line in step["run"].splitlines() if not line.lstrip().startswith("#")
     )
-    assert (
-        "commits/main" in script
-    ), "the nightly must resolve main's live head for base_sha"
-    assert (
-        ".base.sha" not in script
-    ), "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    assert "commits/main" in script, (
+        "the nightly must resolve main's live head for base_sha"
+    )
+    assert ".base.sha" not in script, (
+        "the PR list's .base.sha does not track main, so it cannot key the bundle"
+    )
 
 
 def test_mio_validator_runs_for_localisation_changes():
@@ -539,9 +539,9 @@ def test_ci_run_steps_default_to_strict():
             for step in workflow["jobs"][job]["steps"]
             if step.get("name") == "Run validation"
         )
-        assert (
-            'matrix.validator.strict }}" != "false"' in run
-        ), f"{job}'s Run step must default to --strict when `strict:` is absent."
+        assert 'matrix.validator.strict }}" != "false"' in run, (
+            f"{job}'s Run step must default to --strict when `strict:` is absent."
+        )
 
 
 def test_oob_routes_cover_every_create_unit_source():

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -386,6 +386,51 @@ def test_mio_validator_runs_for_localisation_changes():
         assert f"needs.detect-changes.outputs.{output} == 'true'" in expression
 
 
+def test_check_baseline_saves_only_on_clean_diff():
+    # The save gating is the whole nightly alarm: baseline_check exits 1 on
+    # new errors, and only `steps.diff.outcome == 'success'` reaches the
+    # save step. If that `if` is dropped, a red night saves tonight's
+    # regressed results as the new baseline and the alarm self-heals
+    # silently.
+    config = yaml.safe_load(VALIDATOR_CACHE_WORKFLOW.read_text(encoding="utf-8"))
+    job = config["jobs"]["check-baseline"]
+    assert job["needs"] == ["build-cache"]
+
+    diff = next(step for step in job["steps"] if step.get("id") == "diff")
+    assert "tools/baseline_check.py" in diff["run"]
+
+    save = next(
+        step for step in job["steps"] if step.get("name") == "Save validation baseline"
+    )
+    assert save["if"] == "steps.diff.outcome == 'success'"
+
+
+def test_report_job_wires_baseline_flags():
+    # The PR report only annotates when the workflow passes the restored
+    # baseline and the matching toolshash; a drifted flag or path silently
+    # drops the NEW/EXISTING annotation for every PR.
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["validation-report"]
+
+    restore = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Restore validation baseline"
+    )
+    baseline_prefix = (
+        "md-baseline-v1-${{ runner.os }}-${{ steps.toolshash.outputs.hash }}-"
+    )
+    assert baseline_prefix in restore["with"]["restore-keys"]
+
+    run = next(
+        step["run"]
+        for step in job["steps"]
+        if step.get("name") == "Generate and post validation report"
+    )
+    assert "--baseline-dir .validation_baseline" in run
+    assert "--baseline-toolshash" in run
+
+
 def test_tools_validation_triggers_for_consumed_configuration():
     paths = _pull_request_paths(TOOLS_WORKFLOW)
     assert {

--- a/tools/validation/tests/run_all_validators_test.py
+++ b/tools/validation/tests/run_all_validators_test.py
@@ -4,6 +4,7 @@ import io
 import json
 from types import SimpleNamespace
 
+import pytest
 import run_all_validators as runner
 
 
@@ -188,6 +189,36 @@ def test_persist_results_writes_nothing_when_clean(tmp_path, monkeypatch):
 
     assert code == 0
     assert list(persist_dir.iterdir()) == []
+
+
+def test_persist_results_copy_failure_propagates(tmp_path, monkeypatch):
+    # A copy failure must fail the run, never silently save a truncated
+    # baseline under a valid-looking meta.
+    issues = [
+        {
+            "severity": "error",
+            "category": "test-finding",
+            "message": "finding",
+            "file": "test.txt",
+            "line": 1,
+        }
+    ]
+    monkeypatch.setattr(runner, "launch_validator", _launcher_with(issues))
+
+    def broken_copy(_src, _dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(runner.shutil, "copyfile", broken_copy)
+    persist_dir = tmp_path / "persisted"
+
+    with pytest.raises(OSError, match="disk full"):
+        runner._run_suite(
+            _args("both", persist_results=str(persist_dir)),
+            [],
+            str(tmp_path),
+            [("stub", "validate_stub.py", "Stub")],
+            str(tmp_path),
+        )
 
 
 def test_crashed_validator_fails_run_without_strict(tmp_path, monkeypatch, capsys):

--- a/tools/validation/tests/run_all_validators_test.py
+++ b/tools/validation/tests/run_all_validators_test.py
@@ -15,17 +15,26 @@ class _Process:
         return self.returncode
 
 
-def _args(format_, output=None, strict=False):
-    return SimpleNamespace(format=format_, output=output, strict=strict, no_color=True)
+def _args(format_, output=None, strict=False, persist_results=None):
+    return SimpleNamespace(
+        format=format_,
+        output=output,
+        strict=strict,
+        no_color=True,
+        persist_results=persist_results,
+    )
 
 
 def _launcher_with(issues, returncode=0):
     def launch(_script, _flags, output_dir, name, _mod_path):
-        try:
-            with open(f"{output_dir}/{name}.json", "w", encoding="utf-8") as stream:
-                json.dump(issues, stream)
-        except OSError:
-            raise
+        # Mirror BaseValidator.save_output: a validator with no findings
+        # writes no JSON sidecar at all.
+        if issues:
+            try:
+                with open(f"{output_dir}/{name}.json", "w", encoding="utf-8") as stream:
+                    json.dump(issues, stream)
+            except OSError:
+                raise
         return _Process(returncode), io.StringIO()
 
     return launch
@@ -134,6 +143,51 @@ def test_json_without_output_prints_json_for_findings(tmp_path, monkeypatch, cap
     assert payload["total_errors"] == 1
     assert payload["issues"][0]["message"] == "broken café"
     assert "VALIDATION FAILED" in captured.err
+
+
+def test_persist_results_copies_json_sidecars(tmp_path, monkeypatch):
+    issues = [
+        {
+            "severity": "error",
+            "category": "test-finding",
+            "message": "finding",
+            "file": "test.txt",
+            "line": 1,
+        }
+    ]
+    monkeypatch.setattr(runner, "launch_validator", _launcher_with(issues))
+    persist_dir = tmp_path / "persisted"
+
+    code = runner._run_suite(
+        _args("both", persist_results=str(persist_dir)),
+        [],
+        str(tmp_path),
+        [("stub", "validate_stub.py", "Stub")],
+        str(tmp_path),
+    )
+
+    assert code == 0
+    try:
+        payload = json.loads((persist_dir / "stub.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AssertionError("persisted sidecar is missing or invalid") from exc
+    assert payload == issues
+
+
+def test_persist_results_writes_nothing_when_clean(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "launch_validator", _launcher_with([]))
+    persist_dir = tmp_path / "persisted"
+
+    code = runner._run_suite(
+        _args("both", persist_results=str(persist_dir)),
+        [],
+        str(tmp_path),
+        [("stub", "validate_stub.py", "Stub")],
+        str(tmp_path),
+    )
+
+    assert code == 0
+    assert list(persist_dir.iterdir()) == []
 
 
 def test_crashed_validator_fails_run_without_strict(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Closes #2926

**What**

- `validator-cache.yml` gains a `check-baseline` job: after the nightly warm-up it re-runs the suite and diffs the findings against the previous night's baseline. New errors on main fail the run and keep the old baseline, so the alarm repeats until the regression is fixed or a validator-code change (`toolshash`) re-establishes it. New warnings are reported but never fail.
- PR `validation-report` jobs restore the baseline cache entry and `generate_validation_report.py` tags each finding `NEW` vs `EXISTING`. The step summary gets a "New findings vs main baseline" section; the PR comment's verdict carries the new count ("2 new against the main baseline"). Strict gating is untouched — the baseline only annotates.

**Why**

Every validation finding a PR triggers currently looks identical; a reviewer must know main's backlog by heart to tell what the PR introduced. This gives a nightly regression alarm for main itself and makes the PR report distinguish introduced findings from the pre-existing backlog.

**How**

- Baseline storage is a separate `md-baseline-v1-<os>-<toolshash>-…` cache entry (path `.validation_baseline/`: per-validator JSON sidecars + `baseline-meta.json`), saved only on a clean diff. Cache entries work for fork PRs' read-only tokens where cross-run artifact downloads would not, and the `toolshash` keying comes free with the existing restore-keys pattern.
- Fingerprint is `(severity, category, file, line, message)` after the same cross-validator dedupe on both sides — severity is in the key, so an existing warning escalated to an error reads as a new error. Known limitation: unrelated line shifts make existing findings look new.
- `run_all_validators.py` gains `--persist-results DIR` (copies sidecars before the temp dir is reclaimed); a clean validator writes no sidecar, which is exactly the empty findings set the baseline wants.
- New code: `tools/report_lib/baseline.py` (load/save/classify), `tools/baseline_check.py` (nightly diff CLI), tests for both plus rendering and the drift guard (`test_validator_cache_restore_is_source_hash_scoped` now covers both cache prefixes).

**Verification**

- `python -m pytest -q` full suite green (report_lib, validation, linting, standardization, docs_checks, tools).
- `ruff check`, `black --check`, `pylint`, `mypy` clean on changed files. Two pre-existing black violations in `config_drift_test.py` (on main, blocking Tools Validation) are fixed in this PR since the file is already touched.