### PR TITLE
Fix the Saudi content against the newer validator checks

### DIFF
--- a/common/decisions/Saudi Arabia.txt
+++ b/common/decisions/Saudi Arabia.txt
@@ -1026,7 +1026,7 @@ SAU_Foregin_affairs_category = {
 			PER = { add_opinion_modifier = { target = ROOT modifier = SAU_islamic_rivalry } }
 			set_temp_variable = { treasury_change = -15.00 }
 			modify_treasury_effect = yes
-			country_event = { id = SAU_events.210 days = 2 }
+			news_event = { id = SAU_events.210 days = 2 }
 		}
 
 		ai_will_do = {

--- a/common/dynamic_modifiers/99_SAU_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/99_SAU_dynamic_modifiers.txt
@@ -1,5 +1,4 @@
 SAU_Monarchy_house_of_al_saud = {
-	enable = { always = yes }
 	icon = GFX_idea_mbn_abdullah_idea
 	remove_trigger = {
 		has_country_flag = SAU_monarchy_abolished
@@ -75,7 +74,6 @@ SAU_Monarchy_house_of_al_saud = {
 # power: the Saudi Communist Party (ruling_party = 4) or the National Liberation Front
 # (ruling_party = 19). The moment neither holds power, every buff switches off.
 SAU_communist_state = {
-	enable = { always = yes }
 	remove_trigger = {
 		NOT = {
 			OR = {
@@ -99,7 +97,6 @@ SAU_communist_state = {
 # SCP-exclusive doctrine (Moscow-line, orthodox Marxism-Leninism). Active only while the
 # Saudi Communist Party rules; the National Liberation Front can never gain these.
 SAU_scp_doctrine = {
-	enable = { always = yes }
 	remove_trigger = {
 		NOT = { emerging_communist_state_are_in_power = yes }
 	}
@@ -114,7 +111,6 @@ SAU_scp_doctrine = {
 # NLF-exclusive doctrine (non-aligned Arab socialism). Active only while the National
 # Liberation Front rules; the Saudi Communist Party can never gain these.
 SAU_nlf_doctrine = {
-	enable = { always = yes }
 	remove_trigger = {
 		NOT = { neutrality_neutral_communism_are_in_power = yes }
 	}
@@ -126,7 +122,6 @@ SAU_nlf_doctrine = {
 }
 
 SAU_rep_shia_moderate_doctrine = {
-	enable = { always = yes }
 	remove_trigger = { NOT = { emerging_moderate_shiite_are_in_power = yes } }
 	icon = GFX_idea_SAU_islamic_traditions_ns
 	custom_modifier_tooltip = SAU_rep_shia_moderate_doctrine_tt
@@ -137,7 +132,6 @@ SAU_rep_shia_moderate_doctrine = {
 }
 
 SAU_rep_shia_hardline_doctrine = {
-	enable = { always = yes }
 	remove_trigger = { NOT = { emerging_hardline_shiite_are_in_power = yes } }
 	icon = GFX_idea_SAU_islamic_traditions_ns
 	custom_modifier_tooltip = SAU_rep_shia_hardline_doctrine_tt
@@ -148,7 +142,6 @@ SAU_rep_shia_hardline_doctrine = {
 }
 
 SAU_rep_shia_state = {
-	enable = { always = yes }
 	remove_trigger = {
 		NOT = {
 			OR = {
@@ -172,7 +165,6 @@ SAU_rep_shia_state = {
 }
 
 SAU_nda_state = {
-	enable = { always = yes }
 	remove_trigger = { NOT = { western_liberals_are_in_power = yes } }
 	icon = GFX_idea_social_liberalism
 	custom_modifier_tooltip = SAU_nda_state_tt
@@ -186,7 +178,6 @@ SAU_nda_state = {
 	custom_modifier_tooltip = SAU_nda_state_2_tt
 }
 SAU_baath_state = {
-	enable = { always = yes }
 	remove_trigger = { NOT = { nationalist_fascist_are_in_power = yes } }
 	icon = GFX_idea_baath_party
 	custom_modifier_tooltip = SAU_baath_state_tt
@@ -201,7 +192,6 @@ SAU_baath_state = {
 # The junta's own spirit, entirely separate from SAU_Monarchy_house_of_al_saud. The House
 # survives under military rule, so both can be active at once. (Not the Focuses of Historical Al Saud Focuses)
 SAU_Military_Rule = {
-	enable = { always = yes }
 	icon = GFX_idea_saudi_armed_forces_idea
 	remove_trigger = {
 		has_country_flag = SAU_military_rule_ended
@@ -236,7 +226,6 @@ SAU_peoples_council_works = {
 }
 
 SAU_corporate_policy = {
-	enable = { always = yes }
 	icon = GFX_idea_generic_construction
 	custom_modifier_tooltip = SAU_corporate_policy_tt
 	corporate_tax_income_multiplier_modifier = SAU_corp_tax
@@ -258,7 +247,6 @@ SAU_corporate_policy = {
 }
 
 SAU_gip_network = {
-	enable = { always = yes }
 	icon = GFX_idea_generic_intelligence_agency
 
 	operative_slot = SAU_gip_slots

--- a/common/national_focus/sau_focus.txt
+++ b/common/national_focus/sau_focus.txt
@@ -1597,7 +1597,7 @@ focus_tree = {
 				}
 			}
 			set_cosmetic_tag = GCC
-			country_event = gcc.17
+			news_event = gcc.17
 			log = "[GetDateText]: [This.GetName]: focus SAU_unif_khaleeji_union executed"
 		}
 


### PR DESCRIPTION
### Changes
- Removes twelve `enable = { always = yes }` blocks from the Saudi dynamic modifiers, which is what an absent enable block already means
- Fires SAU_events.210 and gcc.17 with news_event, matching how both are declared

The Saudi content landed alongside the checks that reject these two patterns, so main is currently failing Validate Modifier Names and Validate Events, and every open pull request picks the failure up when it merges main.
