### PR TITLE
Tighten the two new common-mistake checks against the review findings

### DIFF
--- a/tools/linting/check_common_mistakes.py
+++ b/tools/linting/check_common_mistakes.py
@@ -2741,11 +2741,11 @@ def _ai_zero_modifier_conditions(modifier_block):
         else:
             return "none", False
 
-    if not has_target_condition:
-        return "none", False
-    if factor_zero:
+    if factor_zero and has_target_condition:
         return "zero", has_bankruptcy_condition
-    if positive_add:
+    if positive_add and (has_target_condition or len(assignments) == 1):
+        # An addition with no condition of its own applies under the target
+        # state as well, so it restores an option an earlier factor = 0 zeroed.
         return "add", has_bankruptcy_condition
     return "none", False
 
@@ -2770,6 +2770,30 @@ def _event_option_zeroes_historical_bankruptcy(option_block):
     return False, False
 
 
+_RE_NOT_BLOCK_OPEN = re.compile(r"\bNOT\s*=\s*\{")
+
+
+def _negates_bankruptcy_mission(code):
+    """Whether the bankruptcy mission sits inside a NOT block in `code`.
+
+    Testing for a NOT and for the mission independently would also match an
+    unrelated negation standing beside a positive mission check.
+    """
+    cursor = 0
+    while True:
+        match = _RE_NOT_BLOCK_OPEN.search(code, cursor)
+        if not match:
+            return False
+        open_pos = code.index("{", match.start())
+        close_pos = _find_brace_close(code, open_pos)
+        if (
+            "has_active_mission = bankruptcy_incoming_collapse"
+            in code[open_pos:close_pos]
+        ):
+            return True
+        cursor = match.end()
+
+
 def _option_unavailable_under_bankruptcy(option_block):
     """Whether the option's own trigger rules it out under bankruptcy.
 
@@ -2780,10 +2804,7 @@ def _option_unavailable_under_bankruptcy(option_block):
         option_block, _RE_TRIGGER_BLOCK_OPEN
     ):
         code = " ".join(strip_inline_comment(line) for line in trigger_block)
-        if (
-            "NOT" in code
-            and "has_active_mission = bankruptcy_incoming_collapse" in code
-        ):
+        if _negates_bankruptcy_mission(code):
             return True
     return False
 
@@ -3214,6 +3235,36 @@ def _check_leader_rotation(lines):
     return sorted(issues)
 
 
+def classify_file_path(filepath):
+    """Return which per-directory checks apply to `filepath`.
+
+    Separators are normalised first: on Windows the paths arrive with
+    backslashes, and matching "common/ideas" against them would silently
+    disable every directory-scoped check.
+    """
+    normalized = filepath.replace("\\", "/")
+    is_ideas = "common/ideas" in normalized
+    is_focus_file = "common/national_focus" in normalized
+    is_decision_file = "common/decisions" in normalized
+    is_ai_file = (
+        is_focus_file
+        or is_decision_file
+        or "common/military_industrial_organization" in normalized
+    )
+    is_common_or_events_file = "common/" in normalized or "events/" in normalized
+    is_event_file = "events/" in normalized
+    is_political_leaders_file = normalized.endswith("_political_leaders.txt")
+    return (
+        is_ideas,
+        is_focus_file,
+        is_decision_file,
+        is_ai_file,
+        is_common_or_events_file,
+        is_event_file,
+        is_political_leaders_file,
+    )
+
+
 def check_file(filepath):
     """Check a single file for common mistakes. Returns list of (filepath, line_num, message) tuples."""
     issues = []
@@ -3224,20 +3275,15 @@ def check_file(filepath):
     except Exception:
         return issues
 
-    normalized_filepath = filepath.replace("\\", "/")
-    is_ideas = "common/ideas" in normalized_filepath
-    is_focus_file = "common/national_focus" in normalized_filepath
-    is_decision_file = "common/decisions" in normalized_filepath
-    is_ai_file = (
-        is_focus_file
-        or is_decision_file
-        or "common/military_industrial_organization" in normalized_filepath
-    )
-    is_common_or_events_file = (
-        "common/" in normalized_filepath or "events/" in normalized_filepath
-    )
-    is_event_file = "events/" in normalized_filepath
-    is_political_leaders_file = normalized_filepath.endswith("_political_leaders.txt")
+    (
+        is_ideas,
+        is_focus_file,
+        is_decision_file,
+        is_ai_file,
+        is_common_or_events_file,
+        is_event_file,
+        is_political_leaders_file,
+    ) = classify_file_path(filepath)
 
     # Only track idea categories for idea files (non-selectable vs selectable)
     # Dynamically parsed from common/idea_tags/*.txt

--- a/tools/linting/check_common_mistakes.py
+++ b/tools/linting/check_common_mistakes.py
@@ -2780,7 +2780,10 @@ def _option_unavailable_under_bankruptcy(option_block):
         option_block, _RE_TRIGGER_BLOCK_OPEN
     ):
         code = " ".join(strip_inline_comment(line) for line in trigger_block)
-        if "NOT" in code and "has_active_mission = bankruptcy_incoming_collapse" in code:
+        if (
+            "NOT" in code
+            and "has_active_mission = bankruptcy_incoming_collapse" in code
+        ):
             return True
     return False
 

--- a/tools/linting/check_common_mistakes.py
+++ b/tools/linting/check_common_mistakes.py
@@ -111,7 +111,7 @@ _RE_CHECK_EXPR_BAD_OPERAND = re.compile(
 )
 _RE_EVERY_OWNED_CONTROLLED_STATE = re.compile(r"\bevery_owned_controlled_state\b")
 _RE_NOR = re.compile(r"\bNOR\s*=\s*\{")
-_RE_IS_AT_WAR = re.compile(r"\bis_at_war\s*=")
+_RE_IS_AT_WAR = re.compile(r"\bis_at_war\s*=\s*(?:yes|no)\b")
 _RE_WHILE_LOOP_OPEN = re.compile(r"\bwhile_loop_effect\s*=\s*\{")
 _RE_MAX_ITERATIONS = re.compile(r"\bmax_iterations\s*=")
 # var:x^i needs the full variable name; a one-letter base is the shorthand the
@@ -297,6 +297,7 @@ _RE_HAS_IDEA = re.compile(r"has_idea\s*=\s*(\w+)")
 _RE_OR_CONTENT = re.compile(r"OR\s*=\s*\{([^}]*)\}")
 _RE_LOG_ONLY_EFFECT = re.compile(r"log\s*=\s*\"[^\"]+\"\s*$")
 _RE_OPTION_BLOCK_OPEN = re.compile(r"\boption\s*=\s*\{")
+_RE_TRIGGER_BLOCK_OPEN = re.compile(r"\btrigger\s*=\s*\{")
 _RE_COMPLETE_EFFECT_OPEN = re.compile(r"\bcomplete_effect\s*=\s*\{")
 _RE_REMOVE_EFFECT_OPEN = re.compile(r"\bremove_effect\s*=\s*\{")
 _RE_IS_IN_FACTION_TAG = re.compile(r"\bis_in_faction\s*=\s*(?!yes\b|no\b)(\w+)")
@@ -2656,8 +2657,28 @@ def _check_event_log_id(lines):
     return issues
 
 
+def _explode_braces(line):
+    """Split one line into pseudo-lines at every brace.
+
+    `ai_chance = { base = 5 modifier = { factor = 2 has_war = no } }` is valid
+    and appears in events/, but a one-element block hides its children from the
+    scan below. Exploding on braces gives those children a line each.
+    """
+    out, buf = [], ""
+    for ch in line:
+        buf += ch
+        if ch in "{}":
+            out.append(buf)
+            buf = ""
+    if buf.strip():
+        out.append(buf)
+    return out
+
+
 def _direct_child_blocks(lines, opener):
     """Yield direct child blocks matching opener as (offset, block)."""
+    if len(lines) == 1:
+        lines = _explode_braces(lines[0])
     i = 1
     while i < len(lines) - 1:
         code = strip_inline_comment(lines[i])
@@ -2672,57 +2693,96 @@ def _direct_child_blocks(lines, opener):
 
 
 def _ai_zero_modifier_conditions(modifier_block):
-    """Return whether a factor-zero modifier is guaranteed by the target state."""
+    """Classify one ai_chance modifier as it applies under the target state.
+
+    Returns (kind, is_bankruptcy) where kind is "zero" for a factor = 0 gated on
+    historical focus or bankruptcy, "add" for a positive addition gated the same
+    way, and "none" for anything this check cannot reason about.
+    """
     code = " ".join(strip_inline_comment(line) for line in modifier_block)
     if re.search(r"\bNOT\s*=", code):
-        return False, False
+        return "none", False
 
     body_start = code.find("{")
     body_end = code.rfind("}")
     if body_start < 0 or body_end <= body_start:
-        return False, False
+        return "none", False
 
     body = code[body_start + 1 : body_end]
     assignments = []
     cursor = 0
     for match in _RE_AI_ASSIGNMENT.finditer(body):
         if body[cursor : match.start()].strip():
-            return False, False
+            return "none", False
         assignments.append(match.groups())
         cursor = match.end()
     if body[cursor:].strip():
-        return False, False
+        return "none", False
 
     factor_zero = False
+    positive_add = False
     has_target_condition = False
     has_bankruptcy_condition = False
     for key, value in assignments:
         if key == "factor" and value in {"0", "0.0", "0.00"}:
             factor_zero = True
+        elif key == "add":
+            try:
+                positive_add = float(value) > 0
+            except ValueError:
+                return "none", False
+            if not positive_add:
+                return "none", False
         elif key == "is_historical_focus_on" and value == "yes":
             has_target_condition = True
         elif key == "has_active_mission" and value == "bankruptcy_incoming_collapse":
             has_target_condition = True
             has_bankruptcy_condition = True
         else:
-            return False, False
+            return "none", False
 
-    zeroes_option = factor_zero and has_target_condition
-    return zeroes_option, zeroes_option and has_bankruptcy_condition
+    if not has_target_condition:
+        return "none", False
+    if factor_zero:
+        return "zero", has_bankruptcy_condition
+    if positive_add:
+        return "add", has_bankruptcy_condition
+    return "none", False
 
 
 def _event_option_zeroes_historical_bankruptcy(option_block):
     for _offset, ai_block in _direct_child_blocks(option_block, _RE_AI_CHANCE_OPEN):
+        # AI weight operations apply in order, so a later addition undoes an
+        # earlier factor = 0 and the option stays selectable.
         zeroes_option = False
         has_bankruptcy_zero = False
         for _modifier_offset, modifier_block in _direct_child_blocks(
             ai_block, _RE_AI_MODIFIER_OPEN
         ):
-            zeroes, bankruptcy_zero = _ai_zero_modifier_conditions(modifier_block)
-            zeroes_option = zeroes_option or zeroes
-            has_bankruptcy_zero = has_bankruptcy_zero or bankruptcy_zero
+            kind, is_bankruptcy = _ai_zero_modifier_conditions(modifier_block)
+            if kind == "zero":
+                zeroes_option = True
+                has_bankruptcy_zero = has_bankruptcy_zero or is_bankruptcy
+            elif kind == "add":
+                zeroes_option = False
+                has_bankruptcy_zero = False
         return zeroes_option, has_bankruptcy_zero
     return False, False
+
+
+def _option_unavailable_under_bankruptcy(option_block):
+    """Whether the option's own trigger rules it out under bankruptcy.
+
+    Such an option is not a usable fallback, so it must not suppress the
+    finding just because its AI weight was never zeroed.
+    """
+    for _offset, trigger_block in _direct_child_blocks(
+        option_block, _RE_TRIGGER_BLOCK_OPEN
+    ):
+        code = " ".join(strip_inline_comment(line) for line in trigger_block)
+        if "NOT" in code and "has_active_mission = bankruptcy_incoming_collapse" in code:
+            return True
+    return False
 
 
 def _check_event_ai_historical_bankruptcy_fallback(lines):
@@ -2747,9 +2807,12 @@ def _check_event_ai_historical_bankruptcy_fallback(lines):
         for _offset, option_block in _direct_child_blocks(
             event_block, _RE_OPTION_BLOCK_OPEN
         ):
-            option_states.append(
-                _event_option_zeroes_historical_bankruptcy(option_block)
+            zeroes, bankruptcy = _event_option_zeroes_historical_bankruptcy(
+                option_block
             )
+            if _option_unavailable_under_bankruptcy(option_block):
+                zeroes = True
+            option_states.append((zeroes, bankruptcy))
 
         if (
             event_id

--- a/tools/linting/tests/check_common_mistakes_test.py
+++ b/tools/linting/tests/check_common_mistakes_test.py
@@ -52,8 +52,6 @@ import sys
 import tempfile
 
 from check_common_mistakes import (
-    classify_file_path,
-    _negates_bankruptcy_mission,
     _RE_IS_X_NATION,
     _ai_zero_modifier_conditions,
     _check_active_decision_defined,
@@ -95,8 +93,10 @@ from check_common_mistakes import (
     _equipment_names,
     _files_need_global_refs,
     _get_block,
+    _negates_bankruptcy_mission,
     _provincial_building_types,
     check_file,
+    classify_file_path,
 )
 
 passed = 0

--- a/tools/linting/tests/check_common_mistakes_test.py
+++ b/tools/linting/tests/check_common_mistakes_test.py
@@ -43,6 +43,7 @@ Unit tests for the checks added to check_common_mistakes.py (in file order):
   40. event AI choices cannot all be zero under historical bankruptcy
   41. is_at_war is not a valid trigger (use has_war)
   42. review regressions: add-after-zero, excluded fallback, single-line ai_chance
+  43. windows path separators keep the directory-scoped checks enabled
 """
 
 import os
