### PR TITLE
Fix LAR-based systems crash: add every_country-optimized token cleanup and save corruption docs

### DIFF
--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2051,20 +2051,14 @@ on_actions = {
 
 			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
 
-			# LAR cleanup: free bugged operatives captured by THIS when it becomes a puppet
-			# Optimized with every_country to avoid iterating all countries unconditionally
+			# Free operatives held by the new subject.
 			every_country = {
 				limit = {
-					OR = {
-						has_captured_operative = ROOT
-						has_captured_operative = FROM
-					}
+					ROOT = { has_captured_operative = PREV }
 				}
-				ROOT = {
-					free_random_operative = {
-						captured_by = THIS
-						all = yes
-					}
+				free_random_operative = {
+					captured_by = ROOT
+					all = yes
 				}
 			}
 		}

--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -2050,6 +2050,23 @@ on_actions = {
 			reapply_agreement_opinion_modifiers = yes
 
 			if = { limit = { original_tag = TAL } AFG_reapply_taliban_opinion_modifiers = yes }
+
+			# LAR cleanup: free bugged operatives captured by THIS when it becomes a puppet
+			# Optimized with every_country to avoid iterating all countries unconditionally
+			every_country = {
+				limit = {
+					OR = {
+						has_captured_operative = ROOT
+						has_captured_operative = FROM
+					}
+				}
+				ROOT = {
+					free_random_operative = {
+						captured_by = THIS
+						all = yes
+					}
+				}
+			}
 		}
 	}
 

--- a/common/on_actions/01_tfv_on_actions.txt
+++ b/common/on_actions/01_tfv_on_actions.txt
@@ -86,6 +86,22 @@ on_actions = {
 				}
 			}
 		}
+
+		# LAR cleanup: free bugged operatives captured by ROOT when a subject is annexed
+		every_country = {
+			limit = {
+				OR = {
+					has_captured_operative = ROOT
+					has_captured_operative = FROM
+				}
+			}
+			ROOT = {
+				free_random_operative = {
+					captured_by = THIS
+					all = yes
+				}
+			}
+		}
 	}
 
 	#used when puppeting in a peace conference

--- a/common/on_actions/01_tfv_on_actions.txt
+++ b/common/on_actions/01_tfv_on_actions.txt
@@ -85,21 +85,44 @@ on_actions = {
 					}
 				}
 			}
-		}
 
-		# LAR cleanup: free bugged operatives captured by ROOT when a subject is annexed
-		every_country = {
-			limit = {
-				OR = {
-					has_captured_operative = ROOT
-					has_captured_operative = FROM
+			# Free operatives held by the annexed subject.
+			every_country = {
+				limit = {
+					ROOT = { has_captured_operative = PREV }
 				}
-			}
-			ROOT = {
 				free_random_operative = {
-					captured_by = THIS
+					captured_by = ROOT
 					all = yes
 				}
+			}
+
+			# Clear operation assets targeting the annexed subject.
+			every_country = {
+				limit = {
+					OR = {
+						has_operation_token = { tag = ROOT token = token_airforce }
+						has_operation_token = { tag = ROOT token = token_army }
+						has_operation_token = { tag = ROOT token = token_civilian }
+						has_operation_token = { tag = ROOT token = token_navy }
+						has_operation_token = { tag = ROOT token = token_resistance_contacts }
+						has_operation_token = { tag = ROOT token = token_hvt }
+						has_operation_token = { tag = ROOT token = token_arms_cache }
+						has_operation_token = { tag = ROOT token = token_training_camps }
+						has_operation_token = { tag = ROOT token = token_regional_headquarters }
+						has_operation_token = { tag = ROOT token = token_foreign_advisors }
+					}
+				}
+				remove_operation_token = { tag = ROOT token = token_airforce }
+				remove_operation_token = { tag = ROOT token = token_army }
+				remove_operation_token = { tag = ROOT token = token_civilian }
+				remove_operation_token = { tag = ROOT token = token_navy }
+				remove_operation_token = { tag = ROOT token = token_resistance_contacts }
+				remove_operation_token = { tag = ROOT token = token_hvt }
+				remove_operation_token = { tag = ROOT token = token_arms_cache }
+				remove_operation_token = { tag = ROOT token = token_training_camps }
+				remove_operation_token = { tag = ROOT token = token_regional_headquarters }
+				remove_operation_token = { tag = ROOT token = token_foreign_advisors }
 			}
 		}
 	}

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -541,6 +541,22 @@ on_actions = {
 			}
 
 			log = "[GetDateText]: [ROOT.GetName] annexed [FROM.GetName] - Inflation blended to [?ROOT.inflation_rate_var|%], GDP/C tracker reset to [?ROOT.last_quarter_gdpc_total]"
+
+			# LAR cleanup: free bugged operatives captured by ROOT or FROM when a country is annexed
+			every_country = {
+				limit = {
+					OR = {
+						has_captured_operative = ROOT
+						has_captured_operative = FROM
+					}
+				}
+				ROOT = {
+					free_random_operative = {
+						captured_by = THIS
+						all = yes
+					}
+				}
+			}
 		}
 	}
 
