### PR TITLE
Fix Character-scope errors in CHI general quote on_actions

### DIFF
--- a/common/on_actions/99_CHI_on_actions.txt
+++ b/common/on_actions/99_CHI_on_actions.txt
@@ -358,7 +358,6 @@ on_actions = {
 						rule = allow_fictional_content
 						option = yes
 					}
-					is_ai = no
 					ROOT = {
 						OR = {
 							has_trait = CHI_special_weapons_general
@@ -369,21 +368,19 @@ on_actions = {
 					}
 					FROM = {
 						original_tag = CHI
+						is_ai = no
+						NOT = { has_country_flag = CHI_muted_generals }
 						OR = {
 							has_country_flag = {
 								flag = CHI_cnc_general_quote_used
 								days > 90
 							}
 							NOT = { has_country_flag = CHI_cnc_general_quote_used }
-							NOT = { has_country_flag = CHI_muted_generals }
 						}
 					}
 				}
 				CHI_general_quote_shout = yes
-				if = {
-					limit = { NOT = { has_country_flag = CHI_first_general_quote_shout } }
-					set_country_flag = CHI_first_general_quote_shout
-				}
+				FROM = { set_country_flag = CHI_first_general_quote_shout }
 			}
 		}
 	}
@@ -395,8 +392,6 @@ on_actions = {
 						rule = allow_fictional_content
 						option = yes
 					}
-					CHI = { NOT = { has_country_flag = CHI_muted_generals } }
-					is_ai = no
 					ROOT = {
 						OR = {
 							has_trait = CHI_special_weapons_general
@@ -407,14 +402,12 @@ on_actions = {
 					}
 					FROM = {
 						original_tag = CHI
+						is_ai = no
 						NOT = { has_country_flag = CHI_muted_generals }
 					}
 				}
 				CHI_general_quote_shout = yes
-				if = {
-					limit = { NOT = { has_country_flag = CHI_first_general_quote_shout } }
-					set_country_flag = CHI_first_general_quote_shout
-				}
+				FROM = { set_country_flag = CHI_first_general_quote_shout }
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`error.log` was reporting:

```
[trigger.cpp:457]: common/on_actions/99_CHI_on_actions.txt:361: is_ai: Invalid Scope, supported: Country, provided: Character
```

`on_army_leader_won_combat` and `on_unit_leader_level_up` run in **Character** scope (`ROOT` = unit leader, `FROM` = owner country), but the CHI general-quote blocks placed country-only script at the bare level: `is_ai = no` (both on_actions) and the `set_country_flag = CHI_first_general_quote_shout` write.

Because the flag never landed on CHI, the "mute my generals" decision gated on `visible = { has_country_flag = CHI_first_general_quote_shout }` was permanently hidden.

## Changes

- Moved `is_ai = no` into `FROM = { }` in both on_actions.
- Moved the `CHI_first_general_quote_shout` write into `FROM = { }`. The `if = { limit = { NOT = { has_country_flag = ... } } }` guard around it is dropped — a permanent `set_country_flag` with no `days` is already idempotent.
- Lifted `NOT = { has_country_flag = CHI_muted_generals } ` out of the cooldown `OR` in `on_army_leader_won_combat`. Inside the `OR` it did nothing: once the 90-day cooldown expired the `OR` passed regardless, so muting never actually muted. `on_unit_leader_level_up` already treated it as an AND condition.
- Dropped the duplicate hardcoded `CHI = { NOT = { has_country_flag = CHI_muted_generals } }` in `on_unit_leader_level_up` — it repeats the `FROM` check, and the literal `CHI` tag misses civil-war split-offs where `original_tag = CHI` still holds.

`CHI_general_quote_shout = yes` stays at Character scope: the scripted effect reads traits via `ROOT` and wraps every country effect in its own `FROM = { }`, so it was already correct.

## Test plan

**China (CHI), 2000, `allow_fictional_content = yes`**

- [ ] Recruit/appoint a general with `CHI_special_weapons_general`, `CHI_infantry_general`, `CHI_tank_general`, or `CHI_nuke_general` and win a land combat with them. Voice line plays. (#N)
- [ ] The mute-generals decision becomes visible after the first quote. (#N)
- [ ] Take the mute decision, win another combat and level a general: no further quotes fire. Un-mute restores them. (#N)
- [ ] Playing as any other nation, or as AI China, produces no quotes and no `99_CHI_on_actions.txt` entries in `error.log`. (#N)
