### PR TITLE
CHI: rebalance focus tree costs onto a 5-tier rubric

### DIFF
--- a/common/ideas/05_china.txt
+++ b/common/ideas/05_china.txt
@@ -3,18 +3,17 @@ ideas = {
 		CHI_bri_partner_1 = {
 			picture = foreign_capital
 			allowed_civil_war = { always = yes }
-			removal_cost = -1
 			modifier = {
 				production_speed_buildings_factor = 0.04
 				production_factory_max_efficiency_factor = 0.02
 				stability_factor = 0.04
 				research_speed_factor = 0.02
 			}
+			removal_cost = -1
 		}
 		CHI_bri_partner_2 = {
 			picture = foreign_capital
 			allowed_civil_war = { always = yes }
-			removal_cost = -1
 			modifier = {
 				production_speed_buildings_factor = 0.07
 				production_factory_max_efficiency_factor = 0.04
@@ -23,11 +22,11 @@ ideas = {
 				research_speed_factor = 0.03
 				intel_network_gain_factor = 0.04
 			}
+			removal_cost = -1
 		}
 		CHI_bri_partner_3 = {
 			picture = foreign_capital
 			allowed_civil_war = { always = yes }
-			removal_cost = -1
 			modifier = {
 				production_speed_buildings_factor = 0.10
 				production_factory_max_efficiency_factor = 0.06
@@ -38,11 +37,11 @@ ideas = {
 				intel_network_gain_factor = 0.07
 				industry_repair_factor = 0.10
 			}
+			removal_cost = -1
 		}
 		CHI_bri_partner_4 = {
 			picture = foreign_capital
 			allowed_civil_war = { always = yes }
-			removal_cost = -1
 			modifier = {
 				production_speed_buildings_factor = 0.13
 				production_factory_max_efficiency_factor = 0.08
@@ -54,11 +53,11 @@ ideas = {
 				intel_network_gain_factor = 0.09
 				industry_repair_factor = 0.15
 			}
+			removal_cost = -1
 		}
 		CHI_bri_partner_5 = {
 			picture = foreign_capital
 			allowed_civil_war = { always = yes }
-			removal_cost = -1
 			modifier = {
 				production_speed_buildings_factor = 0.15
 				production_factory_max_efficiency_factor = 0.10
@@ -71,6 +70,7 @@ ideas = {
 				intelligence_agency_defense = 0.05
 				industry_repair_factor = 0.20
 			}
+			removal_cost = -1
 		}
 		CHI_belt_and_road_initiative_idea = {
 			picture = china_unified
@@ -80,7 +80,6 @@ ideas = {
 		CHI_bri_resource_concession_idea = {
 			picture = foreign_capital
 			allowed_civil_war = { always = yes }
-			removal_cost = -1
 			modifier = {
 				local_resources_factor = -0.15
 				resource_export_multiplier_modifier = -0.20
@@ -90,6 +89,7 @@ ideas = {
 				tag = CHI
 				trade_opinion_factor = 0.15
 			}
+			removal_cost = -1
 		}
 
 		TAI_civil_defense_readiness = {
@@ -2687,9 +2687,7 @@ ideas = {
 			picture = generic_political_support
 			allowed = { original_tag = CHI }
 			allowed_civil_war = { always = yes }
-			modifier = {
-				trade_opinion_factor = 0.05
-			}
+			modifier = { trade_opinion_factor = 0.05 }
 			on_add = {
 				add_to_variable = { CHI_bri_project_slots = 2 }
 				log = "[GetDateText]: [Root.GetName]: add idea CHI_bri_forum_surge"
@@ -3039,14 +3037,14 @@ ideas = {
 				log = "[GetDateText]: [Root.GetName]: Idea CHI_scientific_outlook_idea_1 added"
 				reduce_focus_completion_cost = {
 					focus = { CHI_scientific_outlook_on_development }
-					cost = 35
+					cost = 25
 				}
 			}
 			on_remove = {
 				log = "[GetDateText]: [Root.GetName]: Idea CHI_scientific_outlook_idea_1 removed"
 				reduce_focus_completion_cost = {
 					focus = { CHI_scientific_outlook_on_development }
-					cost = -35
+					cost = -25
 				}
 			}
 		}

--- a/common/national_focus/05_china.txt
+++ b/common/national_focus/05_china.txt
@@ -155,7 +155,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_scientific_development_outlook_foreshadowed
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_scientific_development_outlook_foreshadowed }
 
@@ -234,7 +234,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_three_represents
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_three_represents }
 
@@ -324,7 +324,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_three_represents
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_three_represents }
 		mutually_exclusive = { focus = CHI_the_610_office_mandate }
@@ -460,7 +460,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_yangtze_delta_integration
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_yangtze_delta_integration }
 
@@ -609,7 +609,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_hu_jintao_reign }
 
@@ -648,7 +648,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_scientific_outlook_on_development }
 
@@ -678,7 +678,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_property_tax_pilot_program }
 
@@ -706,7 +706,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_property_tax_pilot_program }
 		prerequisite = { focus = CHI_western_development_strategy }
@@ -732,7 +732,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_youth_league_pipeline }
 		prerequisite = { focus = CHI_western_development_strategy }
@@ -761,7 +761,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_youth_league_pipeline }
 
@@ -795,7 +795,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_scientific_outlook_on_development }
 		prerequisite = { focus = CHI_cadre_evaluation_reform }
@@ -836,7 +836,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_cadre_evaluation_reform }
 
@@ -863,7 +863,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_hu_jintao_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_hu_jintao_reign }
 
@@ -926,7 +926,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_eleventh_five_year_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_eleventh_five_year_plan }
 
@@ -965,7 +965,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_eleventh_five_year_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_banking_recapitalisation }
 
@@ -1001,7 +1001,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_eleventh_five_year_plan
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_eleventh_five_year_plan }
 
@@ -1077,7 +1077,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_eleventh_five_year_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_eleventh_five_year_plan }
 
@@ -1088,7 +1088,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_wto_implementation"
 			if = {
-				limit = { NOT = {  has_completed_focus = CHI_wto_accession_drive } }
+				limit = { NOT = { has_completed_focus = CHI_wto_accession_drive } }
 				custom_effect_tooltip = CHI_wto_implementation_tt
 				newline = yes
 				add_timed_idea = { idea = CHI_wto_implementation_idea years = 5 }
@@ -1231,7 +1231,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_eleventh_five_year_plan
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_yuan_internationalisation }
 		prerequisite = { focus = CHI_western_pipeline_corridor }
@@ -1259,7 +1259,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_shanghai_succession
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_the_shanghai_succession }
 
@@ -1283,7 +1283,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_zeng_qinghong_reign
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_zeng_qinghong_reign }
 
@@ -1310,7 +1310,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_zeng_qinghong_reign
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_organisation_department_mandate }
 
@@ -1338,7 +1338,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_zeng_qinghong_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_provincial_reshuffle }
 		prerequisite = { focus = CHI_selective_anti_corruption }
@@ -1463,7 +1463,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_china_among_the_starts"
 			reduce_focus_completion_cost = {
-				cost = 30
+				cost = 20
 				focus = {
 					CHI_project_921
 					CHI_shenzhou_program
@@ -1490,7 +1490,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_zeng_qinghong_reign
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_quiet_succession_engineering }
 		prerequisite = { focus = CHI_selective_anti_corruption }
@@ -1516,7 +1516,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_zeng_qinghong_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_organisation_department_mandate }
 
@@ -1543,7 +1543,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_zeng_qinghong_reign
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_organisation_department_mandate }
 
@@ -1597,7 +1597,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_chinese_dream
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_chinese_dream }
 
@@ -1628,7 +1628,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_chinese_dream
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_chinese_dream }
 
@@ -1683,7 +1683,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_chinese_dream
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_leading_small_group_doctrine }
 
@@ -1711,7 +1711,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_chinese_dream
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_leading_small_group_doctrine }
 
@@ -1786,7 +1786,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_chinese_dream
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_leading_small_group_doctrine }
 
@@ -1845,7 +1845,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_xi_jinping_thought_enshrined
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_xi_jinping_thought_enshrined }
 
@@ -1872,7 +1872,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_xi_jinping_thought_enshrined
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_abolish_term_limits }
 
@@ -1898,7 +1898,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_xi_jinping_thought_enshrined
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_wolf_warrior_doctrine }
 
@@ -1935,7 +1935,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_xi_jinping_thought_enshrined
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_xi_jinping_thought_enshrined }
 
@@ -1959,7 +1959,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_the_chinese_dream
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_mass_line_education }
 		prerequisite = { focus = CHI_astana_speech }
@@ -1989,7 +1989,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_two_establishments
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_two_establishments }
 
@@ -2018,7 +2018,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_two_establishments
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_common_prosperity }
 
@@ -2048,7 +2048,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_two_establishments
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_common_prosperity }
 
@@ -2074,7 +2074,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_two_establishments
 
-		cost = 10
+		cost = 15
 
 		prerequisite = { focus = CHI_designated_succesor }
 		prerequisite = { focus = CHI_governance_moderenisation }
@@ -2131,7 +2131,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_chongqing_model_nationalisation }
 
@@ -2156,7 +2156,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_chongqing_model_nationalisation }
 
@@ -2182,7 +2182,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_chongqing_model_nationalisation }
 
@@ -2211,7 +2211,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_strike_black_sing_red }
 		prerequisite = { focus = CHI_mass_line_renewed }
@@ -2240,7 +2240,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_strike_black_sing_red }
 		prerequisite = { focus = CHI_public_rental_housing_drive }
@@ -2269,7 +2269,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_cadre_rotation focus = CHI_politics_law_commision_realigned }
 
@@ -2296,7 +2296,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_cadre_rotation focus = CHI_politics_law_commision_realigned }
 
@@ -2322,7 +2322,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_two_reaffirmations }
 		prerequisite = { focus = CHI_davos_boycott }
@@ -2352,7 +2352,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_common_prosperity_original }
 
@@ -2379,7 +2379,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_chongqing_model_nationalisation
 
-		cost = 10
+		cost = 15
 
 		prerequisite = { focus = CHI_common_prosperity_original }
 
@@ -2473,7 +2473,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_eat_imperial_grain
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_eat_imperial_grain }
 
@@ -2508,7 +2508,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_fifty_vanke_handover
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_eat_imperial_grain }
 
@@ -2573,7 +2573,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_eat_imperial_grain
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_eat_imperial_grain }
 
@@ -2602,7 +2602,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_sasac
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_sasac }
 		prerequisite = { focus = CHI_fifty_vanke_handover }
@@ -2637,7 +2637,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_nco_corps_reform }
 
@@ -2661,7 +2661,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_nco_corps_reform }
 
@@ -2739,7 +2739,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_establish_defence_conglomerates }
 
