### PR TITLE
Stop the zombie horde flying, hoarding, and collecting canal tolls

### DIFF
--- a/common/ideas/zombies.txt
+++ b/common/ideas/zombies.txt
@@ -1,10 +1,8 @@
 ideas = {
 	country = {
 		shock_and_zombie_awe = {
-			allowed_civil_war = { always = yes }
-
 			picture = the_zombies
-
+			allowed_civil_war = { always = yes }
 			modifier = {
 				army_attack_factor = 0.35
 				army_defence_factor = 0.35
@@ -14,10 +12,8 @@ ideas = {
 		}
 
 		Zombie = {
-			allowed_civil_war = { always = yes }
-
 			picture = the_zombies
-
+			allowed_civil_war = { always = yes }
 			modifier = {
 				nationalist_drift = 100
 				conscription = 0.975
@@ -29,12 +25,21 @@ ideas = {
 				monthly_population = -10
 				land_night_attack = 1.0
 				supply_consumption_factor = -0.95 # Gotta have SOME brains yk
-
+				army_morale_factor = 1.00
+				mobilization_speed = 1.00
+				org_damage_multiplier = -0.50
+				str_damage_multiplier = 0.50
+				cas_damage_reduction = 0.25
+				enemy_army_bonus_air_superiority_factor = -1.00
+				equipment_capture_factor = -1.00
+				war_support_factor = 1.00
+				weekly_casualties_war_support = 0.05
+				weekly_convoys_war_support = 0.05
+				weekly_bombing_war_support = 0.05
 				democratic_acceptance = -100
 				communism_acceptance = -100
 				nationalist_acceptance = -100
 				fascism_acceptance = -100
-
 				hidden_modifier = {
 					industrial_capacity_factory = 1.50
 					ai_focus_aggressive_factor = 1000
@@ -43,10 +48,8 @@ ideas = {
 			}
 		}
 		ZOM_cure_developed = {
-			allowed_civil_war = { always = yes }
-
 			picture = the_zombies
-
+			allowed_civil_war = { always = yes }
 			targeted_modifier = {
 				tag = ZOM
 				defense_bonus_against = 0.10
@@ -55,10 +58,8 @@ ideas = {
 		}
 
 		better_instincts = {
-			allowed_civil_war = { always = yes }
-
 			picture = the_zombies
-
+			allowed_civil_war = { always = yes }
 			modifier = {
 				army_org_factor = 1
 				army_infantry_attack_factor = 1

--- a/common/on_actions/02_dod_on_actions.txt
+++ b/common/on_actions/02_dod_on_actions.txt
@@ -6,6 +6,7 @@ on_actions = {
 			#Panama and Suez income shifted to controller
 			if = {
 				limit = {
+					NOT = { MD_special_countries = yes }
 					OR = {
 						AND = {
 							FROM.FROM = { state = 852 }
@@ -21,6 +22,7 @@ on_actions = {
 			}
 			if = {
 				limit = {
+					NOT = { MD_special_countries = yes }
 					OR = {
 						AND = {
 							FROM.FROM = { state = 213 }
@@ -48,15 +50,22 @@ on_actions = {
 					}
 				}
 				ROOT = {
-					add_ideas = partial_control_of_suez
+					if = {
+						limit = { NOT = { MD_special_countries = yes } }
+						add_ideas = partial_control_of_suez
+					}
 				}
 				FROM = {
-					add_ideas = partial_control_of_suez
+					if = {
+						limit = { NOT = { MD_special_countries = yes } }
+						add_ideas = partial_control_of_suez
+					}
 				}
 			}
 			#Gate awal to asia income shifted to controller
 			if = {
 				limit = {
+					NOT = { MD_special_countries = yes }
 					OR = {
 						AND = {
 							FROM.FROM = { state = 530 }

--- a/common/on_actions/99_ZOM_on_actions.txt
+++ b/common/on_actions/99_ZOM_on_actions.txt
@@ -160,6 +160,8 @@ on_actions = {
 
 	on_monthly_ZOM = {
 		effect = {
+			ZOM_purge_captured_equipment = yes
+
 			add_manpower = -100000
 			capital_scope = {
 				create_unit = {

--- a/common/scripted_effects/00_ZOM_scripted_effects.txt
+++ b/common/scripted_effects/00_ZOM_scripted_effects.txt
@@ -262,3 +262,141 @@ ZOM_execute_zombie_spawn = {
 		}
 	}
 }
+
+# No engine effect deletes an air wing, so draining the stockpile that annexations keep refilling is the only way to keep zombies out of cockpits.
+ZOM_purge_captured_equipment = {
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@infantry_weapons_type multiply = -1 } }
+	add_equipment_to_stockpile = { type = infantry_weapons_type amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@land_drone_equipment_type multiply = -1 } }
+	add_equipment_to_stockpile = { type = land_drone_equipment_type amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cnc_equipment_type multiply = -1 } }
+	add_equipment_to_stockpile = { type = cnc_equipment_type amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@AA_Equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = AA_Equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@L_AT_Equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = L_AT_Equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@H_AT_Equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = H_AT_Equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@artillery_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = artillery_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@space_artillery_equipment_type multiply = -1 } }
+	add_equipment_to_stockpile = { type = space_artillery_equipment_type amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@util_vehicle_type multiply = -1 } }
+	add_equipment_to_stockpile = { type = util_vehicle_type amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@heavy_util_vehicle_type multiply = -1 } }
+	add_equipment_to_stockpile = { type = heavy_util_vehicle_type amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@HACS_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = HACS_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@CHIMERA_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = CHIMERA_equipment amount = ZOM_scrap_stock }
+
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@heavy_tank_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = heavy_tank_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@heavy_tank_amphibious_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = heavy_tank_amphibious_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_aa_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_aa_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_artillery_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_artillery_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_destroyer_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_destroyer_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_amphibious_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_amphibious_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_flame_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_flame_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_tank_rocket_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_tank_rocket_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@super_heavy_tank_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = super_heavy_tank_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@super_heavy_tank_destroyer_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = super_heavy_tank_destroyer_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@super_heavy_tank_artillery_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = super_heavy_tank_artillery_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@walker_tank_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = walker_tank_chassis amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@heavy_walker_tank_chassis multiply = -1 } }
+	add_equipment_to_stockpile = { type = heavy_walker_tank_chassis amount = ZOM_scrap_stock }
+
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@small_plane_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = small_plane_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@small_plane_cas_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = small_plane_cas_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@small_plane_strike_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = small_plane_strike_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@small_plane_naval_bomber_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = small_plane_naval_bomber_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@small_plane_suicide_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = small_plane_suicide_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_small_plane_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_small_plane_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_small_plane_cas_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_small_plane_cas_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_small_plane_strike_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_small_plane_strike_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_small_plane_naval_bomber_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_small_plane_naval_bomber_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_small_plane_suicide_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_small_plane_suicide_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_plane_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_plane_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_plane_fighter_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_plane_fighter_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_plane_cas_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_plane_cas_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_plane_suicide_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_plane_suicide_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_plane_maritime_patrol_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_plane_maritime_patrol_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@medium_plane_air_transport_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = medium_plane_air_transport_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_medium_plane_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_medium_plane_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_medium_plane_fighter_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_medium_plane_fighter_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_medium_plane_cas_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_medium_plane_cas_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_medium_plane_scout_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_medium_plane_scout_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_medium_plane_maritime_patrol_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_medium_plane_maritime_patrol_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@cv_medium_plane_air_transport_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = cv_medium_plane_air_transport_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@large_plane_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = large_plane_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@large_plane_maritime_patrol_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = large_plane_maritime_patrol_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@large_plane_awacs_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = large_plane_awacs_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@large_plane_cas_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = large_plane_cas_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@large_plane_air_transport_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = large_plane_air_transport_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@mothership_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = mothership_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@mothership_strike_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = mothership_strike_airframe amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@mothership_naval_bomber_airframe multiply = -1 } }
+	add_equipment_to_stockpile = { type = mothership_naval_bomber_airframe amount = ZOM_scrap_stock }
+
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@Missile multiply = -1 } }
+	add_equipment_to_stockpile = { type = Missile amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@sam_missile_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = sam_missile_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@guided_missile_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = guided_missile_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@hypersonic_missile_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = hypersonic_missile_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@ballistic_missile_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = ballistic_missile_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@nuclear_ballistic_missile_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = nuclear_ballistic_missile_equipment amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@nuclear_missile_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = nuclear_missile_equipment amount = ZOM_scrap_stock }
+
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@convoy multiply = -1 } }
+	add_equipment_to_stockpile = { type = convoy amount = ZOM_scrap_stock }
+	set_temp_variable = { ZOM_scrap_stock = { value = num_equipment@train_equipment multiply = -1 } }
+	add_equipment_to_stockpile = { type = train_equipment amount = ZOM_scrap_stock }
+}

--- a/history/countries/ZOM - Zombies.txt
+++ b/history/countries/ZOM - Zombies.txt
@@ -1,5 +1,6 @@
 capital = 459
 oob = "ZOM_2000"
+set_war_support = 1
 set_research_slots = 0
 set_convoys = 0
 set_country_flag = disabled_economic_system


### PR DESCRIPTION
Closes #2610

## What

- **`ZOM_purge_captured_equipment`** (`common/scripted_effects/00_ZOM_scripted_effects.txt`), called from `on_monthly_ZOM`. Zeroes all 65 non-zombie stockpile archetypes: land, armour, every airframe (including the `duplicate_archetypes` role variants), missiles and satellites, convoys, trains, and the Event Horizon mechs.
- **`Zombie` spirit reworked** (`common/ideas/zombies.txt`): `org_damage_multiplier = -0.50`, `str_damage_multiplier = 0.50`, `cas_damage_reduction = 0.25`, `enemy_army_bonus_air_superiority_factor = -1.00`, `equipment_capture_factor = -1.00`, `army_morale_factor = 1.00`, `mobilization_speed = 1.00`, `war_support_factor = 1.00`, and `weekly_casualties/convoys/bombing_war_support = 0.05`.
- **`set_war_support = 1`** on ZOM (`history/countries/ZOM - Zombies.txt`).
- **`NOT = { MD_special_countries = yes }`** guards on the Panama, Suez, and gateway-to-Asia spirits granted in `on_state_control_changed` (`common/on_actions/02_dod_on_actions.txt`).

## Why

**The horde's aircraft do not come from production.** ZOM has `set_research_slots = 0` and only `zombietech`, which enables the three zombie infantry types and nothing else, so it cannot build a plane. It flies captured ones: annexing a nation transfers that nation's stockpile, and the AI deploys air wings straight out of stockpile. That means the negative `unit_ratio` the issue suggests would be dead script. The engine has no effect that deletes an air wing (`delete_unit*` is divisions only), so draining the stockpile is the only lever there is, and it fixes the bloat in the same pass.

Nothing was draining it before. `ai_weapon_dump` is gated on `has_war = no` and `threat < 0.51`; ZOM is permanently at war with 100 threat, so it never ran.

**War support was load-bearing and set to nothing.** ZOM never runs the startup pass that gives everyone else their laws and spirits, and its history set no base, so it sat at 0 war support and carried the lowest possible surrender limit. Pinning it at 100% is both the flavour the issue asked for and the reason the horde stops folding early.

## How

- The purge reads `num_equipment@<archetype>` (stockpile count, per vanilla's own `NOR.txt` debug string) and subtracts exactly that. An empty line reads 0 and the effect is a no-op, so no gating is needed and nothing can go negative. This avoids relying on undocumented clamping behaviour from a blanket `amount = -1000000`. The `{ value = num_equipment@X multiply = -1 }` shape already appears throughout `00_money_system.txt`.
- Naval hulls are deliberately absent: ships are units, not stockpile equipment.
- The `partial_control_of_suez` guard is applied inside the `ROOT` and `FROM` blocks rather than on the outer `limit`, so a human nation losing half the canal to the horde still gets its own spirit.

## Judgement calls worth a look

- **`org_damage_multiplier`** is a multiplier on org damage *dealt* (see the comment in vanilla `00_critical_parts.txt`), not received. At the `-1.00` a literal reading of the issue implies, the horde could never break a defender's organisation and so could never take a province: mode-breaking. `-0.50` keeps the intent without that.
- The issue asks for `war_support`, which is not a real modifier and would have compiled to nothing. Used `war_support_factor`.
- The issue reads "cas_damage_reduction & str_damage_multiplier ... should be nerfed as org damage is decreased". Both are owner-side modifiers, so I read that as compensation for the org nerf and moved both in the horde's favour.
- **Difficulty goes up.** No air superiority bonus against the horde, less CAS damage, and a maximal surrender limit all make the mode harder. Combined with the horde losing its own air force, air power against zombies is now CAS and bombing only.
- **Convoys and trains are purged too.** That returns ZOM to the zero-logistics baseline it already spawns with (`ZOM_2000` has no trains, `set_convoys = 0`) and its `supply_consumption_factor = -0.95` / `attrition = -1.00` are built for it, but if playtesting shows the horde stalling, those are the two lines to drop.
- Annexations between ticks can still leave the horde up to a month of captured aircraft. The issue asked for monthly; moving the call to `on_weekly_ZOM` would halve that window at negligible cost.

## Not done

The issue's fourth point is truncated mid-sentence on GitHub (the Discord sync bot cut every line at ~100 chars), so "trade, economy ... or other ..." is unrecoverable from the issue text. I checked the named systems anyway: ZOM is not a UN member and cannot become one (it does not exist during the startup `un_recog_setup_check` pass, and the admission event needs a recognition vote it cannot reach), and trade agreements are gated behind `NOT = { has_war_with = ROOT }` plus positive opinion, which the horde can never satisfy. The state-control spirits were the only reachable case, and they are fixed here.

## Note for review

`validate_modifiers.py` warns that `org_damage_multiplier` and `str_damage_multiplier` are unknown. They are valid: both are present in the current game's `modifiers_documentation.md` under scopes `army` and `defensive`, the same bucket as `cas_damage_reduction` and `supply_consumption_factor`, which MD already uses on country spirits. The checked-in `resources/documentation/modifiers_documentation.md` the validator reads predates them. That validator runs `strict: false` in CI precisely for this class of false positive. Refreshing the reference doc is a separate job.
