### PR TITLE
Remove redundant party popularity defaults

### DIFF
--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -4385,30 +4385,7 @@ focus_tree = {
 					}
 					start_politics_input = yes
 					### Party Popularities
-					set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-					set_variable = { party_pop_array^1 = 0.00 } #conservatism
-					set_variable = { party_pop_array^2 = 0.00 } #liberalism
-					set_variable = { party_pop_array^3 = 0.00 } #socialism
-					set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-					set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-					set_variable = { party_pop_array^6 = 0.00 } #Conservative
-					set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-					set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-					set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
 					set_variable = { party_pop_array^10 = 1.00 } #Kingdom
-					set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-					set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-					set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-					set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-					set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-					set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-					set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-					set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-					set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-					set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-					set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-					set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-					set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 					### Ruling Party
 					add_to_array = { ruling_party = 10 }
 					startup_politics = yes

--- a/events/Iran.txt
+++ b/events/Iran.txt
@@ -2517,30 +2517,9 @@ country_event = {
 			#set_province_controller = 3795
 			news_event = axis_of_resistance_events.31
 			start_politics_input = yes
-			set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-			set_variable = { party_pop_array^1 = 0.00 } #conservatism
-			set_variable = { party_pop_array^2 = 0.00 } #liberalism
-			set_variable = { party_pop_array^3 = 0.00 } #socialism
-			set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-			set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-			set_variable = { party_pop_array^6 = 0.00 } #Conservative
-			set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-			set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-			set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
 			set_variable = { party_pop_array^10 = 0.47 } #Kingdom
-			set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-			set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
 			set_variable = { party_pop_array^13 = 0.06 } #Neutral_Autocracy
-			set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-			set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-			set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-			set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-			set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-			set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-			set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-			set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 			set_variable = { party_pop_array^22 = 0.47 } #Nat_Autocracy
-			set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 			add_to_array = { ruling_party = 10 }
 			startup_politics = yes
 		}
