### PR TITLE
Fix automation script parser errors

### DIFF
--- a/common/scripted_effects/!_energy_effects.txt
+++ b/common/scripted_effects/!_energy_effects.txt
@@ -50,7 +50,7 @@ automation_energy_consumption_policy_weekly = {
 				value = energy_consumption
 				add = energy_balance
 				divide = energy_consumption
-				clamp = { min = 0 }
+				clamp = { min = 0 max = 999999999 }
 			}
 		}
 	}

--- a/common/scripted_effects/99_investment_scripted_effects.txt
+++ b/common/scripted_effects/99_investment_scripted_effects.txt
@@ -773,7 +773,7 @@ calculate_internal_investment_costs = {
 					value = 1
 					add = modifier@internal_investments_pp_cost_modifier
 				}
-				clamp = { min = 25 }
+				clamp = { min = 25 max = 999999999 }
 			}
 		}
 

--- a/events/03_benelux.txt
+++ b/events/03_benelux.txt
@@ -20,7 +20,7 @@ country_event = {
 			}
 			modifier = {
 				add = 20
-				same_government = FROM
+				has_government = FROM
 			}
 			modifier = {
 				add = 20
@@ -44,7 +44,7 @@ country_event = {
 			}
 			modifier = {
 				add = -20
-				same_government = FROM
+				has_government = FROM
 			}
 			modifier = {
 				add = -20
@@ -76,7 +76,7 @@ country_event = {
 			}
 			modifier = {
 				add = 20
-				same_government = FROM
+				has_government = FROM
 			}
 			modifier = {
 				add = 20
@@ -100,7 +100,7 @@ country_event = {
 			}
 			modifier = {
 				add = -20
-				same_government = FROM
+				has_government = FROM
 			}
 			modifier = {
 				add = -20
@@ -132,7 +132,7 @@ country_event = {
 			}
 			modifier = {
 				add = 20
-				same_government = FROM
+				has_government = FROM
 			}
 			modifier = {
 				add = 20
@@ -156,7 +156,7 @@ country_event = {
 			}
 			modifier = {
 				add = -20
-				same_government = FROM
+				has_government = FROM
 			}
 			modifier = {
 				add = -20


### PR DESCRIPTION
## What

Fix the automation math-expression parser errors and unsupported Benelux trigger reported during game loading.

## Why

The automation expressions used incomplete clamp blocks, which caused parser failures and cascading script-math errors. The Benelux events used an unavailable same_government trigger.

## Scope

The unrelated PHI missing-focus reference is intentionally unchanged.

Validation: scoped pre-commit hooks, MD validators, parser checks, and git diff --check passed.