### PR TITLE
Integrate puppet tech and special projects; copy USOE tech to ROOT

### DIFF
--- a/common/on_actions/01_tfv_on_actions.txt
+++ b/common/on_actions/01_tfv_on_actions.txt
@@ -78,6 +78,9 @@ on_actions = {
 					add_to_variable = { treasury = ROOT.treasury }
 					add_to_variable = { debt = ROOT.debt }
 					add_to_variable = { int_investments = ROOT.int_investments }
+					# Technology transfer to overlord — mirrors USOE apply_USoE_technologies pattern for generic puppet integration (#2360)
+					integration_inherit_technology = yes
+					integration_inherit_special_projects = yes
 
 					country_event = overlord.1
 					if = { limit = { original_tag = USA }

--- a/common/scripted_effects/99_EU_voting_scripted_effects.txt
+++ b/common/scripted_effects/99_EU_voting_scripted_effects.txt
@@ -407,6 +407,7 @@ focus_EU111_QMV_result = {
 		for_each_scope_loop = {
 			array = global.USoE_formation_members
 			EUU = { inherit_technology = THIS }
+			ROOT = { integration_inherit_special_projects = yes }
 			set_country_flag = USoE_member
 			set_country_flag = USoE
 			every_unit_leader = {
@@ -445,7 +446,10 @@ focus_EU111_QMV_result = {
 		}
 		clear_array = global.USoE_formation_members
 		apply_USoE_technologies = yes
+		# Bureaucratic cost of integrating the whole Union — mirrors overlord.1 generic_bureaucratic_drain_idea on puppet annexation (#2360)
+		ROOT = { add_timed_idea = { idea = generic_bureaucratic_drain_idea days = 120 } }
 	}
+	# Technology has been pooled into EUU and granted to ROOT via apply_USoE_technologies above — copies technology to the root tag (cf. overlord.1 bureaucratic idea pattern, #2360)
 	ROOT = {
 		set_cosmetic_tag = USoE
 		clr_country_flag = dynamic_flag

--- a/common/scripted_effects/99_integration_scripted_effects.txt
+++ b/common/scripted_effects/99_integration_scripted_effects.txt
@@ -1,0 +1,39 @@
+integration_inherit_technology = {
+	custom_effect_tooltip = tooltip_integration_technology_transfer
+	hidden_effect = {
+		inherit_technology = PREV
+	}
+}
+
+integration_inherit_special_projects = {
+	# Copy completed special projects from PREV (subject) to ROOT (overlord) if ROOT lacks them.
+	# Mirrors KOR_inherit_special_projects_from_south pattern but generic for annexation.
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_aircraft_project } PREV = { is_special_project_completed = sp:sp_aircraft_project } } complete_special_project = sp:sp_aircraft_project }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_helicopter_project } PREV = { is_special_project_completed = sp:sp_helicopter_project } } complete_special_project = sp:sp_helicopter_project }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_nuclear_energy } PREV = { is_special_project_completed = sp:sp_nuclear_energy } } complete_special_project = sp:sp_nuclear_energy }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_nuclear_bomb } PREV = { is_special_project_completed = sp:sp_nuclear_bomb } } complete_special_project = sp:sp_nuclear_bomb }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_nuclear_warhead_program } PREV = { is_special_project_completed = sp:sp_nuclear_warhead_program } } complete_special_project = sp:sp_nuclear_warhead_program }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_missile_project } PREV = { is_special_project_completed = sp:sp_missile_project } } complete_special_project = sp:sp_missile_project }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_armoured_vehicle_project } PREV = { is_special_project_completed = sp:sp_armoured_vehicle_project } } complete_special_project = sp:sp_armoured_vehicle_project }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_naval_vessel_project } PREV = { is_special_project_completed = sp:sp_naval_vessel_project } } complete_special_project = sp:sp_naval_vessel_project }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_microchip_production } PREV = { is_special_project_completed = sp:sp_microchip_production } } complete_special_project = sp:sp_microchip_production }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_composite_production } PREV = { is_special_project_completed = sp:sp_composite_production } } complete_special_project = sp:sp_composite_production }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_smart_grid } PREV = { is_special_project_completed = sp:sp_smart_grid } } complete_special_project = sp:sp_smart_grid }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_solar_engines } PREV = { is_special_project_completed = sp:sp_solar_engines } } complete_special_project = sp:sp_solar_engines }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_nuclear_engines } PREV = { is_special_project_completed = sp:sp_nuclear_engines } } complete_special_project = sp:sp_nuclear_engines }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_awacs_project } PREV = { is_special_project_completed = sp:sp_awacs_project } } complete_special_project = sp:sp_awacs_project }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_stealth_technology } PREV = { is_special_project_completed = sp:sp_stealth_technology } } complete_special_project = sp:sp_stealth_technology }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_active_camouflage } PREV = { is_special_project_completed = sp:sp_active_camouflage } } complete_special_project = sp:sp_active_camouflage }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_tank_electric_engine } PREV = { is_special_project_completed = sp:sp_tank_electric_engine } } complete_special_project = sp:sp_tank_electric_engine }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_double_shot_rifle } PREV = { is_special_project_completed = sp:sp_double_shot_rifle } } complete_special_project = sp:sp_double_shot_rifle }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_experimental_exoskeleton } PREV = { is_special_project_completed = sp:sp_experimental_exoskeleton } } complete_special_project = sp:sp_experimental_exoskeleton }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_tactical_augmented_reality } PREV = { is_special_project_completed = sp:sp_tactical_augmented_reality } } complete_special_project = sp:sp_tactical_augmented_reality }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_fire_support_land_drone } PREV = { is_special_project_completed = sp:sp_fire_support_land_drone } } complete_special_project = sp:sp_fire_support_land_drone }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_ground_fireandforget } PREV = { is_special_project_completed = sp:sp_ground_fireandforget } } complete_special_project = sp:sp_ground_fireandforget }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_stealth_frigate } PREV = { is_special_project_completed = sp:sp_stealth_frigate } } complete_special_project = sp:sp_stealth_frigate }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_stealth_corvette } PREV = { is_special_project_completed = sp:sp_stealth_corvette } } complete_special_project = sp:sp_stealth_corvette }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_stealth_destroyer } PREV = { is_special_project_completed = sp:sp_stealth_destroyer } } complete_special_project = sp:sp_stealth_destroyer }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_rail_gun_naval_cannons } PREV = { is_special_project_completed = sp:sp_rail_gun_naval_cannons } } complete_special_project = sp:sp_rail_gun_naval_cannons }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_medium_naval_nuclear_engines } PREV = { is_special_project_completed = sp:sp_medium_naval_nuclear_engines } } complete_special_project = sp:sp_medium_naval_nuclear_engines }
+	if = { limit = { NOT = { is_special_project_completed = sp:sp_space_program } PREV = { is_special_project_completed = sp:sp_space_program } } complete_special_project = sp:sp_space_program }
+}

