### PR TITLE
Wire North Korea AI behavior determinism into focus tree, add historical AI bias (#55)

### DIFF
--- a/common/ai_strategy/NKO.txt
+++ b/common/ai_strategy/NKO.txt
@@ -173,3 +173,14 @@ NKO_prewar_reunification_staging = {
 	ai_strategy = { type = unit_ratio id = fighter value = 8 }
 	ai_strategy = { type = unit_ratio id = cas value = 6 }
 }
+
+# Losing-war brake — back off from the reunification war instead of fighting to the last man
+NKO_cancel_war_KOR = {
+	allowed = { original_tag = NKO }
+	enable = {
+		has_war_with = KOR
+		strength_ratio = { tag = KOR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+	ai_strategy = { type = declare_war id = "KOR" value = -4000 }
+}

--- a/common/decisions/05_north_korea.txt
+++ b/common/decisions/05_north_korea.txt
@@ -1483,7 +1483,13 @@ NKO_power_struggle = {
 				}
 			}
 		}
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 10
+				has_global_flag = NKO_nam_rules_focus_path
+			}
+		}
 	}
 
 	Kim_Jong_un_support = {
@@ -1523,7 +1529,13 @@ NKO_power_struggle = {
 				}
 			}
 		}
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 10
+				has_global_flag = NKO_un_rules_focus_path
+			}
+		}
 	}
 
 	Kim_Jong_il_Death = {

--- a/common/national_focus/03_joint_korea_confederation.txt
+++ b/common/national_focus/03_joint_korea_confederation.txt
@@ -547,7 +547,13 @@ joint_focus = {
 		}
 	}
 
-	ai_will_do = { base = 1 }
+	ai_will_do = {
+		base = 1
+		modifier = {
+			factor = 0
+			is_historical_focus_on = yes
+		}
+	}
 }
 
 joint_focus = {
@@ -617,7 +623,13 @@ joint_focus = {
 		}
 	}
 
