### PR TITLE
Stop reserve currency adoption counts going negative

### DIFF
--- a/common/ideas/AA_law_expanded_economics.txt
+++ b/common/ideas/AA_law_expanded_economics.txt
@@ -4,17 +4,15 @@ ideas = {
 		use_list_view = yes
 
 		comprehensive_regulations = {
-			cost = 100
-			removal_cost = -1
-			level = 1
-
 			modifier = {
 				buildings_worker_requirement_modifier = 0.25
 				high_unemployment_threshold_modifier = -0.05
 				stability_factor = 0.04
 				weekly_casualties_war_support = -0.005
 			}
-
+			cost = 100
+			removal_cost = -1
+			level = 1
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -58,16 +56,14 @@ ideas = {
 		}
 
 		strong_regulations = {
-			cost = 75
-			removal_cost = -1
-			level = 2
-
 			modifier = {
 				buildings_worker_requirement_modifier = 0.12
 				high_unemployment_threshold_modifier = -0.02
 				stability_factor = 0.02
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 2
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -107,24 +103,19 @@ ideas = {
 			cost = 50
 			removal_cost = -1
 			level = 3
-
-			ai_will_do = {
-				base = 5
-			}
+			ai_will_do = { base = 5 }
 		}
 
 		light_regulations = {
-			cost = 75
-			removal_cost = -1
-			level = 4
-
 			modifier = {
 				buildings_worker_requirement_modifier = -0.12
 				high_unemployment_threshold_modifier = 0.02
 				production_speed_buildings_factor = 0.02
 				stability_factor = -0.02
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 4
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -158,17 +149,15 @@ ideas = {
 		}
 
 		minimal_regulations = {
-			cost = 100
-			removal_cost = -1
-			level = 5
-
 			modifier = {
 				buildings_worker_requirement_modifier = -0.25
 				high_unemployment_threshold_modifier = 0.05
 				production_speed_buildings_factor = 0.04
 				stability_factor = -0.04
 			}
-
+			cost = 100
+			removal_cost = -1
+			level = 5
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -209,15 +198,14 @@ ideas = {
 		use_list_view = yes
 
 		fully_privatized_healthcare = {
-			cost = 100
-			removal_cost = -1
-			level = 1
-
 			modifier = {
 				health_cost_multiplier_modifier = -0.35
 				healthcare_income_multiplier_modifier = -0.40
 				healthcare_workforce_requirement_modifier = -0.15
 			}
+			cost = 100
+			removal_cost = -1
+			level = 1
 			available = {
 				NOT = {
 					OR = {
@@ -227,7 +215,6 @@ ideas = {
 					}
 				}
 			}
-
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -256,15 +243,14 @@ ideas = {
 		}
 
 		partially_privatized_healthcare = {
-			cost = 75
-			removal_cost = -1
-			level = 2
-
 			modifier = {
 				health_cost_multiplier_modifier = -0.15
 				healthcare_income_multiplier_modifier = -0.20
 				healthcare_workforce_requirement_modifier = -0.08
 			}
+			cost = 75
+			removal_cost = -1
+			level = 2
 			available = {
 				NOT = {
 					OR = {
@@ -273,7 +259,6 @@ ideas = {
 					}
 				}
 			}
-
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -295,15 +280,14 @@ ideas = {
 		}
 
 		partially_nationalized_healthcare = {
-			cost = 75
-			removal_cost = -1
-			level = 3
-
 			modifier = {
 				health_cost_multiplier_modifier = 0.15
 				healthcare_income_multiplier_modifier = 0.15
 				healthcare_workforce_requirement_modifier = 0.08
 			}
+			cost = 75
+			removal_cost = -1
+			level = 3
 			available = {
 				NOT = {
 					OR = {
@@ -312,7 +296,6 @@ ideas = {
 					}
 				}
 			}
-
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -330,15 +313,14 @@ ideas = {
 		}
 
 		fully_nationalized_healthcare = {
-			cost = 100
-			removal_cost = -1
-			level = 4
-
 			modifier = {
 				health_cost_multiplier_modifier = 0.35
 				healthcare_income_multiplier_modifier = 0.30
 				healthcare_workforce_requirement_modifier = 0.15
 			}
+			cost = 100
+			removal_cost = -1
+			level = 4
 			available = {
 				NOT = {
 					OR = {
@@ -348,7 +330,6 @@ ideas = {
 					}
 				}
 			}
-
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -374,10 +355,6 @@ ideas = {
 		use_list_view = yes
 
 		full_environmental_protections = {
-			cost = 100
-			removal_cost = -1
-			level = 1
-
 			modifier = {
 				local_resources_oil_factor = -0.10
 				local_resources_aluminium_factor = -0.10
@@ -394,7 +371,9 @@ ideas = {
 				renewable_infra_cost_multiplier_modifier = -0.10
 				production_speed_fossil_powerplant_factor = -0.10
 			}
-
+			cost = 100
+			removal_cost = -1
+			level = 1
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -426,10 +405,6 @@ ideas = {
 		}
 
 		partial_environmental_protections = {
-			cost = 75
-			removal_cost = -1
-			level = 2
-
 			modifier = {
 				local_resources_oil_factor = -0.05
 				local_resources_aluminium_factor = -0.05
@@ -446,7 +421,9 @@ ideas = {
 				renewable_infra_cost_multiplier_modifier = -0.05
 				production_speed_fossil_powerplant_factor = -0.05
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 2
 			ai_will_do = {
 				base = 2
 				modifier = {
@@ -461,10 +438,6 @@ ideas = {
 		}
 
 		balanced_protections = {
-			cost = 75
-			removal_cost = -1
-			level = 3
-
 			modifier = {
 				local_resources_oil_factor = 0.025
 				local_resources_aluminium_factor = 0.025
@@ -474,7 +447,9 @@ ideas = {
 				local_resources_chromium_factor = 0.025
 				stability_factor = 0.025
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 3
 			ai_will_do = {
 				base = 3
 				modifier = {
@@ -494,10 +469,6 @@ ideas = {
 		}
 
 		economic_motivated_mining = {
-			cost = 75
-			removal_cost = -1
-			level = 4
-
 			modifier = {
 				local_resources_oil_factor = 0.075
 				local_resources_aluminium_factor = 0.075
@@ -512,7 +483,9 @@ ideas = {
 				production_speed_renewable_energy_infra_factor = -0.075
 				production_speed_fossil_powerplant_factor = 0.05
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 4
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -544,10 +517,6 @@ ideas = {
 		}
 
 		strip_mining = {
-			cost = 100
-			removal_cost = -1
-			level = 5
-
 			modifier = {
 				local_resources_oil_factor = 0.125
 				local_resources_aluminium_factor = 0.125
@@ -563,7 +532,9 @@ ideas = {
 				renewable_infra_cost_multiplier_modifier = 0.10
 				production_speed_fossil_powerplant_factor = 0.10
 			}
-
+			cost = 100
+			removal_cost = -1
+			level = 5
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -605,10 +576,6 @@ ideas = {
 		use_list_view = yes
 
 		minimal_maintenance = {
-			cost = 75
-			removal_cost = -1
-			level = 1
-
 			modifier = {
 				infrastructure_cost_multiplier_modifier = -0.25
 				infrastructure_tax_gain_multiplier_modifier = -0.15
@@ -616,7 +583,9 @@ ideas = {
 				energy_gain_multiplier = -0.15
 				energy_use_multiplier = -0.05
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 1
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -641,16 +610,14 @@ ideas = {
 		}
 
 		standard_maintenance = {
-			cost = 75
-			removal_cost = -1
-			level = 2
-
 			modifier = {
 				infrastructure_cost_multiplier_modifier = -0.05
 				energy_gain_multiplier = -0.015
 				energy_use_multiplier = -0.01
 			}
-
+			cost = 75
+			removal_cost = -1
+			level = 2
 			ai_will_do = {
 				base = 3
 				modifier = {
@@ -670,17 +637,15 @@ ideas = {
 		}
 
 		extensive_maintenance = {
-			cost = 100
-			removal_cost = -1
-			level = 3
-
 			modifier = {
 				infrastructure_cost_multiplier_modifier = 0.25
 				infrastructure_tax_gain_multiplier_modifier = 0.35
 				infrastructure_workforce_requirement_modifier = 0.20
 				energy_gain_multiplier = 0.15
 			}
-
+			cost = 100
+			removal_cost = -1
+			level = 3
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -711,13 +676,7 @@ ideas = {
 		use_list_view = yes
 
 		us_dollar = {
-			cost = 75
-			removal_cost = -1
-
-			modifier = {
-				custom_modifier_tooltip = usd_reserve_users_tt
-			}
-
+			modifier = { custom_modifier_tooltip = usd_reserve_users_tt }
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted us_dollar reserve"
 				hidden_effect = {
@@ -726,16 +685,16 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea us_dollar removed"
 				hidden_effect = {
 					subtract_from_variable = { global.usd_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.usd_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
+			cost = 75
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
 			ai_will_do = {
 				base = 5
 				modifier = {
@@ -759,19 +718,21 @@ ideas = {
 		}
 
 		euro = {
-			cost = 75
-			removal_cost = -1
-
 			allowed_civil_war = { has_idea = EU_member }
-
-			available = {
-				has_idea = EU_member
-				has_country_flag = EU_joined_the_eurozone
-				if = { limit = { original_tag = GRE }
-					NOT = { has_idea = GRE_the_drachma_idea }
-				}
+			cancel = {
+				#please add here exception for some countries like Andorra, San Marino, Vatican, Monaco if you need this.
+				NOT = { has_idea = EU_member }
+				# Disabled if not in the EU
+				has_global_flag = GAME_RULE_eu_disabled
 			}
-
+			modifier = {
+				custom_modifier_tooltip = eur_reserve_users_tt
+				economic_cycles_cost_factor = 0.5
+				trade_opinion_factor = 0.2
+				consumer_goods_factor = -0.01
+				interest_rate_multiplier_modifier = -2
+				econ_cycle_upg_cost_multiplier_modifier = 0.50
+			}
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted euro reserve"
 				hidden_effect = {
@@ -780,8 +741,10 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea euro removed"
 				hidden_effect = {
 					subtract_from_variable = { global.eur_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.eur_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 				if = {
@@ -796,6 +759,8 @@ ideas = {
 								has_idea = russia_rouble
 								has_idea = british_pound
 								has_idea = swiss_frank
+								has_idea = gulden
+								has_idea = no_foreign_reserve
 							}
 						}
 					}
@@ -803,22 +768,15 @@ ideas = {
 					add_ideas = no_foreign_reserve
 				}
 			}
-			cancel = {
-				#please add here exception for some countries like Andorra, San Marino, Vatican, Monaco if you need this.
-				NOT = { has_idea = EU_member }
-				# Disabled if not in the EU
-				has_global_flag = GAME_RULE_eu_disabled
+			cost = 75
+			removal_cost = -1
+			available = {
+				has_idea = EU_member
+				has_country_flag = EU_joined_the_eurozone
+				if = { limit = { original_tag = GRE }
+					NOT = { has_idea = GRE_the_drachma_idea }
+				}
 			}
-
-			modifier = {
-				custom_modifier_tooltip = eur_reserve_users_tt
-				economic_cycles_cost_factor = 0.5
-				trade_opinion_factor = 0.2
-				consumer_goods_factor = -0.01
-				interest_rate_multiplier_modifier = -2
-				econ_cycle_upg_cost_multiplier_modifier = 0.50
-			}
-
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -842,9 +800,13 @@ ideas = {
 		}
 
 		chinese_yuan = {
-			cost = 75
-			removal_cost = -1
-
+			modifier = {
+				custom_modifier_tooltip = cny_reserve_users_tt
+				resource_trade_cost_bonus_per_factory = 1
+				trade_opinion_factor = 0.10
+				consumer_goods_factor = -0.025
+				investment_cost_modifier = 0.05
+			}
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted chinese_yuan reserve"
 				hidden_effect = {
@@ -853,29 +815,20 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea chinese_yuan removed"
 				hidden_effect = {
 					subtract_from_variable = { global.cny_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.cny_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
+			cost = 75
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
 			visible = {
 				NOT = { CHI = { has_completed_focus = CHI_Renminbi_Internationalization } }
 				NOT = { CHI = { has_completed_focus = CHI_yuan_internationalisation } }
 			}
-
-			modifier = {
-				custom_modifier_tooltip = cny_reserve_users_tt
-				resource_trade_cost_bonus_per_factory = 1
-				trade_opinion_factor = 0.10
-				consumer_goods_factor = -0.025
-				investment_cost_modifier = 0.05
-			}
-
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -919,32 +872,6 @@ ideas = {
 		}
 		chinese_yuan_2 = {
 			name = chinese_yuan
-			cost = 75
-			removal_cost = -1
-
-			on_add = {
-				log = "[GetDateText]: [Root.GetName]: Adopted chinese_yuan_2 reserve"
-				hidden_effect = {
-					add_to_variable = { global.cny_reserve_adoption_count = 1 }
-					calculate_reserve_roi_bonus = yes
-				}
-			}
-			on_remove = {
-				hidden_effect = {
-					subtract_from_variable = { global.cny_reserve_adoption_count = 1 }
-					calculate_reserve_roi_bonus = yes
-				}
-			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
-			visible = {
-				CHI = { has_completed_focus = CHI_Renminbi_Internationalization }
-				NOT = { CHI = { has_completed_focus = CHI_yuan_internationalisation } }
-			}
-
 			modifier = {
 				custom_modifier_tooltip = cny_reserve_users_tt
 				resource_trade_cost_bonus_per_factory = 1
@@ -954,7 +881,28 @@ ideas = {
 				return_on_investment_modifier = 0.015
 				international_market_income_modifier = 0.10
 			}
-
+			on_add = {
+				log = "[GetDateText]: [Root.GetName]: Adopted chinese_yuan_2 reserve"
+				hidden_effect = {
+					add_to_variable = { global.cny_reserve_adoption_count = 1 }
+					calculate_reserve_roi_bonus = yes
+				}
+			}
+			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea chinese_yuan_2 removed"
+				hidden_effect = {
+					subtract_from_variable = { global.cny_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.cny_reserve_adoption_count min = 0 }
+					calculate_reserve_roi_bonus = yes
+				}
+			}
+			cost = 75
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
+			visible = {
+				CHI = { has_completed_focus = CHI_Renminbi_Internationalization }
+				NOT = { CHI = { has_completed_focus = CHI_yuan_internationalisation } }
+			}
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -998,31 +946,6 @@ ideas = {
 		}
 		chinese_yuan_3 = {
 			name = chinese_yuan
-			cost = 75
-			removal_cost = -1
-
-			on_add = {
-				log = "[GetDateText]: [Root.GetName]: Adopted chinese_yuan_3 reserve"
-				hidden_effect = {
-					add_to_variable = { global.cny_reserve_adoption_count = 1 }
-					calculate_reserve_roi_bonus = yes
-				}
-			}
-			on_remove = {
-				hidden_effect = {
-					subtract_from_variable = { global.cny_reserve_adoption_count = 1 }
-					calculate_reserve_roi_bonus = yes
-				}
-			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
-			visible = {
-				CHI = { has_completed_focus = CHI_yuan_internationalisation }
-			}
-
 			modifier = {
 				custom_modifier_tooltip = cny_reserve_users_tt
 				resource_trade_cost_bonus_per_factory = 1
@@ -1032,7 +955,25 @@ ideas = {
 				return_on_investment_modifier = 0.02
 				international_market_income_modifier = 0.15
 			}
-
+			on_add = {
+				log = "[GetDateText]: [Root.GetName]: Adopted chinese_yuan_3 reserve"
+				hidden_effect = {
+					add_to_variable = { global.cny_reserve_adoption_count = 1 }
+					calculate_reserve_roi_bonus = yes
+				}
+			}
+			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea chinese_yuan_3 removed"
+				hidden_effect = {
+					subtract_from_variable = { global.cny_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.cny_reserve_adoption_count min = 0 }
+					calculate_reserve_roi_bonus = yes
+				}
+			}
+			cost = 75
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
+			visible = { CHI = { has_completed_focus = CHI_yuan_internationalisation } }
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -1076,9 +1017,6 @@ ideas = {
 		}
 
 		japanese_yen = {
-			cost = 75
-			removal_cost = -1
-
 			modifier = {
 				custom_modifier_tooltip = jpy_reserve_users_tt
 				interest_rate_multiplier_modifier = -1.75
@@ -1086,7 +1024,6 @@ ideas = {
 				investment_cost_modifier = -0.10
 				return_on_investment_modifier = -0.02
 			}
-
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted japanese_yen reserve"
 				hidden_effect = {
@@ -1095,16 +1032,16 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea japanese_yen removed"
 				hidden_effect = {
 					subtract_from_variable = { global.jpy_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.jpy_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
+			cost = 75
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -1133,21 +1070,7 @@ ideas = {
 		}
 
 		russia_rouble = {
-			cost = 75
-			removal_cost = -1
-
-			modifier = {
-				custom_modifier_tooltip = rub_reserve_users_tt
-			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-				OR = {
-					tag = SOV
-					is_in_faction_with = SOV
-				}
-			}
-
+			modifier = { custom_modifier_tooltip = rub_reserve_users_tt }
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted russia_rouble reserve"
 				hidden_effect = {
@@ -1156,12 +1079,22 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea russia_rouble removed"
 				hidden_effect = {
 					subtract_from_variable = { global.rub_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.rub_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 			}
-
+			cost = 75
+			removal_cost = -1
+			available = {
+				NOT = { has_country_flag = EU_joined_the_eurozone }
+				OR = {
+					tag = SOV
+					is_in_faction_with = SOV
+				}
+			}
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -1191,17 +1124,7 @@ ideas = {
 		}
 
 		british_pound = {
-			cost = 75
-			removal_cost = -1
-
-			modifier = {
-				custom_modifier_tooltip = gbp_reserve_users_tt
-			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
+			modifier = { custom_modifier_tooltip = gbp_reserve_users_tt }
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted british_pound reserve"
 				hidden_effect = {
@@ -1210,12 +1133,16 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea british_pound removed"
 				hidden_effect = {
 					subtract_from_variable = { global.gbp_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.gbp_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 			}
-
+			cost = 75
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
 			ai_will_do = {
 				base = 1
 				modifier = {
@@ -1244,17 +1171,10 @@ ideas = {
 		}
 
 		swiss_frank = {
-			cost = 50
-			removal_cost = -1
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-				OR = {
-					original_tag = SWI
-					original_tag = LIC
-				}
+			modifier = {
+				custom_modifier_tooltip = chf_reserve_users_tt
+				foreign_influence_defense_modifier = 0.05
 			}
-
 			on_add = {
 				log = "[GetDateText]: [Root.GetName]: Adopted swiss_frank reserve"
 				hidden_effect = {
@@ -1263,17 +1183,22 @@ ideas = {
 				}
 			}
 			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea swiss_frank removed"
 				hidden_effect = {
 					subtract_from_variable = { global.chf_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.chf_reserve_adoption_count min = 0 }
 					calculate_reserve_roi_bonus = yes
 				}
 			}
-
-			modifier = {
-				custom_modifier_tooltip = chf_reserve_users_tt
-				foreign_influence_defense_modifier = 0.05
+			cost = 50
+			removal_cost = -1
+			available = {
+				NOT = { has_country_flag = EU_joined_the_eurozone }
+				OR = {
+					original_tag = SWI
+					original_tag = LIC
+				}
 			}
-
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -1291,31 +1216,6 @@ ideas = {
 		}
 
 		gulden = {
-			cost = 50
-			removal_cost = -1
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-				OR = {
-					HOL = { has_completed_focus = HOL_bring_back_the_gulden }
-					HOL = { has_completed_focus = HOL_restore_royal_authority }
-				}
-			}
-
-			on_add = {
-				log = "[GetDateText]: [Root.GetName]: Adopted gulden reserve"
-				hidden_effect = {
-					add_to_variable = { global.nlg_reserve_adoption_count = 1 }
-					calculate_reserve_roi_bonus = yes
-				}
-			}
-			on_remove = {
-				hidden_effect = {
-					subtract_from_variable = { global.nlg_reserve_adoption_count = 1 }
-					calculate_reserve_roi_bonus = yes
-				}
-			}
-
 			modifier = {
 				custom_modifier_tooltip = nlg_reserve_users_tt
 				econ_cycle_upg_cost_multiplier_modifier = -0.15
@@ -1324,7 +1224,30 @@ ideas = {
 				return_on_investment_modifier = -0.02
 				base_migration_rate_value = -0.05
 			}
-
+			on_add = {
+				log = "[GetDateText]: [Root.GetName]: Adopted gulden reserve"
+				hidden_effect = {
+					add_to_variable = { global.nlg_reserve_adoption_count = 1 }
+					calculate_reserve_roi_bonus = yes
+				}
+			}
+			on_remove = {
+				log = "[GetDateText]: [Root.GetName]: Idea gulden removed"
+				hidden_effect = {
+					subtract_from_variable = { global.nlg_reserve_adoption_count = 1 }
+					clamp_variable = { var = global.nlg_reserve_adoption_count min = 0 }
+					calculate_reserve_roi_bonus = yes
+				}
+			}
+			cost = 50
+			removal_cost = -1
+			available = {
+				NOT = { has_country_flag = EU_joined_the_eurozone }
+				OR = {
+					HOL = { has_completed_focus = HOL_bring_back_the_gulden }
+					HOL = { has_completed_focus = HOL_restore_royal_authority }
+				}
+			}
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -1339,22 +1262,15 @@ ideas = {
 		}
 
 		no_foreign_reserve = {
-			cost = 50
-			removal_cost = -1
-
+			modifier = { political_power_gain = 0.05 }
 			on_add = {
+				log = "[GetDateText]: [Root.GetName]: Idea no_foreign_reserve added"
 				set_variable = { reserve_roi_bonus = 0 }
 				set_variable = { reserve_trade_bonus = 0 }
 			}
-
-			available = {
-				NOT = { has_country_flag = EU_joined_the_eurozone }
-			}
-
-			modifier = {
-				political_power_gain = 0.05
-			}
-
+			cost = 50
+			removal_cost = -1
+			available = { NOT = { has_country_flag = EU_joined_the_eurozone } }
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -1380,13 +1296,6 @@ ideas = {
 		use_list_view = yes
 
 		gold_standard_back = {
-			cost = 100
-			removal_cost = -1
-
-			available = {
-				NOT = { has_idea = euro }
-			}
-
 			modifier = {
 				stability_factor = 0.06
 				trade_opinion_factor = 0.08
@@ -1394,7 +1303,9 @@ ideas = {
 				consumer_goods_factor = 0.01
 				inflation_cost_multiplier_modifier = -0.15
 			}
-
+			cost = 100
+			removal_cost = -1
+			available = { NOT = { has_idea = euro } }
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -1428,20 +1339,15 @@ ideas = {
 		}
 
 		silver_standard = {
-			cost = 100
-			removal_cost = -1
-
-			available = {
-				NOT = { has_idea = euro }
-			}
-
 			modifier = {
 				stability_factor = 0.04
 				trade_opinion_factor = 0.04
 				political_power_factor = -0.05
 				inflation_cost_multiplier_modifier = -0.10
 			}
-
+			cost = 100
+			removal_cost = -1
+			available = { NOT = { has_idea = euro } }
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -1470,19 +1376,14 @@ ideas = {
 		}
 
 		bi_metal_standard = {
-			cost = 100
-			removal_cost = -1
-
-			available = {
-				NOT = { has_idea = euro }
-			}
-
 			modifier = {
 				stability_factor = 0.04
 				trade_opinion_factor = 0.02
 				inflation_cost_multiplier_modifier = -0.05
 			}
-
+			cost = 100
+			removal_cost = -1
+			available = { NOT = { has_idea = euro } }
 			ai_will_do = {
 				base = 0
 				modifier = {
@@ -1507,16 +1408,14 @@ ideas = {
 		}
 
 		no_currency_backing = {
-			cost = 100
-			removal_cost = -1
-
 			modifier = {
 				political_power_gain = 0.06
 				stability_factor = -0.05
 				inflation_cost_multiplier_modifier = 0.10
 				return_on_investment_modifier = 0.01
 			}
-
+			cost = 100
+			removal_cost = -1
 			ai_will_do = {
 				base = 10
 				modifier = {

--- a/common/on_actions/00_on_actions.txt
+++ b/common/on_actions/00_on_actions.txt
@@ -1635,16 +1635,9 @@ on_actions = {
 			set_variable = { global.update_monie_ui = 1 }
 			set_variable = { global.update_influence_ui = 1 }
 			set_variable = { global.storage_scripted_gui_var = 1 }
-			# Currency system global counters
-			# on_add does not fire for history-file ideas, so we count them manually here
-			set_variable = { global.usd_reserve_adoption_count = 0 }
-			set_variable = { global.eur_reserve_adoption_count = 0 }
-			set_variable = { global.cny_reserve_adoption_count = 0 }
-			set_variable = { global.rub_reserve_adoption_count = 0 }
-			set_variable = { global.jpy_reserve_adoption_count = 0 }
-			set_variable = { global.gbp_reserve_adoption_count = 0 }
-			set_variable = { global.chf_reserve_adoption_count = 0 }
-			set_variable = { global.nlg_reserve_adoption_count = 0 }
+			# on_add does not fire for history-file ideas, so count them manually here.
+			# Must precede the every_country loop below, whose ingame_update_setup reads the counts.
+			recount_global_reserve_currency = yes
 			set_variable = { global.general_operating_budget_contribute_percent = 0.0001 }
 
 			ABK = {
@@ -1815,8 +1808,6 @@ on_actions = {
 				setup_missile_configuration_effect = yes
 
 				mio_catalog_rebuild_visible_yes = yes
-
-				increment_global_reserve_currency = yes
 
 				# Needed for inflation initialization
 				set_variable = { last_quarter_gdp_total = gdp_total }

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -1347,6 +1347,8 @@ on_actions = {
 
 				counter_terror_global = yes
 
+				recount_global_reserve_currency = yes
+
 				# On Monthly Flag:
 				# Set this to 27 days to time out so that way February isn't missed
 				set_global_flag = { flag = on_monthly_done value = 1 days = 27 }

--- a/common/scripted_effects/00_economic_system_utilities.txt
+++ b/common/scripted_effects/00_economic_system_utilities.txt
@@ -219,3 +219,16 @@ increment_global_reserve_currency = {
 		add_to_variable = { global.nlg_reserve_adoption_count = 1 }
 	}
 }
+
+# Resync against live holders. on_add/on_remove drifts when a holder is annexed or a law slot changes hands outside swap_ideas.
+recount_global_reserve_currency = {
+	set_variable = { global.usd_reserve_adoption_count = 0 }
+	set_variable = { global.eur_reserve_adoption_count = 0 }
+	set_variable = { global.cny_reserve_adoption_count = 0 }
+	set_variable = { global.rub_reserve_adoption_count = 0 }
+	set_variable = { global.jpy_reserve_adoption_count = 0 }
+	set_variable = { global.gbp_reserve_adoption_count = 0 }
+	set_variable = { global.chf_reserve_adoption_count = 0 }
+	set_variable = { global.nlg_reserve_adoption_count = 0 }
+	every_country = { increment_global_reserve_currency = yes }
+}


### PR DESCRIPTION
Closes #3057
Closes #3059

## What

- Clamp all ten `global.*_reserve_adoption_count` decrements at zero (`common/ideas/AA_law_expanded_economics.txt`).
- Add `recount_global_reserve_currency` (`common/scripted_effects/00_economic_system_utilities.txt`): zeroes the eight counts and rebuilds them from the countries that actually hold each reserve law.
- Call it once at `on_startup`, replacing the eight manual `set_variable = 0` lines and the in-loop `increment_global_reserve_currency`, and once a month from the `on_monthly_done` global block.
- Add `gulden` and `no_foreign_reserve` to the `euro` `on_remove` fallback check.

## Why

The counts were maintained purely by paired `on_add` / `on_remove` bookkeeping with no floor. Any unpaired removal (a holder annexed, a law slot changing hands outside `swap_ideas`, a save carried over from an older build) leaves them wrong, and nothing ever pulled them back.

Negative values are not cosmetic. `calculate_seigniorage_income` and `apply_reserve_roi_curve` (`common/scripted_effects/00_currency_effects.txt`) both read the counts, so a negative one drains the issuer's income and return on investment on top of the `-1` the player sees in the reserve currency law list.

The `euro` `on_remove` list omitted `gulden` and `no_foreign_reserve`, so `HOL_bring_back_the_gulden` picked up a spurious `add_ideas = no_foreign_reserve` immediately before `gulden` landed.

## How

The clamp is the immediate stop. The monthly recount is the durable half: it resyncs against live holders, so drift in either direction corrects itself within a month without needing every unpaired path enumerated.

Startup ordering changed as a side effect worth calling out. Seeding used to happen inside the big `on_startup` `every_country` loop, after each country's `ingame_update_setup`, so early-iterated countries computed seigniorage against half-built counts. `recount_global_reserve_currency` now runs before that loop.

The recount is an `every_country` pass. There is no all-countries array to iterate instead, and it runs once a month from the already-gated global block, so the cost is one cheap `if`/`else_if` chain per country per month.

## Note for reviewers

`common/ideas/AA_law_expanded_economics.txt` is reformatted throughout by the repo's own `md-standardize` commit hook, which fires on any `common/ideas/*.txt` commit. The functional change in that file is twelve lines: ten `clamp_variable` calls and two `has_idea` entries.

## Not fixed

I could not pin the exact double-decrement behind the UK report from script alone. `joining_the_euro` swaps once, `british_pound` is held only by ENG at start, and GBP has exactly one decrement site, so landing on `-1` means GBP already read `0` before the swap. That is engine-side (either the startup seed not applying, or a law-slot removal firing `on_remove` twice) and needs a game session to confirm. The recount corrects it either way, but if the underlying double-fire is real it will still show a transient `-1` clamped to `0` until the next monthly tick.
