### PR TITLE
Harden Liechtenstein AI paths (issue #55)

### DIFF
--- a/common/ai_strategy/LIC.txt
+++ b/common/ai_strategy/LIC.txt
@@ -1,0 +1,401 @@
+# Losing-war brakes for the LIC_claim_the_HRE / LIC_path_of_conquest fictional conquest branch - back off from a war LIC itself started instead of fighting to the last man
+LIC_cancel_war_FRA = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = FRA
+		strength_ratio = { tag = FRA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = -4000 }
+}
+LIC_cancel_war_CZE = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = CZE
+		strength_ratio = { tag = CZE ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CZE value = -4000 }
+}
+LIC_cancel_war_HOL = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = HOL
+		strength_ratio = { tag = HOL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = HOL value = -4000 }
+}
+LIC_cancel_war_BEL = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = BEL
+		strength_ratio = { tag = BEL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = BEL value = -4000 }
+}
+LIC_cancel_war_ITA = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = ITA
+		strength_ratio = { tag = ITA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ITA value = -4000 }
+}
+LIC_cancel_war_SLV = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SLV
+		strength_ratio = { tag = SLV ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SLV value = -4000 }
+}
+LIC_cancel_war_SWI = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SWI
+		strength_ratio = { tag = SWI ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SWI value = -4000 }
+}
+LIC_cancel_war_LUX = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = LUX
+		strength_ratio = { tag = LUX ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LUX value = -4000 }
+}
+LIC_cancel_war_POL = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = POL
+		strength_ratio = { tag = POL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = POL value = -4000 }
+}
+LIC_cancel_war_GER = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = GER
+		strength_ratio = { tag = GER ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GER value = -4000 }
+}
+LIC_cancel_war_AUS = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = AUS
+		strength_ratio = { tag = AUS ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = AUS value = -4000 }
+}
+LIC_cancel_war_HLS = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = HLS
+		strength_ratio = { tag = HLS ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = HLS value = -4000 }
+}
+LIC_cancel_war_SMA = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SMA
+		strength_ratio = { tag = SMA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SMA value = -4000 }
+}
+LIC_cancel_war_CRO = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = CRO
+		strength_ratio = { tag = CRO ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CRO value = -4000 }
+}
+LIC_cancel_war_BOS = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = BOS
+		strength_ratio = { tag = BOS ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = BOS value = -4000 }
+}
+LIC_cancel_war_SER = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SER
+		strength_ratio = { tag = SER ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SER value = -4000 }
+}
+LIC_cancel_war_ENG = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = ENG
+		strength_ratio = { tag = ENG ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ENG value = -4000 }
+}
+LIC_cancel_war_SPR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SPR
+		strength_ratio = { tag = SPR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SPR value = -4000 }
+}
+LIC_cancel_war_HUN = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = HUN
+		strength_ratio = { tag = HUN ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = HUN value = -4000 }
+}
+LIC_cancel_war_BUL = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = BUL
+		strength_ratio = { tag = BUL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = BUL value = -4000 }
+}
+LIC_cancel_war_ROM = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = ROM
+		strength_ratio = { tag = ROM ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ROM value = -4000 }
+}
+LIC_cancel_war_TUR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = TUR
+		strength_ratio = { tag = TUR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUR value = -4000 }
+}
+LIC_cancel_war_POR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = POR
+		strength_ratio = { tag = POR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = POR value = -4000 }
+}
+LIC_cancel_war_MOR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = MOR
+		strength_ratio = { tag = MOR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = MOR value = -4000 }
+}
+LIC_cancel_war_MNC = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = MNC
+		strength_ratio = { tag = MNC ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = MNC value = -4000 }
+}
+LIC_cancel_war_GRE = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = GRE
+		strength_ratio = { tag = GRE ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = GRE value = -4000 }
+}
+LIC_cancel_war_FYR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = FYR
+		strength_ratio = { tag = FYR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FYR value = -4000 }
+}
+LIC_cancel_war_ALB = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = ALB
+		strength_ratio = { tag = ALB ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ALB value = -4000 }
+}
+LIC_cancel_war_TUN = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = TUN
+		strength_ratio = { tag = TUN ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = TUN value = -4000 }
+}
+LIC_cancel_war_ALG = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = ALG
+		strength_ratio = { tag = ALG ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ALG value = -4000 }
+}
+LIC_cancel_war_LBA = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = LBA
+		strength_ratio = { tag = LBA ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LBA value = -4000 }
+}
+LIC_cancel_war_EGY = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = EGY
+		strength_ratio = { tag = EGY ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = EGY value = -4000 }
+}
+LIC_cancel_war_ISR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = ISR
+		strength_ratio = { tag = ISR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = ISR value = -4000 }
+}
+LIC_cancel_war_SYR = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SYR
+		strength_ratio = { tag = SYR ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SYR value = -4000 }
+}
+LIC_cancel_war_LEB = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = LEB
+		strength_ratio = { tag = LEB ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = LEB value = -4000 }
+}
+LIC_cancel_war_PAL = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = PAL
+		strength_ratio = { tag = PAL ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = PAL value = -4000 }
+}
+LIC_cancel_war_HEZ = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = HEZ
+		strength_ratio = { tag = HEZ ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = HEZ value = -4000 }
+}
+LIC_cancel_war_CYP = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = CYP
+		strength_ratio = { tag = CYP ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = CYP value = -4000 }
+}
+LIC_cancel_war_NCY = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = NCY
+		strength_ratio = { tag = NCY ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = NCY value = -4000 }
+}
+LIC_cancel_war_SLO = {
+	allowed = { original_tag = LIC }
+	enable = {
+		has_war_with = SLO
+		strength_ratio = { tag = SLO ratio < 1 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = SLO value = -4000 }
+}

--- a/common/national_focus/05_liechtenstein.txt
+++ b/common/national_focus/05_liechtenstein.txt
@@ -91,7 +91,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				add = 3
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -125,7 +131,7 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				add = 3
+				factor = 0
 				is_historical_focus_on = yes
 			}
 		}
