### PR TITLE
Stop poor nations locking to minimum spending desire

### DIFF
--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -1016,7 +1016,6 @@ on_actions = {
 				every_country = {
 					recalculate_party = yes
 					gov_pop_calculation = yes
-					recalculate_law_desires = yes
 					update_neighbors_effects = yes
 
 					civilian_microchip_consumption = yes
@@ -1044,6 +1043,7 @@ on_actions = {
 					}
 
 					calculate_expected_spending = yes
+					recalculate_law_desires = yes
 					apply_protest_effects = yes
 
 					un_check_if_valid_for_sanctions = yes

--- a/common/scripted_effects/00_desired_law_calculations.txt
+++ b/common/scripted_effects/00_desired_law_calculations.txt
@@ -1,164 +1,9 @@
 # Author(s): Angriest Bird, Mkemper, Crocomoth
 
-# Bureaucracy desire is chiefly determined by the size/strength of the nation. More powerful the nation, more it wants a higher level of bureaucracy.
-# Secondary to size and power of the nation is the GDP of the nation - impoverished nations can't afford an extensive bureaucracy.
-recalculate_bureaucracy_desire = {
-	add_to_variable = { expected_adm_spending = bureau_desire_offset }
-	round_variable = bureau_desire_offset
-	clamp_variable = {
-		var = expected_adm_spending
-		min = 1
-		max = 5
-	}
-}
-
-# Police desire should tend to gravitate toward the middle (police_03) in most nations. This is also affected by politics - repressive governments
-# want more police apparatus than more liberal/libertarian ones. Also influenced by GDP - impoverished nations cannot afford large police forces.
-recalculate_police_desire = {
-	add_to_variable = { expected_police_spending = police_desire_offset }
-	round_variable = police_desire_offset
-	clamp_variable = {
-		var = expected_police_spending
-		min = 1
-		max = 5
-	}
-}
-
-# Education desire is highly dependent on wealth and development level. Underdeveloped or developing nations should have edu_01 or edu_02.
-# Most developed nations should never go below edu_03. Richer nations should have edu_04. Also dependent on political policies.
-recalculate_edu_desire = {
-	add_to_variable = { expected_edu_spending = education_desire_offset }
-	round_variable = education_desire_offset
-	clamp_variable = {
-		var = expected_edu_spending
-		min = 1
-		max = 5
-	}
-}
-
-# Health is again highly dependent on development.
-recalculate_health_desire = {
-	add_to_variable = { expected_health_spending = health_desire_offset }
-	round_variable = health_desire_offset
-	clamp_variable = {
-		var = expected_health_spending
-		min = 1
-		max = 6
-	}
-}
-
-# Welfare is highly dependent on development, but with more GDP categories skewing lower.
-recalculate_social_desire = {
-	add_to_variable = { expected_welfare_spending = social_desire_offset }
-	round_variable = social_desire_offset
-	clamp_variable = {
-		var = expected_welfare_spending
-		min = 1
-		max = 6
-	}
-}
-
-##Military Laws
-recalculate_defence_desire_change = {
-	# if expected spending is low, see if we can boost it
-	if = {
-		limit = {
-			NOT = { has_idea = no_military }
-			check_variable = { expected_military_sp < 5 }
-			NOT = {
-				OR = {
-					ai_has_major_economic_problems = yes
-					ai_has_moderate_economic_problems = yes
-				}
-			}
-		}
-
-		if = {
-			limit = {
-				OR = {
-					has_idea = intervention_neo_imperialism
-					has_idea = intervention_global_interventionism
-				}
-			}
-
-			add_to_variable = { expected_military_sp = 2 }
-		}
-		if = {
-			limit = { threat > 0.35 }
-			add_to_variable = { expected_military_sp = 1 }
-		}
-		if = {
-			limit = {
-				OR = {
-					threat > 0.6
-					any_neighbor_country = {
-						has_war = yes
-					}
-				}
-			}
-			add_to_variable = { expected_military_sp = 1 }
-		}
-		if = {
-			limit = {
-				any_home_area_neighbor_country = {
-					OR = {
-						has_war_with = PREV
-						has_wargoal_against = PREV
-						is_justifying_wargoal_against = PREV
-					}
-				}
-			}
-
-			add_to_variable = { expected_military_sp = 1 }
-		}
-
-		if = {
-			limit = { has_variable = expected_military_sp }
-			clamp_variable = {
-				var = expected_military_sp
-				min = 1
-				max = 4
-			}
-		}
-	}
-
-	# can get up to 5 with offset
-	if = {
-		limit = {
-			has_variable = defence_desire_offset
-		}
-
-		add_to_variable = { expected_military_sp = defence_desire_offset }
-		round_variable = defence_desire_offset
-		clamp_variable = {
-			var = expected_military_sp
-			min = 1
-			max = 5
-		}
-	}
-
-	# if we STILL lower than 4 AND we have low manpower, increase it
-	if = {
-		limit = {
-			check_variable = { expected_military_sp < 5 }
-			manpower_per_military_factory < 450
-		}
-
-		add_to_variable = { expected_military_sp = 1 }
-	}
-
-
-}
-
-# Wrapper function to do everything in one place.
+# calculate_expected_spending zeroes and rebuilds the expected_* vars, so it is their only
+# writer and folds the offsets below in itself. Nothing here may write them.
 recalculate_law_desires = {
 	focus_on_laws_due_to_economic_despair = yes
-	recalculate_bureaucracy_desire = yes
-	recalculate_police_desire = yes
-	recalculate_edu_desire = yes
-	recalculate_health_desire = yes
-	recalculate_social_desire = yes
-	recalculate_defence_desire_change = yes
 	# will increase next month, just in case
 	increase_spending_if_possible = yes
 	ai_reduce_spending_on_deficit = yes
@@ -234,21 +79,22 @@ increase_spending_if_possible = {
 			has_social_law_desired = yes
 		}
 
+		set_temp_variable = { desire_change = 1 }
 		random_list = {
 			10 = {
-				add_to_variable = { bureau_desire_offset = 1 }
+				change_expected_bureaucracy_spending = yes
 			}
 			10 = {
-				add_to_variable = { education_desire_offset = 1 }
+				change_expected_education_spending = yes
 			}
 			10 = {
-				add_to_variable = { health_desire_offset = 1 }
+				change_expected_health_spending = yes
 			}
 			10 = {
-				add_to_variable = { police_desire_offset = 1 }
+				change_expected_police_spending = yes
 			}
 			10 = {
-				add_to_variable = { social_desire_offset = 1 }
+				change_expected_social_spending = yes
 			}
 		}
 	}

--- a/common/scripted_effects/00_desired_law_calculations.txt
+++ b/common/scripted_effects/00_desired_law_calculations.txt
@@ -21,13 +21,7 @@ focus_on_laws_due_to_economic_despair = {
 			}
 		}
 		set_country_flag = AI_economic_downspiral
-
-		# reset increased spending if we are doing bad
-		set_variable = { bureau_desire_offset = 0 }
-		set_variable = { education_desire_offset = 0 }
-		set_variable = { health_desire_offset = 0 }
-		set_variable = { police_desire_offset = 0 }
-		set_variable = { social_desire_offset = 0 }
+		clear_law_desire_offsets = yes
 		if = { limit = { is_debug = yes }
 			log = "[GetDateText]: [ROOT.GetName]: DEBUG: AI Scripted Trigger: focus_on_laws_due_to_economic_despair fired"
 		}
@@ -56,13 +50,18 @@ focus_on_laws_due_to_economic_despair = {
 			check_variable = { corporate_tax_rate > 30 }
 		}
 
-		# reset increased spending if we are doing bad
-		set_variable = { bureau_desire_offset = 0 }
-		set_variable = { education_desire_offset = 0 }
-		set_variable = { health_desire_offset = 0 }
-		set_variable = { police_desire_offset = 0 }
-		set_variable = { social_desire_offset = 0 }
+		clear_law_desire_offsets = yes
 	}
