### PR TITLE
Fold multiply temp-variable chains in national focuses

### DIFF
--- a/common/national_focus/00_generic.txt
+++ b/common/national_focus/00_generic.txt
@@ -245,8 +245,7 @@ focus_tree = {
 			}
 			# Agricultural economy effects
 			if = { limit = { is_agrarian_economy = yes }
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.015 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 				modify_treasury_effect = yes
 				set_temp_variable = { AGRI_protections_change = 2 }
 				AGRI_protection_update = yes
@@ -484,8 +483,7 @@ focus_tree = {
 				change_influence_percentage = yes
 			}
 			custom_effect_tooltip = influence_on_neighbors_tt
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -618,8 +616,7 @@ focus_tree = {
 			add_ideas = generic_decentralization
 			# Agricultural economy effects
 			if = { limit = { is_agrarian_economy = yes }
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.005 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 				modify_treasury_effect = yes
 				set_temp_variable = { AGRI_protections_change = 1 }
 				AGRI_protection_update = yes
@@ -1992,8 +1989,7 @@ focus_tree = {
 			}
 			# Agricultural economy effects
 			if = { limit = { is_agrarian_economy = yes }
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.005 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 				modify_treasury_effect = yes
 				set_temp_variable = { AGRI_protections_change = 1 }
 				AGRI_protection_update = yes
@@ -2013,8 +2009,7 @@ focus_tree = {
 			change_oligarchs_opinion = yes
 			change_defense_industry_opinion = yes
 			change_landowners_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.001 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.001 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2107,8 +2102,7 @@ focus_tree = {
 				remove_idea = economic_autonomy2
 				add_idea = economic_autonomy3
 			}
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.03 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.03 } }
 			modify_debt_effect = yes
 			# Agricultural economy effects
 			if = { limit = { is_agrarian_economy = yes }
@@ -2151,8 +2145,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus GENERIC_productivity_measures"
 			set_temp_variable = { temp_productivity_change = 25 }
 			flat_productivity_change_effect = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2428,8 +2421,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GENERIC_debt_refactoring"
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = 0.05 }
+			set_temp_variable = { debt_change = { value = debt multiply = 0.05 } }
 			clamp_temp_variable = { var = debt_change min = 0 max = 100 }
 			modify_debt_effect = yes
 			add_timed_idea = {
@@ -3292,8 +3284,7 @@ focus_tree = {
 				idea = hydroelectric_energy_production_idea
 				days = 1095
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.007 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.007 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3336,8 +3327,7 @@ focus_tree = {
 				idea = geothermal_energy_production_idea
 				days = 1095
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.007 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.007 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3724,8 +3714,7 @@ focus_tree = {
 			change_the_wahabi_ulema_opinion = yes
 			change_the_clergy_opinion = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.01 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3819,8 +3808,7 @@ focus_tree = {
 			}
 			# Agricultural economy effects
 			if = { limit = { is_agrarian_economy = yes }
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.005 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 				modify_treasury_effect = yes
 				set_temp_variable = { AGRI_protections_change = 1 }
 				AGRI_protection_update = yes

--- a/common/national_focus/03_benelux_shared.txt
+++ b/common/national_focus/03_benelux_shared.txt
@@ -1340,8 +1340,7 @@ joint_focus = {
 		}
 		navy_experience = 25
 		add_to_variable = { BNL_integration = 5 tooltip = BNL_integration_tt }
-		set_temp_variable = { treasury_change = gdp_per_capita }
-		multiply_temp_variable = { treasury_change = -0.10 }
+		set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 		modify_treasury_effect = yes
 	}
 
@@ -1421,8 +1420,7 @@ joint_focus = {
 		create_ship = { type = frigate_hull_3 equipment_variant = "Hollandklasse" creator = HOL name = "HNLMS Zeeland" }
 		create_ship = { type = frigate_hull_3 equipment_variant = "Hollandklasse" creator = HOL name = "HNLMS Friesland" }
 		create_ship = { type = frigate_hull_3 equipment_variant = "Hollandklasse" creator = HOL name = "HNLMS Groningen" }
-		set_temp_variable = { treasury_change = gdp_per_capita }
-		multiply_temp_variable = { treasury_change = -0.10 }
+		set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 		modify_treasury_effect = yes
 	}
 

--- a/common/national_focus/03_shared_korea_unified.txt
+++ b/common/national_focus/03_shared_korea_unified.txt
@@ -1773,8 +1773,7 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [This.GetName]: focus KOR_a_stable_economy executed"
-		set_temp_variable = { treasury_change = gdp_total }
-		multiply_temp_variable = { treasury_change = 0.05 }
+		set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 		modify_treasury_effect = yes
 	}
 

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -7286,8 +7286,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AFG_embezzle_foreign_funds"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 			newline = yes
 			AFG_national_assembly_checks = yes
@@ -7399,8 +7398,7 @@ focus_tree = {
 				newline = yes
 			}
 			hidden_effect = {
-				set_temp_variable = { int_investment_change = gdp_total }
-				multiply_temp_variable = { int_investment_change = 0.02 }
+				set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.02 } }
 				modify_international_investment_effect = yes
 			}
 			custom_effect_tooltip = AFG_02_of_are_GDP_in_int_investment

--- a/common/national_focus/05_algeria.txt
+++ b/common/national_focus/05_algeria.txt
@@ -2186,24 +2186,21 @@ focus_tree = {
 			custom_effect_tooltip = PER_develop_pumped_hydro_TT
 			hidden_effect = {
 				385 = {
-					set_temp_variable = { added_storage_capacity = hydroelectric_energy_production_var }
-					multiply_temp_variable = { added_storage_capacity = 100 }
+					set_temp_variable = { added_storage_capacity = { value = hydroelectric_energy_production_var multiply = 100 } }
 					add_to_variable = { hydroelectric_energy_storage_var = added_storage_capacity }
 					add_dynamic_modifier = {
 						modifier = hydroelectric_infrastructure_in_state
 					}
 				}
 				386 = {
-					set_temp_variable = { added_storage_capacity = hydroelectric_energy_production_var }
-					multiply_temp_variable = { added_storage_capacity = 100 }
+					set_temp_variable = { added_storage_capacity = { value = hydroelectric_energy_production_var multiply = 100 } }
 					add_to_variable = { hydroelectric_energy_storage_var = added_storage_capacity }
 					add_dynamic_modifier = {
 						modifier = hydroelectric_infrastructure_in_state
 					}
 				}
 				383 = {
-					set_temp_variable = { added_storage_capacity = hydroelectric_energy_production_var }
-					multiply_temp_variable = { added_storage_capacity = 100 }
+					set_temp_variable = { added_storage_capacity = { value = hydroelectric_energy_production_var multiply = 100 } }
 					add_to_variable = { hydroelectric_energy_storage_var = added_storage_capacity }
 					add_dynamic_modifier = {
 						modifier = hydroelectric_infrastructure_in_state
@@ -10598,8 +10595,7 @@ focus_tree = {
 				change_industrial_conglomerates_opinion = yes
 				newline = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10637,8 +10633,7 @@ focus_tree = {
 				newline = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.35 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.35 } }
 				modify_treasury_effect = yes
 			}
 			add_tech_bonus = {
@@ -10691,8 +10686,7 @@ focus_tree = {
 				change_farmers_opinion = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.35 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.35 } }
 				modify_treasury_effect = yes
 			}
 			add_tech_bonus = {
@@ -11025,8 +11019,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_digital_government"
 			add_ideas = ALG_gov_reforms_1
 			add_political_power = 25
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.0019 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.0019 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -11073,8 +11066,7 @@ focus_tree = {
 				remove_idea = ALG_gov_reforms_1
 				add_idea = ALG_gov_reforms_2
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.0025 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.0025 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -11173,8 +11165,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.0020 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.0020 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -11357,8 +11348,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_social_contract_21st_century"
 			add_ideas = ALG_social_contract_idea
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.0030 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.0030 } }
 			modify_treasury_effect = yes
 			newline = yes
 			custom_effect_tooltip = {
@@ -13610,8 +13600,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ALG_assassinate_gaddafi"
 			LBA = {
 				set_leader = yes
-				set_temp_variable = { coup_chance = party_popularity@fascism }
-				multiply_temp_variable = { coup_chance = 2 }
+				set_temp_variable = { coup_chance = { value = party_popularity@fascism multiply = 2 } }
 				clamp_temp_variable = { var = coup_chance max = 1 }
 				set_temp_variable = { coup_fail_chance = 1 }
 				subtract_from_temp_variable = { coup_fail_chance = coup_chance }

--- a/common/national_focus/05_azerbaijan.txt
+++ b/common/national_focus/05_azerbaijan.txt
@@ -310,8 +310,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_hist_new"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
@@ -405,8 +404,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_the_economy"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -460,11 +458,9 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			change_industrial_conglomerates_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 		}
 
@@ -494,8 +490,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_money_stimulum"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.07 } }
 			modify_treasury_effect = yes
 		}
 
@@ -762,8 +757,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_fly_with_mark"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.09 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.09 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
@@ -1232,8 +1226,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_prepare_the_border"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 			1038 = {
 				add_building_construction = {
@@ -1569,8 +1562,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_more_media_control"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { modify_aliev_cult = 2 }
 			modify_aliev_suppport = yes
@@ -1605,8 +1597,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_aze_increase_propaganda_funding"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
@@ -1835,8 +1826,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_reg_soc_prog"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 			add_stability = 0.07
 		}
@@ -2042,8 +2032,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_oil_turkey_deal"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 			TUR = {
 				random_owned_controlled_state = {
@@ -2170,8 +2159,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_money_reform"
 			set_temp_variable = { modify_aliev_cult = -3 }
 			modify_aliev_suppport = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2507,8 +2495,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_firm_grip"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.09 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.09 } }
 			modify_treasury_effect = yes
 			increase_corruption = yes
 		}
@@ -2713,8 +2700,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_econ_interv"
 			set_temp_variable = { modify_aliev_cult = -3 }
 			modify_aliev_suppport = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2770,8 +2756,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_future_development"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 2
@@ -2812,8 +2797,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_modern_style"
 			set_temp_variable = { modify_aliev_cult = 2 }
 			modify_aliev_suppport = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2842,8 +2826,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_bandit_style"
 			set_temp_variable = { modify_aliev_cult = -5 }
 			modify_aliev_suppport = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 			increase_corruption = yes
 		}
@@ -3044,8 +3027,7 @@ focus_tree = {
 			set_temp_variable = { tag_index = CHI }
 			set_temp_variable = { influence_target = ROOT.id }
 			change_influence_percentage = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3101,8 +3083,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_oil_deal"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 			CHI = {
 				random_owned_controlled_state = {
@@ -3894,8 +3875,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_simple_is_better_naz"
 			decrease_education_budget = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 			add_political_power = 150
 		}
@@ -4006,8 +3986,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_buy_the_support"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
 			aze_replace_to_nationalst_drift = yes
 		}
@@ -4427,8 +4406,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_future_of_industry"
 			set_temp_variable = { temp_opinion = 5 }
 			change_fossil_fuel_industry_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5174,8 +5152,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_military_police_train"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 			add_ideas = AZE_polic_trainig_idea
 		}
@@ -6001,8 +5978,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Allow_external_funding"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.02 } }
 			modify_treasury_effect = yes
 			add_timed_idea = {
 				idea = AZE_external_news_idea
@@ -6034,8 +6010,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Give_them_honey"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 			add_opinion_modifier = { target = ARM modifier = ARM_honey }
 		}
@@ -6239,12 +6214,10 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Allied_funding"
 			every_neighbor_country = {
 				limit = { has_opinion = { target = AZE value > 50 } }
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = 0.03 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 				modify_treasury_effect = yes
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = AZE_allied_funding_TT
 		}
@@ -6328,8 +6301,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_International_bank_loans"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_international_bankers_opinion = yes
@@ -6363,8 +6335,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Restoration_of_Azerbaijan_fund"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -6691,8 +6662,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Petrolium_plant"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 			TUR = {
 				random_owned_controlled_state = {
@@ -7269,8 +7239,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Freedom_of_press"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.02 } }
 			modify_treasury_effect = yes
 			add_timed_idea = {
 				idea = AZE_external_news_idea
@@ -7339,8 +7308,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_The_restoration_fund"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8215,8 +8183,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_EU_grants"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8853,8 +8820,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus AZE_Defense_funds"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.02 } }
 			modify_treasury_effect = yes
 			every_neighbor_country = {
 				limit = {
@@ -8864,8 +8830,7 @@ focus_tree = {
 						value > 25
 					}
 				}
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = 0.02 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.02 } }
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = AZE_allied_funding_TT

--- a/common/national_focus/05_bashkiriya.txt
+++ b/common/national_focus/05_bashkiriya.txt
@@ -3795,11 +3795,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BSH_weaken_the_banks"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			one_random_fossil_fuel_powerplant = yes
 			random_owned_controlled_state = {

--- a/common/national_focus/05_belarus.txt
+++ b/common/national_focus/05_belarus.txt
@@ -12526,8 +12526,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus BLR_dissolve_monasteries"
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			change_relative_party_popularity = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 			reverse_add_opinion_modifier = { target = HLS modifier = SPR_dissolved_monasteries_HLS }
 			every_country = {

--- a/common/national_focus/05_bosnia.txt
+++ b/common/national_focus/05_bosnia.txt
@@ -5938,8 +5938,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BOS_bosnian_elections"
 			add_timed_idea = { idea = BOS_election_stimulus days = 200 }
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_brazil.txt
+++ b/common/national_focus/05_brazil.txt
@@ -145,12 +145,10 @@ focus_tree = {
 				limit = { has_idea = BRA_idea_foreign_debt_assistance }
 				remove_ideas = BRA_idea_foreign_debt_assistance
 			}
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.15 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.15 } }
 			clamp_temp_variable = { var = debt_change max = 0 min = -300 }
 			modify_debt_effect = yes
-			set_temp_variable = { treasury_change = debt_change }
-			multiply_temp_variable = { treasury_change = 0.50 }
+			set_temp_variable = { treasury_change = { value = debt_change multiply = 0.50 } }
 			modify_treasury_effect = yes
 		}
 
@@ -211,8 +209,7 @@ focus_tree = {
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3300,8 +3297,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_support_international_bankers"
-			set_temp_variable = { int_investment_change = gdp_total }
-			multiply_temp_variable = { int_investment_change = 0.03 }
+			set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.03 } }
 			modify_international_investment_effect = yes
 			set_temp_variable = { temp_opinion = 10 }
 			change_international_bankers_opinion = yes
@@ -6121,8 +6117,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus BRA_brazilian_space"
 			add_ideas = BRA_idea_brazilian_space_force
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_bulgaria.txt
+++ b/common/national_focus/05_bulgaria.txt
@@ -1220,13 +1220,11 @@ focus_tree = {
 				set_temp_variable = { col_two = 5 }
 				set_temp_variable = { col_three = 18 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^4 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				set_temp_variable = { temp_outlook_increase = 0 }
 				set_temp_variable = { party_index = 19 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }

--- a/common/national_focus/05_chechnya.txt
+++ b/common/national_focus/05_chechnya.txt
@@ -3664,8 +3664,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHE_zalizat_rani"
 			increase_economic_growth = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_china.txt
+++ b/common/national_focus/05_china.txt
@@ -15280,8 +15280,7 @@ focus_tree = {
 				add_to_variable = { ROOT.CHI_write_off_total = 30 }
 			}
 			custom_effect_tooltip = CHI_Write_Off_Debts_tt
-			set_temp_variable = { treasury_change = CHI_write_off_total }
-			multiply_temp_variable = { treasury_change = -1 }
+			set_temp_variable = { treasury_change = { value = CHI_write_off_total multiply = -1 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_comoros.txt
+++ b/common/national_focus/05_comoros.txt
@@ -4035,8 +4035,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus COM_debt_refactoring"
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = 0.05 }
+			set_temp_variable = { debt_change = { value = debt multiply = 0.05 } }
 			clamp_temp_variable = { var = debt_change min = 0 max = 100 }
 			modify_debt_effect = yes
 			add_timed_idea = {

--- a/common/national_focus/05_cuba.txt
+++ b/common/national_focus/05_cuba.txt
@@ -8783,8 +8783,7 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 0 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^0 }
-				multiply_temp_variable = { current_cons_popularity = 0.05 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^0 multiply = 0.05 } }
 				recalculate_party = yes
 				set_temp_variable = { party_index = 19 }
 				set_temp_variable = { add_col_one = 19 }
@@ -9275,8 +9274,7 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 4 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^0 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^0 multiply = 0.5 } }
 				recalculate_party = yes
 				add_popularity = {
 					ideology = communism
@@ -9368,12 +9366,10 @@ focus_tree = {
 			set_temp_variable = { add_col_one = 3 }
 			add_coalition_members_effect = yes
 			set_temp_variable = { party_index = 2 }
-			set_temp_variable = { party_popularity_increase = current_cons_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 3 }
-			set_temp_variable = { party_popularity_increase = current_cons_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			update_government_coalition_strength = yes
 		}
@@ -9579,8 +9575,7 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 22 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^22 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^22 multiply = 0.5 } }
 				recalculate_party = yes
 			}
 			create_country_leader = {

--- a/common/national_focus/05_egypt.txt
+++ b/common/national_focus/05_egypt.txt
@@ -5230,8 +5230,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus EGY_us_mil_support"
 			hidden_effect = { add_ideas = EGY_us_helps }
-			set_temp_variable = { additional_income_change = gdp_total }
-			multiply_temp_variable = { additional_income_change = 0.0004 } #2% of yearly GDP
+			set_temp_variable = { additional_income_change = { value = gdp_total multiply = 0.0004 } } #2% of yearly GDP
 			custom_effect_tooltip = additional_income_rate_percent_tt
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = USA }

--- a/common/national_focus/05_estonia.txt
+++ b/common/national_focus/05_estonia.txt
@@ -1240,8 +1240,7 @@ focus_tree = {
 				idea = idea_focus_generic_public_service_investment
 				days = 730
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1627,8 +1626,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus EST_pink_shirts executed"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.001 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.001 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = {
@@ -1881,8 +1879,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus EST_restructuring_finance_department executed"
 			add_ideas = EST_restructuring_finance_department
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1939,8 +1936,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus EST_dark_green_on_market executed"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes
@@ -2553,8 +2549,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus EST_center_party executed"
 			if = { limit = { check_variable = { party_pop_array^4 > 0.05 } }
 				set_temp_variable = { party_index = 4 }
-				set_temp_variable = { party_popularity_increase = party_pop_array^4 }
-				multiply_temp_variable = { party_popularity_increase = -0.5 }
+				set_temp_variable = { party_popularity_increase = { value = party_pop_array^4 multiply = -0.5 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 15 }
 				multiply_temp_variable = { party_popularity_increase = -1 }

--- a/common/national_focus/05_ethiopia.txt
+++ b/common/national_focus/05_ethiopia.txt
@@ -870,8 +870,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ETH_refactor_our_debt"
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.20 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.20 } }
 			clamp_variable = { var = debt_change min = 0 max = 15 }
 			modify_debt_effect = yes
 			if = { limit = { has_idea = IMF_debt_relief_received }
@@ -2660,8 +2659,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_farmers_opinion = yes
 			change_landowners_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 			add_ideas = agricultural_investments3
 		}

--- a/common/national_focus/05_france.txt
+++ b/common/national_focus/05_france.txt
@@ -14663,8 +14663,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 		}
 
@@ -15024,8 +15023,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 		}
 
@@ -18156,8 +18154,7 @@ focus_tree = {
 				change_influence_percentage = yes
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.005 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 			modify_treasury_effect = yes
 		}
 
@@ -18223,8 +18220,7 @@ focus_tree = {
 				change_influence_percentage = yes
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.005 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 			modify_treasury_effect = yes
 		}
 
@@ -18290,8 +18286,7 @@ focus_tree = {
 				change_influence_percentage = yes
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.005 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 			modify_treasury_effect = yes
 		}
 
@@ -18471,8 +18466,7 @@ focus_tree = {
 				change_influence_percentage = yes
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.007 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.007 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_georgia.txt
+++ b/common/national_focus/05_georgia.txt
@@ -423,12 +423,7 @@ focus_tree = {
 					set_temp_variable = { col_one = 22 }
 					set_temp_variable = { disable_elections = 1 }
 					change_ruling_party_effect = yes
-					set_temp_variable = {
-						current_cons_popularity = party_pop_array^6
-					}
-					multiply_temp_variable = {
-						current_cons_popularity = 0.5
-					}
+					set_temp_variable = { current_cons_popularity = { value = party_pop_array^6 multiply = 0.5 } }
 					subtract_from_variable = {
 						party_pop_array^22 = current_cons_popularity
 					}
@@ -465,12 +460,7 @@ focus_tree = {
 				set_temp_variable = { col_one = 4 }
 				set_temp_variable = { disable_elections = 1 }
 				change_ruling_party_effect = yes
-				set_temp_variable = {
-					current_cons_popularity = party_pop_array^19
-				}
-				multiply_temp_variable = {
-					current_cons_popularity = 0.5
-				}
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^19 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				subtract_from_variable = {
 					party_pop_array^4 = current_cons_popularity
@@ -681,12 +671,10 @@ focus_tree = {
 				set_temp_variable = { col_two = 5 }
 				set_temp_variable = { col_three = 18 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^4 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				set_temp_variable = { party_index = 19 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -734,12 +722,10 @@ focus_tree = {
 				set_temp_variable = { col_two = 5 }
 				set_temp_variable = { col_three = 18 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^4 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^4 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				set_temp_variable = { party_index = 19 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 4 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -813,12 +799,10 @@ focus_tree = {
 				set_temp_variable = { col_two = 5 }
 				set_temp_variable = { col_three = 18 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^19 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^19 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				set_temp_variable = { party_index = 4 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 19 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -5315,12 +5299,7 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 2 }
 				set_temp_variable = { col_one = 20 }
 				change_ruling_party_effect = yes
-				set_temp_variable = {
-					current_cons_popularity = party_pop_array^2
-				}
-				multiply_temp_variable = {
-					current_cons_popularity = 0.5
-				}
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^2 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				subtract_from_variable = {
 					party_pop_array^6 = current_cons_popularity

--- a/common/national_focus/05_germany.txt
+++ b/common/national_focus/05_germany.txt
@@ -5520,14 +5520,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_foreign_investment_opportunities"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.02 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.02 } }
 			modify_debt_effect = yes
 		}
 
@@ -7731,8 +7728,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_air_eqp
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = {
@@ -7779,8 +7775,7 @@ focus_tree = {
 			add_to_variable = { GER_air_mission_efficiency = 0.07 tooltip = air_mission_efficiency_tt }
 			add_to_variable = { GER_air_attack = 0.05 tooltip = air_attack_factor_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -7884,8 +7879,7 @@ focus_tree = {
 			add_to_variable = { GER_air_superiority_bonus_in_combat = 0.02 tooltip = air_superiority_bonus_in_combat_tt }
 			add_to_variable = { GER_intercept_efficiency = 0.02 tooltip = air_intercept_efficiency_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -7988,8 +7982,7 @@ focus_tree = {
 			}
 			add_to_variable = { GER_initiative_factor = 0.02 tooltip = initiative_factor_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8055,8 +8048,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_own_killsat_capability"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = GER_own_killsat_capability
@@ -8091,8 +8083,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_own_rec_sattelites"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = GER_own_rec_sattelites
@@ -9248,8 +9239,7 @@ focus_tree = {
 				MODIFIER = GER_Deutsche_Marine_modifier
 			}
 			add_to_variable = { GER_dockyard_productivity = 0.03 tooltip = dockyard_productivity_tt }
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9295,8 +9285,7 @@ focus_tree = {
 			}
 			add_to_variable = { GER_dockyard_productivity = 0.03 tooltip = dockyard_productivity_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9343,8 +9332,7 @@ focus_tree = {
 			}
 			add_to_variable = { GER_dockyard_productivity = 0.03 tooltip = dockyard_productivity_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9390,8 +9378,7 @@ focus_tree = {
 			}
 			add_to_variable = { GER_dockyard_productivity = 0.03 tooltip = dockyard_productivity_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9432,8 +9419,7 @@ focus_tree = {
 				limit = { has_dlc = "Arms Against Tyranny" }
 				unlock_military_industrial_organization_tooltip = mio:GER_german_naval_yards
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9489,8 +9475,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9548,8 +9533,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9605,8 +9589,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9662,8 +9645,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9701,8 +9683,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_AFV_projects"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.12 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.12 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9977,8 +9958,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_sam
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10013,8 +9993,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_aa
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10116,8 +10095,7 @@ focus_tree = {
 				uses = 3
 				category = CAT_air_eqp
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10163,8 +10141,7 @@ focus_tree = {
 					category = CAT_air_eqp
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10199,8 +10176,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_sam
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10235,8 +10211,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_mr_fighter
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10282,8 +10257,7 @@ focus_tree = {
 					category = CAT_air_eqp
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10318,8 +10292,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_fighter
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10622,8 +10595,7 @@ focus_tree = {
 			add_to_variable = { GER_leader_xp_gain = 0.04 tooltip = leader_experience_gain_factor_tt }
 			add_to_variable = { GER_army_leader_start_level = 1 tooltip = army_leader_start_level_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10658,8 +10630,7 @@ focus_tree = {
 				remove_idea = GER_idea_Innere_fuhrung_I
 				add_idea = GER_Idea_Innere_fuhrung_II
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10739,8 +10710,7 @@ focus_tree = {
 			add_to_variable = { GER_army_leader_start_logistics_level = 0.04 tooltip = army_leader_start_logistics_level_tt }
 			add_to_variable = { GER_army_leader_start_planning_level = 0.02 tooltip = army_leader_start_planning_level_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10821,8 +10791,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10874,8 +10843,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10926,8 +10894,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10962,8 +10929,7 @@ focus_tree = {
 				uses = 2
 				cost_reduction = 0.5
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11006,8 +10972,7 @@ focus_tree = {
 			add_to_variable = { GER_army_morale_factor = 0.02 tooltip = army_morale_factor_tt }
 			add_to_variable = { GER_Army_attack = 0.02 tooltip = army_attack_factor_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11043,8 +11008,7 @@ focus_tree = {
 			add_to_variable = { GER_max_planning_modifier = 0.05 tooltip = max_planning_factor_tt }
 			add_to_variable = { GER_planning_speed = 0.06 tooltip = planning_speed_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11087,8 +11051,7 @@ focus_tree = {
 			}
 			add_to_variable = { GER_decryption_factor_luftwaffe = 0.07 tooltip = decryption_factor_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11253,8 +11216,7 @@ focus_tree = {
 			add_to_variable = { GER_intel_from_combat_factor = 0.04 tooltip = intel_from_combat_factor_tt }
 			add_to_variable = { GER_no_supply_grace = 0.02 tooltip = no_supply_grace_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11425,8 +11387,7 @@ focus_tree = {
 			add_to_variable = { GER_special_forces_out_of_supply_factor = 0.04 tooltip = special_forces_out_of_supply_factor_tt }
 			add_to_variable = { GER_special_forces_cap = 0.04 tooltip = special_forces_cap_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11581,11 +11542,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_Alexander_von_humboldt_Institutes_Strengthen_reswarch_cooperations"
 			add_dynamic_modifier = { modifier = GER_Diplomatic }
-			set_temp_variable = { int_investment_change = GER.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.34 }
+			set_temp_variable = { int_investment_change = { value = GER.gdp_per_capita multiply = 0.34 } }
 					modify_international_investment_effect = yes
-					set_temp_variable = { debt_change = GER.gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.31 }
+					set_temp_variable = { debt_change = { value = GER.gdp_per_capita multiply = 0.31 } }
 					modify_debt_effect = yes
 			set_country_flag = GER_Humbold_foundation
 			newline = yes
@@ -12811,11 +12770,9 @@ focus_tree = {
 			effect_tooltip = {
 				USA = {
 					add_to_tech_sharing_group = Humbold_foundation_sharing_group
-					set_temp_variable = { int_investment_change = gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.46 }
+					set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.46 } }
 					modify_international_investment_effect = yes
-					set_temp_variable = { debt_change = gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.31 }
+					set_temp_variable = { debt_change = { value = gdp_per_capita multiply = 0.31 } }
 					modify_debt_effect = yes
 					add_tech_bonus = {
 						name = CAT_ai
@@ -12829,11 +12786,9 @@ focus_tree = {
 				set_temp_variable = { tag_index = GER }
 				set_temp_variable = { influence_target = USA }
 				change_influence_percentage = yes
-				set_temp_variable = { int_investment_change = USA.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.39 }
+				set_temp_variable = { int_investment_change = { value = USA.gdp_per_capita multiply = 0.39 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = USA.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.30 }
+				set_temp_variable = { debt_change = { value = USA.gdp_per_capita multiply = 0.30 } }
 				modify_debt_effect = yes
 				add_tech_bonus = {
 					name = CAT_ai
@@ -12853,11 +12808,9 @@ focus_tree = {
 			effect_tooltip = {
 				CAN = {
 					add_to_tech_sharing_group = Humbold_foundation_sharing_group
-					set_temp_variable = { int_investment_change = gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.46 }
+					set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.46 } }
 					modify_international_investment_effect = yes
-					set_temp_variable = { debt_change = gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.31 }
+					set_temp_variable = { debt_change = { value = gdp_per_capita multiply = 0.31 } }
 					modify_debt_effect = yes
 					add_tech_bonus = {
 						name = CAT_ai
@@ -12871,11 +12824,9 @@ focus_tree = {
 				set_temp_variable = { tag_index = GER }
 				set_temp_variable = { influence_target = CAN }
 				change_influence_percentage = yes
-				set_temp_variable = { int_investment_change = CAN.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.39 }
+				set_temp_variable = { int_investment_change = { value = CAN.gdp_per_capita multiply = 0.39 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = CAN.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.30 }
+				set_temp_variable = { debt_change = { value = CAN.gdp_per_capita multiply = 0.30 } }
 				modify_debt_effect = yes
 				add_tech_bonus = {
 					name = CAT_ai
@@ -12918,11 +12869,9 @@ focus_tree = {
 			effect_tooltip = {
 				AST = {
 					add_to_tech_sharing_group = Humbold_foundation_sharing_group
-					set_temp_variable = { int_investment_change = gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.46 }
+					set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.46 } }
 					modify_international_investment_effect = yes
-					set_temp_variable = { debt_change = gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.31 }
+					set_temp_variable = { debt_change = { value = gdp_per_capita multiply = 0.31 } }
 					modify_debt_effect = yes
 					add_tech_bonus = {
 						name = CAT_ai
@@ -12936,11 +12885,9 @@ focus_tree = {
 				set_temp_variable = { tag_index = GER }
 				set_temp_variable = { influence_target = AST }
 				change_influence_percentage = yes
-				set_temp_variable = { int_investment_change = AST.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.39 }
+				set_temp_variable = { int_investment_change = { value = AST.gdp_per_capita multiply = 0.39 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = AST.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.30 }
+				set_temp_variable = { debt_change = { value = AST.gdp_per_capita multiply = 0.30 } }
 				modify_debt_effect = yes
 				add_tech_bonus = {
 					name = CAT_ai
@@ -12960,11 +12907,9 @@ focus_tree = {
 			effect_tooltip = {
 				TAI = {
 					add_to_tech_sharing_group = Humbold_foundation_sharing_group
-					set_temp_variable = { int_investment_change = gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.46 }
+					set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.46 } }
 					modify_international_investment_effect = yes
-					set_temp_variable = { debt_change = gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.31 }
+					set_temp_variable = { debt_change = { value = gdp_per_capita multiply = 0.31 } }
 					modify_debt_effect = yes
 					add_tech_bonus = {
 						name = CAT_ai
@@ -12978,11 +12923,9 @@ focus_tree = {
 				set_temp_variable = { tag_index = GER }
 				set_temp_variable = { influence_target = TAI }
 				change_influence_percentage = yes
-				set_temp_variable = { int_investment_change = TAI.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.39 }
+				set_temp_variable = { int_investment_change = { value = TAI.gdp_per_capita multiply = 0.39 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = TAI.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.30 }
+				set_temp_variable = { debt_change = { value = TAI.gdp_per_capita multiply = 0.30 } }
 				modify_debt_effect = yes
 				add_tech_bonus = {
 					name = CAT_ai
@@ -15116,9 +15059,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_partnership_with_companies"
 			hidden_effect = { add_ideas = GER_russian_buddies }
-			set_temp_variable = { additional_income_change = gdp_total }
-			multiply_temp_variable = { additional_income_change = 0.02 } #2% of yearly GDP
-			multiply_temp_variable = { additional_income_change = 0.02 } #weekly
+			set_temp_variable = { additional_income_change = { value = gdp_total multiply = 0.02 multiply = 0.02 } } #2% of yearly GDP #weekly
 			custom_effect_tooltip = additional_income_rate_percent_tt
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = SOV }
@@ -15331,11 +15272,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GER_european_business_opportunities"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 		}
 
@@ -20401,14 +20340,12 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					ENG = {
-						set_temp_variable = { treasury_change = gdp_total }
-						multiply_temp_variable = { treasury_change = -0.015 }
+						set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 						modify_treasury_effect = yes
 						set_temp_variable = { treasury_change = -40.00 }
 						modify_treasury_effect = yes
 					}
-					set_temp_variable = { treasury_change = ENG.gdp_total }
-					multiply_temp_variable = { treasury_change = 0.015 }
+					set_temp_variable = { treasury_change = { value = ENG.gdp_total multiply = 0.015 } }
 					modify_treasury_effect = yes
 					set_temp_variable = { treasury_change = 40.00 }
 					modify_treasury_effect = yes
@@ -20423,14 +20360,12 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					FRA = {
-						set_temp_variable = { treasury_change = gdp_total }
-						multiply_temp_variable = { treasury_change = -0.015 }
+						set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 						modify_treasury_effect = yes
 						set_temp_variable = { treasury_change = -40.00 }
 						modify_treasury_effect = yes
 					}
-					set_temp_variable = { treasury_change = FRA.gdp_total }
-					multiply_temp_variable = { treasury_change = 0.015 }
+					set_temp_variable = { treasury_change = { value = FRA.gdp_total multiply = 0.015 } }
 					modify_treasury_effect = yes
 					set_temp_variable = { treasury_change = 40.00 }
 					modify_treasury_effect = yes
@@ -20445,14 +20380,12 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					USA = {
-						set_temp_variable = { treasury_change = gdp_total }
-						multiply_temp_variable = { treasury_change = -0.015 }
+						set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 						modify_treasury_effect = yes
 						set_temp_variable = { treasury_change = -40.00 }
 						modify_treasury_effect = yes
 					}
-					set_temp_variable = { treasury_change = USA.gdp_total }
-					multiply_temp_variable = { treasury_change = 0.015 }
+					set_temp_variable = { treasury_change = { value = USA.gdp_total multiply = 0.015 } }
 					modify_treasury_effect = yes
 					set_temp_variable = { treasury_change = 40.00 }
 					modify_treasury_effect = yes
@@ -20467,14 +20400,12 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					SOV = {
-						set_temp_variable = { treasury_change = gdp_total }
-						multiply_temp_variable = { treasury_change = -0.015 }
+						set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 						modify_treasury_effect = yes
 						set_temp_variable = { treasury_change = -40.00 }
 						modify_treasury_effect = yes
 					}
-					set_temp_variable = { treasury_change = SOV.gdp_total }
-					multiply_temp_variable = { treasury_change = 0.015 }
+					set_temp_variable = { treasury_change = { value = SOV.gdp_total multiply = 0.015 } }
 					modify_treasury_effect = yes
 					set_temp_variable = { treasury_change = 40.00 }
 					modify_treasury_effect = yes

--- a/common/national_focus/05_greece.txt
+++ b/common/national_focus/05_greece.txt
@@ -1023,8 +1023,7 @@ focus_tree = {
 					bonus = 0.50
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2996,8 +2995,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GRE_greek_bonds"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.15 } }
 			clamp_temp_variable = { var = treasury_change max = 150 }
 			modify_treasury_effect = yes
 			newline = yes
@@ -3321,8 +3319,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GRE_debt_refactoring"
 			# Reduce generic debt by 5%
-			set_temp_variable = { GRE_refactor_amount = debt }
-			multiply_temp_variable = { GRE_refactor_amount = -0.05 }
+			set_temp_variable = { GRE_refactor_amount = { value = debt multiply = -0.05 } }
 			set_temp_variable = { debt_change = GRE_refactor_amount }
 			modify_debt_effect = yes
 			newline = yes
@@ -3333,15 +3330,13 @@ focus_tree = {
 					array = GRE_creditors
 					value = v
 					index = i
-					set_temp_variable = { GRE_reduce = GRE_creditor_debt^i }
-					multiply_temp_variable = { GRE_reduce = 0.05 }
+					set_temp_variable = { GRE_reduce = { value = GRE_creditor_debt^i multiply = 0.05 } }
 					subtract_from_variable = { GRE_creditor_debt^i = GRE_reduce }
 					var:GRE_creditors^i = {
 						subtract_from_variable = { GRE_debt_held_by_us = ROOT.GRE_reduce }
 					}
 				}
-				set_temp_variable = { GRE_total_reduce = GRE_total_creditor_debt }
-				multiply_temp_variable = { GRE_total_reduce = 0.05 }
+				set_temp_variable = { GRE_total_reduce = { value = GRE_total_creditor_debt multiply = 0.05 } }
 				subtract_from_variable = { GRE_total_creditor_debt = GRE_total_reduce }
 			}
 			GRE_calculate_unified_debt = yes
@@ -3701,8 +3696,7 @@ focus_tree = {
 			add_to_variable = { GRE_economy_stability_factor = 0.03 tooltip = stability_factor_tt }
 			newline = yes
 			# Reduce generic debt by 3%
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.03 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.03 } }
 			modify_debt_effect = yes
 			# Also reduce creditor-held debt by 3%
 			if = {
@@ -3711,15 +3705,13 @@ focus_tree = {
 					array = GRE_creditors
 					value = v
 					index = i
-					set_temp_variable = { GRE_reduce = GRE_creditor_debt^i }
-					multiply_temp_variable = { GRE_reduce = 0.03 }
+					set_temp_variable = { GRE_reduce = { value = GRE_creditor_debt^i multiply = 0.03 } }
 					subtract_from_variable = { GRE_creditor_debt^i = GRE_reduce }
 					var:GRE_creditors^i = {
 						subtract_from_variable = { GRE_debt_held_by_us = ROOT.GRE_reduce }
 					}
 				}
-				set_temp_variable = { GRE_total_reduce = GRE_total_creditor_debt }
-				multiply_temp_variable = { GRE_total_reduce = 0.03 }
+				set_temp_variable = { GRE_total_reduce = { value = GRE_total_creditor_debt multiply = 0.03 } }
 				subtract_from_variable = { GRE_total_creditor_debt = GRE_total_reduce }
 			}
 			GRE_calculate_unified_debt = yes
@@ -5056,8 +5048,7 @@ focus_tree = {
 				limit = { country_exists = CHI }
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
-					set_temp_variable = { treasury_change = gdp_total }
-					multiply_temp_variable = { treasury_change = 0.10 }
+					set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 					clamp_temp_variable = { var = treasury_change max = 100 }
 					modify_treasury_effect = yes
 				}
@@ -5065,8 +5056,7 @@ focus_tree = {
 				CHI = { country_event = { id = greece.46 days = 2 random_hours = 12 } }
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = 0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 				clamp_temp_variable = { var = treasury_change max = 100 }
 				modify_treasury_effect = yes
 			}
@@ -5313,8 +5303,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GRE_tax_the_shipowners"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			clamp_temp_variable = { var = treasury_change max = 60 }
 			modify_treasury_effect = yes
 		}
@@ -5490,8 +5479,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GRE_privatize_banks"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.08 } }
 			clamp_temp_variable = { var = treasury_change max = 80 }
 			modify_treasury_effect = yes
 			newline = yes
@@ -7809,8 +7797,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus GRE_revise_national_debt"
 			# Reduce generic debt by 10%
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.1 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.1 } }
 			modify_debt_effect = yes
 			# Also reduce creditor debt by 10%
 			if = {
@@ -7819,15 +7806,13 @@ focus_tree = {
 					array = GRE_creditors
 					value = v
 					index = i
-					set_temp_variable = { GRE_reduce = GRE_creditor_debt^i }
-					multiply_temp_variable = { GRE_reduce = 0.1 }
+					set_temp_variable = { GRE_reduce = { value = GRE_creditor_debt^i multiply = 0.1 } }
 					subtract_from_variable = { GRE_creditor_debt^i = GRE_reduce }
 					var:GRE_creditors^i = {
 						subtract_from_variable = { GRE_debt_held_by_us = ROOT.GRE_reduce }
 					}
 				}
-				set_temp_variable = { GRE_total_reduce = GRE_total_creditor_debt }
-				multiply_temp_variable = { GRE_total_reduce = 0.1 }
+				set_temp_variable = { GRE_total_reduce = { value = GRE_total_creditor_debt multiply = 0.1 } }
 				subtract_from_variable = { GRE_total_creditor_debt = GRE_total_reduce }
 			}
 			GRE_calculate_unified_debt = yes

--- a/common/national_focus/05_india.txt
+++ b/common/national_focus/05_india.txt
@@ -14010,8 +14010,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus RAJ_breaking_the_neck_of_shivsena"
 			set_temp_variable = { party_index = 21 }
-			set_temp_variable = { party_popularity_increase = current_cons_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -14082,8 +14081,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus RAJ_stomping_the_pretenders"
 			set_temp_variable = { party_index = 20 }
-			set_temp_variable = { party_popularity_increase = current_cons_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 21 }
 			set_temp_variable = { party_popularity_increase = current_cons_popularity }

--- a/common/national_focus/05_iran.txt
+++ b/common/national_focus/05_iran.txt
@@ -989,11 +989,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus PER_prepare_the_economy"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			set_temp_variable = { temp_opinion = 25 }
@@ -1797,8 +1795,7 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = PER_economy_modifier }
 			add_to_variable = { PER_production_speed_infrastructure_factor = 0.10 tooltip = production_speed_infrastructure_factor_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.02 } }
 			modify_treasury_effect = yes
 			add_to_variable = { PER_self_sufficiency = 1 }
 		}
@@ -8353,8 +8350,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_black_market_exploits"
 			hidden_effect = { add_ideas = PER_irgc_black_market_exploits }
-			set_temp_variable = { additional_income_change = gdp_total }
-			multiply_temp_variable = { additional_income_change = 0.002 } #10% of GDP yearly
+			set_temp_variable = { additional_income_change = { value = gdp_total multiply = 0.002 } } #10% of GDP yearly
 			custom_effect_tooltip = additional_income_rate_percent_tt
 			newline = yes
 			increase_corruption = yes
@@ -10792,8 +10788,7 @@ focus_tree = {
 				}
 				else = { set_temp_variable = { iran_influence_percentage = 0 } }
 				set_temp_variable = { iraq_domestic_influence_var = domestic_influence_amount }
-				set_temp_variable = { iraq_emerging_outlook_percentage = party_popularity@communism }
-				multiply_temp_variable = { iraq_emerging_outlook_percentage = 100 }
+				set_temp_variable = { iraq_emerging_outlook_percentage = { value = party_popularity@communism multiply = 100 } }
 				#Chances
 				#Coup
 				set_temp_variable = { coup_chance = 0 }
@@ -11086,8 +11081,7 @@ focus_tree = {
 					}
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -11208,8 +11202,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 4 }
 			set_temp_variable = { influence_target = IRQ }
 			change_influence_percentage = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.013 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.013 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 2 }
 			change_the_military_opinion = yes
@@ -11493,8 +11486,7 @@ focus_tree = {
 					set_temp_variable = { percent_change = 2 }
 					change_influence_percentage = yes
 				}
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.012 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.012 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11745,8 +11737,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.015 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 			modify_treasury_effect = yes
 		}
 
@@ -13332,8 +13323,7 @@ focus_tree = {
 				}
 				else = { set_temp_variable = { iran_influence_percentage = 0 } }
 				set_temp_variable = { aze_domestic_influence_var = domestic_influence_amount }
-				set_temp_variable = { aze_emerging_outlook_percentage = party_popularity@communism }
-				multiply_temp_variable = { aze_emerging_outlook_percentage = 100 }
+				set_temp_variable = { aze_emerging_outlook_percentage = { value = party_popularity@communism multiply = 100 } }
 				set_temp_variable = { aze_not_emerging_popularity = 100 }
 				subtract_from_temp_variable = { aze_not_emerging_popularity = aze_emerging_outlook_percentage }
 				#Chances
@@ -19684,8 +19674,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_break_the_piggybank"
 			custom_effect_tooltip = PER_20_percent_GPD_TT
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.20 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.20 } }
 			modify_treasury_effect = yes
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = PER_political_modifier }
@@ -24942,11 +24931,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.1 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.1 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			custom_effect_tooltip = PER_chance_of_corruption2_TT
@@ -28461,9 +28448,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus PER_redirect_money_from_proxies"
 			hidden_effect = { add_ideas = PER_redirecting_money_from_proxies }
-			set_temp_variable = { additional_income_change = gdp_total }
-			multiply_temp_variable = { additional_income_change = 0.02 } #2% of GDP yearly
-			multiply_temp_variable = { additional_income_change = 0.02 } #weekly
+			set_temp_variable = { additional_income_change = { value = gdp_total multiply = 0.02 multiply = 0.02 } } #2% of GDP yearly #weekly
 			custom_effect_tooltip = additional_income_rate_percent_tt
 			newline = yes
 			HEZ = {
@@ -28804,8 +28789,7 @@ focus_tree = {
 			custom_effect_tooltip = PER_develop_pumped_hydro_TT
 				hidden_effect = {
 				408 = {
-					set_temp_variable = { added_storage_capacity = hydroelectric_energy_production_var }
-					multiply_temp_variable = { added_storage_capacity = 100 }
+					set_temp_variable = { added_storage_capacity = { value = hydroelectric_energy_production_var multiply = 100 } }
 					add_to_variable = { hydroelectric_energy_storage_var = added_storage_capacity }
 					add_dynamic_modifier = {
 						modifier = hydroelectric_infrastructure_in_state
@@ -28842,8 +28826,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus PER_guaranteed_purchase_agreements"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.015 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.015 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes

--- a/common/national_focus/05_iraq.txt
+++ b/common/national_focus/05_iraq.txt
@@ -8162,11 +8162,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_reroute_kurdish_funds"
 			# ADD EVENT
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			KUR = {
@@ -10163,11 +10161,9 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_fossil_fuel_industry_opinion = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 		}
 

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -6407,8 +6407,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_subsidize_outposts executed"
 			add_stability = 0.02
 			add_ideas = ISR_settlements_subsidized_1
-			set_temp_variable = { treasury_change = gdp_from_agriculture }
-			multiply_temp_variable = { treasury_change = -0.3 }
+			set_temp_variable = { treasury_change = { value = gdp_from_agriculture multiply = -0.3 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = {
@@ -6494,8 +6493,7 @@ focus_tree = {
 					remove_idea = ISR_settlements_subsidized_1
 					add_idea = ISR_settlements_subsidized_2
 				}
-				set_temp_variable = { treasury_change = gdp_from_agriculture }
-				multiply_temp_variable = { treasury_change = -0.5 }
+				set_temp_variable = { treasury_change = { value = gdp_from_agriculture multiply = -0.5 } }
 				modify_treasury_effect = yes
 			}
 			if = {

--- a/common/national_focus/05_japan.txt
+++ b/common/national_focus/05_japan.txt
@@ -3037,8 +3037,7 @@ base = 1
 			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			newline = yes
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = 0.05 }
+			set_temp_variable = { debt_change = { value = debt multiply = 0.05 } }
 			modify_debt_effect = yes
 			set_temp_variable = { treasury_change = -60 }
 			modify_treasury_effect = yes
@@ -5842,8 +5841,7 @@ base = 1
 			newline = yes
 			add_timed_idea = { idea = JAP_pharmaceutical_powerhouse_idea years = 1 }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8248,8 +8246,7 @@ base = 1
 				MODIFIER = JAP_diplomacy_modifier
 			}
 			add_to_variable = { JAP_diplomacy_research_speed_factor = 0.10 tooltip = research_speed_factor_tt }
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.001 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.001 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8284,8 +8281,7 @@ base = 1
 			}
 			add_to_variable = { JAP_diplomacy_production_speed_offices_factor = 0.10 tooltip = production_speed_offices_factor_tt }
 			add_to_variable = { JAP_diplomacy_production_speed_internet_station_factor = 0.10 tooltip = production_speed_internet_station_factor_tt }
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.002 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.002 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9957,8 +9953,7 @@ base = 4
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.005 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.005 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10019,8 +10014,7 @@ base = 4
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.003 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.003 } }
 			modify_treasury_effect = yes
 		}
 
@@ -15039,8 +15033,7 @@ base = 4
 				limit = { has_dynamic_modifier = { modifier = JAP_galapagos_modifier } }
 				add_to_variable = { JAP_galapagos_openness = 12 tooltip = JAP_galapagos_openness_up_tt }
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.001 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.001 } }
 			modify_treasury_effect = yes
 			newline = yes
 			custom_effect_tooltip = {
@@ -15144,8 +15137,7 @@ base = 4
 				limit = { has_dynamic_modifier = { modifier = JAP_galapagos_modifier } }
 				add_to_variable = { JAP_galapagos_openness = 12 tooltip = JAP_galapagos_openness_up_tt }
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.002 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.002 } }
 			modify_treasury_effect = yes
 			newline = yes
 			custom_effect_tooltip = {

--- a/common/national_focus/05_libya.txt
+++ b/common/national_focus/05_libya.txt
@@ -723,8 +723,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_assassinate_gaddafi"
 			set_leader = yes
-			set_temp_variable = { coup_chance = party_popularity@fascism }
-			multiply_temp_variable = { coup_chance = 2 }
+			set_temp_variable = { coup_chance = { value = party_popularity@fascism multiply = 2 } }
 			clamp_temp_variable = { var = coup_chance max = 1 }
 			set_temp_variable = { coup_fail_chance = 1 }
 			subtract_from_temp_variable = { coup_fail_chance = coup_chance }
@@ -3291,8 +3290,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_hunt_down_royals"
 			set_temp_variable = { party_index = 23 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^23 }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = party_pop_array^23 multiply = -1 } }
 			set_temp_variable = { temp_outlook_increase = party_popularity_increase }
 			change_relative_party_popularity = yes
 			custom_effect_tooltip = LBA_hunt_down_royals_tt
@@ -10780,13 +10778,11 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_humanitarian_aid_to_chad"
 			CHA = { country_event = LibyaFocus.99 }
-			set_temp_variable = { treasury_change = CHA.gdp_total }
-			multiply_temp_variable = { treasury_change = -0.50 }
+			set_temp_variable = { treasury_change = { value = CHA.gdp_total multiply = -0.50 } }
 			modify_treasury_effect = yes
 			effect_tooltip = {
 				CHA = {
-					set_temp_variable = { treasury_change = CHA.gdp_total }
-					multiply_temp_variable = { treasury_change = 0.50 }
+					set_temp_variable = { treasury_change = { value = CHA.gdp_total multiply = 0.50 } }
 					modify_treasury_effect = yes
 					add_stability = 0.10
 				}
@@ -14453,9 +14449,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_emergency_privatisation"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.075 }
-			multiply_temp_variable = { treasury_change = 4 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.075 multiply = 4 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = LBA_emergency_privatisation_tt
 			add_to_variable = { lba_oil_nationalisation = -0.20 }

--- a/common/national_focus/05_myanmar.txt
+++ b/common/national_focus/05_myanmar.txt
@@ -57,8 +57,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BRM_the_new_economic_boom"
 			increase_economic_growth = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -89,8 +88,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus BRM_loan_refactoring"
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.20 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.20 } }
 			clamp_temp_variable = { var = debt_change max = 0 min = -100 }
 			modify_debt_effect = yes
 			add_timed_idea = { idea = BRM_loan_refactoring_idea days = 365 }

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -137,13 +137,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 			update_focus_tree_obsolete_branches = yes
@@ -198,13 +196,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -319,13 +315,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -401,13 +395,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -473,13 +465,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1007,12 +997,10 @@ focus_tree = {
 				change_international_bankers_opinion = yes
 			}
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.12 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.12 } }
 			modify_international_investment_effect = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = 0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = 0.08 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1070,8 +1058,7 @@ focus_tree = {
 				change_international_bankers_opinion = yes
 				newline = yes
 			}
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.18 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.18 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			custom_effect_tooltip = {
@@ -1136,8 +1123,7 @@ focus_tree = {
 			add_to_variable = { HOL_economy_production_speed_internet_station_factor = 0.10 tooltip = production_speed_internet_station_factor_tt }
 			add_to_variable = { HOL_economy_political_power_gain = 0.05 tooltip = political_power_gain_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.10 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.10 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			if = {
@@ -1259,13 +1245,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.14 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.14 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1501,13 +1485,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 			}
 			update_focus_tree_obsolete_branches = yes
@@ -1568,13 +1550,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1619,13 +1599,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.14 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.14 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1696,13 +1674,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.24 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.24 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1762,13 +1738,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1851,13 +1825,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.24 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.24 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1903,13 +1875,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.24 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.24 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -1961,13 +1931,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.24 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.24 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2018,13 +1986,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.34 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.34 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.35 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.35 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2071,13 +2037,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2237,8 +2201,7 @@ focus_tree = {
 				build_railway = {
 					path = { 9335 14631 241 11264 14632 3326 }
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			if = {
@@ -2298,13 +2261,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.14 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.14 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 			hidden_effect = {
@@ -2349,13 +2310,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2550,13 +2509,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.09 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.09 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2669,13 +2626,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.09 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.09 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2841,13 +2796,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.09 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.09 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -2907,13 +2860,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.09 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.09 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -4741,8 +4692,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus HOL_space_efforts"
 			complete_special_project = sp:sp_space_program
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.40 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.40 } }
 			modify_treasury_effect = yes
 		}
 
@@ -4787,8 +4737,7 @@ focus_tree = {
 			add_to_variable = { HOL_economy_education_cost_multiplier_modifier = 0.10 tooltip = education_cost_multiplier_modifier_tt }
 			add_to_variable = { HOL_economy_agricolture_productivity_modifier = 0.05 tooltip = agricolture_productivity_modifier_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.40 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.40 } }
 			modify_treasury_effect = yes
 		}
 
@@ -4922,8 +4871,7 @@ focus_tree = {
 			}
 			add_to_variable = { HOL_economy_spysat_production_speed_modifier = 0.10 tooltip = spysat_production_speed_modifier_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.50 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.50 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -5092,8 +5040,7 @@ focus_tree = {
 			unlock_decision_category_tooltip = HOL_space_program_category
 			activate_mission = HOL_mars_colony_mission
 			hidden_effect = { country_event = { id = HOL_military.089 days = 150 random_hours = 720 } }
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.60 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.60 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5162,13 +5109,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.18 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.18 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -5361,13 +5306,11 @@ focus_tree = {
 			else = {
 				if = {
 					limit = { HOL_liberal_society_top_tier = yes }
-					set_temp_variable = { treasury_change = gdp_per_capita }
-					multiply_temp_variable = { treasury_change = -0.09 }
+					set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.09 } }
 					modify_treasury_effect = yes
 				}
 				else = {
-					set_temp_variable = { treasury_change = gdp_per_capita }
-					multiply_temp_variable = { treasury_change = -0.10 }
+					set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 					modify_treasury_effect = yes
 				}
 				custom_effect_tooltip = {
@@ -5427,8 +5370,7 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.135 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.135 } }
 				modify_treasury_effect = yes
 			}
 			else_if = {
@@ -5436,19 +5378,16 @@ focus_tree = {
 					HOL_liberal_society_top_tier = yes
 					has_completed_focus = HOL_robotics_navy
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 			else_if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.06 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.06 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -5552,13 +5491,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.135 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.135 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -5770,13 +5707,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.135 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.135 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -5817,13 +5752,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.18 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.18 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -5937,8 +5870,7 @@ focus_tree = {
 				uses = 2
 				bonus = 0.15
 			}
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.15 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.15 } }
 			modify_international_investment_effect = yes
 		}
 
@@ -5968,8 +5900,7 @@ focus_tree = {
 			add_to_variable = { HOL_economy_dockyard_productivity = 0.10 tooltip = dockyard_productivity_tt }
 			add_to_variable = { HOL_economy_offices_productivity = 0.05 tooltip = offices_productivity_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.12 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.12 } }
 			modify_international_investment_effect = yes
 			if = {
 				limit = { has_idea = maritime_industry }
@@ -6021,13 +5952,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.135 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.135 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -6066,8 +5995,7 @@ focus_tree = {
 			add_to_variable = { HOL_economy_international_market_income_modifier = 0.05 tooltip = international_market_income_modifier_tt }
 			add_to_variable = { HOL_economy_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.12 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.12 } }
 			modify_international_investment_effect = yes
 			activate_mission = HOL_ijstad_mission
 			newline = yes
@@ -6075,13 +6003,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.14 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.14 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -6172,13 +6098,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -6228,13 +6152,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -6278,13 +6200,11 @@ focus_tree = {
 				limit = {
 					HOL_liberal_society_top_tier = yes
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.18 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.18 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -6483,8 +6403,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = -3 }
-			multiply_temp_variable = { treasury_change = num_core_states }
+			set_temp_variable = { treasury_change = { value = -3 multiply = num_core_states } }
 			modify_treasury_effect = yes
 		}
 
@@ -6638,8 +6557,7 @@ focus_tree = {
 				ENG = { country_event = HOL_military.001 }
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
-					set_temp_variable = { int_investment_change = gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.05 }
+					set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 					modify_international_investment_effect = yes
 				}
 			}
@@ -7346,8 +7264,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.12 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.12 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -7476,8 +7393,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -7558,8 +7474,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -7623,8 +7538,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.06 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.06 } }
 			modify_treasury_effect = yes
 		}
 
@@ -7731,8 +7645,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.07 } }
 			modify_treasury_effect = yes
 		}
 
@@ -7838,8 +7751,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -7916,8 +7828,7 @@ focus_tree = {
 					change_defense_industry_opinion = yes
 				}
 				newline = yes
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.08 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 				modify_treasury_effect = yes
 			}
 
@@ -7980,8 +7891,7 @@ focus_tree = {
 					}
 				}
 				newline = yes
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 
@@ -8063,8 +7973,7 @@ focus_tree = {
 					change_the_military_opinion = yes
 				}
 				newline = yes
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 
@@ -8820,13 +8729,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_daf_investments }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 				custom_effect_tooltip = HOL_DAF_Trucks_tt1
 				else = {
-					set_temp_variable = { treasury_change = gdp_per_capita }
-					multiply_temp_variable = { treasury_change = -0.10 }
+					set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 					modify_treasury_effect = yes
 					custom_effect_tooltip = HOL_DAF_Trucks_tt2
 				}
@@ -8903,8 +8810,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -8945,8 +8851,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9009,8 +8914,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9093,8 +8997,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9157,8 +9060,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9290,8 +9192,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = -3.25 }
-			multiply_temp_variable = { treasury_change = num_core_states }
+			set_temp_variable = { treasury_change = { value = -3.25 multiply = num_core_states } }
 			modify_treasury_effect = yes
 		}
 
@@ -9337,8 +9238,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 5 }
 				change_defense_industry_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.20 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9385,8 +9285,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9447,8 +9346,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9501,8 +9399,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9545,8 +9442,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = -3.25 }
-			multiply_temp_variable = { treasury_change = num_core_states }
+			set_temp_variable = { treasury_change = { value = -3.25 multiply = num_core_states } }
 			modify_treasury_effect = yes
 		}
 
@@ -9581,8 +9477,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9651,8 +9546,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9717,8 +9611,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9786,8 +9679,7 @@ focus_tree = {
 				set_temp_variable = { temp_opinion = 2 }
 				change_the_military_opinion = yes
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.15 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 			modify_treasury_effect = yes
 		}
 
@@ -10129,13 +10021,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10217,13 +10107,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10380,13 +10268,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.075 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.075 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.15 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.15 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10426,13 +10312,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10508,13 +10392,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10652,13 +10534,11 @@ focus_tree = {
 			newline = yes
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10716,13 +10596,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -10899,13 +10777,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.045 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.045 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.09 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.09 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11077,13 +10953,11 @@ focus_tree = {
 			newline = yes
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11151,13 +11025,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11239,13 +11111,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11332,13 +11202,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11425,13 +11293,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -11554,13 +11420,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.125 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.125 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 			update_focus_tree_obsolete_branches = yes
@@ -11728,13 +11592,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.125 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.125 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 			update_focus_tree_obsolete_branches = yes
@@ -11899,13 +11761,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.05 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.05 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 			}
@@ -12045,13 +11905,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -12301,13 +12159,11 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.25 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.50 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.50 } }
 				modify_treasury_effect = yes
 			}
 			hidden_effect = {
@@ -12351,13 +12207,11 @@ focus_tree = {
 			change_the_military_opinion = yes
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.40 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.40 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.80 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.80 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -12448,8 +12302,7 @@ focus_tree = {
 			unlock_decision_tooltip = HOL_antilles_expand_mil_industry
 			unlock_decision_tooltip = HOL_antilles_expand_agriculture
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -14050,8 +13903,7 @@ focus_tree = {
 				change_influence_percentage = yes
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -14115,8 +13967,7 @@ focus_tree = {
 				years = 5
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -20130,8 +19981,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 2
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = -2 }
-			multiply_temp_variable = { treasury_change = num_core_states }
+			set_temp_variable = { treasury_change = { value = -2 multiply = num_core_states } }
 			modify_treasury_effect = yes
 		}
 
@@ -21314,8 +21164,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -21367,8 +21216,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_D66_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-			multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_D66_focus_in_progress_tt
@@ -21422,8 +21270,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21473,8 +21320,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21526,8 +21372,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21579,8 +21424,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21657,8 +21501,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21714,8 +21557,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21765,8 +21607,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_D66_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_D66_focus_in_progress_tt
@@ -21845,8 +21686,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_SGP_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = HOL_SGP_focus_in_progress_tt
@@ -21897,8 +21737,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -21947,8 +21786,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -21997,8 +21835,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -22052,8 +21889,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -22105,8 +21941,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -22182,8 +22017,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -22318,8 +22152,7 @@ focus_tree = {
 			limit = {
 				has_country_flag = HOL_SGP_in_progress_flag
 			}
-			set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-			multiply_temp_variable = { temp_focus_days = 7 }
+			set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 			custom_override_tooltip = {
 				tooltip = {
 					localization_key = HOL_SGP_focus_in_progress_tt
@@ -22376,8 +22209,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22433,8 +22265,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 }
-				multiply_temp_variable = { temp_focus_days = 7 }
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } }
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22496,8 +22327,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22576,8 +22406,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22668,8 +22497,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22728,8 +22556,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22785,8 +22612,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22842,8 +22668,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22900,8 +22725,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -22958,8 +22782,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = HOL_GL_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @HOL_D66_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @HOL_D66_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -23501,8 +23324,7 @@ focus_tree = {
 				add_idea = HOL_stadtholderate3
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -24600,13 +24422,11 @@ focus_tree = {
 			newline = yes
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -24649,8 +24469,7 @@ focus_tree = {
 				years = 1
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -25205,8 +25024,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -26343,8 +26161,7 @@ focus_tree = {
 				add_ideas = HOL_dutchaid
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -26651,13 +26468,11 @@ focus_tree = {
 			newline = yes
 			if = {
 				limit = { has_completed_focus = HOL_robotics_navy }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.10 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 				modify_treasury_effect = yes
 			}
 			else = {
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -27008,8 +26823,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = SRI }
 			change_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -27413,8 +27227,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = SAF }
 			change_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -27490,8 +27303,7 @@ focus_tree = {
 			}
 			activate_mission = HOL_voc_saf_mission2
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -27927,8 +27739,7 @@ focus_tree = {
 			newline = yes
 			remove_ideas = HOL_voc_territory_focus
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -28467,8 +28278,7 @@ focus_tree = {
 				change_fossil_fuel_industry_opinion = yes
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 			update_focus_tree_obsolete_branches = yes
 		}
@@ -28576,8 +28386,7 @@ focus_tree = {
 			set_temp_variable = { influence_target = AST }
 			change_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.25 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.25 } }
 			modify_treasury_effect = yes
 		}
 
@@ -29105,8 +28914,7 @@ focus_tree = {
 				years = 1
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -29171,8 +28979,7 @@ focus_tree = {
 				add_idea = HOL_corporatist_economy2
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -30812,8 +30619,7 @@ focus_tree = {
 			newline = yes
 			GER = { country_event = HOL_nvu.15 }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -31182,8 +30988,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -4459,8 +4459,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NIG_spur_regional_development"
 			increase_economic_growth = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_north_korea.txt
+++ b/common/national_focus/05_north_korea.txt
@@ -423,8 +423,7 @@ focus_tree = {
 			newline = yes
 			country_event = korea.51
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -6525,8 +6524,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { has_idea = NKO_china_economic_assistant }
@@ -6572,8 +6570,7 @@ focus_tree = {
 				add_idea = NKO_broken_juche_2
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
 		}
 
@@ -6737,8 +6734,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus NKO_civilian_control_of_the_economy executed"
 			increase_Free_Market_Economy = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -7167,8 +7163,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus NKO_step_up_joint_ventures executed"
 			add_offsite_building = { type = industrial_complex level = 1 }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8005,8 +8000,7 @@ focus_tree = {
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8182,8 +8176,7 @@ focus_tree = {
 			change_communist_cadres_opinion = yes
 			update_focus_tree_obsolete_branches = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.08 } }
 			modify_treasury_effect = yes
 		}
 
@@ -8274,8 +8267,7 @@ focus_tree = {
 				remove_ideas = NKO_the_private_markets
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.08 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_poland.txt
+++ b/common/national_focus/05_poland.txt
@@ -14140,14 +14140,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_soften_the_cons"
 			custom_effect_tooltip = POL_party_pop_TT
-			set_temp_variable = {
-				current_cons_popularity = party_pop_array^1
-			}
-			multiply_temp_variable = { current_cons_popularity = 0.2 }
+			set_temp_variable = { current_cons_popularity = { value = party_pop_array^1 multiply = 0.2 } }
 			# Remove most of support, retrack it to Liberal party
 			set_temp_variable = { party_index = 1 }
-			set_temp_variable = { party_popularity_increase = current_cons_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -19104,12 +19100,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_connect_to_conservative_politicians"
 			custom_effect_tooltip = POL_increase_nationalist_support_TT
-			set_temp_variable = { current_cons_popularity = party_pop_array^1 }
-			multiply_temp_variable = { current_cons_popularity = 0.5 }
+			set_temp_variable = { current_cons_popularity = { value = party_pop_array^1 multiply = 0.5 } }
 			# Remove most of support, retrack it to fascists party
 			set_temp_variable = { party_index = 1 }
-			set_temp_variable = { party_popularity_increase = current_cons_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -19316,12 +19310,10 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_discreditate_opponents"
 			custom_effect_tooltip = POL_increase_nationalist_support_TT
 			add_stability = -0.05
-			set_temp_variable = { current_soc_popularity = party_pop_array^3 }
-			multiply_temp_variable = { current_soc_popularity = 0.25 }
+			set_temp_variable = { current_soc_popularity = { value = party_pop_array^3 multiply = 0.25 } }
 			# Remove most of support, retrack it to fascists party
 			set_temp_variable = { party_index = 1 }
-			set_temp_variable = { party_popularity_increase = current_soc_popularity }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = current_soc_popularity multiply = -1 } }
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 20 }
 			set_temp_variable = { party_popularity_increase = current_soc_popularity }
@@ -19829,8 +19821,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_ally_infrastructure"
 			custom_effect_tooltip = POL_ally_industry_TT
-			set_temp_variable = { base_change = -7 }
-			multiply_temp_variable = { base_change = num_faction_members }
+			set_temp_variable = { base_change = { value = -7 multiply = num_faction_members } }
 			set_temp_variable = {
 				treasury_change = base_change
 			}
@@ -19883,8 +19874,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus POL_ally_industry"
 			custom_effect_tooltip = POL_ally_industry_TT
-			set_temp_variable = { base_change = -7.5 }
-			multiply_temp_variable = { base_change = num_faction_members }
+			set_temp_variable = { base_change = { value = -7.5 multiply = num_faction_members } }
 			set_temp_variable = {
 				treasury_change = base_change
 			}

--- a/common/national_focus/05_russia.txt
+++ b/common/national_focus/05_russia.txt
@@ -2945,8 +2945,7 @@ focus_tree = {
 				target = UKR
 				modifier = diplomatic_support
 			}
-			set_temp_variable = { base_change = -7.5 }
-			multiply_temp_variable = { base_change = num_faction_members }
+			set_temp_variable = { base_change = { value = -7.5 multiply = num_faction_members } }
 			set_temp_variable = { treasury_change = base_change }
 			modify_treasury_effect = yes
 			one_random_industrial_complex = yes
@@ -16266,12 +16265,10 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 2 }
 				set_temp_variable = { col_one = 1 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^2 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^2 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				set_temp_variable = { party_index = 6 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 2 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -16998,12 +16995,10 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 2 }
 				set_temp_variable = { col_one = 1 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^2 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^2 multiply = 0.5 } }
 				# Remove most of support, retrack it to emerg communist party
 				set_temp_variable = { party_index = 6 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 2 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -17065,11 +17060,9 @@ focus_tree = {
 				set_temp_variable = { rul_party_temp = 1 }
 				set_temp_variable = { col_one = 2 }
 				change_ruling_party_effect = yes
-				set_temp_variable = { current_cons_popularity = party_pop_array^1 }
-				multiply_temp_variable = { current_cons_popularity = 0.5 }
+				set_temp_variable = { current_cons_popularity = { value = party_pop_array^1 multiply = 0.5 } }
 				set_temp_variable = { party_index = 6 }
-				set_temp_variable = { party_popularity_increase = current_cons_popularity }
-				multiply_temp_variable = { party_popularity_increase = -1 }
+				set_temp_variable = { party_popularity_increase = { value = current_cons_popularity multiply = -1 } }
 				change_relative_party_popularity = yes
 				set_temp_variable = { party_index = 1 }
 				set_temp_variable = { party_popularity_increase = current_cons_popularity }
@@ -17735,12 +17728,7 @@ focus_tree = {
 					set_temp_variable = { col_one = 3 }
 					set_temp_variable = { disable_elections = 1 }
 					change_ruling_party_effect = yes
-					set_temp_variable = {
-						current_cons_popularity = party_pop_array^2
-					}
-					multiply_temp_variable = {
-						current_cons_popularity = 0.5
-					}
+					set_temp_variable = { current_cons_popularity = { value = party_pop_array^2 multiply = 0.5 } }
 					subtract_from_variable = {
 						party_pop_array^3 = current_cons_popularity
 					}

--- a/common/national_focus/05_serbia.txt
+++ b/common/national_focus/05_serbia.txt
@@ -9806,10 +9806,8 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus SER_reinforce_the_population executed"
 			add_political_power = 100
 			random_owned_state = {
-				set_temp_variable = { movable_pop = THIS.state_population_k }
-				multiply_temp_variable = { movable_pop = 50 }
-				set_temp_variable = { movable_pop_red = movable_pop }
-				multiply_temp_variable = { movable_pop_red = -1 }
+				set_temp_variable = { movable_pop = { value = THIS.state_population_k multiply = 50 } }
+				set_temp_variable = { movable_pop_red = { value = movable_pop multiply = -1 } }
 				add_manpower = movable_pop_red
 			}
 			random_owned_state = {

--- a/common/national_focus/05_singapore.txt
+++ b/common/national_focus/05_singapore.txt
@@ -228,8 +228,7 @@ focus_tree = {
 			log = "[GetDateText]: [THIS.GetName]: Focus SIN_bankers_of_asia"
 			set_temp_variable = { temp_opinion = 15 }
 			change_international_bankers_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 			modify_treasury_effect = yes
 			add_ideas = SIN_bankers_of_asia_idea_1
 		}
@@ -5656,14 +5655,11 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus SIN_economic_champion"
 			increase_economic_growth = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.07 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.05 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.05 } }
 			modify_debt_effect = yes
 		}
 
@@ -7118,8 +7114,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus SIN_pressure_the_japanese"
-			set_temp_variable = { treasury_change = JAP.int_investments }
-			multiply_temp_variable = { treasury_change = 0.07 }
+			set_temp_variable = { treasury_change = { value = JAP.int_investments multiply = 0.07 } }
 			modify_treasury_effect = yes
 			capital_scope = {
 				add_building_construction = {

--- a/common/national_focus/05_spain.txt
+++ b/common/national_focus/05_spain.txt
@@ -6241,8 +6241,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_support_our_people"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.001 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.001 } }
 			modify_treasury_effect = yes
 			add_stability = 0.06
 		}
@@ -7639,11 +7638,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_nationalize_the_banks"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			random_owned_controlled_state = {
 				limit = { free_shared_building_slots = yes }
@@ -8016,14 +8013,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_for_the_beneficiaries"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.02 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.02 } }
 			modify_debt_effect = yes
 		}
 
@@ -8779,8 +8773,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_erase_francoism"
 			set_country_flag = party22_banned
 			set_temp_variable = { party_index = 21 }
-			set_temp_variable = { party_popularity_increase = party_pop_array^21 }
-			multiply_temp_variable = { party_popularity_increase = -1 }
+			set_temp_variable = { party_popularity_increase = { value = party_pop_array^21 multiply = -1 } }
 			change_relative_party_popularity = yes
 			custom_effect_tooltip = SPR_bans_francoist_party_tt
 		}
@@ -9001,8 +8994,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_decommodify_the_basics"
 			unlock_decision_tooltip = SPR_socialism_policy_replacer_decision
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
 			add_stability = 0.05
 			add_ideas = SPR_decommodify_the_basics_idea
@@ -9382,8 +9374,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_the_fair_share"
 			set_temp_variable = { pop_change = 2 }
 			modify_population_tax_rate_effect = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.01 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_landowners_opinion = yes
@@ -9565,8 +9556,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_state_sponsored_interventionism"
 			increase_economic_growth = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9662,11 +9652,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_a_state_bank"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			swap_ideas = {
 				remove_idea = landowners
@@ -10778,8 +10766,7 @@ focus_tree = {
 			change_relative_party_popularity = yes
 			set_temp_variable = { party_index = 19 }
 			change_relative_party_popularity = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 			reverse_add_opinion_modifier = { target = HLS modifier = SPR_dissolved_monasteries_HLS }
 			every_other_country = {
@@ -11115,8 +11102,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SPR_liquidate_private_assets"
 			set_temp_variable = { temp_opinion = -10 }
 			change_landowners_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.05 } }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_sweden.txt
+++ b/common/national_focus/05_sweden.txt
@@ -79,8 +79,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_found_visit_sverige"
 			set_country_flag = SWE_idea_tourist_industry_1
 			add_ideas = SWE_idea_sverige_tourism
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.008 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.008 } }
 			modify_treasury_effect = yes
 		}
 
@@ -138,11 +137,9 @@ focus_tree = {
 					category = CAT_infrastructure
 				}
 			}
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.058 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.058 } }
 				modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.053 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.053 } }
 				modify_treasury_effect = yes
 		}
 
@@ -183,11 +180,9 @@ focus_tree = {
 				add_dynamic_modifier = { modifier = SWE_regional_tourism_invest }
 			}
 			add_political_power = 100
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 				modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.043 } }
 				modify_treasury_effect = yes
 		}
 
@@ -233,11 +228,9 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.04 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.04 } }
 				modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.033 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.033 } }
 				modify_treasury_effect = yes
 		}
 
@@ -404,8 +397,7 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_digital_modifier }
 			add_to_variable = { SWE_Digital_political_power_factor = 0.02 tooltip = political_power_factor_tt }
 			add_to_variable = { SWE_Digital_productivity_growth_modifier = 0.03 tooltip = productivity_growth_modifier_tt }
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 				modify_treasury_effect = yes
 		}
 
@@ -591,8 +583,7 @@ focus_tree = {
 				category = CAT_ai
 				category = CAT_internet_tech
 				}
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.023 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.023 } }
 				modify_treasury_effect = yes
 			}
 			DEN = {
@@ -641,8 +632,7 @@ focus_tree = {
 				category = CAT_ai
 				category = CAT_internet_tech
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.053 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.053 } }
 				modify_treasury_effect = yes
 		}
 
@@ -937,8 +927,7 @@ focus_tree = {
 			add_dynamic_modifier = { modifier = SWE_pharmacy_modifier }
 			add_to_variable = { SWE_Pharma_monthly_population = 0.05 tooltip = monthly_population_tt }
 			add_to_variable = { SWE_Pharma_health_cost_multiplier_modifier = 0.05 tooltip = health_cost_multiplier_modifier_tt }
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.043 } }
 				modify_treasury_effect = yes
 		}
 
@@ -1050,11 +1039,9 @@ focus_tree = {
 			}
 			set_temp_variable = { percent_change = -2 }
 			change_domestic_influence_percentage = yes
-			set_temp_variable = { int_investment_change = USA.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = USA.gdp_per_capita multiply = 0.05 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = USA.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.04 }
+				set_temp_variable = { debt_change = { value = USA.gdp_per_capita multiply = 0.04 } }
 				modify_debt_effect = yes
 		}
 
@@ -1111,11 +1098,9 @@ focus_tree = {
 				category = CAT_nfibers
 				uses = 1
 			}
-			set_temp_variable = { int_investment_change = SWI.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.055 }
+			set_temp_variable = { int_investment_change = { value = SWI.gdp_per_capita multiply = 0.055 } }
 				modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = SWI.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.06 }
+			set_temp_variable = { treasury_change = { value = SWI.gdp_per_capita multiply = -0.06 } }
 				modify_treasury_effect = yes
 		}
 
@@ -1216,11 +1201,9 @@ focus_tree = {
 				category = CAT_genes
 				uses = 1
 			}
-			set_temp_variable = { int_investment_change = ENG.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = ENG.gdp_per_capita multiply = 0.05 } }
 				modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = ENG.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = ENG.gdp_per_capita multiply = -0.043 } }
 				modify_treasury_effect = yes
 		}
 
@@ -1318,11 +1301,9 @@ focus_tree = {
 			}
 			set_temp_variable = { percent_change = -4 }
 			change_domestic_influence_percentage = yes
-			set_temp_variable = { int_investment_change = ENG.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+			set_temp_variable = { int_investment_change = { value = ENG.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = ENG.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.04 }
+				set_temp_variable = { debt_change = { value = ENG.gdp_per_capita multiply = 0.04 } }
 				modify_debt_effect = yes
 		}
 
@@ -1445,11 +1426,9 @@ focus_tree = {
 				category = CAT_3d
 				uses = 1
 			}
-			set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.064 }
+			set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.064 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = SWE.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.07 }
+				set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.07 } }
 				modify_debt_effect = yes
 		}
 
@@ -1565,11 +1544,9 @@ focus_tree = {
 			set_temp_variable = { influence_target = HOL }
 			change_influence_percentage = yes
 			SWE = {
-				set_temp_variable = { int_investment_change = HOL.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = HOL.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = HOL.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = HOL.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
 			}
 		}
@@ -1621,11 +1598,9 @@ focus_tree = {
 			change_influence_percentage = yes
 			newline = yes
 			SWE = {
-				set_temp_variable = { int_investment_change = GER.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = GER.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = GER.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = GER.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
 			}
 		}
@@ -1677,11 +1652,9 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_Vattenfall_modifier }
 			add_to_variable = { SWE_V_energy_use_multiplier = -0.05 tooltip = energy_use_multiplier_tt }
 			SWE = {
-				set_temp_variable = { int_investment_change = POL.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = POL.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = POL.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = POL.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
 			}
 		}
@@ -1728,8 +1701,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1776,8 +1748,7 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_Vattenfall_modifier }
 			add_to_variable = { SWE_V_nuclear_energy_generation_modifier = 0.05 tooltip = nuclear_energy_generation_modifier_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1857,11 +1828,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { int_investment_change = GER.gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.03 }
+			set_temp_variable = { int_investment_change = { value = GER.gdp_per_capita multiply = 0.03 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = GER.gdp_per_capita }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = GER.gdp_per_capita multiply = 0.02 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2004,11 +1973,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { int_investment_change = LAT.gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.03 }
+			set_temp_variable = { int_investment_change = { value = LAT.gdp_per_capita multiply = 0.03 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = LAT.gdp_per_capita }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = LAT.gdp_per_capita multiply = 0.02 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2081,8 +2048,7 @@ focus_tree = {
 				add_manpower = 1200
 			}
 			newline = yes
-			set_temp_variable = { debt_change = SWE.gdp_per_capita }
-			multiply_temp_variable = { debt_change = 0.04 }
+			set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.04 } }
 			modify_debt_effect = yes
 		}
 
@@ -2130,8 +2096,7 @@ focus_tree = {
 				uses = 1
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.07 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2171,8 +2136,7 @@ focus_tree = {
 				uses = 1
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.07 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2216,8 +2180,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.07 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2256,11 +2219,9 @@ focus_tree = {
 			add_to_variable = { SWE_Industry_civ_facs_worker_requirement_modifier = -0.05 tooltip = civ_facs_worker_requirement_modifier_tt }
 			add_to_variable = { SWE_Industry_mil_facs_worker_requirement_modifier = -0.05 tooltip = mil_facs_worker_requirement_modifier_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = SWE.gdp_per_capita }
-			multiply_temp_variable = { debt_change = 0.04 }
+			set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.04 } }
 			modify_debt_effect = yes
 			newline = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -2315,11 +2276,9 @@ focus_tree = {
 			set_temp_variable = { influence_target = USA }
 			change_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = SWE.gdp_per_capita }
-			multiply_temp_variable = { debt_change = 0.04 }
+			set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.04 } }
 			modify_debt_effect = yes
 			newline = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -2363,8 +2322,7 @@ focus_tree = {
 			add_to_variable = { SWE_Industry_consumer_goods_factor = -0.07 tooltip = consumer_goods_factor_tt }
 			add_to_variable = { SWE_Industry_production_factory_efficiency_gain_factor = 0.07 tooltip = production_factory_efficiency_gain_factor_tt }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2410,8 +2368,7 @@ focus_tree = {
 			newline = yes
 			35 = { add_manpower = 2210 }
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.02 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2607,8 +2564,7 @@ focus_tree = {
 			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.043 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2648,12 +2604,10 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_in_market_production"
 			add_offsite_building = { type = industrial_complex level = 2 }
 			newline = yes
-			set_temp_variable = { int_investment_change = USA.gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = USA.gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
 			newline = yes
-			set_temp_variable = { debt_change = USA.gdp_per_capita }
-			multiply_temp_variable = { debt_change = 0.04 }
+			set_temp_variable = { debt_change = { value = USA.gdp_per_capita multiply = 0.04 } }
 			modify_debt_effect = yes
 			newline = yes
 			set_temp_variable = { percent_change = -3 }
@@ -2739,8 +2693,7 @@ focus_tree = {
 				category = CAT_util
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2787,8 +2740,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2841,8 +2793,7 @@ focus_tree = {
 				category = CAT_apc
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2884,8 +2835,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.043 } }
 			modify_treasury_effect = yes
 		}
 
@@ -2922,12 +2872,10 @@ focus_tree = {
 					amount = 4
 				}
 			}
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.02 } }
 			modify_treasury_effect = yes
 			newline = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -2975,8 +2923,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_excavation_tech
 			}
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -7.50 }
@@ -3018,8 +2965,7 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_mining_modifier }
 			add_to_variable = { SWE_Mining_production_speed_industrial_complex_factor = 0.05 tooltip = production_speed_industrial_complex_factor_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -4.69 }