@@ -2653,30 +2632,9 @@ country_event = {
 			set_political_party = { ideology = democratic popularity = -100 }
 			set_political_party = { ideology = communism popularity = -100 }
 			start_politics_input = yes
-			set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-			set_variable = { party_pop_array^1 = 0.00 } #conservatism
-			set_variable = { party_pop_array^2 = 0.00 } #liberalism
-			set_variable = { party_pop_array^3 = 0.00 } #socialism
-			set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-			set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-			set_variable = { party_pop_array^6 = 0.00 } #Conservative
-			set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-			set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-			set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
 			set_variable = { party_pop_array^10 = 0.67 } #Kingdom
-			set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-			set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
 			set_variable = { party_pop_array^13 = 0.06 } #Neutral_Autocracy
-			set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-			set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-			set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-			set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-			set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-			set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-			set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-			set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 			set_variable = { party_pop_array^22 = 0.27 } #Nat_Autocracy
-			set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 			add_to_array = { ruling_party = 12 }
 			startup_politics = yes
 			create_country_leader = {
@@ -3229,30 +3187,10 @@ country_event = {
 			set_political_party = { ideology = nationalist popularity = 29 }
 			set_political_party = { ideology = fascism popularity = 12 }
 			start_politics_input = yes
-			set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-			set_variable = { party_pop_array^1 = 0.00 } #conservatism
-			set_variable = { party_pop_array^2 = 0.00 } #liberalism
-			set_variable = { party_pop_array^3 = 0.00 } #socialism
-			set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-			set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-			set_variable = { party_pop_array^6 = 0.00 } #Conservative
-			set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-			set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-			set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
 			set_variable = { party_pop_array^10 = 0.10 } #Kingdom
-			set_variable = { party_pop_array^11 = 0.00 } #Caliphate
 			set_variable = { party_pop_array^12 = 0.47 } #Neutral_Muslim_Brotherhood
 			set_variable = { party_pop_array^13 = 0.06 } #Neutral_Autocracy
-			set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-			set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-			set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-			set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-			set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-			set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-			set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-			set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 			set_variable = { party_pop_array^22 = 0.37 } #Nat_Autocracy
-			set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 			add_to_array = { ruling_party = 12 }
 			startup_politics = yes
 			create_country_leader = {
@@ -17653,29 +17591,8 @@ country_event = {
 				start_politics_input = yes
 				### Party Popularities
 				set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
 				set_variable = { party_pop_array^8 = 0.47 } #Mod_Vilayat_e_Faqih -> Reformists
 				set_variable = { party_pop_array^9 = 0.47 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 6 }
 				startup_politics = yes
@@ -18043,29 +17960,7 @@ country_event = {
 				start_politics_input = yes
 				### Party Popularities
 				set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 				set_variable = { party_pop_array^22 = 0.94 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 22 }
 				startup_politics = yes
@@ -18536,29 +18431,7 @@ country_event = {
 				start_politics_input = yes
 				### Party Popularities
 				set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 				set_variable = { party_pop_array^22 = 0.94 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 22 }
 				startup_politics = yes

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -3572,29 +3572,7 @@ country_event = { # Sunni Officers Rally Around Al-Douri
 						start_politics_input = yes
 						### Party Popularities
 						set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-						set_variable = { party_pop_array^1 = 0.00 } #conservatism
-						set_variable = { party_pop_array^2 = 0.00 } #liberalism
-						set_variable = { party_pop_array^3 = 0.00 } #socialism
-						set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-						set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-						set_variable = { party_pop_array^6 = 0 } #Conservative
-						set_variable = { party_pop_array^7 = 0 } #Autocracy
-						set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-						set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
-						set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-						set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-						set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-						set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-						set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-						set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-						set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-						set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-						set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-						set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-						set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
 						set_variable = { party_pop_array^21 = 0.94 } #Nat_Fascism
-						set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-						set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 						### Ruling Party
 						add_to_array = { ruling_party = 21 }
 						startup_politics = yes
@@ -3790,29 +3768,7 @@ country_event = { # Sunni Officers Rally Around Al-Douri
 				start_politics_input = yes
 				### Party Popularities
 				set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
 				set_variable = { party_pop_array^7 = 0.94 } #Autocracy
-				set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 7 }
 				startup_politics = yes
@@ -4055,29 +4011,7 @@ country_event = { # Sunni Officers Rally Around Al-Douri
 						start_politics_input = yes
 						### Party Popularities
 						set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-						set_variable = { party_pop_array^1 = 0.00 } #conservatism
-						set_variable = { party_pop_array^2 = 0.00 } #liberalism
-						set_variable = { party_pop_array^3 = 0.00 } #socialism
-						set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-						set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-						set_variable = { party_pop_array^6 = 0 } #Conservative
-						set_variable = { party_pop_array^7 = 0 } #Autocracy
-						set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-						set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
-						set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-						set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-						set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-						set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-						set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-						set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-						set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-						set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-						set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-						set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-						set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
 						set_variable = { party_pop_array^21 = 0.94 } #Nat_Fascism
-						set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-						set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 						### Ruling Party
 						add_to_array = { ruling_party = 21 }
 						startup_politics = yes
@@ -6358,30 +6292,7 @@ country_event = {
 			}
 			start_politics_input = yes
 			### Party Popularities
-			set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-			set_variable = { party_pop_array^1 = 0.00 } #conservatism
 			set_variable = { party_pop_array^2 = 1 } #liberalism
-			set_variable = { party_pop_array^3 = 0.00 } #socialism
-			set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-			set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-			set_variable = { party_pop_array^6 = 0.00 } #Conservative
-			set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-			set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-			set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-			set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-			set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-			set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-			set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-			set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-			set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-			set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-			set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-			set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-			set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-			set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-			set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-			set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-			set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 			### Ruling Party
 			add_to_array = { ruling_party = 2 }
 			startup_politics = yes
@@ -6891,30 +6802,7 @@ country_event = {
 				set_variable = { domestic_influence_amount = 100 }
 				start_politics_input = yes
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0.00 } #Conservative
-				set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
 				set_variable = { party_pop_array^20 = 1 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 20 }
 				startup_politics = yes
@@ -7106,30 +6994,7 @@ country_event = {
 			}
 			start_politics_input = yes
 			### Party Popularities
-			set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-			set_variable = { party_pop_array^1 = 0.00 } #conservatism
 			set_variable = { party_pop_array^2 = 1 } #liberalism
-			set_variable = { party_pop_array^3 = 0.00 } #socialism
-			set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-			set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-			set_variable = { party_pop_array^6 = 0.00 } #Conservative
-			set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-			set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-			set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-			set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-			set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-			set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-			set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-			set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-			set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-			set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-			set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-			set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-			set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-			set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-			set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-			set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-			set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 			### Ruling Party
 			add_to_array = { ruling_party = 22 }
 			startup_politics = yes
@@ -7374,30 +7239,7 @@ country_event = {
 				set_variable = { domestic_influence_amount = 100 }
 				start_politics_input = yes
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0.00 } #Conservative
-				set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
 				set_variable = { party_pop_array^9 = 1 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 20 }
 				startup_politics = yes
@@ -7601,30 +7443,7 @@ country_event = {
 				}
 				start_politics_input = yes
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
 				set_variable = { party_pop_array^2 = 1 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0.00 } #Conservative
-				set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 22 }
 				startup_politics = yes

--- a/events/Tajikistan.txt
+++ b/events/Tajikistan.txt
@@ -105,30 +105,7 @@ country_event = {
 		}
 		start_politics_input = yes
 		### Party Popularities
-		set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-		set_variable = { party_pop_array^1 = 0.00 } #conservatism
-		set_variable = { party_pop_array^2 = 0.00 } #liberalism
-		set_variable = { party_pop_array^3 = 0.00 } #socialism
-		set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-		set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-		set_variable = { party_pop_array^6 = 0.00 } #Conservative
-		set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-		set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-		set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-		set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-		set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-		set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-		set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-		set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-		set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-		set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-		set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-		set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-		set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-		set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-		set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 		set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-		set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 		### Ruling Party
 		add_to_array = { ruling_party = 22 }
 		startup_politics = yes
@@ -1372,30 +1349,8 @@ country_event = { # Tajik Revolution
 					start_politics_input = yes
 
 					### Party Popularities
-					set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-					set_variable = { party_pop_array^1 = 0.00 } #conservatism
-					set_variable = { party_pop_array^2 = 0.00 } #liberalism
-					set_variable = { party_pop_array^3 = 0.00 } #socialism
-					set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-					set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
 					set_variable = { party_pop_array^6 = 0.80 } #Conservative
-					set_variable = { party_pop_array^7 = 0 } #Autocracy
-					set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-					set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
 					set_variable = { party_pop_array^10 = 0.20 } #Kingdom
-					set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-					set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-					set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-					set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-					set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-					set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-					set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-					set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-					set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-					set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-					set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-					set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-					set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 
 					# Leader Rahmon
 					if = {
@@ -1555,30 +1510,8 @@ country_event = { # Tajik Revolution
 					start_politics_input = yes
 
 					### Party Popularities
-					set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-					set_variable = { party_pop_array^1 = 0.00 } #conservatism
-					set_variable = { party_pop_array^2 = 0.00 } #liberalism
-					set_variable = { party_pop_array^3 = 0.00 } #socialism
-					set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-					set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
 					set_variable = { party_pop_array^6 = 0.80 } #Conservative
-					set_variable = { party_pop_array^7 = 0 } #Autocracy
-					set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-					set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
 					set_variable = { party_pop_array^10 = 0.20 } #Kingdom
-					set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-					set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-					set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-					set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-					set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-					set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-					set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-					set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-					set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-					set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-					set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-					set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-					set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 
 					# Leader Rahmon
 					if = {
@@ -3628,30 +3561,8 @@ country_event = {
 				start_politics_input = yes
 
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
 				set_variable = { party_pop_array^10 = 0.20 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
 				set_variable = { party_pop_array^12 = 0.80 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 
 				# Leader (Before/After Nuri's death)
 				if = {
@@ -4360,30 +4271,8 @@ country_event = {
 				start_politics_input = yes
 
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
 				set_variable = { party_pop_array^10 = 0.80 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
 				set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 
 				# Leader
 				create_country_leader = {
@@ -4488,34 +4377,11 @@ country_event = {
 				start_politics_input = yes
 
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 				set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 
 				# Leader
 				create_country_leader = {
-					name = "Sherali Mirzo "
+					name = "Sherali Mirzo"
 					picture = "Portrait_Sherali_Mirzo.dds"
 					ideology = Nat_Autocracy
 					traits = {
@@ -4566,30 +4432,7 @@ country_event = {
 				start_politics_input = yes
 
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 				set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 
 				# Leader
 				create_country_leader = {

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -27339,29 +27339,9 @@ country_event = {
 			start_politics_input = yes
 			### Party Popularities
 			set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-			set_variable = { party_pop_array^1 = 0.00 } #conservatism
-			set_variable = { party_pop_array^2 = 0.00 } #liberalism
-			set_variable = { party_pop_array^3 = 0.00 } #socialism
-			set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-			set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-			set_variable = { party_pop_array^6 = 0 } #Conservative
-			set_variable = { party_pop_array^7 = 0 } #Autocracy
 			set_variable = { party_pop_array^8 = 0.47 } #Mod_Vilayat_e_Faqih -> Reformists
 			set_variable = { party_pop_array^9 = 0.47 } #Vilayat_e_Faqih -> Principalists
-			set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-			set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-			set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-			set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-			set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-			set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-			set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-			set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-			set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-			set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-			set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-			set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-			set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-			set_variable = { party_pop_array^23 = 0.00 } #Monarchist
+
 			### Ruling Party
 			add_to_array = { ruling_party = 6 }
 			startup_politics = yes
@@ -27674,29 +27654,7 @@ country_event = {
 				start_politics_input = yes
 				### Party Popularities
 				set_variable = { party_pop_array^0 = 0.06 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
-				set_variable = { party_pop_array^2 = 0.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0 } #Conservative
-				set_variable = { party_pop_array^7 = 0 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 				set_variable = { party_pop_array^22 = 0.94 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 22 }
 				startup_politics = yes
@@ -29971,30 +29929,7 @@ country_event = {
 				start_politics_input = yes
 				ingame_startup_nations_effect = yes
 				### Party Popularities
-				set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
-				set_variable = { party_pop_array^1 = 0.00 } #conservatism
 				set_variable = { party_pop_array^2 = 1.00 } #liberalism
-				set_variable = { party_pop_array^3 = 0.00 } #socialism
-				set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-				set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
-				set_variable = { party_pop_array^6 = 0.00 } #Conservative
-				set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-				set_variable = { party_pop_array^8 = 0.00 } #Mod_Vilayat_e_Faqih -> Reformists
-				set_variable = { party_pop_array^9 = 0.00 } #Vilayat_e_Faqih -> Principalists
-				set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-				set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-				set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-				set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
-				set_variable = { party_pop_array^14 = 0.00 } #Neutral_conservatism
-				set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-				set_variable = { party_pop_array^16 = 0.00 } #Neutral_Libertarian
-				set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-				set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-				set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
-				set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-				set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-				set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-				set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 				### Ruling Party
 				add_to_array = { ruling_party = 2 }
 				startup_politics = yes

--- a/history/countries/ABK - Abkhazia.txt
+++ b/history/countries/ABK - Abkhazia.txt
@@ -152,30 +152,10 @@ capital = 706
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.51 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.15 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.25 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.09 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 4 }
 
 	startup_politics = yes

--- a/history/countries/ACE - Aceh.txt
+++ b/history/countries/ACE - Aceh.txt
@@ -100,30 +100,7 @@ capital = 622
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 1.0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 12 }
 	startup_politics = yes
 

--- a/history/countries/ADJ - Adjara.txt
+++ b/history/countries/ADJ - Adjara.txt
@@ -82,30 +82,7 @@ capital = 466
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 1.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/ADO - Andorra.txt
+++ b/history/countries/ADO - Andorra.txt
@@ -209,30 +209,12 @@ capital = 945
 
 	start_politics_input = yes
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.087 } #conservatism
 	set_variable = { party_pop_array^2 = 0.405 } #liberalism
 	set_variable = { party_pop_array^3 = 0.271 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.087 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.02 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.13 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/ADS - Aegist.txt
+++ b/history/countries/ADS - Aegist.txt
@@ -160,30 +160,7 @@ capital = 17
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 22 }
 
 	startup_politics = yes

--- a/history/countries/ADY - Adygea.txt
+++ b/history/countries/ADY - Adygea.txt
@@ -88,30 +88,12 @@ capital = 1127
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.10 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.14 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.07 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.5 } #Conservative
 	set_variable = { party_pop_array^7 = 0.10 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.08 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/AFG - Afghanistan.txt
+++ b/history/countries/AFG - Afghanistan.txt
@@ -186,26 +186,13 @@ capital = 411
 	set_variable = { party_pop_array^0 = 0.23 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
 	set_variable = { party_pop_array^2 = 0.09 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.04 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.13 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.32 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.04 } #Monarchist
 	add_to_array = { ruling_party = 12 }
 	add_to_array = { gov_coalition_array = 0 }

--- a/history/countries/AFR - Armed Forces Revolutionary Council.txt
+++ b/history/countries/AFR - Armed Forces Revolutionary Council.txt
@@ -115,30 +115,9 @@ capital = 357
 	start_politics_input = yes
 
 	### Party Variables
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.35 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.1 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.55 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 22 }
 	startup_politics = yes
 

--- a/history/countries/AGL - Angola.txt
+++ b/history/countries/AGL - Angola.txt
@@ -154,30 +154,14 @@ capital = 298
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.227 } #conservatism
 	set_variable = { party_pop_array^2 = 0.014 } #liberalism
 	set_variable = { party_pop_array^3 = 0.004 } #socialism
 	set_variable = { party_pop_array^4 = 0.136 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.562 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.019 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.028 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.01 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 5 }
 	add_to_array = { gov_coalition_array = 4 } #Communist-State

--- a/history/countries/AIA - Al-Shabaabya.txt
+++ b/history/countries/AIA - Al-Shabaabya.txt
@@ -175,30 +175,8 @@ capital = 1222
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.76 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.24 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 11 }

--- a/history/countries/ALA - Alawite State.txt
+++ b/history/countries/ALA - Alawite State.txt
@@ -93,30 +93,7 @@ capital = 189
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 1.0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/ALB - Albania.txt
+++ b/history/countries/ALB - Albania.txt
@@ -186,26 +186,7 @@ capital = 137
 	set_variable = { party_pop_array^1 = 0.429 } #conservatism
 	set_variable = { party_pop_array^2 = 0.067 } #liberalism
 	set_variable = { party_pop_array^3 = 0.448 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.026 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/ALG - Algeria.txt
+++ b/history/countries/ALG - Algeria.txt
@@ -305,30 +305,15 @@ set_research_slots = 4
 	set_variable = { election_threshold = 0.01 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy -PAR
-	set_variable = { party_pop_array^1 = 0 } #conservatism - ANR
 	set_variable = { party_pop_array^2 = 0.257 } #liberalism - RND
-	set_variable = { party_pop_array^3 = 0 } #socialism - UDR then MPA
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.013 } #Conservative - FNA
 	set_variable = { party_pop_array^7 = 0.447 } #Autocracy - FLN
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.001 } #Caliphate - Salafist Group for Preaching and Combat
 	set_variable = { party_pop_array^12 = 0.143 } #Neutral_Muslim_Brotherhood - Movement of Society for Peace
 	set_variable = { party_pop_array^13 = 0.024 } #Neutral_Autocracy - Islah/MRN
 	set_variable = { party_pop_array^14 = 0.056 } #Neutral_conservatism - Nahda/MRI
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian - RCD
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green - AGP
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social - FFS
 	set_variable = { party_pop_array^19 = 0.039 } #Neutral_Communism - Worker's Party
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism - Ahd 54
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism - New Dawn - Arab Bath Party of Algeria
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy - Algerian People's National Armed Forces
-	set_variable = { party_pop_array^23 = 0 } #Monarchist - Kingdom of Algeria
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/ALT - Altai.txt
+++ b/history/countries/ALT - Altai.txt
@@ -71,30 +71,12 @@ capital = 684
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.11 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.26 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.31 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.08 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/ANJ - Anjouan.txt
+++ b/history/countries/ANJ - Anjouan.txt
@@ -132,30 +132,10 @@ capital = 1214
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.2 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
 	set_variable = { party_pop_array^3 = 0.45 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.25 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/ANT - Antigua and Barbuda.txt
+++ b/history/countries/ANT - Antigua and Barbuda.txt
@@ -152,30 +152,9 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.182 } #conservatism
 	set_variable = { party_pop_array^2 = 0.091 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.727 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/AQY - Al-Qaeda in Yemen.txt
+++ b/history/countries/AQY - Al-Qaeda in Yemen.txt
@@ -110,31 +110,7 @@ capital = 199
 	}
 
 	start_politics_input = yes
-
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 1.0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 11 }
 	startup_politics = yes
 

--- a/history/countries/ARA - Arabistan.txt
+++ b/history/countries/ARA - Arabistan.txt
@@ -214,30 +214,11 @@ capital = 399
 	set_variable = { var = population_tax_rate value = 25 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.15 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.15 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.45 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/ARG - Argentina.txt
+++ b/history/countries/ARG - Argentina.txt
@@ -444,30 +444,15 @@ capital = 453
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.14 } #conservatism
 	set_variable = { party_pop_array^2 = 0.14 } #liberalism
 	set_variable = { party_pop_array^3 = 0.35 } #socialism
 	set_variable = { party_pop_array^4 = 0.005 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.01 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.005 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.34 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.005 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.005 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/ARK - Rakhine.txt
+++ b/history/countries/ARK - Rakhine.txt
@@ -118,30 +118,7 @@ capital = 500
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/ARM - Armenia.txt
+++ b/history/countries/ARM - Armenia.txt
@@ -262,27 +262,15 @@ capital = 709
 	set_variable = { party_pop_array^0 = 0.020 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.025 } #conservatism1
 	set_variable = { party_pop_array^2 = 0.232 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.006 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism2
 	set_variable = { party_pop_array^6 = 0.236 } #Conservative
 	set_variable = { party_pop_array^7 = 0.110 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood3
 	set_variable = { party_pop_array^13 = 0.083 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism4
-	set_variable = { party_pop_array^15 = 0 } #oligarchism5
 	set_variable = { party_pop_array^16 = 0.050 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social6
 	set_variable = { party_pop_array^19 = 0.133 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.030 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.050 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.025 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 6 }
 	startup_politics = yes
 

--- a/history/countries/ASK - Alaska.txt
+++ b/history/countries/ASK - Alaska.txt
@@ -406,14 +406,6 @@ capital = 814
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
@@ -421,9 +413,6 @@ capital = 814
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/AST - Australia.txt
+++ b/history/countries/AST - Australia.txt
@@ -613,30 +613,17 @@ capital = 742
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.4 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
 	set_variable = { party_pop_array^3 = 0.39 } #socialism
 	set_variable = { party_pop_array^4 = 0.002 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.002 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.002 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.04 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.02 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.009 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.082 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.003 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { gov_coalition_array = 14 } #LNP coalition
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes

--- a/history/countries/AUS - Austria.txt
+++ b/history/countries/AUS - Austria.txt
@@ -427,30 +427,13 @@ capital = 76
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.3 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.31 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.01 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.25 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/AZE - Azerbaijan.txt
+++ b/history/countries/AZE - Azerbaijan.txt
@@ -208,29 +208,18 @@ capital = 713
 	start_politics_input = yes
 
 	set_variable = { party_pop_array^0 = 0.04 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.3 } #socialism
 	set_variable = { party_pop_array^4 = 0.04 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.02 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.30 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.04 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.06 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.06 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.03 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 13 }
 	startup_politics = yes
 

--- a/history/countries/BAH - Bahamas.txt
+++ b/history/countries/BAH - Bahamas.txt
@@ -150,30 +150,8 @@ capital = 856
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.521 } #conservatism
 	set_variable = { party_pop_array^2 = 0.479 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/BAL - Anti-Balaka.txt
+++ b/history/countries/BAL - Anti-Balaka.txt
@@ -95,30 +95,7 @@ capital = 922
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/BAN - Bangladesh.txt
+++ b/history/countries/BAN - Bangladesh.txt
@@ -194,30 +194,13 @@ capital = 490
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.094 } #conservatism
 	set_variable = { party_pop_array^2 = 0.009 } #liberalism
-	set_variable = { party_pop_array^3 = 0.0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.41 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.043 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.414 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/BAR - Barbados.txt
+++ b/history/countries/BAR - Barbados.txt
@@ -162,30 +162,8 @@ capital = 865
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.351 } #liberalism
 	set_variable = { party_pop_array^3 = 0.649 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/BDA - Badakhshan.txt
+++ b/history/countries/BDA - Badakhshan.txt
@@ -61,30 +61,7 @@ capital = 722
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/BEL - Belgium.txt
+++ b/history/countries/BEL - Belgium.txt
@@ -399,30 +399,13 @@ capital = 51
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.22 } #conservatism
 	set_variable = { party_pop_array^2 = 0.274 } #liberalism
 	set_variable = { party_pop_array^3 = 0.222 } #socialism
 	set_variable = { party_pop_array^4 = 0.027 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.143 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.099 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.015 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/BEN - Benin.txt
+++ b/history/countries/BEN - Benin.txt
@@ -169,30 +169,13 @@ capital = 344
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.09 } #conservatism
 	set_variable = { party_pop_array^2 = 0.27 } #liberalism
 	set_variable = { party_pop_array^3 = 0.45 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.12 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.01 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.09 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/BFA - Burkino Faso.txt
+++ b/history/countries/BFA - Burkino Faso.txt
@@ -173,30 +173,14 @@ capital = 350
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.074 } #liberalism
 	set_variable = { party_pop_array^3 = 0.121 } #socialism
 	set_variable = { party_pop_array^4 = 0.113 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.068 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.010 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.014 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.094 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.506 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 22 }
 	startup_politics = yes

--- a/history/countries/BHR - Bahrain.txt
+++ b/history/countries/BHR - Bahrain.txt
@@ -284,29 +284,13 @@ capital = 423
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.29 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.3 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.12 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.095 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.02 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.115 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.04 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.02 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/BHU - Bhutan.txt
+++ b/history/countries/BHU - Bhutan.txt
@@ -115,29 +115,6 @@ capital = 484
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 1.0 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/BLC - Balochistan.txt
+++ b/history/countries/BLC - Balochistan.txt
@@ -213,30 +213,11 @@ capital = 416
 	set_variable = { var = population_tax_rate value = 25 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.15 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.45 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 11 }

--- a/history/countries/BLR - Belarus.txt
+++ b/history/countries/BLR - Belarus.txt
@@ -264,30 +264,14 @@ capital = 703
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.02 } #conservatism
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.85 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.03 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/BLZ - Belize.txt
+++ b/history/countries/BLZ - Belize.txt
@@ -148,30 +148,10 @@ capital = 845
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.394 } #conservatism
 	set_variable = { party_pop_array^2 = 0.007 } #liberalism
 	set_variable = { party_pop_array^3 = 0.597 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.002 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/BOL - Bolivia.txt
+++ b/history/countries/BOL - Bolivia.txt
@@ -205,30 +205,11 @@ capital = 897
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.3 } #conservatism
 	set_variable = { party_pop_array^2 = 0.151 } #liberalism
 	set_variable = { party_pop_array^3 = 0.167 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.2 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.182 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/BOS - Bosnia.txt
+++ b/history/countries/BOS - Bosnia.txt
@@ -223,30 +223,13 @@ set_war_support = 0.27
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.3 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.27 } #socialism
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.16 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.11 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.08 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/BOT - Botswana.txt
+++ b/history/countries/BOT - Botswana.txt
@@ -159,29 +159,13 @@ capital = 287
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.043 } #liberalism
 	set_variable = { party_pop_array^3 = 0.261 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.001 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.423 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.141 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.129 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.001 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/BRA - Brazil.txt
+++ b/history/countries/BRA - Brazil.txt
@@ -827,30 +827,16 @@ capital = 885
 	start_politics_input = yes
 
 	# Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.006 } #conservatism
 	set_variable = { party_pop_array^2 = 0.428 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
 	set_variable = { party_pop_array^4 = 0.036 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.34 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.015 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.003 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.11 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.002 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.021 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 } # liberalism

--- a/history/countries/BRM - Burma.txt
+++ b/history/countries/BRM - Burma.txt
@@ -296,30 +296,10 @@ capital = 504
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0.0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.04 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.61 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.02 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.33 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 22 }
 	startup_politics = yes
 

--- a/history/countries/BRU - Brunei.txt
+++ b/history/countries/BRU - Brunei.txt
@@ -149,30 +149,7 @@ capital = 752
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 1.0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 12 }
 	startup_politics = yes
 

--- a/history/countries/BRY - Buryatia.txt
+++ b/history/countries/BRY - Buryatia.txt
@@ -96,30 +96,12 @@ capital = 686
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.03 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.15 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.34 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.11 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/BSH - Bashkiria.txt
+++ b/history/countries/BSH - Bashkiria.txt
@@ -92,26 +92,11 @@ capital = 664
 	set_variable = { party_pop_array^1 = 0.04 } #conservatism
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.702 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.01 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.1 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.098 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/BUL - Bulgaria.txt
+++ b/history/countries/BUL - Bulgaria.txt
@@ -308,29 +308,12 @@ capital = 153
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.30 } #conservatism
 	set_variable = { party_pop_array^2 = 0.03 } #liberalism
 	set_variable = { party_pop_array^3 = 0.40 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.10 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/BUR - Burundi.txt
+++ b/history/countries/BUR - Burundi.txt
@@ -158,30 +158,8 @@ capital = 251
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.73 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.27 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/CAB - Cabinda.txt
+++ b/history/countries/CAB - Cabinda.txt
@@ -63,30 +63,8 @@ capital = 296
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.52 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.48 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/CAL - California.txt
+++ b/history/countries/CAL - California.txt
@@ -573,22 +573,11 @@ capital = 811
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.03 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.10 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 	add_to_array = { ruling_party = 2 }
 	startup_politics = yes
 

--- a/history/countries/CAM - Cameroon.txt
+++ b/history/countries/CAM - Cameroon.txt
@@ -195,27 +195,9 @@ capital = 321
 
 	set_variable = { party_pop_array^0 = 0.65 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.03 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.03 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.18 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.04 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.07 } #Monarchist
 	add_to_array = { ruling_party = 0 }
 	startup_politics = yes

--- a/history/countries/CAN - Canada.txt
+++ b/history/countries/CAN - Canada.txt
@@ -1006,30 +1006,11 @@ capital = 763
 	#set_variable = { election_threshold = 0.04 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.067 } #conservatism
 	set_variable = { party_pop_array^2 = 0.517 } #liberalism
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.2 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.147 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 } #liberalism

--- a/history/countries/CAR - Central African Republic.txt
+++ b/history/countries/CAR - Central African Republic.txt
@@ -141,30 +141,11 @@ capital = 324
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.069 } #liberalism
 	set_variable = { party_pop_array^3 = 0.274 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.088 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.059 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.51 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }
 	startup_politics = yes

--- a/history/countries/CAS - Cascadia.txt
+++ b/history/countries/CAS - Cascadia.txt
@@ -768,22 +768,14 @@ capital = 809
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.02 } #Conservative
 	set_variable = { party_pop_array^7 = 0.02 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.01 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.025 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0.00 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.025 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.015 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/CAT - Catalonia.txt
+++ b/history/countries/CAT - Catalonia.txt
@@ -99,30 +99,11 @@ capital = 91
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.088 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.267 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.141 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.089 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.415 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 20 }
 	startup_politics = yes
 

--- a/history/countries/CBD - Cambodia.txt
+++ b/history/countries/CBD - Cambodia.txt
@@ -183,30 +183,11 @@ capital = 514
 	}
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.13 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.68 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.02 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.02 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.15 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 7 }
 	startup_politics = yes
 

--- a/history/countries/CDI - Cote D'Ivoire.txt
+++ b/history/countries/CDI - Cote D'Ivoire.txt
@@ -63,30 +63,11 @@ capital = 352
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.08 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.37 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.15 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.26 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.14 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 22 }
 	startup_politics = yes
 

--- a/history/countries/CHA - Chad.txt
+++ b/history/countries/CHA - Chad.txt
@@ -167,29 +167,11 @@ capital = 328
 	start_politics_input = yes
 
 	set_variable = { party_pop_array^0 = 0.043 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.051 } #liberalism
 	set_variable = { party_pop_array^3 = 0.128 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.032 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.711 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.035 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 13 }
 	startup_politics = yes
 

--- a/history/countries/CHE - Chechnya.txt
+++ b/history/countries/CHE - Chechnya.txt
@@ -142,30 +142,7 @@ capital = 672
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 22 }
 	startup_politics = yes
 	recruit_character = CHE_aslan_maskhadov

--- a/history/countries/CHI - China.txt
+++ b/history/countries/CHI - China.txt
@@ -337,7 +337,6 @@ capital = 547
 	set_variable = { var = population_tax_rate value = 22 }
 	set_variable = { overall_productivity = 584 }
 	set_variable = { election_threshold = 0.01 }
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.036 } #conservatism
 	set_variable = { party_pop_array^2 = 0.054 } #liberalism
 	set_variable = { party_pop_array^3 = 0.18 } #socialism
@@ -345,20 +344,11 @@ capital = 547
 	set_variable = { party_pop_array^5 = 0.065 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
 	set_variable = { party_pop_array^7 = 0.064 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.01 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.01 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.062 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.005 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.01 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.005 } #Monarchist
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/CHL - Chile.txt
+++ b/history/countries/CHL - Chile.txt
@@ -227,30 +227,13 @@ capital = 468
 	set_variable = { election_threshold = 0.02 }
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.192 } #conservatism
 	set_variable = { party_pop_array^2 = 0.169 } #liberalism
 	set_variable = { party_pop_array^3 = 0.134 } #socialism
 	set_variable = { party_pop_array^4 = 0.069 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.031 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.198 } #Neutral_conservatism #adjusted for next elections
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.207 } #neutral_Social #adjusted for next elections
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 } #socialism
 
 	add_to_array = { gov_coalition_array = 5 } #anarchist_communism

--- a/history/countries/CHS - Chin.txt
+++ b/history/countries/CHS - Chin.txt
@@ -118,30 +118,7 @@ capital = 499
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/CHU - Chuvashia.txt
+++ b/history/countries/CHU - Chuvashia.txt
@@ -97,30 +97,12 @@ capital = 1135
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.18 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.37 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.06 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.08 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/CKK - Chukotka.txt
+++ b/history/countries/CKK - Chukotka.txt
@@ -96,30 +96,12 @@ capital = 689
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.04 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.54 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/CNG - Congo.txt
+++ b/history/countries/CNG - Congo.txt
@@ -132,30 +132,11 @@ capital = 315
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.70 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.10 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.10 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 5 }
 	startup_politics = yes
 

--- a/history/countries/CNR - Canary Islands.txt
+++ b/history/countries/CNR - Canary Islands.txt
@@ -78,30 +78,7 @@ capital = 95
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 1.0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/COL - Colombia.txt
+++ b/history/countries/COL - Colombia.txt
@@ -252,30 +252,8 @@ capital = 911
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.519 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.481 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/COM - Comoros.txt
+++ b/history/countries/COM - Comoros.txt
@@ -150,30 +150,10 @@ capital = 269
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.2 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
 	set_variable = { party_pop_array^3 = 0.45 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.25 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/COS - Costa Rica.txt
+++ b/history/countries/COS - Costa Rica.txt
@@ -140,30 +140,13 @@ capital = 850
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.46 } #conservatism
 	set_variable = { party_pop_array^2 = 0.44 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.02 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/CRM - Crimea.txt
+++ b/history/countries/CRM - Crimea.txt
@@ -85,30 +85,16 @@ capital = 669
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.197 } #conservatism
 	set_variable = { party_pop_array^2 = 0.036 } #liberalism
 	set_variable = { party_pop_array^3 = 0.163 } #socialism
 	set_variable = { party_pop_array^4 = 0.011 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.001 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.327 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.043 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.034 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.174 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.013 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/CRO - Croatia.txt
+++ b/history/countries/CRO - Croatia.txt
@@ -378,30 +378,12 @@ capital = 126
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.313 } #conservatism
 	set_variable = { party_pop_array^2 = 0.197 } #liberalism
 	set_variable = { party_pop_array^3 = 0.299 } #socialism
-	set_variable = { party_pop_array^4 = 0.0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.007 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.156 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.028 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0.0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	add_to_array = { gov_coalition_array = 2 } #liberalism
 	startup_politics = yes

--- a/history/countries/CSA - Confederate States.txt
+++ b/history/countries/CSA - Confederate States.txt
@@ -385,18 +385,12 @@ capital = 792
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.035 } #Conservative
 	set_variable = { party_pop_array^7 = 0.035 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.09 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.18 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.03 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy

--- a/history/countries/CSB - Central Siberia.txt
+++ b/history/countries/CSB - Central Siberia.txt
@@ -61,30 +61,7 @@ capital = 676
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/CSM - Casamance.txt
+++ b/history/countries/CSM - Casamance.txt
@@ -141,29 +141,7 @@ capital = 362
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.57 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.43 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/CYP - Cyprus.txt
+++ b/history/countries/CYP - Cyprus.txt
@@ -153,25 +153,9 @@ capital = 145
 	set_variable = { party_pop_array^2 = 0.037 } #liberalism
 	set_variable = { party_pop_array^3 = 0.08 } #socialism
 	set_variable = { party_pop_array^4 = 0.33 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.02 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.01 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.014 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	add_to_array = { gov_coalition_array = 0 }
 	startup_politics = yes

--- a/history/countries/CYR - Cyrenaica.txt
+++ b/history/countries/CYR - Cyrenaica.txt
@@ -123,29 +123,10 @@ capital = 395
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.80 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/CZE - Czech Republic.txt
+++ b/history/countries/CZE - Czech Republic.txt
@@ -567,30 +567,14 @@ capital = 117
 		elections_allowed = yes
 	}
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.277 } #conservatism
 	set_variable = { party_pop_array^2 = 0.086 } #liberalism
 	set_variable = { party_pop_array^3 = 0.383 } #socialism
 	set_variable = { party_pop_array^4 = 0.11 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.09 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.011 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.003 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.04 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	add_to_array = { gov_coalition_array = 1 }
 	startup_politics = yes

--- a/history/countries/DAG - Dagestan.txt
+++ b/history/countries/DAG - Dagestan.txt
@@ -62,30 +62,12 @@ capital = 671
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.08 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.18 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.66 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/DAR - Darfur.txt
+++ b/history/countries/DAR - Darfur.txt
@@ -104,30 +104,13 @@ capital = 224
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.30 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.30 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/DEN - Denmark.txt
+++ b/history/countries/DEN - Denmark.txt
@@ -658,30 +658,15 @@ capital = 4
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.089 } #conservatism
 	set_variable = { party_pop_array^2 = 0.241 } #liberalism
 	set_variable = { party_pop_array^3 = 0.359 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.024 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.055 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.038 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.075 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.074 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.005 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 3 }
 	add_to_array = { gov_coalition_array = 14 } #Neutral_conservatism

--- a/history/countries/DJI - Djibouti.txt
+++ b/history/countries/DJI - Djibouti.txt
@@ -166,30 +166,11 @@ capital = 230
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.1 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.1 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.12 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.68 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 18 }
 	startup_politics = yes
 

--- a/history/countries/DMI - Dominica.txt
+++ b/history/countries/DMI - Dominica.txt
@@ -126,30 +126,9 @@ oob = "GENERIC_OOB"
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.095 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.429 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.476 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 14 }
 	startup_politics = yes
 

--- a/history/countries/DOM - Dominican Republic.txt
+++ b/history/countries/DOM - Dominican Republic.txt
@@ -146,30 +146,12 @@ capital = 861
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.246 } #conservatism
 	set_variable = { party_pop_array^2 = 0.249 } #liberalism
 	set_variable = { party_pop_array^3 = 0.499 } #socialism
 	set_variable = { party_pop_array^4 = 0.002 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.001 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.003 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/DON - Don.txt
+++ b/history/countries/DON - Don.txt
@@ -61,30 +61,7 @@ capital = 667
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/DPR - Donetsk People's Republic.txt
+++ b/history/countries/DPR - Donetsk People's Republic.txt
@@ -177,30 +177,8 @@ capital = 693
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.7 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.3 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/DRP - Dnipro People's Republic.txt
+++ b/history/countries/DRP - Dnipro People's Republic.txt
@@ -182,30 +182,8 @@ capital = 1087
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.1 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.9 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 15 }

--- a/history/countries/ECU - Ecuador.txt
+++ b/history/countries/ECU - Ecuador.txt
@@ -235,30 +235,12 @@ capital = 906
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.209 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.171 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.256 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.109 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.195 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/EGU - Equatorial Guinea.txt
+++ b/history/countries/EGU - Equatorial Guinea.txt
@@ -163,30 +163,17 @@ capital = 319
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.3 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
 	set_variable = { party_pop_array^3 = 0.08 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.47 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/EGY - Egypt.txt
+++ b/history/countries/EGY - Egypt.txt
@@ -520,29 +520,16 @@ capital = 215
 	start_politics_input = yes
 
 	set_variable = { party_pop_array^0 = 0.30 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.06 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.01 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.05 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.03 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.35 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.02 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.15 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 0 }	#Western_Autocracy
 	add_to_array = { gov_coalition_array = 22 } #Nat_Autocracy

--- a/history/countries/ELS - El Salvador.txt
+++ b/history/countries/ELS - El Salvador.txt
@@ -150,30 +150,14 @@ capital = 843
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.02 } #conservatism
 	set_variable = { party_pop_array^2 = 0.072 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.352 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.037 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.085 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.36 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.054 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 14 }
 	startup_politics = yes
 

--- a/history/countries/ENG - United Kingdom.txt
+++ b/history/countries/ENG - United Kingdom.txt
@@ -2434,30 +2434,16 @@ capital = 13
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.21 } #conservatism
 	set_variable = { party_pop_array^2 = 0.183 } #liberalism
 	set_variable = { party_pop_array^3 = 0.507 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.01 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.01 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.02 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.03 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/ERI - Eritrea.txt
+++ b/history/countries/ERI - Eritrea.txt
@@ -145,30 +145,9 @@ capital = 229
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.75 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.1 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.15 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 5 }
 	startup_politics = yes
 

--- a/history/countries/ESB - Eastern Siberia.txt
+++ b/history/countries/ESB - Eastern Siberia.txt
@@ -61,30 +61,7 @@ capital = 692
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/EST - Estonia.txt
+++ b/history/countries/EST - Estonia.txt
@@ -201,30 +201,14 @@ capital = 105
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.27 } #conservatism
 	set_variable = { party_pop_array^2 = 0.16 } #liberalism
 	set_variable = { party_pop_array^3 = 0.16 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.08 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.07 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.24 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 1 }
 	add_to_array = { gov_coalition_array = 2 } #liberalism

--- a/history/countries/ETH - Ethiopia.txt
+++ b/history/countries/ETH - Ethiopia.txt
@@ -161,29 +161,10 @@ capital = 233
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.07 } #conservatism
 	set_variable = { party_pop_array^2 = 0.16 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.629 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.071 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.07 } #Monarchist
 	add_to_array = { ruling_party = 5 }
 	startup_politics = yes

--- a/history/countries/ETK - East Turkestan.txt
+++ b/history/countries/ETK - East Turkestan.txt
@@ -72,30 +72,12 @@ capital = 592
 	#Politics
 	start_politics_input = yes
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
 	set_variable = { party_pop_array^2 = 0.10 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.10 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.10 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.50 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.10 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 11 }

--- a/history/countries/FAO - Faroe Islands.txt
+++ b/history/countries/FAO - Faroe Islands.txt
@@ -336,11 +336,6 @@ capital = 2
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.03 } #Conservative
 	set_variable = { party_pop_array^7 = 0.02 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.20 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.03 } #oligarchism
@@ -348,8 +343,6 @@ capital = 2
 	set_variable = { party_pop_array^17 = 0.03 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.04 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/FAR - Far Eastern Republic.txt
+++ b/history/countries/FAR - Far Eastern Republic.txt
@@ -64,30 +64,7 @@ capital = 692
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/FEZ - Fezzan.txt
+++ b/history/countries/FEZ - Fezzan.txt
@@ -134,29 +134,10 @@ capital = 392
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.80 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/FIJ - Fiji.txt
+++ b/history/countries/FIJ - Fiji.txt
@@ -225,7 +225,6 @@ capital = 535
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.100 } #conservatism
 	set_variable = { party_pop_array^2 = 0.050 } #liberalism
 	set_variable = { party_pop_array^3 = 0.500 } #socialism
@@ -233,20 +232,12 @@ capital = 535
 	set_variable = { party_pop_array^5 = 0.015 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.025 } #Conservative
 	set_variable = { party_pop_array^7 = 0.025 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.025 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.025 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.015 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.015 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.015 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.030 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.050 } #Military_Junta
 	set_variable = { party_pop_array^23 = 0.020 } #Monarchist
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/FIN - Finland.txt
+++ b/history/countries/FIN - Finland.txt
@@ -559,20 +559,10 @@ capital = 102
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.049 } #conservatism
 	set_variable = { party_pop_array^2 = 0.206 } #liberalism
 	set_variable = { party_pop_array^3 = 0.243 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.232 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.051 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.01 } #Neutral_Libertarian
@@ -580,9 +570,6 @@ capital = 102
 	set_variable = { party_pop_array^18 = 0.107 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.008 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.013 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	#Government:
 	add_to_array = { ruling_party = 3 } #socialist

--- a/history/countries/FLA - Florida.txt
+++ b/history/countries/FLA - Florida.txt
@@ -771,27 +771,15 @@ capital = 795
 	set_variable = { party_pop_array^0 = 0.05 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
-	set_variable = { party_pop_array^3 = 0.00 } #socialism
-	set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-	set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.10 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.10 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.10 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.25 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 16 }
 	startup_politics = yes
 

--- a/history/countries/FLN - Flanders.txt
+++ b/history/countries/FLN - Flanders.txt
@@ -329,30 +329,13 @@ capital = 50
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.22 } #conservatism
 	set_variable = { party_pop_array^2 = 0.274 } #liberalism
 	set_variable = { party_pop_array^3 = 0.222 } #socialism
 	set_variable = { party_pop_array^4 = 0.027 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.143 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.099 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.015 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/FNC - Forces Nouvelles de Cote d'Ivoire.txt
+++ b/history/countries/FNC - Forces Nouvelles de Cote d'Ivoire.txt
@@ -49,30 +49,10 @@ capital = 353
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.06 } #conservatism
 	set_variable = { party_pop_array^2 = 0.12 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.15 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.67 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 20 }
 	startup_politics = yes
 

--- a/history/countries/FRA - France.txt
+++ b/history/countries/FRA - France.txt
@@ -2605,30 +2605,14 @@ capital = 56
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.24 } #conservatism
 	set_variable = { party_pop_array^2 = 0.06 } #liberalism
 	set_variable = { party_pop_array^3 = 0.32 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.11 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.03 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.12 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 
 	startup_politics = yes

--- a/history/countries/FYR - Macedonia.txt
+++ b/history/countries/FYR - Macedonia.txt
@@ -142,30 +142,10 @@ capital = 136
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.033 } #liberalism
 	set_variable = { party_pop_array^3 = 0.233 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.25 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.483 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 20 }
 	startup_politics = yes
 

--- a/history/countries/GAB - Gabon.txt
+++ b/history/countries/GAB - Gabon.txt
@@ -130,30 +130,17 @@ capital = 317
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.44 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
 	set_variable = { party_pop_array^3 = 0.25 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.02 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.03 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.17 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/GAH - Ghana.txt
+++ b/history/countries/GAH - Ghana.txt
@@ -150,30 +150,11 @@ capital = 346
 	set_variable = { election_threshold = 0.01 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.448 } #conservatism - NPP
-	set_variable = { party_pop_array^2 = 0 } #liberalism - PPP
 	set_variable = { party_pop_array^3 = 0.469 } #socialism - NDC
 	set_variable = { party_pop_array^4 = 0.028 } #Communist-State - CPP
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism - DPP
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism - NDP
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.018 } #Neutral_Libertarian - NRF
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green - GCPP
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social - EGLE
 	set_variable = { party_pop_array^19 = 0.037 } #Neutral_Communism - PNC
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/GAL - Galicia.txt
+++ b/history/countries/GAL - Galicia.txt
@@ -64,30 +64,15 @@ capital = 944
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.35 } #conservatism
 	set_variable = { party_pop_array^2 = 0.20 } #liberalism
 	set_variable = { party_pop_array^3 = 0.10 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.03 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.03 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0.0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.06 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/GAM - Gambia.txt
+++ b/history/countries/GAM - Gambia.txt
@@ -82,30 +82,14 @@ capital = 365
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.17 } #conservatism
 	set_variable = { party_pop_array^2 = 0.08 } #liberalism
 	set_variable = { party_pop_array^3 = 0.12 } #socialism
 	set_variable = { party_pop_array^4 = 0.09 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.04 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.06 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.41 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/GEO - Georgia.txt
+++ b/history/countries/GEO - Georgia.txt
@@ -194,30 +194,9 @@ capital = 707
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.9 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/GGZ - Gagauzia.txt
+++ b/history/countries/GGZ - Gagauzia.txt
@@ -61,30 +61,7 @@ capital = 997
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/GLC - Great Lakes Confederation.txt
+++ b/history/countries/GLC - Great Lakes Confederation.txt
@@ -391,14 +391,6 @@ capital = 777
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
@@ -406,9 +398,6 @@ capital = 777
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/GNA - Government of National Accord - Libya.txt
+++ b/history/countries/GNA - Government of National Accord - Libya.txt
@@ -100,30 +100,7 @@ capital = 391
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 1.0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/GOR - Gorskaya Republic.txt
+++ b/history/countries/GOR - Gorskaya Republic.txt
@@ -64,30 +64,7 @@ capital = 673
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/GRA - Grenada.txt
+++ b/history/countries/GRA - Grenada.txt
@@ -129,30 +129,7 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 1.0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/GRE - Greece.txt
+++ b/history/countries/GRE - Greece.txt
@@ -363,30 +363,13 @@ capital = 141
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.427 } #conservatism
 	set_variable = { party_pop_array^2 = 0.007 } #liberalism
 	set_variable = { party_pop_array^3 = 0.438 } #socialism
 	set_variable = { party_pop_array^4 = 0.055 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.034 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.037 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.002 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/GRN - Greenland.txt
+++ b/history/countries/GRN - Greenland.txt
@@ -420,20 +420,11 @@ capital = 1161
 	set_variable = { party_pop_array^5 = 0.025 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.025 } #Conservative
 	set_variable = { party_pop_array^7 = 0.025 } #Autocracy
-	set_variable = { party_pop_array^8 = 0.000 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0.000 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0.000 } #Kingdom
-	set_variable = { party_pop_array^11 = 0.000 } #Caliphate
-	set_variable = { party_pop_array^12 = 0.000 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.000 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.025 } #Neutral_conservatism - Polar Party
 	set_variable = { party_pop_array^15 = 0.025 } #oligarchism - Qulleq
-	set_variable = { party_pop_array^16 = 0.000 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social - Inuit Ataqatigiit
-	set_variable = { party_pop_array^19 = 0.000 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.035 } #Nat_Populism - Naleraq
-	set_variable = { party_pop_array^21 = 0.000 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.035 } #Nat_Autocracy - Armed Forces of Greenland
 	set_variable = { party_pop_array^23 = 0.030 } #Monarchist - House of Greenland
 

--- a/history/countries/GUA - Guatemala.txt
+++ b/history/countries/GUA - Guatemala.txt
@@ -193,30 +193,11 @@ capital = 841
 	set_variable = { election_threshold = 0.01 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.332 } #conservatism - PAN
-	set_variable = { party_pop_array^2 = 0 } #liberalism - PP
-	set_variable = { party_pop_array^3 = 0 } #socialism - UNE
 	set_variable = { party_pop_array^4 = 0.063 } #Communist-State - URNG-MAIZ
 	set_variable = { party_pop_array^5 = 0.073 } #anarchist_communism - New Nation Alliance -> Winaq
-	set_variable = { party_pop_array^6 = 0 } #Conservative - Unionist Party
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism - Renewed Democratic Liberty
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian - UCN
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green - Todos
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social - Encuentro por Guatemala
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism - MLP
 	set_variable = { party_pop_array^20 = 0.012 } #Nat_Populism - National Liberation Movement
 	set_variable = { party_pop_array^21 = 0.52 } #Nat_Fascism - Guatemalan Republican Front
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy - Armed Forces of Guatemala
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 21 }

--- a/history/countries/GUB - Guinea Bissau.txt
+++ b/history/countries/GUB - Guinea Bissau.txt
@@ -139,30 +139,12 @@ capital = 361
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.36 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.24 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.28 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/GUI - Guinea.txt
+++ b/history/countries/GUI - Guinea.txt
@@ -169,29 +169,11 @@ capital = 360
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.17 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.08 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.47 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.15 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.06 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/GUY - Guyana.txt
+++ b/history/countries/GUY - Guyana.txt
@@ -148,30 +148,12 @@ capital = 877
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.009 } #conservatism - TUF
-	set_variable = { party_pop_array^2 = 0 } #liberalism - AFC
 	set_variable = { party_pop_array^3 = 0.42 } #socialism - People's National Congress -> APNU
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.543 } #anarchist_communism - PPP/C
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.007 } #Neutral_conservatism - ROAR
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.012 } #neutral_Social - WPA
 	set_variable = { party_pop_array^19 = 0.009 } #Neutral_Communism - GAP
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism - URP
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	#1997 election results
 	set_variable = { party_pop_elect_array^1 = 0.015 } #conservatism - TUF

--- a/history/countries/HAI - Haiti.txt
+++ b/history/countries/HAI - Haiti.txt
@@ -145,30 +145,12 @@ capital = 860
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.12 } #conservatism - RDNP 0.02
 	set_variable = { party_pop_array^2 = 0.03 } #liberalism - PHTK 0.07
 	set_variable = { party_pop_array^3 = 0.46 } #socialism - FL 0.19
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State - NPCH(ML) 0.1
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism - PPD 0.41
-	set_variable = { party_pop_array^6 = 0 } #Conservative 0.03
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.09 } #Neutral_conservatism - MCNH 0.15
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green - RP
 	set_variable = { party_pop_array^18 = 0.27 } #neutral_Social - OPL
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism - AAA 0.03
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism - PUN
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy - FAd'H
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/HAM - Hamas.txt
+++ b/history/countries/HAM - Hamas.txt
@@ -135,28 +135,12 @@ capital = 209
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.15 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.08 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.1 } #socialism
 	set_variable = { party_pop_array^4 = 0.06 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.08 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.03 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.10 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.4 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/HAZ - Hazaristan.txt
+++ b/history/countries/HAZ - Hazaristan.txt
@@ -71,30 +71,11 @@ set_country_flag = disable_different_country_flag
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.60 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.15 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 8 }

