### PR TITLE
Add historical synthetic refineries to state history

### DIFF
--- a/history/states/10-Yorkshire and the Humber.txt
+++ b/history/states/10-Yorkshire and the Humber.txt
@@ -45,6 +45,7 @@ state = {
 			}
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.428 }
 		add_core_of = ENG

--- a/history/states/102-Uusimaa.txt
+++ b/history/states/102-Uusimaa.txt
@@ -39,6 +39,7 @@ state = {
 			}
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.280 }

--- a/history/states/1067-Omsk.txt
+++ b/history/states/1067-Omsk.txt
@@ -16,6 +16,7 @@ state = {
 			internet_station = 2
 			air_base = 2
 			offices = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.131 }

--- a/history/states/1075-Luhansk.txt
+++ b/history/states/1075-Luhansk.txt
@@ -15,6 +15,7 @@ state = {
 			infrastructure = 3
 			internet_station = 2
 			air_base = 2
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.965 }
 		set_variable = { productivity_state_var = 404 }

--- a/history/states/109-Samogitia-Aukstaitija.txt
+++ b/history/states/109-Samogitia-Aukstaitija.txt
@@ -18,6 +18,7 @@ state = {
 			internet_station = 1
 			air_base = 5
 			nuclear_reactor = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.217 }
 		add_core_of = LIT

--- a/history/states/1094-Vitebsk.txt
+++ b/history/states/1094-Vitebsk.txt
@@ -18,6 +18,7 @@ state = {
 			infrastructure = 1
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 
 
 		}

--- a/history/states/11-Greater Manchester.txt
+++ b/history/states/11-Greater Manchester.txt
@@ -36,6 +36,7 @@ state = {
 				naval_base = 5
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.337 }
 		add_core_of = ENG

--- a/history/states/1114-Central Java.txt
+++ b/history/states/1114-Central Java.txt
@@ -21,6 +21,7 @@ state = {
 				naval_base = 4
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 
 		set_variable = { hydroelectric_energy_production_var = 0.181 }

--- a/history/states/112-Malopolska.txt
+++ b/history/states/112-Malopolska.txt
@@ -22,6 +22,7 @@ state = {
 			air_base = 3
 			industrial_complex = 2
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = POL
 		set_variable = { productivity_state_var = 629 }

--- a/history/states/114-Masovia.txt
+++ b/history/states/114-Masovia.txt
@@ -31,8 +31,9 @@ state = {
 				# PGZ
 				land_facility = 1
 			}
-			fossil_powerplant = 3
+			fossil_powerplant = 4
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = POL
 		set_variable = { hydroelectric_energy_production_var = 0.162 }

--- a/history/states/117-Bohemia.txt
+++ b/history/states/117-Bohemia.txt
@@ -33,6 +33,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { hydroelectric_energy_production_var = 0.584 }

--- a/history/states/1189-Moscow Oblast.txt
+++ b/history/states/1189-Moscow Oblast.txt
@@ -47,6 +47,7 @@ state = {
 				air_facility = 1
 			}
 			fossil_powerplant = 6
+			composite_plant = 1
 		}
 		set_variable = { productivity_state_var = 742 }
 	}