@@ -3066,8 +3012,7 @@ focus_tree = {
 				category = CAT_construction_tech
 			}
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -8.44 }
@@ -3114,8 +3059,7 @@ focus_tree = {
 			change_industrial_conglomerates_opinion = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3153,8 +3097,7 @@ focus_tree = {
 				add_dynamic_modifier = { modifier = SWE_upgraded_mining_equipment }
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3191,8 +3134,7 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_mining_modifier }
 			add_to_variable = { SWE_Mining_gdp_from_resource_sector_modifier = 0.05 tooltip = gdp_from_resource_sector_modifier_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 			modify_international_investment_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
@@ -3225,11 +3167,9 @@ focus_tree = {
 			set_temp_variable = { percent_change = -5 }
 			change_domestic_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.025 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.025 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = 0.02 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = 0.02 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_industrial_conglomerates_opinion = yes
@@ -3278,11 +3218,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_AP_fonderna_restructure"
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.05 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.05 } }
 				modify_international_investment_effect = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.043 } }
 				modify_treasury_effect = yes
 			newline = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_financial_place_modifier }
@@ -3347,11 +3285,9 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_financial_place_modifier }
 			add_to_variable = { SWE_Finance_return_on_investment_modifier = 0.01 tooltip = return_on_investment_modifier_tt }
 			newline = yes
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.055 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.055 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = gdp_per_capita }
-			multiply_temp_variable = { debt_change = -0.040 }
+			set_temp_variable = { debt_change = { value = gdp_per_capita multiply = -0.040 } }
 			modify_debt_effect = yes
 			set_temp_variable = { percent_change = -2 }
 			change_domestic_influence_percentage = yes
