### PR TITLE
Wire Germany AI behavior determinism into focus tree, ease the BfV system for AI (#55)

### DIFF
--- a/common/ai_strategy/GER.txt
+++ b/common/ai_strategy/GER.txt
@@ -744,3 +744,254 @@ GER_construct_additional_microchips = {
 	ai_strategy = { type = build_building id = microchip_plant value = 50 }
 	ai_strategy = { type = building_target id = microchip_plant value = 50 }
 }
+
+GER_cancel_war_FRA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = FRA
+		strength_ratio = { tag = FRA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = -4000 }
+}
+GER_cancel_war_POL = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = POL
+		strength_ratio = { tag = POL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = POL value = -4000 }
+}
+GER_cancel_war_SWE = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = SWE
+		strength_ratio = { tag = SWE ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SWE value = -4000 }
+}
+GER_cancel_war_SWI = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = SWI
+		strength_ratio = { tag = SWI ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SWI value = -4000 }
+}
+GER_cancel_war_LIC = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = LIC
+		strength_ratio = { tag = LIC ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LIC value = -4000 }
+}
+GER_cancel_war_LUX = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = LUX
+		strength_ratio = { tag = LUX ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LUX value = -4000 }
+}
+GER_cancel_war_TNZ = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = TNZ
+		strength_ratio = { tag = TNZ ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TNZ value = -4000 }
+}
+GER_cancel_war_CAM = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = CAM
+		strength_ratio = { tag = CAM ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CAM value = -4000 }
+}
+GER_cancel_war_NAM = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = NAM
+		strength_ratio = { tag = NAM ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NAM value = -4000 }
+}
+GER_cancel_war_TOG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = TOG
+		strength_ratio = { tag = TOG ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TOG value = -4000 }
+}
+GER_cancel_war_DRC = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = DRC
+		strength_ratio = { tag = DRC ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = DRC value = -4000 }
+}
+GER_cancel_war_PAP = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = PAP
+		strength_ratio = { tag = PAP ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAP value = -4000 }
+}
+GER_cancel_war_MIC = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = MIC
+		strength_ratio = { tag = MIC ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = MIC value = -4000 }
+}
+GER_cancel_war_CZE = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = CZE
+		strength_ratio = { tag = CZE ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CZE value = -4000 }
+}
+GER_cancel_war_AUS = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = AUS
+		strength_ratio = { tag = AUS ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = AUS value = -4000 }
+}
+GER_cancel_war_BEL = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = BEL
+		strength_ratio = { tag = BEL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = BEL value = -4000 }
+}
+GER_cancel_war_ITA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = ITA
+		strength_ratio = { tag = ITA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ITA value = -4000 }
+}
+GER_cancel_war_DEN = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = DEN
+		strength_ratio = { tag = DEN ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = DEN value = -4000 }
+}
+GER_cancel_war_SOV = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = SOV
+		strength_ratio = { tag = SOV ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SOV value = -4000 }
+}
+GER_cancel_war_UKR = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = UKR
+		strength_ratio = { tag = UKR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = UKR value = -4000 }
+}
+GER_cancel_war_ENG = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = ENG
+		strength_ratio = { tag = ENG ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = -4000 }
+}
+GER_cancel_war_CAN = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = CAN
+		strength_ratio = { tag = CAN ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CAN value = -4000 }
+}
+GER_cancel_war_USA = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = USA
+		strength_ratio = { tag = USA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = USA value = -4000 }
+}
+GER_cancel_war_MEX = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = MEX
+		strength_ratio = { tag = MEX ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = MEX value = -4000 }
+}
+GER_cancel_war_CHI = {
+	allowed = { original_tag = GER }
+	enable = {
+		has_war_with = CHI
+		strength_ratio = { tag = CHI ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CHI value = -4000 }
+}

--- a/common/national_focus/05_germany.txt
+++ b/common/national_focus/05_germany.txt
@@ -2525,7 +2525,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 3
+				has_idea = GER_idea_germany_divided
+			}
+		}
 	}
 
 	focus = {
@@ -2769,7 +2775,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				has_idea = GER_idea_aging_population
+			}
+		}
 	}
 
 	focus = {
@@ -2821,7 +2833,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 3
+				has_idea = GER_idea_aging_population
+			}
+		}
 	}
 
 	focus = {
@@ -4963,7 +4981,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				has_idea = GER_idea_unemployment_crisis
+			}
+		}
 	}
 
 	focus = {
@@ -5133,7 +5157,13 @@ focus_tree = {
 			remove_ideas = GER_idea_unemployment_crisis2
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 3
+				has_idea = GER_idea_unemployment_crisis2
+			}
+		}
 	}
 
 	focus = {
@@ -5559,7 +5589,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				has_idea = GER_idea_unemployment_crisis
+			}
+		}
 	}
 
 	focus = {
@@ -5738,7 +5774,13 @@ focus_tree = {
 			remove_ideas = GER_idea_unemployment_crisis2
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 3
+				has_idea = GER_idea_unemployment_crisis2
+			}
+		}
 	}
 	#Bundeswehr
 	focus = {
@@ -9738,6 +9780,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -9784,6 +9830,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -9828,6 +9878,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -10521,6 +10575,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				can_staff_an_arms_industry = no
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -14520,7 +14578,27 @@ focus_tree = {
 			custom_effect_tooltip = GER_how_to_overthrow_TT
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = -4
+				is_historical_focus_on = yes
+				NOT = {
+					OR = {
+						has_global_flag = GER_NATIONALIST
+						has_global_flag = GER_MONARCHIST
+					}
+				}
+			}
+			modifier = {
+				add = 25
+				has_global_flag = GER_NATIONALIST
+			}
+			modifier = {
+				add = 25
+				has_global_flag = GER_MONARCHIST
+			}
+		}
 	}
 	#
 	#SPD Tree