@@ -558,6 +574,17 @@ on_actions = {
 					NOT = { has_global_flag = GLOBAL_yemeni_civil_war_over }
 				}
 				remove_from_faction = AQY
+			}
+
+			# LAR cleanup: free bugged operatives captured by ROOT when a country capitulates
+			every_country = {
+				limit = { has_captured_operative = ROOT }
+				ROOT = {
+					free_random_operative = {
+						captured_by = ROOT
+						all = yes
+					}
+				}
 			}
 		}
 	}

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -542,20 +542,43 @@ on_actions = {
 
 			log = "[GetDateText]: [ROOT.GetName] annexed [FROM.GetName] - Inflation blended to [?ROOT.inflation_rate_var|%], GDP/C tracker reset to [?ROOT.last_quarter_gdpc_total]"
 
-			# LAR cleanup: free bugged operatives captured by ROOT or FROM when a country is annexed
+			# Free operatives held by the annexed country.
+			every_country = {
+				limit = {
+					FROM = { has_captured_operative = PREV }
+				}
+				free_random_operative = {
+					captured_by = FROM
+					all = yes
+				}
+			}
+
+			# Clear operation assets targeting the annexed country.
 			every_country = {
 				limit = {
 					OR = {
-						has_captured_operative = ROOT
-						has_captured_operative = FROM
+						has_operation_token = { tag = FROM token = token_airforce }
+						has_operation_token = { tag = FROM token = token_army }
+						has_operation_token = { tag = FROM token = token_civilian }
+						has_operation_token = { tag = FROM token = token_navy }
+						has_operation_token = { tag = FROM token = token_resistance_contacts }
+						has_operation_token = { tag = FROM token = token_hvt }
+						has_operation_token = { tag = FROM token = token_arms_cache }
+						has_operation_token = { tag = FROM token = token_training_camps }
+						has_operation_token = { tag = FROM token = token_regional_headquarters }
+						has_operation_token = { tag = FROM token = token_foreign_advisors }
 					}
 				}
-				ROOT = {
-					free_random_operative = {
-						captured_by = THIS
-						all = yes
-					}
-				}
+				remove_operation_token = { tag = FROM token = token_airforce }
+				remove_operation_token = { tag = FROM token = token_army }
+				remove_operation_token = { tag = FROM token = token_civilian }
+				remove_operation_token = { tag = FROM token = token_navy }
+				remove_operation_token = { tag = FROM token = token_resistance_contacts }
+				remove_operation_token = { tag = FROM token = token_hvt }
+				remove_operation_token = { tag = FROM token = token_arms_cache }
+				remove_operation_token = { tag = FROM token = token_training_camps }
+				remove_operation_token = { tag = FROM token = token_regional_headquarters }
+				remove_operation_token = { tag = FROM token = token_foreign_advisors }
 			}
 		}
 	}
@@ -574,17 +597,6 @@ on_actions = {
 					NOT = { has_global_flag = GLOBAL_yemeni_civil_war_over }
 				}
 				remove_from_faction = AQY
-			}
-
-			# LAR cleanup: free bugged operatives captured by ROOT when a country capitulates
-			every_country = {
-				limit = { has_captured_operative = ROOT }
-				ROOT = {
-					free_random_operative = {
-						captured_by = ROOT
-						all = yes
-					}
-				}
 			}
 		}
 	}

--- a/docs/src/content/tutorials/troubleshooting-guide.md
+++ b/docs/src/content/tutorials/troubleshooting-guide.md
@@ -67,6 +67,16 @@ To resolve this:
 
 Save games in Millennium Dawn are much larger than other mods. It is important to ensure you are using local game saves over cloud saves for the most stability. Typically this becomes more problematic in the late game around the 2020+ mark when save files start to exceed 100MB or more. You can easily bypass this issue by not saving anything on the cloud for _Millennium Dawn_.
 