@@ -2786,7 +2786,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_establish_defence_conglomerates }
 
@@ -2827,7 +2827,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_avic_reunification }
 
@@ -2868,7 +2868,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_avic_reunification }
 		prerequisite = { focus = CHI_norinco_rationalism }
@@ -2907,7 +2907,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_norinco_rationalism focus = CHI_own_designs }
 
@@ -2934,7 +2934,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_ws15_bottleneck_solve }
 
@@ -2972,7 +2972,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_establish_defence_conglomerates
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_central_military_civil_fusion }
 		prerequisite = { focus = CHI_jiangnan_scale }
@@ -3038,7 +3038,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_joint_operations_command }
 
@@ -3069,7 +3069,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_joint_operations_command }
 
@@ -3097,7 +3097,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_joint_operations_command }
 
@@ -3123,7 +3123,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_military_training_outline }
 
@@ -3155,7 +3155,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_nco_corps_reform
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_military_training_outline }
 
@@ -3228,7 +3228,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_poly_compromise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_poly_compromise }
 
@@ -3256,7 +3256,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_poly_compromise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_poly_compromise }
 
@@ -3285,7 +3285,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_poly_compromise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_poly_compromise }
 
@@ -3316,7 +3316,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_poly_compromise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_poly_compromise }
 
@@ -3343,7 +3343,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_keep_the_shell_companies
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_keep_the_shell_companies }
 
@@ -3371,7 +3371,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_smuggling_tax
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_keep_the_shell_companies }
 		prerequisite = { focus = CHI_smuggling_tax }
@@ -3398,7 +3398,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_smuggling_tax
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_smuggling_tax }
 
@@ -3425,7 +3425,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_northeast_tiger
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_northeast_tiger }
 
@@ -3454,7 +3454,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_smuggling_tax
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_yuanhua_model }
 
@@ -3478,7 +3478,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_smuggling_tax
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_money_alliance }
 
@@ -3500,7 +3500,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_smuggling_tax
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_money_alliance }
 
@@ -3524,7 +3524,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_northeast_tiger
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_beijing_command_clique }
 		prerequisite = { focus = CHI_money_alliance }
@@ -3657,7 +3657,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_streamline_the_ranks
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_streamline_the_ranks }
 
@@ -3706,7 +3706,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_streamline_the_ranks
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_streamline_the_ranks }
 
@@ -3769,7 +3769,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_type_95_adoption
 
-		cost = 7.8
+		cost = 5
 
 		prerequisite = { focus = CHI_type_95_adoption }
 
@@ -3799,7 +3799,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_type_95_adoption
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_type_95_adoption }
 
@@ -3838,7 +3838,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_type_95_adoption
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_individual_soldier_system }
 
@@ -3873,7 +3873,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_streamline_the_ranks
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_streamline_the_ranks }
 
@@ -3931,7 +3931,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_plz_howitzer_program
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_plz_howitzer_program }
 
@@ -3963,7 +3963,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_plz_howitzer_program
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_plz_howitzer_program }
 
@@ -4034,7 +4034,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_plz_howitzer_program
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_hq17_short_range_sam }
 
@@ -4072,7 +4072,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_plz_howitzer_program
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_hq17_short_range_sam }
 
@@ -4097,7 +4097,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_informatized_local_wars
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_informatized_local_wars }
 		mutually_exclusive = { focus = CHI_the_iron_fist }
@@ -4125,7 +4125,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_informatized_local_wars
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_informatized_local_wars }
 		mutually_exclusive = { focus = CHI_the_great_wall }
@@ -4153,7 +4153,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_informatized_local_wars
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_informatized_local_wars }
 		mutually_exclusive = { focus = CHI_the_great_wall }
@@ -4181,7 +4181,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_great_wall
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_the_great_wall }
 
@@ -4207,7 +4207,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_great_wall
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_the_great_wall }
 
@@ -4232,7 +4232,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_great_wall
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_strategic_reserve_system }
 		prerequisite = { focus = CHI_peoples_armed_police_integration }
@@ -4265,7 +4265,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_great_wall
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_active_defense_doctrine }
 
@@ -4289,7 +4289,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_iron_fist
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_iron_fist }
 
@@ -4318,7 +4318,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_iron_fist
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_iron_fist }
 
@@ -4346,7 +4346,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_iron_fist
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_ztz99_rollout }
 
@@ -4371,7 +4371,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_iron_fist
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_heavy_combined_arms_brigade }
 
@@ -4395,7 +4395,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_sharp_blade
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_the_sharp_blade }
 
@@ -4430,7 +4430,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_sharp_blade
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_type_15_light_tank }
 
@@ -4482,7 +4482,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_sharp_blade
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_sharp_blade }
 
@@ -4513,7 +4513,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_sharp_blade
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_special_operations_forces }
 
@@ -4568,7 +4568,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_ztz96_mainstreaming
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_ztz96_mainstreaming }
 
@@ -4623,7 +4623,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_ztz96_mainstreaming
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_ztz96_mainstreaming }
 
@@ -4650,7 +4650,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_ztz96_mainstreaming
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_mengshi_program }
 
@@ -4676,7 +4676,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_ztz96_mainstreaming
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_streamline_the_ranks }
 
@@ -4735,7 +4735,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_ztz96_mainstreaming
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_zbd04_apex_ifv }
 
@@ -4838,7 +4838,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_integrated_air_and_space }
 		mutually_exclusive = { focus = CHI_the_komsomolsk_pipeline }
@@ -4884,7 +4884,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_the_komsomolsk_pipeline }
 
@@ -4962,7 +4962,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_the_self_reliant_path }
 
@@ -5020,7 +5020,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_j11b_sinification focus = CHI_project_no_10 }
 
@@ -5068,7 +5068,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_saturn_engine_crisis }
 
@@ -5118,7 +5118,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_saturn_engine_crisis }
 
@@ -5146,7 +5146,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_integrated_air_and_space
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_saturn_engine_crisis }
 
@@ -5172,7 +5172,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_project_jxx
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_project_jxx }
 
@@ -5333,7 +5333,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_998_project
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_the_998_project }
 
@@ -5425,7 +5425,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_998_project
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_h6k_revival }
 
@@ -5485,7 +5485,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_998_project
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_yj12_standoff_family }
 		prerequisite = { focus = CHI_jh7a_update }
@@ -5581,7 +5581,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_jxx
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_j10c_multirole_refit }
 		prerequisite = { focus = CHI_shenyang_j35_gyrfalcon }
@@ -5618,7 +5618,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_project_jxx
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_cj10_cj20_cruise_missile_family }
 		prerequisite = { focus = CHI_the_sharp_sword_doctrine }
@@ -5652,7 +5652,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_kj2000_mainring_awacs
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_kj2000_mainring_awacs }
 
@@ -5678,7 +5678,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_kj2000_mainring_awacs
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_kj2000_mainring_awacs }
 
@@ -5703,7 +5703,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_kj2000_mainring_awacs
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_kj2000_mainring_awacs }
 
@@ -5729,7 +5729,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_kj2000_mainring_awacs
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_kj500_network_centric_hub }
 		prerequisite = { focus = CHI_the_tanker_gap }
@@ -5756,7 +5756,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_kj2000_mainring_awacs
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_the_tanker_gap }
 		prerequisite = { focus = CHI_y20_strategic_lift_program }
@@ -5783,7 +5783,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_kj2000_mainring_awacs
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_pterodactyl_generation }
 		prerequisite = { focus = CHI_the_soaring_dragon }
@@ -5863,7 +5863,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_open_the_august_1st_building
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_open_the_august_1st_building }
 
@@ -5896,7 +5896,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_project_921 }
 
@@ -5931,7 +5931,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_project_921 }
 
@@ -5968,7 +5968,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_shenzhou_program }
 
@@ -6005,7 +6005,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_long_march_modernisation }
 
@@ -6040,7 +6040,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_tiangong_station }
 
@@ -6084,7 +6084,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_commercial_launch_sector }
 
@@ -6120,7 +6120,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_change_lunar_exploration }
 		mutually_exclusive = { focus = CHI_ilrs_lunar_base }
@@ -6161,7 +6161,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_project_921
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_change_lunar_exploration }
 		mutually_exclusive = { focus = CHI_lunar_sample_return }
@@ -6267,7 +6267,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_liu_huaqing_first_island_chain
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_liu_huaqing_first_island_chain }
 
@@ -6295,7 +6295,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_liu_huaqing_first_island_chain
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_liu_huaqing_first_island_chain }
 
@@ -6346,7 +6346,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_project_998
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_project_998 }
 
@@ -6371,7 +6371,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_project_998
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_project_998 }
 
@@ -6414,7 +6414,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_sovremenny_bridge }
 
@@ -6441,7 +6441,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_sovremenny_bridge }
 
@@ -6474,7 +6474,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_998
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_yuan_and_the_shang }
 
@@ -6555,7 +6555,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_998
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_the_yuan_and_the_shang }
 
@@ -6580,7 +6580,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_998
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_jiangnan_changxing_move }
 
@@ -6619,7 +6619,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_project_998
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_jiangnan_changxing_move }
 
@@ -6643,7 +6643,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_flying_leopard_doctrine }
 
@@ -6711,7 +6711,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_flying_leopard_doctrine }
 
@@ -6733,7 +6733,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_yuzhao_pathfinders }
 
@@ -6758,7 +6758,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_yuzhao_pathfinders }
 
@@ -6784,7 +6784,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_project_998
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_dragon_eye_over_lanzhou }
 		prerequisite = { focus = CHI_the_varyag_refit }
@@ -6810,7 +6810,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_liu_huaqing_first_island_chain
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_huludao_schoolhouse }
 		prerequisite = { focus = CHI_sea_eagles_of_the_liaoning }
@@ -6889,7 +6889,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_sovremenny_bridge
 
-		cost = 7.8
+		cost = 7
 
 		prerequisite = { focus = CHI_sea_eagles_carrier_wing }
 		prerequisite = { focus = CHI_yuzhao_hull_coral_brigades }
@@ -6936,7 +6936,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_liu_huaqing_first_island_chain
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_service_of_the_three_distances }
 		prerequisite = { focus = CHI_the_renhai_cruiser }
@@ -6963,7 +6963,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_liu_huaqing_first_island_chain
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_renhai_cruiser }
 		prerequisite = { focus = CHI_shandong_at_sanya }
@@ -7028,7 +7028,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_fujian_catapults
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_fujian_catapults }
 
@@ -7054,7 +7054,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_type_075_yushen
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_type_075_yushen }
 
@@ -7096,7 +7096,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_fujian_catapults
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_quiet_dragons }
 		mutually_exclusive = { focus = CHI_the_surface_capital_fleet }
