### PR TITLE
Trim Switzerland ROI bonuses and fold roi_rate math

### DIFF
--- a/common/national_focus/05_switzerland.txt
+++ b/common/national_focus/05_switzerland.txt
@@ -6766,7 +6766,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWI_foreign_investments"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWI_politica_estera_svizzera_modifier }
 			add_to_variable = { SWI_fp_investment_duration_modifier = -0.05 tooltip = investment_duration_modifier_tt }
-			add_to_variable = { SWI_fp_return_on_investment_modifier = 0.05 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { SWI_fp_return_on_investment_modifier = 0.02 tooltip = return_on_investment_modifier_tt }
 		}
 
 		ai_will_do = { base = 1 }
@@ -7037,7 +7037,7 @@ focus_tree = {
 			set_country_flag = SWI_west_bank_established
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWI_politica_estera_svizzera_modifier }
 			add_to_variable = { SWI_fp_consumer_goods_factor = -0.1 tooltip = consumer_goods_factor_tt }
-			add_to_variable = { SWI_fp_return_on_investment_modifier = 0.15 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { SWI_fp_return_on_investment_modifier = 0.03 tooltip = return_on_investment_modifier_tt }
 			add_to_variable = { SWI_fp_interest_rate_multiplier_modifier = -2 tooltip = interest_rate_multiplier_modifier_tt }
 			newline = yes
 			74 = {
@@ -7445,7 +7445,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWI_invest_in_eu"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWI_politica_estera_svizzera_modifier }
-			add_to_variable = { SWI_fp_return_on_investment_modifier = 0.05 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { SWI_fp_return_on_investment_modifier = 0.02 tooltip = return_on_investment_modifier_tt }
 		}
 
 		ai_will_do = { base = 1 }

--- a/common/scripted_effects/00_money_system.txt
+++ b/common/scripted_effects/00_money_system.txt
@@ -4186,12 +4186,8 @@ calculate_additional_expense_rate = {
 # Effect: calculate_int_investments_rate
 # Purpose: Computes weekly ROI from international investments and splits it into treasury vs reinvested shares
 calculate_int_investments_rate = {
-	# Set base ROI rate
-	set_variable = { roi_rate = 0.06 }	#6%
-
-	# Modifier for ROI
-	add_to_variable = { roi_rate = modifier@return_on_investment_modifier }
-	clamp_variable = { var = roi_rate min = 0 max = 0.20 }
+	# Base ROI + stacked return_on_investment_modifier, clamped to the engine-wide ceiling
+	set_variable = { roi_rate = { value = 0.06 add = modifier@return_on_investment_modifier clamp = { min = 0 max = 0.20 } } }
 
 	#This is how much money we get back in a year, converted to weekly
 	set_variable = { int_investments_rate = { value = int_investments multiply = roi_rate multiply = 0.019 clamp = { min = 0 max = @math_expressions_max } } }


### PR DESCRIPTION
**What**

- `common/national_focus/05_switzerland.txt`: drop the three `SWI_fp_return_on_investment_modifier` bonuses from `+5% / +15% / +5%` to `+2% / +3% / +2%`.
- `common/scripted_effects/00_money_system.txt`: fold the three-statement `roi_rate` calculation in `calculate_int_investments_rate` (set + add + clamp) into one inline math expression, matching the `int_investments_rate` style on the next line.

**Why**

Closes #3089. The engine-wide `roi_rate` is hard-capped at 20% in `calculate_int_investments_rate` (6% base + modifiers). Switzerland's three ROI focuses stack to +25% on the modifier, which means a player taking all three hits the ceiling and the in-game modifier tooltip shows a higher number than the actual ROI. Reducing the bonuses to a combined +7% gives 13% ROI with comfortable headroom under the clamp, keeps the three branches numerically comparable, and stays in the user-requested 1-3% range.

The clamp itself is intentionally untouched — it is engine-wide balance, not a SWI bug.

**How**

Arithmetic is identical for the engine fold: `0.06 + modifier@return_on_investment_modifier`, clamped to `0.20`. The new form is one `set_variable = { roi_rate = { value = 0.06 add = modifier@… clamp = { min = 0 max = 0.20 } } }` statement instead of three sequential mutations. The dynamic modifier tooltip self-reports the new stacked value, so no localisation edits are needed.

Files: `common/national_focus/05_switzerland.txt` (L6769, L7040, L7448), `common/scripted_effects/00_money_system.txt` (L4189).