@@ -3484,8 +3420,7 @@ focus_tree = {
 				set_country_flag = { flag = SWE_notice_pending days = 15 value = 1 }
 				news_event = { id = Sweden_news.4 days = 1 }
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.03 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = SWE_allow_crypto_tt
 		}
@@ -3564,8 +3499,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_regularly_bond_trade"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.08 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.08 } }
 			modify_treasury_effect = yes
 			add_timed_idea = {
 				idea = SWE_idea_back_by_bonds
@@ -3604,8 +3538,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_no_bonds_just_gold"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.04 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.04 } }
 				modify_treasury_effect = yes
 			add_ideas = SWE_idea_gold_standart
 		}
@@ -3640,8 +3573,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_stabilize_the_exchange"
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_financial_place_modifier }
 			add_to_variable = { SWE_Finance_interest_rate_multiplier_modifier = -0.20 tooltip = interest_rate_multiplier_modifier_tt }
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.07 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.07 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3877,8 +3809,7 @@ focus_tree = {
 				target_state = 442
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.13 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.13 } }
 			modify_treasury_effect = yes
 		}
 
@@ -3967,8 +3898,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.020 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.020 } }
 			modify_treasury_effect = yes
 		}
 
@@ -4198,8 +4128,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_expand_e20"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.20 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { 881 = { infrastructure < 5 } }
@@ -4263,8 +4192,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_expand_e6"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.20 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { 35 = { infrastructure < 5 } }
@@ -4348,8 +4276,7 @@ focus_tree = {
 				start_state = 442
 				target_state = 442
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.1 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.1 } }
 			modify_treasury_effect = yes
 		}
 