@@ -7124,7 +7124,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_type_075_yushen
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_bohai_bastion }
 		mutually_exclusive = { focus = CHI_undersea_supremacy }
@@ -7249,7 +7249,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_South_China_Sea
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_South_China_Sea }
 		mutually_exclusive = { focus = CHI_The_Spirit_Of_Zheng_He }
@@ -7300,7 +7300,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_Cabbage_Strategy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_The_Cabbage_Strategy }
 
@@ -7348,7 +7348,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Cabbage_Strategy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_Sansha_Administrative_Upgrade }
 
@@ -7386,7 +7386,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_The_Cabbage_Strategy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_Scarborough_Model }
 
@@ -7427,7 +7427,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_The_Cabbage_Strategy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_The_Cabbage_Tightens }
 
@@ -7478,7 +7478,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_South_China_Sea
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_South_China_Sea }
 		mutually_exclusive = { focus = CHI_The_Cabbage_Strategy }
@@ -7521,7 +7521,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_Spirit_Of_Zheng_He
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_The_Spirit_Of_Zheng_He }
 
@@ -7556,7 +7556,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Spirit_Of_Zheng_He
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_Maritime_Silk_Road_Initiative }
 
@@ -7598,7 +7598,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Spirit_Of_Zheng_He
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_The_Maritime_Silk_Road_Initiative }
 
@@ -7636,7 +7636,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_The_Spirit_Of_Zheng_He
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_The_Duterte_Pivot }
 		prerequisite = { focus = CHI_The_Treasure_Fleet_Returns }
@@ -7691,7 +7691,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_South_China_Sea
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_South_China_Sea }
 		mutually_exclusive = { focus = CHI_The_Cabbage_Strategy }
@@ -7741,7 +7741,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_Mandate_Of_The_Seas
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_Mandate_Of_The_Seas }
 
@@ -7781,7 +7781,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Mandate_Of_The_Seas
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Liu_Huaqing_Doctrine }
 
@@ -7819,7 +7819,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Mandate_Of_The_Seas
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Liu_Huaqing_Doctrine }
 
@@ -7866,7 +7866,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_The_Mandate_Of_The_Seas
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_PLAN_Expeditionary_Buildup }
 		prerequisite = { focus = CHI_Reclaim_The_Heavenly_Waters }
@@ -8090,7 +8090,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_Respect_Nepalese_Neutrality focus = CHI_Support_Nepals_Maoists }
 
@@ -8138,7 +8138,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Respect_Nepalese_Neutrality focus = CHI_Support_Nepals_Maoists }
 		mutually_exclusive = { focus = CHI_Doklam_Road_Standoff }
@@ -8185,7 +8185,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Respect_Nepalese_Neutrality focus = CHI_Support_Nepals_Maoists }
 		mutually_exclusive = { focus = CHI_Drop_Claims_on_Bhutan }
@@ -8239,7 +8239,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_Indian_Subcontinent }
 		mutually_exclusive = { focus = CHI_Disengage_from_Pakistan }
@@ -8281,7 +8281,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_The_China_Pakistan_Economic_Corridor }
 
@@ -8315,7 +8315,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_The_China_Pakistan_Economic_Corridor }
 
@@ -8395,7 +8395,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Joint_Military_Projects }
 		prerequisite = { focus = CHI_Cooperate_on_Counterterrorism }
@@ -8443,7 +8443,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Cooperate_on_Counterterrorism }
 
@@ -8484,7 +8484,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_The_Quadrilateral_Cooperation_and_Coordination_Mechanism }
 		mutually_exclusive = { focus = CHI_Joint_Operations }
@@ -8540,7 +8540,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_The_Quadrilateral_Cooperation_and_Coordination_Mechanism }
 		mutually_exclusive = { focus = CHI_Support_Negotiations }
@@ -8595,7 +8595,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_Iron_Brothers
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Joint_Operations focus = CHI_Support_Negotiations }
 		will_lead_to_war_with = TAL
@@ -8676,7 +8676,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_The_Indian_Subcontinent }
 		mutually_exclusive = { focus = CHI_Iron_Brothers }
@@ -8718,7 +8718,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_Disengage_from_Pakistan }
 
@@ -8818,7 +8818,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_The_Border_Personnel_Meetings focus = CHI_Drop_Claims_on_Bhutan }
 		mutually_exclusive = { focus = CHI_Strike_Across_the_Himalayas }
@@ -8875,7 +8875,7 @@ focus_tree = {
 		y = 6
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Sino_Indian_Treaty_of_Friendship }
 
@@ -8931,7 +8931,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Militarize_Gwadar_Port }
 		prerequisite = { focus = CHI_Doklam_Road_Standoff }
@@ -8984,7 +8984,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Militarize_Gwadar_Port }
 
@@ -9045,7 +9045,7 @@ focus_tree = {
 		y = 6
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Strike_Across_the_Himalayas }
 		prerequisite = { focus = CHI_String_of_Pearls }
@@ -9089,7 +9089,7 @@ focus_tree = {
 		y = 6
 		relative_position_id = CHI_The_Indian_Subcontinent
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Strike_Across_the_Himalayas }
 		prerequisite = { focus = CHI_String_of_Pearls }
@@ -9263,7 +9263,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_japan_question
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_japan_question }
 		mutually_exclusive = { focus = CHI_the_fukuda_doctrine_revisited }
@@ -9292,7 +9292,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_historical_reckoning
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_historical_reckoning }
 
@@ -9351,7 +9351,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_historical_reckoning
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_historical_reckoning }
 
@@ -9380,7 +9380,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_historical_reckoning
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_nanjing_memorial_mandate }
 
@@ -9418,7 +9418,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_historical_reckoning
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_diaoyu_sovereignty_declaration }
 
@@ -9482,7 +9482,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_historical_reckoning
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_yasukuni_protest_doctrine }
 		prerequisite = { focus = CHI_the_maritime_militia_initiative }
@@ -9548,7 +9548,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_japan_question
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_japan_question }
 		mutually_exclusive = { focus = CHI_the_historical_reckoning }
@@ -9688,7 +9688,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_the_fukuda_doctrine_revisited
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_the_fukuda_doctrine_revisited }
 
@@ -9748,7 +9748,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_the_fukuda_doctrine_revisited
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_the_panda_diplomacy_renewal }
 
@@ -9813,7 +9813,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_the_fukuda_doctrine_revisited
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_assuage_japanese_concerns }
 		prerequisite = { focus = CHI_the_anime_generation_gambit }
@@ -9863,7 +9863,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_the_fukuda_doctrine_revisited
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_the_anime_generation_gambit }
 		prerequisite = { focus = CHI_the_china_plus_one_counteroffensive }
@@ -10121,7 +10121,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Emphasize_Economic_Cooperation }
 
@@ -10165,7 +10165,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Civilian_Technology_Sharing }
 
@@ -10198,7 +10198,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Crack_Down_on_the_Three_Evils }
 
@@ -10292,7 +10292,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Emphasize_Political_Cooperation }
 
@@ -10372,7 +10372,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Emphasize_Military_Cooperation }
 
@@ -10449,7 +10449,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Military_Technology_Sharing }
 
@@ -10493,7 +10493,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Civilian_Technology_Sharing focus = CHI_Military_Technology_Sharing focus = CHI_Crack_Down_on_the_Three_Evils }
 		mutually_exclusive = { focus = CHI_Equal_Partners }
@@ -10555,7 +10555,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Civilian_Technology_Sharing focus = CHI_Military_Technology_Sharing focus = CHI_Crack_Down_on_the_Three_Evils }
 		mutually_exclusive = { focus = CHI_Chinese_Dominance }
@@ -10608,7 +10608,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Chinese_Dominance focus = CHI_Equal_Partners }
 		prerequisite = { focus = CHI_Development_Assistance focus = CHI_Counter_Terrorism_Cooperation }
@@ -10656,7 +10656,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Chinese_Dominance focus = CHI_Equal_Partners }
 		prerequisite = { focus = CHI_Development_Assistance focus = CHI_Counter_Terrorism_Cooperation }
@@ -10707,7 +10707,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_SCO_Plus_Expansion focus = CHI_SCO_Exclusive_Core }
 
@@ -10772,7 +10772,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Chinese_Dominance }
 		prerequisite = { focus = CHI_Strengthen_Security_Framework }
@@ -10863,7 +10863,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Form_the_SCO
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Equal_Partners }
 		prerequisite = { focus = CHI_Strengthen_Security_Framework }
@@ -10997,7 +10997,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Chinese_Diplomacy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Chinese_Diplomacy }
 
@@ -11023,7 +11023,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Chinese_Diplomacy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Chinese_Diplomacy }
 
@@ -11050,7 +11050,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Chinese_Diplomacy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Chinese_Diplomacy }
 
@@ -11077,7 +11077,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Chinese_Diplomacy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Expand_Foreign_Service }
 		prerequisite = { focus = CHI_Soft_Power_Projection }
@@ -11139,7 +11139,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Chinese_Diplomacy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Expand_Foreign_Service }
 		prerequisite = { focus = CHI_Soft_Power_Projection }
@@ -11183,7 +11183,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Wolf_Warrior_Diplomacy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Wolf_Warrior_Diplomacy }
 
@@ -11205,7 +11205,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Wolf_Warrior_Diplomacy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Wolf_Warrior_Diplomacy }
 
@@ -11241,7 +11241,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Wolf_Warrior_Diplomacy
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Debt_Trap_Diplomacy }
 
@@ -11275,7 +11275,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Wolf_Warrior_Diplomacy
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Challenge_Dollar_Hegemony }
 
@@ -11303,7 +11303,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Wolf_Warrior_Diplomacy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Information_Warfare }
 		prerequisite = { focus = CHI_Media_Offensive }
@@ -11335,7 +11335,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Bide_Your_Time
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Bide_Your_Time }
 
@@ -11367,7 +11367,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Bide_Your_Time
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Bide_Your_Time }
 
@@ -11397,7 +11397,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Bide_Your_Time
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Belt_and_Road_Vision }
 
@@ -11429,7 +11429,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Bide_Your_Time
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Community_of_Shared_Future }
 
@@ -11464,7 +11464,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Bide_Your_Time
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Digital_Silk_Road }
 		prerequisite = { focus = CHI_Peaceful_Development }
@@ -11529,7 +11529,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Belt_and_Road_Initiative }
 
@@ -11595,7 +11595,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_AIIB_Founding }
 
@@ -11626,7 +11626,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Belt_and_Road_Initiative }
 
@@ -11648,7 +11648,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Silk_Road_Fund
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Silk_Road_Fund }
 
