### PR TITLE
Wire KOR AI behavior determinism into focus tree, add historical AI bias (#55)

### DIFF
--- a/common/ai_strategy/KOR.txt
+++ b/common/ai_strategy/KOR.txt
@@ -130,3 +130,14 @@ KOR_construct_additional_microchips = {
 	ai_strategy = { type = build_building id = microchip_plant value = 50 }
 	ai_strategy = { type = building_target id = microchip_plant value = 50 }
 }
+
+# Losing-war brake - back off from a war KOR itself started instead of fighting to the last man
+KOR_cancel_war_NKO = {
+	allowed = { original_tag = KOR }
+	enable = {
+		has_war_with = NKO
+		strength_ratio = { tag = NKO ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+	ai_strategy = { type = declare_war id = "NKO" value = -4000 }
+}

--- a/common/national_focus/05_south_korea.txt
+++ b/common/national_focus/05_south_korea.txt
@@ -124,6 +124,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -180,6 +184,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -218,6 +226,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -273,6 +285,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -334,6 +350,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -368,6 +388,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -404,6 +428,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -438,6 +466,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -662,6 +694,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -697,6 +733,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -731,6 +771,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -790,6 +834,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -891,6 +939,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -927,6 +979,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -1054,6 +1110,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -1088,6 +1148,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -1146,6 +1210,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -2422,7 +2490,13 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus KOR_address_inequality executed"
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 10
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -3810,7 +3884,13 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus KOR_champion_human_rights executed"
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 10
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -4074,7 +4154,13 @@ focus_tree = {
 			support_for_reunification_2_less = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 10
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {


### PR DESCRIPTION
## Summary
- Pairs the three existing `is_historical_focus_on` killswitches (`KOR_anti_capitalist_backlash`, `KOR_commemorate_dictatorship`, `KOR_offensive_approach`/`KOR_subversive_approach`) with a positive boost (`factor = 10`) on their historical, mutually-exclusive sibling (`KOR_address_inequality`, `KOR_champion_human_rights`, `KOR_defensive_approach`), mirroring Spain's pattern. The communist-submission chain (`KOR_ignite_the_rebellion` → `KOR_request_northern_assistance` → `KOR_juche_in_the_south`) and the KOR-initiated war branch (`KOR_provoke_confrontation`/`KOR_spark_insurrection`) were investigated and are already fully suppressed upstream by the existing killswitches - verified as strictly linear, single-path prerequisite chains with no alternate entry point, so no redundant gating was added further downstream.
- Adds `ai_is_threatened` weighting (`factor = 2`) to the 17 combat-capacity/equipment-tech-bonus focuses in the `KOR_the_rok_armed_forces` branch that previously only carried a bankruptcy guard, mirroring Georgia's (#3128) and North Korea's (#3147) issue-55 passes.
- Adds `KOR_cancel_war_NKO` to `common/ai_strategy/KOR.txt`, a `strength_ratio`-gated losing-war brake symmetric to `NKO_cancel_war_KOR` (added by #3147) so KOR backs off a war it started against NKO instead of fighting to the last man.
- `can_staff`/bankruptcy guard coverage was already clean per `tools/validation/validate_focus_tree.py` - no gaps found, no changes needed there.
- **No new `KOR_ai_behavior` game rule added.** Unlike NKO (succession crisis, no election model) or Belarus/Georgia (regime-type forks with no other determinism source), KOR's left/right ideology fork is already fully driven by native election-based triggers (`KOR_has_progressive_government`, `KOR_has_conservative_government`, `western_liberals_are_in_power`, `has_elections`) - this matches Azerbaijan/Afghanistan/Tajikistan's case where native triggers already suffice.
- Investigated cross-country interactions with Armenia, Georgia, Azerbaijan, Spain, Afghanistan, Belarus, Tajikistan, and North Korea - none of the other completed countries' focus files reference KOR, so nothing further to reconcile.

## Test plan
- [ ] Scoped pre-commit passes on both touched files (confirmed locally: `pre-commit run --files common/national_focus/05_south_korea.txt common/ai_strategy/KOR.txt`)
- [ ] **KOR, historical AI focus ON, progressive/liberal government**: verify AI South Korea takes `KOR_address_inequality`, not `KOR_anti_capitalist_backlash` (#55)
- [ ] **KOR, historical AI focus ON, conservative government**: verify AI South Korea takes `KOR_champion_human_rights`, not `KOR_commemorate_dictatorship` (#55)
- [ ] **KOR, historical AI focus ON, at the offensive/defensive/subversive fork**: verify AI South Korea takes `KOR_defensive_approach`, not `KOR_offensive_approach`/`KOR_subversive_approach` (#55)
- [ ] **KOR, military equipment focuses (e.g. `KOR_kss_program`, `KOR_experimental_fighter`)**: verify AI South Korea prioritizes these more when threatened and avoids them while near bankruptcy (#55)
- [ ] **KOR vs. NKO, weak KOR after declaring war**: verify AI South Korea backs off (doesn't keep pursuing the war) once `strength_ratio < 1.0` (#55)