### PR TITLE
Enforce brace and `=` spacing in standardizer output

### DIFF
--- a/tools/linting/fix_styling.py
+++ b/tools/linting/fix_styling.py
@@ -13,6 +13,7 @@ from shared_utils import (
     collect_files_by_mode,
     create_linting_parser,
     get_root_dir,
+    normalize_spacing,
     print_timing_summary,
     run_with_pool,
     strip_inline_comment,
@@ -21,20 +22,6 @@ from shared_utils import (
 __version__ = 2.0
 
 _RE_EQ_SEP = re.compile(r"={3,}")
-_RE_MULTI_SP_BEFORE_EQ = re.compile(r"  +=")
-_RE_MULTI_SP_AFTER_EQ = re.compile(r"=  +")
-_RE_TAB_BEFORE_EQ = re.compile(r"\t+(=)")
-_RE_NO_SP_BEFORE_EQ = re.compile(r"([^\s!<>=])=")
-_RE_NO_SP_AFTER_EQ = re.compile(r"=([^\s=>{])")
-_RE_NO_SP_BEFORE_OPEN = re.compile(r"([^\s])\{")
-_RE_NO_SP_AFTER_OPEN = re.compile(r"\{([^\s\n])")
-_RE_NO_SP_BEFORE_CLOSE = re.compile(r"([^\s])\}")
-_RE_NO_SP_AFTER_CLOSE = re.compile(r"\}([^\s\n}])")
-_RE_MULTI_SP_BEFORE_OPEN = re.compile(r"  +\{")
-_RE_MULTI_SP_AFTER_OPEN = re.compile(r"\{  +")
-_RE_MULTI_SP_BEFORE_CLOSE = re.compile(r"  +\}")
-_RE_MULTI_SP_AFTER_CLOSE = re.compile(r"\}  +")
-_RE_MULTI_SP = re.compile(r"  +")
 
 
 def fix_line(line):
@@ -60,76 +47,25 @@ def fix_line(line):
         # Fix === separator lines in comments (validators flag these as = issues)
         if _RE_EQ_SEP.search(line):
             line = _RE_EQ_SEP.sub(lambda m: "-" * len(m.group()), line)
-            if line != original:
+            fixes += 1
+    else:
+        comment_pos = line.find("#")
+        if comment_pos > 0:
+            comment_part = line[comment_pos:]
+            # Fix === in inline comments too
+            if _RE_EQ_SEP.search(comment_part):
+                line = line[:comment_pos] + _RE_EQ_SEP.sub(
+                    lambda m: "-" * len(m.group()), comment_part
+                )
                 fixes += 1
-        # Remove trailing whitespace on comment lines
-        rstripped = line.rstrip(" \t")
-        if rstripped != line.rstrip("\n"):
-            line = rstripped + "\n" if original.endswith("\n") else rstripped
-            fixes += 1
-        return line, fixes
 
-    comment_pos = line.find("#")
-    if comment_pos > 0:
-        code_part = line[:comment_pos]
-        comment_part = line[comment_pos:]
-        # Fix === in inline comments too
-        if _RE_EQ_SEP.search(comment_part):
-            comment_part = _RE_EQ_SEP.sub(lambda m: "-" * len(m.group()), comment_part)
-            fixes += 1
-    else:
-        code_part = line
-        comment_part = ""
-
-    if "=" in code_part:
-        # Fix double+ spaces before =
-        new_code = _RE_MULTI_SP_BEFORE_EQ.sub(" =", code_part)
-        new_code = _RE_MULTI_SP_AFTER_EQ.sub("= ", new_code)
-        new_code = _RE_TAB_BEFORE_EQ.sub(r" \1", new_code)
-        new_code = _RE_NO_SP_BEFORE_EQ.sub(r"\1 =", new_code)
-        new_code = _RE_NO_SP_AFTER_EQ.sub(r"= \1", new_code)
-        if new_code != code_part:
-            code_part = new_code
-            fixes += 1
-
-    if "{" in code_part or "}" in code_part:
-        new_code = code_part
-        # Add space before { if missing (not at line start)
-        new_code = _RE_NO_SP_BEFORE_OPEN.sub(r"\1 {", new_code)
-        new_code = _RE_NO_SP_AFTER_OPEN.sub(r"{ \1", new_code)
-        new_code = _RE_NO_SP_BEFORE_CLOSE.sub(r"\1 }", new_code)
-        new_code = _RE_NO_SP_AFTER_CLOSE.sub(r"} \1", new_code)
-        # Handle }} -> } } (add space between consecutive closing braces)
-        while "}}" in new_code:
-            new_code = new_code.replace("}}", "} }")
-        # Fix double+ spaces around braces
-        new_code = _RE_MULTI_SP_BEFORE_OPEN.sub(" {", new_code)
-        new_code = _RE_MULTI_SP_AFTER_OPEN.sub("{ ", new_code)
-        new_code = _RE_MULTI_SP_BEFORE_CLOSE.sub(" }", new_code)
-        new_code = _RE_MULTI_SP_AFTER_CLOSE.sub("} ", new_code)
-        if new_code != code_part:
-            code_part = new_code
-            fixes += 1
-
-    code_stripped = code_part.lstrip("\t")
-    code_indent = code_part[: len(code_part) - len(code_stripped)]
-    if "    " in code_stripped:
-        new_stripped = _RE_MULTI_SP.sub(" ", code_stripped)
-        if new_stripped != code_stripped:
-            code_part = code_indent + new_stripped
-            fixes += 1
-
-    line = code_part + comment_part
-
-    if line.endswith("\n"):
-        rstripped = line.rstrip(" \t\n") + "\n"
-    else:
-        rstripped = line.rstrip(" \t")
-    if rstripped != line:
-        line = rstripped
+    newline = line[len(line.rstrip("\r\n")) :]
+    body = line[: len(line) - len(newline)]
+    normalized = normalize_spacing(body)
+    if normalized != body:
         fixes += 1
 
-    return line, fixes
+    return normalized + newline, fixes
 
 
 def fix_file(filepath):

--- a/tools/linting/tests/fix_styling_test.py
+++ b/tools/linting/tests/fix_styling_test.py
@@ -1,0 +1,54 @@
+"""Tests for fix_styling.fix_line after it delegated spacing to normalize_spacing.
+
+Guards the parts fix_line still owns on its own: leading spaces become tabs,
+``===`` runs inside comments become ``---``, and a trailing newline survives.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fix_styling import fix_line  # noqa: E402
+
+
+def test_pads_inline_block():
+    fixed, fixes = fix_line("\t\tNOT = {country_exists = ENG}\n")
+    assert fixed == "\t\tNOT = { country_exists = ENG }\n"
+    assert fixes == 1
+
+
+def test_leading_spaces_become_tabs():
+    fixed, _ = fix_line("    x = { y = 1 }")
+    assert fixed == "\tx = { y = 1 }"
+
+
+def test_equals_separator_in_comment():
+    fixed, _ = fix_line("\t# ==== section ====\n")
+    assert fixed == "\t# ---- section ----\n"
+
+
+def test_inline_comment_preserved():
+    fixed, _ = fix_line("\tfoo=bar  # note ==== here\n")
+    assert fixed == "\tfoo = bar # note ---- here\n"
+
+
+def test_quoted_string_not_rewritten():
+    line = '\tlog = "a=b {c}"\n'
+    assert fix_line(line) == (line, 0)
+
+
+def test_comment_line_keeps_single_newline():
+    line = "# plain {comment}\n"
+    assert fix_line(line) == (line, 0)
+
+
+def test_trailing_whitespace_stripped():
+    fixed, _ = fix_line("\tcost = 10   \n")
+    assert fixed == "\tcost = 10\n"
+
+
+def test_clean_line_reports_no_fixes():
+    line = "\tavailable = { has_country_flag = some_flag }\n"
+    assert fix_line(line) == (line, 0)

--- a/tools/shared_utils.py
+++ b/tools/shared_utils.py
@@ -270,6 +270,51 @@ def _normalize_oneline_braces(text: str) -> str:
     return collapse_ws_outside_quotes("".join(out))
 
 
+_COMPARISON_OPS = {"!=", "==", ">=", "<="}
+
+
+def normalize_spacing(line: str) -> str:
+    """Put single spaces around ``{``, ``}`` and ``=`` in one line of script.
+
+    Leading indentation, ``"..."`` string interiors and any trailing ``#``
+    comment are left byte-exact; a whole-line comment is returned unchanged.
+    ``!=``/``==``/``>=``/``<=`` are padded as one operator, and an empty block
+    keeps the spacing it was written with (``{}`` and ``{ }`` both survive).
+    Idempotent.
+    """
+    code = strip_inline_comment(line)
+    comment = line[len(code) :].strip()
+    stripped = code.strip()
+    if not stripped or stripped.startswith("#"):
+        return line.rstrip()
+
+    indent = code[: len(code) - len(code.lstrip())]
+
+    out: List[str] = []
+    in_str = False
+    i = 0
+    n = len(code)
+    while i < n:
+        c = code[i]
+        if c == '"' and (i == 0 or code[i - 1] != "\\"):
+            in_str = not in_str
+            out.append(c)
+        elif in_str:
+            out.append(c)
+        elif code[i : i + 2] in _COMPARISON_OPS or code[i : i + 2] == "{}":
+            out.append(f" {code[i : i + 2]} ")
+            i += 2
+            continue
+        elif c in "{}=":
+            out.append(f" {c} ")
+        else:
+            out.append(c)
+        i += 1
+
+    body = collapse_ws_outside_quotes("".join(out))
+    return f"{indent}{body} {comment}".rstrip() if comment else f"{indent}{body}"
+
+
 def collapse_or_compact(
     block_lines: List[str], indent: Optional[str] = None
 ) -> List[str]:

--- a/tools/standardization/README.md
+++ b/tools/standardization/README.md
@@ -130,6 +130,14 @@ All standardizers support these command-line options:
 
 ## Code Standards Enforced
 
+### All File Types
+
+Every line written by a standardizer passes through `normalize_spacing`
+(`tools/shared_utils.py`), which puts single spaces around `{`, `}` and `=`, so
+`NOT = {country_exists = ENG}` comes out as `NOT = { country_exists = ENG }`.
+Indentation, `"..."` string interiors and `#` comments are left byte-exact.
+`tools/linting/fix_styling.py` uses the same helper.
+
 ### Focus Trees
 
 - Use `relative_position_id` for positioning

--- a/tools/standardization/common_utils.py
+++ b/tools/standardization/common_utils.py
@@ -19,6 +19,7 @@ from shared_utils import (
     create_backup,
     extract_block,
     log_message,
+    normalize_spacing,
     run_tool_main,
 )
 
@@ -209,7 +210,7 @@ class BaseStandardizer(ABC):
             tmp_path = output_file + ".tmp"
             with open(tmp_path, "w", encoding="utf-8") as f:
                 for line in output_lines:
-                    f.write(line + "\n")
+                    f.write(normalize_spacing(line) + "\n")
             os.replace(tmp_path, output_file)
 
             time_str = format_elapsed(time.time() - self.start_time)

--- a/tools/standardization/standardize_focus_tree.py
+++ b/tools/standardization/standardize_focus_tree.py
@@ -27,6 +27,7 @@ from shared_utils import (
     create_backup,
     extract_block,
     log_message,
+    normalize_spacing,
     strip_inline_comment,
 )
 
@@ -1039,7 +1040,7 @@ def standardize_focus_tree(
     try:
         with open(tmp_path, "w", encoding="utf-8") as f:
             for line in output_lines:
-                f.write(line + "\n")
+                f.write(normalize_spacing(line) + "\n")
         os.replace(tmp_path, output_file)
 
         time_str = format_elapsed(time.time() - start_time)

--- a/tools/standardization/standardize_ideas.py
+++ b/tools/standardization/standardize_ideas.py
@@ -17,6 +17,7 @@ from shared_utils import (
     collapse_or_compact,
     extract_block,
     log_message,
+    normalize_spacing,
     strip_inline_comment,
 )
 
@@ -480,7 +481,7 @@ class IdeaStandardizer(BaseStandardizer):
         try:
             with open(output_file, "w", encoding="utf-8") as f:
                 for line in output_lines:
-                    f.write(line + "\n")
+                    f.write(normalize_spacing(line) + "\n")
 
             time_str = format_elapsed(time.time() - self.start_time)
 

--- a/tools/standardization/tests/standardize_spacing_test.py
+++ b/tools/standardization/tests/standardize_spacing_test.py
@@ -1,0 +1,94 @@
+"""End-to-end guard: standardized output carries MD brace / `=` spacing.
+
+Both writer paths (BaseStandardizer.standardize_file and standardize_focus_tree)
+run every emitted line through normalize_spacing, so a hand-written
+`NOT = {country_exists = ENG}` cannot survive a standardization pass.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+_CLI = Path(__file__).resolve().parents[1] / "standardize.py"
+
+_IDEA_FILE = """ideas = {
+\tcountry = {
+\t\tTST_test_idea = {
+\t\t\tpicture = test_picture
+\t\t\tallowed = {
+\t\t\t\toriginal_tag = TST
+\t\t\t}
+\t\t\tcancel = {
+\t\t\t\tOR = {
+\t\t\t\t\tNOT = {country_exists = ENG}
+\t\t\t\t\tNOT = {TST={has_idea = EU_member}}
+\t\t\t\t\tNOT = {western_liberals_are_in_power=yes}
+\t\t\t\t}
+\t\t\t}
+\t\t\tmodifier = {
+\t\t\t\tpolitical_power_factor = 0.1
+\t\t\t}
+\t\t}
+\t}
+}
+"""
+
+_FOCUS_FILE = """focus_tree = {
+\tid = TST_tree
+\tcountry = {
+\t\tfactor = 0
+\t}
+
+\tfocus = {
+\t\tid = TST_focus
+\t\ticon = GFX_goal_generic_political_pressure
+\t\tx = 0
+\t\ty = 0
+\t\tcost = 10
+\t\tavailable = {
+\t\t\tNOT = {country_exists = ENG}
+\t\t}
+\t\tcompletion_reward = {
+\t\t\tlog = "[GetDateText]: [Root.GetName]: Focus TST_focus"
+\t\t}
+\t}
+}
+"""
+
+
+def _standardize(tmp_path, subcommand, text, name="input.txt"):
+    source = tmp_path / name
+    output = tmp_path / "output.txt"
+    source.write_text(text, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(_CLI), subcommand, str(source), "-o", str(output)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return output.read_text(encoding="utf-8")
+
+
+def test_idea_writer_pads_inline_braces(tmp_path):
+    out = _standardize(tmp_path, "idea", _IDEA_FILE)
+    assert "NOT = { country_exists = ENG }" in out
+    assert "NOT = { TST = { has_idea = EU_member } }" in out
+    assert "NOT = { western_liberals_are_in_power = yes }" in out
+    assert "{country_exists" not in out
+
+
+def test_focus_writer_pads_inline_braces(tmp_path):
+    out = _standardize(tmp_path, "focus", _FOCUS_FILE)
+    assert "NOT = { country_exists = ENG }" in out
+
+
+def test_log_string_survives_standardization(tmp_path):
+    out = _standardize(tmp_path, "focus", _FOCUS_FILE)
+    assert '"[GetDateText]: [Root.GetName]: Focus TST_focus"' in out
+
+
+def test_second_pass_is_a_no_op(tmp_path):
+    first = _standardize(tmp_path, "idea", _IDEA_FILE)
+    second = _standardize(tmp_path, "idea", first, name="second.txt")
+    assert second == first

--- a/tools/tests/shared_utils_spacing_test.py
+++ b/tools/tests/shared_utils_spacing_test.py
@@ -1,0 +1,94 @@
+"""Unit tests for shared_utils.normalize_spacing.
+
+Guards the MD style rule (AGENTS.md) that ``{``, ``}`` and ``=`` carry single
+spaces, while string interiors, comments and indentation stay byte-exact.
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO_ROOT, "tools"))
+
+from shared_utils import normalize_spacing  # noqa: E402
+
+
+def test_pads_inline_block():
+    assert (
+        normalize_spacing("\t\t\t\tNOT = {country_exists = ENG}")
+        == "\t\t\t\tNOT = { country_exists = ENG }"
+    )
+
+
+def test_pads_nested_and_splits_double_close():
+    assert (
+        normalize_spacing("\t\tNOT = {FRA={has_idea = EU_member}}")
+        == "\t\tNOT = { FRA = { has_idea = EU_member } }"
+    )
+
+
+def test_pads_equals():
+    assert (
+        normalize_spacing("\tNOT = {western_liberals_are_in_power=yes}")
+        == "\tNOT = { western_liberals_are_in_power = yes }"
+    )
+
+
+def test_quoted_string_untouched():
+    line = '\tlog = "[GetDateText]: a=b {c}  d"'
+    assert normalize_spacing(line) == line
+
+
+def test_inline_comment_kept_with_single_space():
+    assert (
+        normalize_spacing("\tfoo = {bar = yes}\t# why {this} matters")
+        == "\tfoo = { bar = yes } # why {this} matters"
+    )
+
+
+def test_whole_line_comment_untouched():
+    assert normalize_spacing("\t# a note = {x}") == "\t# a note = {x}"
+
+
+def test_blank_line_untouched():
+    assert normalize_spacing("") == ""
+    assert normalize_spacing("\t\t") == ""
+
+
+def test_indentation_preserved():
+    assert normalize_spacing("\t\t\tid = focus") == "\t\t\tid = focus"
+
+
+def test_already_correct_line_unchanged():
+    line = "\tavailable = { has_country_flag = some_flag }"
+    assert normalize_spacing(line) == line
+
+
+def test_idempotent():
+    once = normalize_spacing("\tNOT={FRA={has_idea=EU_member}}")
+    assert normalize_spacing(once) == once
+
+
+def test_empty_block_keeps_its_spacing():
+    assert normalize_spacing("\ton_add = {}") == "\ton_add = {}"
+    assert normalize_spacing("\tsearch_filters = { }") == "\tsearch_filters = { }"
+
+
+def test_comparison_operators_not_split():
+    assert (
+        normalize_spacing("\tcheck_variable = {x != 3}")
+        == "\tcheck_variable = { x != 3 }"
+    )
+    assert (
+        normalize_spacing("\tcheck_variable = {x>=3}")
+        == "\tcheck_variable = { x >= 3 }"
+    )
+    assert normalize_spacing("\thas_war_support > 0.5") == "\thas_war_support > 0.5"
+
+
+def test_collapses_extra_whitespace_outside_strings():
+    assert normalize_spacing("\tcost   =    10") == "\tcost = 10"
+
+
+def test_trailing_whitespace_stripped():
+    assert normalize_spacing("\tcost = 10   ") == "\tcost = 10"


### PR DESCRIPTION
## Summary

Standardizing a file left hand-written inline blocks untouched, so `NOT = {country_exists = ENG}` survived a pass despite the rule in `AGENTS.md` ("Simple checks on one line: `available = { has_country_flag = some_flag }`"). `common/ideas/05_france.txt` alone carried 151 unpadded opening and 144 unpadded closing braces.

Why it survived: the only single-line renderer, `collapse_or_compact`, pads correctly, but every other path falls back to `compact_block`, which is byte-preserving. The one tool that did pad, `tools/linting/fix_styling.py`, is `stages: [manual]` and never runs on commit; `validate_style.py` only warns.

## Changes

- **`tools/shared_utils.py`** — new `normalize_spacing(line)`: puts single spaces around `{`, `}` and `=`, with indentation, `"..."` string interiors and `#` comments left byte-exact. `!=`/`==`/`>=`/`<=` are padded as one operator, and empty blocks keep the spacing they were written with (`{}` and `{ }` both survive). Idempotent.
- **Standardizer writers** — `BaseStandardizer.standardize_file` (events, decisions, MIO, history), `standardize_focus_tree` and `IdeaStandardizer.standardize_file` run every emitted line through it, so wrapper and top-level lines are covered too.
- **`tools/linting/fix_styling.py`** — `fix_line` delegates to the same helper instead of its own 13-regex stack. Side effects: it no longer rewrites `=` and braces **inside** quoted strings, no longer turns `{}` into `{ }`, and no longer appends a second newline to comment lines.
- **`tools/standardization/README.md`** — documents the writer-level pass.

## Verification

- `python -m pytest`: 1359 passed, +26 new tests, failing set byte-identical to `main` (20 pre-existing environment failures, unchanged).
- `common/ideas/05_france.txt`: 151/144 unpadded braces → 0/0; a second standardization pass is byte-identical; `validate_style` spacing warnings drop to 0.
- `events/France.txt`: all 629 string literals byte-identical to the source; only 738 lines differ from the previous standardizer output, all of them intended spacing fixes.
- ruff, black, pylint (10.00/10) and mypy clean.

## Note for reviewers

`md-standardize` runs on commit for `common/{national_focus,decisions,ideas}` and `events/`, so the first commit touching such a file now also pads every unpadded brace in it — a larger one-time diff than before. That is the intent, but worth knowing before staging unrelated files.
