### PR TITLE
Retire the corpus-walking scripted param caller guard

### DIFF
--- a/.github/workflows/tools-validation.yml
+++ b/.github/workflows/tools-validation.yml
@@ -83,13 +83,12 @@ jobs:
       # wiring around them. pyproject.toml supplies the pytest testpaths so all
       # six test dirs are collected. typo-watchlist.md is read by
       # loc_typo_watchlist_test's doc-sync guard, and modifiers_documentation.md
-      # by validate_modifiers_test's parse guard. The three script trees are
-      # walked whole by config_drift_test's scripted-effect caller scan, which
-      # derives the caller directories from the corpus rather than from the
-      # validator's pattern list; they also carry the files focus_pp_malus_test
-      # and check_common_mistakes_test read (national_focus, script_enums,
-      # equipment, decisions, modifiers), which return None and blow up at
-      # collection time when absent.
+      # by validate_modifiers_test's parse guard. common/national_focus is
+      # walked by focus_pp_malus_test's exemption-freshness guard.
+      # check_common_mistakes_test asserts its script_enums, equipment, decision
+      # and modifier loaders against the real files those loaders read; without
+      # them each returns None and the module-level assertions blow up at
+      # collection time.
       - name: Checkout (unit tests)
         if: matrix.check.id == 'unit'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -102,9 +101,12 @@ jobs:
             .pre-commit-config.yaml
             .claude/docs/typo-watchlist.md
             resources/documentation/modifiers_documentation.md
-            common
-            events
-            history
+            common/national_focus
+            common/script_enums.txt
+            common/units/equipment
+            common/decisions
+            common/opinion_modifiers
+            common/modifiers
             .github/workflows/coding-pipeline.yml
             .github/workflows/nightly-pr-validation.yml
             .github/workflows/tools-validation.yml

--- a/tools/validate_staged.py
+++ b/tools/validate_staged.py
@@ -35,8 +35,6 @@ import os
 import subprocess
 import sys
 import time
-from math import floor
-from subprocess import TimeoutExpired
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 from shared_utils import timing_enabled
@@ -291,7 +289,7 @@ def main():
         t0 = time.perf_counter()
         try:
             result = subprocess.run(v["cmd"], timeout=300)
-        except TimeoutExpired:
+        except subprocess.TimeoutExpired:
             print(f"ERROR: {v['name']} validator timed out after 5 minutes")
             failed = True
             timings.append((v["name"], 300.0))
@@ -307,7 +305,7 @@ def main():
         print(f"\n\033[90m{'─' * (max_label + 18)}", file=sys.stderr)
         print("  Validator timing:", file=sys.stderr)
         for name, elapsed in timings:
-            bar_len = floor(elapsed / total * 20) if total > 0 else 0
+            bar_len = int(elapsed / total * 20) if total > 0 else 0
             bar = "█" * bar_len + "░" * (20 - bar_len)
             print(
                 f"  {name:<{max_label}}  {elapsed:6.3f}s  {bar}",

--- a/tools/validation/tests/config_drift_test.py
+++ b/tools/validation/tests/config_drift_test.py
@@ -32,13 +32,8 @@ from precommit_validate import _REGISTRY
 from validate_decisions import _DECISION_REFERENCE_SOURCE_PATTERNS
 from validate_ideas import Validator as IdeaValidator
 from validate_oob_units import _CREATE_UNIT_SOURCE_PATTERNS
-from validate_scripted_params import (
-    _CALLER_PATTERNS,
-    HARDCODED_CONTRACTS,
-    _parse_effect_contracts_from_file,
-)
+from validate_scripted_params import _CALLER_PATTERNS
 from validate_staged import VALIDATORS as STAGED_VALIDATORS
-from validator_common import strip_comments
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 VALIDATION_DIR = Path(__file__).resolve().parents[1]
@@ -49,8 +44,8 @@ VALIDATOR_CACHE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validator-cach
 NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly-pr-validation.yml"
 
 # Every tree the engine runs script from. Deliberately not derived from a
-# validator's own pattern list: the caller scan below has to be able to find a
-# call site that the list under test does not cover.
+# validator's own pattern list: it is the independent expectation the caller
+# patterns are checked against.
 SCRIPT_ROOTS = ("common", "events", "history")
 
 
@@ -593,12 +588,17 @@ def test_tools_tests_checkout_consumed_configuration():
         # validate_modifiers_test parses the shipped doc to catch a Paradox
         # format change; without it here the test reads an absent file.
         "resources/documentation/modifiers_documentation.md",
-        # The scripted-effect caller scan walks these whole; a missing tree
-        # reads as "no callers here" and passes on nothing. They also carry
-        # what focus_pp_malus_test and check_common_mistakes_test read
-        # (national_focus, script_enums, equipment, decisions, modifiers),
-        # which raise at collection time when absent.
-        *SCRIPT_ROOTS,
+        # common/national_focus is walked by focus_pp_malus_test's
+        # exemption-freshness guard. check_common_mistakes_test asserts its
+        # script_enums, equipment, decision and modifier loaders against the
+        # real files those loaders read; without them each returns None and the
+        # module-level assertions blow up at collection time.
+        "common/national_focus",
+        "common/script_enums.txt",
+        "common/units/equipment",
+        "common/decisions",
+        "common/opinion_modifiers",
+        "common/modifiers",
         ".github/workflows/coding-pipeline.yml",
         ".github/workflows/validator-cache.yml",
         ".github/workflows/nightly-pr-validation.yml",
@@ -676,62 +676,22 @@ def test_ci_idea_icon_check_is_enabled():
     assert (VALIDATION_DIR / "vanilla_sprites.txt").is_file()
 
 
-def _contracted_effect_names():
-    """The effect names validate_scripted_params builds contracts for."""
-    names = set(HARDCODED_CONTRACTS)
-    effects_dir = REPO_ROOT / "common" / "scripted_effects"
-    for path in sorted(effects_dir.glob("*.txt")):
-        for effect, contract in _parse_effect_contracts_from_file(str(path)).items():
-            if contract["required"]:
-                names.add(effect)
-    return names
+def test_scripted_param_patterns_scan_every_script_root():
+    """Each script tree must be scanned whole, not by named subdirectories.
 
-
-def _actual_caller_dirs():
-    """Directories that really call a contracted effect, read off the corpus.
-
-    Deriving this from the tree rather than from _CALLER_PATTERNS is the whole
-    point: a caller directory the pattern list never named is exactly the drift
-    being guarded, and a test that re-read the list could not see it.
+    The hand-maintained caller list this replaced missed six live directories.
+    Any narrowing back to `common/<dir>/**` reintroduces that blind spot, so
+    assert the patterns still cover each root wholesale.
     """
-    names = _contracted_effect_names()
-    encoded = [name.encode() for name in names]
-    call_re = re.compile(r"\b([a-z][a-z0-9_]*)\s*=\s*yes\b")
-    dirs = set()
-    caller_files = 0
-    for root in SCRIPT_ROOTS:
-        base = REPO_ROOT / root
-        assert base.is_dir(), (
-            f"{root}/ is absent from this checkout, so the scan below would "
-            "find no callers there and pass on nothing"
-        )
-        for path in base.rglob("*.txt"):
-            raw = path.read_bytes()
-            if not any(name in raw for name in encoded):
-                continue
-            text = strip_comments(raw.decode("utf-8-sig", errors="ignore"))
-            if {m.group(1) for m in call_re.finditer(text)} & names:
-                caller_files += 1
-                dirs.add(path.parent.relative_to(REPO_ROOT).as_posix() + "/")
-    assert caller_files >= 100, (
-        f"only {caller_files} files call a contracted effect across "
-        f"{list(SCRIPT_ROOTS)} — the corpus has hundreds, so this checkout is "
-        "too sparse for the scan to prove anything"
-    )
-    return dirs
-
-
-def test_scripted_param_patterns_scan_every_actual_caller():
-    prefixes = [pattern.split("*", 1)[0] for pattern in _CALLER_PATTERNS]
-    missed = sorted(
-        directory
-        for directory in _actual_caller_dirs()
-        if not any(directory.startswith(prefix) for prefix in prefixes)
-    )
+    whole_tree = {
+        pattern.split("/", 1)[0]
+        for pattern in _CALLER_PATTERNS
+        if pattern.split("/", 1)[1:] == ["**/*.txt"]
+    }
+    missed = sorted(root for root in SCRIPT_ROOTS if root not in whole_tree)
     assert not missed, (
-        "these directories call a contracted scripted effect but no "
-        f"_CALLER_PATTERNS entry scans them, so edits there are never "
-        f"validated: {missed}"
+        f"_CALLER_PATTERNS no longer scans {missed} whole, so callers in any "
+        f"directory it does not name are never validated: {_CALLER_PATTERNS}"
     )
 
 


### PR DESCRIPTION
## Bottom line

Closes #3224. The scripted-param caller guard walked three script trees to prove something that stopped being provable the moment the caller patterns went whole-tree. Replaced with a structural check on the patterns themselves: same drift caught, 0.98s and ~110MB of CI checkout gone. Also reverts the two stray imports from item 4.

## Why

`test_scripted_param_patterns_scan_every_actual_caller` compared corpus-derived caller directories against the `_CALLER_PATTERNS` prefixes. `_actual_caller_dirs()` only ever walked `common/`, `events/` and `history/`, and the patterns are now `common/**/*.txt`, `events/**/*.txt`, `history/**/*.txt`. Every directory it could return started with a prefix it was checking against, so `missed` was always empty and the test could not fail.

What it genuinely guarded was a future narrowing of `_CALLER_PATTERNS` back to named subdirectories, which is the bug 843edcd7ce fixed. That does not need the corpus: assert the patterns still cover each script root wholesale. Verified by narrowing `_CALLER_PATTERNS` to `common/decisions/**/*.txt` — the new test fails and names `common`, alongside `test_scripted_param_routes_cover_every_caller_source`.

With the scan gone the `>= 100` non-vacuity assert goes too, and with it the reason the unit job checked out `common`, `events` and `history` whole. The six narrower `common/*` entries that 843edcd7ce replaced come back, since `focus_pp_malus_test` and `check_common_mistakes_test` still read them.

Item 3 needed no work: `validate_scripted_params_test.py::test_validator_scans_all_scripted_effect_caller_directories` already covers all ten directories end to end.

## How

`SCRIPT_ROOTS` stays where it is and changes role. It is no longer a second walker of the tree, it is the independent expectation `_CALLER_PATTERNS` is checked against, which is what makes the drift visible at all.

The idea `allowed` / dynamic modifier `enable` cleanup discussed alongside this is split out to #3228.

BLUF
