### PR TITLE
Gate doctrine-themed office core spirits on doctrine choices

### DIFF
--- a/common/ideas/zzz_air_spirits.txt
+++ b/common/ideas/zzz_air_spirits.txt
@@ -2,291 +2,223 @@ ideas = {
 	air_force_spirit = {
 
 		independent_air_force_spirit = {
+			modifier = { air_advisor_cost_factor = -0.75 }
 			ledger = air
-			modifier = {
-				air_advisor_cost_factor = -0.75
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		industrial_destruction_spirit = {
-			ledger = air
-			research_bonus = {
-				CAT_large_plane = 0.15
-			}
 			modifier = {
+				strategic_destruction_mastery_gain_factor = 0.10
 				large_plane_airframe_design_cost_factor = -0.50
 				large_plane_maritime_patrol_airframe_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_large_plane = 0.15 }
+			ledger = air
+			available = { has_doctrine = strategic_destruction }
+			ai_will_do = { factor = 1 }
 		}
 
 		ground_element_destruction_spirit = {
-			ledger = air
-			research_bonus = {
-				CAT_medium_plane = 0.15
-			}
 			modifier = {
+				air_battlefield_support_mastery_gain_factor = 0.10
 				medium_plane_airframe_design_cost_factor = -0.50
 				medium_plane_cas_airframe_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_medium_plane = 0.15 }
+			ledger = air
+			available = { has_doctrine = air_battlefield_support }
+			ai_will_do = { factor = 1 }
 		}
 
 		clear_the_skies_spirit = {
-			ledger = air
-			research_bonus = {
-				CAT_medium_plane = 0.15
-			}
 			modifier = {
+				air_supremacy_mastery_gain_factor = 0.10
 				medium_plane_fighter_airframe_design_cost_factor = -0.50
 				medium_plane_airframe_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_medium_plane = 0.15 }
+			ledger = air
+			available = { has_doctrine = air_supremacy }
+			ai_will_do = { factor = 1 }
 		}
 
 		cost_efficient_airforce_spirit = {
-			ledger = air
-			research_bonus = {
-				CAT_small_plane = 0.15
-			}
 			modifier = {
+				local_airspace_defense_mastery_gain_factor = 0.10
 				medium_plane_airframe_design_cost_factor = -0.50
 				small_plane_suicide_airframe_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			research_bonus = { CAT_small_plane = 0.15 }
+			ledger = air
+			available = { has_doctrine = local_airspace_defense }
+			ai_will_do = { factor = 1.5 }
 		}
 
 		naval_support_aviation_spirit = {
-			ledger = air
+			modifier = {
+				carrier_operations_mastery_gain_factor = 0.10
+				cv_medium_plane_airframe_design_cost_factor = -0.50
+				small_plane_airframe_design_cost_factor = -0.50
+			}
 			research_bonus = {
 				CAT_small_plane = 0.15
 				CAT_medium_plane = 0.15
 			}
-			modifier = {
-				cv_medium_plane_airframe_design_cost_factor = -0.50
-				small_plane_airframe_design_cost_factor = -0.50
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			available = { has_doctrine = carrier_operations }
+			ai_will_do = { factor = 1 }
 		}
 
 		helicopter_cavalry_spirit = {
-			ledger = air
-			research_bonus = {
-				CAT_heli = 0.15
-			}
 			modifier = {
+				heavy_gunships_mastery_gain_factor = 0.10
 				heavy_tank_chassis_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_heli = 0.15 }
+			ledger = air
+			available = { has_doctrine = heavy_gunships }
+			ai_will_do = { factor = 1 }
 		}
 
 		effective_training_programs_spirit = {
+			modifier = { air_training_xp_gain_factor = 0.25 }
 			ledger = air
-			modifier = {
-				air_training_xp_gain_factor = 0.25
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		air_crew_surveys_spirit = {
-			ledger = air
 			modifier = {
 				air_doctrine_cost_factor = -0.10
 				air_accidents_factor = -0.25
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 	}
 
 	air_force_command_spirit = {
 
 		battlefield_air_interdiction_spirit = {
-			ledger = air
 			modifier = {
 				ground_attack_factor = 0.05
 				air_escort_efficiency = 0.05
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 
 		cvw_night_fighting_spirit = {
+			modifier = { air_carrier_night_penalty_reduction_factor = 0.33 }
 			ledger = air
-			modifier = {
-				air_carrier_night_penalty_reduction_factor = 0.33
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		veteran_air_instructors_spirit = {
+			modifier = { air_wing_xp_loss_when_killed_factor = -0.25 }
 			ledger = air
-			modifier = {
-				air_wing_xp_loss_when_killed_factor = -0.25
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		centralized_control_spirit = {
-			ledger = air
 			modifier = {
 				air_superiority_detect_factor = 0.1
 				air_mission_efficiency = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 
 		steel_wings_steel_hearts_spirit = {
+			modifier = { air_untrained_pilots_penalty_factor = -0.33 }
 			ledger = air
-			modifier = {
-				air_untrained_pilots_penalty_factor = -0.33
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		home_defence_spirit = {
+			modifier = { air_home_defence_factor = 0.1 }
 			ledger = air
-			modifier = {
-				air_home_defence_factor = 0.1
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		air_power_projection_spirit = {
+			modifier = { air_power_projection_factor = 0.1 }
 			ledger = air
-			modifier = {
-				air_power_projection_factor = 0.1
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		massed_strike_spirit = {
+			modifier = { army_bonus_air_superiority_factor = 0.05 }
 			ledger = air
-			modifier = {
-				army_bonus_air_superiority_factor = 0.05
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		continuous_strike_spirit = {
+			modifier = { air_cas_efficiency = 0.25 }
 			ledger = air
-			modifier = {
-				air_cas_efficiency = 0.25
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		total_devastation_spirit = {
+			modifier = { air_strategic_bomber_bombing_factor = 0.1 }
 			ledger = air
-			modifier = {
-				air_strategic_bomber_bombing_factor = 0.1
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 	}
 
 	air_force_academy_spirit = {
 
 		air_combat_training_courses = {
-			ledger = air
 			modifier = {
 				air_untrained_pilots_penalty_factor = -0.1
 				air_training_xp_gain_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 
 		logistics_training_focus = {
-			ledger = air
 			modifier = {
 				air_manpower_requirement_factor = -0.15
 				air_range_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 
 		aerospace_defence_focus = {
-			ledger = air
 			modifier = {
 				air_home_defence_factor = 0.1
 				air_intercept_efficiency = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 
 		legends_of_the_academy = {
-			ledger = air
 			modifier = {
 				air_ace_generation_chance_factor = 0.15
 				air_ace_bonuses_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 
 		air_dominance_theory = {
-			ledger = air
 			modifier = {
 				air_superiority_efficiency = 0.1
 				air_superiority_detect_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 		the_bomber_must_get_through = {
-			ledger = air
 			modifier = {
 				strategic_bomb_visibility = -0.1
 				air_strategic_bomber_bombing_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = air
+			ai_will_do = { factor = 1 }
 		}
 	}
 }

--- a/common/ideas/zzz_air_spirits.txt
+++ b/common/ideas/zzz_air_spirits.txt
@@ -2,60 +2,61 @@ ideas = {
 	air_force_spirit = {
 
 		independent_air_force_spirit = {
-			modifier = { air_advisor_cost_factor = -0.75 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_advisor_cost_factor = -0.75 }
+			ai_will_do = { base = 1 }
 		}
 
 		industrial_destruction_spirit = {
+			ledger = air
 			modifier = {
 				strategic_destruction_mastery_gain_factor = 0.10
 				large_plane_airframe_design_cost_factor = -0.50
 				large_plane_maritime_patrol_airframe_design_cost_factor = -0.50
 			}
 			research_bonus = { CAT_large_plane = 0.15 }
-			ledger = air
 			available = { has_doctrine = strategic_destruction }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		ground_element_destruction_spirit = {
+			ledger = air
 			modifier = {
 				air_battlefield_support_mastery_gain_factor = 0.10
 				medium_plane_airframe_design_cost_factor = -0.50
 				medium_plane_cas_airframe_design_cost_factor = -0.50
 			}
 			research_bonus = { CAT_medium_plane = 0.15 }
-			ledger = air
 			available = { has_doctrine = air_battlefield_support }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		clear_the_skies_spirit = {
+			ledger = air
 			modifier = {
 				air_supremacy_mastery_gain_factor = 0.10
 				medium_plane_fighter_airframe_design_cost_factor = -0.50
 				medium_plane_airframe_design_cost_factor = -0.50
 			}
 			research_bonus = { CAT_medium_plane = 0.15 }
-			ledger = air
 			available = { has_doctrine = air_supremacy }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		cost_efficient_airforce_spirit = {
+			ledger = air
 			modifier = {
 				local_airspace_defense_mastery_gain_factor = 0.10
 				medium_plane_airframe_design_cost_factor = -0.50
 				small_plane_suicide_airframe_design_cost_factor = -0.50
 			}
 			research_bonus = { CAT_small_plane = 0.15 }
-			ledger = air
 			available = { has_doctrine = local_airspace_defense }
-			ai_will_do = { factor = 1.5 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		naval_support_aviation_spirit = {
+			ledger = air
 			modifier = {
 				carrier_operations_mastery_gain_factor = 0.10
 				cv_medium_plane_airframe_design_cost_factor = -0.50
@@ -65,160 +66,159 @@ ideas = {
 				CAT_small_plane = 0.15
 				CAT_medium_plane = 0.15
 			}
-			ledger = air
 			available = { has_doctrine = carrier_operations }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		helicopter_cavalry_spirit = {
+			ledger = air
 			modifier = {
 				heavy_gunships_mastery_gain_factor = 0.10
 				heavy_tank_chassis_design_cost_factor = -0.50
 			}
 			research_bonus = { CAT_heli = 0.15 }
-			ledger = air
 			available = { has_doctrine = heavy_gunships }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		effective_training_programs_spirit = {
-			modifier = { air_training_xp_gain_factor = 0.25 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_training_xp_gain_factor = 0.25 }
+			ai_will_do = { base = 1 }
 		}
 
 		air_crew_surveys_spirit = {
+			ledger = air
 			modifier = {
 				air_doctrine_cost_factor = -0.10
 				air_accidents_factor = -0.25
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 	}
 
 	air_force_command_spirit = {
 
 		battlefield_air_interdiction_spirit = {
+			ledger = air
 			modifier = {
 				ground_attack_factor = 0.05
 				air_escort_efficiency = 0.05
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		cvw_night_fighting_spirit = {
-			modifier = { air_carrier_night_penalty_reduction_factor = 0.33 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_carrier_night_penalty_reduction_factor = 0.33 }
+			ai_will_do = { base = 1 }
 		}
 
 		veteran_air_instructors_spirit = {
-			modifier = { air_wing_xp_loss_when_killed_factor = -0.25 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_wing_xp_loss_when_killed_factor = -0.25 }
+			ai_will_do = { base = 1 }
 		}
 
 		centralized_control_spirit = {
+			ledger = air
 			modifier = {
 				air_superiority_detect_factor = 0.1
 				air_mission_efficiency = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		steel_wings_steel_hearts_spirit = {
-			modifier = { air_untrained_pilots_penalty_factor = -0.33 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_untrained_pilots_penalty_factor = -0.33 }
+			ai_will_do = { base = 1 }
 		}
 
 		home_defence_spirit = {
-			modifier = { air_home_defence_factor = 0.1 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_home_defence_factor = 0.1 }
+			ai_will_do = { base = 1 }
 		}
 
 		air_power_projection_spirit = {
-			modifier = { air_power_projection_factor = 0.1 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_power_projection_factor = 0.1 }
+			ai_will_do = { base = 1 }
 		}
 
 		massed_strike_spirit = {
-			modifier = { army_bonus_air_superiority_factor = 0.05 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { army_bonus_air_superiority_factor = 0.05 }
+			ai_will_do = { base = 1 }
 		}
 
 		continuous_strike_spirit = {
-			modifier = { air_cas_efficiency = 0.25 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_cas_efficiency = 0.25 }
+			ai_will_do = { base = 1 }
 		}
 
 		total_devastation_spirit = {
-			modifier = { air_strategic_bomber_bombing_factor = 0.1 }
 			ledger = air
-			ai_will_do = { factor = 1 }
+			modifier = { air_strategic_bomber_bombing_factor = 0.1 }
+			ai_will_do = { base = 1 }
 		}
 	}
 
 	air_force_academy_spirit = {
 
 		air_combat_training_courses = {
+			ledger = air
 			modifier = {
 				air_untrained_pilots_penalty_factor = -0.1
 				air_training_xp_gain_factor = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		logistics_training_focus = {
+			ledger = air
 			modifier = {
 				air_manpower_requirement_factor = -0.15
 				air_range_factor = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		aerospace_defence_focus = {
+			ledger = air
 			modifier = {
 				air_home_defence_factor = 0.1
 				air_intercept_efficiency = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		legends_of_the_academy = {
+			ledger = air
 			modifier = {
 				air_ace_generation_chance_factor = 0.15
 				air_ace_bonuses_factor = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		air_dominance_theory = {
+			ledger = air
 			modifier = {
 				air_superiority_efficiency = 0.1
 				air_superiority_detect_factor = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 		the_bomber_must_get_through = {
+			ledger = air
 			modifier = {
 				strategic_bomb_visibility = -0.1
 				air_strategic_bomber_bombing_factor = 0.1
 			}
-			ledger = air
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 	}
 }

--- a/common/ideas/zzz_army_spirits.txt
+++ b/common/ideas/zzz_army_spirits.txt
@@ -4,39 +4,32 @@ ideas = {
 
 		#50% of +1 attack on level up
 		bold_attack_spirit = {
+			modifier = { custom_modifier_tooltip = bold_attack_spirit_tt }
 			ledger = army
-			modifier = {
-				custom_modifier_tooltip = bold_attack_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% of +1 defence on level up
 		tenacious_defense_spirit = {
+			modifier = { custom_modifier_tooltip = tenacious_defense_spirit_tt }
 			ledger = army
-			modifier = {
-				custom_modifier_tooltip = tenacious_defense_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% of +1 planning & logistics on level up
 		meticulous_preparation_spirit = {
+			modifier = { custom_modifier_tooltip = meticulous_preparation_spirit_tt }
 			ledger = army
-			modifier = {
-				custom_modifier_tooltip = meticulous_preparation_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#No negative modifiers
 		best_of_the_best_spirit = {
+			modifier = {
+				army_leader_cost_factor = 0.15
+				land_doctrine_cost_factor = -0.05
+				custom_modifier_tooltip = best_of_the_best_spirit_tt
+			}
 			ledger = army
 			available = {
 				OR = {
@@ -45,18 +38,16 @@ ideas = {
 					has_idea = officer_international_education
 				}
 			}
-			modifier = {
-				army_leader_cost_factor = 0.15
-				custom_modifier_tooltip = best_of_the_best_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
-
+			ai_will_do = { factor = 1 }
 		}
 
 		#Leaders might start one level higher
 		military_science_doctorate_spirit = {
+			modifier = {
+				army_leader_cost_factor = 0.15
+				land_doctrine_cost_factor = -0.10
+				custom_modifier_tooltip = military_science_doctorate_spirit_tt
+			}
 			ledger = army
 			available = {
 				OR = {
@@ -65,43 +56,35 @@ ideas = {
 					has_idea = officer_international_education
 				}
 			}
-			modifier = {
-				army_leader_cost_factor = 0.15
-				custom_modifier_tooltip = military_science_doctorate_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#Cheaper leaders
 		battlefield_promotions_spirit = {
-			ledger = army
 			modifier = {
 				army_leader_cost_factor = -0.15
 				unit_leader_as_advisor_cp_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		#Less army intelligence to enemies
 		electronic_warfare_generals_spirit = {
+			modifier = { army_intel_to_others = -15.0 }
 			ledger = army
-			available = {
-				has_intelligence_agency = yes
-			}
-			modifier = {
-				army_intel_to_others = -15.0
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			available = { has_intelligence_agency = yes }
+			ai_will_do = { factor = 1 }
 		}
 
 		#New leaders start with politically connected or media personality traits
 		political_loyalty_spirit = {
+			modifier = {
+				military_leader_cost_factor = -0.5
+				party_popularity_stability_factor = 0.15
+				political_power_factor = -0.10
+				custom_modifier_tooltip = political_loyalty_spirit_tt
+			}
 			ledger = army
 			available = {
 				OR = {
@@ -110,93 +93,77 @@ ideas = {
 					has_elections = no
 				}
 			}
-			modifier = {
-				military_leader_cost_factor = -0.5
-				party_popularity_stability_factor = 0.15
-				political_power_factor = -0.10
-				custom_modifier_tooltip = political_loyalty_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with trickster, commando or invader traits
 		inventive_leadership_spirit = {
-			ledger = army
 			modifier = {
 				custom_modifier_tooltip = inventive_leadership_spirit_tt
 				trait_naval_invader_xp_gain_factor = 0.2
 				trait_commando_xp_gain_factor = 0.2
 				trait_trickster_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with panzer leader, armoured cavalry leader or air cavalry leader
 		combined_arms_schools_spirit = {
-			ledger = army
 			modifier = {
+				combined_arms_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = combined_arms_schools_spirit_tt
 				trait_panzer_leader_xp_gain_factor = 0.2
 				trait_air_cavalry_leader_xp_gain_factor = 0.2
 				trait_armoured_cavalry_leader_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with engineer, artillery leader or desperate defender
 		deep_defence_spirit = {
-			ledger = army
 			modifier = {
+				defence_in_depth_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = deep_defence_spirit_tt
 				trait_engineer_xp_gain_factor = 0.2
 				trait_artillery_leader_xp_gain_factor = 0.2
 				trait_desperate_defender_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with a terrain trait
 		extreme_weather_spirit = {
-			ledger = army
 			modifier = {
 				custom_modifier_tooltip = extreme_weather_spirit_tt
 				terrain_trait_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with infantry leader
 		infantry_combat_schools_spirit = {
-			ledger = army
 			modifier = {
+				shock_and_awe_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = infantry_combat_schools_spirit_tt
 				trait_infantry_leader_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with guerrilla leader
 		self_taught_academy_spirit = {
-			ledger = army
 			modifier = {
+				guerrilla_warfare_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = self_taught_academy_spirit_tt
 				trait_guerrilla_leader_trait_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 	}
@@ -204,6 +171,11 @@ ideas = {
 	army_spirit = {
 
 		professional_officer_corps_spirit = {
+			modifier = {
+				experience_gain_army_factor = 0.10
+				command_power_gain = 0.2
+				land_doctrine_cost_factor = -0.10
+			}
 			ledger = army
 			available = {
 				if = {
@@ -212,16 +184,11 @@ ideas = {
 				}
 				NOT = { has_idea = officer_baptism_by_fire }
 			}
-			modifier = {
-				experience_gain_army_factor = 0.10
-				command_power_gain = 0.2
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		old_boys_club_spirit = {
+			modifier = { nationalist_drift = 0.05 }
 			ledger = army
 			available = {
 				OR = {
@@ -230,70 +197,44 @@ ideas = {
 					salafist_kingdom_are_in_power = yes
 				}
 			}
-			modifier = {
-				nationalist_drift = 0.05
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		elevated_engineering_corps_spirit = {
-			ledger = army
 			modifier = {
 				trait_engineer_xp_gain_factor = 0.25
 				unit_L_Engi_Comp_design_cost_factor = -0.75
 				dig_in_speed_factor = 0.1
 				max_dig_in_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		quick_improvisation_spirit = {
-			ledger = army
 			modifier = {
 				command_abilities_cost_factor = -0.20
 				command_power_gain = 0.2
 				planning_speed = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		relief_of_command_spirit = {
+			modifier = { army_advisor_cost_factor = -0.50 }
 			ledger = army
-			modifier = {
-				army_advisor_cost_factor = -0.50
-			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ai_will_do = { factor = 1.5 }
 		}
 
 		fanatical_loyalty_spirit = {
+			modifier = { pocket_penalty = -0.2 }
 			ledger = army
-			available = {
-				has_government = fascism
-			}
-			modifier = {
-				pocket_penalty = -0.2
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			available = { has_government = fascism }
+			ai_will_do = { factor = 1 }
 		}
 
 		state_serves_the_military_spirit = {
-			ledger = army
-			available = {
-				OR = {
-					has_idea = the_military
-					nationalist_military_junta_are_in_power = yes
-				}
-			}
 			modifier = {
 				military_spending_cost_factor = -0.25
 				conscription_law_cost_factor = -0.25
@@ -301,64 +242,79 @@ ideas = {
 				foreign_intervention_law_cost_factor = -0.25
 				officer_training_law_cost_factor = -0.25
 			}
-			ai_will_do = {
-				factor = 1
+			ledger = army
+			available = {
+				OR = {
+					has_idea = the_military
+					nationalist_military_junta_are_in_power = yes
+				}
 			}
+			ai_will_do = { factor = 1 }
 		}
 
 		armoured_assault_spirit = {
-			ledger = army
 			modifier = {
+				combined_arms_mastery_gain_factor = 0.10
 				unit_armor_Bat_design_cost_factor = -0.50
 				unit_L_arm_Bat_design_cost_factor = -0.50
 				unit_Arm_Inf_Bat_design_cost_factor = -0.50
 				unit_Mech_Inf_Bat_design_cost_factor = -0.50
 				experience_gain_army_factor = -0.10
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			available = { has_doctrine = combined_arms }
+			ai_will_do = { factor = 1 }
 		}
 
 		superior_firepower_spirit = {
-			ledger = army
 			modifier = {
+				shock_and_awe_mastery_gain_factor = 0.10
 				unit_Arty_Bat_design_cost_factor = -0.50
 				unit_SP_Arty_Bat_design_cost_factor = -0.50
 				unit_SP_AA_Bat_design_cost_factor = -0.50
 				experience_gain_army_factor = -0.10
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			available = { has_doctrine = shock_and_awe }
+			ai_will_do = { factor = 1 }
 		}
 
 		infantry_strength_spirit = {
-			ledger = army
 			modifier = {
+				defence_in_depth_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
 				unit_L_Inf_Bat_design_cost_factor = -0.50
 				unit_Mot_Inf_Bat_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			available = { has_doctrine = defence_in_depth }
+			ai_will_do = { factor = 1 }
 		}
 
 		praetorian_guard_spirit = {
-			ledger = army
 			modifier = {
+				special_forces_mixed_mastery_gain_factor = 0.10
+				special_forces_marine_focus_mastery_gain_factor = 0.10
+				special_forces_airborne_focus_mastery_gain_factor = 0.10
+				special_forces_ranger_focus_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
 				unit_Special_Forces_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
+			ledger = army
+			available = {
+				OR = {
+					has_doctrine = special_forces_mixed
+					has_doctrine = special_forces_marine_focus
+					has_doctrine = special_forces_airborne_focus
+					has_doctrine = special_forces_ranger_focus
+				}
 			}
+			ai_will_do = { factor = 1 }
 		}
 
 		death_from_above_spirit = {
-			ledger = army
 			modifier = {
+				special_forces_airborne_focus_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
 				unit_L_Air_Inf_Bat_design_cost_factor = -0.50
 				unit_Mot_Air_Inf_Bat_design_cost_factor = -0.50
@@ -367,36 +323,26 @@ ideas = {
 				unit_L_Air_assault_Bat_design_cost_factor = -0.50
 				extra_paratrooper_supply_grace = 24
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			available = { has_doctrine = special_forces_airborne_focus }
+			ai_will_do = { factor = 1 }
 		}
 
 		guerrilla_warfare_spirit = {
-			ledger = army
 			modifier = {
+				guerrilla_warfare_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
 				unit_Militia_Bat_design_cost_factor = -0.50
 				unit_Mot_Militia_Bat_design_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			available = { has_doctrine = guerrilla_warfare }
+			ai_will_do = { factor = 1 }
 		}
 
 		# Custom National Spirits
 		BOT_army_against_poaching = {
-			ledger = army
-			allowed = {
-				original_tag = BOT
-			}
-			visible = {
-				original_tag = BOT
-			}
-			available = {
-				has_completed_focus = BOT_anti_poaching_army
-			}
-
+			allowed = { original_tag = BOT }
 			modifier = {
 				custom_modifier_tooltip = BOT_army_against_poaching_tt
 				hidden_modifier = {
@@ -408,85 +354,67 @@ ideas = {
 				army_core_attack_factor = 0.05
 				army_core_defence_factor = 0.05
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			visible = { original_tag = BOT }
+			available = { has_completed_focus = BOT_anti_poaching_army }
+			ai_will_do = { factor = 1 }
 		}
 
 		BOT_army_of_peacekeepers = {
-			allowed = {
-				original_tag = BOT
-			}
-			visible = {
-				original_tag = BOT
-			}
-			available = {
-				has_completed_focus = BOT_peacekeeping_army
-			}
-
+			allowed = { original_tag = BOT }
 			modifier = {
 				political_power_factor = -0.15
 				send_volunteers_tension = -0.20
 				send_volunteer_divisions_required = -0.5
 				send_volunteer_size = 1
 			}
+			visible = { original_tag = BOT }
+			available = { has_completed_focus = BOT_peacekeeping_army }
 		}
 	}
 
 	division_command_spirit = {
 		modern_trench_warfare_spirit = {
-			ledger = army
 			modifier = {
 				max_dig_in_factor = 0.1
 				dig_in_speed_factor = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		flexible_organization_spirit = {
-			ledger = army
 			modifier = {
 				org_loss_when_moving = -0.15
 				army_speed_factor = 0.05
 				choose_preferred_tactics_cost = -15
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		aggressive_reconnaisance_spirit = {
-			ledger = army
 			modifier = {
 				intel_from_combat_factor = 0.15
 				recon_factor = 0.15
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		reserve_officers_spirit = {
-			ledger = army
 			modifier = {
 				tactic_delay_preferred_weight_factor = 1
 				training_time_army_factor = -0.10
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = army
+			ai_will_do = { factor = 1 }
 		}
 
 		victory_or_death_spirit = {
+			modifier = { org_loss_at_low_org_factor = -0.15 }
 			ledger = army
-			modifier = {
-				org_loss_at_low_org_factor = -0.15
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		maneuver_warfare_spirit = {
@@ -495,61 +423,41 @@ ideas = {
 				army_speed_factor = 0.05
 				coordination_bonus = 0.05
 			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ai_will_do = { factor = 1.5 }
 		}
 
 		smoke_and_fire_spirit = {
+			modifier = { breakthrough_factor = 0.05 }
 			ledger = army
-			modifier = {
-				breakthrough_factor = 0.05
-			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ai_will_do = { factor = 1.5 }
 		}
 
 		logistical_focus_spirit = {
-			ledger = army
 			modifier = {
 				supply_consumption_factor = -0.05
 				air_fuel_consumption_factor = -0.05
 				navy_fuel_consumption_factor = -0.05
 			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ledger = army
+			ai_will_do = { factor = 1.5 }
 		}
 
 		operational_reserve_spirit = {
+			modifier = { army_strength_factor = 0.1 }
 			ledger = army
-			modifier = {
-				army_strength_factor = 0.1
-			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ai_will_do = { factor = 1.5 }
 		}
 
 		hit_and_run_spirit = {
+			modifier = { resistance_target_on_our_occupied_states = 0.1 }
 			ledger = army
-			modifier = {
-				resistance_target_on_our_occupied_states = 0.1
-			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ai_will_do = { factor = 1.5 }
 		}
 
 		counter_insurgency_spirit = {
+			modifier = { resistance_target = -0.1 }
 			ledger = army
-			modifier = {
-				resistance_target = -0.1
-			}
-			ai_will_do = {
-				factor = 1.5
-			}
+			ai_will_do = { factor = 1.5 }
 		}
 	}
 

--- a/common/ideas/zzz_army_spirits.txt
+++ b/common/ideas/zzz_army_spirits.txt
@@ -4,33 +4,33 @@ ideas = {
 
 		#50% of +1 attack on level up
 		bold_attack_spirit = {
-			modifier = { custom_modifier_tooltip = bold_attack_spirit_tt }
 			ledger = army
-			ai_will_do = { factor = 1 }
+			modifier = { custom_modifier_tooltip = bold_attack_spirit_tt }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% of +1 defence on level up
 		tenacious_defense_spirit = {
-			modifier = { custom_modifier_tooltip = tenacious_defense_spirit_tt }
 			ledger = army
-			ai_will_do = { factor = 1 }
+			modifier = { custom_modifier_tooltip = tenacious_defense_spirit_tt }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% of +1 planning & logistics on level up
 		meticulous_preparation_spirit = {
-			modifier = { custom_modifier_tooltip = meticulous_preparation_spirit_tt }
 			ledger = army
-			ai_will_do = { factor = 1 }
+			modifier = { custom_modifier_tooltip = meticulous_preparation_spirit_tt }
+			ai_will_do = { base = 1 }
 		}
 
 		#No negative modifiers
 		best_of_the_best_spirit = {
+			ledger = army
 			modifier = {
 				army_leader_cost_factor = 0.15
 				land_doctrine_cost_factor = -0.05
 				custom_modifier_tooltip = best_of_the_best_spirit_tt
 			}
-			ledger = army
 			available = {
 				OR = {
 					has_idea = officer_military_school
@@ -38,17 +38,17 @@ ideas = {
 					has_idea = officer_international_education
 				}
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#Leaders might start one level higher
 		military_science_doctorate_spirit = {
+			ledger = army
 			modifier = {
 				army_leader_cost_factor = 0.15
 				land_doctrine_cost_factor = -0.10
 				custom_modifier_tooltip = military_science_doctorate_spirit_tt
 			}
-			ledger = army
 			available = {
 				OR = {
 					has_idea = officer_military_school
@@ -56,36 +56,36 @@ ideas = {
 					has_idea = officer_international_education
 				}
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#Cheaper leaders
 		battlefield_promotions_spirit = {
+			ledger = army
 			modifier = {
 				army_leader_cost_factor = -0.15
 				unit_leader_as_advisor_cp_cost_factor = -0.50
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#Less army intelligence to enemies
 		electronic_warfare_generals_spirit = {
-			modifier = { army_intel_to_others = -15.0 }
 			ledger = army
+			modifier = { army_intel_to_others = -15.0 }
 			available = { has_intelligence_agency = yes }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#New leaders start with politically connected or media personality traits
 		political_loyalty_spirit = {
+			ledger = army
 			modifier = {
 				military_leader_cost_factor = -0.5
 				party_popularity_stability_factor = 0.15
 				political_power_factor = -0.10
 				custom_modifier_tooltip = political_loyalty_spirit_tt
 			}
-			ledger = army
 			available = {
 				OR = {
 					has_idea = the_military
@@ -93,23 +93,24 @@ ideas = {
 					has_elections = no
 				}
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with trickster, commando or invader traits
 		inventive_leadership_spirit = {
+			ledger = army
 			modifier = {
 				custom_modifier_tooltip = inventive_leadership_spirit_tt
 				trait_naval_invader_xp_gain_factor = 0.2
 				trait_commando_xp_gain_factor = 0.2
 				trait_trickster_xp_gain_factor = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with panzer leader, armoured cavalry leader or air cavalry leader
 		combined_arms_schools_spirit = {
+			ledger = army
 			modifier = {
 				combined_arms_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = combined_arms_schools_spirit_tt
@@ -117,12 +118,12 @@ ideas = {
 				trait_air_cavalry_leader_xp_gain_factor = 0.2
 				trait_armoured_cavalry_leader_xp_gain_factor = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with engineer, artillery leader or desperate defender
 		deep_defence_spirit = {
+			ledger = army
 			modifier = {
 				defence_in_depth_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = deep_defence_spirit_tt
@@ -130,40 +131,39 @@ ideas = {
 				trait_artillery_leader_xp_gain_factor = 0.2
 				trait_desperate_defender_xp_gain_factor = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with a terrain trait
 		extreme_weather_spirit = {
+			ledger = army
 			modifier = {
 				custom_modifier_tooltip = extreme_weather_spirit_tt
 				terrain_trait_xp_gain_factor = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with infantry leader
 		infantry_combat_schools_spirit = {
+			ledger = army
 			modifier = {
 				shock_and_awe_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = infantry_combat_schools_spirit_tt
 				trait_infantry_leader_xp_gain_factor = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with guerrilla leader
 		self_taught_academy_spirit = {
+			ledger = army
 			modifier = {
 				guerrilla_warfare_mastery_gain_factor = 0.10
 				custom_modifier_tooltip = self_taught_academy_spirit_tt
 				trait_guerrilla_leader_trait_xp_gain_factor = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 	}
@@ -171,12 +171,12 @@ ideas = {
 	army_spirit = {
 
 		professional_officer_corps_spirit = {
+			ledger = army
 			modifier = {
 				experience_gain_army_factor = 0.10
 				command_power_gain = 0.2
 				land_doctrine_cost_factor = -0.10
 			}
-			ledger = army
 			available = {
 				if = {
 					limit = { original_tag = BOT }
@@ -184,12 +184,12 @@ ideas = {
 				}
 				NOT = { has_idea = officer_baptism_by_fire }
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		old_boys_club_spirit = {
-			modifier = { nationalist_drift = 0.05 }
 			ledger = army
+			modifier = { nationalist_drift = 0.05 }
 			available = {
 				OR = {
 					nationalist_military_junta_are_in_power = yes
@@ -197,44 +197,45 @@ ideas = {
 					salafist_kingdom_are_in_power = yes
 				}
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		elevated_engineering_corps_spirit = {
+			ledger = army
 			modifier = {
 				trait_engineer_xp_gain_factor = 0.25
 				unit_L_Engi_Comp_design_cost_factor = -0.75
 				dig_in_speed_factor = 0.1
 				max_dig_in_factor = 0.1
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		quick_improvisation_spirit = {
+			ledger = army
 			modifier = {
 				command_abilities_cost_factor = -0.20
 				command_power_gain = 0.2
 				planning_speed = 0.2
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		relief_of_command_spirit = {
-			modifier = { army_advisor_cost_factor = -0.50 }
 			ledger = army
-			ai_will_do = { factor = 1.5 }
+			modifier = { army_advisor_cost_factor = -0.50 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		fanatical_loyalty_spirit = {
-			modifier = { pocket_penalty = -0.2 }
 			ledger = army
+			modifier = { pocket_penalty = -0.2 }
 			available = { has_government = fascism }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		state_serves_the_military_spirit = {
+			ledger = army
 			modifier = {
 				military_spending_cost_factor = -0.25
 				conscription_law_cost_factor = -0.25
@@ -242,17 +243,17 @@ ideas = {
 				foreign_intervention_law_cost_factor = -0.25
 				officer_training_law_cost_factor = -0.25
 			}
-			ledger = army
 			available = {
 				OR = {
 					has_idea = the_military
 					nationalist_military_junta_are_in_power = yes
 				}
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		armoured_assault_spirit = {
+			ledger = army
 			modifier = {
 				combined_arms_mastery_gain_factor = 0.10
 				unit_armor_Bat_design_cost_factor = -0.50
@@ -261,12 +262,12 @@ ideas = {
 				unit_Mech_Inf_Bat_design_cost_factor = -0.50
 				experience_gain_army_factor = -0.10
 			}
-			ledger = army
 			available = { has_doctrine = combined_arms }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		superior_firepower_spirit = {
+			ledger = army
 			modifier = {
 				shock_and_awe_mastery_gain_factor = 0.10
 				unit_Arty_Bat_design_cost_factor = -0.50
@@ -274,24 +275,24 @@ ideas = {
 				unit_SP_AA_Bat_design_cost_factor = -0.50
 				experience_gain_army_factor = -0.10
 			}
-			ledger = army
 			available = { has_doctrine = shock_and_awe }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		infantry_strength_spirit = {
+			ledger = army
 			modifier = {
 				defence_in_depth_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
 				unit_L_Inf_Bat_design_cost_factor = -0.50
 				unit_Mot_Inf_Bat_design_cost_factor = -0.50
 			}
-			ledger = army
 			available = { has_doctrine = defence_in_depth }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		praetorian_guard_spirit = {
+			ledger = army
 			modifier = {
 				special_forces_mixed_mastery_gain_factor = 0.10
 				special_forces_marine_focus_mastery_gain_factor = 0.10
@@ -300,7 +301,6 @@ ideas = {
 				experience_gain_army_factor = -0.10
 				unit_Special_Forces_design_cost_factor = -0.50
 			}
-			ledger = army
 			available = {
 				OR = {
 					has_doctrine = special_forces_mixed
@@ -309,10 +309,11 @@ ideas = {
 					has_doctrine = special_forces_ranger_focus
 				}
 			}
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		death_from_above_spirit = {
+			ledger = army
 			modifier = {
 				special_forces_airborne_focus_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
@@ -323,26 +324,26 @@ ideas = {
 				unit_L_Air_assault_Bat_design_cost_factor = -0.50
 				extra_paratrooper_supply_grace = 24
 			}
-			ledger = army
 			available = { has_doctrine = special_forces_airborne_focus }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		guerrilla_warfare_spirit = {
+			ledger = army
 			modifier = {
 				guerrilla_warfare_mastery_gain_factor = 0.10
 				experience_gain_army_factor = -0.10
 				unit_Militia_Bat_design_cost_factor = -0.50
 				unit_Mot_Militia_Bat_design_cost_factor = -0.50
 			}
-			ledger = army
 			available = { has_doctrine = guerrilla_warfare }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		# Custom National Spirits
 		BOT_army_against_poaching = {
 			allowed = { original_tag = BOT }
+			ledger = army
 			modifier = {
 				custom_modifier_tooltip = BOT_army_against_poaching_tt
 				hidden_modifier = {
@@ -354,10 +355,9 @@ ideas = {
 				army_core_attack_factor = 0.05
 				army_core_defence_factor = 0.05
 			}
-			ledger = army
 			visible = { original_tag = BOT }
 			available = { has_completed_focus = BOT_anti_poaching_army }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		BOT_army_of_peacekeepers = {
@@ -375,46 +375,46 @@ ideas = {
 
 	division_command_spirit = {
 		modern_trench_warfare_spirit = {
+			ledger = army
 			modifier = {
 				max_dig_in_factor = 0.1
 				dig_in_speed_factor = 0.1
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		flexible_organization_spirit = {
+			ledger = army
 			modifier = {
 				org_loss_when_moving = -0.15
 				army_speed_factor = 0.05
 				choose_preferred_tactics_cost = -15
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		aggressive_reconnaisance_spirit = {
+			ledger = army
 			modifier = {
 				intel_from_combat_factor = 0.15
 				recon_factor = 0.15
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		reserve_officers_spirit = {
+			ledger = army
 			modifier = {
 				tactic_delay_preferred_weight_factor = 1
 				training_time_army_factor = -0.10
 			}
-			ledger = army
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		victory_or_death_spirit = {
-			modifier = { org_loss_at_low_org_factor = -0.15 }
 			ledger = army
-			ai_will_do = { factor = 1 }
+			modifier = { org_loss_at_low_org_factor = -0.15 }
+			ai_will_do = { base = 1 }
 		}
 
 		maneuver_warfare_spirit = {
@@ -423,41 +423,41 @@ ideas = {
 				army_speed_factor = 0.05
 				coordination_bonus = 0.05
 			}
-			ai_will_do = { factor = 1.5 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		smoke_and_fire_spirit = {
-			modifier = { breakthrough_factor = 0.05 }
 			ledger = army
-			ai_will_do = { factor = 1.5 }
+			modifier = { breakthrough_factor = 0.05 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		logistical_focus_spirit = {
+			ledger = army
 			modifier = {
 				supply_consumption_factor = -0.05
 				air_fuel_consumption_factor = -0.05
 				navy_fuel_consumption_factor = -0.05
 			}
-			ledger = army
-			ai_will_do = { factor = 1.5 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		operational_reserve_spirit = {
-			modifier = { army_strength_factor = 0.1 }
 			ledger = army
-			ai_will_do = { factor = 1.5 }
+			modifier = { army_strength_factor = 0.1 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		hit_and_run_spirit = {
-			modifier = { resistance_target_on_our_occupied_states = 0.1 }
 			ledger = army
-			ai_will_do = { factor = 1.5 }
+			modifier = { resistance_target_on_our_occupied_states = 0.1 }
+			ai_will_do = { base = 1.5 }
 		}
 
 		counter_insurgency_spirit = {
-			modifier = { resistance_target = -0.1 }
 			ledger = army
-			ai_will_do = { factor = 1.5 }
+			modifier = { resistance_target = -0.1 }
+			ai_will_do = { base = 1.5 }
 		}
 	}
 

--- a/common/ideas/zzz_navy_spirits.txt
+++ b/common/ideas/zzz_navy_spirits.txt
@@ -4,105 +4,105 @@ ideas = {
 
 		#50% of +1 attack on level up
 		instilled_aggression_spirit = {
-			modifier = { custom_modifier_tooltip = instilled_aggression_spirit_tt }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { custom_modifier_tooltip = instilled_aggression_spirit_tt }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% of +1 defence on level up
 		calculated_restraint_spirit = {
-			modifier = { custom_modifier_tooltip = calculated_restraint_spirit_tt }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { custom_modifier_tooltip = calculated_restraint_spirit_tt }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% of +1 maneuvering & coordination on level up
 		signals_training_spirit = {
-			modifier = { custom_modifier_tooltip = signals_training_spirit_tt }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { custom_modifier_tooltip = signals_training_spirit_tt }
+			ai_will_do = { base = 1 }
 		}
 
 		#No negative modifiers
 		best_of_the_best_naval_academy_spirit = {
+			ledger = navy
 			modifier = {
 				navy_leader_cost_factor = 0.15
 				custom_modifier_tooltip = best_of_the_best_naval_academy_spirit_tt
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#Leaders might start one level higher
 		naval_tradition_spirit = {
+			ledger = navy
 			modifier = {
 				navy_leader_cost_factor = 0.15
 				custom_modifier_tooltip = naval_tradition_spirit_tt
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#Cheaper leaders
 		first_mate_to_captain_spirit = {
+			ledger = navy
 			modifier = {
 				navy_leader_cost_factor = -0.15
 				unit_leader_as_advisor_cp_cost_factor = -0.50
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#Less army intelligence to enemies
 		electronic_warfare_admirals_spirit = {
-			modifier = { navy_intel_to_others = -15.0 }
 			ledger = navy
+			modifier = { navy_intel_to_others = -15.0 }
 			available = { has_intelligence_agency = yes }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with seawolf or blockade runner traits
 		convoy_warfare_spirit = {
+			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = convoy_warfare_spirit_tt
 				trait_seawolf_xp_gain_factor = 0.2
 				trait_blockade_runner_xp_gain_factor = 0.2
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with fleet protector, fly swatter or spotter traits
 		littoral_combat_spirit = {
+			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = littoral_combat_spirit_tt
 				trait_fleet_protector_xp_gain_factor = 0.2
 				trait_fly_swatter_xp_gain_factor = 0.2
 				trait_spotter_xp_gain_factor = 0.2
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with ironside or superior tactician traits
 		grand_fleet_spirit = {
+			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = grand_fleet_spirit_tt
 				trait_ironside_xp_gain_factor = 0.2
 				trait_superior_tactician_xp_gain_factor = 0.2
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		#50% to start with air controller trait
 		naval_air_arm_spirit = {
+			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = naval_air_arm_spirit_tt
 				trait_air_controller_xp_gain_factor = 0.2
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 	}
@@ -110,66 +110,67 @@ ideas = {
 	navy_spirit = {
 
 		flexible_contracts_spirit = {
-			modifier = { naval_manufacturer_cost_factor = -0.8 }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { naval_manufacturer_cost_factor = -0.8 }
+			ai_will_do = { base = 1 }
 		}
 
 		integrated_designers_spirit = {
-			research_bonus = { CAT_naval_modules = 0.30 }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			research_bonus = { CAT_naval_modules = 0.30 }
+			ai_will_do = { base = 1 }
 		}
 
 		naval_reform_spirit = {
-			modifier = { experience_gain_navy_factor = 0.15 }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { experience_gain_navy_factor = 0.15 }
+			ai_will_do = { base = 1 }
 		}
 
 		naval_refit_yards_spirit = {
+			ledger = navy
 			modifier = {
 				refit_speed = 0.25
 				repair_speed_factor = 0.15
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		coastal_defence_spirit = {
+			ledger = navy
 			modifier = {
 				green_water_mastery_gain_factor = 0.10
 				corvette_design_cost_factor = -0.5
 			}
 			research_bonus = { CAT_corvette = 0.20 }
-			ledger = navy
 			available = { has_doctrine = green_water }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		multi_purpose_ships_spirit = {
+			ledger = navy
 			modifier = {
 				green_water_mastery_gain_factor = 0.10
 				frigate_design_cost_factor = -0.5
 			}
 			research_bonus = { CAT_frigate = 0.20 }
-			ledger = navy
 			available = { has_doctrine = green_water }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		jeune_ecole_spirit = {
+			ledger = navy
 			modifier = {
 				jeune_ecole_mastery_gain_factor = 0.10
 				patrol_boat_design_cost_factor = -0.5
 			}
 			research_bonus = { CAT_corvette = 0.20 }
-			ledger = navy
 			available = { has_doctrine = jeune_ecole }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		big_guns_spirit = {
+			ledger = navy
 			modifier = {
 				blue_water_mastery_gain_factor = 0.10
 				cruiser_design_cost_factor = -0.5
@@ -177,36 +178,36 @@ ideas = {
 				battleship_hull_0_design_cost_factor = -0.5
 			}
 			research_bonus = { CAT_cruiser = 0.20 }
-			ledger = navy
 			available = { has_doctrine = blue_water }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		silent_killers_spirit = {
+			ledger = navy
 			modifier = {
 				guerre_de_course_mastery_gain_factor = 0.10
 				attack_submarine_design_cost_factor = -0.5
 				missile_submarine_design_cost_factor = -0.5
 			}
 			research_bonus = { CAT_sub = 0.20 }
-			ledger = navy
 			available = { has_doctrine = guerre_de_course }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		power_projection_spirit = {
+			ledger = navy
 			modifier = {
 				blue_water_mastery_gain_factor = 0.10
 				helicopter_operator_design_cost_factor = -0.5
 				carrier_design_cost_factor = -0.5
 			}
 			research_bonus = { CAT_carrier = 0.20 }
-			ledger = navy
 			available = { has_doctrine = blue_water }
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		marine_corps_spirit = {
+			ledger = navy
 			modifier = {
 				experience_gain_army_factor = -0.50
 				unit_L_Marine_Bat_design_cost_factor = -0.50
@@ -217,87 +218,86 @@ ideas = {
 				extra_marine_supply_grace = 24
 				naval_invasion_planning_bonus_speed = 0.2
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 	}
 
 	naval_command_spirit = {
 
 		close_combat_navy_spirit = {
+			ledger = navy
 			modifier = {
 				navy_screen_attack_factor = 0.05
 				naval_torpedo_screen_penetration_factor = 0.05
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		night_fighting_spirit = {
+			ledger = navy
 			modifier = {
 				night_spotting_chance = 0.1
 				naval_night_attack = 0.1
 				navy_visibility = -0.05
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		surprise_attacks_spirit = {
+			ledger = navy
 			modifier = {
 				naval_retreat_speed_after_initial_combat = 0.1
 				naval_retreat_chance_after_initial_combat = 0.1
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		efficient_communications_spirit = {
-			modifier = { positioning = 0.1 }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { positioning = 0.1 }
+			ai_will_do = { base = 1 }
 		}
 
 		surface_raiders_spirit = {
+			ledger = navy
 			modifier = {
 				screening_without_screens = 0.2
 				naval_retreat_speed = 0.1
 				naval_retreat_chance = 0.1
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		decisive_battle_spirit = {
+			ledger = navy
 			modifier = {
 				naval_retreat_chance = -0.1
 				naval_retreat_speed = -0.1
 				naval_torpedo_hit_chance_factor = 0.1
 				naval_hit_chance = 0.1
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		inclement_weather_experience_spirit = {
-			modifier = { navy_weather_penalty = -0.4 }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { navy_weather_penalty = -0.4 }
+			ai_will_do = { base = 1 }
 		}
 
 		brave_commanders_spirit = {
+			ledger = navy
 			modifier = {
 				naval_critical_score_chance_factor = 0.15
 				naval_retreat_chance = -0.05
 			}
-			ledger = navy
-			ai_will_do = { factor = 1 }
+			ai_will_do = { base = 1 }
 		}
 
 		bureau_of_ordnance_spirit = {
-			modifier = { naval_torpedo_hit_chance_factor = 0.1 }
 			ledger = navy
-			ai_will_do = { factor = 1 }
+			modifier = { naval_torpedo_hit_chance_factor = 0.1 }
+			ai_will_do = { base = 1 }
 		}
 
 	}

--- a/common/ideas/zzz_navy_spirits.txt
+++ b/common/ideas/zzz_navy_spirits.txt
@@ -4,137 +4,105 @@ ideas = {
 
 		#50% of +1 attack on level up
 		instilled_aggression_spirit = {
+			modifier = { custom_modifier_tooltip = instilled_aggression_spirit_tt }
 			ledger = navy
-			modifier = {
-				custom_modifier_tooltip = instilled_aggression_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% of +1 defence on level up
 		calculated_restraint_spirit = {
+			modifier = { custom_modifier_tooltip = calculated_restraint_spirit_tt }
 			ledger = navy
-			modifier = {
-				custom_modifier_tooltip = calculated_restraint_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% of +1 maneuvering & coordination on level up
 		signals_training_spirit = {
+			modifier = { custom_modifier_tooltip = signals_training_spirit_tt }
 			ledger = navy
-			modifier = {
-				custom_modifier_tooltip = signals_training_spirit_tt
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		#No negative modifiers
 		best_of_the_best_naval_academy_spirit = {
-			ledger = navy
 			modifier = {
 				navy_leader_cost_factor = 0.15
 				custom_modifier_tooltip = best_of_the_best_naval_academy_spirit_tt
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		#Leaders might start one level higher
 		naval_tradition_spirit = {
-			ledger = navy
 			modifier = {
 				navy_leader_cost_factor = 0.15
 				custom_modifier_tooltip = naval_tradition_spirit_tt
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		#Cheaper leaders
 		first_mate_to_captain_spirit = {
-			ledger = navy
 			modifier = {
 				navy_leader_cost_factor = -0.15
 				unit_leader_as_advisor_cp_cost_factor = -0.50
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		#Less army intelligence to enemies
 		electronic_warfare_admirals_spirit = {
+			modifier = { navy_intel_to_others = -15.0 }
 			ledger = navy
-			available = {
-				has_intelligence_agency = yes
-			}
-			modifier = {
-				navy_intel_to_others = -15.0
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			available = { has_intelligence_agency = yes }
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with seawolf or blockade runner traits
 		convoy_warfare_spirit = {
-			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = convoy_warfare_spirit_tt
 				trait_seawolf_xp_gain_factor = 0.2
 				trait_blockade_runner_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with fleet protector, fly swatter or spotter traits
 		littoral_combat_spirit = {
-			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = littoral_combat_spirit_tt
 				trait_fleet_protector_xp_gain_factor = 0.2
 				trait_fly_swatter_xp_gain_factor = 0.2
 				trait_spotter_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with ironside or superior tactician traits
 		grand_fleet_spirit = {
-			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = grand_fleet_spirit_tt
 				trait_ironside_xp_gain_factor = 0.2
 				trait_superior_tactician_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		#50% to start with air controller trait
 		naval_air_arm_spirit = {
-			ledger = navy
 			modifier = {
 				custom_modifier_tooltip = naval_air_arm_spirit_tt
 				trait_air_controller_xp_gain_factor = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 	}
@@ -142,130 +110,103 @@ ideas = {
 	navy_spirit = {
 
 		flexible_contracts_spirit = {
+			modifier = { naval_manufacturer_cost_factor = -0.8 }
 			ledger = navy
-			modifier = {
-				naval_manufacturer_cost_factor = -0.8
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		integrated_designers_spirit = {
+			research_bonus = { CAT_naval_modules = 0.30 }
 			ledger = navy
-			research_bonus = {
-				CAT_naval_modules = 0.30
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		naval_reform_spirit = {
+			modifier = { experience_gain_navy_factor = 0.15 }
 			ledger = navy
-			modifier = {
-				experience_gain_navy_factor = 0.15
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		naval_refit_yards_spirit = {
-			ledger = navy
 			modifier = {
 				refit_speed = 0.25
 				repair_speed_factor = 0.15
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		coastal_defence_spirit = {
-			ledger = navy
-			research_bonus = {
-				CAT_corvette = 0.20
-			}
 			modifier = {
+				green_water_mastery_gain_factor = 0.10
 				corvette_design_cost_factor = -0.5
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_corvette = 0.20 }
+			ledger = navy
+			available = { has_doctrine = green_water }
+			ai_will_do = { factor = 1 }
 		}
 
 		multi_purpose_ships_spirit = {
-			ledger = navy
-			research_bonus = {
-				CAT_frigate = 0.20
-			}
 			modifier = {
+				green_water_mastery_gain_factor = 0.10
 				frigate_design_cost_factor = -0.5
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_frigate = 0.20 }
+			ledger = navy
+			available = { has_doctrine = green_water }
+			ai_will_do = { factor = 1 }
 		}
 
 		jeune_ecole_spirit = {
-			ledger = navy
-			research_bonus = {
-				CAT_corvette = 0.20
-			}
 			modifier = {
+				jeune_ecole_mastery_gain_factor = 0.10
 				patrol_boat_design_cost_factor = -0.5
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_corvette = 0.20 }
+			ledger = navy
+			available = { has_doctrine = jeune_ecole }
+			ai_will_do = { factor = 1 }
 		}
 
 		big_guns_spirit = {
-			ledger = navy
-			research_bonus = {
-				CAT_cruiser = 0.20
-			}
 			modifier = {
+				blue_water_mastery_gain_factor = 0.10
 				cruiser_design_cost_factor = -0.5
 				battle_cruiser_design_cost_factor = -0.5
 				battleship_hull_0_design_cost_factor = -0.5
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_cruiser = 0.20 }
+			ledger = navy
+			available = { has_doctrine = blue_water }
+			ai_will_do = { factor = 1 }
 		}
 
 		silent_killers_spirit = {
-			ledger = navy
-			research_bonus = {
-				CAT_sub = 0.20
-			}
 			modifier = {
+				guerre_de_course_mastery_gain_factor = 0.10
 				attack_submarine_design_cost_factor = -0.5
 				missile_submarine_design_cost_factor = -0.5
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_sub = 0.20 }
+			ledger = navy
+			available = { has_doctrine = guerre_de_course }
+			ai_will_do = { factor = 1 }
 		}
 
 		power_projection_spirit = {
-			ledger = navy
-			research_bonus = {
-				CAT_carrier = 0.20
-			}
 			modifier = {
+				blue_water_mastery_gain_factor = 0.10
 				helicopter_operator_design_cost_factor = -0.5
 				carrier_design_cost_factor = -0.5
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			research_bonus = { CAT_carrier = 0.20 }
+			ledger = navy
+			available = { has_doctrine = blue_water }
+			ai_will_do = { factor = 1 }
 		}
 
 		marine_corps_spirit = {
-			ledger = navy
 			modifier = {
 				experience_gain_army_factor = -0.50
 				unit_L_Marine_Bat_design_cost_factor = -0.50
@@ -276,112 +217,87 @@ ideas = {
 				extra_marine_supply_grace = 24
 				naval_invasion_planning_bonus_speed = 0.2
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 	}
 
 	naval_command_spirit = {
 
 		close_combat_navy_spirit = {
-			ledger = navy
 			modifier = {
 				navy_screen_attack_factor = 0.05
 				naval_torpedo_screen_penetration_factor = 0.05
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		night_fighting_spirit = {
-			ledger = navy
 			modifier = {
 				night_spotting_chance = 0.1
 				naval_night_attack = 0.1
 				navy_visibility = -0.05
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		surprise_attacks_spirit = {
-			ledger = navy
 			modifier = {
 				naval_retreat_speed_after_initial_combat = 0.1
 				naval_retreat_chance_after_initial_combat = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		efficient_communications_spirit = {
+			modifier = { positioning = 0.1 }
 			ledger = navy
-			modifier = {
-				positioning = 0.1
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		surface_raiders_spirit = {
-			ledger = navy
 			modifier = {
 				screening_without_screens = 0.2
 				naval_retreat_speed = 0.1
 				naval_retreat_chance = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		decisive_battle_spirit = {
-			ledger = navy
 			modifier = {
 				naval_retreat_chance = -0.1
 				naval_retreat_speed = -0.1
 				naval_torpedo_hit_chance_factor = 0.1
 				naval_hit_chance = 0.1
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		inclement_weather_experience_spirit = {
+			modifier = { navy_weather_penalty = -0.4 }
 			ledger = navy
-			modifier = {
-				navy_weather_penalty = -0.4
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 		brave_commanders_spirit = {
-			ledger = navy
 			modifier = {
 				naval_critical_score_chance_factor = 0.15
 				naval_retreat_chance = -0.05
 			}
-			ai_will_do = {
-				factor = 1
-			}
+			ledger = navy
+			ai_will_do = { factor = 1 }
 		}
 
 		bureau_of_ordnance_spirit = {
+			modifier = { naval_torpedo_hit_chance_factor = 0.1 }
 			ledger = navy
-			modifier = {
-				naval_torpedo_hit_chance_factor = 0.1
-			}
-			ai_will_do = {
-				factor = 1
-			}
+			ai_will_do = { factor = 1 }
 		}
 
 	}

--- a/tools/standardization/standardize_ideas.py
+++ b/tools/standardization/standardize_ideas.py
@@ -21,7 +21,7 @@ from shared_utils import (
     strip_inline_comment,
 )
 
-_SINGLE_LINE_PROPS = {"name", "picture"}
+_SINGLE_LINE_PROPS = {"name", "picture", "ledger"}
 
 _BLOCK_PROPS = {
     "allowed",
@@ -133,6 +133,7 @@ class IdeaStandardizer(BaseStandardizer):
             "allowed": [],
             "allowed_civil_war": [],
             "picture": "",
+            "ledger": "",
             "cancel": [],
             "modifier": [],
             "targeted_modifier": [],
@@ -395,11 +396,23 @@ class IdeaStandardizer(BaseStandardizer):
             emit_comments("picture")
             lines.append(prop_indent + props["picture"])
 
-        # 3-10. Simple blocks emitted in order
+        # 3. allowed-family blocks (gates evaluated once at game start)
         for key in (
             "allowed",
             "allowed_civil_war",
             "cancel",
+        ):
+            for index, block in enumerate(props[key]):
+                emit_comments(key, index)
+                lines.extend(self._reindent_or_collapse(block, prop_indent))
+
+        # 4. ledger (single-line categorisation, sits above the effect blocks)
+        if props["ledger"]:
+            emit_comments("ledger")
+            lines.append(prop_indent + props["ledger"])
+
+        # 5-10. Effect blocks emitted in order
+        for key in (
             "modifier",
             "targeted_modifier",
             "research_bonus",

--- a/tools/standardization/tests/standardize_ideas_test.py
+++ b/tools/standardization/tests/standardize_ideas_test.py
@@ -186,6 +186,32 @@ def test_allowed_tag_rewritten_to_original_tag():
     assert not any(line.strip() == "tag = TAG" for line in out)
 
 
+def test_ledger_emitted_after_allowed_but_before_modifier():
+    block = _idea(
+        [
+            "\tTAG_test_idea = {",
+            "\t\tmodifier = { stability_factor = 0.05 }",
+            "\t\tledger = army",
+            "\t\tallowed = {",
+            "\t\t\toriginal_tag = TAG",
+            "\t\t}",
+            "\t\tai_will_do = { base = 1 }",
+            "\t}",
+        ]
+    )
+    out = _standardize(block)
+    allowed_idx = next(
+        i for i, line in enumerate(out) if line.strip().startswith("allowed")
+    )
+    ledger_idx = next(
+        i for i, line in enumerate(out) if line.strip() == "ledger = army"
+    )
+    modifier_idx = next(
+        i for i, line in enumerate(out) if line.strip().startswith("modifier")
+    )
+    assert allowed_idx < ledger_idx < modifier_idx
+
+
 def test_idempotent():
     block = _idea(
         [


### PR DESCRIPTION
Closes #670.

## What
Doctrine-themed office core spirits (army/navy/air) now require their matching grand doctrine (or, where it is a cleaner fit, a subdoctrine) before they are selectable, and grant a 10% mastery-gain bonus to that doctrine. Officer-corps spirits gain doctrine-progress bonuses (mastery gain for doctrine-school academy spirits; land-doctrine cost reduction for the generic officer-corps spirits).

Also standardizes the touched spirit files: `ai_will_do` uses `base` rather than `factor` at the root (project convention), and the idea standardizer now pins `ledger` directly below the `allowed`-family and above `modifier`/the effect blocks.

## Why
- These core spirits were already named and effect-themed after specific doctrines (armoured_assault, superior_firepower, guerrilla_warfare, jeune_ecole, industrial_destruction, etc.) but any country could pick them regardless of doctrine choice. Gating them makes the office core spirit selection reflect the player's grand/sub doctrine choices, as requested in #670, and the added mastery gain makes each spirit reinforce its doctrine's progression rather than just its unit design costs.
- `base` vs `factor` at the ai_will_do root: the project convention is `base` at root. For these simple one-line blocks (no nested modifiers) the two are numerically equivalent, so the swap is safe.
- `ledger` is a categorisation field; pinning it above the effect blocks (and below `allowed`) gives idea blocks a consistent layout. Only three idea files in the repo currently use `ledger` (these three spirit files), so the retroactive re-standardize is scoped to them.

## How
- Core spirits: added `available = { has_doctrine = <grand_doctrine> }` and a `<grand_doctrine>_mastery_gain_factor = 0.10` line. Single-doctrine gates for the 1:1 matches; `death_from_above` gates on the `special_forces_airborne_focus` grand doctrine; `praetorian_guard` gates on an OR of all four `special_forces_*` grand doctrines (and carries all four mastery-gain lines, since only the active one fires).
- Selective subdoctrine gating (Option C) where the 1:1 match is a subdoctrine, not a grand doctrine: `naval_support_aviation_spirit` -> `carrier_operations` (naval subdoctrine), `helicopter_cavalry_spirit` -> `heavy_gunships` (air subdoctrine).
- Officer corps: academy doctrine-school spirits (`combined_arms_schools`, `deep_defence`, `infantry_combat_schools`, `self_taught_academy`) gain matching grand-doctrine mastery gain with no new gate (the modifier is a no-op unless that doctrine is held, so the school stays pickable early). `professional_officer_corps_spirit`, `military_science_doctorate_spirit`, and `best_of_the_best_spirit` gain `land_doctrine_cost_factor` reduction.
- `helicopter_cavalry_spirit` keeps its existing `heavy_tank_chassis_design_cost_factor` — in MD `heavy_tank_chassis` is the designable attack-helicopter chassis (`common/units/equipment/equipment_archetypes.md`), so the bonus is correct and synergistic with the `heavy_gunships` gate.
- Standardizer (`tools/standardization/standardize_ideas.py`): `ledger` added to the recognised single-line props and emitted in a new fixed position (after `allowed`/`allowed_civil_war`/`cancel`, before `modifier`/`targeted_modifier`/`research_bonus`/`rule`/`equipment_bonus`). Regression test added in `standardize_ideas_test.py`; full `python -m pytest` suite green.

## Scope and follow-ups
- Non-doctrine core spirits are untouched, so countries with no grand doctrine unlocked still have core spirits to pick.
- Legacy spirits are accepted for now: HOI4 does not auto-remove an idea when its `available` turns false, so a country that switches grand doctrines keeps the old spirit. Forced-removal handling is tracked in #3028.
- Navy/air officer-corps doctrine-gain (e.g. `naval_doctrine_cost_factor` / `air_doctrine_cost_factor` equivalents) is deferred to #3027; this pass is land-only for officer-corps bonuses.

## Notes
- The idea-file diffs are large because the pre-commit `md-standardize` auto-fixer restandardizes the whole touched file (collapsing simple one-line blocks, reordering fields to the canonical layout, and now placing `ledger` above `modifier`). The functional changes are the `available` gates, the `*_mastery_gain_factor` / `land_doctrine_cost_factor` lines, and the `factor`->`base` swap; the rest is mechanical reformatting of pre-existing blocks.
- No new localisation: `has_doctrine` and `*_mastery_gain_factor` are engine/auto-mapped per `common/doctrines/_documentation.md` and already used in `common/dynamic_modifiers/99_CHI_dynamic_modifiers.txt` / `99_GRE_dynamic_modifiers.txt`.