--- a/history/countries/HEJ - Hejaz.txt
+++ b/history/countries/HEJ - Hejaz.txt
@@ -95,28 +95,10 @@ capital = 177
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.05 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.01 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.05 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.10 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.78 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.01 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/HEZ - Hezbollah.txt
+++ b/history/countries/HEZ - Hezbollah.txt
@@ -163,30 +163,7 @@ capital = 201
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 1.0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 9 }

--- a/history/countries/HKG - Hong Kong.txt
+++ b/history/countries/HKG - Hong Kong.txt
@@ -241,30 +241,13 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.238 } #conservatism
 	set_variable = { party_pop_array^2 = 0.038 } #liberalism
 	set_variable = { party_pop_array^3 = 0.057 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.016 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.353 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.297 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.001 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/HLS - Holy See.txt
+++ b/history/countries/HLS - Holy See.txt
@@ -193,29 +193,6 @@ capital = 929
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 1 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/HOL - Holland.txt
+++ b/history/countries/HOL - Holland.txt
@@ -868,30 +868,16 @@ capital = 46
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.183 } #conservatism
 	set_variable = { party_pop_array^2 = 0.247 } #liberalism
 	set_variable = { party_pop_array^3 = 0.29 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.049 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.012 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.073 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.09 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.035 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 } #PvdA
 	add_to_array = { gov_coalition_array = 2 } #VVD
 	add_to_array = { gov_coalition_array = 18 } #D66