@@ -4383,8 +4310,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_sodra_lanken"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.16 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.16 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { 34 = { infrastructure < 5 } }
@@ -4456,8 +4382,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_norra_lanken"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.16 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.16 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { 34 = { infrastructure < 5 } }
@@ -4572,8 +4497,7 @@ focus_tree = {
 				amount = 100
 				producer = SWE
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.1 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.1 } }
 			modify_treasury_effect = yes
 		}
 
@@ -9667,8 +9591,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_m_privatisation_state_property"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.043 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SWE_politics_modifier }
 			add_to_variable = { SWE_pol_consumer_goods_factor = -0.05 tooltip = consumer_goods_factor_tt }
@@ -11474,8 +11397,7 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					add_to_tech_sharing_group = SWE_Technologie_Exchange_groupe
-					set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.1 }
+					set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.1 } }
 					modify_international_investment_effect = yes
 				}
 			}
@@ -11905,8 +11827,7 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					add_to_tech_sharing_group = SWE_Technologie_Exchange_groupe
-					set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.1 }
+					set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.1 } }
 					modify_international_investment_effect = yes
 				}
 			}
@@ -12098,8 +12019,7 @@ focus_tree = {
 					set_temp_variable = { tag_index = SWE }
 					change_influence_percentage = yes
 				}
