### PR TITLE
Wire Ethiopia AI behavior determinism into focus tree (#55)

### DIFF
--- a/common/ai_strategy/ETH.txt
+++ b/common/ai_strategy/ETH.txt
@@ -26,7 +26,7 @@ ETH_support_somalia_against_SHB = {
 
 #If Mengistu comes to power, he will support Sudanese rebels against Sudan
 ETH_support_SSU = {
-	allowed = { original_tag = ERI }
+	allowed = { original_tag = ETH }
 
 	enable = {
 		NOT = { has_war_with = SSU }
@@ -39,4 +39,15 @@ ETH_support_SSU = {
 	ai_strategy = { type = befriend id = "SSU" value = 50 }
 	ai_strategy = { type = support id = "SUD" value = -50 }
 	ai_strategy = { type = befriend id = "SUD" value = -50 }
+}
+
+# Losing-war brake - back off from the Eritrea reclamation war instead of fighting to the last man
+ETH_cancel_war_ERI = {
+	allowed = { original_tag = ETH }
+	enable = {
+		has_war_with = ERI
+		strength_ratio = { tag = ERI ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+	ai_strategy = { type = declare_war id = "ERI" value = -4000 }
 }

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -2360,6 +2360,31 @@ GER_ai_behavior = {
 	}
 }
 
+ETH_ai_behavior = {
+	name = "ETH_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	default = {
+		name = ETH_HISTORICAL
+		text = "RULE_OPTION_ETH_HISTORICAL"
+		desc = "RULE_OPTION_ETH_HISTORICAL_DESC"
+	}
+	option = {
+		name = ETH_MONARCHIST_RESTORATION
+		text = "RULE_OPTION_ETH_MONARCHIST_RESTORATION"
+		desc = "RULE_OPTION_ETH_MONARCHIST_RESTORATION_DESC"
+	}
+	option = {
+		name = ETH_COMMUNIST_RESTORATION
+		text = "RULE_OPTION_ETH_COMMUNIST_RESTORATION"
+		desc = "RULE_OPTION_ETH_COMMUNIST_RESTORATION_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_DESC"
+	}
+}
+
 BUL_ai_behavior = {
 	name = "BUL_AI_BEHAVIOR"
 	group = "RULE_GROUP_AI_BEHAVIOR"

--- a/common/national_focus/05_ethiopia.txt
+++ b/common/national_focus/05_ethiopia.txt
@@ -687,6 +687,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -750,6 +754,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -1193,8 +1201,9 @@ focus_tree = {
 			modifier = {
 				factor = 3
 				OR = {
-					has_idea = ETH_looming_famine
-					has_idea = ETH_idea_famine_strikes
+					has_idea = corruption_level_03
+					has_idea = corruption_level_02
+					has_idea = corruption_level_01
 				}
 			}
 		}
@@ -1397,7 +1406,13 @@ focus_tree = {
 			add_ideas = rifle_production_bonus
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1419,7 +1434,13 @@ focus_tree = {
 			air_experience = 50
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1479,7 +1500,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1600,7 +1627,13 @@ focus_tree = {
 				}
 			}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1705,7 +1738,13 @@ focus_tree = {
 				}
 			}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1834,7 +1873,13 @@ focus_tree = {
 				}
 			}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2024,7 +2069,13 @@ focus_tree = {
 				add_ideas = army_morale_bonus
 			}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2051,7 +2102,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2078,7 +2135,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	#Future of Ethiopia
@@ -2133,6 +2196,15 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = ETH_MONARCHIST_RESTORATION_PATH }
+			}
+			modifier = {
+				factor = 150
+				has_global_flag = ETH_MONARCHIST_RESTORATION_PATH
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = ETH_COMMUNIST_RESTORATION_PATH
 			}
 		}
 	}
@@ -2448,7 +2520,20 @@ focus_tree = {
 			change_oligarchs_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 10
+				is_historical_focus_on = yes
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					has_global_flag = ETH_MONARCHIST_RESTORATION_PATH
+					has_global_flag = ETH_COMMUNIST_RESTORATION_PATH
+				}
+			}
+		}
 	}
 
 	focus = {
@@ -2708,6 +2793,15 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = ETH_COMMUNIST_RESTORATION_PATH }
+			}
+			modifier = {
+				factor = 150
+				has_global_flag = ETH_COMMUNIST_RESTORATION_PATH
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = ETH_MONARCHIST_RESTORATION_PATH
 			}
 		}
 	}

--- a/common/national_focus/05_ethiopia.txt
+++ b/common/national_focus/05_ethiopia.txt
@@ -2749,7 +2749,13 @@ focus_tree = {
 			add_ideas = agricultural_investments3
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	##Communist

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -4031,6 +4031,25 @@ on_actions = {
 				}
 			}
 