--- a/history/countries/HON - Honduras.txt
+++ b/history/countries/HON - Honduras.txt
@@ -180,30 +180,11 @@ capital = 846
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0.0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.51 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
 	set_variable = { party_pop_array^4 = 0.04 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.42 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/HOR - House of Representatives - Libya.txt
+++ b/history/countries/HOR - House of Representatives - Libya.txt
@@ -66,30 +66,9 @@ capital = 396
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.1 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.3 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.6 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	sort_influence = yes
 
 	### Ruling Party

--- a/history/countries/HPR - Harkov.txt
+++ b/history/countries/HPR - Harkov.txt
@@ -164,30 +164,7 @@ capital = 696
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 1.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/HRM - Hormuz.txt
+++ b/history/countries/HRM - Hormuz.txt
@@ -95,29 +95,11 @@ capital = 425
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.03 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.15 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.64 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.01 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.16 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 9 }

--- a/history/countries/HUN - Hungary.txt
+++ b/history/countries/HUN - Hungary.txt
@@ -273,30 +273,11 @@ capital = 121
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.156 } #liberalism
 	set_variable = { party_pop_array^3 = 0.298 } #socialism
 	set_variable = { party_pop_array^4 = 0.056 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.357 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.133 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/HWI - Hawaii.txt
+++ b/history/countries/HWI - Hawaii.txt
@@ -783,14 +783,6 @@ capital = 817
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
@@ -798,9 +790,6 @@ capital = 817
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/HZG - Herzegovinian.txt
+++ b/history/countries/HZG - Herzegovinian.txt
@@ -158,23 +158,10 @@ capital = 129
 	set_variable = { party_pop_array^3 = 0.076 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.023 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.155 } #Neutral_conservatism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.212 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.17 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 6 } #Conservative
 

--- a/history/countries/IDH - Idaho.txt
+++ b/history/countries/IDH - Idaho.txt
@@ -771,27 +771,15 @@ capital = 808
 	set_variable = { party_pop_array^0 = 0.05 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
-	set_variable = { party_pop_array^3 = 0.00 } #socialism
-	set_variable = { party_pop_array^4 = 0.00 } #Communist-State
-	set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.10 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.10 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.10 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.25 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 16 }
 	startup_politics = yes
 

--- a/history/countries/IEK - Islamic Emirate of Kurdistan.txt
+++ b/history/countries/IEK - Islamic Emirate of Kurdistan.txt
@@ -119,30 +119,12 @@ capital = 1078
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.06 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.03 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.37 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.49 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.06 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 12 } #Neutral_Muslim_Brotherhood

--- a/history/countries/IKR - Iranian Kurdistan.txt
+++ b/history/countries/IKR - Iranian Kurdistan.txt
@@ -88,30 +88,16 @@ capital = 408
 	set_variable = { var = corporate_tax_rate value = 15 }
 	set_variable = { var = population_tax_rate value = 18 }
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.03 } #conservatism
 	set_variable = { party_pop_array^2 = 0.09 } #liberalism
 	set_variable = { party_pop_array^3 = 0.12 } #socialism
 	set_variable = { party_pop_array^4 = 0.15 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.08 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.04 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.02 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 8 } #Neutral_green
 	set_variable = { party_pop_array^18 = 32 } #neutral_Social
 	set_variable = { party_pop_array^19 = 7 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/IND - Indonesia.txt
+++ b/history/countries/IND - Indonesia.txt
@@ -305,30 +305,14 @@ capital = 631
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.424 } #conservatism
 	set_variable = { party_pop_array^2 = 0.071 } #liberalism
 	set_variable = { party_pop_array^3 = 0.001 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.33 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.003 } #Conservative
-	set_variable = { party_pop_array^7 = 0.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.107 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.014 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/ING - Ingushetia.txt
+++ b/history/countries/ING - Ingushetia.txt
@@ -96,30 +96,12 @@ capital = 1126
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.01 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.57 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/IOM - Isle of Mann.txt
+++ b/history/countries/IOM - Isle of Mann.txt
@@ -400,30 +400,16 @@ capital = 955
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.31 } #conservatism
 	set_variable = { party_pop_array^2 = 0.183 } #liberalism
 	set_variable = { party_pop_array^3 = 0.407 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.01 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.01 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.02 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.03 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/IRE - Ireland.txt
+++ b/history/countries/IRE - Ireland.txt
@@ -245,30 +245,13 @@ capital = 27
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.393 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.104 } #socialism
 	set_variable = { party_pop_array^4 = 0.08 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.064 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.279 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/IRQ - Iraq.txt
+++ b/history/countries/IRQ - Iraq.txt
@@ -438,30 +438,16 @@ capital = 557
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
 	set_variable = { party_pop_array^2 = 0.03 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.14 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.07 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.07 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.08 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.01 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.03 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.52 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 21 }

--- a/history/countries/ITA - Italy.txt
+++ b/history/countries/ITA - Italy.txt
@@ -1794,30 +1794,16 @@ capital = 81
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.19 } #conservatism
 	set_variable = { party_pop_array^2 = 0.159 } #liberalism
 	set_variable = { party_pop_array^3 = 0.346 } #socialism
 	set_variable = { party_pop_array^4 = 0.028 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0.000 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.075 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.014 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.031 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.017 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.138 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.001 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/JAM - Jamaica.txt
+++ b/history/countries/JAM - Jamaica.txt
@@ -153,30 +153,8 @@ capital = 858
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.167 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.833 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/JAP - Japan.txt
+++ b/history/countries/JAP - Japan.txt
@@ -180,29 +180,12 @@ capital = 615
 
 	start_politics_input = yes
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.526 } #conservatism
 	set_variable = { party_pop_array^2 = 0.181 } #liberalism
 	set_variable = { party_pop_array^3 = 0.092 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.075 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.026 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.05 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/JOR - Jordan.txt
+++ b/history/countries/JOR - Jordan.txt
@@ -203,27 +203,10 @@ capital = 210
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.50 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/JUB - Jubaland.txt
+++ b/history/countries/JUB - Jubaland.txt
@@ -101,25 +101,13 @@ capital = 581
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.10 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.025 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.10 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.1 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 } #Nat_Autocracy