@@ -11687,7 +11687,7 @@ focus_tree = {
 				set_temp_variable = { treasury_change = -175 }
 				modify_treasury_effect = yes
 				add_to_variable = { CHI_bri_southasia_engagement = 3 tooltip = CHI_bri_southasia_engagement_tt }
-				add_to_variable = { CHI_bri_africa_engagement = 2 tooltip = CHI_bri_africa_engagement_tt  }
+				add_to_variable = { CHI_bri_africa_engagement = 2 tooltip = CHI_bri_africa_engagement_tt }
 				add_to_variable = { CHI_bri_winwin_score = 3 tooltip = CHI_bri_predatory_score_tt }
 				if = {
 					limit = { country_exists = SRI }
@@ -11751,7 +11751,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Silk_Road_Fund
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Silk_Road_Fund }
 
@@ -11880,7 +11880,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Silk_Road_Fund
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Digital_Silk_Road_Initiative }
 
@@ -11963,7 +11963,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Silk_Road_Fund }
 
@@ -12077,7 +12077,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_Silk_Road_Fund }
 
@@ -12124,7 +12124,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Forum_on_China_African_Cooperation }
 
@@ -12164,7 +12164,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_China_Africa_Development_Fund }
 		mutually_exclusive = { focus = CHI_Invest_in_Clean_Energy }
@@ -12213,7 +12213,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_China_Africa_Development_Fund }
 		mutually_exclusive = { focus = CHI_Invest_in_Cheap_Energy }
@@ -12267,7 +12267,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Invest_in_Cheap_Energy focus = CHI_Invest_in_Clean_Energy }
 		mutually_exclusive = { focus = CHI_Workers_Rights }
@@ -12300,7 +12300,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Invest_in_Cheap_Energy focus = CHI_Invest_in_Clean_Energy }
 		mutually_exclusive = { focus = CHI_Outsource_Cheap_Labor }
@@ -12335,7 +12335,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_China_Africa_Development_Fund }
 
@@ -12377,7 +12377,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Agriculture }
 
@@ -12416,7 +12416,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Develop_Hospitals }
 		prerequisite = { focus = CHI_Outsource_Cheap_Labor focus = CHI_Workers_Rights }
@@ -12452,7 +12452,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Develop_Hospitals }
 		prerequisite = { focus = CHI_Outsource_Cheap_Labor focus = CHI_Workers_Rights }
@@ -12503,7 +12503,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Forum_on_China_African_Cooperation }
 
@@ -12544,7 +12544,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Friendship_Schools
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Friendship_Schools }
 
@@ -12584,7 +12584,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Friendship_Schools
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Joint_Research }
 
@@ -12617,7 +12617,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Project_Coordination_Cell }
 		mutually_exclusive = { focus = CHI_Win_Win_Cooperation }
@@ -12650,7 +12650,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Project_Coordination_Cell }
 		mutually_exclusive = { focus = CHI_Predatory_Lending_Doctrine }
@@ -12676,7 +12676,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Project_Coordination_Cell }
 
@@ -12708,7 +12708,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 5
 
 		prerequisite = {
 			focus = CHI_Digital_Silk_Road
@@ -12759,7 +12759,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Project_Coordination_Cell }
 
@@ -12803,7 +12803,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Polar_Silk_Road }
 
@@ -12848,7 +12848,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Petroyuan_Settlement }
 
@@ -12895,7 +12895,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Health_Silk_Road }
 
@@ -12952,7 +12952,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Renminbi_Internationalization focus = CHI_Polar_Silk_Road }
 
@@ -13004,7 +13004,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_Forum_on_China_African_Cooperation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = {
 			focus = CHI_Leverage_Influence
@@ -13130,7 +13130,7 @@ focus_tree = {
 		y = 8
 		relative_position_id = CHI_Project_Coordination_Cell
 
-		cost = 10
+		cost = 15
 
 		prerequisite = { focus = CHI_African_Continental_Integration }
 
@@ -13199,7 +13199,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_Silk_Road_Fund }
 
@@ -13244,7 +13244,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Forum_China_CELAC
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Forum_China_CELAC }
 
@@ -13311,7 +13311,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Forum_China_CELAC
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Forum_China_CELAC }
 
@@ -13382,7 +13382,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Forum_China_CELAC
 
-		cost = 12
+		cost = 7
 
 		prerequisite = { focus = CHI_Lithium_Triangle_Accord focus = CHI_Petrocaribe_Successor }
 
@@ -13460,7 +13460,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Forum_China_CELAC
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Five_Stars_Highway }
 
@@ -13556,7 +13556,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_Forum_China_CELAC
 
-		cost = 12
+		cost = 10
 
 		prerequisite = { focus = CHI_Beidou_Latin_Constellation }
 
@@ -13623,7 +13623,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Belt_and_Road_Initiative
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_Silk_Road_Fund }
 
@@ -13670,7 +13670,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Arab_League_Cooperation_Forum
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Arab_League_Cooperation_Forum }
 
@@ -13707,7 +13707,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Arab_League_Cooperation_Forum
 
-		cost = 12
+		cost = 7
 
 		prerequisite = { focus = CHI_Arab_League_Cooperation_Forum }
 		mutually_exclusive = { focus = CHI_Vision_2030_Partnership }
@@ -13763,7 +13763,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Arab_League_Cooperation_Forum
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Arab_League_Cooperation_Forum }
 		mutually_exclusive = { focus = CHI_TwentyFive_Year_Iran_Accord }
@@ -13804,7 +13804,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Arab_League_Cooperation_Forum
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_TwentyFive_Year_Iran_Accord focus = CHI_Vision_2030_Partnership }
 
@@ -13886,7 +13886,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Arab_League_Cooperation_Forum
 
-		cost = 12
+		cost = 7
 
 		prerequisite = { focus = CHI_Beijing_Communique }
 		prerequisite = { focus = CHI_Suez_Eastern_Bank }
@@ -13934,7 +13934,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Maritime_Silk_Road_Indian_Ocean
 
-		cost = 8
+		cost = 5
 
 		prerequisite = { focus = CHI_Maritime_Silk_Road_Indian_Ocean }
 
@@ -13979,7 +13979,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_Maritime_Silk_Road_Indian_Ocean
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_Maritime_Silk_Road_Indian_Ocean }
 
@@ -14042,7 +14042,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_Maritime_Silk_Road_Indian_Ocean
 
-		cost = 8
+		cost = 5
 
 		prerequisite = { focus = CHI_Pacific_Island_Forum_Pivot }
 		prerequisite = { focus = CHI_Honiara_Security_Pact }
@@ -14111,7 +14111,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Maritime_Silk_Road_Indian_Ocean
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_Tonga_Tuna_Concession }
 
@@ -14164,7 +14164,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_Maritime_Silk_Road_Indian_Ocean
 
-		cost = 12
+		cost = 10
 
 		prerequisite = { focus = CHI_Tonga_Tuna_Concession }
 
@@ -14238,7 +14238,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_seventeen_plus_one_mechanism
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_seventeen_plus_one_mechanism }
 
@@ -14295,7 +14295,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_seventeen_plus_one_mechanism
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_seventeen_plus_one_mechanism }
 
@@ -14345,7 +14345,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_seventeen_plus_one_mechanism
 
-		cost = 12
+		cost = 7
 
 		prerequisite = { focus = CHI_Rome_Memorandum }
 		prerequisite = { focus = CHI_Piraeus_Model }
@@ -14427,7 +14427,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_seventeen_plus_one_mechanism
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_Comprehensive_Agreement_Investment }
 
@@ -14482,7 +14482,7 @@ focus_tree = {
 		x = 113
 		y = 11
 
-		cost = 10
+		cost = 7
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
@@ -14520,7 +14520,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_coastal_sez_2nd_generation }
 
@@ -14567,7 +14567,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_coastal_sez_2nd_generation }
 
@@ -14614,7 +14614,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 3
 
 		prerequisite = {
 			focus = CHI_pudong_financial_hub
@@ -14642,7 +14642,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_joint_venture_framework
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_joint_venture_framework }
 
@@ -14671,7 +14671,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
@@ -14753,7 +14753,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_western_energy_strategy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_western_energy_strategy }
 
@@ -14898,7 +14898,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_western_energy_strategy
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_west_east_gas_pipeline }
 		prerequisite = { focus = CHI_rare_earth_dominance }
@@ -14961,7 +14961,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
@@ -15000,7 +15000,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_northeast_revitalization_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_northeast_revitalization_plan }
 
@@ -15048,7 +15048,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_northeast_revitalization_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_northeast_revitalization_plan }
 
@@ -15101,7 +15101,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_northeast_revitalization_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_northeast_revitalization_plan }
 
@@ -15131,7 +15131,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_northeast_revitalization_plan
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_faw_changchun_automotive }
 		prerequisite = { focus = CHI_harbin_equipment_manufacturing }
@@ -15169,7 +15169,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 3
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
@@ -15191,7 +15191,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_central_china_development
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_central_china_development }
 
@@ -15235,7 +15235,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_central_china_development
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_central_china_development }
 
@@ -15285,7 +15285,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_central_china_development
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_central_china_development }
 
@@ -15319,7 +15319,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_central_china_development
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_henan_grain_modernization }
 		prerequisite = { focus = CHI_wuhan_automotive_hub }
@@ -15347,7 +15347,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_export_processing_zones }
 		prerequisite = { focus = CHI_qinghai_tibet_railway_planning focus = CHI_xinjiang_industrial_zones }
@@ -15400,7 +15400,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_agricultural_tax_abolition }
 
@@ -15450,7 +15450,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_agricultural_tax_abolition }
 
@@ -15501,7 +15501,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_agricultural_tax_abolition }
 
@@ -15544,7 +15544,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_hybrid_rice_super_program }
 		prerequisite = { focus = CHI_sinograin_strategic_reserve }
@@ -15591,7 +15591,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_hybrid_rice_super_program }
 		prerequisite = { focus = CHI_sinograin_strategic_reserve }
@@ -15636,7 +15636,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_distant_water_fishing_strategy focus = CHI_blue_granary_aquaculture }
 
@@ -15678,7 +15678,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_agricultural_tax_abolition
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_grain_for_green_program }
 
@@ -15702,7 +15702,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_xinjiang_industrial_zones }
 		prerequisite = { focus = CHI_anshan_steel_modernization }
@@ -15738,7 +15738,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_three_gorges_completion
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_three_gorges_completion }
 
@@ -15781,7 +15781,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_three_gorges_completion
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_beijing_tianjin_hsr }
 
@@ -15930,7 +15930,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_three_gorges_completion
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_western_industrial_drive }
 
@@ -15975,7 +15975,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_three_gorges_completion
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_central_manufacturing_belt }
 
@@ -16021,7 +16021,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_three_gorges_completion
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_liangjiang_new_area }
 		prerequisite = { focus = CHI_shantytown_renovation }