@@ -14540,7 +14618,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14573,7 +14650,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14606,7 +14682,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14640,7 +14715,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14674,7 +14748,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14706,7 +14779,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14738,7 +14810,6 @@ focus_tree = {
 				is_owned_and_controlled_by = GER
 			}
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		bypass = { NOT = { 545 = { is_owned_and_controlled_by = GER } } }
@@ -14789,7 +14860,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14828,7 +14898,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14863,7 +14932,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -14896,7 +14964,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 			42 = {
 				is_owned_and_controlled_by = GER
 			}
@@ -14987,7 +15054,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -15022,7 +15088,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -15049,7 +15114,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 			country_exists = SOV
 			NOT = {
 				has_war_with = SOV
@@ -15098,7 +15162,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 			country_exists = CHI
 			NOT = {
 				has_war_with = CHI
@@ -16181,6 +16244,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				can_staff_an_arms_industry = no
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -17806,6 +17873,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -20037,6 +20108,10 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -21218,7 +21293,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -21248,7 +21322,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -21289,7 +21362,6 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		completion_reward = {
@@ -21328,7 +21400,6 @@ focus_tree = {
 				is_owned_and_controlled_by = GER
 			}
 			western_social_democrats_are_in_power = yes
-			has_country_leader = { name = "Gerhard Schröder" ruling_only = yes }
 		}
 
 		bypass = {
@@ -21890,6 +21961,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				can_staff_an_arms_industry = no
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -4029,6 +4029,26 @@ on_actions = {
 					}
 					set_global_flag = GER_MONARCHIST
 				}
+
+				if = {
+					limit = {
+						is_ai = yes
+						OR = {
+							has_global_flag = GER_NATIONALIST
+							has_global_flag = GER_MONARCHIST
+						}
+					}
+					set_variable = { GER_rightwing_spending_level = 1 }
+					set_variable = { GER_leftwing_spending_level = 3 }
+				}
+				if = {
+					limit = {
+						is_ai = yes
+						has_global_flag = GER_SOCIALIST
+					}
+					set_variable = { GER_leftwing_spending_level = 1 }
+					set_variable = { GER_rightwing_spending_level = 3 }
+				}
 			}
 
 			JAP = {


### PR DESCRIPTION
## Summary

Part of #55 (AI Paths in Game Rules) — Germany: *"Let the AI handle the BfV system so a proper communist/nationalist/Monarchist Germany can be achieved by the AI."*

- **BfV steering (the core fix):** AI Germany now eases BfV suppression on its `GER_ai_behavior`-selected ideology (nationalist/monarchist → ease rightwing, max leftwing; socialist → ease leftwing, max rightwing) at game start. Previously, BfV spending levels were only ever changeable via a player-only GUI, so AI Germany stayed permanently stuck at the historical MED/MED suppression plateau from turn one, making a nationalist/monarchist/communist AI Germany effectively unreachable regardless of the game rule.
- **Historical AI focus support:** added `is_historical_focus_on` suppression (soft, not a hard kill — an explicit `GER_ai_behavior` pick overrides it) on the alt-history gateway `GER_stray_from_the_republic`, mirroring Sweden's pattern. `GER_ai_behavior` itself already existed and its flags were already wired into the party "rises" focuses — no new game rule needed.
- **`ai_is_threatened` weighting:** added to the 8 focuses that build arms-industry capacity (self-identified via `can_staff_an_arms_industry`), matching the existing Venezuela convention. Germany had zero uses of this trigger anywhere in its 588-focus tree.
- **Losing-war brakes:** added 25 `GER_cancel_war_<TAG>` entries to `common/ai_strategy/GER.txt` for every unique wargoal target in the NPD/Kaiser world-conquest branches (previously unthrottled `ai_will_do = { base = 1 }` with no threat gating and no ai_strategy safety valve at all — Sweden's `ai_strategy/SWE.txt` already has the reciprocal `SWE_cancel_war_GER`).
- **SPD branch immortality bug:** 19 SPD-legacy focuses (root `GER_agenda_2010` and descendants) were hard-locked to `has_country_leader = { name = "Gerhard Schröder" }`, with no successor SPD character ever defined in `common/characters/GER.txt`. The instant Schröder stops ruling (old-age death, election loss), the entire SPD branch becomes permanently unreachable for the rest of the game — for AI and human players alike. Fixed by dropping the leader-name lock and relying on the already-present `western_social_democrats_are_in_power = yes` gate, matching every other party branch's convention. (24 unrelated `NOT = { has_country_leader = Schröder }` NATO-diplomacy checks elsewhere in the file are intentional and untouched.)
- **Crisis-resolution priority:** added `ai_will_do` modifiers (active only while the relevant problem idea is present) to 7 focuses that resolve the East/West divide, unemployment crisis, and aging population — previously these sat at the same uniform `base = 1` as all other focuses, giving the AI no elevated urgency to actually fix a live problem.

`tools/validation/validate_focus_tree.py` baseline for Germany was already clean (no bankruptcy/can-staff guard gaps) and remains clean after this change.

## Test plan

- [ ] Boot as GER with `GER_ai_behavior` set to `GER_NATIONALIST`, observer/AI mode, historical AI focuses off — confirm `GER_rightwing_spending_level` drops and the BfV rightwing idea tier eases within the first weekly tick; over a long AI-only run (fast-forward decades), confirm AI Germany can reach `nationalist_fascist_are_in_power` or `nationalist_monarchists_are_in_power`.
- [ ] Repeat with `GER_ai_behavior` set to `GER_SOCIALIST` — confirm leftwing spending eases and AI Germany can reach `emerging_anarchist_communism_are_in_power`.
- [ ] Boot as GER with `GER_ai_behavior` on `DEFAULT`/a democratic option and historical AI focuses on — confirm AI Germany does not wander into `GER_stray_from_the_republic`.
- [ ] Fast-forward an AI Germany game until Schröder dies of old age (or is otherwise replaced) under an SPD government — confirm SPD-legacy focuses (`GER_agenda_2010` and descendants) remain available/completable.
- [ ] Trigger the unemployment crisis / aging population / East-West divide ideas on an AI Germany and confirm the AI prioritizes the corresponding fix focus over unrelated same-tier content.
- [ ] As AI-controlled fascist/monarchist Germany losing a war against one of the 25 `GER_cancel_war_*` targets, confirm Germany sues for peace/cancels the war goal instead of fighting to annihilation.