-				set_temp_variable = { int_investment_change = DEN.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.09 }
+				set_temp_variable = { int_investment_change = { value = DEN.gdp_per_capita multiply = 0.09 } }
 				modify_international_investment_effect = yes
 				set_temp_variable = { party_popularity_increase = 0.01 }
 				set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -12258,8 +12178,7 @@ focus_tree = {
 					set_temp_variable = { tag_index = SWE }
 					change_influence_percentage = yes
 				}
-				set_temp_variable = { int_investment_change = NRY.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.09 }
+				set_temp_variable = { int_investment_change = { value = NRY.gdp_per_capita multiply = 0.09 } }
 				modify_international_investment_effect = yes
 				set_temp_variable = { party_popularity_increase = 0.01 }
 				set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -12327,8 +12246,7 @@ focus_tree = {
 						set_temp_variable = { tag_index = SWE }
 						change_influence_percentage = yes
 					}
-					set_temp_variable = { int_investment_change = EST.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.09 }
+					set_temp_variable = { int_investment_change = { value = EST.gdp_per_capita multiply = 0.09 } }
 					modify_international_investment_effect = yes
 					set_temp_variable = { party_popularity_increase = 0.01 }
 					set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -12368,8 +12286,7 @@ focus_tree = {
 						set_temp_variable = { tag_index = SWE }
 						change_influence_percentage = yes
 					}