--- a/history/countries/KAC - Kachin.txt
+++ b/history/countries/KAC - Kachin.txt
@@ -140,30 +140,7 @@ capital = 496
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/KAE - Karelia.txt
+++ b/history/countries/KAE - Karelia.txt
@@ -96,30 +96,11 @@ capital = 1128
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.07 } #liberalism
 	set_variable = { party_pop_array^3 = 0.37 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.15 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.14 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/KAM - Kamtapur.txt
+++ b/history/countries/KAM - Kamtapur.txt
@@ -81,30 +81,7 @@ capital = 452
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/KAN - Kansas.txt
+++ b/history/countries/KAN - Kansas.txt
@@ -771,23 +771,13 @@ capital = 784
 	set_variable = { party_pop_array^0 = 0.05 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
-	set_variable = { party_pop_array^3 = 0.00 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
-	set_variable = { party_pop_array^5 = 0.00 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0.00 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.25 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.03 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.07 } #Nat_Autocracy

--- a/history/countries/KAR - Karen.txt
+++ b/history/countries/KAR - Karen.txt
@@ -133,30 +133,7 @@ capital = 501
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/KAS - Kashmir.txt
+++ b/history/countries/KAS - Kashmir.txt
@@ -87,29 +87,6 @@ capital = 427
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 1 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/KAZ - Kazakhstan.txt
+++ b/history/countries/KAZ - Kazakhstan.txt
@@ -209,30 +209,10 @@ capital = 716
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.239 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.371 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.188 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.202 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/KBK - Kabardino Balkaria.txt
+++ b/history/countries/KBK - Kabardino Balkaria.txt
@@ -95,30 +95,12 @@ capital = 674
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.06 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.77 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KBY - Kabylia.txt
+++ b/history/countries/KBY - Kabylia.txt
@@ -60,26 +60,13 @@ capital = 385
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.089 } #conservatism
 	set_variable = { party_pop_array^2 = 0.241 } #liberalism
 	set_variable = { party_pop_array^3 = 0.359 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.024 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.055 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.038 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_Islamism
 	set_variable = { party_pop_array^18 = 0.075 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.079 } #Nat_Populism
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes

--- a/history/countries/KCC - Karachay Cherkessia.txt
+++ b/history/countries/KCC - Karachay Cherkessia.txt
@@ -96,30 +96,12 @@ capital = 1125
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.13 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.04 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.49 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KEN - Kenya.txt
+++ b/history/countries/KEN - Kenya.txt
@@ -154,30 +154,11 @@ capital = 242
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.197 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.092 } #socialism
 	set_variable = { party_pop_array^4 = 0.083 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.017 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.611 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/KHA - Punjab.txt
+++ b/history/countries/KHA - Punjab.txt
@@ -81,29 +81,6 @@ capital = 563
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 1.0 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/KHM - Khanty-Mansi.txt
+++ b/history/countries/KHM - Khanty-Mansi.txt
@@ -64,30 +64,10 @@ capital = 678
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 6 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 24 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 60 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KHS - Khakassia.txt
+++ b/history/countries/KHS - Khakassia.txt
@@ -96,30 +96,12 @@ capital = 1065
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.19 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.09 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.30 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KIR - Kiribati.txt
+++ b/history/countries/KIR - Kiribati.txt
@@ -115,30 +115,9 @@ capital = 546
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.48 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.34 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.16 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KLM - Kalmykia.txt
+++ b/history/countries/KLM - Kalmykia.txt
@@ -93,30 +93,12 @@ capital = 1107
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.50 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KOM - Komi.txt
+++ b/history/countries/KOM - Komi.txt
@@ -96,30 +96,12 @@ capital = 648
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.08 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.08 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.33 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KOR - Korea.txt
+++ b/history/countries/KOR - Korea.txt
@@ -1098,30 +1098,12 @@ capital = 604
 
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.462 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.484 } #socialism
 	set_variable = { party_pop_array^4 = 0.009 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.039 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.005 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.001 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/KOS - Kosovo.txt
+++ b/history/countries/KOS - Kosovo.txt
@@ -140,30 +140,11 @@ capital = 133
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.47 } #conservatism
 	set_variable = { party_pop_array^2 = 0.2 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.31 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/KRP - Karakalpakstan.txt
+++ b/history/countries/KRP - Karakalpakstan.txt
@@ -113,30 +113,12 @@ capital = 727
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.1 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.47 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.31 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/KSH - Kashubia.txt
+++ b/history/countries/KSH - Kashubia.txt
@@ -128,30 +128,17 @@ capital = 115
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.383 } #conservatism
 	set_variable = { party_pop_array^2 = 0.019 } #liberalism
 	set_variable = { party_pop_array^3 = 0.108 } #socialism
 	set_variable = { party_pop_array^4 = 0.008 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.086 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.137 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.018 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.131 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.03 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.062 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.018 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 
 	# Relation Starting Configuration (moved from on_startup)

--- a/history/countries/KUB - Kuban Republic.txt
+++ b/history/countries/KUB - Kuban Republic.txt
@@ -89,30 +89,10 @@ capital = 668
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.14 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.67 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.09 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/KUR - Kurdistan.txt
+++ b/history/countries/KUR - Kurdistan.txt
@@ -128,30 +128,12 @@ capital = 164
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.41 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.09 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.06 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.37 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 } #conservatism

--- a/history/countries/KUW - Kuwait.txt
+++ b/history/countries/KUW - Kuwait.txt
@@ -269,29 +269,15 @@ capital = 172
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.31 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0.0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.06 } #liberalism
 	set_variable = { party_pop_array^3 = 0.04 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.11 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.02 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.1 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.01 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.1 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.1 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/KYR - Kyrgyzstan.txt
+++ b/history/countries/KYR - Kyrgyzstan.txt
@@ -202,30 +202,10 @@ capital = 720
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.198 } #socialism
 	set_variable = { party_pop_array^4 = 0.293 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.44 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.069 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/LAD - Ladakh.txt
+++ b/history/countries/LAD - Ladakh.txt
@@ -81,30 +81,7 @@ capital = 993
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/LAG - Latgale.txt
+++ b/history/countries/LAG - Latgale.txt
@@ -136,30 +136,8 @@ capital = 1013
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.1 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.9 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 21 }

--- a/history/countries/LAO - Laos.txt
+++ b/history/countries/LAO - Laos.txt
@@ -154,30 +154,7 @@ capital = 516
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 1.0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/LAT - Latvia.txt
+++ b/history/countries/LAT - Latvia.txt
@@ -172,30 +172,14 @@ capital = 107
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.181 } #liberalism
 	set_variable = { party_pop_array^3 = 0.129 } #socialism
 	set_variable = { party_pop_array^4 = 0.09 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.142 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.213 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.073 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.147 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/LBA - Libya.txt
+++ b/history/countries/LBA - Libya.txt
@@ -224,28 +224,10 @@ capital = 391
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.65 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.09 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.15 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.10 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 

--- a/history/countries/LES - Lesotho.txt
+++ b/history/countries/LES - Lesotho.txt
@@ -114,30 +114,10 @@ capital = 272
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.077 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.119 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.392 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.412 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/LIB - Liberia.txt
+++ b/history/countries/LIB - Liberia.txt
@@ -128,26 +128,15 @@ capital = 355
 	set_variable = { party_pop_array^1 = 0.011 } #conservatism
 	set_variable = { party_pop_array^2 = 0.180 } #liberalism
 	set_variable = { party_pop_array^3 = 0.005 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.017 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.009 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.004 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.043 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.001 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.007 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.024 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.063 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.585 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 21 }

--- a/history/countries/LIC - Liechenstein.txt
+++ b/history/countries/LIC - Liechenstein.txt
@@ -218,30 +218,9 @@ oob = "GENERIC_OOB"
 
 	start_politics_input = yes
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.392 } #conservatism
 	set_variable = { party_pop_array^2 = 0.492 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.116 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	##Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/LIT - Lithuania.txt
+++ b/history/countries/LIT - Lithuania.txt
@@ -170,30 +170,17 @@ capital = 110
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.383 } #conservatism
 	set_variable = { party_pop_array^2 = 0.019 } #liberalism
 	set_variable = { party_pop_array^3 = 0.108 } #socialism
 	set_variable = { party_pop_array^4 = 0.008 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.086 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.137 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.018 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.131 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.03 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.062 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.018 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/LKT - Lakota.txt
+++ b/history/countries/LKT - Lakota.txt
@@ -321,14 +321,6 @@ capital = 786
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
@@ -336,9 +328,6 @@ capital = 786
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/LOR - Luristan.txt
+++ b/history/countries/LOR - Luristan.txt
@@ -65,30 +65,11 @@ capital = 406
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.60 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.15 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/LPR - Lugansk People's Republic.txt
+++ b/history/countries/LPR - Lugansk People's Republic.txt
@@ -239,30 +239,7 @@ capital = 1075
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 1.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/LRP - Lviv Democratic Republic.txt
+++ b/history/countries/LRP - Lviv Democratic Republic.txt
@@ -200,30 +200,8 @@ capital = 700
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.9 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/LUR - Liberians United for Reconciliation and Democracy.txt
+++ b/history/countries/LUR - Liberians United for Reconciliation and Democracy.txt
@@ -136,26 +136,15 @@ capital = 356
 	set_variable = { party_pop_array^1 = 0.011 } #conservatism
 	set_variable = { party_pop_array^2 = 0.180 } #liberalism
 	set_variable = { party_pop_array^3 = 0.005 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.017 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.009 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.004 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.043 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.001 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.007 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.585 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.063 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.024 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/LUX - Luxemburg.txt
+++ b/history/countries/LUX - Luxemburg.txt
@@ -286,30 +286,13 @@ capital = 53
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.113 } #conservatism
 	set_variable = { party_pop_array^2 = 0.224 } #liberalism
 	set_variable = { party_pop_array^3 = 0.223 } #socialism
 	set_variable = { party_pop_array^4 = 0.033 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.015 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.301 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.091 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/MAC - Macau.txt
+++ b/history/countries/MAC - Macau.txt
@@ -124,30 +124,13 @@ capital = 1106
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.058 } #conservatism
 	set_variable = { party_pop_array^2 = 0.058 } #liberalism
 	set_variable = { party_pop_array^3 = 0.057 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.313 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.500 } #Conservative
 	set_variable = { party_pop_array^7 = 0.003 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.001 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/MAD - Madagascar.txt
+++ b/history/countries/MAD - Madagascar.txt
@@ -201,30 +201,12 @@ capital = 267
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.45 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.3 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.09 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.06 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/MAL - Mali.txt
+++ b/history/countries/MAL - Mali.txt
@@ -185,30 +185,9 @@ capital = 368
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.014 } #liberalism
 	set_variable = { party_pop_array^3 = 0.027 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.959 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/MAN - Manipur.txt
+++ b/history/countries/MAN - Manipur.txt
@@ -81,30 +81,7 @@ capital = 477
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/MAR - Marshall Islands.txt
+++ b/history/countries/MAR - Marshall Islands.txt
@@ -105,30 +105,8 @@ capital = 820
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.82 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.18 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/MAU - Mauritania.txt
+++ b/history/countries/MAU - Mauritania.txt
@@ -143,29 +143,13 @@ capital = 369
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.41 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.1 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.02 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.06 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.1 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.22 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/MAY - Malaysia.txt
+++ b/history/countries/MAY - Malaysia.txt
@@ -229,30 +229,12 @@ capital = 528
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.149 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.15 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.125 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.565 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/MEG - Meghalaya State.txt
+++ b/history/countries/MEG - Meghalaya State.txt
@@ -81,30 +81,7 @@ capital = 980
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/MEL - Mari El.txt
+++ b/history/countries/MEL - Mari El.txt
@@ -94,30 +94,12 @@ capital = 1134
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.14 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.07 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.34 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.07 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.11 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/MEX - Mexico.txt
+++ b/history/countries/MEX - Mexico.txt
@@ -416,30 +416,11 @@ capital = 835
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.37 } #conservatism
 	set_variable = { party_pop_array^2 = 0.39 } #liberalism
 	set_variable = { party_pop_array^3 = 0.16 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.03 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.05 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/MIC - Micronesian Federation.txt
+++ b/history/countries/MIC - Micronesian Federation.txt
@@ -104,30 +104,12 @@ capital = 821
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.2 } #conservatism
 	set_variable = { party_pop_array^2 = 0.54 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.09 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.09 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.03 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/MLC - Movement for the Liberation of Congo.txt
+++ b/history/countries/MLC - Movement for the Liberation of Congo.txt
@@ -114,30 +114,10 @@ capital = 312
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.09 } #conservatism
 	set_variable = { party_pop_array^2 = 0.51 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.2 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.2 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/MLD - Maldives.txt
+++ b/history/countries/MLD - Maldives.txt
@@ -114,30 +114,9 @@ capital = 480
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.4 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.04 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.56 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/MLR - Malorossiya.txt
+++ b/history/countries/MLR - Malorossiya.txt
@@ -161,30 +161,11 @@ capital = 698
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.150 } #Conservative
 	set_variable = { party_pop_array^7 = 0.700 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.50 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.50 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.50 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/MLT - Malta.txt
+++ b/history/countries/MLT - Malta.txt
@@ -140,30 +140,8 @@ capital = 85
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.538 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.462 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/MLV - Moldova.txt
+++ b/history/countries/MLV - Moldova.txt
@@ -198,30 +198,9 @@ capital = 147
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.302 } #socialism
 	set_variable = { party_pop_array^4 = 0.396 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.302 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/MLW - Malawi.txt
+++ b/history/countries/MLW - Malawi.txt
@@ -119,30 +119,9 @@ capital = 260
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.495 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.351 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.154 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/MNC - Monaco.txt
+++ b/history/countries/MNC - Monaco.txt
@@ -204,28 +204,7 @@ oob = "GENERIC_OOB"
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.495 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.396 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.109 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	##Ruling Party
 	add_to_array = { ruling_party = 0 } #Western Autocracy

--- a/history/countries/MNT - Montenegro.txt
+++ b/history/countries/MNT - Montenegro.txt
@@ -142,30 +142,13 @@ oob = "GENERIC_OOB"
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.06 } #conservatism
 	set_variable = { party_pop_array^2 = 0.066 } #liberalism
 	set_variable = { party_pop_array^3 = 0.211 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.08 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.427 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.06 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.020 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 15 }
 	startup_politics = yes
 

--- a/history/countries/MON - Mongolia.txt
+++ b/history/countries/MON - Mongolia.txt
@@ -145,30 +145,12 @@ capital = 596
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.04 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
 	set_variable = { party_pop_array^4 = 0.42 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.4 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.04 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 4 }
 	startup_politics = yes
 

--- a/history/countries/MOR - Morocco.txt
+++ b/history/countries/MOR - Morocco.txt
@@ -260,29 +260,13 @@ capital = 1177
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.47 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.111 } #liberalism
 	set_variable = { party_pop_array^3 = 0.139 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.043 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.001 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.001 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.132 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.103 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	add_to_array = { gov_coalition_array = 0 } #Western_Autocracy
 	add_to_array = { gov_coalition_array = 14 } #Neutral_conservatism

--- a/history/countries/MOV - Mordovia.txt
+++ b/history/countries/MOV - Mordovia.txt
@@ -66,30 +66,7 @@ capital = 1132
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/MOZ - Mozambique.txt
+++ b/history/countries/MOZ - Mozambique.txt
@@ -150,30 +150,13 @@ capital = 264
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.36 } #conservatism
 	set_variable = { party_pop_array^2 = 0.08 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.48 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.03 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.02 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.01 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 5 }
 	startup_politics = yes
 

