### PR TITLE
Wire Sweden AI behavior determinism into focus tree, add historical AI bias (#55)

### DIFF
--- a/common/ai_strategy/SWE.txt
+++ b/common/ai_strategy/SWE.txt
@@ -373,3 +373,155 @@ SWE_end_Neutrality = {
 	ai_strategy = { type = alliance id = "CHI" value = -100 }
 	ai_strategy = { type = alliance id = "GER" value = 100 }
 }
+
+## Losing-war brakes for the SWE_royalist_revival "Greater Sweden" conquest branch - back off from a war SWE itself started instead of fighting to the last man
+SWE_cancel_war_SWI = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = SWI
+		strength_ratio = { tag = SWI ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SWI value = -4000 }
+}
+SWE_cancel_war_STK = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = STK
+		strength_ratio = { tag = STK ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = STK value = -4000 }
+}
+SWE_cancel_war_GAH = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = GAH
+		strength_ratio = { tag = GAH ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GAH value = -4000 }
+}
+SWE_cancel_war_USA = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = USA
+		strength_ratio = { tag = USA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = USA value = -4000 }
+}
+SWE_cancel_war_LIT = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = LIT
+		strength_ratio = { tag = LIT ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LIT value = -4000 }
+}
+SWE_cancel_war_LAT = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = LAT
+		strength_ratio = { tag = LAT ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LAT value = -4000 }
+}
+SWE_cancel_war_SOV = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = SOV
+		strength_ratio = { tag = SOV ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = -4000 }
+}
+SWE_cancel_war_GER = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = GER
+		strength_ratio = { tag = GER ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = -4000 }
+}
+SWE_cancel_war_POL = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = POL
+		strength_ratio = { tag = POL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = POL value = -4000 }
+}
+SWE_cancel_war_ICE = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = ICE
+		strength_ratio = { tag = ICE ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ICE value = -4000 }
+}
+SWE_cancel_war_GRN = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = GRN
+		strength_ratio = { tag = GRN ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GRN value = -4000 }
+}
+SWE_cancel_war_FAO = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = FAO
+		strength_ratio = { tag = FAO ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FAO value = -4000 }
+}
+SWE_cancel_war_ENG = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = ENG
+		strength_ratio = { tag = ENG ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = -4000 }
+}
+SWE_cancel_war_IRE = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = IRE
+		strength_ratio = { tag = IRE ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = IRE value = -4000 }
+}
+SWE_cancel_war_CAN = {
+	allowed = { original_tag = SWE }
+	enable = {
+		has_war_with = CAN
+		strength_ratio = { tag = CAN ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CAN value = -4000 }
+}

--- a/common/national_focus/05_sweden.txt
+++ b/common/national_focus/05_sweden.txt
@@ -2977,7 +2977,13 @@ focus_tree = {
 			change_labour_unions_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -5092,6 +5098,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5131,6 +5141,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5162,6 +5176,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -5191,6 +5209,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -6265,6 +6287,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -6300,6 +6326,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -6375,6 +6405,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -6428,6 +6462,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -6457,6 +6495,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -6491,6 +6533,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -6881,6 +6927,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -18275,7 +18325,13 @@ focus_tree = {
 			change_domestic_influence_percentage = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 10
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {


### PR DESCRIPTION
## Summary
- Adds `ai_is_threatened` weighting (`factor = 2`) to the 11 combat-capacity/equipment focuses in `SWE_the_New_army` (navy corvettes/submarines/radar, army panzer/attack-helicopter/CV90/Lvkv-90/airmobile/small-arms modernization, drone integration) that previously only carried a bankruptcy guard, mirroring Georgia's/North Korea's/South Korea's issue-55 passes.
- Adds the missing bankruptcy guard to `SWE_Aitik` (a real -4.69bn spend that fell under the validator's 5bn detection threshold). `SWE_west_host_nato_exercises` was checked - its `treasury_change` sits inside an `effect_tooltip` scoped to `every_other_country` (previewing the *other* nation's cost when they accept a NATO-exercise invite), not a direct SWE spend, so no guard was needed there.
- Pairs the existing `SWE_royalist_revival` historical killswitch with a `factor = 10` / `is_historical_focus_on = yes` boost on its mutually-exclusive historical sibling `SWE_the_royal_family` (previously plain `ai_will_do = { base = 1 }`), mirroring Spain's/KOR's pattern. The other three historical-killswitch roots (`SWE_towards_communism`, `SWE_sverigedemokraterna`, `SWE_the_eastern_horizon`) are gated behind native party-/government-in-power triggers with no single mutually-exclusive sibling to pair, so (like KOR's ideology fork) they need no further pairing.
- Adds 15 `SWE_cancel_war_<TAG>` losing-war brakes to `common/ai_strategy/SWE.txt` (SWI, STK, GAH, USA, LIT, LAT, SOV, GER, POL, ICE, GRN, FAO, ENG, IRE, CAN) for the `SWE_royalist_revival` "Greater Sweden"/Viking conquest branch, a `strength_ratio`-gated brake symmetric to `NKO_cancel_war_KOR`/`KOR_cancel_war_NKO`. These 15 targets previously had zero strength-based safety valve once SWE was already at war with them (unlike EST/FIN/NRY/DEN, which already have preemptive `_is_protected`/`_too_stronk` deterrents and were left as-is).
- **No new `SWE_ai_behavior` game rule added.** Unlike KOR (already native-triggered) or NKO/Belarus/Georgia (needed a new rule), Sweden already has a fully-wired `SWE_ai_behavior` game rule (`common/game_rules/00_game_rules.txt`, options DEFAULT/NORTHERN_AMBITION/PRO_WESTERN/RED_SWEDEN/RANDOM) driving global flags (`SWE_PRO_WESTERN_FOCUS_PATH`, `SWE_NORTHERN_AMBITION_FOCUS_PATH`, `SWE_RED_SWEDEN_FOCUS_PATH`) that are already consumed by the focus tree's historical-boost/killswitch modifiers - this pass builds on that existing scheme rather than duplicating it.
- `tools/validation/validate_focus_tree.py` was clean before and after (the 3 pre-existing `missing-bankruptcy-guard-scripted` warnings on `SWE_Vattenfall_energy_link_ger`/`SWE_Vattenfall_energy_link_baltics`/`SWE_attract_investors` are confirmed false positives - all three are positive `gdp_per_capita * 0.02` income effects, not spends).

## Test plan
- [ ] Scoped pre-commit passes on both touched files (confirmed locally: `pre-commit run --files common/national_focus/05_sweden.txt common/ai_strategy/SWE.txt`)
- [ ] **SWE, historical AI focus ON, monarchist/populist government**: verify AI Sweden takes `SWE_the_royal_family`, not `SWE_royalist_revival` (#55)
- [ ] **SWE, `SWE_ai_behavior` game rule = NORTHERN_AMBITION**: verify AI Sweden still takes `SWE_royalist_revival` despite historical AI focus being on (#55)
- [ ] **SWE, military equipment focuses (e.g. `SWE_cv90_modernization`, `SWE_corvettes`)**: verify AI Sweden prioritizes these more when threatened and avoids them while near bankruptcy (#55)
- [ ] **SWE vs. a Viking-branch target (e.g. GER via `SWE_reclaim_swedish_pomerania`), weak SWE after declaring war**: verify AI Sweden backs off once `strength_ratio < 1.0` (#55)