--- a/history/states/119-Western Slovakia.txt
+++ b/history/states/119-Western Slovakia.txt
@@ -21,6 +21,7 @@ state = {
 				land_facility = 1
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 		set_variable = { productivity_state_var = 690 }
 

--- a/history/states/121-Northern Hungary.txt
+++ b/history/states/121-Northern Hungary.txt
@@ -28,6 +28,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = HUN
 		set_variable = { productivity_state_var = 840 }

--- a/history/states/1229-Central Luzon.txt
+++ b/history/states/1229-Central Luzon.txt
@@ -31,6 +31,7 @@ state = {
 			offices = 2
 			arms_factory = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { hydroelectric_energy_production_var = 0.2 }

--- a/history/states/126-Slavonia.txt
+++ b/history/states/126-Slavonia.txt
@@ -23,6 +23,7 @@ state = {
 				land_facility = 1
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 0.736 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/130-Vojvodina.txt
+++ b/history/states/130-Vojvodina.txt
@@ -16,6 +16,7 @@ state = {
 			infrastructure = 1
 			internet_station = 1
 			arms_factory = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = SER
 		add_core_of = VOJ

--- a/history/states/141-Central Greece.txt
+++ b/history/states/141-Central Greece.txt
@@ -35,6 +35,7 @@ state = {
 			}
 			fossil_powerplant = 4
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.083 }
 		add_core_of = GRE

--- a/history/states/150-Wallachia.txt
+++ b/history/states/150-Wallachia.txt
@@ -47,6 +47,7 @@ state = {
 				land_facility = 1
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 		add_core_of = ROM
 		set_variable = { productivity_state_var = 804 }

--- a/history/states/154-Eastern Bulgaria.txt
+++ b/history/states/154-Eastern Bulgaria.txt
@@ -29,6 +29,7 @@ state = {
 			9902 = {
 				naval_base = 1
 			}
+			synthetic_refinery = 1
 		}
 		add_core_of = BUL
 		set_variable = { productivity_state_var = 476 }

--- a/history/states/156-Izmir.txt
+++ b/history/states/156-Izmir.txt
@@ -6,7 +6,7 @@ state = {
 		owner = TUR
 		victory_points = {
 			4112 20
-		}	
+		}
 		victory_points = {
 			7130 1
 		}
@@ -16,7 +16,7 @@ state = {
 		victory_points = {
 			11796 1
 		}
-		
+
 		buildings = {
 			infrastructure = 2
 			internet_station = 1
@@ -31,6 +31,7 @@ state = {
 				naval_base = 6
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 2
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.190 }
 		add_core_of = TUR

--- a/history/states/167-Salahuddin.txt
+++ b/history/states/167-Salahuddin.txt
@@ -17,6 +17,7 @@ state = {
 			arms_factory = 1
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = IRQ
 		add_to_array = {

--- a/history/states/172-Kuwait.txt
+++ b/history/states/172-Kuwait.txt
@@ -22,6 +22,7 @@ state = {
 			}
 			fossil_powerplant = 4
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.239 }
 		set_variable = { productivity_state_var = 1251 }

--- a/history/states/174-Haasa.txt
+++ b/history/states/174-Haasa.txt
@@ -39,6 +39,7 @@ state = {
 				}
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 2
 		}
 		add_core_of = SAU
 		add_core_of = QTF

--- a/history/states/177-Hejaz.txt
+++ b/history/states/177-Hejaz.txt
@@ -41,6 +41,7 @@ state = {
 				}
 			}
 			fossil_powerplant = 4
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.230 }

--- a/history/states/179-Dubai.txt
+++ b/history/states/179-Dubai.txt
@@ -23,6 +23,7 @@ state = {
 			arms_factory = 2
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = UAE
 		set_variable = { productivity_state_var = 1365 }

--- a/history/states/181-Qatar.txt
+++ b/history/states/181-Qatar.txt
@@ -30,6 +30,7 @@ state = {
 			}
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { productivity_state_var = 1168 }

--- a/history/states/188-Homs.txt
+++ b/history/states/188-Homs.txt
@@ -14,6 +14,7 @@ state = {
 			infrastructure = 1
 			internet_station = 1
 			air_base = 3
+			synthetic_refinery = 1
 		}
 		set_variable = { productivity_state_var = 686 }
 

--- a/history/states/205-Galilee.txt
+++ b/history/states/205-Galilee.txt
@@ -27,6 +27,7 @@ state = {
 				air_facility = 1
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { productivity_state_var = 748 }
 

--- a/history/states/216-Alexandria.txt
+++ b/history/states/216-Alexandria.txt
@@ -42,6 +42,7 @@ state = {
 				}
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 		add_core_of = EGY
 		set_variable = { productivity_state_var = 517 }

--- a/history/states/265-Romagna.txt
+++ b/history/states/265-Romagna.txt
@@ -33,6 +33,7 @@ state = {
 				naval_base = 2
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 		add_core_of = ITA
 		set_variable = { hydroelectric_energy_production_var = 0.609 }

--- a/history/states/274-Mpumalanga.txt
+++ b/history/states/274-Mpumalanga.txt
@@ -26,6 +26,7 @@ state = {
 			internet_station = 1
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 
 		}
 		add_core_of = SAF

--- a/history/states/277-Free State.txt
+++ b/history/states/277-Free State.txt
@@ -20,6 +20,7 @@ state = {
 		buildings = {
 			infrastructure = 2
 			internet_station = 1
+			synthetic_refinery = 1
 
 		}
 		add_core_of = SAF

--- a/history/states/32-Ostlandet.txt
+++ b/history/states/32-Ostlandet.txt
@@ -30,6 +30,7 @@ state = {
 			}
 			fossil_powerplant = 1
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.445 }
 		add_core_of = NRY

--- a/history/states/332-Biafra.txt
+++ b/history/states/332-Biafra.txt
@@ -33,6 +33,7 @@ state = {
 
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 
 		}
 		add_core_of = NIG

--- a/history/states/334-Lagos.txt
+++ b/history/states/334-Lagos.txt
@@ -39,7 +39,7 @@ state = {
 					}
 				}
 			}
-			fossil_powerplant = 1
+			fossil_powerplant = 2
 		}
 		set_variable = { hydroelectric_energy_production_var = 0.651 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/35-Gotaland.txt
+++ b/history/states/35-Gotaland.txt
@@ -25,6 +25,7 @@ state = {
 			383 = {
 				naval_base = 4
 			}
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.298 }
 		add_core_of = SWE

--- a/history/states/384-Constantinois.txt
+++ b/history/states/384-Constantinois.txt
@@ -26,6 +26,7 @@ state = {
 				naval_base = 4
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.279 }
 		set_variable = { productivity_state_var = 686 }

--- a/history/states/39-Nordrhein-Westfalen.txt
+++ b/history/states/39-Nordrhein-Westfalen.txt
@@ -48,6 +48,7 @@ state = {
 			}
 			fossil_powerplant = 4
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_dynamic_modifier = { modifier = GER_downfall_of_heavy_industrie }
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.853 }

--- a/history/states/395-Benghazi.txt
+++ b/history/states/395-Benghazi.txt
@@ -20,6 +20,7 @@ state = {
 				naval_base = 6
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = LBA
 		add_core_of = CYR

--- a/history/states/399-Khuzestan.txt
+++ b/history/states/399-Khuzestan.txt
@@ -41,6 +41,7 @@ state = {
 				naval_base = 4
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 2
 		}
 		add_core_of = PER
 		add_core_of = ARA

--- a/history/states/40-Rheinland-Pfalz.txt
+++ b/history/states/40-Rheinland-Pfalz.txt
@@ -33,6 +33,7 @@ state = {
 				nuclear_facility = 1
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = GER
 		set_variable = { productivity_state_var = 759 }

--- a/history/states/42-Baden-Wurttemberg.txt
+++ b/history/states/42-Baden-Wurttemberg.txt
@@ -36,7 +36,7 @@ state = {
 			anti_air_building = 1
 			nuclear_reactor = 1
 			agriculture_district = 1
-			fossil_powerplant = 5
+			fossil_powerplant = 6
 			composite_plant = 1
 		}
 		add_dynamic_modifier = { modifier = GER_new_economic_hubs }

--- a/history/states/426-Sindh.txt
+++ b/history/states/426-Sindh.txt
@@ -45,6 +45,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = PAK
 		set_variable = { productivity_state_var = 784 }

--- a/history/states/440-Braj.txt
+++ b/history/states/440-Braj.txt
@@ -35,6 +35,7 @@ state = {
 				}
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 		add_core_of = RAJ
 		set_variable = { productivity_state_var = 472 }

--- a/history/states/447-Bihar.txt
+++ b/history/states/447-Bihar.txt
@@ -47,7 +47,7 @@ state = {
 			industrial_complex = 6
 			offices = 3
 			renewable_energy_infra = 1
-			fossil_powerplant = 4
+			fossil_powerplant = 5
 			composite_plant = 1
 		}
 		add_core_of = RAJ

--- a/history/states/450-Cordoba.txt
+++ b/history/states/450-Cordoba.txt
@@ -27,6 +27,7 @@ state = {
 			nuclear_reactor = 1
 			industrial_complex = 4
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 0.050 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/453-Pampas.txt
+++ b/history/states/453-Pampas.txt
@@ -42,6 +42,7 @@ state = {
 			}
 			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.161 }
 		set_variable = { hydroelectric_energy_production_var = 0.917 }

--- a/history/states/46-West-Nederland.txt
+++ b/history/states/46-West-Nederland.txt
@@ -45,6 +45,7 @@ state = {
 			}
 			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { hydroelectric_energy_production_var = 0.0118 }

--- a/history/states/468-Central Chile.txt
+++ b/history/states/468-Central Chile.txt
@@ -46,6 +46,7 @@ state = {
 			}
 			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.206 }

--- a/history/states/47-Zuid-Nederland.txt
+++ b/history/states/47-Zuid-Nederland.txt
@@ -30,6 +30,7 @@ state = {
 				nuclear_facility = 1
 			}
 			fossil_powerplant = 4
+			synthetic_refinery = 1
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.953 }

--- a/history/states/471-Mumbai.txt
+++ b/history/states/471-Mumbai.txt
@@ -30,6 +30,7 @@ state = {
 				}
 			}
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 		add_core_of = RAJ
 		set_variable = { productivity_state_var = 542 }

--- a/history/states/50-Vlaanderen.txt
+++ b/history/states/50-Vlaanderen.txt
@@ -42,8 +42,9 @@ state = {
 					}
 				}
 			}
-			fossil_powerplant = 2
+			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 2
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.230 }