-	ai_will_do = { base = 1 }
+	ai_will_do = {
+		base = 1
+		modifier = {
+			factor = 0
+			is_historical_focus_on = yes
+		}
+	}
 }
 
 joint_focus = {

--- a/common/national_focus/05_north_korea.txt
+++ b/common/national_focus/05_north_korea.txt
@@ -108,6 +108,10 @@ focus_tree = {
 				add = 2
 				is_historical_focus_on = yes
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -2041,7 +2045,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -2076,7 +2086,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -2110,7 +2126,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -2619,7 +2641,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	#ARMY TREE
@@ -2658,6 +2686,10 @@ focus_tree = {
 				add = 0.10
 				date < 2002.1.1
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -2683,7 +2715,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 10 }
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 
@@ -3220,7 +3258,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3255,6 +3299,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -3302,6 +3350,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -3339,6 +3391,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -3370,6 +3426,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				can_staff_an_dockyard = no
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -3434,6 +3494,10 @@ focus_tree = {
 				factor = 0
 				can_staff_an_dockyard = no
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -3460,7 +3524,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3499,7 +3569,13 @@ focus_tree = {
 			country_event = { id = nko_naval_buildup.70 days = 1 }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3532,7 +3608,13 @@ focus_tree = {
 			country_event = { id = nko_naval_buildup.71 days = 1 }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3564,7 +3646,13 @@ focus_tree = {
 			country_event = { id = nko_naval_buildup.72 days = 1 }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3597,7 +3685,13 @@ focus_tree = {
 			country_event = { id = nko_naval_buildup.73 days = 1 }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3623,7 +3717,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3679,7 +3779,13 @@ focus_tree = {
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3718,7 +3824,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3772,6 +3884,10 @@ focus_tree = {
 				factor = 0
 				can_staff_an_dockyard = no
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -3819,6 +3935,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -3854,6 +3974,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -3893,7 +4017,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3915,7 +4045,13 @@ focus_tree = {
 			add_ideas = NKO_marines_idea
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -4430,7 +4566,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -4506,6 +4648,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -4531,7 +4677,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -4577,6 +4729,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -4602,7 +4758,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -4627,7 +4789,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -4653,7 +4821,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 
@@ -4760,7 +4934,21 @@ focus_tree = {
 			update_focus_tree_obsolete_branches = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 2
+				is_historical_focus_on = yes
+			}
+			modifier = {
+				add = 15
+				has_global_flag = NKO_un_rules_focus_path
+			}
+			modifier = {
+				add = 15
+				has_global_flag = NKO_junta_rules_focus_path
+			}
+		}
 	}
 
 	focus = {
@@ -5030,6 +5218,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+			}
+			modifier = {
+				add = 15
+				has_global_flag = NKO_nam_rules_focus_path
 			}
 		}
 	}
@@ -5517,6 +5709,10 @@ focus_tree = {
 			modifier = {
 				is_historical_focus_on = yes
 				factor = 0
+			}
+			modifier = {
+				add = 200
+				has_global_flag = NKO_junta_rules_focus_path
 			}
 		}
 	}
@@ -6402,7 +6598,13 @@ focus_tree = {
 			update_focus_tree_obsolete_branches = yes
 		}
 
-		ai_will_do = { base = 100 }
+		ai_will_do = {
+			base = 100
+			modifier = {
+				add = 100
+				has_global_flag = NKO_un_rules_focus_path
+			}
+		}
 	}
 
 	focus = {
@@ -7044,6 +7246,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+			}
+			modifier = {
+				add = 100
+				has_global_flag = NKO_nam_rules_focus_path
 			}
 		}
 	}
@@ -8657,7 +8863,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -8713,7 +8925,13 @@ focus_tree = {
 			change_domestic_influence_percentage = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -8777,6 +8995,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -8994,7 +9216,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -9135,7 +9363,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -9254,7 +9488,13 @@ focus_tree = {
 			set_country_flag = KOR_proposed_south_reunification
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {

--- a/events/05_north_korea_events.txt
+++ b/events/05_north_korea_events.txt
@@ -169,6 +169,17 @@ country_event = {
 		name = kim_jong_il_death.1.a #Kim Jong-un
 		set_country_flag = NKO_kim_jong_un_successor
 		log = "[GetDateText]: [This.GetName]: kim_jong_il_death.1.a executed"
+		ai_chance = {
+			base = 50
+			modifier = {
+				factor = 20
+				has_global_flag = NKO_un_rules_focus_path
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = NKO_nam_rules_focus_path
+			}
+		}
 	}
 
 	# Kim Jong-nam
@@ -176,6 +187,17 @@ country_event = {
 		name = kim_jong_il_death.1.b #Kim Jong-nam
 		set_country_flag = NKO_kim_jong_nam_successor
 		log = "[GetDateText]: [This.GetName]: kim_jong_il_death.1.b executed"
+		ai_chance = {
+			base = 50
+			modifier = {
+				factor = 20
+				has_global_flag = NKO_nam_rules_focus_path
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = NKO_un_rules_focus_path
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wires the existing (but previously unused-in-`ai_will_do`) `NKO_ai_behavior` game rule flags (`NKO_un_rules_focus_path`/`NKO_nam_rules_focus_path`/`NKO_junta_rules_focus_path`) into both succession-fork tiers (`NKO_orthodox_successor`/`NKO_call_for_change`, `NKO_kim_jong_un`/`NKO_kim_jong_nam`/`NKO_junta`), the `Kim_Jong_Nam_support`/`Kim_Jong_un_support` decisions (previously `ai_will_do = { base = 0 }`, AI never took them), and the `kim_jong_il_death.1` nomination event (previously no `ai_chance` at all) so the AI reliably backs the successor matching its selected path.
- Adds `is_historical_focus_on` killswitches to the peaceful reunification/confederation joint focuses (`KOR_reunification`, `KOR_confederation`) and to `NKO_united_again` - the war-path annexation was already gated via `NKO_foment_insurrection`, but the peaceful annex/puppet paths had zero historical-AI coverage.
- Adds `ai_is_threatened` weighting to 33 combat-capacity focuses (previously absent file-wide), bankruptcy guards to 5 unguarded treasury-spend focuses, and a `strength_ratio`-gated losing-war brake (`NKO_cancel_war_KOR`) mirroring Belarus's PR #3144 pattern.

## Test plan
- [ ] **NKO, 2010, Orthodox Successor rule**: let the AI play; confirm `NKO_orthodox_successor` and eventually `NKO_kim_jong_un` get picked over the Great Change/Junta alternatives, and `kim_jong_il_death.1` fires toward Kim Jong-un.
- [ ] **NKO, 2010, The Great Change rule**: confirm `NKO_call_for_change` and `NKO_kim_jong_nam` get preferred, and the AI now takes `Kim_Jong_Nam_support` decisions when available.
- [ ] **NKO, 2010, Junta Coup rule**: confirm `NKO_junta` outcompetes both Kim focuses.
- [ ] **NKO, Historical AI Focuses on**: confirm the AI does not pursue `KOR_reunification`, `KOR_confederation`, or `NKO_united_again`.
- [ ] **NKO vs KOR reunification war, historical AI off, NKO losing**: confirm the AI backs off via `NKO_cancel_war_KOR` instead of fighting to annihilation.
- [ ] Scoped pre-commit passes on all 5 touched files (already verified locally).