--- a/history/countries/MRT - Mauritius.txt
+++ b/history/countries/MRT - Mauritius.txt
@@ -113,30 +113,14 @@ capital = 270
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.48 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
 	set_variable = { party_pop_array^3 = 0.15 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.11 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.08 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.02 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	add_to_array = { gov_coalition_array = 18 }
 	startup_politics = yes

--- a/history/countries/MTE - Mayotte.txt
+++ b/history/countries/MTE - Mayotte.txt
@@ -133,30 +133,10 @@ oob = "GENERIC_OOB"
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.2 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
 	set_variable = { party_pop_array^3 = 0.45 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.25 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 3 }
 	startup_politics = yes
 

--- a/history/countries/NAM - Namibia.txt
+++ b/history/countries/NAM - Namibia.txt
@@ -111,30 +111,14 @@ capital = 283
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.09 } #conservatism
 	set_variable = { party_pop_array^2 = 0.03 } #liberalism
 	set_variable = { party_pop_array^3 = 0.10 } #socialism
 	set_variable = { party_pop_array^4 = 0.6 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.69 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0.00 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 5 }
 	add_to_array = { gov_coalition_array = 4 } #Communist-State
 	startup_politics = yes

--- a/history/countries/NAU - Nauru.txt
+++ b/history/countries/NAU - Nauru.txt
@@ -113,30 +113,9 @@ capital = 1117
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.52 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.20 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.28 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 15 }

--- a/history/countries/NAV - Basque Country.txt
+++ b/history/countries/NAV - Basque Country.txt
@@ -84,30 +84,15 @@ capital = 88
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.35 } #conservatism
 	set_variable = { party_pop_array^2 = 0.20 } #liberalism
 	set_variable = { party_pop_array^3 = 0.10 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.03 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.03 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0.0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.06 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/NCY - Northern Cyprus.txt
+++ b/history/countries/NCY - Northern Cyprus.txt
@@ -121,30 +121,13 @@ oob = "GENERIC_OOB"
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.41 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.14 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.23 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.15 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/NEE - Nenets.txt
+++ b/history/countries/NEE - Nenets.txt
@@ -96,30 +96,12 @@ capital = 683
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.09 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.38 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.14 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/NEJ - Nejd.txt
+++ b/history/countries/NEJ - Nejd.txt
@@ -93,28 +93,10 @@ capital = 176
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.15 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.01 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.20 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.58 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.01 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/NEN - New England.txt
+++ b/history/countries/NEN - New England.txt
@@ -382,24 +382,13 @@ capital = 767
 	set_variable = { party_pop_array^3 = 0.20 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.025 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 2 }
 	startup_politics = yes
 

--- a/history/countries/NEP - Nepal.txt
+++ b/history/countries/NEP - Nepal.txt
@@ -149,29 +149,11 @@ capital = 485
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.24 } #socialism
 	set_variable = { party_pop_array^4 = 0.11 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.005 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.055 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.023 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.567 } #Monarchist
 	add_to_array = { ruling_party = 23 }
 	startup_politics = yes

--- a/history/countries/NGR - Niger.txt
+++ b/history/countries/NGR - Niger.txt
@@ -115,30 +115,18 @@ capital = 331
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.49 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
 	set_variable = { party_pop_array^3 = 0.12 } #socialism
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.13 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.03 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.03 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.02 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.02 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/NHN - North Shan State.txt
+++ b/history/countries/NHN - North Shan State.txt
@@ -116,30 +116,7 @@ capital = 930
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/NIC - Nicaragua.txt
+++ b/history/countries/NIC - Nicaragua.txt
@@ -163,30 +163,12 @@ capital = 849
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.019 } #conservatism
 	set_variable = { party_pop_array^2 = 0.547 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.014 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.412 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.002 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.006 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 2 }
 	startup_politics = yes
 

--- a/history/countries/NIG - Nigeria.txt
+++ b/history/countries/NIG - Nigeria.txt
@@ -212,30 +212,16 @@ capital = 337
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.11 } #conservatism
 	set_variable = { party_pop_array^2 = 0.06 } #liberalism
 	set_variable = { party_pop_array^3 = 0.1 } #socialism
 	set_variable = { party_pop_array^4 = 0.19 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.04 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.09 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.31 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.03 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/NIR - Northern Ireland.txt
+++ b/history/countries/NIR - Northern Ireland.txt
@@ -168,30 +168,13 @@ capital = 17
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.393 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.104 } #socialism
 	set_variable = { party_pop_array^4 = 0.08 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.064 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.279 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/NKO - North Korea.txt
+++ b/history/countries/NKO - North Korea.txt
@@ -876,30 +876,10 @@ capital = 602
 	set_variable = { var = NKO_kim_jong_nam value = 55 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.9 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.044 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.005 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/NKR - Artsakh.txt
+++ b/history/countries/NKR - Artsakh.txt
@@ -138,30 +138,13 @@ capital = 710
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.177 } #conservatism
 	set_variable = { party_pop_array^2 = 0.009 } #liberalism
 	set_variable = { party_pop_array^3 = 0.284 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.514 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.004 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.001 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/NLA - Netherlands Antilles.txt
+++ b/history/countries/NLA - Netherlands Antilles.txt
@@ -108,30 +108,10 @@ capital = 49
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.3 } #conservatism
 	set_variable = { party_pop_array^2 = 0.3 } #liberalism
 	set_variable = { party_pop_array^3 = 0.29 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.11 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/NOV - Novorossiya.txt
+++ b/history/countries/NOV - Novorossiya.txt
@@ -172,30 +172,7 @@ capital = 693
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 1.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/NPM - Nepal Maoist.txt
+++ b/history/countries/NPM - Nepal Maoist.txt
@@ -140,30 +140,10 @@ capital = 489
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.25 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.51 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.15 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.09 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 4 }
 	startup_politics = yes
 

--- a/history/countries/NUS - Al-Nusra.txt
+++ b/history/countries/NUS - Al-Nusra.txt
@@ -131,30 +131,11 @@ capital = 190
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.01 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 1.0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.01 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 11 } #Caliphate

--- a/history/countries/NYK - New York.txt
+++ b/history/countries/NYK - New York.txt
@@ -787,22 +787,11 @@ capital = 769
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.03 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.10 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 	add_to_array = { ruling_party = 2 }
 	startup_politics = yes
 

--- a/history/countries/NZL - New Zealand.txt
+++ b/history/countries/NZL - New Zealand.txt
@@ -313,30 +313,14 @@ capital = 750
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.31 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.39 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.08 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.02 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.07 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.04 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/OMA - Oman.txt
+++ b/history/countries/OMA - Oman.txt
@@ -261,30 +261,10 @@ capital = 182
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.01 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.97 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/OMG - Outer Mongolia.txt
+++ b/history/countries/OMG - Outer Mongolia.txt
@@ -93,30 +93,12 @@ capital = 556
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.03 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
 	set_variable = { party_pop_array^4 = 0.80 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 4 }
 	startup_politics = yes

--- a/history/countries/OPR - Odessa.txt
+++ b/history/countries/OPR - Odessa.txt
@@ -172,30 +172,7 @@ capital = 695
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 1.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/PAK - Pakistan.txt
+++ b/history/countries/PAK - Pakistan.txt
@@ -486,30 +486,18 @@ capital = 422
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.02 } #conservatism
 	set_variable = { party_pop_array^2 = 0.07 } #liberalism
 	set_variable = { party_pop_array^3 = 0.26 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.045 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 25.5 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.03 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.02 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.005 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.005 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.23 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 22 }

--- a/history/countries/PAL - Palestine.txt
+++ b/history/countries/PAL - Palestine.txt
@@ -288,30 +288,17 @@ capital = 208
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.08 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.1 } #socialism
 	set_variable = { party_pop_array^4 = 0.06 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.01 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.04 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.09 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.02 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.23 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.02 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.34 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/PAN - Panama.txt
+++ b/history/countries/PAN - Panama.txt
@@ -145,30 +145,14 @@ capital = 853
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.31 } #conservatism
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
 	set_variable = { party_pop_array^3 = 0.06 } #socialism
 	set_variable = { party_pop_array^4 = 0.06 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.11 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.02 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.04 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.39 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/PAP - Papua New Guinea.txt
+++ b/history/countries/PAP - Papua New Guinea.txt
@@ -136,30 +136,11 @@ capital = 730
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.2 } #liberalism
 	set_variable = { party_pop_array^3 = 0.19 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.13 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.45 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/PAR - Paraguay.txt
+++ b/history/countries/PAR - Paraguay.txt
@@ -171,27 +171,12 @@ capital = 895
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.33 } #liberalism
 	set_variable = { party_pop_array^3 = 0.04 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
-	set_variable = { party_pop_array^5 = 0.0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.58 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/PAU - Palau.txt
+++ b/history/countries/PAU - Palau.txt
@@ -107,30 +107,8 @@ capital = 819
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.78 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.22 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/PER - Iran.txt
+++ b/history/countries/PER - Iran.txt
@@ -1010,23 +1010,14 @@ capital = 405
 	set_variable = { party_pop_array^3 = 0.035 } #socialism
 	set_variable = { party_pop_array^4 = 0.002 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.021 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0.00 } #Conservative
-	set_variable = { party_pop_array^7 = 0.000 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.385 } #Mod_Vilayat_e_Faqih -> Reformists
 	set_variable = { party_pop_array^9 = 0.365 } #Vilayat_e_Faqih -> Principalists
-	set_variable = { party_pop_array^10 = 0.00 } #Kingdom
-	set_variable = { party_pop_array^11 = 0.00 } #Caliphate
-	set_variable = { party_pop_array^12 = 0.00 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.029 } #Neutral_conservatism 3
-	set_variable = { party_pop_array^15 = 0.00 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.045 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.018 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.011 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.002 } #Nat_Populism 1
 	set_variable = { party_pop_array^21 = 0.001 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.025 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/PHI - Philippines.txt
+++ b/history/countries/PHI - Philippines.txt
@@ -274,30 +274,16 @@ capital = 1230
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.1587 } #conservatism
 	set_variable = { party_pop_array^2 = 0.0871 } #liberalism
 	set_variable = { party_pop_array^3 = 0.0098 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.102 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.0117 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.3786 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.02 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.1383 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.0296 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.0642 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 } ##PWP

--- a/history/countries/PKK - Kurdistan Workers Party.txt
+++ b/history/countries/PKK - Kurdistan Workers Party.txt
@@ -124,30 +124,13 @@ capital = 162
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.23 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.225 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.225 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.15 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.05 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/PMR - Transnistria.txt
+++ b/history/countries/PMR - Transnistria.txt
@@ -249,30 +249,13 @@ capital = 149
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.14 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.1 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0.0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.50 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.07 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.09 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.03 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/POR - Portugal.txt
+++ b/history/countries/POR - Portugal.txt
@@ -543,29 +543,14 @@ capital = 96
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.331 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.452 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.092 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.085 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.004 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.007 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.003 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/PRP - Podolia People's Republic.txt
+++ b/history/countries/PRP - Podolia People's Republic.txt
@@ -190,30 +190,8 @@ capital = 1087
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.1 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.9 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 15 }

--- a/history/countries/PRU - Peru.txt
+++ b/history/countries/PRU - Peru.txt
@@ -232,30 +232,15 @@ capital = 904
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.03 } #conservatism
 	set_variable = { party_pop_array^2 = 0.41 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.03 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.03 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.42 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/PTR - Puerto Rico.txt
+++ b/history/countries/PTR - Puerto Rico.txt
@@ -784,22 +784,11 @@ capital = 815
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.03 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.10 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0.00 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0.00 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 	add_to_array = { ruling_party = 2 }
 	startup_politics = yes
 

--- a/history/countries/PUK - PUK Kurdistan.txt
+++ b/history/countries/PUK - PUK Kurdistan.txt
@@ -122,30 +122,12 @@ capital = 630
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.37 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.06 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.03 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.06 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0.00 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.49 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 } #conservatism

--- a/history/countries/PUN - Puntland.txt
+++ b/history/countries/PUN - Puntland.txt
@@ -95,30 +95,7 @@ capital = 239
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/QAT - Qatar.txt
+++ b/history/countries/QAT - Qatar.txt
@@ -249,30 +249,13 @@ capital = 181
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.01 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.01 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.02 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.01 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.025 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.92 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.005 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/QTF - Qatif.txt
+++ b/history/countries/QTF - Qatif.txt
@@ -91,29 +91,11 @@ capital = 174
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.01 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.22 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.5 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.01 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.25 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 9 }

--- a/history/countries/QUE - Quebec.txt
+++ b/history/countries/QUE - Quebec.txt
@@ -69,30 +69,13 @@ capital = 762
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
 	set_variable = { party_pop_array^2 = 0.10 } #liberalism
 	set_variable = { party_pop_array^3 = 0.20 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.40 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/RAJ - India.txt
+++ b/history/countries/RAJ - India.txt
@@ -967,29 +967,18 @@ capital = 431
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.04 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.3 } #socialism
 	set_variable = { party_pop_array^4 = 0.04 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.02 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.04 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.26 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.03 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.06 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.06 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.03 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/RCD - Rally for Congolese Democracy.txt
+++ b/history/countries/RCD - Rally for Congolese Democracy.txt
@@ -105,30 +105,13 @@ capital = 310
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.1 } #conservatism
 	set_variable = { party_pop_array^2 = 0.4 } #liberalism
 	set_variable = { party_pop_array^3 = 0.1 } #socialism
 	set_variable = { party_pop_array^4 = 0.15 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.15 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/ROJ - Rojava.txt
+++ b/history/countries/ROJ - Rojava.txt
@@ -96,30 +96,9 @@ capital = 193
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.35 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.1 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.55 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 } #neutral_Social

--- a/history/countries/ROM - Romania.txt
+++ b/history/countries/ROM - Romania.txt
@@ -908,25 +908,10 @@ capital = 150
 	set_variable = { party_pop_array^2 = 0.12 } #liberalism
 	set_variable = { party_pop_array^3 = 0.35 } #socialism
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.055 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.03 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.065 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.28 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/RSK - Republika Srpska.txt
+++ b/history/countries/RSK - Republika Srpska.txt
@@ -172,23 +172,10 @@ capital = 1054
 	set_variable = { party_pop_array^3 = 0.076 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.023 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.155 } #Neutral_conservatism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.212 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.17 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 6 } #Conservative
 

--- a/history/countries/RUS - Lokot Republic.txt
+++ b/history/countries/RUS - Lokot Republic.txt
@@ -61,29 +61,15 @@ capital = 656
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.30 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.15 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.10 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.15 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.15 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/RWA - Rwanda.txt
+++ b/history/countries/RWA - Rwanda.txt
@@ -182,28 +182,11 @@ capital = 250
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.02 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.02 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.09 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.25 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.12 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.12 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.38 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/RYU - Ryukyu.txt
+++ b/history/countries/RYU - Ryukyu.txt
@@ -105,30 +105,8 @@ capital = 618
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.52 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.48 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/SAF - South Africa.txt
+++ b/history/countries/SAF - South Africa.txt
@@ -710,30 +710,11 @@ capital = 275
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.069 } #conservatism
 	set_variable = { party_pop_array^2 = 0.108 } #liberalism
 	set_variable = { party_pop_array^3 = 0.06 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.663 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.1 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0.0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/SAM - Samoa.txt
+++ b/history/countries/SAM - Samoa.txt
@@ -120,30 +120,8 @@ capital = 569
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.52 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.48 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/SAO - Sao Tome & Principe.txt
+++ b/history/countries/SAO - Sao Tome & Principe.txt
@@ -116,30 +116,9 @@ capital = 320
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.2 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.42 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.56 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/SAR - Sardinia.txt
+++ b/history/countries/SAR - Sardinia.txt
@@ -103,30 +103,7 @@ capital = 84
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 1.0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/SAU - Saudi Arabia.txt
+++ b/history/countries/SAU - Saudi Arabia.txt
@@ -422,29 +422,13 @@ capital = 176
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.01 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.1 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.01 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.7 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.11 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.01 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 10 }