--- a/history/states/508-Central Thailand.txt
+++ b/history/states/508-Central Thailand.txt
@@ -46,6 +46,7 @@ state = {
 			}
 			fossil_powerplant = 6
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 0.361 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/529-Eastern Malaya.txt
+++ b/history/states/529-Eastern Malaya.txt
@@ -29,6 +29,7 @@ state = {
 				naval_base = 2
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 1.000 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/530-Singapore.txt
+++ b/history/states/530-Singapore.txt
@@ -28,6 +28,7 @@ state = {
 			}
 			fossil_powerplant = 6
 			composite_plant = 1
+			synthetic_refinery = 2
 		}
 
 		add_dynamic_modifier = { modifier = SIN_singapore_problem }

--- a/history/states/534-Guangdong.txt
+++ b/history/states/534-Guangdong.txt
@@ -85,6 +85,7 @@ state = {
 			}
 			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = CHI
 		add_core_of = TAI

--- a/history/states/536-Nanjing.txt
+++ b/history/states/536-Nanjing.txt
@@ -38,6 +38,7 @@ state = {
 			}
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = CHI
 		add_core_of = TAI

--- a/history/states/54-Haute-de-France.txt
+++ b/history/states/54-Haute-de-France.txt
@@ -28,6 +28,7 @@ state = {
 			575 = {
 				naval_base = 6
 			}
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.272 }
 		set_variable = { productivity_state_var = 1020 }

