### PR TITLE
Fix Eurozone debt crisis trigger

### DIFF
--- a/common/decisions/05_GRE_decisions.txt
+++ b/common/decisions/05_GRE_decisions.txt
@@ -128,12 +128,14 @@ GRE_debt_crisis_category = {
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
+			newline = yes
 			if = {
 				limit = {
 					has_idea = EU_member
 					NOT = { has_global_flag = EUU_european_debt_crisis }
 					NOT = { has_global_flag = eurozone_reforms }
 					NOT = { has_active_mission = eurozone_reforms }
+					NOT = { EU_eurozone_reforms_passed = yes }
 				}
 				country_event = EUevent.7
 			}

--- a/common/decisions/EU_voting_decisions.txt
+++ b/common/decisions/EU_voting_decisions.txt
@@ -734,16 +734,7 @@ EU_fiscal_category = {
 
 		activation = { always = no }
 
-		available = {
-			# European Banking Union
-			is_in_array = { array = global.EU_passed_votes value = 202 }
-			OR = {
-				# Eurobonds
-				is_in_array = { array = global.EU_passed_votes value = 203 }
-				# European Stability Mechanism (ESM)
-				is_in_array = { array = global.EU_passed_votes value = 205 }
-			}
-		}
+		available = { EU_eurozone_reforms_passed = yes }
 
 		days_mission_timeout = 900
 

--- a/common/scripted_triggers/99_EU_voting_scripted_triggers.txt
+++ b/common/scripted_triggers/99_EU_voting_scripted_triggers.txt
@@ -22,6 +22,14 @@ EU_voting_decision_result_trigger = {
 	}
 }
 
+EU_eurozone_reforms_passed = {
+	is_in_array = { array = global.EU_passed_votes value = 202 }
+	OR = {
+		is_in_array = { array = global.EU_passed_votes value = 203 }
+		is_in_array = { array = global.EU_passed_votes value = 205 }
+	}
+}
+
 ################################
 ### EU focus voting triggers ###
 ################################

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -8189,21 +8189,27 @@ country_event = {
 		hidden_effect = {
 			if = {
 				limit = {
-					any_of_scopes = {
+					NOT = { has_global_flag = GAME_RULE_eu_disabled }
+					NOT = { EU_eurozone_reforms_passed = yes }
+				}
+				if = {
+					limit = {
+						any_of_scopes = {
+							array = global.EU_member
+							is_ai = no
+						}
+					}
+					random_scope_in_array = {
 						array = global.EU_member
-						is_ai = no
+						limit = { is_ai = no }
+						country_event = EUevent.7
 					}
 				}
-				random_scope_in_array = {
-					array = global.EU_member
-					limit = { is_ai = no }
-					country_event = EUevent.7
-				}
-			}
-			else = {
-				random_scope_in_array = {
-					array = global.EU_member
-					country_event = EUevent.7
+				else = {
+					random_scope_in_array = {
+						array = global.EU_member
+						country_event = EUevent.7
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Prevents the Eurozone-reforms mission from starting after its required votes pass.

Moves the shared vote predicate into an EU scripted trigger.