-					set_temp_variable = { int_investment_change = LAT.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.09 }
+					set_temp_variable = { int_investment_change = { value = LAT.gdp_per_capita multiply = 0.09 } }
 					modify_international_investment_effect = yes
 					set_temp_variable = { party_popularity_increase = 0.01 }
 					set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -12409,8 +12326,7 @@ focus_tree = {
 						set_temp_variable = { tag_index = SWE }
 						change_influence_percentage = yes
 					}
-					set_temp_variable = { int_investment_change = LIT.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.09 }
+					set_temp_variable = { int_investment_change = { value = LIT.gdp_per_capita multiply = 0.09 } }
 					modify_international_investment_effect = yes
 					set_temp_variable = { party_popularity_increase = 0.01 }
 					set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -12454,11 +12370,9 @@ focus_tree = {
 				effect_tooltip = {
 					EST = {
 						add_ideas = SWE_idea_swedish_banking
-						set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-						multiply_temp_variable = { int_investment_change = 0.23 }
+						set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.23 } }
 						modify_international_investment_effect = yes
-						set_temp_variable = { debt_change = SWE.gdp_per_capita }
-						multiply_temp_variable = { debt_change = 0.20 }
+						set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.20 } }
 						modify_debt_effect = yes
 						set_temp_variable = { percent_change = 5 }
 						set_temp_variable = { tag_index = SWE }
@@ -12479,11 +12393,9 @@ focus_tree = {
 				effect_tooltip = {
 					LAT = {
 						add_ideas = SWE_idea_swedish_banking
-						set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-						multiply_temp_variable = { int_investment_change = 0.23 }
+						set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.23 } }
 						modify_international_investment_effect = yes
-						set_temp_variable = { debt_change = SWE.gdp_per_capita }
-						multiply_temp_variable = { debt_change = 0.20 }
+						set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.20 } }
 						modify_debt_effect = yes
 						set_temp_variable = { percent_change = 5 }
 						set_temp_variable = { tag_index = SWE }
@@ -12504,11 +12416,9 @@ focus_tree = {
 				effect_tooltip = {
 					LIT = {
 						add_ideas = SWE_idea_swedish_banking
-						set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-						multiply_temp_variable = { int_investment_change = 0.23 }
+						set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.23 } }
 						modify_international_investment_effect = yes
-						set_temp_variable = { debt_change = SWE.gdp_per_capita }
-						multiply_temp_variable = { debt_change = 0.20 }
+						set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.20 } }
 						modify_debt_effect = yes
 						set_temp_variable = { percent_change = 5 }
 						set_temp_variable = { tag_index = SWE }
@@ -12672,8 +12582,7 @@ focus_tree = {
 					set_temp_variable = { tag_index = SWE }
 					change_influence_percentage = yes
 				}
-				set_temp_variable = { int_investment_change = FIN.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.09 }
+				set_temp_variable = { int_investment_change = { value = FIN.gdp_per_capita multiply = 0.09 } }
 				modify_international_investment_effect = yes
 				set_temp_variable = { party_popularity_increase = 0.01 }
 				set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -12712,11 +12621,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_found_nordbanken"
 			SWE = {
 				add_ideas = SWE_idea_nordbanken
-				set_temp_variable = { int_investment_change = SWE.gdp_per_capita }
-					multiply_temp_variable = { int_investment_change = 0.34 }
+				set_temp_variable = { int_investment_change = { value = SWE.gdp_per_capita multiply = 0.34 } }
 					modify_international_investment_effect = yes
-					set_temp_variable = { debt_change = SWE.gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.31 }
+					set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.31 } }
 					modify_debt_effect = yes
 			}
 			every_other_country = {
@@ -12727,8 +12634,7 @@ focus_tree = {
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					add_ideas = SWE_idea_nordbanken
-					set_temp_variable = { debt_change = SWE.gdp_per_capita }
-					multiply_temp_variable = { debt_change = 0.10 }
+					set_temp_variable = { debt_change = { value = SWE.gdp_per_capita multiply = 0.10 } }
 					modify_debt_effect = yes
 				}
 			}
@@ -12933,8 +12839,7 @@ focus_tree = {
 					set_temp_variable = { tag_index = SWE }
 					change_influence_percentage = yes
 				}
-				set_temp_variable = { int_investment_change = ICE.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.09 }
+				set_temp_variable = { int_investment_change = { value = ICE.gdp_per_capita multiply = 0.09 } }
 				modify_international_investment_effect = yes
 				set_temp_variable = { party_popularity_increase = 0.01 }
 				set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -13167,8 +13072,7 @@ focus_tree = {
 					}
 					add_political_power = -50
 					add_command_power = -20
-					set_temp_variable = { treasury_change = gdp_per_capita }
-					multiply_temp_variable = { treasury_change = -0.20 }
+					set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.20 } }
 					modify_treasury_effect = yes
 				}
 			}
@@ -14020,8 +13924,7 @@ focus_tree = {
 				idea = SWE_energy_autarky_program_idea
 				years = 2
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.10 } }
 			modify_treasury_effect = yes
 		}
 
@@ -18843,8 +18746,7 @@ focus_tree = {
 					set_temp_variable = { tag_index = SWE }
 					change_influence_percentage = yes
 					SWE = {
-						set_temp_variable = { int_investment_change = PREV.gdp_per_capita }
-						multiply_temp_variable = { int_investment_change = 0.09 }
+						set_temp_variable = { int_investment_change = { value = PREV.gdp_per_capita multiply = 0.09 } }
 						modify_international_investment_effect = yes
 						set_temp_variable = { party_popularity_increase = 0.01 }
 						set_temp_variable = { temp_outlook_increase = 0.01 }

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -98,8 +98,7 @@ focus_tree = {
 			subtract_from_temp_variable = { stability_loss = max_leader }
 			multiply_temp_variable = { stability_loss = 0.01 }
 			add_stability = stability_loss
-			set_temp_variable = { leader_popularity = bushra_popularity }
-			multiply_temp_variable = { leader_popularity = 0.005 }
+			set_temp_variable = { leader_popularity = { value = bushra_popularity multiply = 0.005 } }
 			set_temp_variable = { party_index = 15 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
@@ -466,8 +465,7 @@ focus_tree = {
 			subtract_from_temp_variable = { stability_loss = max_leader }
 			multiply_temp_variable = { stability_loss = 0.01 }
 			add_stability = stability_loss
-			set_temp_variable = { leader_popularity = bashar_popularity }
-			multiply_temp_variable = { leader_popularity = 0.005 }
+			set_temp_variable = { leader_popularity = { value = bashar_popularity multiply = 0.005 } }
 			set_temp_variable = { party_index = 7 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
@@ -793,8 +791,7 @@ focus_tree = {
 			subtract_from_temp_variable = { stability_loss = max_leader }
 			multiply_temp_variable = { stability_loss = 0.01 }
 			add_stability = stability_loss
-			set_temp_variable = { leader_popularity = maher_popularity }
-			multiply_temp_variable = { leader_popularity = 0.005 }
+			set_temp_variable = { leader_popularity = { value = maher_popularity multiply = 0.005 } }
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
@@ -1342,59 +1339,46 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_reestablish_political_parties"
 			custom_effect_tooltip = TT_RESHUFFLE_PARTIES
 			hidden_effect = {
-				set_temp_variable = { western_popularity = random }
-				multiply_temp_variable = { western_popularity = 0.20 }
-				set_temp_variable = { emerging_popularity = random }
-				multiply_temp_variable = { emerging_popularity = 0.20 }
-				set_temp_variable = { salafist_popularity = random }
-				multiply_temp_variable = { salafist_popularity = 0.10 }
-				set_temp_variable = { neutrality_popularity = random }
-				multiply_temp_variable = { neutrality_popularity = 0.20 }
-				set_temp_variable = { nationalist_popularity = random }
-				multiply_temp_variable = { nationalist_popularity = 0.10 }
+				set_temp_variable = { western_popularity = { value = random multiply = 0.20 } }
+				set_temp_variable = { emerging_popularity = { value = random multiply = 0.20 } }
+				set_temp_variable = { salafist_popularity = { value = random multiply = 0.10 } }
+				set_temp_variable = { neutrality_popularity = { value = random multiply = 0.20 } }
+				set_temp_variable = { nationalist_popularity = { value = random multiply = 0.10 } }
 				add_popularity = { ideology = democratic popularity = western_popularity }
 				add_popularity = { ideology = communism popularity = emerging_popularity }
 				add_popularity = { ideology = fascism popularity = salafist_popularity }
 				add_popularity = { ideology = neutrality popularity = neutrality_popularity }
 				add_popularity = { ideology = nationalist popularity = nationalist_popularity }
 				set_temp_variable = { party_popularity_increase = 0.10 }
-				set_temp_variable = { party_1 = random }
-				multiply_temp_variable = { party_1 = 23 }
+				set_temp_variable = { party_1 = { value = random multiply = 23 } }
 				round_variable = party_1
 				set_temp_variable = { party_index = party_1 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_2 = random }
-				multiply_temp_variable = { party_2 = 23 }
+				set_temp_variable = { party_2 = { value = random multiply = 23 } }
 				round_variable = party_2
 				set_temp_variable = { party_index = party_2 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_3 = random }
-				multiply_temp_variable = { party_3 = 23 }
+				set_temp_variable = { party_3 = { value = random multiply = 23 } }
 				round_variable = party_3
 				set_temp_variable = { party_index = party_3 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_4 = random }
-				multiply_temp_variable = { party_4 = 23 }
+				set_temp_variable = { party_4 = { value = random multiply = 23 } }
 				round_variable = party_4
 				set_temp_variable = { party_index = party_4 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_5 = random }
-				multiply_temp_variable = { party_5 = 23 }
+				set_temp_variable = { party_5 = { value = random multiply = 23 } }
 				round_variable = party_5
 				set_temp_variable = { party_index = party_5 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_6 = random }
-				multiply_temp_variable = { party_6 = 23 }
+				set_temp_variable = { party_6 = { value = random multiply = 23 } }
 				round_variable = party_6
 				set_temp_variable = { party_index = party_6 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_7 = random }
-				multiply_temp_variable = { party_7 = 23 }
+				set_temp_variable = { party_7 = { value = random multiply = 23 } }
 				round_variable = party_7
 				set_temp_variable = { party_index = party_7 }
 				change_relative_party_popularity = yes
-				set_temp_variable = { party_8 = random }
-				multiply_temp_variable = { party_8 = 23 }
+				set_temp_variable = { party_8 = { value = random multiply = 23 } }
 				round_variable = party_8
 				set_temp_variable = { party_index = party_8 }
 				change_relative_party_popularity = yes
@@ -10256,8 +10240,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_assault_jordan"
 		custom_effect_tooltip = TT_SYR_ASSAULT_JORDAN
-		set_temp_variable = { success_chance = JOR.party_popularity@nationalist }
-		multiply_temp_variable = { success_chance = 200 }
+		set_temp_variable = { success_chance = { value = JOR.party_popularity@nationalist multiply = 200 } }
 		clamp_temp_variable = {
 			var = success_chance
 			min = 0
@@ -10265,8 +10248,7 @@ shared_focus = {
 		}
 		set_temp_variable = { remaining_chance = 100 }
 		subtract_from_temp_variable = { remaining_chance = success_chance }
-		set_temp_variable = { civil_war_chance = remaining_chance }
-		multiply_temp_variable = { civil_war_chance = 0.5 }
+		set_temp_variable = { civil_war_chance = { value = remaining_chance multiply = 0.5 } }
 		clamp_temp_variable = {
 			var = civil_war_chance
 			min = 0

--- a/common/national_focus/05_tatarstan.txt
+++ b/common/national_focus/05_tatarstan.txt
@@ -2178,11 +2178,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_weaken_the_banks"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 			one_random_fossil_fuel_powerplant = yes
 			random_owned_controlled_state = {
@@ -4282,11 +4280,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TAT_alabuga_invest"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
 		}
 

--- a/common/national_focus/05_thailand.txt
+++ b/common/national_focus/05_thailand.txt
@@ -14043,8 +14043,7 @@ focus_tree = {
 			add_to_variable = { SIA_econ_return_on_investment_modifier = 0.03 tooltip = return_on_investment_modifier_tt }
 			add_to_variable = { SIA_econ_internal_investments_money_cost_modifier = -0.05 tooltip = internal_investments_money_cost_modifier_tt }
 			add_to_variable = { SIA_econ_stability_factor = -0.05 tooltip = stability_factor_tt }
-			set_temp_variable = { int_investment_change = gdp_per_capita }
-			multiply_temp_variable = { int_investment_change = 0.20 }
+			set_temp_variable = { int_investment_change = { value = gdp_per_capita multiply = 0.20 } }
 			modify_international_investment_effect = yes
 			if = {
 				limit = { has_idea = international_bankers }

--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -16739,8 +16739,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_harmony_doctrine_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -16816,8 +16815,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_climate_alarm_bell_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -16898,8 +16896,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_duchy_originals_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -16998,8 +16995,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_heir_of_the_realm_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_4 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_4 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17190,8 +17186,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_appoint_trade_representative_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17267,8 +17262,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_emerging_markets_circuit_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_2 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_2 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17342,8 +17336,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_digital_enterprise_patronage_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17416,8 +17409,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_duty_of_the_crown_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_4 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_4 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17662,8 +17654,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_carers_recognition_campaign_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17722,8 +17713,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_discipline_service_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_2 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_2 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17823,8 +17813,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_princess_admiral_royal_navy_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17910,8 +17899,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_colonel_of_horse_logistics_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -17975,8 +17963,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_quiet_professionalism_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_4 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_4 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18199,8 +18186,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_trustee_network_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18271,8 +18257,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_commonwealth_youth_outreach_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_2 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_2 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18343,8 +18328,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_production_guild_patronage_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18439,8 +18423,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_steady_hand_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_4 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_4 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18690,8 +18673,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_international_award_conference_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18757,8 +18739,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_wwf_president_emeritus_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_2 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_2 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18830,8 +18811,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_prince_phillip_medal_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -18909,8 +18889,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_strength_and_stay_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_4 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_4 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -19121,8 +19100,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_royal_foundation_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_1 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_1 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -19204,8 +19182,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_heads_together_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_2 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_2 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -19279,8 +19256,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_veteran_armed_forces_support_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_3 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_3 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -19352,8 +19328,7 @@ focus_tree = {
 				limit = {
 					has_country_flag = ENG_bridge_to_the_future_in_progress_flag
 				}
-				set_temp_variable = { temp_focus_days = @inner_circle_time_tier_4 } #For tooltip purposes
-				multiply_temp_variable = { temp_focus_days = 7 } #The constant uses focus cost which is in weeks, so convert to days
+				set_temp_variable = { temp_focus_days = { value = @inner_circle_time_tier_4 multiply = 7 } } #The constant uses focus cost which is in weeks, so convert to days
 				custom_override_tooltip = {
 					tooltip = {
 						localization_key = ENG_inner_circle_focus_in_progress_tt
@@ -20133,8 +20108,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus ENG_two_way_concessions"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.03 } }
 			modify_treasury_effect = yes
 			newline = yes
 			SCO = {

--- a/common/national_focus/05_venezuela.txt
+++ b/common/national_focus/05_venezuela.txt
@@ -5432,8 +5432,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_bolivarian_missions"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.10 } }
 			clamp_temp_variable = {
 				var = treasury_change
 				min = 0
@@ -8209,9 +8208,7 @@ focus_tree = {
 			change_fossil_fuel_industry_opinion = yes
 			change_oligarchs_opinion = yes
 			add_ideas = VEN_iron_control_vdp
-			set_temp_variable = { additional_income_change = gdp_total }
-			multiply_temp_variable = { additional_income_change = 0.10 } #5% of GDP yearly
-			multiply_temp_variable = { additional_income_change = 0.02 } #weekly
+			set_temp_variable = { additional_income_change = { value = gdp_total multiply = 0.10 multiply = 0.02 } } #5% of GDP yearly #weekly
 			custom_effect_tooltip = additional_income_rate_percent_tt
 		}
 
@@ -8590,11 +8587,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus VEN_council_of_international_corporations"
 			set_temp_variable = { temp_opinion = 10 }
 			change_fossil_fuel_industry_opinion = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.10 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.10 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -2 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -2 } }
 			modify_international_investment_effect = yes
 		}
 

--- a/common/national_focus/06_AfricanUnion_shared.txt
+++ b/common/national_focus/06_AfricanUnion_shared.txt
@@ -110,8 +110,7 @@ shared_focus = {
 		custom_effect_tooltip = AFRICAN_UNION_shared_focus_create_investment_bank_2_tt
 		newline = yes
 		#For the originator
-		set_temp_variable = { treasury_change = gdp_total }
-		multiply_temp_variable = { treasury_change = -0.1 }
+		set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.1 } }
 		modify_treasury_effect = yes
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = african_union_reforms_modifier }
 		set_temp_variable = { african_union_return_on_investment_modifier_temp = 0.03 }
@@ -186,8 +185,7 @@ shared_focus = {
 		unlock_decision_tooltip = bankruptcy_seek_bailout_from_african_monetary_fund
 		newline = yes
 		#For the originator
-		set_temp_variable = { treasury_change = gdp_total }
-		multiply_temp_variable = { treasury_change = -0.1 }
+		set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.1 } }
 		modify_treasury_effect = yes
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = african_union_reforms_modifier }
 		set_temp_variable = { african_union_interest_rate_multiplier_modifier_temp = -2 }
@@ -612,8 +610,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus AFRICAN_UNION_shared_focus_create_central_bank"
 		clr_global_flag = AU_create_central_bank_reserved
 		#For the originator
-		set_temp_variable = { treasury_change = gdp_total }
-		multiply_temp_variable = { treasury_change = -0.1 }
+		set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.1 } }
 		modify_treasury_effect = yes
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = african_union_reforms_modifier }
 		set_temp_variable = { african_union_productivity_growth_modifier_temp = 3 }
@@ -1642,8 +1639,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus AFRICAN_UNION_shared_focus_hq_in_our_country"
 		clr_global_flag = AU_headquarters_reserved
 		#For the originator
-		set_temp_variable = { treasury_change = gdp_total }
-		multiply_temp_variable = { treasury_change = -0.2 }
+		set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.2 } }
 		modify_treasury_effect = yes
 		capital_scope = {
 			add_dynamic_modifier = {

--- a/common/national_focus/centralasia.txt
+++ b/common/national_focus/centralasia.txt
@@ -3607,8 +3607,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CES_debt_reafctoring"
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = 0.05 }
+			set_temp_variable = { debt_change = { value = debt multiply = 0.05 } }
 			clamp_temp_variable = { var = debt_change min = 0 max = 100 }
 			modify_debt_effect = yes
 			add_timed_idea = {

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -139,8 +139,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_small_arms"
 			add_ideas = DEN_idea_streamline_infantry_production
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.035 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.035 } }
 			modify_treasury_effect = yes
 		}
 
@@ -201,8 +200,7 @@ focus_tree = {
 				amount = 3000
 				producer = GER
 			}
-			set_temp_variable = { treasury_change = GER.gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.17 }
+			set_temp_variable = { treasury_change = { value = GER.gdp_per_capita multiply = -0.17 } }
 			modify_treasury_effect = yes
 		}
 
@@ -263,8 +261,7 @@ focus_tree = {
 				amount = 3000
 				producer = CAN
 			}
-			set_temp_variable = { treasury_change = CAN.gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.17 }
+			set_temp_variable = { treasury_change = { value = CAN.gdp_per_capita multiply = -0.17 } }
 			modify_treasury_effect = yes
 		}
 
@@ -323,8 +320,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.018 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.018 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = DEN_streamline_infantry_production
@@ -373,8 +369,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_inf_wep
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.012 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.012 } }
 			modify_treasury_effect = yes
 		}
 