--- a/history/states/544-Shandong.txt
+++ b/history/states/544-Shandong.txt
@@ -58,6 +58,7 @@ state = {
 			agriculture_district = 2
 			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = CHI
 		add_core_of = TAI

--- a/history/states/547-Beijing.txt
+++ b/history/states/547-Beijing.txt
@@ -34,6 +34,7 @@ state = {
 			}
 			fossil_powerplant = 4
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = CHI
 		add_core_of = TAI

--- a/history/states/55-Normandie.txt
+++ b/history/states/55-Normandie.txt
@@ -31,6 +31,7 @@ state = {
 			485 = {
 				naval_base = 1
 			}
+			synthetic_refinery = 1
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.310 }

--- a/history/states/552-Liaoning.txt
+++ b/history/states/552-Liaoning.txt
@@ -76,6 +76,7 @@ state = {
 				air_facility = 1
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 		add_core_of = CHI
 		add_core_of = TAI

--- a/history/states/560-Gansu.txt
+++ b/history/states/560-Gansu.txt
@@ -56,6 +56,7 @@ state = {
 			air_base = 4
 			fossil_powerplant = 2
 			enrichment_facility = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.784 }
 		add_core_of = CHI

--- a/history/states/598-Taipei.txt
+++ b/history/states/598-Taipei.txt
@@ -28,7 +28,7 @@ state = {
 					}
 				}
 			}
-			fossil_powerplant = 5
+			fossil_powerplant = 6
 			composite_plant = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.234 }

--- a/history/states/599-Kaohsiung.txt
+++ b/history/states/599-Kaohsiung.txt
@@ -27,6 +27,7 @@ state = {
 				naval_facility = 1
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 2
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.321 }
 		add_core_of = TAI

--- a/history/states/605-Yeongnam.txt
+++ b/history/states/605-Yeongnam.txt
@@ -54,6 +54,7 @@ state = {
 			}
 			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 2
 		}
 		add_core_of = NKO
 		add_core_of = KOR

--- a/history/states/607-Honam.txt
+++ b/history/states/607-Honam.txt
@@ -35,6 +35,7 @@ state = {
 				air_facility = 1
 			}
 			fossil_powerplant = 4
+			synthetic_refinery = 2
 		}
 		add_core_of = NKO
 		add_core_of = KOR

--- a/history/states/609-Kyushu.txt
+++ b/history/states/609-Kyushu.txt
@@ -51,6 +51,7 @@ state = {
 			}
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 2.938 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/613-Chubu.txt
+++ b/history/states/613-Chubu.txt
@@ -63,6 +63,7 @@ state = {
 			}
 			fossil_powerplant = 6
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.494 }
 		set_variable = { hydroelectric_energy_production_var = 3.350 }

--- a/history/states/615-Kanto.txt
+++ b/history/states/615-Kanto.txt
@@ -53,6 +53,7 @@ state = {
 			}
 			fossil_powerplant = 9
 			composite_plant = 1
+			synthetic_refinery = 2
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.478 }
 		set_variable = { hydroelectric_energy_production_var = 3.071 }

--- a/history/states/616-Tohoku.txt
+++ b/history/states/616-Tohoku.txt
@@ -48,6 +48,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.498 }
 		set_variable = { hydroelectric_energy_production_var = 2.100 }