@@ -16066,7 +16066,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_harbin_equipment_manufacturing }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -16108,7 +16108,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_baosteel_ipo
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_baosteel_ipo }
 
@@ -16133,7 +16133,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_baosteel_ipo
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_baosteel_ipo }
 
@@ -16176,7 +16176,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_baosteel_ipo
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_iron_ore_pricing_war }
 		prerequisite = { focus = CHI_hebei_steel_group }
@@ -16215,7 +16215,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_baosteel_ipo
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_ditiao_gang_crackdown }
 
@@ -16258,7 +16258,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_baosteel_ipo
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_baowu_merger }
 
@@ -16281,7 +16281,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_baosteel_ipo
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_baowu_merger }
 
@@ -16309,7 +16309,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_northeast_revitalization_plan
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_harbin_equipment_manufacturing }
 
@@ -16333,7 +16333,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_863_ic_preparatory_research
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_northeast_russia_corridor }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -16393,7 +16393,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_weqi_pipeline_lines
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_northeast_russia_corridor }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -16467,7 +16467,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_weqi_pipeline_lines
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_weqi_pipeline_lines }
 
@@ -16502,7 +16502,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_weqi_pipeline_lines
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_weqi_pipeline_lines focus = CHI_three_noc_overseas }
 
@@ -16585,7 +16585,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_weqi_pipeline_lines
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_pipechina_gas_reform }
 
@@ -16615,7 +16615,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_weqi_pipeline_lines
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_three_noc_overseas }
 
@@ -16676,7 +16676,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_weqi_pipeline_lines
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_caojing_seven_chem_bases }
 		prerequisite = { focus = CHI_bayan_obo_ree_group }
@@ -16711,7 +16711,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_xinjiang_industrial_zones
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_xinjiang_industrial_zones }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -16757,7 +16757,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_private_oem_rise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_xinjiang_industrial_zones }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -16805,7 +16805,7 @@ focus_tree = {
 		y = 0
 		relative_position_id = CHI_private_oem_rise
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_xinjiang_industrial_zones }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -16843,7 +16843,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_private_oem_rise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_private_oem_rise }
 
@@ -16887,7 +16887,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_private_oem_rise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_863_nev_program }
 		prerequisite = { focus = CHI_geely_volvo_acquisition }
@@ -16933,7 +16933,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_private_oem_rise
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_byd_catl_integration }
 		mutually_exclusive = { focus = CHI_dual_credit_auto_export }
@@ -16959,7 +16959,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_private_oem_rise
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_great_wall_suv_dominance }
 		prerequisite = { focus = CHI_byd_catl_integration }
@@ -16989,7 +16989,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 5
+		cost = 7
 
 		prerequisite = { focus = CHI_863_ic_preparatory_research }
 		prerequisite = { focus = CHI_central_urbanization_drive }
@@ -17041,7 +17041,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_big_fund_phase_1
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_big_fund_phase_1 }
 
@@ -17091,7 +17091,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_smic_zhangjiang
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_smic_zhangjiang }
 		mutually_exclusive = { focus = CHI_smic_advanced_node }
@@ -17146,7 +17146,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_smic_zhangjiang
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_smic_zhangjiang }
 		mutually_exclusive = { focus = CHI_hua_hong_mature_node }
@@ -17202,7 +17202,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_big_fund_phase_1
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_big_fund_phase_1 }
 
@@ -17305,7 +17305,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_fabless_design_cluster
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_hisilicon_kirin focus = CHI_loongson_riscv }
 		prerequisite = { focus = CHI_strategic_materials focus = CHI_smee_lithography }
@@ -17361,7 +17361,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_fabless_design_cluster
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_fabless_design_cluster }
 		mutually_exclusive = { focus = CHI_hisilicon_kirin }
@@ -17423,7 +17423,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_big_fund_phase_1
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_big_fund_phase_1 }
 
@@ -17470,7 +17470,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_naura_amec
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_naura_amec }
 		mutually_exclusive = { focus = CHI_smee_lithography }
@@ -17516,7 +17516,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_naura_amec
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_naura_amec }
 		mutually_exclusive = { focus = CHI_strategic_materials }
@@ -17574,7 +17574,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_smic_zhangjiang
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_smic_advanced_node focus = CHI_hua_hong_mature_node }
 
@@ -17635,7 +17635,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_big_fund_phase_1
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_memory_independence }
 		prerequisite = { focus = CHI_domestic_eda }
@@ -17686,7 +17686,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_big_fund_phase_1
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_big_fund_phase2 }
 
@@ -17805,7 +17805,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_coastal_sez_2nd_generation }
 
@@ -17830,7 +17830,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_miit_licensing_framework }
 		prerequisite = { focus = CHI_export_processing_zones }
@@ -17894,7 +17894,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_45g_national_deployment
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_45g_national_deployment }
 
@@ -17936,7 +17936,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_telecom_reorganization
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_telecom_reorganization }
 
@@ -17984,7 +17984,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_telecom_reorganization
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_bat_platform_rise }
 
@@ -18066,7 +18066,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_telecom_reorganization
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_telecom_reorganization }
 
@@ -18109,7 +18109,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_ecommerce_infrastructure
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_ecommerce_infrastructure }
 
@@ -18146,7 +18146,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_ecommerce_infrastructure
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_ecommerce_infrastructure }
 
@@ -18188,7 +18188,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_45g_national_deployment
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_45g_national_deployment }
 
@@ -18234,7 +18234,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_45g_national_deployment
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_45g_national_deployment }
 
@@ -18276,7 +18276,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_45g_national_deployment
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_mobile_payment_duopoly }
 		prerequisite = { focus = CHI_huawei_zte_export }
@@ -18311,7 +18311,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_bat_platform_rise
 
-		cost = 10
+		cost = 7
 
 		prerequisite = {
 			focus = CHI_cloud_computing_triumvirate
@@ -18361,7 +18361,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_bat_platform_rise
 
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHI_second_gen_platforms }
 		prerequisite = { focus = CHI_crossborder_ecommerce }
@@ -18460,7 +18460,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_coastal_sez_2nd_generation
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_863_ic_preparatory_research }
 
@@ -18510,7 +18510,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_wto_commercial_bank_reform }
 
@@ -18555,7 +18555,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_wto_commercial_bank_reform }
 
@@ -18587,7 +18587,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_wto_commercial_bank_reform }
 
@@ -18663,7 +18663,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_shadow_banking_cleanup }
 
@@ -18697,7 +18697,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_stock_exchanges_shanghai_shenzhen }
 
@@ -18743,7 +18743,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 3
 
 		prerequisite = { focus = CHI_policy_banks_cdb }
 
@@ -18768,7 +18768,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_joint_stock_city_banks }
 		prerequisite = { focus = CHI_three_red_lines_crackdown }
@@ -18813,7 +18813,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_wto_commercial_bank_reform
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_joint_stock_city_banks }
 		prerequisite = { focus = CHI_star_market_bse }
@@ -18859,7 +18859,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_SAR_one_china_framework
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_SAR_one_china_framework }
 
@@ -18871,7 +18871,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.03  tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.03 tooltip = trade_opinion_factor_tt }
 		}
 
 		ai_will_do = { base = 5 }
@@ -18886,7 +18886,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_SAR_one_china_framework
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -18911,7 +18911,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.05  tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
 			newline = yes
 			custom_effect_tooltip = CHI_SAR_two_systems_commitment_tt
 			update_focus_tree_obsolete_branches = yes
@@ -18934,7 +18934,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_SAR_two_systems_commitment
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_SAR_two_systems_commitment }
 
@@ -18956,7 +18956,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_SAR_two_systems_commitment
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			has_dlc = "Arms Against Tyranny"
@@ -19016,7 +19016,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_SAR_one_china_framework
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_SAR_one_china_framework }
 
@@ -19028,7 +19028,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_terror_threat_detection_modifier = 0.05  tooltip = terror_threat_detection_modifier_tt }
+			add_to_variable = { CHI_network_terror_threat_detection_modifier = 0.05 tooltip = terror_threat_detection_modifier_tt }
 		}
 
 		ai_will_do = { base = 5 }
@@ -19069,7 +19069,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_political_power_factor = 0.05  tooltip = political_power_factor_tt }
+			add_to_variable = { CHI_network_political_power_factor = 0.05 tooltip = political_power_factor_tt }
 			newline = yes
 			custom_effect_tooltip = CHI_SAR_one_system_declaration_tt
 		}
@@ -19100,7 +19100,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_political_system
 			}
-			add_to_variable = { CHI_pol_compliance_growth = 0.05  tooltip = compliance_growth_tt }
+			add_to_variable = { CHI_pol_compliance_growth = 0.05 tooltip = compliance_growth_tt }
 		}
 
 		ai_will_do = { base = 1 }
@@ -19126,13 +19126,13 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_civilian_factories_productivity = 0.05  tooltip = civilian_factories_productivity_tt }
+			add_to_variable = { CHI_network_civilian_factories_productivity = 0.05 tooltip = civilian_factories_productivity_tt }
 			HKG = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_civilian_factories_productivity = 0.10  tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_HKG_civilian_factories_productivity = 0.10 tooltip = civilian_factories_productivity_tt }
 				add_political_power = 75
 			}
 		}
@@ -19160,13 +19160,13 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_corporate_tax_income_multiplier_modifier = 0.04  tooltip = corporate_tax_income_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_corporate_tax_income_multiplier_modifier = 0.04 tooltip = corporate_tax_income_multiplier_modifier_tt }
 			HKG = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_corporate_tax_income_multiplier_modifier = 0.04  tooltip = corporate_tax_income_multiplier_modifier_tt }
+				add_to_variable = { CHI_HKG_corporate_tax_income_multiplier_modifier = 0.04 tooltip = corporate_tax_income_multiplier_modifier_tt }
 			}
 			random_owned_state = {
 				add_building_construction = {
@@ -19221,13 +19221,13 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_production_factory_efficiency_gain_factor = 0.03  tooltip = production_factory_efficiency_gain_factor_tt }
+			add_to_variable = { CHI_network_production_factory_efficiency_gain_factor = 0.03 tooltip = production_factory_efficiency_gain_factor_tt }
 			HKG = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_production_factory_efficiency_gain_factor = 0.03  tooltip = production_factory_efficiency_gain_factor_tt }
+				add_to_variable = { CHI_HKG_production_factory_efficiency_gain_factor = 0.03 tooltip = production_factory_efficiency_gain_factor_tt }
 				random_owned_state = {
 					add_building_construction = {
 						type = infrastructure
@@ -19257,7 +19257,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_HKG_greater_bay_area
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_financial_integration }
 
@@ -19269,13 +19269,13 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_consumer_goods_factor = -0.015  tooltip = consumer_goods_factor_tt }
+			add_to_variable = { CHI_network_consumer_goods_factor = -0.015 tooltip = consumer_goods_factor_tt }
 			HKG = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_consumer_goods_factor = -0.02  tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_HKG_consumer_goods_factor = -0.02 tooltip = consumer_goods_factor_tt }
 			}
 		}
 