+}
+
+# Defence is deliberately left alone: it is driven by security pressure, not by what the
+# treasury can spare.
+clear_law_desire_offsets = {
+	set_variable = { bureau_desire_offset = 0 }
+	set_variable = { education_desire_offset = 0 }
+	set_variable = { health_desire_offset = 0 }
+	set_variable = { police_desire_offset = 0 }
+	set_variable = { social_desire_offset = 0 }
 }
 
 increase_spending_if_possible = {

--- a/common/scripted_effects/00_expected_spending_effects.txt
+++ b/common/scripted_effects/00_expected_spending_effects.txt
@@ -216,9 +216,9 @@ calculate_expected_military_spending = {
 add_security_pressure_to_expected_military = {
 	if = {
 		limit = {
-			NOT = { has_idea = no_military }
 			NOT = {
 				OR = {
+					has_idea = no_military
 					ai_has_major_economic_problems = yes
 					ai_has_moderate_economic_problems = yes
 				}
@@ -322,28 +322,27 @@ resolve_gdp_c_deltas = {
 resolve_gdp_scale_delta = {
 	if = {
 		limit = { check_variable = { gdp_total < 10 } }
-		set_temp_variable = { gdp_scale_tier = 0 }
+		set_temp_variable = { gdp_scale_delta = -0.2 }
 	}
 	else_if = {
 		limit = { check_variable = { gdp_total < 50 } }
-		set_temp_variable = { gdp_scale_tier = 1 }
+		set_temp_variable = { gdp_scale_delta = 0 }
 	}
 	else_if = {
 		limit = { check_variable = { gdp_total < 150 } }
-		set_temp_variable = { gdp_scale_tier = 2 }
+		set_temp_variable = { gdp_scale_delta = 0.3 }
 	}
 	else_if = {
 		limit = { check_variable = { gdp_total < 500 } }
-		set_temp_variable = { gdp_scale_tier = 3 }
+		set_temp_variable = { gdp_scale_delta = 0.6 }
 	}
 	else_if = {
 		limit = { check_variable = { gdp_total < 1500 } }
-		set_temp_variable = { gdp_scale_tier = 4 }
+		set_temp_variable = { gdp_scale_delta = 0.9 }
 	}
 	else = {
-		set_temp_variable = { gdp_scale_tier = 5 }
+		set_temp_variable = { gdp_scale_delta = 1.2 }
 	}
-	set_temp_variable = { gdp_scale_delta = global.gdp_scale_delta_table^gdp_scale_tier }
 }
 
 setup_initial_expected_spending_by_party = {
@@ -382,14 +381,6 @@ setup_initial_expected_spending_by_party = {
 	add_to_array = { global.gdp_c_delta_mil_table = 0.2 }
 	add_to_array = { global.gdp_c_delta_mil_table = 0.6 }
 	add_to_array = { global.gdp_c_delta_mil_table = 1 }
-
-	clear_array = global.gdp_scale_delta_table
-	add_to_array = { global.gdp_scale_delta_table = -0.2 }
-	add_to_array = { global.gdp_scale_delta_table = 0 }
-	add_to_array = { global.gdp_scale_delta_table = 0.3 }
-	add_to_array = { global.gdp_scale_delta_table = 0.6 }
-	add_to_array = { global.gdp_scale_delta_table = 0.9 }
-	add_to_array = { global.gdp_scale_delta_table = 1.2 }
 
 	add_to_array = { global.expected_adm_sp = 2.5 }
 	add_to_array = { global.expected_adm_sp = 2.5 }

--- a/common/scripted_effects/00_expected_spending_effects.txt
+++ b/common/scripted_effects/00_expected_spending_effects.txt
@@ -78,6 +78,7 @@ calculate_expected_welfare_spending = {
 		subtract_from_variable = { expected_welfare_spending = 1 }
 	}
 	add_to_variable = { expected_welfare_spending = modifier@expected_welfare_modifier }
+	add_to_variable = { expected_welfare_spending = social_desire_offset }
 	round_variable = expected_welfare_spending
 
 	if = { limit = { is_debug = yes }
@@ -96,6 +97,7 @@ calculate_expected_healthcare_spending = {
 		subtract_from_variable = { expected_health_spending = 1 }
 	}
 	add_to_variable = { expected_health_spending = modifier@expected_healthcare_modifier }
+	add_to_variable = { expected_health_spending = health_desire_offset }
 	round_variable = expected_health_spending
 
 	if = { limit = { is_debug = yes }
@@ -115,6 +117,7 @@ calculate_expected_education_spending = {
 		subtract_from_variable = { expected_edu_spending = 1 }
 	}
 	add_to_variable = { expected_edu_spending = modifier@expected_education_modifier }
+	add_to_variable = { expected_edu_spending = education_desire_offset }
 	round_variable = expected_edu_spending
 
 	if = { limit = { is_debug = yes }
@@ -134,6 +137,7 @@ calculate_expected_police_spending = {
 		subtract_from_variable = { expected_police_spending = 1 }
 	}
 	add_to_variable = { expected_police_spending = modifier@expected_police_modifier }
+	add_to_variable = { expected_police_spending = police_desire_offset }
 	round_variable = expected_police_spending
 
 	if = { limit = { is_debug = yes }
@@ -153,6 +157,7 @@ calculate_expected_adm_spending = {
 		subtract_from_variable = { expected_adm_spending = 1 }
 	}
 	add_to_variable = { expected_adm_spending = modifier@expected_adm_modifier }
+	add_to_variable = { expected_adm_spending = bureau_desire_offset }
 	round_variable = expected_adm_spending
 
 	if = { limit = { is_debug = yes }
@@ -172,6 +177,8 @@ calculate_expected_military_spending = {
 		add_to_variable = { expected_military_sp = 3 }
 	}
 	add_to_variable = { expected_military_sp = modifier@expected_mil_modifier }
+	add_security_pressure_to_expected_military = yes
+	add_to_variable = { expected_military_sp = defence_desire_offset }
 	round_variable = expected_military_sp
 
 	if = {
@@ -193,7 +200,7 @@ calculate_expected_military_spending = {
 		clamp_variable = {
 			var = expected_military_sp
 			min = 1
-			max = 4
+			max = 5
 		}
 	}
 	else = {
@@ -205,37 +212,138 @@ calculate_expected_military_spending = {
 	}
 }
 
+# Read off the engine-maintained hostility arrays, so it lapses on its own once they empty.
+add_security_pressure_to_expected_military = {
+	if = {
+		limit = {
+			NOT = { has_idea = no_military }
+			NOT = {
+				OR = {
+					ai_has_major_economic_problems = yes
+					ai_has_moderate_economic_problems = yes
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				OR = {
+					has_idea = intervention_neo_imperialism
+					has_idea = intervention_global_interventionism
+				}
+			}
+			add_to_variable = { expected_military_sp = 2 }
+		}
+		if = {
+			limit = { check_variable = { potential_and_current_enemies^num > 0 } }
+			add_to_variable = { expected_military_sp = 1 }
+		}
+		if = {
+			limit = { check_variable = { potential_and_current_enemies^num > 2 } }
+			add_to_variable = { expected_military_sp = 1 }
+		}
+		if = {
+			limit = { we_are_being_justified_against_or_wargoal_against_us = yes }
+			add_to_variable = { expected_military_sp = 1 }
+		}
+		if = {
+			limit = { threat > 0.35 }
+			add_to_variable = { expected_military_sp = 1 }
+		}
+		if = {
+			limit = {
+				OR = {
+					threat > 0.6
+					any_neighbor_country = { has_war = yes }
+				}
+			}
+			add_to_variable = { expected_military_sp = 1 }
+		}
+		if = {
+			limit = { manpower_per_military_factory < 450 }
+			add_to_variable = { expected_military_sp = 1 }
+		}
+	}
+}
+
 resolve_gdp_c_deltas = {
 	if = {
-		limit = { check_variable = { gdp_per_capita < 5 } }
+		limit = { check_variable = { gdp_per_capita < 1 } }
 		set_temp_variable = { gdp_c_tier = 0 }
 	}
 	else_if = {
-		limit = { check_variable = { gdp_per_capita < 10 } }
+		limit = { check_variable = { gdp_per_capita < 2.5 } }
 		set_temp_variable = { gdp_c_tier = 1 }
 	}
 	else_if = {
-		limit = { check_variable = { gdp_per_capita < 15 } }
+		limit = { check_variable = { gdp_per_capita < 5 } }
 		set_temp_variable = { gdp_c_tier = 2 }
 	}
 	else_if = {
-		limit = { check_variable = { gdp_per_capita < 20 } }
+		limit = { check_variable = { gdp_per_capita < 10 } }
 		set_temp_variable = { gdp_c_tier = 3 }
 	}
 	else_if = {
-		limit = { check_variable = { gdp_per_capita < 30 } }
+		limit = { check_variable = { gdp_per_capita < 15 } }
 		set_temp_variable = { gdp_c_tier = 4 }
 	}
 	else_if = {
-		limit = { check_variable = { gdp_per_capita < 40 } }
+		limit = { check_variable = { gdp_per_capita < 20 } }
 		set_temp_variable = { gdp_c_tier = 5 }
 	}
-	else = {
+	else_if = {
+		limit = { check_variable = { gdp_per_capita < 30 } }
 		set_temp_variable = { gdp_c_tier = 6 }
+	}
+	else_if = {
+		limit = { check_variable = { gdp_per_capita < 40 } }
+		set_temp_variable = { gdp_c_tier = 7 }
+	}
+	else = {
+		set_temp_variable = { gdp_c_tier = 8 }
 	}
 	set_temp_variable = { gdp_c_delta = global.gdp_c_delta_table^gdp_c_tier }
 	set_temp_variable = { gdp_c_delta_lvl5 = global.gdp_c_delta_lvl5_table^gdp_c_tier }
 	set_temp_variable = { gdp_c_delta_mil = global.gdp_c_delta_mil_table^gdp_c_tier }
+
+	# Economy size only offsets a poverty penalty, so the clamp stops it adding to wealth.
+	if = {
+		limit = { check_variable = { gdp_c_tier < 5 } }
+		resolve_gdp_scale_delta = yes
+		add_to_temp_variable = { gdp_c_delta = gdp_scale_delta }
+		add_to_temp_variable = { gdp_c_delta_lvl5 = gdp_scale_delta }
+		add_to_temp_variable = { gdp_c_delta_mil = gdp_scale_delta }
+		clamp_temp_variable = { var = gdp_c_delta max = 0 }
+		clamp_temp_variable = { var = gdp_c_delta_lvl5 max = 0 }
+		clamp_temp_variable = { var = gdp_c_delta_mil max = 0 }
+	}
+}
+
+resolve_gdp_scale_delta = {
+	if = {
+		limit = { check_variable = { gdp_total < 10 } }
+		set_temp_variable = { gdp_scale_tier = 0 }
+	}
+	else_if = {
+		limit = { check_variable = { gdp_total < 50 } }
+		set_temp_variable = { gdp_scale_tier = 1 }
+	}
+	else_if = {
+		limit = { check_variable = { gdp_total < 150 } }
+		set_temp_variable = { gdp_scale_tier = 2 }
+	}
+	else_if = {
+		limit = { check_variable = { gdp_total < 500 } }
+		set_temp_variable = { gdp_scale_tier = 3 }
+	}
+	else_if = {
+		limit = { check_variable = { gdp_total < 1500 } }
+		set_temp_variable = { gdp_scale_tier = 4 }
+	}
+	else = {
+		set_temp_variable = { gdp_scale_tier = 5 }
+	}
+	set_temp_variable = { gdp_scale_delta = global.gdp_scale_delta_table^gdp_scale_tier }
 }
 
 setup_initial_expected_spending_by_party = {
@@ -243,31 +351,45 @@ setup_initial_expected_spending_by_party = {
 		log = "[GetDateText]: Setup for expected spending started"
 	}
 	clear_array = global.gdp_c_delta_table
-	add_to_array = { global.gdp_c_delta_table = -1.8 }
+	add_to_array = { global.gdp_c_delta_table = -1.5 }
 	add_to_array = { global.gdp_c_delta_table = -1.2 }
+	add_to_array = { global.gdp_c_delta_table = -0.9 }
 	add_to_array = { global.gdp_c_delta_table = -0.6 }
+	add_to_array = { global.gdp_c_delta_table = -0.3 }
 	add_to_array = { global.gdp_c_delta_table = -0.1 }
 	add_to_array = { global.gdp_c_delta_table = 0.4 }
 	add_to_array = { global.gdp_c_delta_table = 0.9 }
 	add_to_array = { global.gdp_c_delta_table = 1.4 }
 
 	clear_array = global.gdp_c_delta_lvl5_table
-	add_to_array = { global.gdp_c_delta_lvl5_table = -1.5 }
+	add_to_array = { global.gdp_c_delta_lvl5_table = -1.3 }
 	add_to_array = { global.gdp_c_delta_lvl5_table = -1 }
+	add_to_array = { global.gdp_c_delta_lvl5_table = -0.8 }
 	add_to_array = { global.gdp_c_delta_lvl5_table = -0.5 }
+	add_to_array = { global.gdp_c_delta_lvl5_table = -0.2 }
 	add_to_array = { global.gdp_c_delta_lvl5_table = 0.1 }
 	add_to_array = { global.gdp_c_delta_lvl5_table = 0.4 }
 	add_to_array = { global.gdp_c_delta_lvl5_table = 0.8 }
 	add_to_array = { global.gdp_c_delta_lvl5_table = 1.2 }
 
 	clear_array = global.gdp_c_delta_mil_table
-	add_to_array = { global.gdp_c_delta_mil_table = -1.5 }
+	add_to_array = { global.gdp_c_delta_mil_table = -1.3 }
 	add_to_array = { global.gdp_c_delta_mil_table = -1 }
+	add_to_array = { global.gdp_c_delta_mil_table = -0.8 }
 	add_to_array = { global.gdp_c_delta_mil_table = -0.5 }
+	add_to_array = { global.gdp_c_delta_mil_table = -0.3 }
 	add_to_array = { global.gdp_c_delta_mil_table = 0 }
 	add_to_array = { global.gdp_c_delta_mil_table = 0.2 }
 	add_to_array = { global.gdp_c_delta_mil_table = 0.6 }
 	add_to_array = { global.gdp_c_delta_mil_table = 1 }
+
+	clear_array = global.gdp_scale_delta_table
+	add_to_array = { global.gdp_scale_delta_table = -0.2 }
+	add_to_array = { global.gdp_scale_delta_table = 0 }
+	add_to_array = { global.gdp_scale_delta_table = 0.3 }
+	add_to_array = { global.gdp_scale_delta_table = 0.6 }
+	add_to_array = { global.gdp_scale_delta_table = 0.9 }
+	add_to_array = { global.gdp_scale_delta_table = 1.2 }
 
 	add_to_array = { global.expected_adm_sp = 2.5 }
 	add_to_array = { global.expected_adm_sp = 2.5 }


### PR DESCRIPTION
## Bottom line

Poor nations were pinned to level 1 in every budget category forever. Two defects stacked: the desire offsets were being erased before anything could read them, and the GDP/C penalty was harsh enough to floor the entire developing world on its own. Closes #3226.

## Why

`calculate_expected_spending` opens by zeroing `expected_*` and rebuilding them from the party table plus the GDP delta. In `on_monthly` it ran 27 lines *after* `recalculate_law_desires`, so every offset that effect applied was wiped before the AI, the protest triggers, or the budget tab ever saw it.

That was harmless until #1439. The `wants_bureau_03`-style flags used to snapshot the post-offset value and survive the reset for the rest of the month; replacing them with direct `check_variable = { expected_adm_spending … }` reads pointed every consumer at the offset-free baseline. Dead as a result: `increase_spending_if_possible`, every focus and decision `change_expected_*_spending` grant, and the whole threat-driven military boost.

It also deadlocked. Once one offset hit 1, `has_*_law_desired` went false so the ratchet stopped adding, while the AI still read baseline and never raised the law.

Separately, a flat -1.8 for everything under $5k GDP/C put the whole developing world at the floor by itself. Weighted party bases average 2.25 to 2.9, so tier 0 landed at 0.5 to 1.4 and clamped to 1 in all six categories. India: welfare 2.59 - 1.8 = 0.79. That one bucket also lumped Somalia in with Ukraine, a 30x spread.

## How

**Single writer.** The offsets and the military threat logic now live inside `calculate_expected_spending`, alongside `modifier@expected_*_modifier` in the same formula. `recalculate_law_desires` no longer writes `expected_*` at all; it only runs the AI decisions (despair reset, ratchet, deficit cuts) off finished numbers. The five near-identical `recalculate_*_desire` wrappers and their duplicated clamps are gone, and the ordering hazard with them. This also fixes `on_puppet` and the tag-switch path, which called the recompute without ever applying offsets.

**GDP tiers.** Nine per-capita bands instead of seven, split at 1 and 2.5 with a smoother ramp below 15k. Everything above 15k keeps its current values exactly. On top of that, an economy-size term keyed to `gdp_total`, clamped so it can only offset a poverty penalty and never adds to wealth. That is what separates a developing giant from a country a hundredth its size while leaving the genuinely destitute at the floor.

**Military.** Desire now weighs `potential_and_current_enemies^num` at two thresholds plus `we_are_being_justified_against_or_wargoal_against_us`, replacing an `any_home_area_neighbor_country` scan that was both narrower and more expensive. Peacetime ceiling goes 4 to 5, which the offset path already reached by design.

Also folded in: `round_variable` was rounding the offset instead of the total it had just been added to, and the ratchet's `add_to_variable` bypassed the clamp that `change_expected_*_spending` applies. Both were inert while the offsets were dead and are live now.

Note this is a balance change as well as a bug fix. Every sub-$15k/c nation's opening budget shifts.

BLUF