--- a/history/states/617-Hokkaido.txt
+++ b/history/states/617-Hokkaido.txt
@@ -34,6 +34,7 @@ state = {
 				naval_base = 2
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.441 }
 		set_variable = { hydroelectric_energy_production_var = 0.277 }

--- a/history/states/63-Provence.txt
+++ b/history/states/63-Provence.txt
@@ -31,6 +31,7 @@ state = {
 				naval_base = 3
 			}
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.226 }
 		set_variable = { hydroelectric_energy_production_var = 0.536 }

--- a/history/states/656-Voronezh.txt
+++ b/history/states/656-Voronezh.txt
@@ -27,6 +27,7 @@ state = {
 			air_base = 8
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.071 }
 		add_core_of = SOV

--- a/history/states/660-Nizhny Novgorod.txt
+++ b/history/states/660-Nizhny Novgorod.txt
@@ -37,6 +37,7 @@ state = {
 			air_base = 3
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 
 		add_core_of = SOV

--- a/history/states/661-Tartarstan.txt
+++ b/history/states/661-Tartarstan.txt
@@ -35,6 +35,7 @@ state = {
 			air_base = 4
 			industrial_complex = 1
 			fossil_powerplant = 3
+			synthetic_refinery = 1
 		}
 
 		add_core_of = SOV

--- a/history/states/663-Samara.txt
+++ b/history/states/663-Samara.txt
@@ -38,6 +38,7 @@ state = {
 			nuclear_reactor = 1
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.883 }

--- a/history/states/664-Bashkortostan.txt
+++ b/history/states/664-Bashkortostan.txt
@@ -42,6 +42,7 @@ state = {
 			air_base = 4
 			industrial_complex = 1
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 
 		add_core_of = SOV

--- a/history/states/713-Baku.txt
+++ b/history/states/713-Baku.txt
@@ -20,6 +20,7 @@ state = {
 				naval_base = 1
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.101 }
 		set_variable = { productivity_state_var = 818 }

--- a/history/states/718-Caspian Basin.txt
+++ b/history/states/718-Caspian Basin.txt
@@ -44,6 +44,7 @@ state = {
 				naval_base = 1
 
 			}
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.300 }

--- a/history/states/725-Fergana.txt
+++ b/history/states/725-Fergana.txt
@@ -35,6 +35,7 @@ state = {
 			industrial_complex = 2
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { hydroelectric_energy_production_var = 0.333 }

--- a/history/states/743-Victoria.txt
+++ b/history/states/743-Victoria.txt
@@ -29,6 +29,7 @@ state = {
 				naval_facility = 1
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.610 }
 		set_variable = { hydroelectric_energy_production_var = 0.300 }

--- a/history/states/755-Alberta.txt
+++ b/history/states/755-Alberta.txt
@@ -41,6 +41,7 @@ state = {
 			air_base = 4
 			offices = 1
 			renewable_energy_infra = 1
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.609 }

--- a/history/states/76-Austria Proper.txt
+++ b/history/states/76-Austria Proper.txt
@@ -32,8 +32,9 @@ state = {
 				}
 				land_facility = 1
 			}
-			fossil_powerplant = 1
+			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 3.139 } #Might include storage
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/763-Ontario.txt
+++ b/history/states/763-Ontario.txt
@@ -93,6 +93,7 @@ state = {
 			}
 			fossil_powerplant = 1
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.266 }
 		set_variable = { hydroelectric_energy_production_var = 4.407 }

--- a/history/states/770-New Jersey.txt
+++ b/history/states/770-New Jersey.txt
@@ -30,6 +30,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = USA
 		set_variable = { productivity_state_var = 1410 }

--- a/history/states/775-Ohio.txt
+++ b/history/states/775-Ohio.txt
@@ -35,6 +35,7 @@ state = {
 			fossil_powerplant = 2
 			composite_plant = 1
 			enrichment_facility = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.726 }
 		add_core_of = USA

--- a/history/states/778-Illinois.txt
+++ b/history/states/778-Illinois.txt
@@ -36,6 +36,7 @@ state = {
 			nuclear_reactor = 1
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.720 }
 		add_core_of = USA