@@ -19290,7 +19290,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_HKG_greater_bay_area
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_individual_visit_scheme }
 
@@ -19302,14 +19302,14 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_corporate_tax_income_multiplier_modifier = 0.04  tooltip = corporate_tax_income_multiplier_modifier_tt }
-			add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.03  tooltip = office_park_income_tax_modifier_tt }
+			add_to_variable = { CHI_network_corporate_tax_income_multiplier_modifier = 0.04 tooltip = corporate_tax_income_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.03 tooltip = office_park_income_tax_modifier_tt }
 			HKG = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_offices_productivity = 0.05  tooltip = offices_productivity_tt }
+				add_to_variable = { CHI_HKG_offices_productivity = 0.05 tooltip = offices_productivity_tt }
 			}
 		}
 
@@ -19365,11 +19365,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_HKG_media_freedom"
-			USA = { add_opinion_modifier = { target = CHI  modifier = hkg_press_freedom_guarantees } }
-			ENG = { add_opinion_modifier = { target = CHI  modifier = hkg_press_freedom_guarantees } }
-			FRA = { add_opinion_modifier = { target = CHI  modifier = hkg_press_freedom_guarantees } }
-			GER = { add_opinion_modifier = { target = CHI  modifier = hkg_press_freedom_guarantees } }
-			AUS = { add_opinion_modifier = { target = CHI  modifier = hkg_press_freedom_guarantees } }
+			USA = { add_opinion_modifier = { target = CHI modifier = hkg_press_freedom_guarantees } }
+			ENG = { add_opinion_modifier = { target = CHI modifier = hkg_press_freedom_guarantees } }
+			FRA = { add_opinion_modifier = { target = CHI modifier = hkg_press_freedom_guarantees } }
+			GER = { add_opinion_modifier = { target = CHI modifier = hkg_press_freedom_guarantees } }
+			AUS = { add_opinion_modifier = { target = CHI modifier = hkg_press_freedom_guarantees } }
 			newline = yes
 			HKG = {
 				random_owned_state = {
@@ -19385,8 +19385,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_offices_productivity = 0.02  tooltip = offices_productivity_tt }
-				add_to_variable = { CHI_HKG_communism_drift = -0.05  tooltip = communism_drift_tt }
+				add_to_variable = { CHI_HKG_offices_productivity = 0.02 tooltip = offices_productivity_tt }
+				add_to_variable = { CHI_HKG_communism_drift = -0.05 tooltip = communism_drift_tt }
 			}
 			set_temp_variable = { sinicization_base_change = -5 }
 			CHI_apply_sinicization_HKG = yes
@@ -19455,9 +19455,9 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = HKG }
 			change_influence_percentage = yes
-			USA = { add_opinion_modifier = { target = CHI  modifier = hkg_electoral_interference } }
-			ENG = { add_opinion_modifier = { target = CHI  modifier = hkg_electoral_interference } }
-			FRA = { add_opinion_modifier = { target = CHI  modifier = hkg_electoral_interference } }
+			USA = { add_opinion_modifier = { target = CHI modifier = hkg_electoral_interference } }
+			ENG = { add_opinion_modifier = { target = CHI modifier = hkg_electoral_interference } }
+			FRA = { add_opinion_modifier = { target = CHI modifier = hkg_electoral_interference } }
 			newline = yes
 			random = {
 				chance = 50
@@ -19487,7 +19487,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_HKG_electoral_reform
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_electoral_reform }
 
@@ -19499,15 +19499,15 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_bureaucracy_cost_multiplier_modifier = 0.05  tooltip = bureaucracy_cost_multiplier_modifier_tt }
-			add_to_variable = { CHI_network_police_cost_multiplier_modifier = 0.05  tooltip = police_cost_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_bureaucracy_cost_multiplier_modifier = 0.05 tooltip = bureaucracy_cost_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_police_cost_multiplier_modifier = 0.05 tooltip = police_cost_multiplier_modifier_tt }
 			HKG = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_communism_drift = 0.05  tooltip = communism_drift_tt }
-				add_to_variable = { CHI_HKG_stability_factor = -0.10  tooltip = stability_factor_tt }
+				add_to_variable = { CHI_HKG_communism_drift = 0.05 tooltip = communism_drift_tt }
+				add_to_variable = { CHI_HKG_stability_factor = -0.10 tooltip = stability_factor_tt }
 			}
 			set_temp_variable = { sinicization_base_change = 10 }
 			CHI_apply_sinicization_HKG = yes
@@ -19526,7 +19526,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_HKG_electoral_reform
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_electoral_reform }
 
@@ -19574,10 +19574,10 @@ focus_tree = {
 				set_temp_variable = { influence_target = HKG }
 				change_influence_percentage = yes
 				newline = yes
-				USA = { add_opinion_modifier = { target = CHI  modifier = hkg_nsl_imposed } }
-				ENG = { add_opinion_modifier = { target = CHI  modifier = hkg_nsl_imposed } }
-				FRA = { add_opinion_modifier = { target = CHI  modifier = hkg_nsl_imposed } }
-				GER = { add_opinion_modifier = { target = CHI  modifier = hkg_nsl_imposed } }
+				USA = { add_opinion_modifier = { target = CHI modifier = hkg_nsl_imposed } }
+				ENG = { add_opinion_modifier = { target = CHI modifier = hkg_nsl_imposed } }
+				FRA = { add_opinion_modifier = { target = CHI modifier = hkg_nsl_imposed } }
+				GER = { add_opinion_modifier = { target = CHI modifier = hkg_nsl_imposed } }
 			}
 			newline = yes
 			set_temp_variable = { sinicization_base_change = 15 }
@@ -19635,7 +19635,7 @@ focus_tree = {
 				remove_core_of = HKG
 			}
 			newline = yes
-			annex_country = { target = HKG  transfer_troops = yes }
+			annex_country = { target = HKG transfer_troops = yes }
 			newline = yes
 			news_event = { id = hongkong_news.10 days = 1 }
 			if = {
@@ -19657,7 +19657,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.03  tooltip = population_tax_income_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.03 tooltip = population_tax_income_multiplier_modifier_tt }
 		}
 
 		bypass_effect = {
@@ -19673,7 +19673,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.03  tooltip = population_tax_income_multiplier_modifier_tt }
+				add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.03 tooltip = population_tax_income_multiplier_modifier_tt }
 			}
 		}
 
@@ -19688,7 +19688,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_HKG_media_freedom
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_media_freedom }
 
@@ -19739,7 +19739,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_HKG_media_freedom
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_lok_ma_chau_loop }
 
@@ -19756,7 +19756,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_global_building_slots_factor = 0.10  tooltip = global_building_slots_factor_tt }
+				add_to_variable = { CHI_HKG_global_building_slots_factor = 0.10 tooltip = global_building_slots_factor_tt }
 			}
 			add_tech_bonus = {
 				name = CHI_HKG_2030_study
@@ -19788,7 +19788,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_HKG_media_freedom focus = CHI_HKG_electoral_reform }
 
@@ -19801,7 +19801,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.03  tooltip = office_park_income_tax_modifier_tt }
+				add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.03 tooltip = office_park_income_tax_modifier_tt }
 			}
 			newline = yes
 			HKG = {
@@ -19852,7 +19852,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_civilian_factories_productivity = 0.02  tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_network_civilian_factories_productivity = 0.02 tooltip = civilian_factories_productivity_tt }
 			}
 			set_temp_variable = { sinicization_base_change = 15 }
 			CHI_apply_sinicization_HKG = yes
@@ -19861,7 +19861,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_HKG_integration_modifier
 				}
-				add_to_variable = { CHI_HKG_state_productivity_growth_modifier = 0.10  tooltip = state_productivity_growth_modifier_tt }
+				add_to_variable = { CHI_HKG_state_productivity_growth_modifier = 0.10 tooltip = state_productivity_growth_modifier_tt }
 				every_owned_state = {
 					add_building_construction = {
 						type = infrastructure
@@ -19885,7 +19885,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_HKG_palace_museum
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_HKG_palace_museum }
 
@@ -19898,7 +19898,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_production_speed_infrastructure_factor = 0.05  tooltip = production_speed_infrastructure_factor_tt }
+				add_to_variable = { CHI_network_production_speed_infrastructure_factor = 0.05 tooltip = production_speed_infrastructure_factor_tt }
 			}
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
@@ -19971,8 +19971,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_trade_opinion_factor = 0.05  tooltip = trade_opinion_factor_tt }
-				add_to_variable = { CHI_network_civilian_factories_productivity = 0.02  tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_network_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_network_civilian_factories_productivity = 0.02 tooltip = civilian_factories_productivity_tt }
 			}
 			newline = yes
 			MAC = {
@@ -19980,8 +19980,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_trade_opinion_factor = 0.05  tooltip = trade_opinion_factor_tt }
-				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.02  tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_MAC_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.02 tooltip = civilian_factories_productivity_tt }
 			}
 			set_temp_variable = { treasury_change = -21 }
 			modify_treasury_effect = yes
@@ -20040,8 +20040,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.05  tooltip = consumer_goods_factor_tt }
-				add_to_variable = { CHI_MAC_political_power_factor = 0.025  tooltip = political_power_factor_tt }
+				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.05 tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_MAC_political_power_factor = 0.025 tooltip = political_power_factor_tt }
 			}
 			newline = yes
 			CHI = {
@@ -20049,7 +20049,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.02  tooltip = office_park_income_tax_modifier_tt }
+				add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.02 tooltip = office_park_income_tax_modifier_tt }
 			}
 			newline = yes
 			random_owned_state = {
@@ -20105,7 +20105,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -20137,7 +20137,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_corporate_tax_income_multiplier_modifier = 0.06  tooltip = corporate_tax_income_multiplier_modifier_tt }
+				add_to_variable = { CHI_network_corporate_tax_income_multiplier_modifier = 0.06 tooltip = corporate_tax_income_multiplier_modifier_tt }
 			}
 			random_owned_state = {
 				add_building_construction = {
@@ -20152,11 +20152,11 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.03  tooltip = consumer_goods_factor_tt }
-				add_to_variable = { CHI_MAC_office_park_income_tax_modifier = 0.03  tooltip = office_park_income_tax_modifier_tt }
-				add_to_variable = { CHI_MAC_corporate_tax_income_multiplier_modifier = 0.025  tooltip = corporate_tax_income_multiplier_modifier_tt }
-				add_to_variable = { CHI_MAC_research_speed_factor = 0.05  tooltip = research_speed_factor_tt }
-				add_to_variable = { CHI_MAC_production_speed_internet_station_factor = 0.10  tooltip = production_speed_internet_station_factor_tt }
+				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.03 tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_MAC_office_park_income_tax_modifier = 0.03 tooltip = office_park_income_tax_modifier_tt }
+				add_to_variable = { CHI_MAC_corporate_tax_income_multiplier_modifier = 0.025 tooltip = corporate_tax_income_multiplier_modifier_tt }
+				add_to_variable = { CHI_MAC_research_speed_factor = 0.05 tooltip = research_speed_factor_tt }
+				add_to_variable = { CHI_MAC_production_speed_internet_station_factor = 0.10 tooltip = production_speed_internet_station_factor_tt }
 			}
 			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