@@ -525,7 +531,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -557,7 +569,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -627,7 +645,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -707,7 +731,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -734,7 +764,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -761,7 +797,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -788,7 +830,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -817,7 +865,13 @@ focus_tree = {
 			change_defense_industry_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -861,6 +915,10 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -883,7 +941,13 @@ focus_tree = {
 			add_ideas = LIC_idea_expanding_military_research
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -913,8 +977,10 @@ focus_tree = {
 			base = 1
 			modifier = {
 				factor = 0
-				check_variable = { treasury < 1 }
-				check_variable = { debt_ratio > 0.4 }
+				OR = {
+					check_variable = { treasury < 1 }
+					check_variable = { debt_ratio > 0.4 }
+				}
 			}
 		}
 	}
@@ -1092,8 +1158,10 @@ focus_tree = {
 			base = 1
 			modifier = {
 				factor = 0
-				check_variable = { treasury < 2 }
-				check_variable = { debt_ratio > 0.3 }
+				OR = {
+					check_variable = { treasury < 2 }
+					check_variable = { debt_ratio > 0.3 }
+				}
 			}
 		}
 	}
@@ -1277,8 +1345,10 @@ focus_tree = {
 			base = 1
 			modifier = {
 				factor = 0
-				check_variable = { treasury < 1 }
-				check_variable = { debt_ratio > 0.7 }
+				OR = {
+					check_variable = { treasury < 1 }
+					check_variable = { debt_ratio > 0.7 }
+				}
 			}
 		}
 	}
@@ -1905,6 +1975,10 @@ focus_tree = {
 			base = 1
 			modifier = {
 				factor = 0
+				is_historical_focus_on = yes
+			}
+			modifier = {
+				factor = 0
 				OR = {
 					check_variable = { treasury < 0 }
 					AND = {
@@ -2251,6 +2325,10 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
+				add = 3
+				is_historical_focus_on = yes
+			}
+			modifier = {
 				factor = 0
 				OR = {
 					check_variable = { treasury < 1 }
@@ -2469,7 +2547,13 @@ focus_tree = {
 			add_ideas = LIC_idea_limited_exports
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2672,6 +2756,10 @@ focus_tree = {
 					}
 				}
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -2723,6 +2811,10 @@ focus_tree = {
 					}
 				}
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -2773,6 +2865,10 @@ focus_tree = {
 						check_variable = { debt_ratio > 0.1 }
 					}
 				}
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -2908,6 +3004,14 @@ focus_tree = {
 					}
 				}
 			}
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -2961,6 +3065,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -3017,6 +3125,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -3056,6 +3168,14 @@ focus_tree = {
 						check_variable = { debt_ratio > 0.1 }
 					}
 				}
+			}
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -3110,6 +3230,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Part of the #55 top-to-bottom AI-paths hardening pass, this time for Liechtenstein (`LIC`).

- Fixed a backward `is_historical_focus_on` weighting bug on the monarchy-power fork: the historical-AI boost was wired to `LIC_modern_monarchy` (the non-historical, power-reducing path) instead of `LIC_traditional` (the real 2003-referendum path where the Prince's powers were expanded). Swapped so `LIC_traditional` gets the boost and `LIC_modern_monarchy` gets a killswitch.
- Wired up historical weighting on two forks that had none at all: `LIC_international_cooperation` gets a killswitch and `LIC_immigrants` gets a boost (its `is_historical_focus_on` counterparts `LIC_tax_haven` and `LIC_closed_borders`/`LIC_tax_haven` sides were already partially wired).
- Added `ai_is_threatened` weighting to all 18 AI-reachable combat-capacity focuses (military branch + foreign-legion equipment purchases). Deliberately AI-disabled focuses (`ai_will_do = { base = 0 }`) were left untouched.
- Normalized bankruptcy/treasury guard inconsistencies: added the missing `bankruptcy_incoming_collapse` guard to two foreign-legion purchase focuses whose siblings already had it, and rewrapped three focuses' implicit-AND treasury/debt checks into the `OR` pattern used everywhere else in the file.
- Added `common/ai_strategy/LIC.txt` (new file) with 40 `LIC_cancel_war_<TARGET>` losing-war brakes covering every wargoal target of the fictional `LIC_claim_the_HRE` / `LIC_path_of_conquest` branch, mirroring the SWE/ARM/ETH pattern.

Checked and found no action needed: no leader-gated branch exists for LIC (nothing to orphan), no live crisis/fix-idea pair outside the AI-disabled fictional branch, and `tools/validation/validate_focus_tree.py` was already clean before and after.

## Test plan

- [ ] Start a game as `LIC`, enable historical AI focus mode, confirm the AI takes `LIC_traditional` (not `LIC_modern_monarchy`), `LIC_tax_haven`, and `LIC_immigrants`, and does not build a military (#55)
- [ ] Disable historical AI focus mode, confirm the AI is now free to path into `LIC_modern_monarchy`, `LIC_international_cooperation`, and `LIC_closed_borders` when conditions favor them (#55)
- [ ] Observe an AI-controlled `LIC` under external threat and confirm it prioritizes the military/foreign-legion focus chain over civilian-branch alternatives (#55)
- [ ] Enable the `allow_fictional_content` game rule, let a human-controlled `LIC` complete `LIC_path_of_conquest`, then hand control to the AI (observer takeover) and confirm it backs off wars it's losing rather than fighting to the last man (#55)