--- a/history/states/782-Kentucky.txt
+++ b/history/states/782-Kentucky.txt
@@ -35,6 +35,7 @@ state = {
 			renewable_energy_infra = 1
 			fossil_powerplant = 1
 			enrichment_facility = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = USA
 		add_core_of = GLC

--- a/history/states/793-Tennessee.txt
+++ b/history/states/793-Tennessee.txt
@@ -38,6 +38,7 @@ state = {
 			agriculture_district = 2
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 1.987 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/797-Louisiana.txt
+++ b/history/states/797-Louisiana.txt
@@ -42,6 +42,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 2
 		}
 		add_core_of = USA
 		set_variable = { productivity_state_var = 1025 }

--- a/history/states/80-Lombardia.txt
+++ b/history/states/80-Lombardia.txt
@@ -18,8 +18,9 @@ state = {
 			offices = 6
 			air_base = 10
 			anti_air_building = 3
-			fossil_powerplant = 5
+			fossil_powerplant = 6
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 5.636 } #average power output in gw of all hydropower infrastructure in the state (you can convert it from annual twh if you have that data)
 		set_variable = { hydroelectric_energy_storage_var = 300 } #this is the storage capacity of the dam in gwh				   #divide the number of annual twh produced by 8.760 to obtain the average power in gw

--- a/history/states/800-Texas.txt
+++ b/history/states/800-Texas.txt
@@ -68,8 +68,9 @@ state = {
 			10337 = { naval_base = 4 }
 			2042 = { naval_base = 2 }
 			4884 = { naval_base = 1 }
-			fossil_powerplant = 4
+			fossil_powerplant = 5
 			composite_plant = 2
+			synthetic_refinery = 2
 		}
 		add_core_of = USA
 		add_core_of = TEX

--- a/history/states/811-California.txt
+++ b/history/states/811-California.txt
@@ -89,8 +89,9 @@ state = {
 				# Ratheon
 				land_facility = 1
 			}
-			fossil_powerplant = 5
+			fossil_powerplant = 6
 			composite_plant = 3
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.636 }
 		set_variable = { hydroelectric_energy_production_var = 1.845 }

--- a/history/states/83-Sicilia.txt
+++ b/history/states/83-Sicilia.txt
@@ -41,6 +41,7 @@ state = {
 				naval_base = 7
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.231 }
 		set_variable = { hydroelectric_energy_production_var = 0.729 }

--- a/history/states/832-Nuevo Leon.txt
+++ b/history/states/832-Nuevo Leon.txt
@@ -36,6 +36,7 @@ state = {
 				land_facility = 1
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.239 }
 		add_core_of = MEX

--- a/history/states/838-Veracruz.txt
+++ b/history/states/838-Veracruz.txt
@@ -30,6 +30,7 @@ state = {
 			}
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = MEX
 		add_core_of = TRC

--- a/history/states/86-Catalunya.txt
+++ b/history/states/86-Catalunya.txt
@@ -28,6 +28,7 @@ state = {
 				naval_base = 4
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.196 }

--- a/history/states/869-Trinidad.txt
+++ b/history/states/869-Trinidad.txt
@@ -25,6 +25,7 @@ state = {
 				naval_base = 3
 			}
 			fossil_powerplant = 2
+			synthetic_refinery = 1
 
 		}
 

--- a/history/states/875-Coastal Venezuela.txt
+++ b/history/states/875-Coastal Venezuela.txt
@@ -22,6 +22,7 @@ state = {
 				naval_base = 6
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.384 }
 		add_core_of = VEN

--- a/history/states/879-Rio Grande do Sul.txt
+++ b/history/states/879-Rio Grande do Sul.txt
@@ -46,6 +46,7 @@ state = {
 
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.782 }

--- a/history/states/882-Sao Paulo.txt
+++ b/history/states/882-Sao Paulo.txt
@@ -42,8 +42,9 @@ state = {
 				# Avibras
 				land_facility = 1
 			}
-			fossil_powerplant = 4
+			fossil_powerplant = 5
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = BRA
 		add_core_of = SPL

--- a/history/states/883-Rio de Janerio.txt
+++ b/history/states/883-Rio de Janerio.txt
@@ -48,6 +48,7 @@ state = {
 				air_facility = 1
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.995 }

--- a/history/states/884-Minas Gerais.txt
+++ b/history/states/884-Minas Gerais.txt
@@ -70,7 +70,7 @@ state = {
 			offices = 4
 			industrial_complex = 8
 			agriculture_district = 1
-			fossil_powerplant = 1
+			fossil_powerplant = 2
 			composite_plant = 1
 		}
 		add_core_of = BRA

--- a/history/states/9-Central Belt.txt
+++ b/history/states/9-Central Belt.txt
@@ -39,6 +39,7 @@ state = {
 			}
 			fossil_powerplant = 3
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.370 }
 		set_variable = { hydroelectric_energy_production_var = 1.459 }

--- a/history/states/904-Coastal Peru.txt
+++ b/history/states/904-Coastal Peru.txt
@@ -33,6 +33,7 @@ state = {
 			}
 			fossil_powerplant = 4
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.622 }