@@ -20191,7 +20191,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -20222,7 +20222,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_trade_opinion_factor = 0.02  tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_network_trade_opinion_factor = 0.02 tooltip = trade_opinion_factor_tt }
 			}
 			random_owned_state = {
 				add_extra_state_shared_building_slots = 2
@@ -20238,12 +20238,12 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_trade_opinion_factor = 0.04  tooltip = trade_opinion_factor_tt }
-				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.03  tooltip = civilian_factories_productivity_tt }
-				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.04  tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_MAC_trade_opinion_factor = 0.04 tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.03 tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.04 tooltip = consumer_goods_factor_tt }
 			}
-			POR = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
-			BRA = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
+			POR = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
+			BRA = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
 			set_temp_variable = { treasury_change = -17 }
 			modify_treasury_effect = yes
 		}
@@ -20269,7 +20269,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_MAC_lotus_flower_economy
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_MAC_cultural_autonomy_push }
 
@@ -20280,36 +20280,36 @@ focus_tree = {
 			set_temp_variable = { sinicization_base_change = -5 }
 			CHI_apply_sinicization_MAC = yes
 			newline = yes
-			POR = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
-			BRA = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
+			POR = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
+			BRA = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
 			newline = yes
 			CHI = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_trade_opinion_factor = 0.05  tooltip = trade_opinion_factor_tt }
-				add_to_variable = { CHI_network_civilian_factories_productivity = 0.02  tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_network_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_network_civilian_factories_productivity = 0.02 tooltip = civilian_factories_productivity_tt }
 			}
 			newline = yes
-			POR = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
-			BRA = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
-			AGL = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
-			MOZ = { add_opinion_modifier = { target = MAC  modifier = mutual_trade_agreement } }
+			POR = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
+			BRA = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
+			AGL = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
+			MOZ = { add_opinion_modifier = { target = MAC modifier = mutual_trade_agreement } }
 			newline = yes
 			MAC = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_trade_opinion_factor = 0.05  tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_MAC_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
 			}
 			CHI = {
 				custom_effect_tooltip = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_trade_opinion_factor = 0.03  tooltip = trade_opinion_factor_tt }
+				add_to_variable = { CHI_network_trade_opinion_factor = 0.03 tooltip = trade_opinion_factor_tt }
 			}
 		}
 
@@ -20335,7 +20335,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_MAC_pearl_river_delta }
 
@@ -20355,8 +20355,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.04  tooltip = office_park_income_tax_modifier_tt }
-				add_to_variable = { CHI_network_interest_rate_multiplier_modifier = 0.02  tooltip = interest_rate_multiplier_modifier_tt }
+				add_to_variable = { CHI_network_office_park_income_tax_modifier = 0.04 tooltip = office_park_income_tax_modifier_tt }
+				add_to_variable = { CHI_network_interest_rate_multiplier_modifier = 0.02 tooltip = interest_rate_multiplier_modifier_tt }
 			}
 			newline = yes
 			MAC = {
@@ -20364,8 +20364,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.04  tooltip = civilian_factories_productivity_tt }
-				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.04  tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.04 tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.04 tooltip = consumer_goods_factor_tt }
 			}
 			1106 = {
 				add_extra_state_shared_building_slots = 1
@@ -20412,7 +20412,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -20452,7 +20452,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_civilian_factories_productivity = 0.03  tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_network_civilian_factories_productivity = 0.03 tooltip = civilian_factories_productivity_tt }
 			}
 			newline = yes
 			MAC = {
@@ -20460,8 +20460,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.04  tooltip = civilian_factories_productivity_tt }
-				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.03  tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.04 tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.03 tooltip = consumer_goods_factor_tt }
 			}
 			1106 = {
 				add_extra_state_shared_building_slots = 1
@@ -20507,7 +20507,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_MAC_infrastructure_link }
 
@@ -20527,8 +20527,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.04  tooltip = population_tax_income_multiplier_modifier_tt }
-				add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.03  tooltip = border_control_multiplier_modifier_tt }
+				add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.04 tooltip = population_tax_income_multiplier_modifier_tt }
+				add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.03 tooltip = border_control_multiplier_modifier_tt }
 			}
 			newline = yes
 			MAC = {
@@ -20536,8 +20536,8 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_MAC_integration_modifier
 				}
-				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.04  tooltip = civilian_factories_productivity_tt }
-				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.03  tooltip = consumer_goods_factor_tt }
+				add_to_variable = { CHI_MAC_civilian_factories_productivity = 0.04 tooltip = civilian_factories_productivity_tt }
+				add_to_variable = { CHI_MAC_consumer_goods_factor = -0.03 tooltip = consumer_goods_factor_tt }
 			}
 			1106 = {
 				add_extra_state_shared_building_slots = 2
@@ -20622,7 +20622,7 @@ focus_tree = {
 				remove_dynamic_modifier = { modifier = CHI_MAC_sinicization_modifier }
 				remove_core_of = MAC
 			}
-			annex_country = { target = MAC  transfer_troops = yes }
+			annex_country = { target = MAC transfer_troops = yes }
 		}
 
 		bypass_effect = {
@@ -20756,7 +20756,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.04  tooltip = border_control_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.04 tooltip = border_control_multiplier_modifier_tt }
 		}
 
 		ai_will_do = { base = 5 }
@@ -20781,7 +20781,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_TIB_sinification }
 
@@ -20798,8 +20798,8 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_civilian_factories_productivity = 0.03  tooltip = civilian_factories_productivity_tt }
-			add_to_variable = { CHI_network_bureaucracy_cost_multiplier_modifier = -0.05  tooltip = bureaucracy_cost_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_civilian_factories_productivity = 0.03 tooltip = civilian_factories_productivity_tt }
+			add_to_variable = { CHI_network_bureaucracy_cost_multiplier_modifier = -0.05 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		}
 
 		ai_will_do = { base = 5 }
@@ -20825,7 +20825,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -20853,11 +20853,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TIB_release_falun_gong"
-			USA = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
-			ENG = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
-			FRA = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
-			GER = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
-			IND = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
+			USA = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
+			ENG = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
+			FRA = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
+			GER = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
+			IND = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
 			newline = yes
 			589 = {
 				add_resistance = -5
@@ -20894,7 +20894,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TIB_release_falun_gong }
 
@@ -20906,11 +20906,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TIB_return_dalai_lama"
-			USA = { add_opinion_modifier = { target = CHI  modifier = dalai_lama_return_accord } }
-			ENG = { add_opinion_modifier = { target = CHI  modifier = dalai_lama_return_accord } }
-			FRA = { add_opinion_modifier = { target = CHI  modifier = dalai_lama_return_accord } }
-			GER = { add_opinion_modifier = { target = CHI  modifier = dalai_lama_return_accord } }
-			AUS = { add_opinion_modifier = { target = CHI  modifier = dalai_lama_return_accord } }
+			USA = { add_opinion_modifier = { target = CHI modifier = dalai_lama_return_accord } }
+			ENG = { add_opinion_modifier = { target = CHI modifier = dalai_lama_return_accord } }
+			FRA = { add_opinion_modifier = { target = CHI modifier = dalai_lama_return_accord } }
+			GER = { add_opinion_modifier = { target = CHI modifier = dalai_lama_return_accord } }
+			AUS = { add_opinion_modifier = { target = CHI modifier = dalai_lama_return_accord } }
 			newline = yes
 			589 = {
 				add_resistance_target = -8
@@ -20971,7 +20971,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.04  tooltip = resource_export_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.04 tooltip = resource_export_multiplier_modifier_tt }
 			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 		}
@@ -20993,7 +20993,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_TIB_plateau_development
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TIB_railway_modernization }
 
@@ -21009,14 +21009,14 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.04  tooltip = population_tax_income_multiplier_modifier_tt }
-			add_to_variable = { CHI_network_consumer_goods_factor = -0.02  tooltip = consumer_goods_factor_tt }
+			add_to_variable = { CHI_network_population_tax_income_multiplier_modifier = 0.04 tooltip = population_tax_income_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_consumer_goods_factor = -0.02 tooltip = consumer_goods_factor_tt }
 			newline = yes
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_TIB_sinicization_modifier
 			}
-			add_to_variable = { CHI_TIB_state_productivity_growth_modifier = 0.05  tooltip = state_productivity_growth_modifier_tt }
+			add_to_variable = { CHI_TIB_state_productivity_growth_modifier = 0.05 tooltip = state_productivity_growth_modifier_tt }
 		}
 
 		ai_will_do = { base = 5 }
@@ -21042,7 +21042,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -21065,10 +21065,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_TIB_autonomy_preservation"
-			USA = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
-			ENG = { add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance } }
+			USA = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
+			ENG = { add_opinion_modifier = { target = CHI modifier = china_religious_tolerance } }
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_SAR_network_modifier }
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.03  tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.03 tooltip = trade_opinion_factor_tt }
 			newline = yes
 			set_autonomy = {
 				target = TIB
@@ -21103,7 +21103,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TIB_autonomy_preservation }
 
@@ -21125,14 +21125,14 @@ focus_tree = {
 			}
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_TIB_sinicization_modifier }
-			add_to_variable = { CHI_TIB_population_tax_income_multiplier_modifier = 0.06  tooltip = population_tax_income_multiplier_modifier_tt }
+			add_to_variable = { CHI_TIB_population_tax_income_multiplier_modifier = 0.06 tooltip = population_tax_income_multiplier_modifier_tt }
 			newline = yes
 			every_other_country = {
 				limit = { is_western_nation = yes }
-				add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance }
+				add_opinion_modifier = { target = CHI modifier = china_religious_tolerance }
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_SAR_network_modifier }
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.02  tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.02 tooltip = trade_opinion_factor_tt }
 			set_temp_variable = { treasury_change = -4.5 }
 			modify_treasury_effect = yes
 		}
