### PR TITLE
Split new errors and warnings in the validation report

### DIFF
--- a/tools/generate_validation_report.py
+++ b/tools/generate_validation_report.py
@@ -70,9 +70,9 @@ def build_report(results_dir: str, ctx: ReportContext, baseline=None):
         workflow_run_url=ctx.workflow_run_url or "",
     )
 
-    # Step summary — the full report: every validator's issues, more of them, but
-    # skip raw logs (large and redundant with the structured list; omitting them
-    # keeps the summary under 1 MB).
+    # Step summary — the full report: new findings split by severity, then each
+    # failing validator's issues. Skip raw logs (large and redundant with the
+    # structured list; omitting them keeps the summary under 1 MB).
     step_body = render(
         runs,
         deduped,

--- a/tools/report_lib/markdown.py
+++ b/tools/report_lib/markdown.py
@@ -1,14 +1,15 @@
 """Render the validation report as Markdown.
 
 Two renderings come out of the same builder:
-  - PR comment (``include_validator_sections=False``): marker, verdict banner,
+  - PR comment (``include_validator_sections=False``): marker, verdict banner
+    (new errors and new warnings counted separately when a baseline is present),
     metadata strip, and a summary table of only the validators with findings
     (passing ones fold into a count line), plus a pointer to the step summary.
     Kept small so the comment doesn't drown the PR conversation in inline findings.
-  - Step summary (default): the full validator roster in the summary table plus
-    the per-validator <details> sections — failing ones open with issues grouped
-    by category, passing ones collapsed to a one-liner — and optionally the raw
-    per-validator logs.
+  - Step summary (default): the full validator roster in the summary table,
+    new findings split into error and warning groups, and per-validator
+    <details> only for validators that have findings. Clean validators collapse
+    to a single count line. Optionally the raw per-validator logs.
 """
 
 from collections import defaultdict
@@ -49,10 +50,10 @@ def render(
     detail for the step summary.
 
     ``baseline_stats`` (from ``baseline.classify``) adds the new-vs-existing
-    annotation: NEW/EXISTING counts in the verdict and, in the step summary,
-    a dedicated section listing new findings. ``Issue.baseline_status`` drives
-    the per-bullet NEW tag. Omit it (no baseline restored) and the report
-    renders as before.
+    annotation: new-error and new-warning counts in the verdict and, in the
+    step summary, those findings listed in separate groups.
+    ``Issue.baseline_status`` drives the per-bullet NEW tag. Omit it (no
+    baseline restored) and the report renders as before.
     """
     parts: List[str] = []
     parts.append(REPORT_MARKER)
@@ -142,6 +143,22 @@ def _count_label(errors: int, warnings: int) -> str:
     return ", ".join(parts) or "0 issues"
 
 
+def _new_count_label(errors: int, warnings: int) -> str:
+    parts = []
+    if errors:
+        parts.append(_plural(errors, "new error"))
+    if warnings:
+        parts.append(_plural(warnings, "new warning"))
+    return ", ".join(parts)
+
+
+def _new_findings_clause(stats: "BaselineStats") -> str:
+    """Verdict parenthetical: split new errors vs new warnings."""
+    if not stats.new_errors and not stats.new_warnings:
+        return " (none new against the main baseline.)"
+    return f" ({_new_count_label(stats.new_errors, stats.new_warnings)} against the main baseline.)"
+
+
 def _severity_icon(errors: int, warnings: int) -> str:
     if errors:
         return "❌"
@@ -166,10 +183,7 @@ def _render_verdict(
     if total_errors:
         line = f"{_plural(total_errors, 'error')} must be fixed before merge."
         if baseline_stats is not None:
-            if baseline_stats.new_errors:
-                line += f" ({baseline_stats.new_errors} new against the main baseline.)"
-            else:
-                line += " (none new against the main baseline.)"
+            line += _new_findings_clause(baseline_stats)
         if total_warnings:
             line += f" ({_plural(total_warnings, 'warning')}, advisory.)"
         return f"> [!CAUTION]\n> ❌ {line}"
@@ -177,12 +191,7 @@ def _render_verdict(
     if total_warnings:
         line = f"{_plural(total_warnings, 'warning')} to review. None block merge."
         if baseline_stats is not None:
-            if baseline_stats.new_warnings:
-                line += (
-                    f" ({baseline_stats.new_warnings} new against the main baseline.)"
-                )
-            else:
-                line += " (none new against the main baseline.)"
+            line += _new_findings_clause(baseline_stats)
         return f"> [!WARNING]\n> ⚠️ {line}"
 
     tail = (
@@ -257,6 +266,27 @@ def _render_summary_table(runs: List[ValidatorRun], show_passing: bool = True) -
 # ── Issues section ─────────────────────────────────────────────────────────────
 
 
+def _render_new_severity_group(
+    heading: str,
+    word: str,
+    issues: List[Issue],
+    ctx: ReportContext,
+    limit: int,
+) -> Tuple[List[str], int]:
+    """One New-errors or New-warnings block. Returns (lines, overflow)."""
+    if not issues:
+        return [], 0
+    sorted_issues = sorted(issues, key=lambda i: (i.file, i.line, i.message))
+    shown = sorted_issues[: max(limit, 0)]
+    overflow = len(sorted_issues) - len(shown)
+    lines = [f"### {heading} ({len(issues)})", ""]
+    lines.extend(_render_bullet(i, ctx) for i in shown)
+    if overflow:
+        lines.append(f"_…and {_plural(overflow, f'more new {word}')}._")
+    lines.append("")
+    return lines, overflow
+
+
 def _render_baseline_section(
     stats: "BaselineStats", ctx: ReportContext, max_visible: int
 ) -> str:
@@ -272,23 +302,18 @@ def _render_baseline_section(
             )
         return "\n".join(lines)
 
-    label = _count_label(stats.new_errors, stats.new_warnings)
-    lines.append(f"{label} not present on the latest main run:")
-    lines.append("")
-    sorted_new = sorted(
-        stats.new_issues,
-        key=lambda i: (
-            0 if i.severity == Severity.ERROR else 1,
-            i.file,
-            i.line,
-            i.message,
-        ),
+    new_errors = [i for i in stats.new_issues if i.severity == Severity.ERROR]
+    new_warnings = [i for i in stats.new_issues if i.severity != Severity.ERROR]
+    remaining = max_visible
+    error_lines, error_overflow = _render_new_severity_group(
+        "❌ New errors", "error", new_errors, ctx, remaining
     )
-    shown = sorted_new[:max_visible]
-    lines.extend(_render_bullet(i, ctx) for i in shown)
-    overflow = len(sorted_new) - len(shown)
-    if overflow:
-        lines.append(f"_…and {overflow:,} more new findings._")
+    remaining = max(0, remaining - (len(new_errors) - error_overflow))
+    warning_lines, _warning_overflow = _render_new_severity_group(
+        "⚠️ New warnings", "warning", new_warnings, ctx, remaining
+    )
+    lines.extend(error_lines)
+    lines.extend(warning_lines)
     if stats.unclassified:
         lines.append(
             f"_{stats.unclassified} finding(s) could not be compared (no file/line)._"
@@ -309,11 +334,11 @@ def _render_details_pointer(ctx: ReportContext) -> str:
 def _render_validator_sections(
     runs: List[ValidatorRun], issues: List[Issue], ctx: ReportContext, max_visible: int
 ) -> str:
-    """One collapsible <details> per validator (pass or fail).
+    """One collapsible <details> per validator that has findings.
 
     Failing validators open by default and list their issues grouped by
-    category; passing validators collapse to a single 'no issues' line, so the
-    full roster is browsable for review and debugging.
+    category. Clean validators are omitted and counted in a single line so the
+    summary is not a wall of empty dropdowns.
     """
     by_validator: Dict[str, Dict[str, List[Issue]]] = defaultdict(
         lambda: defaultdict(list)
@@ -346,15 +371,23 @@ def _render_validator_sections(
         rank = 0 if e else (1 if w else 2)
         return (rank, title.lower())
 
+    finding_names = [
+        name
+        for name in sorted(order, key=sort_key)
+        if counts[name][1] or counts[name][2]
+    ]
+    clean_count = len(order) - len(finding_names)
+    if not finding_names:
+        return ""
+
     sections: List[str] = ["## Validators", ""]
     rendered_count = 0
     overflow = 0
 
-    for name in sorted(order, key=sort_key):
+    for name in finding_names:
         title, errors, warnings = counts[name]
         icon = _severity_icon(errors, warnings)
         label = _count_label(errors, warnings)
-        has_findings = bool(errors or warnings)
 
         body: List[str] = []
         cat_map = by_validator.get(name, {})
@@ -392,19 +425,21 @@ def _render_validator_sections(
                 if cat_overflow:
                     body.append(f"_…and {cat_overflow:,} more in this category._")
                 body.append("")
-        elif has_findings:
+        else:
             body.append("_Findings reported in the summary line; see the raw log._")
             body.append("")
-        else:
-            body.append("✅ No issues found.")
-            body.append("")
 
-        open_attr = " open" if has_findings else ""
-        sections.append(f"<details{open_attr}>")
+        sections.append("<details open>")
         sections.append(f"<summary>{icon} {title} — {label}</summary>")
         sections.append("")
         sections.extend(body)
         sections.append("</details>")
+        sections.append("")
+
+    if clean_count:
+        sections.append(
+            f"✅ {_plural(clean_count, 'other validator')} completed successfully."
+        )
         sections.append("")
 
     if overflow:

--- a/tools/report_lib/markdown.py
+++ b/tools/report_lib/markdown.py
@@ -6,10 +6,10 @@ Two renderings come out of the same builder:
     metadata strip, and a summary table of only the validators with findings
     (passing ones fold into a count line), plus a pointer to the step summary.
     Kept small so the comment doesn't drown the PR conversation in inline findings.
-  - Step summary (default): the full validator roster in the summary table,
-    new findings split into error and warning groups, and per-validator
-    <details> only for validators that have findings. Clean validators collapse
-    to a single count line. Optionally the raw per-validator logs.
+  - Step summary (default): new findings split into error and warning groups,
+    a summary table of only the validators with findings, and per-validator
+    <details> only for those. Clean validators collapse to a single count
+    line. Optionally the raw per-validator logs.
 """
 
 from collections import defaultdict
@@ -74,9 +74,7 @@ def render(
             parts.append(baseline_section)
             parts.append("")
 
-    # Concise comment hides passing validators (count note only); the step
-    # summary lists the full roster alongside the per-validator sections.
-    summary = _render_summary_table(runs, show_passing=include_validator_sections)
+    summary = _render_summary_table(runs)
     if summary:
         parts.append(summary)
         parts.append("")
@@ -229,7 +227,7 @@ def _run_sort_key(r: ValidatorRun) -> Tuple[int, str]:
     return (rank, r.title.lower())
 
 
-def _render_summary_table(runs: List[ValidatorRun], show_passing: bool = True) -> str:
+def _render_summary_table(runs: List[ValidatorRun]) -> str:
     if not runs:
         return "_No validator results found._"
 
@@ -239,20 +237,13 @@ def _render_summary_table(runs: List[ValidatorRun], show_passing: bool = True) -
         return ""
 
     sorted_runs = sorted(runs, key=_run_sort_key)
+    table_runs = [r for r in sorted_runs if r.errors or r.warnings]
+    passed = sum(1 for r in runs if not r.errors and not r.warnings)
     passed_note = ""
-    if show_passing:
-        # Step summary: every validator gets a row (passing ones included) so the
-        # table is the full at-a-glance roster; failures sort to the top.
-        table_runs = sorted_runs
-    else:
-        # Concise comment: only validators with findings get a row; the rest are
-        # folded into a single count line so the comment stays small.
-        table_runs = [r for r in sorted_runs if r.errors or r.warnings]
-        passed = sum(1 for r in runs if not r.errors and not r.warnings)
-        if passed:
-            passed_note = (
-                f"\n\n✅ {_plural(passed, 'validator')} passed with no issues."
-            )
+    if passed:
+        passed_note = (
+            f"\n\n✅ {_plural(passed, 'other validator')} completed successfully."
+        )
 
     header = "| Validator | Errors | Warnings |\n|-----------|-------:|---------:|"
     rows = [
@@ -376,7 +367,6 @@ def _render_validator_sections(
         for name in sorted(order, key=sort_key)
         if counts[name][1] or counts[name][2]
     ]
-    clean_count = len(order) - len(finding_names)
     if not finding_names:
         return ""
 
@@ -434,12 +424,6 @@ def _render_validator_sections(
         sections.append("")
         sections.extend(body)
         sections.append("</details>")
-        sections.append("")
-
-    if clean_count:
-        sections.append(
-            f"✅ {_plural(clean_count, 'other validator')} completed successfully."
-        )
         sections.append("")
 
     if overflow:

--- a/tools/report_lib/tests/baseline_test.py
+++ b/tools/report_lib/tests/baseline_test.py
@@ -85,6 +85,7 @@ def test_classify_tags_new_and_existing(tmp_path):
         ],
     )
     baseline = load_baseline(str(tmp_path), "h")
+    assert baseline is not None
 
     issues = [
         _issue(file="old.txt", line=1, message="old finding"),
@@ -130,6 +131,7 @@ def test_classify_escalated_severity_counts_as_new(tmp_path):
         [_issue_dict("warning", file="a.txt", line=1, message="escalated")],
     )
     baseline = load_baseline(str(tmp_path), "h")
+    assert baseline is not None
 
     stats = classify([_issue(file="a.txt", line=1, message="escalated")], baseline)
     assert stats.new_errors == 1
@@ -345,6 +347,6 @@ def test_build_report_annotates_new_vs_existing(tmp_path):
     assert stats is not None
     assert stats.new_errors == 1
     assert stats.existing_errors == 1
-    assert "1 new against the main baseline." in body
+    assert "1 new error against the main baseline." in body
     assert "## New findings vs main baseline" in step_body
     assert len(deduped) == 2

--- a/tools/report_lib/tests/generate_validation_report_test.py
+++ b/tools/report_lib/tests/generate_validation_report_test.py
@@ -89,7 +89,7 @@ def test_main_annotates_new_vs_existing_from_baseline(tmp_path, monkeypatch, cap
 
     assert code == 0
     report = (tmp_path / "report.md").read_text(encoding="utf-8")
-    assert "1 new against the main baseline." in report
+    assert "1 new error against the main baseline." in report
     err = capsys.readouterr().err
     assert "vs main baseline: 1 new error(s), 0 new warning(s)" in err
 

--- a/tools/report_lib/tests/markdown_test.py
+++ b/tools/report_lib/tests/markdown_test.py
@@ -37,9 +37,9 @@ def test_render_includes_summary_table_totals():
     ]
     body = render(runs, [], _ctx())
     assert "| **Total** | **3** | **1** |" in body
-    # Every validator gets a row now — passing ones included, failures first.
     assert "| ❌ Events | 3 | 1 |" in body
-    assert "| ✅ Variables | 0 | 0 |" in body
+    assert "| ✅ Variables | 0 | 0 |" not in body
+    assert "✅ 1 other validator completed successfully." in body
 
 
 def test_render_verdict_caution_when_errors():
@@ -237,19 +237,18 @@ def test_concise_comment_hides_passing_validators():
     assert "Variables |" not in body
     assert "Ideas |" not in body
     # ...but are summarised as a count.
-    assert "✅ 2 validators passed with no issues." in body
+    assert "✅ 2 other validators completed successfully." in body
 
 
-def test_step_summary_keeps_passing_validators_in_table():
+def test_step_summary_hides_passing_validators():
     runs = [
         ValidatorRun(name="events", title="Events", status="failed", errors=2),
         ValidatorRun(name="variables", title="Variables", status="passed"),
     ]
-    # Default render (step-summary mode) keeps the full roster.
     body = render(runs, [], _ctx())
-    assert "| ✅ Variables | 0 | 0 |" in body
-    assert "passed with no issues." not in body
+    assert "| ✅ Variables | 0 | 0 |" not in body
     assert "<summary>✅ Variables" not in body
+    assert "<summary>✅ Variables — 0 issues</summary>" not in body
     assert "✅ 1 other validator completed successfully." in body
 
 

--- a/tools/report_lib/tests/markdown_test.py
+++ b/tools/report_lib/tests/markdown_test.py
@@ -154,13 +154,14 @@ def test_render_shows_detected_by_when_multiple_validators():
     assert "also: localisation, variables" in body
 
 
-def test_render_passing_validator_collapses_to_no_issues():
+def test_render_passing_validator_omits_empty_dropdown():
     run = ValidatorRun(name="events", title="Events", status="passed")
     body = render([run], [], _ctx())
     assert "## Issues" not in body  # old per-issue heading is gone
-    assert "## Validators" in body
-    assert "<summary>✅ Events — 0 issues</summary>" in body
-    assert "✅ No issues found." in body
+    assert "## Validators" not in body
+    assert "<summary>✅ Events — 0 issues</summary>" not in body
+    assert "✅ No issues found." not in body
+    assert "All 1 validator passed" in body
 
 
 def test_render_url_encodes_spaces_in_file_path():
@@ -248,6 +249,8 @@ def test_step_summary_keeps_passing_validators_in_table():
     body = render(runs, [], _ctx())
     assert "| ✅ Variables | 0 | 0 |" in body
     assert "passed with no issues." not in body
+    assert "<summary>✅ Variables" not in body
+    assert "✅ 1 other validator completed successfully." in body
 
 
 def test_concise_comment_no_pointer_when_clean():
@@ -275,17 +278,33 @@ def _stats(**overrides):
 
 def test_verdict_counts_new_against_baseline():
     runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
-    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=2))
+    body = render(
+        [runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=2, new_warnings=0)
+    )
     assert (
-        "2 errors must be fixed before merge. (2 new against the main baseline.)"
+        "2 errors must be fixed before merge. (2 new errors against the main baseline.)"
         in body
     )
 
 
 def test_verdict_says_none_new_when_all_existing():
     runs = [ValidatorRun(name="events", title="Events", status="failed", errors=2)]
-    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0))
+    body = render(
+        [runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0, new_warnings=0)
+    )
     assert "(none new against the main baseline.)" in body
+
+
+def test_verdict_splits_new_errors_and_warnings():
+    runs = [
+        ValidatorRun(
+            name="events", title="Events", status="failed", errors=5, warnings=3
+        )
+    ]
+    body = render(
+        [runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=2, new_warnings=1)
+    )
+    assert "(2 new errors, 1 new warning against the main baseline.)" in body
 
 
 def test_step_summary_lists_new_findings():
@@ -294,7 +313,7 @@ def test_step_summary_lists_new_findings():
             name="events", title="Events", status="failed", errors=1, warnings=1
         )
     ]
-    issue = Issue(
+    error = Issue(
         severity=Severity.ERROR,
         category="missing_key",
         message="key FOO not found",
@@ -303,10 +322,23 @@ def test_step_summary_lists_new_findings():
         validator="events",
         baseline_status="new",
     )
-    stats = _stats(new_issues=[issue], unclassified=1)
-    body = render([runs[0]], [issue], _ctx(), baseline_stats=stats)
+    warning = Issue(
+        severity=Severity.WARNING,
+        category="missing_key",
+        message="key BAR unused",
+        file="events/MD_x.txt",
+        line=80,
+        validator="events",
+        baseline_status="new",
+    )
+    stats = _stats(new_issues=[error, warning], unclassified=1)
+    body = render([runs[0]], [error, warning], _ctx(), baseline_stats=stats)
     assert "## New findings vs main baseline" in body
-    assert "1 error, 1 warning not present on the latest main run:" in body
+    assert "### ❌ New errors (1)" in body
+    assert "### ⚠️ New warnings (1)" in body
+    error_pos = body.index("### ❌ New errors (1)")
+    warning_pos = body.index("### ⚠️ New warnings (1)")
+    assert error_pos < warning_pos
     assert "**NEW**" in body
     assert "1 finding(s) could not be compared (no file/line)." in body
 
@@ -323,9 +355,11 @@ def test_warning_verdict_counts_new_against_baseline():
             name="events", title="Events", status="warnings", errors=0, warnings=5
         )
     ]
-    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_warnings=3))
+    body = render(
+        [runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0, new_warnings=3)
+    )
     assert "5 warnings to review. None block merge." in body
-    assert "(3 new against the main baseline.)" in body
+    assert "(3 new warnings against the main baseline.)" in body
 
 
 def test_warning_verdict_says_none_new():
@@ -334,7 +368,9 @@ def test_warning_verdict_says_none_new():
             name="events", title="Events", status="warnings", errors=0, warnings=5
         )
     ]
-    body = render([runs[0]], [], _ctx(), baseline_stats=_stats(new_warnings=0))
+    body = render(
+        [runs[0]], [], _ctx(), baseline_stats=_stats(new_errors=0, new_warnings=0)
+    )
     assert "(none new against the main baseline.)" in body
 
 
@@ -356,9 +392,50 @@ def test_baseline_section_caps_new_findings():
 
     body = render([runs[0]], issues, _ctx(), max_visible=3, baseline_stats=stats)
 
-    assert "_…and 2 more new findings._" in body
+    assert "_…and 2 more new errors._" in body
     assert "key 3 not found" in body
     assert "key 4 not found" not in body
+
+
+def test_baseline_section_gives_remaining_budget_to_warnings():
+    runs = [
+        ValidatorRun(
+            name="events", title="Events", status="failed", errors=2, warnings=2
+        )
+    ]
+    issues = [
+        Issue(
+            severity=Severity.ERROR,
+            category="missing_key",
+            message=f"error {n}",
+            file="events/MD_x.txt",
+            line=n,
+            validator="events",
+            baseline_status="new",
+        )
+        for n in (1, 2)
+    ] + [
+        Issue(
+            severity=Severity.WARNING,
+            category="missing_key",
+            message=f"warning {n}",
+            file="events/MD_x.txt",
+            line=n,
+            validator="events",
+            baseline_status="new",
+        )
+        for n in (3, 4)
+    ]
+    stats = _stats(new_issues=issues, new_errors=2, new_warnings=2)
+
+    body = render([runs[0]], issues, _ctx(), max_visible=3, baseline_stats=stats)
+
+    assert "### ❌ New errors (2)" in body
+    assert "### ⚠️ New warnings (2)" in body
+    assert "error 2" in body
+    assert "warning 3" in body
+    assert "warning 4" not in body
+    assert "_…and 1 more new warning._" in body
 
 
 def test_baseline_section_notes_unclassified_findings():
@@ -399,4 +476,4 @@ def test_concise_comment_omits_baseline_section():
     # The concise PR comment carries the counts in the verdict, not the
     # per-finding section that lives in the step summary.
     assert "## New findings vs main baseline" not in body
-    assert "(1 new against the main baseline.)" in body
+    assert "(1 new error, 1 new warning against the main baseline.)" in body


### PR DESCRIPTION
The PR comment now says how many new errors and new warnings this branch added, instead of a single "N new" count. The step summary splits those lists into separate error and warning groups.

Clean validators no longer get empty dropdowns. They collapse to one line: "N other validators completed successfully."