--- a/localisation/english/events_l_english.yml
+++ b/localisation/english/events_l_english.yml
@@ -1816,9 +1816,10 @@
 
  #Overlord News/Country Events
  overlord.1.t: "Integration of [FROM.GetName]"
- overlord.1.d: "[FROM.GetName] has been our puppet state for far too long. It is no longer a viable partnership to allow them to have autonomy. On this day in [GetYear] marks a day we have long desired. [FROM.GetName] has been integrated into our great nation. They will now become [ROOT.GetAdjective] citizens and receive the same care and treatment as any other citizen in our nation. It is a glorious day for us and the people of [FROM.GetName].\nNOTE: Annexing another sovereign nation forces us to assume all of their debt, treasury, and international investments as they merge with us.\n\nYou gain the following: [?ROOT.treasury|Y] Treasury, [?ROOT.debt|R] Debt, [?ROOT.int_investments] International Investments"
+ overlord.1.d: "[FROM.GetName] has been our puppet state for far too long. It is no longer a viable partnership to allow them to have autonomy. On this day in [GetYear] marks a day we have long desired. [FROM.GetName] has been integrated into our great nation. They will now become [ROOT.GetAdjective] citizens and receive the same care and treatment as any other citizen in our nation. It is a glorious day for us and the people of [FROM.GetName].\nNOTE: Annexing another sovereign nation forces us to assume all of their debt, treasury, and international investments as they merge with us. Scientific and technological assets are also integrated.\n\nYou gain the following: [?ROOT.treasury|Y] Treasury, [?ROOT.debt|R] Debt, [?ROOT.int_investments] International Investments, Technologies and Special Projects"
  overlord.1.a: "Wonderful"
  overlord.1.a_tt: "We gain §YCores§! on §B[FROM.GetName]§!\n"
+ tooltip_integration_technology_transfer: "Integrated §B[FROM.GetName]§! technologies and special projects are transferred to §Y[ROOT.GetName]§!"
 
  overlord_news.1.t: "[ROOT.GetName] Integrates [FROM.FROM.GetName]"
  overlord_news.1.d: "Delegations from [ROOT.GetName] and [FROM.FROM.GetName] have announced today that [FROM.FROM.GetName] will be integrated into [ROOT.GetName]. [FROM.FROM.GetName] has been an autonomous state for quite some time and has become increasingly reliant on [ROOT.GetName] in the past months. It is quoted as 'It only makes sense!' from the two parties involved.\n\nThe truth in that statement is yet to be seen.."


### PR DESCRIPTION
Closes #2360

**What**
- Puppet integration (`on_subject_annexed`) now transfers technologies and completed special projects from the annexed subject to the overlord (`ROOT`) via new helpers `integration_inherit_technology` / `integration_inherit_special_projects`, mirroring the USOE pattern that copies technology to the root tag.
- USOE formation (`focus_EU111_QMV_result`) now also transfers special projects per member (`ROOT = { integration_inherit_special_projects = yes }`) and adds the bureaucratic cost analogue (`generic_bureaucratic_drain_idea` 120d) on `ROOT`, matching `overlord.1` which adds the bureaucratic idea on puppet annexation.
- Localisation: `overlord.1.d` notes scientific/technological assets are integrated and lists Technologies and Special Projects; adds `tooltip_integration_technology_transfer`.

**Why**
Issue asks that integrating a puppet (and specifically USOE) also grant scientists/tech/special projects/latest designs if newer, analogous to the existing bureaucratic idea event.

**How**
- New file `common/scripted_effects/99_integration_scripted_effects.txt` implements the two helpers (technology via `inherit_technology = PREV`, special projects via per-project `complete_special_project` checks like `KOR_inherit_special_projects_from_south`).
- `common/on_actions/01_tfv_on_actions.txt:78` calls both helpers inside `FROM` (overlord) scope where `PREV`/`ROOT` is the subject.
- `common/scripted_effects/99_EU_voting_scripted_effects.txt:407` reuses the special-project helper per USOE member and adds bureaucratic drain after `apply_USoE_technologies` (which already pools `EUU.researched_techs` into `ROOT` via `set_technology`).

Equipment variant ("latest design") transfer has no engine effect to copy variants directly; `inherit_technology` gives the prerequisite techs to design newer variants. Scientist character transfer is not supported as a scripted effect.

**Checks**
- `python -m pytest` 1644 passed, 2 skipped
- `validate_style` / `run_all_validators` no new errors (67 pre-existing warnings)