+			ETH = {
+				if = {
+					limit = { has_game_rule = { rule = ETH_ai_behavior option = RANDOM } }
+					random_list = {
+						34 = { }	#Default (Federal Republic)
+						33 = { set_global_flag = ETH_MONARCHIST_RESTORATION_PATH }
+						33 = { set_global_flag = ETH_COMMUNIST_RESTORATION_PATH }
+					}
+				}
+				if = {
+					limit = { has_game_rule = { rule = ETH_ai_behavior option = ETH_MONARCHIST_RESTORATION } }
+					set_global_flag = ETH_MONARCHIST_RESTORATION_PATH
+				}
+				if = {
+					limit = { has_game_rule = { rule = ETH_ai_behavior option = ETH_COMMUNIST_RESTORATION } }
+					set_global_flag = ETH_COMMUNIST_RESTORATION_PATH
+				}
+			}
+
 			JAP = {
 				if = {
 					limit = {

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -727,6 +727,15 @@
  RULE_OPTION_GER_MONARCHIST: "Monarchist"
  RULE_OPTION_GER_MONARCHIST_DESC: "Germany will try to follow the Monarchist path."
 
+ #Ethiopia
+ ETH_AI_BEHAVIOR: "Ethiopia: AI Regime Path"
+ RULE_OPTION_ETH_HISTORICAL: "Historic"
+ RULE_OPTION_ETH_HISTORICAL_DESC: "The AI will follow the historical path and strengthen the Federal Democratic Republic."
+ RULE_OPTION_ETH_MONARCHIST_RESTORATION: "Restore the Monarchy"
+ RULE_OPTION_ETH_MONARCHIST_RESTORATION_DESC: "The AI will pursue restoration of the Ethiopian monarchy under the Crown Council of Ethiopia."
+ RULE_OPTION_ETH_COMMUNIST_RESTORATION: "Rehabilitate the Derg"
+ RULE_OPTION_ETH_COMMUNIST_RESTORATION_DESC: "The AI will pursue the political rehabilitation of Mengistu Haile Mariam and a return to Communist rule."
+
  # Brazil
  BRA_HISTORICAL: "Historical"
  BRA_HISTORICAL_DESC: "Brazil will be more likely to lean towards Lula and work towards enacting his policies while also maintaing positive relations with Western powers and Eastern powers drawing a fine line between the two groups."


### PR DESCRIPTION
## Summary
- Adds a new `ETH_ai_behavior` game rule (options Historic/Monarchist Restoration/Communist Restoration/Random) driving global flags (`ETH_MONARCHIST_RESTORATION_PATH`, `ETH_COMMUNIST_RESTORATION_PATH`), mirroring Georgia/Belarus/Germany, since Ethiopia's Monarchist/Democratic/Communist regime fork (`ETH_legacy_of_abyssinia` / `ETH_strengthen_the_republic` / `ETH_declare_mengistu_innocent`) had no other source of AI determinism.
- Pairs the existing bare `is_historical_focus_on` killswitches on the Monarchist and Communist roots with a `NOT = { has_global_flag = ... }` guard so an explicit game-rule pick survives "force historical focus" (mirroring Germany's `GER_stray_from_the_republic` pattern), and adds a `factor = 10` historical boost plus a killswitch-on-override to the Democratic root (previously plain `ai_will_do = { base = 1 }`), mirroring Spain's/Sweden's pattern.
- Adds `ai_is_threatened` weighting (`factor = 2`) to 11 combat-capacity/border-security focuses (`ETH_expand_the_endf`, `ETH_expand_the_etaf`, `ETH_modernize_the_military`, `ETH_military_buildup_1/2`, `ETH_land_doctrine`, `ETH_air_doctrine`, and the four `ETH_secure_the_*_border` focuses) that previously sat at flat priority.
- Fixes `ETH_anti_corruption_measurements`'s `ai_will_do` boost, which was keyed to famine ideas (a copy/paste artifact from the neighboring famine focus) instead of the `corruption_level_01/02/03` ideas its own `available` block actually gates on - the AI now prioritizes the focus while corruption is a live problem, matching its `available` trigger.
- Fixes `ETH_support_SSU`'s `allowed = { original_tag = ERI }` to `original_tag = ETH` (the comment and intent - Mengistu-era Ethiopia backing Sudanese rebels - make clear ETH is the actor, not ERI).
- Adds `ETH_cancel_war_ERI`, a `strength_ratio`-gated losing-war brake for the `ETH_reclaim_eritrea` full-annex wargoal, mirroring `NKO_cancel_war_KOR`/`SWE_cancel_war_*`/`GER_cancel_war_*` - Ethiopia's unconditional `conquer id=ERI value=100` AI strategy previously had no restraint if the war went badly.
- Checked for an orphaned/immortal-leader branch: none found. `ETH_restore_the_throne`/`ETH_return_of_mengistu` create an inline leader on completion, but the mod-wide generic `set_leader` dispatch already resolves a successor for both `Monarchist` and `Communist-State` via `ETH_political_leaders.txt`.
- Bankruptcy/`can_staff` guards were already complete on all 4 treasury-spending focuses; `tools/validation/validate_focus_tree.py` was clean before and after.

Part of #55.

## Test plan
- [ ] Scoped pre-commit passes on all touched files (confirmed locally: `pre-commit run --files common/ai_strategy/ETH.txt common/game_rules/00_game_rules.txt common/national_focus/05_ethiopia.txt common/on_actions/999_game_rules_on_actions.txt localisation/english/MD_game_rules_l_english.yml`)
- [ ] **ETH, historical AI focus ON**: verify AI Ethiopia takes `ETH_strengthen_the_republic`, not `ETH_legacy_of_abyssinia`/`ETH_declare_mengistu_innocent` (#55)
- [ ] **ETH, `ETH_ai_behavior` game rule = Monarchist Restoration**: verify AI Ethiopia still takes `ETH_legacy_of_abyssinia` despite historical AI focus being on (#55)
- [ ] **ETH, `ETH_ai_behavior` game rule = Communist Restoration**: verify AI Ethiopia still takes `ETH_declare_mengistu_innocent` despite historical AI focus being on (#55)
- [ ] **ETH, military focuses (e.g. `ETH_expand_the_endf`, `ETH_military_buildup_1`)**: verify AI Ethiopia prioritizes these more when threatened (#55)
- [ ] **ETH vs. ERI, weak Ethiopia after `ETH_reclaim_eritrea`'s wargoal is used**: verify AI Ethiopia backs off once `strength_ratio < 1.0` (#55)
- [ ] **ETH with active corruption (`corruption_level_01/02/03`)**: verify AI Ethiopia prioritizes `ETH_anti_corruption_measurements` (#55)