@@ -21275,11 +21275,11 @@ focus_tree = {
 			}
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_TIB_sinicization_modifier }
-			add_to_variable = { CHI_TIB_trade_opinion_factor = 0.10  tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_TIB_trade_opinion_factor = 0.10 tooltip = trade_opinion_factor_tt }
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_SAR_network_modifier }
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.075  tooltip = trade_opinion_factor_tt }
-			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.05  tooltip = resource_export_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.075 tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.05 tooltip = resource_export_multiplier_modifier_tt }
 			set_temp_variable = { treasury_change = -21.5 }
 			modify_treasury_effect = yes
 		}
@@ -21341,10 +21341,10 @@ focus_tree = {
 			}
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_TIB_sinicization_modifier }
-			add_to_variable = { CHI_TIB_resource_export_multiplier_modifier = 0.04  tooltip = resource_export_multiplier_modifier_tt }
+			add_to_variable = { CHI_TIB_resource_export_multiplier_modifier = 0.04 tooltip = resource_export_multiplier_modifier_tt }
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_SAR_network_modifier }
-			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.04  tooltip = resource_export_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.04 tooltip = resource_export_multiplier_modifier_tt }
 			newline = yes
 			TIB = {
 				add_tech_bonus = {
@@ -21516,7 +21516,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_ETK_silk_road_commerce }
 
@@ -21591,7 +21591,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_ETK_oilfield_development }
 
@@ -21633,7 +21633,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -21692,7 +21692,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_ETK_strike_hard_campaign }
 
@@ -21758,7 +21758,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.05  tooltip = border_control_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.05 tooltip = border_control_multiplier_modifier_tt }
 			newline = yes
 			592 = {
 				custom_effect_tooltip = {
@@ -21846,7 +21846,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.05  tooltip = border_control_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.05 tooltip = border_control_multiplier_modifier_tt }
 		}
 
 		bypass_effect = {
@@ -21868,7 +21868,7 @@ focus_tree = {
 					localization_key = modifies_dynamic_modifier_tt
 					MODIFIER = CHI_SAR_network_modifier
 				}
-				add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.05  tooltip = border_control_multiplier_modifier_tt }
+				add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.05 tooltip = border_control_multiplier_modifier_tt }
 			}
 		}
 
@@ -21895,7 +21895,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -21920,7 +21920,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_ETK_autonomy_statute"
 			every_other_country = {
 				limit = { is_western_nation = yes }
-				add_opinion_modifier = { target = CHI  modifier = china_religious_tolerance }
+				add_opinion_modifier = { target = CHI modifier = china_religious_tolerance }
 			}
 			newline = yes
 			release_autonomy = {
@@ -21955,7 +21955,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_ETK_autonomy_statute }
 
@@ -22025,7 +22025,7 @@ focus_tree = {
 					limit = {
 						OR = {
 							energy_infrastructure < 1
-							industrial_infrastructure  < 1
+							industrial_infrastructure < 1
 						}
 					}
 					add_building_construction = {
@@ -22051,7 +22051,7 @@ focus_tree = {
 			}
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_SAR_network_modifier }
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.03  tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.03 tooltip = trade_opinion_factor_tt }
 		}
 
 		ai_will_do = {
@@ -22130,7 +22130,7 @@ focus_tree = {
 	}
 
 	focus = {
-		id = CHI_TAI_economic_track   #### Localisation needs to be more immersive. Bonus should be a bit more interesting and unique for Taiwan/Chinese Economics. Also needs to be based on real life.
+		id = CHI_TAI_economic_track #### Localisation needs to be more immersive. Bonus should be a bit more interesting and unique for Taiwan/Chinese Economics. Also needs to be based on real life.
 		icon = peoples_republic_of_china
 
 		x = -3
@@ -22170,7 +22170,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_cross_strait_policy
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_cross_strait_policy }
 
@@ -22558,7 +22558,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_political_track }
 
@@ -22587,7 +22587,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_TAI_political_track }
 
@@ -22611,7 +22611,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_resume_party_contacts }
 
@@ -22647,7 +22647,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_TAI_legislative_exchange_forum }
 		prerequisite = { focus = CHI_TAI_offer_confidence_measures }
@@ -22675,7 +22675,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_political_track }
 
@@ -22708,7 +22708,7 @@ focus_tree = {
 		y = 3
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 3
 
 		prerequisite = { focus = CHI_TAI_reaffirm_the_1992_consensus }
 
@@ -22732,7 +22732,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_local_government_dialogue }
 		prerequisite = { focus = CHI_TAI_suspend_independence_initiatives }
@@ -22771,7 +22771,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_TAI_political_track
 
-		cost = 10
+		cost = 15
 
 		prerequisite = { focus = CHI_TAI_back_channel_settlement }
 		prerequisite = { focus = CHI_TAI_deep_economic_integration }
@@ -22985,7 +22985,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_fleet_modernization
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_fleet_modernization }
 
@@ -23018,7 +23018,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_fleet_modernization
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_fleet_modernization }
 
@@ -23074,7 +23074,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_TAI_fleet_modernization
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_amphibious_doctrine }
 		prerequisite = { focus = CHI_TAI_air_superiority }
@@ -23105,7 +23105,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_TAI_fleet_modernization
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_air_superiority }
 		prerequisite = { focus = CHI_TAI_dongfeng_program }
@@ -23230,7 +23230,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_combat_the_traitors
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_combat_the_traitors }
 
@@ -23259,7 +23259,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_economic_leverage
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_TAI_economic_leverage }
 
@@ -23288,7 +23288,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_TAI_economic_leverage
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_TAI_economic_leverage }
 
@@ -23360,7 +23360,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_TAI_economic_leverage
 
-		cost = 5
+		cost = 3
 
 		prerequisite = { focus = CHI_TAI_proxy_strategy }
 
@@ -23392,7 +23392,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = CHI_TAI_combat_the_traitors
 
-		cost = 10
+		cost = 15
 
 		prerequisite = { focus = CHI_TAI_cyber_warfare }
 		prerequisite = { focus = CHI_TAI_blockade_capability }
@@ -23443,7 +23443,7 @@ focus_tree = {
 		y = 5
 		relative_position_id = CHI_TAI_combat_the_traitors
 
-		cost = 10
+		cost = 7
 
 		prerequisite = { focus = CHI_TAI_operation_storm }
 
@@ -23556,7 +23556,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_agriculture_district_income_tax_modifier = 0.04  tooltip = agriculture_district_income_tax_modifier_tt }
+			add_to_variable = { CHI_network_agriculture_district_income_tax_modifier = 0.04 tooltip = agriculture_district_income_tax_modifier_tt }
 			newline = yes
 			556 = {
 				custom_effect_tooltip = {
@@ -23591,7 +23591,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_OMG_steppe_development
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_OMG_steppe_development }
 
@@ -23603,7 +23603,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.04  tooltip = resource_export_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_resource_export_multiplier_modifier = 0.04 tooltip = resource_export_multiplier_modifier_tt }
 			newline = yes
 			build_railway = {
 				path = { 11761 9843 6904 1590 14013 12432 7158 10424 7048 12331 4612 12448 4655 13950 }
@@ -23637,7 +23637,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_OMG_steppe_development
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_OMG_steppe_development }
 
@@ -23694,7 +23694,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -23721,7 +23721,7 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_SAR_network_modifier
 			}
-			add_to_variable = { CHI_network_education_cost_multiplier_modifier = -0.05  tooltip = education_cost_multiplier_modifier_tt }
+			add_to_variable = { CHI_network_education_cost_multiplier_modifier = -0.05 tooltip = education_cost_multiplier_modifier_tt }
 			newline = yes
 			556 = {
 				custom_effect_tooltip = {
@@ -23758,7 +23758,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 7
+		cost = 5
 
 		allow_branch = {
 			if = {
@@ -23810,7 +23810,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_OMG_mandarin_education
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_OMG_mandarin_education }
 
@@ -23950,10 +23950,10 @@ focus_tree = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = CHI_OMG_sinicization_modifier
 			}
-			add_to_variable = { CHI_OMG_trade_opinion_factor = 0.05  tooltip = trade_opinion_factor_tt }
-			add_to_variable = { CHI_OMG_resource_export_multiplier_modifier = 0.075  tooltip = resource_export_multiplier_modifier_tt }
-			add_to_variable = { CHI_OMG_civilian_factories_productivity = 0.10  tooltip = civilian_factories_productivity_tt }
-			add_to_variable = { CHI_OMG_offices_productivity = 0.10  tooltip = offices_productivity_tt }
+			add_to_variable = { CHI_OMG_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
+			add_to_variable = { CHI_OMG_resource_export_multiplier_modifier = 0.075 tooltip = resource_export_multiplier_modifier_tt }
+			add_to_variable = { CHI_OMG_civilian_factories_productivity = 0.10 tooltip = civilian_factories_productivity_tt }
+			add_to_variable = { CHI_OMG_offices_productivity = 0.10 tooltip = offices_productivity_tt }
 			newline = yes
 			556 = {
 				add_building_construction = {
@@ -24008,7 +24008,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = MON }
 			change_influence_percentage = yes
 			newline = yes
-			MON = { country_event = { id = china_sar.035  days = 1 } }
+			MON = { country_event = { id = china_sar.035 days = 1 } }
 			effect_tooltip = { MON = { add_ideas = MON_CHI_cultural_sphere_idea } }
 		}
 
@@ -24023,7 +24023,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = CHI_OMG_steppe_development
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_OMG_steppe_mining_industry }
 		prerequisite = { focus = CHI_OMG_northern_corridor }
@@ -24074,7 +24074,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = CHI_OMG_cultural_recognition
 
-		cost = 7
+		cost = 5
 
 		prerequisite = { focus = CHI_OMG_cultural_recognition }
 
@@ -24108,8 +24108,8 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt  MODIFIER = CHI_SAR_network_modifier }
-			add_to_variable = { CHI_network_trade_opinion_factor = 0.03  tooltip = trade_opinion_factor_tt }
+			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = CHI_SAR_network_modifier }
+			add_to_variable = { CHI_network_trade_opinion_factor = 0.03 tooltip = trade_opinion_factor_tt }
 		}
 
 		ai_will_do = { base = 5 }
@@ -24139,7 +24139,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_MON_reunification_offer"
-			MON = { country_event = { id = china_sar.036  days = 1 } }
+			MON = { country_event = { id = china_sar.036 days = 1 } }
 			custom_effect_tooltip = TT_IF_THEY_REJECT
 			unlock_decision_tooltip = CHI_MON_reunification_retry
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT


### PR DESCRIPTION
### Changes
- Rebalances every focus in the Chinese focus tree onto a 5-tier cost scale, cutting the tree's total completion cost from 4,924 to 3,400 and bringing China's pacing in line with the other major nation trees
- Shortens the longest Chinese prerequisite chain from 185 to 161 cost
- Rescales the space branch and Scientific Outlook focus cost reductions to match their now-cheaper targets