### PR TITLE
Raise saved focus progress cap from 20 to 30 days

### DIFF
--- a/common/defines/MD_defines.lua
+++ b/common/defines/MD_defines.lua
@@ -971,7 +971,7 @@
 	NDefines.NAI.LAND_DEFENSE_MIN_FACTORIES_FOR_AIR_IMPORTANCE = 2 -- 5; even small nations value air defense
 	NDefines.NAI.MAX_AIR_REGIONS_TO_CARE_ABOUT = 7
 	NDefines.NAir.ACE_WING_SIZE = 24 -- 100; smaller wing size for ace bonus scaling (MD uses smaller wings)
-	NDefines.NFocus.MAX_SAVED_FOCUS_PROGRESS = 20 -- 10; AI can restart more focuses after interruption
+	NDefines.NFocus.MAX_SAVED_FOCUS_PROGRESS = 30 -- 10; a month of focus progress banks while the slot sits empty
 	NDefines.NAI.AI_FRACTION_OF_FIGHTERS_RESERVED_FOR_INTERCEPTION = 0.10
 	NDefines.NAI.WANTED_LAND_PLANES_PER_DIVISION = 30
 	NDefines.NAI.BUILDING_TARGETS_BUILDING_PRIORITIES = {				-- buildings in order of priority when considering building targets strategies. First has the greatest priority, omitted has the lowest. NOTE: not all buildings are supported by building targets strategies.


### PR DESCRIPTION
Closes #2335

**What**

`NDefines.NFocus.MAX_SAVED_FOCUS_PROGRESS` goes from 20 to 30. The national focus slot now banks a full month of progress while it sits empty, instead of 20 days.

**Why**

Requested on Discord. MD had already doubled vanilla's 10, and a month reads more naturally than an arbitrary 20 days.

**How**

The define is denominated in days, not focus points: vanilla sets `FOCUS_POINT_DAYS = 7` with `FOCUS_PROGRESS_PEACE` and `FOCUS_PROGRESS_WAR` both at 1, and MD overrides none of the three. So 30 banked days is 4.29 focus points. That instantly clears any focus costing 4 or less, and covers about 86% of a `cost = 5` focus, which is the single most common cost in the mod. Known and accepted.

Also fixes the trailing comment. It described the define as interruption recovery, but per vanilla's own comment it is empty-slot banking.