@@ -409,8 +404,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_inf_wep
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.012 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.012 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_terrain_penalty_reduction = 0.03 tooltip = terrain_penalty_reduction_tt }
@@ -525,8 +519,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_CV"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = SWE.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.17 }
+			set_temp_variable = { treasury_change = { value = SWE.gdp_per_capita multiply = -0.17 } }
 				modify_treasury_effect = yes
 			add_equipment_to_stockpile = {
 				type = medium_tank_flame_chassis_2
@@ -592,8 +585,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_US_Made"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.18 }
+			set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.18 } }
 				modify_treasury_effect = yes
 			add_equipment_to_stockpile = {
 				type = medium_tank_flame_chassis_1
@@ -654,8 +646,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Marder"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = GER.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.18 }
+			set_temp_variable = { treasury_change = { value = GER.gdp_per_capita multiply = -0.18 } }
 				modify_treasury_effect = yes
 			add_equipment_to_stockpile = {
 				type = medium_tank_flame_chassis_1
@@ -704,8 +695,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_afv
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.031 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.031 } }
 			modify_treasury_effect = yes
 		}
 
@@ -744,8 +734,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_ifv
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.035 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.035 } }
 			modify_treasury_effect = yes
 		}
 
@@ -800,8 +789,7 @@ focus_tree = {
 				}
 				icon = "GFX_GER_MBT_4"
 			}
-			set_temp_variable = { treasury_change = GER.gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.18 }
+			set_temp_variable = { treasury_change = { value = GER.gdp_per_capita multiply = -0.18 } }
 			modify_treasury_effect = yes
 		}
 
@@ -867,8 +855,7 @@ focus_tree = {
 				amount = 60
 				producer = USA
 			}
-			set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.28 }
+			set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.28 } }
 				modify_treasury_effect = yes
 			DEN = { add_opinion_modifier = { target = USA modifier = military_deals }
 			}
@@ -927,8 +914,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_mbt
 			}
-			set_temp_variable = { treasury_change = GER.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.28 }
+			set_temp_variable = { treasury_change = { value = GER.gdp_per_capita multiply = -0.28 } }
 				modify_treasury_effect = yes
 			create_equipment_variant = {
 				name = "Leopard 2A7"
@@ -1009,8 +995,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Challenger"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = ENG.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.28 }
+			set_temp_variable = { treasury_change = { value = ENG.gdp_per_capita multiply = -0.28 } }
 				modify_treasury_effect = yes
 				add_tech_bonus = {
 					name = DEN_Challenger
@@ -1119,8 +1104,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_artillery
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.28 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.28 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1180,8 +1164,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_US_Artillerie"
 			mark_focus_tree_layout_dirty = yes
-				set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+				set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 				add_equipment_to_stockpile = {
 					type = artillery_1
@@ -1241,8 +1224,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_domestic_Artillerie"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.012 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.012 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = DEN_domestic_Artillerie
@@ -1304,8 +1286,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_French_Artillerie"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = FRA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.20 }
+			set_temp_variable = { treasury_change = { value = FRA.gdp_per_capita multiply = -0.20 } }
 				modify_treasury_effect = yes
 			add_equipment_to_stockpile = {
 				type = artillery_1
@@ -1359,8 +1340,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_l_at
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.028 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.028 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1406,8 +1386,7 @@ focus_tree = {
 				category = CAT_l_aa
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.031 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.031 } }
 			modify_treasury_effect = yes
 		}
 
@@ -1446,8 +1425,7 @@ focus_tree = {
 				category = CAT_artillery
 			}
 			army_experience = 50
-			set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.13 }
+			set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.13 } }
 				modify_treasury_effect = yes
 		}
 
@@ -1507,8 +1485,7 @@ focus_tree = {
 				amount = 36
 				producer = FRA
 			}
-			set_temp_variable = { treasury_change = FRA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.30 }
+			set_temp_variable = { treasury_change = { value = FRA.gdp_per_capita multiply = -0.30 } }
 				modify_treasury_effect = yes
 			GER = { add_opinion_modifier = { target = FRA modifier = military_deals }
 			}
@@ -1566,8 +1543,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Panzerhaubitze_2000"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = DER.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.30 }
+			set_temp_variable = { treasury_change = { value = DER.gdp_per_capita multiply = -0.30 } }
 				modify_treasury_effect = yes
 			add_equipment_to_stockpile = {
 				type = medium_tank_artillery_chassis_2
@@ -1626,8 +1602,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_SPA"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.035 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.035 } }
 			modify_treasury_effect = yes
 			army_experience = 100
 			add_tech_bonus = {
@@ -1777,8 +1752,7 @@ focus_tree = {
 				amount = -2500
 				producer = DEN
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = 0.18 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = 0.18 } }
 				modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_equipment_cost_multiplier_modifier = 0.03 tooltip = equipment_cost_multiplier_modifier_tt }
@@ -1898,8 +1872,7 @@ focus_tree = {
 				category = CAT_special_forces
 				uses = 1
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.03 } }
 				modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_army_dynamic_modifier }
 			add_to_variable = { DEN_recon_factor = 0.03 tooltip = recon_factor_tt }
@@ -1949,8 +1922,7 @@ focus_tree = {
 				category = CAT_special_forces
 				uses = 2
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.26 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.26 } }
 				modify_treasury_effect = yes
 		}
 
@@ -2156,8 +2128,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_establish_OPLOG_KOR"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			4 = {
 				add_extra_state_shared_building_slots = 1
@@ -2203,8 +2174,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_establish_OPLOG_FRH"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 			4 = {
 				add_extra_state_shared_building_slots = 1
@@ -2290,8 +2260,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Submarine_focus"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.028 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.028 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = DEN_Submarine_focus
@@ -2331,8 +2300,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_attack_submarines"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.032 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.032 } }
 			modify_treasury_effect = yes
 			set_technology = { attack_submarine_hull_3 = 1 }
 			create_equipment_variant = {
@@ -2383,8 +2351,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Rocket_subs"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.031 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.031 } }
 			modify_treasury_effect = yes
 			set_technology = { missile_submarine_hull_3 = 1 }
 			create_equipment_variant = {
@@ -2444,8 +2411,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_modular_focus"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.028 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.028 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = DEN_modular_focus
@@ -2485,8 +2451,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Fregatte"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.025 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.025 } }
 			modify_treasury_effect = yes
 			create_equipment_variant = {
 				name = "Absalon Class"
@@ -2537,8 +2502,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_corvettes"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.020 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.020 } }
 			modify_treasury_effect = yes
 			set_technology = { corvette_hull_4 = 1 }
 			create_equipment_variant = {
@@ -2729,8 +2693,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_the_Eurocopter"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = FRA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.26 }
+			set_temp_variable = { treasury_change = { value = FRA.gdp_per_capita multiply = -0.26 } }
 				modify_treasury_effect = yes
 			if = {
 				limit = { has_dlc = "By Blood Alone" }
@@ -2810,8 +2773,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Apache"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.26 }
+			set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.26 } }
 				modify_treasury_effect = yes
 			if = {
 				limit = { has_dlc = "By Blood Alone" }
@@ -2863,8 +2825,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Helicopter_training"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.012 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.012 } }
 			modify_treasury_effect = yes
 			army_experience = 50
 			add_doctrine_cost_reduction = {
@@ -3166,8 +3127,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Eurofighter"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = ENG.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.32 }
+			set_temp_variable = { treasury_change = { value = ENG.gdp_per_capita multiply = -0.32 } }
 				modify_treasury_effect = yes
 			if = {
 				limit = { has_dlc = "By Blood Alone" }
@@ -3241,8 +3201,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Update_F16"
 			mark_focus_tree_layout_dirty = yes
-			set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.26 }
+			set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.26 } }
 				modify_treasury_effect = yes
 			if = {
 				limit = { has_dlc = "By Blood Alone" }
@@ -3379,8 +3338,7 @@ focus_tree = {
 		}
 			USA = { add_opinion_modifier = { target = DEN modifier = military_cooperation }
 		}
-		set_temp_variable = { treasury_change = USA.gdp_per_capita }
-		multiply_temp_variable = { treasury_change = -0.31 }
+		set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.31 } }
 		modify_treasury_effect = yes
 		}
 
@@ -3502,8 +3460,7 @@ focus_tree = {
 			SPR = { add_opinion_modifier = { target = DEN modifier = military_cooperation }
 			}
 			newline = yes
-				set_temp_variable = { treasury_change = ENG.gdp_per_capita }
-					multiply_temp_variable = { treasury_change = -0.27 }
+				set_temp_variable = { treasury_change = { value = ENG.gdp_per_capita multiply = -0.27 } }
 					modify_treasury_effect = yes
 		}
 
@@ -3581,8 +3538,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Skrydstrup_air_base"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.006 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.006 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = {
@@ -3634,8 +3590,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Skalstrup_air_base"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.007 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.007 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = {
@@ -3701,8 +3656,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.007 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.007 } }
 			modify_treasury_effect = yes
 		}
 
@@ -4586,8 +4540,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_special_municipal_districts"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.06 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.06 } }
 			modify_treasury_effect = yes
 			if = { limit = { has_idea = social_01 }
 				swap_ideas = {
@@ -4649,8 +4602,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_direct_governance"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.06 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.06 } }
 			modify_treasury_effect = yes
 			remove_ideas = DEN_special_municipal_districts_idea
 			add_ideas = DEN_direct_governance_idea
@@ -4742,8 +4694,7 @@ focus_tree = {
 						days = 365
 					}
 				}
-				set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.002 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.002 } }
 			modify_treasury_effect = yes
 			}
 			if = {
@@ -4760,8 +4711,7 @@ focus_tree = {
 						days = 365
 					}
 				}
-				set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.002 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.002 } }
 			modify_treasury_effect = yes
 			}
 			modify_treasury_effect = yes
