### PR TITLE
Add economic productivity and industry events

### DIFF
--- a/common/on_actions/MD_event_on_actions.txt
+++ b/common/on_actions/MD_event_on_actions.txt
@@ -6,7 +6,7 @@ on_actions = {
 
 			#Base: How many times should the event happen in a year * 100
 
-			#Economic events (total 200)
+			#Economic events (total 356)
 			20 = econvent.1		#Central Bank warns of housing bubble & possible crisis
 			25 = econvent.2		#Collapsing housing prices
 			25 = econvent.3		#Stock Market Crash
@@ -21,6 +21,13 @@ on_actions = {
 			15 = econvent.13	#High Debt Causes Companies to Leave
 			10 = econvent.14	#Private Investors Invest in the Civilian Industry
 			10 = econvent.15	#Private investors Invest in Office Parks
+			30 = econvent.16	#Modern Production Methods Spread
+			20 = econvent.17	#Education Investments Bear Fruit
+			20 = econvent.18	#Foreign Technology Spreads Domestically
+			10 = econvent.19	#Semiconductor Foundry Investment
+			10 = econvent.20	#Composite Industry Expansion
+			8 = econvent.21		#Defense Contracts Expand Production
+			8 = econvent.22		#Commercial Shipbuilding Orders Surge
 
 			# Migration Events
 			20 = migrant_event.1 # Migrant Slums

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -1873,6 +1873,441 @@ country_event = {
 
 }
 
+# Modern Production Methods Spread
+country_event = {
+	id = econvent.16
+	title = econvent.16.t
+	desc = econvent.16.d
+	picture = GFX_generic_factory
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 2
+			has_idea = economic_boom
+		}
+		modifier = {
+			factor = 1.75
+			has_idea = fast_growth
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = stable_growth
+		}
+		modifier = {
+			factor = 1.5
+			check_variable = { overall_productivity < 750 }
+		}
+		modifier = {
+			factor = 1.5
+			check_variable = { overall_productivity < 500 }
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = econ_recent_productivity_gain }
+		check_variable = { overall_productivity < global.average_world_productivity }
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_productivity_gain value = 1 days = 365 }
+	}
+
+	option = {
+		name = econvent.16.a
+		log = "[GetDateText]: [This.GetName]: econvent.16.a executed"
+		set_temp_variable = { temp_productivity_change = 10 }
+		flat_productivity_change_effect = yes
+	}
+
+}
+
+# Education Investments Bear Fruit
+country_event = {
+	id = econvent.17
+	title = econvent.17.t
+	desc = econvent.17.d
+	picture = GFX_generic_education_event_picture
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 1.5
+			check_variable = { education_law > 3 }
+		}
+		modifier = {
+			factor = 1.5
+			check_variable = { education_law > 4 }
+		}
+		modifier = {
+			factor = 1.5
+			OR = {
+				has_idea = economic_boom
+				has_idea = fast_growth
+				has_idea = stable_growth
+			}
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = econ_recent_productivity_gain }
+		check_variable = { overall_productivity < global.average_world_productivity }
+		check_variable = { education_law > 2 }
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_productivity_gain value = 1 days = 365 }
+	}
+
+	option = {
+		name = econvent.17.a
+		log = "[GetDateText]: [This.GetName]: econvent.17.a executed"
+		set_temp_variable = { temp_productivity_change = 10 }
+		flat_productivity_change_effect = yes
+	}
+
+}
+
+# Foreign Technology Spreads Domestically
+country_event = {
+	id = econvent.18
+	title = econvent.18.t
+	desc = econvent.18.d
+	picture = GFX_generic_factory
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 1.75
+			has_idea = globalized_trade_economy
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = international_bankers
+			check_variable = { international_bankers_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = industrial_conglomerates
+			check_variable = { industrial_conglomerates_opinion > 60 }
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = econ_recent_productivity_gain }
+		check_variable = { overall_productivity < global.average_world_productivity }
+		OR = {
+			has_idea = export_economy
+			has_idea = globalized_trade_economy
+		}
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_productivity_gain value = 1 days = 365 }
+	}
+
+	option = {
+		name = econvent.18.a
+		log = "[GetDateText]: [This.GetName]: econvent.18.a executed"
+		set_temp_variable = { temp_productivity_change = 10 }
+		flat_productivity_change_effect = yes
+	}
+
+}
+
+# Semiconductor Foundry Investment
+country_event = {
+	id = econvent.19
+	title = econvent.19.t
+	desc = econvent.19.d
+	picture = GFX_generic_factory
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 2
+			check_variable = { resource@microchips < 0 }
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = international_bankers
+			check_variable = { international_bankers_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = industrial_conglomerates
+			check_variable = { industrial_conglomerates_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			OR = {
+				has_idea = economic_boom
+				has_idea = fast_growth
+				has_idea = stable_growth
+			}
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = econ_recent_advanced_industry_investment }
+		has_tech = microchip_production_1
+		check_variable = { resource@chromium > 0 }
+		check_variable = { resource@tungsten > 0 }
+		check_variable = { energy_difference_variable > 0 }
+		any_controlled_state = {
+			is_owned_by = ROOT
+			free_building_slots = {
+				building = microchip_plant
+				size > 0
+			}
+		}
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_advanced_industry_investment value = 1 days = 730 }
+	}
+
+	option = {
+		name = econvent.19.a
+		log = "[GetDateText]: [This.GetName]: econvent.19.a executed"
+		random_owned_controlled_state = {
+			limit = {
+				free_building_slots = {
+					building = microchip_plant
+					size > 0
+				}
+			}
+			add_building_construction = {
+				type = microchip_plant
+				level = 1
+				instant_build = yes
+			}
+		}
+	}
+
+}
+
+# Composite Industry Expansion
+country_event = {
+	id = econvent.20
+	title = econvent.20.t
+	desc = econvent.20.d
+	picture = GFX_generic_factory
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 2
+			check_variable = { resource@composites < 0 }
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = defense_industry
+			check_variable = { defense_industry_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = industrial_conglomerates
+			check_variable = { industrial_conglomerates_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			OR = {
+				check_variable = { military_factory_total > 0 }
+				check_variable = { naval_factory_total > 0 }
+			}
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = econ_recent_advanced_industry_investment }
+		has_tech = composite_production_1
+		check_variable = { resource@chromium > 0 }
+		check_variable = { resource@rubber > 0 }
+		check_variable = { resource@oil > 0 }
+		check_variable = { energy_difference_variable > 0 }
+		any_controlled_state = {
+			is_owned_by = ROOT
+			free_building_slots = {
+				building = composite_plant
+				size > 0
+			}
+		}
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_advanced_industry_investment value = 1 days = 730 }
+	}
+
+	option = {
+		name = econvent.20.a
+		log = "[GetDateText]: [This.GetName]: econvent.20.a executed"
+		random_owned_controlled_state = {
+			limit = {
+				free_building_slots = {
+					building = composite_plant
+					size > 0
+				}
+			}
+			add_building_construction = {
+				type = composite_plant
+				level = 1
+				instant_build = yes
+			}
+		}
+	}
+
+}
+
+# Defense Contracts Expand Production
+country_event = {
+	id = econvent.21
+	title = econvent.21.t
+	desc = econvent.21.d
+	picture = GFX_generic_factory
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 2
+			has_war = yes
+		}
+		modifier = {
+			factor = 1.5
+			check_variable = { military_law > 7 }
+		}
+		modifier = {
+			factor = 2
+			has_idea = defense_industry
+			check_variable = { defense_industry_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			OR = {
+				has_idea = economic_boom
+				has_idea = fast_growth
+				has_idea = stable_growth
+			}
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_idea = no_military }
+		NOT = { has_country_flag = econ_recent_strategic_industry_expansion }
+		check_variable = { military_law > 4 }
+		check_variable = { total_unemployed_percentage_display > 0.01 }
+		check_variable = { energy_difference_variable > 0 }
+		any_controlled_state = {
+			is_owned_by = ROOT
+			free_building_slots = {
+				building = arms_factory
+				size > 0
+			}
+		}
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_strategic_industry_expansion value = 1 days = 730 }
+	}
+
+	option = {
+		name = econvent.21.a
+		log = "[GetDateText]: [This.GetName]: econvent.21.a executed"
+		random_owned_controlled_state = {
+			limit = {
+				free_building_slots = {
+					building = arms_factory
+					size > 0
+				}
+			}
+			add_building_construction = {
+				type = arms_factory
+				level = 1
+				instant_build = yes
+			}
+		}
+	}
+
+}
+
+# Commercial Shipbuilding Orders Surge
+country_event = {
+	id = econvent.22
+	title = econvent.22.t
+	desc = econvent.22.d
+	picture = GFX_cargo_ship
+	is_triggered_only = yes
+
+	mean_time_to_happen = {
+		modifier = {
+			factor = 1.5
+			check_variable = { naval_factory_total > 0 }
+		}
+		modifier = {
+			factor = 2
+			has_idea = maritime_industry
+			check_variable = { maritime_industry_opinion > 60 }
+		}
+		modifier = {
+			factor = 1.5
+			has_idea = globalized_trade_economy
+		}
+	}
+
+	trigger = {
+		NOT = { has_idea = non_state_actor }
+		NOT = { has_country_flag = econ_recent_strategic_industry_expansion }
+		check_variable = { total_unemployed_percentage_display > 0.01 }
+		check_variable = { energy_difference_variable > 0 }
+		OR = {
+			has_idea = export_economy
+			has_idea = globalized_trade_economy
+			AND = {
+				has_idea = maritime_industry
+				check_variable = { maritime_industry_opinion > 60 }
+			}
+		}
+		any_controlled_state = {
+			is_owned_by = ROOT
+			is_coastal = yes
+			free_building_slots = {
+				building = dockyard
+				size > 0
+			}
+		}
+	}
+
+	immediate = {
+		set_country_flag = { flag = econ_recent_strategic_industry_expansion value = 1 days = 730 }
+	}
+
+	option = {
+		name = econvent.22.a
+		log = "[GetDateText]: [This.GetName]: econvent.22.a executed"
+		random_owned_controlled_state = {
+			limit = {
+				is_coastal = yes
+				free_building_slots = {
+					building = dockyard
+					size > 0
+				}
+			}
+			add_building_construction = {
+				type = dockyard
+				level = 1
+				instant_build = yes
+			}
+		}
+	}
+
+}
+
 # Bailout Requested
 country_event = {
 	id = bankruptcy.1

--- a/localisation/english/events_l_english.yml
+++ b/localisation/english/events_l_english.yml
@@ -690,6 +690,34 @@
  econvent.15.d: "A group of a private investors have decided to invest in a number of smaller scale third-party services"
  econvent.15.a: "Amazing!"
 
+ econvent.16.t: "Modern Production Methods Spread"
+ econvent.16.d: "Firms across [ROOT.GetName] are adopting improved production methods and reorganizing their workplaces. The changes are raising output across the economy."
+ econvent.16.a: "Encourage the transition"
+
+ econvent.17.t: "Education Investments Bear Fruit"
+ econvent.17.d: "Years of investment in schools and vocational training have expanded the pool of skilled workers. Employers are putting that expertise to productive use."
+ econvent.17.a: "Put these skills to work"
+
+ econvent.18.t: "Foreign Technology Spreads Domestically"
+ econvent.18.d: "Trade links have exposed local firms to better machinery and industrial practices. Domestic producers are now adapting those methods to their own operations."
+ econvent.18.a: "Support domestic adoption"
+
+ econvent.19.t: "Semiconductor Foundry Investment Announced"
+ econvent.19.d: "A private consortium has committed to building a new semiconductor foundry in [ROOT.GetName]. Reliable access to industrial inputs and power has made the project commercially viable."
+ econvent.19.a: "Welcome the investment"
+
+ econvent.20.t: "Composite Industry Expansion Announced"
+ econvent.20.d: "Manufacturers are expanding domestic composite production to supply advanced civilian and military industries. Investors expect secure raw materials to keep the new plant competitive."
+ econvent.20.a: "Support the expansion"
+
+ econvent.21.t: "Defense Contracts Expand Production"
+ econvent.21.d: "New defense contracts have given manufacturers the confidence to expand production. The project will create skilled jobs while strengthening the national industrial base."
+ econvent.21.a: "Award the contracts"
+
+ econvent.22.t: "Commercial Shipbuilding Orders Surge"
+ econvent.22.d: "Export demand and strong maritime business conditions have filled domestic order books. Shipbuilders are expanding capacity to meet the new contracts."
+ econvent.22.a: "Back the shipyards"
+
  # Public War Weariness (Anti-Bully) System #
  anti_bully.2.t: "Public War Weariness"
  anti_bully.2.d: "We have decided war is our best course of action. However, in order to maintain support among the people we must either win this quickly or push quickly into foreign soil. The people will march as long as they see how necessary this war is. Boots march, drums beat, and the time for [FROM.GetName] to go to war is upon us!\n\n§YThis triggers the Public War Weariness System§!\n"


### PR DESCRIPTION
Closes #1533

## What
- Add three positive productivity events for countries below world-average productivity.
- Add semiconductor, composite, military factory, and dockyard investment events.
- Register the events in the monthly economic pulse and add English localisation.

## Why
The economic pulse has few positive development events and little coverage of advanced or strategic industries. These events reward economic catch-up and viable industrial expansion without granting unrestricted factories.

## How
- Productivity events add 10 productivity to every controlled state and share a 365-day cooldown.
- Advanced-industry events require their production technology, surplus inputs, energy, and a valid free slot.
- Military and dockyard events require employment capacity, energy, and relevant defense, trade, maritime, or coastal conditions.
- Industry events consume existing building slots and use shared 730-day cooldowns.
<img width="1700" height="1253" alt="image" src="https://github.com/user-attachments/assets/5242594c-5b92-4595-ad2c-09dec8a23244" />
