### PR TITLE
Fix Danish left-tree: widen access, party guard, non-aligned route (#256)

### DIFF
--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -9723,6 +9723,8 @@ focus_tree = {
 				emerging_communist_state_in_power_or_coalition = yes
 				neutrality_neutral_communism_in_power_or_coalition = yes
 				emerging_anarchist_communism_in_power_or_coalition = yes
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
 			}
 		}
 
@@ -9760,7 +9762,10 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { NOT = { has_idea = EU_member } }
+		available = {
+			has_socialist_government_or_in_coalition = yes
+			NOT = { has_idea = EU_member }
+		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_broken_system"
@@ -9792,6 +9797,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_the_socialist_agenda }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_reassure_worker_rights"
@@ -9827,6 +9834,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_mandatory_worker_councils"
 			swap_ideas = {
@@ -9857,6 +9866,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_mandatory_worker_councils }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_integrate_the_unions"
@@ -9891,6 +9902,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_marxist_education"
 			add_timed_idea = {
@@ -9921,6 +9934,8 @@ focus_tree = {
 		mutually_exclusive = { focus = DEN_party_first }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_union_first"
@@ -9967,6 +9982,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_organizing"
 			add_popularity = {
@@ -10006,6 +10023,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_council_run_corporations"
 			add_ideas = DEN_council_run_corporations_idea
@@ -10035,6 +10054,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_organizing }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_provide_political_capital"
@@ -10074,6 +10095,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_join_the_ITUC"
 			set_temp_variable = { temp_opinion = 5 }
@@ -10105,6 +10128,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_strike_policy"
 			set_temp_variable = { temp_opinion = 5 }
@@ -10134,6 +10159,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_strike_policy }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_normalise_the_strike"
@@ -10177,6 +10204,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Liberal_Social"
 			swap_ideas = {
@@ -10187,6 +10221,9 @@ focus_tree = {
 				remove_idea = landowners
 				add_idea = farmers
 			}
+			add_popularity = { ideology = neutrality popularity = 0.04 }
+			recalculate_party = yes
+			add_ideas = DEN_idea_neutrality_drift
 			add_stability = -0.15
 		}
 
@@ -10213,11 +10250,20 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Free_harbor_for_RAF"
 			decrease_policing_budget = yes
 			block_police_increase = yes
 			add_ideas = DEN_Anarchism1
+			add_popularity = { ideology = neutrality popularity = 0.02 }
+			recalculate_party = yes
 		}
 
 		ai_will_do = {
@@ -10243,6 +10289,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Anarchism_first"
 			decrease_policing_budget = yes
@@ -10262,6 +10315,8 @@ focus_tree = {
 				remove_idea = DEN_Anarchism1
 				add_idea = DEN_Anarchism2
 			}
+			add_popularity = { ideology = neutrality popularity = 0.02 }
+			recalculate_party = yes
 		}
 
 		ai_will_do = {
@@ -10287,12 +10342,21 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Freetown_Christiana"
 			4 = {
 				add_to_variable = { productivity_state_var = 40 }
 			}
 			custom_effect_tooltip = DEN_Freetown_Christiana_tt
+			add_popularity = { ideology = neutrality popularity = 0.02 }
+			recalculate_party = yes
 		}
 
 		ai_will_do = {
@@ -10318,6 +10382,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_organized_unorganized"
 			decrease_policing_budget = yes
@@ -10326,6 +10397,8 @@ focus_tree = {
 				remove_idea = DEN_Anarchism2
 				add_idea = DEN_Anarchism3
 			}
+			add_popularity = { ideology = neutrality popularity = 0.02 }
+			recalculate_party = yes
 		}
 
 		ai_will_do = {
@@ -10351,6 +10424,13 @@ focus_tree = {
 		mutually_exclusive = { focus = DEN_strike_policy }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_the_art_of_a_riot"
@@ -10387,6 +10467,8 @@ focus_tree = {
 				change_relative_party_popularity = yes
 				add_stability = -0.02
 			}
+			add_popularity = { ideology = neutrality popularity = 0.02 }
+			recalculate_party = yes
 		}
 
 		ai_will_do = {
@@ -10411,6 +10493,13 @@ focus_tree = {
 		prerequisite = { focus = DEN_the_art_of_a_riot }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = {
+			OR = {
+				western_socialism_are_in_power_or_coalition = yes
+				neutrality_neutral_social_in_power_or_coalition = yes
+			}
+		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_structurised_support"
@@ -10448,6 +10537,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_export_the_protest"
 			add_ideas = DEN_inspire_revolutions
@@ -10475,6 +10566,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_council_run_corporations }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_world_forum"
@@ -10508,6 +10601,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_international_stage"
 			add_ideas = DEN_World_Workers_Paradise
@@ -10538,6 +10633,8 @@ focus_tree = {
 		mutually_exclusive = { focus = DEN_union_first }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_party_first"
@@ -10589,6 +10686,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_party_first }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_national_congress"
@@ -10687,6 +10786,8 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
+		available = { has_socialist_government_or_in_coalition = yes }
+
 		bypass = {
 			NOT = {
 				has_idea = large_far_right_movement
@@ -10755,6 +10856,8 @@ focus_tree = {
 		prerequisite = { focus = DEN_the_socialist_agenda }
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
+
+		available = { has_socialist_government_or_in_coalition = yes }
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_abolish_monarchy"

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -10208,6 +10208,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10254,6 +10255,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10293,6 +10295,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10346,6 +10349,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10386,6 +10390,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10429,6 +10434,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10498,6 +10504,7 @@ focus_tree = {
 			OR = {
 				western_socialism_are_in_power_or_coalition = yes
 				neutrality_neutral_social_in_power_or_coalition = yes
+				emerging_anarchist_communism_in_power_or_coalition = yes
 			}
 		}
 
@@ -10762,7 +10769,10 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { NOT = { has_idea = EU_member } }
+		available = {
+			has_socialist_government_or_in_coalition = yes
+			NOT = { has_idea = EU_member }
+		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_end_the_protest"


### PR DESCRIPTION
**Issue:** Closes #256

**What**
- Widens `DEN_the_socialist_agenda` entry gate to include `western_socialism_are_in_power_or_coalition` and `neutrality_neutral_social_in_power_or_coalition` (social democrats / left-radicals) alongside the existing communist/anarchist checks.
- Adds `has_socialist_government_or_in_coalition` `available` guards to all downstream socialist focuses (`DEN_broken_system` now requires it + `NOT EU_member`, plus `DEN_reassure_worker_rights`, `DEN_mandatory_worker_councils` chain, `DEN_union_first`, `DEN_organizing`, `DEN_party_first`, `DEN_world_forum`, etc.) so AI cannot finish the tree after flipping to a right-wing government.
- Retools the `DEN_Liberal_Social` branch as the non-aligned socialist route: narrow gating on `western_socialism OR neutral_social`, plus progressive `neutrality` popularity (0.02–0.04 per focus, recalculate) and `DEN_idea_neutrality_drift` on `DEN_Liberal_Social` to make a non-aligned run viable.

**Why**
#256 reports the tree references socialist democrats but only generic/neutral communists can enter, virtually none of the focuses give enough non-aligned support, and only the first focus checks party in power. The change matches the requested split (communist vs non-aligned socialist vs anarchist) and aligns with other nations' gating.

**How**
- Single file: `common/national_focus/denmark.txt` (105 insertions, no new IDs/loc/AI plans).
- Reused existing triggers/ideas (`has_socialist_government_or_in_coalition`, `western_socialism_are_in_power_or_coalition`, `neutrality_neutral_social_in_power_or_coalition`, `DEN_idea_neutrality_drift`).
- Validation: `python3 tools/validation/run_all_validators.py` — no new errors, warnings unchanged (67 pre-existing).