### PR TITLE
Wire Afghanistan AI behavior determinism into focus tree, add historical AI bias

### DIFF
--- a/common/ai_strategy/AFG.txt
+++ b/common/ai_strategy/AFG.txt
@@ -151,6 +151,44 @@ AFG_pakistan_confrontation = {
 	ai_strategy = { type = befriend id = "PER" value = 40 }
 }
 
+AFG_no_suicide_taj = {
+	allowed = { original_tag = AFG }
+	enable = {
+		country_exists = TAJ
+		OR = {
+			has_wargoal_against = TAJ
+			TAJ = { has_wargoal_against = AFG }
+		}
+		strength_ratio = {
+			tag = TAJ
+			ratio < 1
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = "TAJ" value = -100 }
+	ai_strategy = { type = prepare_for_war id = "TAJ" value = 50 }
+}
+
+AFG_no_suicide_per = {
+	allowed = { original_tag = AFG }
+	enable = {
+		country_exists = PER
+		OR = {
+			has_wargoal_against = PER
+			PER = { has_wargoal_against = AFG }
+		}
+		strength_ratio = {
+			tag = PER
+			ratio < 1
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = "PER" value = -100 }
+	ai_strategy = { type = prepare_for_war id = "PER" value = 50 }
+}
+
 AFG_western_alignment = {
 	allowed = { original_tag = AFG }
 	enable = {

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -85,7 +85,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 5
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -131,6 +137,10 @@ focus_tree = {
 			modifier = {
 				factor = 10
 				has_completed_focus = AFG_cars_over_donkeys
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -432,6 +442,10 @@ focus_tree = {
 					count > 0
 				}
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -473,7 +487,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -519,6 +539,14 @@ focus_tree = {
 				factor = 0
 				check_variable = { treasury < 1.0 }
 			}
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -558,6 +586,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -605,6 +637,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -683,7 +719,13 @@ focus_tree = {
 			increase_officer_training_level = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1303,7 +1345,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3395,6 +3443,10 @@ focus_tree = {
 				factor = 10
 				has_government = nationalist
 			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
 		}
 	}
 
@@ -3740,6 +3792,10 @@ focus_tree = {
 				factor = 2
 				has_stability < 0.05
 			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
 		}
 	}
 
@@ -3953,6 +4009,10 @@ focus_tree = {
 				factor = 10
 				has_government = neutrality
 			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
 		}
 	}
 
@@ -4161,6 +4221,10 @@ focus_tree = {
 			modifier = {
 				factor = 10
 				has_government = communism
+			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
 			}
 		}
 	}
@@ -4387,6 +4451,10 @@ focus_tree = {
 			modifier = {
 				factor = 10
 				has_government = democratic
+			}
+			modifier = {
+				factor = 5
+				is_historical_focus_on = yes
 			}
 		}
 	}
@@ -4625,6 +4693,10 @@ focus_tree = {
 				factor = 3
 				has_idea = AFG_iranian_airbridge
 			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
 		}
 	}
 
@@ -4792,6 +4864,14 @@ focus_tree = {
 				factor = 0
 				num_divisions < 12
 			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -4873,6 +4953,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -4919,6 +5003,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -4983,6 +5071,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -5061,6 +5153,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				num_divisions < 25
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -5141,6 +5237,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5214,6 +5314,10 @@ focus_tree = {
 				factor = 2
 				num_divisions > 40
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5256,6 +5360,10 @@ focus_tree = {
 			modifier = {
 				factor = 3
 				num_divisions < 12
+			}
+			modifier = {
+				factor = 5
+				is_historical_focus_on = yes
 			}
 		}
 	}
@@ -5341,6 +5449,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5369,7 +5481,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -5511,6 +5629,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5575,7 +5697,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -5643,6 +5771,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -5963,6 +6095,10 @@ focus_tree = {
 			modifier = {
 				factor = 3
 				num_divisions < 20
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -7393,7 +7529,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -7564,6 +7706,10 @@ focus_tree = {
 				factor = 2
 				has_manpower < 100000
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -7731,6 +7877,10 @@ focus_tree = {
 			modifier = {
 				factor = 20
 				is_historical_focus_on = no
+			}
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds a Spain-style `is_historical_focus_on` killswitch (factor = 0) to Afghanistan's five alternate-ideology branch roots under `AFG_future_national_policy` (`AFG_monarchy`, `AFG_pro_establishment`, `AFG_moderate_islamists`, `AFG_authortarian`, `AFG_hezb_i_wahdat`), the Panjshir/Massoud-survives branch root (`AFG_anjuman_pass`, since Massoud was historically assassinated in 2001) and the reconstruction branch it exclusively gates (`AFG_civil_war_recovery`), and the Pakistan-invasion branch root (`AFG_aggresive_foreign_policy`, since Afghanistan never actually invaded Pakistan).
- Adds a matching historical boost (factor = 5) to the common-trunk focuses that represent Afghanistan's real trajectory: the Northern-Alliance civil war itself (`AFG_civil_war`), the Karzai-era pro-western branch (`AFG_pro_western`), and the non-wargoal isolationist counterpart to the invasion branch (`AFG_isolism`).
- Afghanistan has no per-country `AFG_ai_behavior` game rule - all six ruling-ideology branches are gated by native ruling-party triggers, so no new game-rule/on_actions infrastructure was needed, matching Azerbaijan's narrower blast radius.
- Adds `ai_is_threatened` weighting (factor = 2) to 21 combat-capacity focuses that had zero prior coverage: army/air-experience grants, equipment/division-template unlocks, war-prep focuses, and the Pakistan wargoal chain (`AFG_eyes_on_pakistan`, `AFG_preparing_invasion`, `AFG_invade_pakistan`).
- Fixes two focuses missing the standard `bankruptcy_incoming_collapse` guard: `AFG_updating_equipment` (had a treasury check but no bankruptcy-mission guard) and `AFG_russian_air_lift` (its sibling `AFG_mil_mi_24_gunships` already had the guard).
- Adds `AFG_no_suicide_taj` / `AFG_no_suicide_per` strategies in `common/ai_strategy/AFG.txt`, mirroring Georgia's `GEO_dont_declare_on_azeri`, since both Tajikistan (`TAJ_anti_afghan_rhetoric`) and Iran (`PER_karim_khalili`) have focuses that can put Afghanistan on the losing end of a border conflict.

## Test plan
**Historical AI path (default game rules):**
- [ ] With "Historical AI Focus" ON, observe AFG AI through the civil war and post-2001 period; confirm it prioritizes `AFG_civil_war` and, once the Islamic Republic forms, the Karzai-aligned `AFG_pro_western` branch (#55)
- [ ] With "Historical AI Focus" ON, confirm the AI never completes `AFG_monarchy`, `AFG_pro_establishment`, `AFG_moderate_islamists`, `AFG_authortarian`, `AFG_hezb_i_wahdat`, `AFG_anjuman_pass`/`AFG_civil_war_recovery`, or `AFG_aggresive_foreign_policy`/`AFG_invade_pakistan` (#55)

**Alternate AI path (Historical AI Focus OFF):**
- [ ] Force conditions for one alt-history branch (e.g. high nationalist popularity for `AFG_monarchy`, or Panjshir survival for `AFG_anjuman_pass`); confirm the AI can now complete it since the killswitch no longer applies (#55)

**Threat/war-avoidance:**
- [ ] Trigger a high-threat scenario near AFG (e.g. hostile neighbor buildup); confirm army/air-experience and equipment focuses get prioritized (#55)
- [ ] Give AFG a losing wargoal against TAJ or PER (`strength_ratio < 1`); confirm the AI does not declare war (#55)

Closes part of #55.