+### Corrupted `operation_assets` Entry (Crash on Load / End of Day)
+
+After 20+ years of play, a contributor country that ceased to exist (annexed or capitulated during a war) may leave behind a dangling entry in another country's `operation_assets` intel data. On save, the now-invalid tag serializes as `={ token_airforce token_army }` (no country tag before the `=`), which desyncs the Clausewitz parser and causes a fatal crash at end-of-day serialization.
+
+**Symptoms:** Crash on load or at end of day with "Unexpected token" errors in the log; all tokens after the corruption are misread.
+
+**Player workaround:** Open the save file in a text editor, locate the malformed `={ token_... }` line (it is brace-balanced and safe to remove), and delete it. The parser resyncs after the removed line and other intel entries are preserved.
+
+**Prevention:** The mod includes automated cleanup of bugged tokens via event hooks (`on_puppet`, `on_annex`, `on_subject_annexed`) that free captured operatives when countries are removed from play.
+
 ## Low Virtual Memory / Paging File
 
 If you receive a "your paging file is low" warning or experience crashes on systems with limited RAM (common on laptops), you may need to increase your Windows virtual memory (page file) =.

--- a/docs/src/content/tutorials/troubleshooting-guide.md
+++ b/docs/src/content/tutorials/troubleshooting-guide.md
@@ -75,7 +75,7 @@ After 20+ years of play, a contributor country that ceased to exist (annexed or 
 
 **Player workaround:** Open the save file in a text editor, locate the malformed `={ token_... }` line (it is brace-balanced and safe to remove), and delete it. The parser resyncs after the removed line and other intel entries are preserved.
 
-**Prevention:** The mod includes automated cleanup of bugged tokens via event hooks (`on_puppet`, `on_annex`, `on_subject_annexed`) that free captured operatives when countries are removed from play.
+**Prevention:** The mod frees captured operatives when a country becomes a puppet or is removed, and clears all operation tokens targeting annexed countries from every nation's intel data.
 
 ## Low Virtual Memory / Paging File
 

--- a/docs/src/content/tutorials/troubleshooting-guide.md
+++ b/docs/src/content/tutorials/troubleshooting-guide.md
@@ -69,7 +69,7 @@ Save games in Millennium Dawn are much larger than other mods. It is important t
 
 ### Corrupted `operation_assets` Entry (Crash on Load / End of Day)
 
-After 20+ years of play, a contributor country that ceased to exist (annexed or capitulated during a war) may leave behind a dangling entry in another country's `operation_assets` intel data. On save, the now-invalid tag serializes as `={ token_airforce token_army }` (no country tag before the `=`), which desyncs the Clausewitz parser and causes a fatal crash at end-of-day serialization.
+After 20+ years of play, a country that ceases to exist through annexation may leave behind a dangling entry in another country's `operation_assets` intel data. On save, the now-invalid tag serializes as `={ token_airforce token_army }` (no country tag before the `=`), which desyncs the Clausewitz parser and causes a fatal crash at end-of-day serialization.
 
 **Symptoms:** Crash on load or at end of day with "Unexpected token" errors in the log; all tokens after the corruption are misread.
 


### PR DESCRIPTION
Closes #2436
Closes #2445.

**What**\n- Documents the player workaround for corrupted `operation_assets` save entries.\n- Frees operatives held by a country when it becomes a puppet, is annexed, or a subject is annexed.\n- Removes stale operation tokens targeting annexed countries from every remaining country's intel data.\n\n**Why**\nA removed country can leave an empty tag in `operation_assets`, corrupting the save parser. Separately, captured operatives held during puppet and annexation transitions can persist as infinite prisoners and cause lag.\n\n**How**\n- `every_country` loops are guarded with `has_captured_operative` or `has_operation_token`, so they only visit relevant countries.\n- Annexation cleanup removes the five vanilla tokens and five MD-defined tokens: `token_airforce`, `token_army`, `token_civilian`, `token_navy`, `token_resistance_contacts`, `token_hvt`, `token_arms_cache`, `token_training_camps`, `token_regional_headquarters`, and `token_foreign_advisors`.\n- Token cleanup runs only for country-removal hooks (`on_annex` and `on_subject_annexed`), not capitulation or puppeting, because those countries remain valid token targets.