@@ -4805,8 +4755,7 @@ focus_tree = {
 				amount = 25
 				state = 1161
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
 			if = { limit = { GRN = { is_subject_of = DEN } }
 				reverse_add_opinion_modifier = {
@@ -4849,8 +4798,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_industrialize_greenland"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.032 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.032 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { 1161 = { infrastructure < 5 } }
@@ -4918,8 +4866,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_faroese_naval_infrastructure"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.024 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.024 } }
 			modify_treasury_effect = yes
 			if = {
 				limit = { 2 = { infrastructure < 5 } }
@@ -4986,8 +4933,7 @@ focus_tree = {
 				amount = 8
 				state = 2
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.042 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.042 } }
 			modify_treasury_effect = yes
 			if = { limit = { FAO = { is_subject_of = DEN } }
 				reverse_add_opinion_modifier = {
@@ -5221,8 +5167,7 @@ focus_tree = {
 					amount = 8
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.036 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.036 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5304,8 +5249,7 @@ focus_tree = {
 					amount = 8
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.042 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.042 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5410,8 +5354,7 @@ focus_tree = {
 					amount = 3
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.041 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.041 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5454,8 +5397,7 @@ focus_tree = {
 					amount = 8
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.029 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.029 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5603,8 +5545,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_urban_improvement_fund"
 			unlock_decision_category_tooltip = DEN_urban_development_fund_category
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.31 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.31 } }
 				modify_treasury_effect = yes
 			set_temp_variable = { temp_change = 10 }
 			modify_urban_development_fund_effect = yes
@@ -5654,8 +5595,7 @@ focus_tree = {
 					level = 1
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.051 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.051 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_international_bankers_opinion = yes
@@ -5714,8 +5654,7 @@ focus_tree = {
 					level = 1
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.043 } }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_international_bankers_opinion = yes
@@ -5772,8 +5711,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.049 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.049 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5825,8 +5763,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.044 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.044 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5879,8 +5816,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.043 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.043 } }
 			modify_treasury_effect = yes
 		}
 
@@ -5930,8 +5866,7 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.028 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.028 } }
 			modify_treasury_effect = yes
 			}
 			else = {
@@ -7386,8 +7321,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = USA.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.22 }
+			set_temp_variable = { treasury_change = { value = USA.gdp_per_capita multiply = -0.22 } }
 				modify_treasury_effect = yes
 		}
 
@@ -7439,8 +7373,7 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = { treasury_change = CAN.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+			set_temp_variable = { treasury_change = { value = CAN.gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9236,59 +9169,46 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Expand_logistic_Companies"
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.01 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 				modify_treasury_effect = yes
-				set_temp_variable = { int_investment_change = CHI.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = CHI.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = CHI.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = CHI.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
-				set_temp_variable = { int_investment_change = HKG.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = HKG.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = HKG.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = HKG.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
-				set_temp_variable = { int_investment_change = JAP.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = JAP.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = JAP.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = JAP.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
-				set_temp_variable = { int_investment_change = IND.gdp_per_capita }
-				multiply_temp_variable = { int_investment_change = 0.03 }
+				set_temp_variable = { int_investment_change = { value = IND.gdp_per_capita multiply = 0.03 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = IND.gdp_per_capita }
-				multiply_temp_variable = { debt_change = 0.02 }
+				set_temp_variable = { debt_change = { value = IND.gdp_per_capita multiply = 0.02 } }
 				modify_debt_effect = yes
 			CHI = {
 				set_temp_variable = { percent_change = 1.2 }
 					change_influence_percentage = yes
-				set_temp_variable = { treasury_change = DEN.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = 0.01 }
+				set_temp_variable = { treasury_change = { value = DEN.gdp_per_capita multiply = 0.01 } }
 				modify_treasury_effect = yes
 			}
 			HKG = {
 				set_temp_variable = { percent_change = 1.2 }
 					change_influence_percentage = yes
-				set_temp_variable = { treasury_change = DEN.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = 0.01 }
+				set_temp_variable = { treasury_change = { value = DEN.gdp_per_capita multiply = 0.01 } }
 				modify_treasury_effect = yes
 			}
 			JAP = {
 				set_temp_variable = { percent_change = 1.2 }
 					change_influence_percentage = yes
-				set_temp_variable = { treasury_change = DEN.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = 0.01 }
+				set_temp_variable = { treasury_change = { value = DEN.gdp_per_capita multiply = 0.01 } }
 				modify_treasury_effect = yes
 			}
 			IND = {
 				set_temp_variable = { percent_change = 1.2 }
 					change_influence_percentage = yes
-				set_temp_variable = { treasury_change = DEN.gdp_per_capita }
-				multiply_temp_variable = { treasury_change = 0.01 }
+				set_temp_variable = { treasury_change = { value = DEN.gdp_per_capita multiply = 0.01 } }
 				modify_treasury_effect = yes
 			}
 		}
@@ -9327,8 +9247,7 @@ focus_tree = {
 				category = CAT_computing_tech
 				uses = 2
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9374,8 +9293,7 @@ focus_tree = {
 				uses = 3
 			}
 			add_ideas = scientific_advances
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.31 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.31 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9422,8 +9340,7 @@ focus_tree = {
 				remove_idea = scientific_advances
 				add_idea = scientific_advances2
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.41 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.41 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9467,8 +9384,7 @@ focus_tree = {
 				}
 			}
 			add_ideas = DEN_idea_schultz_larsen
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9512,8 +9428,7 @@ focus_tree = {
 				}
 			}
 			add_ideas = DEN_idea_DISA
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9586,14 +9501,11 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_construction_industrie"
 			two_random_industrial_complex = yes
-			set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 				modify_treasury_effect = yes
-				set_temp_variable = { int_investment_change = gdp_total }
-				multiply_temp_variable = { int_investment_change = 0.012 }
+				set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.012 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = gdp_total }
-				multiply_temp_variable = { debt_change = 0.008 }
+				set_temp_variable = { debt_change = { value = gdp_total multiply = 0.008 } }
 				modify_debt_effect = yes
 		}
 
@@ -9636,8 +9548,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 		}
 
@@ -9685,8 +9596,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.23 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.23 } }
 				modify_treasury_effect = yes
 		}
 
@@ -10063,8 +9973,7 @@ focus_tree = {
 				idea = DEN_Political_Capital_Injection
 				days = 360
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 		}
 
@@ -11764,8 +11673,7 @@ focus_tree = {
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_Culture_modifier }
 			add_to_variable = { DEN_Culture_country_productivity_growth_modifier = 0.06 tooltip = country_productivity_growth_modifier_tt }
 			add_to_variable = { DEN_Culture_conversion_cost_civ_to_mil_factor = 0.03 tooltip = conversion_cost_civ_to_mil_factor_tt }
-				set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.21 }
+				set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.21 } }
 				modify_treasury_effect = yes
 		}
 
@@ -11824,8 +11732,7 @@ focus_tree = {
 					instant_build = yes
 					}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.17 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.17 } }
 				modify_treasury_effect = yes
 		}
 
@@ -13841,8 +13748,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_explore_digital_possibilitys"
 			add_ideas = DEN_idea_den_education_reform1
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.003 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.003 } }
 			modify_treasury_effect = yes
 		}
 
@@ -13913,8 +13819,7 @@ focus_tree = {
 				remove_idea = DEN_idea_den_education_reform1
 				add_idea = DEN_idea_den_education_reform2
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.0019 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.0019 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_the_State }
 			add_to_variable = { DEN_bureaucracy_cost_multiplier_modifier_var = 0.05 tooltip = bureaucracy_cost_multiplier_modifier_tt }
@@ -13949,8 +13854,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_mobile_broadband"
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.13 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.13 } }
 				modify_treasury_effect = yes
 			if = {
 				limit = { controls_state = 3 }
@@ -14262,8 +14166,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Energinet_dk"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.018 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.018 } }
 			modify_treasury_effect = yes
 			6 = {
 				add_extra_state_shared_building_slots = 1
@@ -14303,8 +14206,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Naviair"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.052 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.052 } }
 			modify_treasury_effect = yes
 			6 = {
 				add_building_construction = {
@@ -14343,8 +14245,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Danske_Statsbaner"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.03 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.03 } }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = DEN_Danske_Statsbaner
@@ -14385,8 +14286,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_form_Postnord"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.023 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.023 } }
 			modify_treasury_effect = yes
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_the_State }
 		add_to_variable = { DEN_offices_contruction_speed = 0.03 tooltip = production_speed_offices_factor_tt }
@@ -14424,8 +14324,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Finansiel_Stabilitet"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = 0.027 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.027 } }
 			modify_treasury_effect = yes
 			add_ideas = DEN_Finansiel_Stabilitet
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_the_State }
@@ -14481,8 +14380,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Copenhagen_Metro"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.021 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.021 } }
 			modify_treasury_effect = yes
 			4 = {
 				add_building_construction = {
@@ -14531,8 +14429,7 @@ focus_tree = {
 				start_state = 4
 				target_state = 37
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.024 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.024 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_Industrial_modifier }
 			add_to_variable = { DEN_production_factory_efficiency_gain_factor = 0.03 tooltip = production_factory_efficiency_gain_factor_tt }
@@ -14573,8 +14470,7 @@ focus_tree = {
 			add_to_variable = { DEN_social_cost_multiplier_modifier_var = 0.025 tooltip = social_cost_multiplier_modifier_tt }
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_Industrial_modifier }
 			add_to_variable = { DEN_receiving_investment_cost_modifier = 0.03 tooltip = receiving_investment_cost_modifier_tt }
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.023 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.023 } }
 			modify_treasury_effect = yes
 		}
 
@@ -14632,8 +14528,7 @@ focus_tree = {
 					amount = 2
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-			multiply_temp_variable = { treasury_change = -0.42 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.42 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_Industrial_modifier }
 			add_to_variable = { DEN_tax_gain_multiplier_modifier = 0.015 tooltip = tax_gain_multiplier_modifier_tt }
@@ -14680,8 +14575,7 @@ focus_tree = {
 				}
 			}
 			increase_exports = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.027 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.027 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = DEN_Industrial_modifier }
 			add_to_variable = { DEN_tax_gain_multiplier_modifier = 0.01 tooltip = tax_gain_multiplier_modifier_tt }
@@ -14719,8 +14613,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_more_Imports"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.026 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.026 } }
 			modify_treasury_effect = yes
 			4 = {
 				add_resource = {
@@ -14740,8 +14633,7 @@ focus_tree = {
 					amount = 2
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.28 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.28 } }
 				modify_treasury_effect = yes
 		}
 
@@ -14780,8 +14672,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.024 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.024 } }
 			modify_treasury_effect = yes
 		}
 
@@ -15985,14 +15876,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Expand_DSV_Invests"
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.02 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 				modify_treasury_effect = yes
-				set_temp_variable = { int_investment_change = gdp_total }
-				multiply_temp_variable = { int_investment_change = 0.025 }
+				set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.025 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = gdp_total }
-				multiply_temp_variable = { debt_change = 0.01 }
+				set_temp_variable = { debt_change = { value = gdp_total multiply = 0.01 } }
 				modify_debt_effect = yes
 		}
 
@@ -16055,8 +15943,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = { treasury_change = gdp_per_capita }
-				multiply_temp_variable = { treasury_change = -0.19 }
+			set_temp_variable = { treasury_change = { value = gdp_per_capita multiply = -0.19 } }
 				modify_treasury_effect = yes
 		}
 
@@ -16089,14 +15976,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Carlsberg_invest"
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.016 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.016 } }
 				modify_treasury_effect = yes
-				set_temp_variable = { int_investment_change = gdp_total }
-				multiply_temp_variable = { int_investment_change = 0.025 }
+				set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.025 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = gdp_total }
-				multiply_temp_variable = { debt_change = 0.01 }
+				set_temp_variable = { debt_change = { value = gdp_total multiply = 0.01 } }
 				modify_debt_effect = yes
 		}
 
@@ -16152,11 +16036,9 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Logistic_Global_Investments"
 			unlock_decision_category_tooltip = DEN_decision_Investments_Global
 			unlock_decision_category_tooltip = DEN_decision_Investments_Global_II
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.01 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 				modify_treasury_effect = yes
-				set_temp_variable = { int_investment_change = gdp_total }
-				multiply_temp_variable = { int_investment_change = 0.02 }
+				set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.02 } }
 				modify_international_investment_effect = yes
 				custom_effect_tooltip = DEN_investment_decision_tt
 		}
@@ -16186,14 +16068,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus DEN_Expand_Maersk_investments"
-				set_temp_variable = { treasury_change = gdp_total }
-				multiply_temp_variable = { treasury_change = -0.02 }
+				set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.02 } }
 				modify_treasury_effect = yes
-				set_temp_variable = { int_investment_change = gdp_total }
-				multiply_temp_variable = { int_investment_change = 0.025 }
+				set_temp_variable = { int_investment_change = { value = gdp_total multiply = 0.025 } }
 				modify_international_investment_effect = yes
-				set_temp_variable = { debt_change = gdp_total }
-				multiply_temp_variable = { debt_change = 0.01 }
+				set_temp_variable = { debt_change = { value = gdp_total multiply = 0.01 } }
 				modify_debt_effect = yes
 		}
 

--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -1961,8 +1961,7 @@ focus_tree = {
 			}
 			else = { set_temp_variable = { treasury_change = 10 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { additional_income_change = gdp_total }
-			multiply_temp_variable = { additional_income_change = 0.0003 }
+			set_temp_variable = { additional_income_change = { value = gdp_total multiply = 0.0003 } }
 			custom_effect_tooltip = additional_income_rate_percent_tt
 			log = "[GetDateText]: [This.GetName]: focus GCC_maintain_exploitation executed"
 		}

--- a/common/national_focus/norway.txt
+++ b/common/national_focus/norway.txt
@@ -158,14 +158,11 @@ focus_tree = {
 			set_temp_variable = { influence_target = ENG }
 			change_influence_percentage = yes
 			newline = yes
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.05 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.05 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -1.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -1.25 } }
 			modify_international_investment_effect = yes
-			set_temp_variable = { debt_change = debt }
-			multiply_temp_variable = { debt_change = -0.02 }
+			set_temp_variable = { debt_change = { value = debt multiply = -0.02 } }
 			modify_debt_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
 			change_fossil_fuel_industry_opinion = yes

--- a/common/national_focus/tajikistan.txt
+++ b/common/national_focus/tajikistan.txt
@@ -2339,11 +2339,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [THIS.GetName]: Focus TAJ_seeking_foreign_aid"
-			set_temp_variable = { treasury_change = gdp_total }
-			multiply_temp_variable = { treasury_change = -0.01 }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = -0.01 } }
 			modify_treasury_effect = yes
-			set_temp_variable = { int_investment_change = treasury_change }
-			multiply_temp_variable = { int_investment_change = -15.25 }
+			set_temp_variable = { int_investment_change = { value = treasury_change multiply = -15.25 } }
 			modify_international_investment_effect = yes
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -6108,15 +6108,13 @@ focus_tree = {
 				max = 100
 			}
 			clr_country_flag = banned_head_scarf
-			set_temp_variable = { FP_pop_drop = party_pop_array^6 }
-			multiply_temp_variable = { FP_pop_drop = -0.25 }
+			set_temp_variable = { FP_pop_drop = { value = party_pop_array^6 multiply = -0.25 } }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = FP_pop_drop }
 			change_relative_party_popularity = yes
 			custom_effect_tooltip = TUR_FP_POP_DROP
 			add_popularity = { ideology = communism popularity = FP_pop_drop }
-			set_temp_variable = { AKP_pop_drop = party_pop_array^12 }
-			multiply_temp_variable = { AKP_pop_drop = -0.25 }
+			set_temp_variable = { AKP_pop_drop = { value = party_pop_array^12 multiply = -0.25 } }
 			set_temp_variable = { party_index = 12 }
 			set_temp_variable = { party_popularity_increase = AKP_pop_drop }
 			change_relative_party_popularity = yes
@@ -7444,10 +7442,8 @@ focus_tree = {
 					level = 2
 					instant_build = yes
 				}
-				set_temp_variable = { movable_pop = THIS.state_population_k }
-				multiply_temp_variable = { movable_pop = 2 }
-				set_temp_variable = { movable_pop_red = -1 }
-				multiply_temp_variable = { movable_pop_red = movable_pop }
+				set_temp_variable = { movable_pop = { value = THIS.state_population_k multiply = 2 } }
+				set_temp_variable = { movable_pop_red = { value = -1 multiply = movable_pop } }
 				add_manpower = movable_pop_red
 			}
 			random_owned_state = {
@@ -16047,8 +16043,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus TUR_encourage_migration_germany"
 			random_owned_state = {
-				set_temp_variable = { movable_pop = THIS.state_population_k }
-				multiply_temp_variable = { movable_pop = 1 }
+				set_temp_variable = { movable_pop = { value = THIS.state_population_k multiply = 1 } }
 				multiply_temp_variable = { movable_pop_red = movable_pop }
 			}
 			random_owned_state = {


### PR DESCRIPTION
Fixes #2353

## What

Fold adjacent set-and-multiply temp-variable chains into inline math expressions across common/national_focus/.

## Why

This removes redundant temporary operations while preserving calculation order, chained multipliers, and explanatory comments.

## Notes

Non-adjacent and branch-scoped multipliers remain unchanged.

Validation: scoped pre-commit hooks, MD validators, parser checks, and git diff --check passed.