@@ -51,6 +52,8 @@ import sys
 import tempfile
 
 from check_common_mistakes import (
+    classify_file_path,
+    _negates_bankruptcy_mission,
     _RE_IS_X_NATION,
     _ai_zero_modifier_conditions,
     _check_active_decision_defined,
@@ -3504,6 +3507,71 @@ assert_finds(
     ],
     1,
     "single-line ai_chance blocks are parsed for modifiers",
+)
+
+
+assert_finds(
+    _check_event_ai_historical_bankruptcy_fallback,
+    [
+        "country_event = {\n",
+        "\tid = test_events.6\n",
+        "\toption = {\n",
+        "\t\tname = test_events.6.a\n",
+        "\t\tai_chance = {\n",
+        "\t\t\tbase = 50\n",
+        "\t\t\tmodifier = {\n",
+        "\t\t\t\tfactor = 0\n",
+        "\t\t\t\thas_active_mission = bankruptcy_incoming_collapse\n",
+        "\t\t\t}\n",
+        "\t\t\tmodifier = { add = 30 }\n",
+        "\t\t}\n",
+        "\t}\n",
+        "\toption = {\n",
+        "\t\tname = test_events.6.b\n",
+        "\t\tai_chance = { base = 50 modifier = { factor = 0 is_historical_focus_on = yes } }\n",
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "an unconditional add also restores a zeroed option",
+)
+
+assert_eq(
+    _negates_bankruptcy_mission(
+        "NOT = { has_war = yes } has_active_mission = bankruptcy_incoming_collapse"
+    ),
+    False,
+    "an unrelated NOT beside a positive mission check is not a negation",
+)
+
+assert_eq(
+    _negates_bankruptcy_mission(
+        "NOT = { has_active_mission = bankruptcy_incoming_collapse }"
+    ),
+    True,
+    "the mission negated inside its own NOT is recognised",
+)
+
+# 43. Windows path separators must not disable the directory-scoped checks.
+
+print("\n── windows path classification ──")
+
+assert_eq(
+    classify_file_path("common\\ideas\\united_states.txt"),
+    classify_file_path("common/ideas/united_states.txt"),
+    "a backslash ideas path classifies the same as a forward-slash one",
+)
+
+assert_eq(
+    classify_file_path("common\\national_focus\\usa.txt")[1],
+    True,
+    "a backslash national_focus path is still a focus file",
+)
+
+assert_eq(
+    classify_file_path("events\\United States.txt")[5],
+    True,
+    "a backslash events path is still an event file",
 )
 
 assert_finds(

--- a/tools/linting/tests/check_common_mistakes_test.py
+++ b/tools/linting/tests/check_common_mistakes_test.py
@@ -42,6 +42,7 @@ Unit tests for the checks added to check_common_mistakes.py (in file order):
   39. add_opinion_modifier / add_relation_modifier naming no modifier
   40. event AI choices cannot all be zero under historical bankruptcy
   41. is_at_war is not a valid trigger (use has_war)
+  42. review regressions: add-after-zero, excluded fallback, single-line ai_chance
 """
 
 import os
@@ -3395,7 +3396,7 @@ assert_eq(
             "}\n",
         ]
     ),
-    (False, False),
+    ("none", False),
     "brace-valued conditions are not treated as unconditional zero modifiers",
 )
 
@@ -3408,6 +3409,101 @@ assert_finds(
     ["\tlimit = { is_at_war = yes }\n", "\tis_at_war = no\n"],
     2,
     "is_at_war assignments flagged",
+)
+
+
+assert_finds(
+    _check_invalid_is_at_war,
+    [
+        "\tset_variable = { is_at_war = 1 }\n",
+        "\tcheck_variable = { is_at_war > 0 }\n",
+    ],
+    0,
+    "a variable named is_at_war is not a trigger and is not flagged",
+)
+
+# 42. Regressions from the review of the two checks above.
+
+print("\n── ai fallback edge cases ──")
+
+assert_finds(
+    _check_event_ai_historical_bankruptcy_fallback,
+    [
+        "country_event = {\n",
+        "\tid = test_events.3\n",
+        "\toption = {\n",
+        "\t\tname = test_events.3.a\n",
+        "\t\tai_chance = {\n",
+        "\t\t\tbase = 50\n",
+        "\t\t\tmodifier = {\n",
+        "\t\t\t\tfactor = 0\n",
+        "\t\t\t\thas_active_mission = bankruptcy_incoming_collapse\n",
+        "\t\t\t}\n",
+        "\t\t\tmodifier = {\n",
+        "\t\t\t\tadd = 30\n",
+        "\t\t\t\thas_active_mission = bankruptcy_incoming_collapse\n",
+        "\t\t\t}\n",
+        "\t\t}\n",
+        "\t}\n",
+        "\toption = {\n",
+        "\t\tname = test_events.3.b\n",
+        "\t\tai_chance = {\n",
+        "\t\t\tbase = 50\n",
+        "\t\t\tmodifier = {\n",
+        "\t\t\t\tfactor = 0\n",
+        "\t\t\t\tis_historical_focus_on = yes\n",
+        "\t\t\t}\n",
+        "\t\t}\n",
+        "\t}\n",
+        "}\n",
+    ],
+    0,
+    "an add after factor = 0 restores the option and clears the finding",
+)
+
+assert_finds(
+    _check_event_ai_historical_bankruptcy_fallback,
+    [
+        "country_event = {\n",
+        "\tid = test_events.4\n",
+        "\toption = {\n",
+        "\t\tname = test_events.4.a\n",
+        "\t\tai_chance = {\n",
+        "\t\t\tbase = 50\n",
+        "\t\t\tmodifier = {\n",
+        "\t\t\t\tfactor = 0\n",
+        "\t\t\t\thas_active_mission = bankruptcy_incoming_collapse\n",
+        "\t\t\t}\n",
+        "\t\t}\n",
+        "\t}\n",
+        "\toption = {\n",
+        "\t\tname = test_events.4.b\n",
+        "\t\ttrigger = { NOT = { has_active_mission = bankruptcy_incoming_collapse } }\n",
+        "\t\tai_chance = { base = 50 }\n",
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "an option its own trigger rules out is not a usable fallback",
+)
+
+assert_finds(
+    _check_event_ai_historical_bankruptcy_fallback,
+    [
+        "country_event = {\n",
+        "\tid = test_events.5\n",
+        "\toption = {\n",
+        "\t\tname = test_events.5.a\n",
+        "\t\tai_chance = { base = 50 modifier = { factor = 0 has_active_mission = bankruptcy_incoming_collapse } }\n",
+        "\t}\n",
+        "\toption = {\n",
+        "\t\tname = test_events.5.b\n",
+        "\t\tai_chance = { base = 50 modifier = { factor = 0 is_historical_focus_on = yes } }\n",
+        "\t}\n",
+        "}\n",
+    ],
+    1,
+    "single-line ai_chance blocks are parsed for modifiers",
 )
 
 assert_finds(


### PR DESCRIPTION
### Changes
- Restricts the `is_at_war` check to the boolean trigger form, so a variable or scripted-trigger definition of that name is no longer reported as an unknown engine trigger
- Reads modifiers inside single-line `ai_chance = { base = N modifier = { ... } }` blocks, which the AI fallback check previously skipped entirely
- Treats a positive `add` after a `factor = 0` as restoring the option, since AI weight operations apply in order and the option stays selectable
- Stops an option whose own trigger rules it out under bankruptcy from counting as a usable fallback
- Adds a regression test for each of the four

Follow-up to [#3251](https://github.com/MillenniumDawn/Millennium-Dawn/pull/3251), which merged before these fixes were pushed to the branch.