--- a/history/countries/SAZ - South Azerbaijan.txt
+++ b/history/countries/SAZ - South Azerbaijan.txt
@@ -206,30 +206,11 @@ capital = 416
 	set_variable = { var = population_tax_rate value = 25 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.45 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.15 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.5 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/SCL - Padania.txt
+++ b/history/countries/SCL - Padania.txt
@@ -75,30 +75,17 @@ capital = 80
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.115 } #conservatism
 	set_variable = { party_pop_array^2 = 0.074 } #liberalism
 	set_variable = { party_pop_array^3 = 0.052 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.083 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.084 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.018 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.043 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.445 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.016 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/SCO - Scotland.txt
+++ b/history/countries/SCO - Scotland.txt
@@ -116,30 +116,7 @@ capital = 9
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/SEL - Seleka.txt
+++ b/history/countries/SEL - Seleka.txt
@@ -91,30 +91,7 @@ capital = 325
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/SEN - Senegal.txt
+++ b/history/countries/SEN - Senegal.txt
@@ -190,25 +190,8 @@ capital = 364
 	set_variable = { party_pop_array^2 = 0.31 } #liberalism
 	set_variable = { party_pop_array^3 = 0.17 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.04 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.37 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/SER - Serbia.txt
+++ b/history/countries/SER - Serbia.txt
@@ -595,23 +595,10 @@ capital = 131
 	set_variable = { party_pop_array^3 = 0.076 } #socialism
 	set_variable = { party_pop_array^4 = 0.001 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.023 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.155 } #Neutral_conservatism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.212 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.17 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 20 } #Nat_Populism
 	add_to_array = { gov_coalition_array = 5 } #anarchist_communism

--- a/history/countries/SEY - Seychelles.txt
+++ b/history/countries/SEY - Seychelles.txt
@@ -140,30 +140,7 @@ capital = 565
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 1.0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/SHA - Sahrawi.txt
+++ b/history/countries/SHA - Sahrawi.txt
@@ -182,30 +182,7 @@ capital = 372
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 1.0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/SHB - Al-Shabaab.txt
+++ b/history/countries/SHB - Al-Shabaab.txt
@@ -142,30 +142,8 @@ capital = 239
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.36 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.64 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 12 }

--- a/history/countries/SHN - South Shan State.txt
+++ b/history/countries/SHN - South Shan State.txt
@@ -130,30 +130,7 @@ capital = 498
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/SIA - Thailand.txt
+++ b/history/countries/SIA - Thailand.txt
@@ -812,30 +812,11 @@ capital = 508
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.32 } #conservatism (Democrats)
 	set_variable = { party_pop_array^2 = 0.13 } #liberalism (Chart Pattana)
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.17 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.08 } #neutral_Social (TRT)
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.30 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/SIB - Siberian Republic.txt
+++ b/history/countries/SIB - Siberian Republic.txt
@@ -64,30 +64,7 @@ capital = 680
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/SIE - Sierra Leone.txt
+++ b/history/countries/SIE - Sierra Leone.txt
@@ -129,30 +129,13 @@ capital = 358
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.236 } #conservatism
 	set_variable = { party_pop_array^2 = 0.368 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.011 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.082 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.04 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.171 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.128 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/SIK - Sikkim State.txt
+++ b/history/countries/SIK - Sikkim State.txt
@@ -81,29 +81,6 @@ capital = 982
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 1.0 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/SIL - Silesia.txt
+++ b/history/countries/SIL - Silesia.txt
@@ -138,30 +138,17 @@ capital = 115
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.383 } #conservatism
 	set_variable = { party_pop_array^2 = 0.019 } #liberalism
 	set_variable = { party_pop_array^3 = 0.108 } #socialism
 	set_variable = { party_pop_array^4 = 0.008 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.086 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.137 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.018 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.131 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.03 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.062 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.018 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 
 	# Relation Starting Configuration (moved from on_startup)

--- a/history/countries/SIN - Singapore.txt
+++ b/history/countries/SIN - Singapore.txt
@@ -623,30 +623,15 @@ capital = 530
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.65 } #conservatism - Western Clique
 	set_variable = { party_pop_array^2 = 0.054 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
 	set_variable = { party_pop_array^4 = 0.008 } #Communist-State
-	set_variable = { party_pop_array^5 = 0.0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.09 } #Autocracy - Eastern Clique
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.084 } #Neutral_Autocracy - Non-Aligned clique
 	set_variable = { party_pop_array^14 = 0.004 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.023 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.067 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	##People's Action Party Clique Coalition

--- a/history/countries/SLA - Sinaloa_Cartel.txt
+++ b/history/countries/SLA - Sinaloa_Cartel.txt
@@ -215,30 +215,7 @@ capital = 831 # Culiacan
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 1 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 15 }

--- a/history/countries/SLO - Slovakia.txt
+++ b/history/countries/SLO - Slovakia.txt
@@ -306,30 +306,10 @@ capital = 119
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.367 } #liberalism
 	set_variable = { party_pop_array^3 = 0.153 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.387 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.093 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/SLV - Slovenia.txt
+++ b/history/countries/SLV - Slovenia.txt
@@ -305,30 +305,17 @@ capital = 124
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.254 } #conservatism
 	set_variable = { party_pop_array^2 = 0.422 } #liberalism
 	set_variable = { party_pop_array^3 = 0.151 } #socialism
 	set_variable = { party_pop_array^4 = 0.02 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.01 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.009 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.044 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/SMA - San Marino.txt
+++ b/history/countries/SMA - San Marino.txt
@@ -186,29 +186,13 @@ capital = 948
 
 	start_politics_input = yes
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.4 } #conservatism
 	set_variable = { party_pop_array^2 = 0.098 } #liberalism
 	set_variable = { party_pop_array^3 = 0.232 } #socialism
 	set_variable = { party_pop_array^4 = 0.055 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.104 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.033 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.012 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.024 } #Monarchist
 
 	##Ruling Party

--- a/history/countries/SML - Somaliland.txt
+++ b/history/countries/SML - Somaliland.txt
@@ -124,30 +124,7 @@ capital = 237
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 1.0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 16 }

--- a/history/countries/SNA - Somali National Alliance.txt
+++ b/history/countries/SNA - Somali National Alliance.txt
@@ -100,30 +100,7 @@ capital = 593
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 1.0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/SOL - Solomon Islands.txt
+++ b/history/countries/SOL - Solomon Islands.txt
@@ -119,30 +119,14 @@ capital = 533
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.53 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.24 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.01 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.01 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.01 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.14 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.01 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/SOM - Somalia.txt
+++ b/history/countries/SOM - Somalia.txt
@@ -181,29 +181,11 @@ capital = 240
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.20 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.30 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.35 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.08 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.02 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/SOO - South Ossetia.txt
+++ b/history/countries/SOO - South Ossetia.txt
@@ -135,30 +135,10 @@ capital = 705
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.30 } #Conservative
 	set_variable = { party_pop_array^7 = 0.55 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.5 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/SPA - Andalusia.txt
+++ b/history/countries/SPA - Andalusia.txt
@@ -63,30 +63,11 @@ capital = 93
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.088 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.267 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.141 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.089 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.415 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 20 }
 	startup_politics = yes
 

--- a/history/countries/SPR - Spain.txt
+++ b/history/countries/SPR - Spain.txt
@@ -1117,30 +1117,15 @@ capital = 91
 	set_variable = { election_threshold = 0.03 }
 	start_politics_input = yes
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.35 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.27 } #socialism
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.12 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.01 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.06 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.07 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.04 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/SRI - Sri Lanka.txt
+++ b/history/countries/SRI - Sri Lanka.txt
@@ -218,30 +218,10 @@ capital = 483
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.003 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.061 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.425 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.511 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/SSU - South Sudan.txt
+++ b/history/countries/SSU - South Sudan.txt
@@ -142,30 +142,13 @@ capital = 227
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.01 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.01 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.53 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.25 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/STH - St Helena.txt
+++ b/history/countries/STH - St Helena.txt
@@ -99,30 +99,10 @@ capital = 24
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.65 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.1 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.15 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.1 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/STK - St.Kitts and Nevis.txt
+++ b/history/countries/STK - St.Kitts and Nevis.txt
@@ -156,30 +156,9 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.182 } #conservatism
 	set_variable = { party_pop_array^2 = 0.091 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.727 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/STL - St.Lucia.txt
+++ b/history/countries/STL - St.Lucia.txt
@@ -127,30 +127,8 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.059 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.941 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/STV - St.Vincent and the Grenadines.txt
+++ b/history/countries/STV - St.Vincent and the Grenadines.txt
@@ -148,30 +148,8 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.533 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.467 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/SUD - Sudan.txt
+++ b/history/countries/SUD - Sudan.txt
@@ -238,30 +238,12 @@ capital = 220
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.15 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.15 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.50 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.15 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 12 }

--- a/history/countries/SUR - Suriname.txt
+++ b/history/countries/SUR - Suriname.txt
@@ -159,30 +159,7 @@ capital = 878
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 1.0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/SWA - Swaziland.txt
+++ b/history/countries/SWA - Swaziland.txt
@@ -117,29 +117,7 @@ capital = 271
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.51 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.49 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/SWI - Switzerland.txt
+++ b/history/countries/SWI - Switzerland.txt
@@ -645,30 +645,12 @@ capital = 74
 	set_variable = { election_threshold = 0.01 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.25 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.18 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.22 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.08 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.02 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.25 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/SWS - South West State of Somalia.txt
+++ b/history/countries/SWS - South West State of Somalia.txt
@@ -86,30 +86,7 @@ capital = 584
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/SYR - Syria.txt
+++ b/history/countries/SYR - Syria.txt
@@ -161,26 +161,12 @@ capital = 186
 		set_variable = { party_pop_array^1 = 0.15 } #conservatism
 		set_variable = { party_pop_array^2 = 0.23 } #liberalism
 		set_variable = { party_pop_array^3 = 0.08 } #socialism
-		set_variable = { party_pop_array^4 = 0 } #Communist-State
-		set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-		set_variable = { party_pop_array^6 = 0 } #Conservative
-		set_variable = { party_pop_array^7 = 0 } #Autocracy
 		set_variable = { party_pop_array^8 = 0.1 } #Mod_Vilayat_e_Faqih
 		set_variable = { party_pop_array^9 = 0.1 } #Vilayat_e_Faqih
-		set_variable = { party_pop_array^10 = 0 } #Kingdom
-		set_variable = { party_pop_array^11 = 0 } #Caliphate
-		set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-		set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 		set_variable = { party_pop_array^14 = 0.22 } #Neutral_conservatism
-		set_variable = { party_pop_array^15 = 0 } #oligarchism
 		set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
-		set_variable = { party_pop_array^17 = 0 } #Neutral_green
-		set_variable = { party_pop_array^18 = 0 } #neutral_Social
-		set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 		set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
 		set_variable = { party_pop_array^21 = 0.03 } #Nat_Fascism
-		set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-		set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 		### Ruling Party
 		add_to_array = { ruling_party = 14 } #Neutral_conservatism
@@ -318,30 +304,15 @@ capital = 186
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
 	set_variable = { party_pop_array^4 = 0.03 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.75 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.03 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.04 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.025 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.02 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.07 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 7 }

--- a/history/countries/TAB - Tabaristan.txt
+++ b/history/countries/TAB - Tabaristan.txt
@@ -67,30 +67,11 @@ capital = 403
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.15 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.60 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/TAI - Taiwan.txt
+++ b/history/countries/TAI - Taiwan.txt
@@ -745,30 +745,11 @@ capital = 598
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.230 } #conservatism
 	set_variable = { party_pop_array^2 = 0.399 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.001 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.368 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.002 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/TAJ - Tajikistan.txt
+++ b/history/countries/TAJ - Tajikistan.txt
@@ -207,30 +207,12 @@ capital = 724
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.050 } #socialism
 	set_variable = { party_pop_array^4 = 0.106 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.682 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.132 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.030 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.100 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/TAL - Afghan Taliban.txt
+++ b/history/countries/TAL - Afghan Taliban.txt
@@ -165,30 +165,10 @@ capital = 415
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.18 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.63 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.06 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.15 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 11 }

--- a/history/countries/TAM - Tamaulpas.txt
+++ b/history/countries/TAM - Tamaulpas.txt
@@ -218,30 +218,7 @@ capital = 835
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 1 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 15 }

--- a/history/countries/TAT - Tatarstan.txt
+++ b/history/countries/TAT - Tatarstan.txt
@@ -91,30 +91,11 @@ capital = 661
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.2 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.6 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.05 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.1 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/TEX - Texas.txt
+++ b/history/countries/TEX - Texas.txt
@@ -758,26 +758,15 @@ capital = 800
 	set_variable = { party_pop_array^1 = 0.40 } #conservatism
 	set_variable = { party_pop_array^2 = 0.10 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.5 } #Conservative
 	set_variable = { party_pop_array^7 = 0.5 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.025 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.025 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/TIB - Tibet.txt
+++ b/history/countries/TIB - Tibet.txt
@@ -84,30 +84,6 @@ capital = 589
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 23 }

--- a/history/countries/TIE - Tibesti.txt
+++ b/history/countries/TIE - Tibesti.txt
@@ -111,29 +111,10 @@ capital = 327
 	start_politics_input = yes
 
 	set_variable = { party_pop_array^0 = 0.10 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.25 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.05 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.55 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.05 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 13 }
 	startup_politics = yes
 

--- a/history/countries/TIM - East Timor.txt
+++ b/history/countries/TIM - East Timor.txt
@@ -132,30 +132,15 @@ capital = 734
 	set_variable = { election_threshold = 0.04 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.02 } #conservatism
 	set_variable = { party_pop_array^2 = 0.09 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
 	set_variable = { party_pop_array^4 = 0.017 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.04 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.02 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.03 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.573 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.02 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/TLS - Talishstan.txt
+++ b/history/countries/TLS - Talishstan.txt
@@ -81,30 +81,7 @@ capital = 9
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/TML - Tamil Eelam.txt
+++ b/history/countries/TML - Tamil Eelam.txt
@@ -177,30 +177,13 @@ capital = 481
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.23 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.425 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.025 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.15 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.05 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/TNZ - Tanzania.txt
+++ b/history/countries/TNZ - Tanzania.txt
@@ -175,30 +175,11 @@ capital = 255
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.044 } #conservatism
 	set_variable = { party_pop_array^2 = 0.171 } #liberalism
 	set_variable = { party_pop_array^3 = 0.038 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.094 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.653 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/TOG - Togo.txt
+++ b/history/countries/TOG - Togo.txt
@@ -165,10 +165,7 @@ capital = 342
 	### Party Popularities
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism - Pan-African Patriotic Convergence
 	set_variable = { party_pop_array^3 = 0.248 } #socialism - Union of Forces for Change
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism - Let's Save Togo Collective
 	set_variable = { party_pop_array^13 = 0.415 } #Neutral_Autocracy - Rally of the Togolese People
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism - New Togolese Commitment
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green - National Alliance for Change
 	set_variable = { party_pop_array^18 = 0.287 } #neutral_Social - Action Committee for Renewal
 
 	#1999 election results

--- a/history/countries/TON - Tonga.txt
+++ b/history/countries/TON - Tonga.txt
@@ -115,28 +115,9 @@ capital = 1115
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.52 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.04 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.302 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.48 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.138 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/TRA - Transylvania.txt
+++ b/history/countries/TRA - Transylvania.txt
@@ -92,29 +92,13 @@ capital = 151
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.30 } #conservatism
 	set_variable = { party_pop_array^2 = 0.30 } #liberalism
 	set_variable = { party_pop_array^3 = 0.05 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.15 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.05 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/TRC - Tierra_Caliente.txt
+++ b/history/countries/TRC - Tierra_Caliente.txt
@@ -231,30 +231,7 @@ capital = 837
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 1 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 15 }

--- a/history/countries/TRI - Trinidad.txt
+++ b/history/countries/TRI - Trinidad.txt
@@ -143,30 +143,8 @@ capital = 869
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.528 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.472 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 18 }