--- a/history/states/913-Santander.txt
+++ b/history/states/913-Santander.txt
@@ -17,6 +17,7 @@ state = {
 			internet_station = 1
 			industrial_complex = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { hydroelectric_energy_production_var = 0.0918 }
 		set_variable = { hydroelectric_energy_storage_var = 0 }

--- a/history/states/916-Anzoategiu.txt
+++ b/history/states/916-Anzoategiu.txt
@@ -21,6 +21,7 @@ state = {
 			infrastructure = 1
 			internet_station = 1
 			industrial_complex = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = VEN
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.484 }

--- a/history/states/966-Koln-Bonn.txt
+++ b/history/states/966-Koln-Bonn.txt
@@ -30,6 +30,7 @@ state = {
 			anti_air_building = 1
 			fossil_powerplant = 2
 			composite_plant = 1
+			synthetic_refinery = 1
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 0.899 }
 		add_core_of = GER

--- a/history/states/970-Castilla-La Manca.txt
+++ b/history/states/970-Castilla-La Manca.txt
@@ -24,6 +24,7 @@ state = {
 			air_base = 6
 			agriculture_district = 2
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = SPR
 		set_variable = { hydroelectric_energy_production_var = 0.321 }

--- a/history/states/972-Sachsen-Anhalt.txt
+++ b/history/states/972-Sachsen-Anhalt.txt
@@ -26,6 +26,7 @@ state = {
 			air_base = 3
 			anti_air_building = 1
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 		}
 		add_core_of = GER
 		set_variable = { productivity_state_var = 695 }

--- a/history/states/987-West Gujarat.txt
+++ b/history/states/987-West Gujarat.txt
@@ -37,6 +37,7 @@ state = {
 
 			}
 			fossil_powerplant = 1
+			synthetic_refinery = 1
 
 		}
 		set_variable = { state_renewable_capacity_factor_modifier_var = 1.333 }


### PR DESCRIPTION
Closes #2828

## What

Places 118 `synthetic_refinery` levels across 107 states in 64 countries, keyed to the refining and petrochemical complexes those countries actually ran around 2000.

Before this, only Portugal started with any (Matosinhos and Sines, 2 levels), so every other nation began with no petrochemical industry at all and had to build it from focuses. World total goes from 2 levels to 120.

## Why

`synthetic_refinery` is MD's petrochemical building: 3 rubber, 2 fuel/hr, $10bn GDP, 184K workers and 0.2 GW per level (`common/buildings/00_buildings.txt:190`). Leaving it unplaced meant Germany, Japan, Korea, the Gulf and Russia all started as pure rubber importers with no domestic synthetics, which is backwards.

## How

**Placement basis.** A country qualifies if in 2000 it had a steam cracker, a synthetic elastomer plant, or a petrochemical complex of international significance. Levels scale at roughly 1 per 250-300 kt/yr of synthetic rubber capacity for the real rubber producers, and 1-2 for pure refining or petrochemical hubs. Each level sits on the state that hosts the actual plant, not on the country's biggest industrial state.

**Slots.** `synthetic_refinery` has `state_max = 2` and shares building slots, so every target state was checked for free shared slots before writing. Nothing is placed over capacity. Two consequences worth knowing: Japan's two heaviest complexes (Mizushima in Chugoku, Sakai in Kansai) had zero free slots, so Japan's remaining levels went to the Sendai and Muroran/Tomakomai refineries instead; and Abu Dhabi was full, so the UAE level sits on Jebel Ali rather than Ruwais.

**Rubber market.** World rubber supply goes from ~1,900 to ~2,254 (+18.6%). MD prices rubber at `0.09 * 2 * (global imports / global exports)` clamped to `[0.018, 0.45]` (`common/scripted_effects/00_money_system.txt:6640-6712`), so expect a roughly proportional drop in the global rubber price and a matching hit to SE Asian export income. This is the devaluation #2828 flagged. If it bites, the lever is spacing out the focus and decision upgrades rather than pulling placements.

**GDP.** Small: Germany +$47bn (+1.0%), Japan +$60bn (+1.2%).

**Energy.** +0.2 GW per level, so `tools/analysis/pre_place_power_plants.py` was re-run with `--write --only <the 64 touched tags>`, adding 12 fossil plant levels. Scoping to the touched tags deliberately leaves the 36 files of pre-existing energy drift on `main` (POR, TML, HKG and others) out of this diff.

Two whitespace-only lines in `156-Izmir.txt` were normalised by the trailing-whitespace hook. Pre-existing, unrelated to the placement.

## Placements

**Americas (25)**
- USA 10: Texas 2 (Port Neches, Baytown, Houston Ship Channel), Louisiana 2 (Baton Rouge, Lake Charles, Geismar), Ohio (Lima, Akron), Kentucky (Louisville ASRC, Catlettsburg), Tennessee (Kingsport), California (LA basin), New Jersey (Bayway), Illinois (Joliet, Robinson)
- Canada 2: Ontario (Sarnia), Alberta (Edmonton, Fort Saskatchewan)
- Mexico 2: Veracruz (Coatzacoalcos), Nuevo Leon (Cadereyta)
- Brazil 3: Rio de Janeiro (Duque de Caxias, Petroflex), Sao Paulo (Paulinia, Cubatao), Rio Grande do Sul (Triunfo)
- Argentina 2: Pampas (Ensenada), Cordoba (Rio Tercero)
- Venezuela 2: Coastal Venezuela (Paraguana, El Palito), Anzoategui (Jose, Puerto La Cruz)
- Chile, Colombia, Peru, Trinidad 1 each: Central Chile (Concon), Santander (Barrancabermeja), Coastal Peru (La Pampilla), Trinidad (Pointe-a-Pierre, Point Lisas)

**Europe (44)**
- Germany 4: Rheinland-Pfalz (BASF Ludwigshafen), Nordrhein-Westfalen (Bayer Dormagen, Huls Marl), Sachsen-Anhalt (Buna Schkopau, Leuna), Koln-Bonn (Wesseling)
- UK 3: Central Belt (Grangemouth), Yorkshire and the Humber (Immingham, Killingholme), Greater Manchester (Stanlow, Runcorn)
- France 3: Normandie (Gonfreville, Port-Jerome), Provence (Berre, Lavera), Haute-de-France (Dunkerque, Ribecourt)
- Italy 3: Romagna (Ravenna elastomers), Sicilia (Priolo, Gela), Lombardia (Mantova, Sannazzaro)
- Russia 6: Tartarstan (Nizhnekamsk), Samara (Togliatti), Voronezh, Bashkortostan (Sterlitamak, Salavat), Omsk, Nizhny Novgorod (Kstovo, Dzerzhinsk)
- Netherlands 2: West-Nederland (Pernis), Zuid-Nederland (Geleen, Terneuzen)
- Belgium 2, Spain 2, Poland 2, Turkey 2: Vlaanderen (Antwerp), Catalunya (Tarragona) + Castilla-La Mancha (Puertollano), Masovia (Plock) + Malopolska (Oswiecim), Izmir (Aliaga, Petkim)
- 1 each: Ukraine (Lysychansk), Belarus (Novopolotsk), Lithuania (Mazeikiai), Finland (Porvoo), Sweden (Stenungsund, Lysekil), Norway (Rafnes), Greece (Aspropyrgos), Austria (Schwechat), Czechia (Litvinov, Kralupy), Slovakia (Slovnaft), Hungary (Tiszaujvaros), Romania (Pitesti, Ploiesti), Bulgaria (Burgas), Serbia (Pancevo), Croatia (Sisak)

**Middle East and Africa (17)**
- Saudi Arabia 3: Haasa 2 (Jubail, Ras Tanura), Hejaz (Yanbu)
- Iran 2: Khuzestan (Abadan, Bandar Imam)
- South Africa 2: Mpumalanga (Secunda), Free State (Sasolburg, Karbochem)
- 1 each: Kuwait (Shuaiba), UAE (Jebel Ali), Qatar (Mesaieed), Iraq (Baiji), Syria (Homs), Israel (Haifa), Algeria (Skikda), Egypt (Alexandria), Libya (Ras Lanuf, Brega), Nigeria (Port Harcourt, Eleme)

**Asia-Pacific (32)**
- Japan 6: Kanto 2 (Kawasaki, Chiba, Kashima), Chubu (Yokkaichi), Kyushu (Oita), Tohoku (Sendai), Hokkaido (Muroran, Tomakomai)
- China 6: Shandong (Qilu), Beijing (Yanshan), Gansu (Lanzhou), Nanjing (Yangzi, Jinling), Liaoning (Fushun, Dalian), Guangdong (Maoming)
- South Korea 4: Yeongnam 2 (Ulsan), Honam 2 (Yeosu)
- India 3: West Gujarat (Jamnagar, Vadodara), Mumbai (Trombay), Braj (Mathura, Bareilly)
- Taiwan 2 (Kaohsiung: CPC, Linyuan, TSRC), Singapore 2 (Jurong Island)
- 1 each: Indonesia (Cilacap), Malaysia (Kerteh), Thailand (Map Ta Phut), Philippines (Limay), Pakistan (Karachi), Australia (Altona, Qenos), Kazakhstan (Atyrau), Azerbaijan (Baku, Sumgait), Uzbekistan (Fergana)

## Checks

`validate_history.py` clean, `pre-commit run` on the staged set clean.