--- a/history/countries/TRK - Turkmenistan.txt
+++ b/history/countries/TRK - Turkmenistan.txt
@@ -182,30 +182,7 @@ capital = 729
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/TRP - Tripolitania.txt
+++ b/history/countries/TRP - Tripolitania.txt
@@ -136,29 +136,11 @@ capital = 391
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.05 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.025 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.025 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.80 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/TTP - Pakistani Taliban.txt
+++ b/history/countries/TTP - Pakistani Taliban.txt
@@ -111,30 +111,7 @@ capital = 594
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 1.0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 11 }

--- a/history/countries/TUA - Tuaregs.txt
+++ b/history/countries/TUA - Tuaregs.txt
@@ -93,29 +93,10 @@ capital = 918
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.05 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.20 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.15 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.50 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.10 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 14 }

--- a/history/countries/TUL - Tuvalu.txt
+++ b/history/countries/TUL - Tuvalu.txt
@@ -114,30 +114,8 @@ capital = 568
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.58 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.42 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/TUN - Tunisia.txt
+++ b/history/countries/TUN - Tunisia.txt
@@ -211,26 +211,10 @@ capital = 388
 	set_variable = { party_pop_array^1 = 0.01 } #conservatism
 	set_variable = { party_pop_array^2 = 0.04 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.01 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.01 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.25 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.07 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/TUR - Turkey.txt
+++ b/history/countries/TUR - Turkey.txt
@@ -812,7 +812,6 @@ capital = 159
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.11 } #conservatism
 	set_variable = { party_pop_array^2 = 0.004 } #liberalism
 	set_variable = { party_pop_array^3 = 0.183 } #socialism
@@ -820,22 +819,13 @@ capital = 159
 	set_variable = { party_pop_array^5 = 0.007 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.20 } #Conservative
 	set_variable = { party_pop_array^7 = 0.001 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.001 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.015 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.117 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.118 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.051 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.163 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.029 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/TUV - Tuva.txt
+++ b/history/countries/TUV - Tuva.txt
@@ -94,30 +94,12 @@ capital = 1011
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.07 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.03 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.66 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.01 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.04 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/UAE - United Arab Emirates.txt
+++ b/history/countries/UAE - United Arab Emirates.txt
@@ -292,29 +292,11 @@ capital = 180
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.75 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
 	set_variable = { party_pop_array^8 = 0.01 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.02 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.2 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.01 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/UDM - Udmurtia.txt
+++ b/history/countries/UDM - Udmurtia.txt
@@ -96,30 +96,12 @@ capital = 1133
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.02 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.09 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.42 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.13 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/UDT - Union of Deseret.txt
+++ b/history/countries/UDT - Union of Deseret.txt
@@ -652,14 +652,6 @@ capital = 805
 	set_variable = { party_pop_array^3 = 0.07 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
@@ -667,9 +659,6 @@ capital = 805
 	set_variable = { party_pop_array^18 = 0.025 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.025 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes
 

--- a/history/countries/UGA - Uganda.txt
+++ b/history/countries/UGA - Uganda.txt
@@ -167,30 +167,7 @@ capital = 249
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 1.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/UKR - Ukraine.txt
+++ b/history/countries/UKR - Ukraine.txt
@@ -1016,30 +1016,15 @@ capital = 698
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.100 } #conservatism
 	set_variable = { party_pop_array^2 = 0.120 } #liberalism
 	set_variable = { party_pop_array^3 = 0.030 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.420 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.180 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.005 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.010 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.100 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.070 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 6 } #Conservative
 

--- a/history/countries/UNI - UNITA.txt
+++ b/history/countries/UNI - UNITA.txt
@@ -106,30 +106,14 @@ capital = 300
 
 	start_politics_input = yes
 
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.692 } #conservatism
 	set_variable = { party_pop_array^2 = 0.014 } #liberalism
 	set_variable = { party_pop_array^3 = 0.004 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.006 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.227 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.019 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.028 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.01 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	add_to_array = { ruling_party = 1 }
 	startup_politics = yes

--- a/history/countries/URA - Ural Republic.txt
+++ b/history/countries/URA - Ural Republic.txt
@@ -996,30 +996,8 @@ capital = 676
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.3 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.7 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/URG - Uruguay.txt
+++ b/history/countries/URG - Uruguay.txt
@@ -162,30 +162,12 @@ capital = 893
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.541 } #liberalism
 	set_variable = { party_pop_array^3 = 0.02 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.259 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.05 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.08 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/USB - Free States of America.txt
+++ b/history/countries/USB - Free States of America.txt
@@ -790,11 +790,6 @@ capital = 1182
 	set_variable = { party_pop_array^5 = 0.06 } #anarchist_communism - Free Socialist Anarchists
 	set_variable = { party_pop_array^6 = 0.01 } #Conservative
 	set_variable = { party_pop_array^7 = 0.02 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.015 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.015 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.07 } #oligarchism - Mid-Atlantic Party Isolationist

--- a/history/countries/UZB - Uzbekistan.txt
+++ b/history/countries/UZB - Uzbekistan.txt
@@ -229,30 +229,9 @@ capital = 725
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.78 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.176 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.044 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 13 }

--- a/history/countries/VAN - Vanuatu.txt
+++ b/history/countries/VAN - Vanuatu.txt
@@ -108,30 +108,10 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.08 } #conservatism
 	set_variable = { party_pop_array^2 = 0.12 } #liberalism
 	set_variable = { party_pop_array^3 = 0.43 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.17 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/VEN - Venezula.txt
+++ b/history/countries/VEN - Venezula.txt
@@ -293,30 +293,7 @@ capital = 875
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 1.0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }

--- a/history/countries/VER - Cape Verde.txt
+++ b/history/countries/VER - Cape Verde.txt
@@ -128,30 +128,10 @@ capital = 398
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.613 } #liberalism
 	set_variable = { party_pop_array^3 = 0.297 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.023 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.067 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 2 }

--- a/history/countries/VIE - Vietnam.txt
+++ b/history/countries/VIE - Vietnam.txt
@@ -279,30 +279,10 @@ capital = 522
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.175 } #liberalism
 	set_variable = { party_pop_array^3 = 0.15 } #socialism
 	set_variable = { party_pop_array^4 = 0.1 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.575 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 19 }

--- a/history/countries/VMT - Vermont.txt
+++ b/history/countries/VMT - Vermont.txt
@@ -511,30 +511,20 @@ capital = 766
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
 	set_variable = { party_pop_array^2 = 0.05 } #liberalism
 	set_variable = { party_pop_array^3 = 0.20 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.05 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.05 } #Conservative
-	set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
 	set_variable = { party_pop_array^13 = 0.05 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.05 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.05 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.05 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.05 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.10 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0.00 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.10 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 	add_to_array = { ruling_party = 16 }
 	startup_politics = yes
 

--- a/history/countries/VOJ - Vojvodina.txt
+++ b/history/countries/VOJ - Vojvodina.txt
@@ -122,30 +122,11 @@ capital = 130
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.47 } #conservatism
 	set_variable = { party_pop_array^2 = 0.2 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.01 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.31 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.01 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/VRP - Volhynia Democratic Republic.txt
+++ b/history/countries/VRP - Volhynia Democratic Republic.txt
@@ -199,30 +199,8 @@ capital = 1110
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
 	set_variable = { party_pop_array^2 = 0.1 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.9 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 20 }

--- a/history/countries/VTB - Vitebsk.txt
+++ b/history/countries/VTB - Vitebsk.txt
@@ -72,30 +72,13 @@ capital = 1094
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.01 } #conservatism
-	set_variable = { party_pop_array^2 = 0.00 } #liberalism
 	set_variable = { party_pop_array^3 = 0.01 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.02 } #anarchist_communism
 	set_variable = { party_pop_array^6 = 0.65 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.01 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0.00 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 20 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 		### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/WAA - Wa.txt
+++ b/history/countries/WAA - Wa.txt
@@ -139,30 +139,7 @@ capital = 497
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 1 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 4 }

--- a/history/countries/WAS - Wales.txt
+++ b/history/countries/WAS - Wales.txt
@@ -110,30 +110,7 @@ capital = 16
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/WLC - Wallachia.txt
+++ b/history/countries/WLC - Wallachia.txt
@@ -102,26 +102,10 @@ capital = 150
 	set_variable = { party_pop_array^0 = 0.05 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.25 } #conservatism
 	set_variable = { party_pop_array^2 = 0.10 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
 	set_variable = { party_pop_array^4 = 0.10 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.20 } #Neutral_conservatism
 	set_variable = { party_pop_array^15 = 0.25 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.05 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
 	set_variable = { party_pop_array^23 = 0.05 } #Monarchist
 
 	### Ruling Party

--- a/history/countries/WVA - West Virginia.txt
+++ b/history/countries/WVA - West Virginia.txt
@@ -501,30 +501,17 @@ capital = 774
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_array^0 = 0.00 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.10 } #conservatism
-	set_variable = { party_pop_array^2 = 0.00 } #liberalism
 	set_variable = { party_pop_array^3 = 0.10 } #socialism
 	set_variable = { party_pop_array^4 = 0.05 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.10 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0.00 } #Conservative
-	set_variable = { party_pop_array^7 = 0.00 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0.00 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.10 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0.00 } #oligarchism
 	set_variable = { party_pop_array^16 = 0.10 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0.00 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.10 } #neutral_Social
 	set_variable = { party_pop_array^19 = 0.05 } #Neutral_Communism
 	set_variable = { party_pop_array^20 = 0.15 } #Nat_Populism
 	set_variable = { party_pop_array^21 = 0.05 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.10 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0.00 } #Monarchist
 	add_to_array = { ruling_party = 18 }
 	startup_politics = yes
 

--- a/history/countries/YAK - Yakutia.txt
+++ b/history/countries/YAK - Yakutia.txt
@@ -65,30 +65,7 @@ capital = 688
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/YAM - Yamalo-Nenets.txt
+++ b/history/countries/YAM - Yamalo-Nenets.txt
@@ -67,30 +67,7 @@ capital = 679
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 1.0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 6 }

--- a/history/countries/YEM - Yemen.txt
+++ b/history/countries/YEM - Yemen.txt
@@ -171,29 +171,14 @@ capital = 195
 
 	### Party Popularities
 	set_variable = { party_pop_array^0 = 0.56 } #Western_Autocracy
-	set_variable = { party_pop_array^1 = 0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
 	set_variable = { party_pop_array^7 = 0.01 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
 	set_variable = { party_pop_array^9 = 0.1 } #Vilayat_e_Faqih
 	set_variable = { party_pop_array^10 = 0.022 } #Kingdom
 	set_variable = { party_pop_array^11 = 0.005 } #Caliphate
 	set_variable = { party_pop_array^12 = 0.234 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
 	set_variable = { party_pop_array^14 = 0.023 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
 	set_variable = { party_pop_array^18 = 0.045 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
 	set_variable = { party_pop_array^22 = 0.001 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 0 }

--- a/history/countries/ZAM - Zambia.txt
+++ b/history/countries/ZAM - Zambia.txt
@@ -142,30 +142,13 @@ capital = 292
 	set_variable = { election_threshold = 0.01 }
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy - Party for Poor People
 	set_variable = { party_pop_array^1 = 0.067 } #conservatism - ZAP
 	set_variable = { party_pop_array^2 = 0.176 } #liberalism - UPND
 	set_variable = { party_pop_array^3 = 0.507 } #socialism - MMD
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.079 } #anarchist_communism - UNIP
-	set_variable = { party_pop_array^6 = 0 } #Conservative - Heritage
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism - NAREP
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
 	set_variable = { party_pop_array^17 = 0.114 } #Neutral_green - FDD
 	set_variable = { party_pop_array^18 = 0.021 } #neutral_Social - PF
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism - Rainbow Party
 	set_variable = { party_pop_array^20 = 0.036 } #Nat_Populism - NP
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 3 }

--- a/history/countries/ZAN - Zanzibar.txt
+++ b/history/countries/ZAN - Zanzibar.txt
@@ -75,30 +75,7 @@ oob = "GENERIC_OOB"
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 1.0 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
-	set_variable = { party_pop_array^3 = 0 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
-	set_variable = { party_pop_array^5 = 0 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 1 }

--- a/history/countries/ZIM - Zimbabwe.txt
+++ b/history/countries/ZIM - Zimbabwe.txt
@@ -147,30 +147,9 @@ capital = 290
 	start_politics_input = yes
 
 	### Party Popularities
-	set_variable = { party_pop_array^0 = 0 } #Western_Autocracy
 	set_variable = { party_pop_array^1 = 0.05 } #conservatism
-	set_variable = { party_pop_array^2 = 0 } #liberalism
 	set_variable = { party_pop_array^3 = 0.4 } #socialism
-	set_variable = { party_pop_array^4 = 0 } #Communist-State
 	set_variable = { party_pop_array^5 = 0.55 } #anarchist_communism
-	set_variable = { party_pop_array^6 = 0.0 } #Conservative
-	set_variable = { party_pop_array^7 = 0 } #Autocracy
-	set_variable = { party_pop_array^8 = 0 } #Mod_Vilayat_e_Faqih
-	set_variable = { party_pop_array^9 = 0 } #Vilayat_e_Faqih
-	set_variable = { party_pop_array^10 = 0 } #Kingdom
-	set_variable = { party_pop_array^11 = 0 } #Caliphate
-	set_variable = { party_pop_array^12 = 0 } #Neutral_Muslim_Brotherhood
-	set_variable = { party_pop_array^13 = 0 } #Neutral_Autocracy
-	set_variable = { party_pop_array^14 = 0 } #Neutral_conservatism
-	set_variable = { party_pop_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_array^16 = 0 } #Neutral_Libertarian
-	set_variable = { party_pop_array^17 = 0 } #Neutral_green
-	set_variable = { party_pop_array^18 = 0 } #neutral_Social
-	set_variable = { party_pop_array^19 = 0 } #Neutral_Communism
-	set_variable = { party_pop_array^20 = 0 } #Nat_Populism
-	set_variable = { party_pop_array^21 = 0 } #Nat_Fascism
-	set_variable = { party_pop_array^22 = 0 } #Nat_Autocracy
-	set_variable = { party_pop_array^23 = 0 } #Monarchist
 
 	### Ruling Party
 	add_to_array = { ruling_party = 5 }


### PR DESCRIPTION
Removes redundant zero-valued party_pop_array startup assignments after start_politics_input resizes the array. Preserves nonzero popularity values, including the restored Neutral_Autocracy value in events/Iran.txt. Also removes the redundant zero blocks in the affected Iraq event setups.