### PR TITLE
Prefix Poland's and Iraq's dynamic modifier variables with their tags

### DIFF
--- a/common/dynamic_modifiers/99_IRQ_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/99_IRQ_dynamic_modifiers.txt
@@ -10,7 +10,7 @@ IRQ_western_aid_to_iraq = {
 		has_completed_focus = IRQ_reconstruction_of_losses
 	}
 
-	industrial_factory_donations = civilian_aid_to_iraq_count
+	industrial_factory_donations = IRQ_civilian_aid_to_iraq_count
 
 }
 IRQ_western_engineers_in_iraq = {
@@ -25,7 +25,7 @@ IRQ_western_engineers_in_iraq = {
 		has_completed_focus = IRQ_foreign_advisors
 	}
 
-	production_speed_buildings_factor = western_engineers_in_iraq_speed
+	production_speed_buildings_factor = IRQ_western_engineers_in_iraq_speed
 
 }
 IRQ_economic_union_member = {

--- a/common/dynamic_modifiers/POL_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/POL_dynamic_modifiers.txt
@@ -1,53 +1,53 @@
 POL_economy_modifier = {
 	icon = "GFX_idea_new_deal"
 	
-	productivity_growth_modifier = economy_productivity_modifier
-	tax_gain_multiplier_modifier = economy_tax_gain_modifier
-	office_park_income_tax_modifier = economy_office_tax_modifier
-	offices_productivity = economy_office_productivity_modifier
-	return_on_investment_modifier = economy_roi_modifier
-	interest_rate_multiplier_modifier = economy_interest_rate_modifier
-	production_speed_buildings_factor = economy_construction_factor
-	research_speed_factor = economy_research_factor
-	stability_factor = economy_stability_modifier
-	stability_weekly = economy_weekly_stability
-	democratic_drift = economy_western_drift
-	communism_drift = economy_emerging_drift
-	nationalist_drift = economy_nationalist_drift
-	expected_welfare_modifier = economy_social_spending_modifier
-	expected_healthcare_modifier = economy_health_spending_modifier
-	expected_education_modifier = economy_education_spending_modifier
-	monthly_population = economy_population_growth_modifier
-	foreign_influence_monthly_domestic_independence_gain_modifier = economy_independence_gain
-	foreign_influence_modifier = economy_influence_modifier
+	productivity_growth_modifier = POL_economy_productivity_modifier
+	tax_gain_multiplier_modifier = POL_economy_tax_gain_modifier
+	office_park_income_tax_modifier = POL_economy_office_tax_modifier
+	offices_productivity = POL_economy_office_productivity_modifier
+	return_on_investment_modifier = POL_economy_roi_modifier
+	interest_rate_multiplier_modifier = POL_economy_interest_rate_modifier
+	production_speed_buildings_factor = POL_economy_construction_factor
+	research_speed_factor = POL_economy_research_factor
+	stability_factor = POL_economy_stability_modifier
+	stability_weekly = POL_economy_weekly_stability
+	democratic_drift = POL_economy_western_drift
+	communism_drift = POL_economy_emerging_drift
+	nationalist_drift = POL_economy_nationalist_drift
+	expected_welfare_modifier = POL_economy_social_spending_modifier
+	expected_healthcare_modifier = POL_economy_health_spending_modifier
+	expected_education_modifier = POL_economy_education_spending_modifier
+	monthly_population = POL_economy_population_growth_modifier
+	foreign_influence_monthly_domestic_independence_gain_modifier = POL_economy_independence_gain
+	foreign_influence_modifier = POL_economy_influence_modifier
 
 }
 
 POL_private_pensions = {
 	icon = "GFX_idea_new_deal"
 	
-	interest_rate_multiplier_modifier = pensions_interest_rate_modifier
-	return_on_investment_modifier = pensions_roi_modifier
-	monthly_population = pensions_population_growth_modifier
+	interest_rate_multiplier_modifier = POL_pensions_interest_rate_modifier
+	return_on_investment_modifier = POL_pensions_roi_modifier
+	monthly_population = POL_pensions_population_growth_modifier
 }
 
 POL_private_healthcare = {
 	icon = "GFX_idea_new_deal"
 
-	interest_rate_multiplier_modifier = healthcare_interest_rate_modifier
-	monthly_population = healthcare_population_growth_modifier
-	weekly_casualties_war_support = healthcare_war_support_modifier
-	army_morale_factor = healthcare_morale_modifier
-	consumer_goods_factor = healthcare_tax_cost_modifier
-	stability_factor = healthcare_stability_modifier
+	interest_rate_multiplier_modifier = POL_healthcare_interest_rate_modifier
+	monthly_population = POL_healthcare_population_growth_modifier
+	weekly_casualties_war_support = POL_healthcare_war_support_modifier
+	army_morale_factor = POL_healthcare_morale_modifier
+	consumer_goods_factor = POL_healthcare_tax_cost_modifier
+	stability_factor = POL_healthcare_stability_modifier
 }
 
 POL_private_education = {
 	icon = "GFX_idea_new_deal"
 
-	interest_rate_multiplier_modifier = education_interest_rate_modifier
-	research_speed_factor = education_research_factor
-	productivity_growth_modifier = education_productivity_modifier
-	special_project_speed_factor = education_project_speed_modifier
-	foreign_influence_modifier = education_influence_modifier
+	interest_rate_multiplier_modifier = POL_education_interest_rate_modifier
+	research_speed_factor = POL_education_research_factor
+	productivity_growth_modifier = POL_education_productivity_modifier
+	special_project_speed_factor = POL_education_project_speed_modifier
+	foreign_influence_modifier = POL_education_influence_modifier
 }

--- a/common/national_focus/05_iraq.txt
+++ b/common/national_focus/05_iraq.txt
@@ -32,7 +32,6 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus IRQ_reconstruction_of_losses"
-			set_variable = { civilian_aid_to_iraq_count = 0 }
 			if = {
 				limit = {
 					country_exists = USA
@@ -248,9 +247,6 @@ focus_tree = {
 				add_dynamic_modifier = {
 					modifier = IRQ_western_engineers_in_iraq
 				}
-			}
-			set_variable = {
-				western_engineers_in_iraq_speed = 0
 			}
 			every_country = {
 				limit = {

--- a/common/national_focus/05_poland.txt
+++ b/common/national_focus/05_poland.txt
@@ -5254,24 +5254,6 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			set_variable = { economy_productivity_modifier = 0 }
-			set_variable = { economy_roi_modifier = 0 }
-			set_variable = { economy_construction_factor = 0 }
-			set_variable = { economy_research_factor = 0 }
-			set_variable = { economy_tax_gain_modifier = 0 }
-			set_variable = { economy_western_drift = 0 }
-			set_variable = { economy_emerging_drift = 0 }
-			set_variable = { economy_social_spending_modifier = 0 }
-			set_variable = { economy_health_spending_modifier = 0 }
-			set_variable = { economy_education_spending_modifier = 0 }
-			set_variable = { economy_stability_modifier = 0 }
-			set_variable = { economy_weekly_stability = 0 }
-			set_variable = { economy_office_tax_modifier = 0 }
-			set_variable = { economy_office_productivity_modifier = 0 }
-			set_variable = { economy_population_growth_modifier = 0 }
-			set_variable = { economy_interest_rate_modifier = 0 }
-			set_variable = { economy_independence_gain = 0 }
-			set_variable = { economy_influence_modifier = 0 }
 			add_dynamic_modifier = { modifier = POL_economy_modifier }
 		}
 
@@ -5318,7 +5300,7 @@ focus_tree = {
 
 		completion_reward = {
 			one_random_industrial_complex = yes
-			add_to_variable = { economy_construction_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -5350,7 +5332,7 @@ focus_tree = {
 		completion_reward = {
 			one_random_industrial_complex = yes
 			one_random_industrial_complex = yes
-			add_to_variable = { economy_construction_factor = 0.1 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.1 tooltip = production_speed_buildings_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -5384,8 +5366,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_construction_factor = 0.15 tooltip = production_speed_buildings_factor_tt }
-			add_to_variable = { economy_productivity_modifier = -0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.15 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = -0.25 tooltip = productivity_growth_modifier_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -5418,8 +5400,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_construction_factor = -0.15 tooltip = production_speed_buildings_factor_tt }
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_construction_factor = -0.15 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -5448,7 +5430,7 @@ focus_tree = {
 		completion_reward = {
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-			add_to_variable = { economy_construction_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
 		}
 		ai_will_do = { base = 25 }
 	}
@@ -5478,8 +5460,8 @@ focus_tree = {
 				set_temp_variable = { influence_target = ROOT.id }
 				change_influence_percentage = yes
 			}
-			add_to_variable = { economy_construction_factor = 0.15 tooltip = production_speed_buildings_factor_tt }
-			add_to_variable = { economy_stability_modifier = -0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.15 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_stability_modifier = -0.05 tooltip = stability_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -5527,7 +5509,7 @@ focus_tree = {
 				set_temp_variable = { influence_target = ROOT.id }
 				change_influence_percentage = yes
 			}
-			add_to_variable = { economy_construction_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -5574,13 +5556,13 @@ focus_tree = {
 
 			if = {
 				limit = { has_completed_focus = POL_mass_scale_construction }
-				add_to_variable = { economy_stability_modifier = 0.07 tooltip = stability_factor_tt }
+				add_to_variable = { POL_economy_stability_modifier = 0.07 tooltip = stability_factor_tt }
 				set_temp_variable = { treasury_change = -3 }
 				modify_treasury_effect = yes
 			}
 			else_if = {
 				limit = { has_completed_focus = POL_innovation_in_construction }
-				add_to_variable = { economy_stability_modifier = 0.1 tooltip = stability_factor_tt }
+				add_to_variable = { POL_economy_stability_modifier = 0.1 tooltip = stability_factor_tt }
 				set_temp_variable = { treasury_change = -5 }
 				modify_treasury_effect = yes
 			}
@@ -5629,15 +5611,15 @@ focus_tree = {
 
 			if = {
 				limit = { has_completed_focus = POL_mass_scale_construction }
-				add_to_variable = { economy_stability_modifier = 0.03 tooltip = stability_factor_tt }
-				add_to_variable = { economy_roi_modifier = 0.003 tooltip = return_on_investment_modifier_tt }
+				add_to_variable = { POL_economy_stability_modifier = 0.03 tooltip = stability_factor_tt }
+				add_to_variable = { POL_economy_roi_modifier = 0.003 tooltip = return_on_investment_modifier_tt }
 				set_temp_variable = { treasury_change = -6 }
 				modify_treasury_effect = yes
 			}
 			else_if = {
 				limit = { has_completed_focus = POL_innovation_in_construction }
-				add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
-				add_to_variable = { economy_roi_modifier = 0.005 tooltip = return_on_investment_modifier_tt }
+				add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+				add_to_variable = { POL_economy_roi_modifier = 0.005 tooltip = return_on_investment_modifier_tt }
 				set_temp_variable = { treasury_change = -10 }
 				modify_treasury_effect = yes
 			}
@@ -5681,8 +5663,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
-			add_to_variable = { economy_roi_modifier = 0.015 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_roi_modifier = 0.015 tooltip = return_on_investment_modifier_tt }
 		}
 		ai_will_do = {
 			base = 5
@@ -5749,8 +5731,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_productivity_modifier = 0.1 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_research_factor = 0.05 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.1 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_research_factor = 0.05 tooltip = research_speed_factor_tt }
 		}
 		ai_will_do = {
 			base = 15
@@ -5781,8 +5763,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_research_factor = 0.05 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_research_factor = 0.05 tooltip = research_speed_factor_tt }
 			custom_effect_tooltip = POL_all_in_cost_TT
 		}
 		ai_will_do = {
@@ -5814,7 +5796,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_productivity_modifier = 0.15 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.15 tooltip = productivity_growth_modifier_tt }
 		}
 		ai_will_do = {
 			base = 15
@@ -5845,8 +5827,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_office_productivity_modifier = 0.2 tooltip = offices_productivity_tt }
-			add_to_variable = { economy_office_tax_modifier = 0.05 tooltip = office_park_income_tax_modifier_tt }
+			add_to_variable = { POL_economy_office_productivity_modifier = 0.2 tooltip = offices_productivity_tt }
+			add_to_variable = { POL_economy_office_tax_modifier = 0.05 tooltip = office_park_income_tax_modifier_tt }
 			if = {
 				limit = { has_completed_focus = POL_go_all_in }
 				set_temp_variable = { treasury_change = -1.2 }
@@ -5900,9 +5882,9 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_independence_gain = 0.02 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
-			add_to_variable = { economy_office_tax_modifier = 0.05 tooltip = office_park_income_tax_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.1 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.02 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_office_tax_modifier = 0.05 tooltip = office_park_income_tax_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.1 tooltip = productivity_growth_modifier_tt }
 			if = {
 				limit = { has_completed_focus = POL_go_all_in }
 				set_temp_variable = { treasury_change = -4.8 }
@@ -5964,9 +5946,9 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_independence_gain = 0.03 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.15 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_influence_modifier = 0.1 tooltip = foreign_influence_modifier_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.03 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.15 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_influence_modifier = 0.1 tooltip = foreign_influence_modifier_tt }
 			if = {
 				limit = { has_completed_focus = POL_go_all_in }
 				set_temp_variable = { treasury_change = -3.6 }
@@ -6024,9 +6006,9 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_independence_gain = 0.02 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_research_factor = 0.1 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.02 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_research_factor = 0.1 tooltip = research_speed_factor_tt }
 			if = {
 				limit = { has_completed_focus = POL_go_all_in }
 				set_temp_variable = { treasury_change = -2.4 }
@@ -6065,9 +6047,9 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_independence_gain = 0.05 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_research_factor = 0.15 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.05 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_research_factor = 0.15 tooltip = research_speed_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -6118,9 +6100,9 @@ focus_tree = {
 				technology = computing5
 				ahead_reduction = 2
 			}
-			add_to_variable = { economy_independence_gain = 0.01 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.05 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_research_factor = 0.01 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.01 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.05 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_research_factor = 0.01 tooltip = research_speed_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -6182,9 +6164,9 @@ focus_tree = {
 				technology = artificial_intelligence_7
 				ahead_reduction = 2
 			}
-			add_to_variable = { economy_independence_gain = 0.02 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.2 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_research_factor = 0.04 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.02 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.2 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_research_factor = 0.04 tooltip = research_speed_factor_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -6241,7 +6223,7 @@ focus_tree = {
 				technology = artificial_intelligence_9
 				ahead_reduction = 4
 			}
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
 		}
 		ai_will_do = {
 			base = 25
@@ -6317,9 +6299,9 @@ focus_tree = {
 				technology = artificial_intelligence_14
 				ahead_reduction = 9
 			}
-			add_to_variable = { economy_productivity_modifier = 1 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_influence_modifier = 0.1 tooltip = foreign_influence_modifier_tt }
-			add_to_variable = { economy_independence_gain = 0.08 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 1 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_influence_modifier = 0.1 tooltip = foreign_influence_modifier_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.08 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
 		}
 		ai_will_do = {
 			base = 50
@@ -6829,7 +6811,7 @@ focus_tree = {
 					}
 				}
 			}
-			add_to_variable = { economy_productivity_modifier = 1 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 1 tooltip = productivity_growth_modifier_tt }
 		}
 		ai_will_do = { base = 50 }
 	}
@@ -7152,7 +7134,7 @@ focus_tree = {
 			modify_treasury_effect = yes
 			add_political_power = 150
 			sre_foreign_influence_spirit = yes
-			add_to_variable = { economy_independence_gain = 0.05 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.05 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
 			114 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -7335,9 +7317,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = -0.1 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = 0.02 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_emerging_drift = 0.02 tooltip = communism_drift_tt }
+			add_to_variable = { POL_economy_productivity_modifier = -0.1 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.02 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_emerging_drift = 0.02 tooltip = communism_drift_tt }
 			set_temp_variable = { temp_opinion = -5 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -7386,9 +7368,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = -0.4 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = 0.075 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_emerging_drift = 0.04 tooltip = communism_drift_tt }
+			add_to_variable = { POL_economy_productivity_modifier = -0.4 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.075 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_emerging_drift = 0.04 tooltip = communism_drift_tt }
 			set_temp_variable = { temp_opinion = -15 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -7433,9 +7415,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = -0.5 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = 0.05 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_emerging_drift = 0.05 tooltip = communism_drift_tt }
+			add_to_variable = { POL_economy_productivity_modifier = -0.5 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_emerging_drift = 0.05 tooltip = communism_drift_tt }
 			set_temp_variable = { temp_opinion = -15 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = 15 }
@@ -7480,10 +7462,10 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = -0.75 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = 0.125 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_emerging_drift = 0.05 tooltip = communism_drift_tt }
-			add_to_variable = { economy_weekly_stability = -0.001 tooltip = stability_weekly_tt }
+			add_to_variable = { POL_economy_productivity_modifier = -0.75 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.125 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_emerging_drift = 0.05 tooltip = communism_drift_tt }
+			add_to_variable = { POL_economy_weekly_stability = -0.001 tooltip = stability_weekly_tt }
 			if = {
 				limit = { has_idea = international_bankers }
 				swap_ideas = {
@@ -7533,9 +7515,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = -0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_western_drift = -0.02 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_education_spending_modifier = 1 tooltip = expected_education_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = -0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = -0.02 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_education_spending_modifier = 1 tooltip = expected_education_modifier_tt }
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 		}
@@ -7578,8 +7560,8 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_health_spending_modifier = 1 tooltip = expected_healthcare_modifier_tt }
-			add_to_variable = { economy_population_growth_modifier = 0.1 tooltip = monthly_population_tt }
+			add_to_variable = { POL_economy_health_spending_modifier = 1 tooltip = expected_healthcare_modifier_tt }
+			add_to_variable = { POL_economy_population_growth_modifier = 0.1 tooltip = monthly_population_tt }
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 		}
@@ -7622,8 +7604,8 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_social_spending_modifier = 1 tooltip = expected_welfare_modifier_tt }
-			add_to_variable = { economy_weekly_stability = -0.001 tooltip = stability_weekly_tt }
+			add_to_variable = { POL_economy_social_spending_modifier = 1 tooltip = expected_welfare_modifier_tt }
+			add_to_variable = { POL_economy_weekly_stability = -0.001 tooltip = stability_weekly_tt }
 			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 		}
@@ -7660,7 +7642,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = 0.05 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.05 tooltip = productivity_growth_modifier_tt }
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_clergy_opinion = yes
 		}
@@ -7685,7 +7667,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_tax_gain_modifier = 0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.05 tooltip = tax_gain_multiplier_modifier_tt }
 			set_temp_variable = { pop_change = 5 }
 			modify_population_tax_rate_effect = yes
 			set_temp_variable = { party_index = 6 }
@@ -7742,8 +7724,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
-			add_to_variable = { economy_western_drift = 0.01 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_western_drift = 0.01 tooltip = democratic_drift_tt }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
@@ -7845,7 +7827,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_roi_modifier = 0.003 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { POL_economy_roi_modifier = 0.003 tooltip = return_on_investment_modifier_tt }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
@@ -7896,7 +7878,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_tax_gain_modifier = 0.10 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.10 tooltip = tax_gain_multiplier_modifier_tt }
 			set_temp_variable = { corp_change = 5 }
 			modify_corporate_tax_rate_effect = yes
 			set_temp_variable = { party_index = 6 }
@@ -7954,10 +7936,10 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_tax_gain_modifier = -0.03 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
-			add_to_variable = { economy_western_drift = 0.01 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_population_growth_modifier = 0.1 tooltip = monthly_population_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.03 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_western_drift = 0.01 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_population_growth_modifier = 0.1 tooltip = monthly_population_tt }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
@@ -8015,8 +7997,8 @@ focus_tree = {
 			modify_treasury_effect = yes
 			set_temp_variable = { int_investment_change = 50 }
 			modify_international_investment_effect = yes
-			add_to_variable = { economy_roi_modifier = 0.01 tooltip = return_on_investment_modifier_tt }
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_roi_modifier = 0.01 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
@@ -8073,8 +8055,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_interest_rate_modifier = -1 tooltip = interest_rate_multiplier_modifier_tt }
-			add_to_variable = { economy_stability_modifier = 0.03 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_interest_rate_modifier = -1 tooltip = interest_rate_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.03 tooltip = stability_factor_tt }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -8131,7 +8113,7 @@ focus_tree = {
 		completion_reward = {
 			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
 			set_temp_variable = { party_index = 6 }
 			set_temp_variable = { party_popularity_increase = 0.01 }
 			set_temp_variable = { temp_outlook_increase = 0.01 }
@@ -8281,10 +8263,10 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_construction_factor = 0.20 tooltip = production_speed_buildings_factor_tt }
-			add_to_variable = { economy_research_factor = 0.05 tooltip = research_speed_factor_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.03 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_construction_factor = 0.20 tooltip = production_speed_buildings_factor_tt }
+			add_to_variable = { POL_economy_research_factor = 0.05 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.03 tooltip = tax_gain_multiplier_modifier_tt }
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
@@ -8341,7 +8323,7 @@ focus_tree = {
 				remove_idea = farmers
 				add_idea = landowners
 			}
-			add_to_variable = { economy_tax_gain_modifier = 0.03 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.03 tooltip = tax_gain_multiplier_modifier_tt }
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
@@ -8396,9 +8378,9 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
-			add_to_variable = { economy_population_growth_modifier = 0.15 tooltip = monthly_population_tt }
-			add_to_variable = { economy_emerging_drift = 0.01 tooltip = communism_drift_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_population_growth_modifier = 0.15 tooltip = monthly_population_tt }
+			add_to_variable = { POL_economy_emerging_drift = 0.01 tooltip = communism_drift_tt }
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
@@ -8451,8 +8433,8 @@ focus_tree = {
 
 
 		completion_reward = {
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
-			add_to_variable = { economy_western_drift = 0.01 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_western_drift = 0.01 tooltip = democratic_drift_tt }
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
@@ -8513,8 +8495,8 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_roi_modifier = 0.005 tooltip = return_on_investment_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_roi_modifier = 0.005 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			set_temp_variable = { temp_outlook_increase = -0.02 }
@@ -8588,9 +8570,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.02 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.02 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.02 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.02 tooltip = democratic_drift_tt }
 			set_temp_variable = { temp_opinion = 10 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = -10 }
@@ -8639,9 +8621,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.06 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.08 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.04 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.08 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.04 tooltip = democratic_drift_tt }
 			set_temp_variable = { temp_opinion = 15 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = -15 }
@@ -8690,11 +8672,11 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.07 }
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.04 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_weekly_stability = 0.001 tooltip = stability_weekly_tt }
-			add_to_variable = { economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.04 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_weekly_stability = 0.001 tooltip = stability_weekly_tt }
+			add_to_variable = { POL_economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
 			if = {
 				limit = { has_idea = comprehensive_regulations }
 				swap_ideas = {
@@ -8773,9 +8755,9 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.1 }
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.05 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.05 tooltip = democratic_drift_tt }
 			set_temp_variable = { temp_opinion = 15 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = -15 }
@@ -8809,12 +8791,12 @@ focus_tree = {
 		completion_reward = {
 
 
-			add_to_variable = { economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.1 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.05 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_weekly_stability = 0.001 tooltip = stability_weekly_tt }
-			add_to_variable = { economy_social_spending_modifier = -5 tooltip = expected_welfare_modifier_tt }
-			add_to_variable = { economy_stability_modifier = -0.25 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.5 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.1 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.05 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_weekly_stability = 0.001 tooltip = stability_weekly_tt }
+			add_to_variable = { POL_economy_social_spending_modifier = -5 tooltip = expected_welfare_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = -0.25 tooltip = stability_factor_tt }
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = -0.03 }
 			set_temp_variable = { temp_outlook_increase = -0.03 }
@@ -8873,9 +8855,7 @@ focus_tree = {
 				}
 			}
 			add_dynamic_modifier = { modifier = POL_private_pensions }
-			set_variable = { pensions_interest_rate_modifier = -36 tooltip = interest_rate_multiplier_modifier_tt }
-			set_variable = { pensions_roi_modifier = 0 }
-			set_variable = { pensions_population_growth_modifier = 0 }
+			set_variable = { POL_pensions_interest_rate_modifier = -36 tooltip = interest_rate_multiplier_modifier_tt }
 			set_variable = { pensions_effective_gdpc = 0 }
 			set_temp_variable = { debt_change = gdp_total }
 			multiply_temp_variable = { debt_change = 3.6 }
@@ -8910,11 +8890,11 @@ focus_tree = {
 
 		completion_reward = {
 
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.03 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_health_spending_modifier = -5 tooltip = expected_healthcare_modifier_tt }
-			add_to_variable = { economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.03 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_health_spending_modifier = -5 tooltip = expected_healthcare_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = -0.01 }
 			set_temp_variable = { temp_outlook_increase = -0.01 }
@@ -8973,12 +8953,7 @@ focus_tree = {
 				}
 			}
 			add_dynamic_modifier = { modifier = POL_private_healthcare }
-			set_variable = { healthcare_interest_rate_modifier = -12 tooltip = interest_rate_multiplier_modifier_tt }
-			set_variable = { healthcare_population_growth_modifier = 0 }
-			set_variable = { healthcare_war_support_modifier = 0 }
-			set_variable = { healthcare_morale_modifier = 0 }
-			set_variable = { healthcare_tax_cost_modifier = 0 }
-			set_variable = { healthcare_stability_modifier = 0 }
+			set_variable = { POL_healthcare_interest_rate_modifier = -12 tooltip = interest_rate_multiplier_modifier_tt }
 			set_variable = { healthcare_effective_gdpc = 0 }
 			set_temp_variable = { debt_change = gdp_total }
 			multiply_temp_variable = { debt_change = 1.2 }
@@ -9025,11 +9000,11 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.04 }
 			set_temp_variable = { temp_outlook_increase = 0.04 }
 			change_relative_party_popularity = yes
-			add_to_variable = { economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
-			add_to_variable = { economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_western_drift = 0.03 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_education_spending_modifier = -5 tooltip = expected_education_modifier_tt }
-			add_to_variable = { economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.25 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = -0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.03 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_education_spending_modifier = -5 tooltip = expected_education_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = -0.1 tooltip = stability_factor_tt }
 			set_temp_variable = { temp_opinion = 7 }
 			change_international_bankers_opinion = yes
 			set_temp_variable = { temp_opinion = -10 }
@@ -9065,11 +9040,7 @@ focus_tree = {
 				}
 			}
 			add_dynamic_modifier = { modifier = POL_private_education }
-			set_variable = { education_interest_rate_modifier = -6 tooltip = interest_rate_multiplier_modifier_tt }
-			set_variable = { education_research_factor = 0 }
-			set_variable = { education_productivity_modifier = 0 }
-			set_variable = { education_project_speed_modifier = 0 }
-			set_variable = { education_influence_modifier = 0 }
+			set_variable = { POL_education_interest_rate_modifier = -6 tooltip = interest_rate_multiplier_modifier_tt }
 			set_variable = { education_effective_gdpc = 0 }
 			set_temp_variable = { debt_change = gdp_total }
 			multiply_temp_variable = { debt_change = 0.6 }
@@ -9110,10 +9081,10 @@ focus_tree = {
 
 
 		completion_reward = {
-			add_to_variable = { economy_emerging_drift = 0.05 tooltip = communism_drift_tt }
-			add_to_variable = { economy_stability_modifier = 0.1 tooltip = stability_factor_tt }
-			add_to_variable = { economy_population_growth_modifier = 0.25 tooltip = monthly_population_tt }
-			add_to_variable = { economy_independence_gain = 0.10 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
+			add_to_variable = { POL_economy_emerging_drift = 0.05 tooltip = communism_drift_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.1 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_population_growth_modifier = 0.25 tooltip = monthly_population_tt }
+			add_to_variable = { POL_economy_independence_gain = 0.10 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
 			set_temp_variable = { temp_opinion = 20 }
 			change_labour_unions_opinion = yes
 			set_temp_variable = { temp_opinion = 20 }
@@ -9150,13 +9121,13 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_nationalist_drift = -0.02 tooltip = nationalist_drift_tt }
-			add_to_variable = { economy_tax_gain_modifier = 0.05 tooltip = tax_gain_multiplier_modifier_tt }
-			add_to_variable = { economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
-			add_to_variable = { economy_population_growth_modifier = 0.1 tooltip = monthly_population_tt }
-			add_to_variable = { economy_research_factor = 0.1 tooltip = research_speed_factor_tt }
-			add_to_variable = { economy_roi_modifier = 0.015 tooltip = return_on_investment_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 0.75 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_nationalist_drift = -0.02 tooltip = nationalist_drift_tt }
+			add_to_variable = { POL_economy_tax_gain_modifier = 0.05 tooltip = tax_gain_multiplier_modifier_tt }
+			add_to_variable = { POL_economy_stability_modifier = 0.05 tooltip = stability_factor_tt }
+			add_to_variable = { POL_economy_population_growth_modifier = 0.1 tooltip = monthly_population_tt }
+			add_to_variable = { POL_economy_research_factor = 0.1 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_roi_modifier = 0.015 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 0.75 tooltip = productivity_growth_modifier_tt }
 			set_temp_variable = { temp_opinion = 10 }
 			change_labour_unions_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9196,10 +9167,10 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_to_variable = { economy_western_drift = 0.05 tooltip = democratic_drift_tt }
-			add_to_variable = { economy_research_factor = 0.25 tooltip = research_speed_factor_tt }
-			add_to_variable = { economy_roi_modifier = 0.03 tooltip = return_on_investment_modifier_tt }
-			add_to_variable = { economy_productivity_modifier = 1.5 tooltip = productivity_growth_modifier_tt }
+			add_to_variable = { POL_economy_western_drift = 0.05 tooltip = democratic_drift_tt }
+			add_to_variable = { POL_economy_research_factor = 0.25 tooltip = research_speed_factor_tt }
+			add_to_variable = { POL_economy_roi_modifier = 0.03 tooltip = return_on_investment_modifier_tt }
+			add_to_variable = { POL_economy_productivity_modifier = 1.5 tooltip = productivity_growth_modifier_tt }
 			set_temp_variable = { temp_opinion = 20 }
 			change_landowners_opinion = yes
 			set_temp_variable = { temp_opinion = 20 }

--- a/common/on_actions/99_POL_on_actions.txt
+++ b/common/on_actions/99_POL_on_actions.txt
@@ -302,21 +302,21 @@ on_actions = {
 				add_to_variable = { pensions_effective_gdpc = gdp_diff }
 				set_temp_variable = { pensions_population_temp = pensions_effective_gdpc }
 				multiply_temp_variable = { pensions_population_temp = 0.005 }
-				set_variable = { pensions_population_growth_modifier = pensions_population_temp }
+				set_variable = { POL_pensions_population_growth_modifier = pensions_population_temp }
 				clamp_variable = {
-					var = pensions_population_growth_modifier
+					var = POL_pensions_population_growth_modifier
 					max = 1.5
 				}
 				set_temp_variable = { pensions_roi_temp = pensions_effective_gdpc }
 				multiply_temp_variable = { pensions_roi_temp = 0.00015 }
-				set_variable = { pensions_roi_modifier = pensions_roi_temp }
+				set_variable = { POL_pensions_roi_modifier = pensions_roi_temp }
 				clamp_variable = {
-					var = pensions_roi_modifier
+					var = POL_pensions_roi_modifier
 					max = 0.045
 				}
-				add_to_variable = { pensions_interest_rate_modifier = 0.2 }
+				add_to_variable = { POL_pensions_interest_rate_modifier = 0.2 }
 				clamp_variable = {
-					var = pensions_interest_rate_modifier
+					var = POL_pensions_interest_rate_modifier
 					max = 0
 				}
 			}
@@ -330,42 +330,42 @@ on_actions = {
 				add_to_variable = { healthcare_effective_gdpc = gdp_diff }
 				set_temp_variable = { healthcare_population_temp = healthcare_effective_gdpc }
 				multiply_temp_variable = { healthcare_population_temp = 0.0025 }
-				set_variable = { healthcare_population_growth_modifier = healthcare_population_temp }
+				set_variable = { POL_healthcare_population_growth_modifier = healthcare_population_temp }
 				clamp_variable = {
-					var = healthcare_population_growth_modifier
+					var = POL_healthcare_population_growth_modifier
 					max = 0.5
 				}
 				set_temp_variable = { healthcare_war_support_temp = healthcare_effective_gdpc }
 				multiply_temp_variable = { healthcare_war_support_temp = 0.00025 }
-				set_variable = { healthcare_war_support_modifier = healthcare_war_support_temp }
+				set_variable = { POL_healthcare_war_support_modifier = healthcare_war_support_temp }
 				clamp_variable = {
-					var = healthcare_war_support_modifier
+					var = POL_healthcare_war_support_modifier
 					max = 0.025
 				}
 				set_temp_variable = { healthcare_morale_temp = healthcare_effective_gdpc }
 				multiply_temp_variable = { healthcare_morale_temp = 0.00125 }
-				set_variable = { healthcare_morale_modifier = healthcare_morale_temp }
+				set_variable = { POL_healthcare_morale_modifier = healthcare_morale_temp }
 				clamp_variable = {
-					var = healthcare_morale_modifier
+					var = POL_healthcare_morale_modifier
 					max = 0.25
 				}
 				set_temp_variable = { healthcare_tax_cost_temp = healthcare_effective_gdpc }
 				multiply_temp_variable = { healthcare_tax_cost_temp = -0.0004 }
-				set_variable = { healthcare_tax_cost_modifier = healthcare_tax_cost_temp }
+				set_variable = { POL_healthcare_tax_cost_modifier = healthcare_tax_cost_temp }
 				clamp_variable = {
-					var = healthcare_tax_cost_modifier
+					var = POL_healthcare_tax_cost_modifier
 					min = -0.2
 				}
 				set_temp_variable = { healthcare_stability_temp = healthcare_effective_gdpc }
 				multiply_temp_variable = { healthcare_stability_temp = -0.001 }
-				set_variable = { healthcare_stability_modifier = healthcare_stability_temp }
+				set_variable = { POL_healthcare_stability_modifier = healthcare_stability_temp }
 				clamp_variable = {
-					var = healthcare_stability_modifier
+					var = POL_healthcare_stability_modifier
 					min = -1
 				}
-				add_to_variable = { healthcare_interest_rate_modifier = 0.1 }
+				add_to_variable = { POL_healthcare_interest_rate_modifier = 0.1 }
 				clamp_variable = {
-					var = healthcare_interest_rate_modifier
+					var = POL_healthcare_interest_rate_modifier
 					max = 0
 				}
 			}
@@ -378,35 +378,35 @@ on_actions = {
 				add_to_variable = { education_effective_gdpc = gdp_diff }
 				set_temp_variable = { education_research_temp = education_effective_gdpc }
 				multiply_temp_variable = { education_research_temp = 0.002 }
-				set_variable = { education_research_factor = education_research_temp }
+				set_variable = { POL_education_research_factor = education_research_temp }
 				clamp_variable = {
-					var = education_research_factor
+					var = POL_education_research_factor
 					max = 2
 				}
 				set_temp_variable = { education_productivity_temp = education_effective_gdpc }
 				multiply_temp_variable = { education_productivity_temp = 0.01 }
-				set_variable = { education_productivity_modifier = education_productivity_temp }
+				set_variable = { POL_education_productivity_modifier = education_productivity_temp }
 				clamp_variable = {
-					var = education_productivity_modifier
+					var = POL_education_productivity_modifier
 					max = 10
 				}
 				set_temp_variable = { education_project_temp = education_effective_gdpc }
 				multiply_temp_variable = { education_project_temp = 0.0025 }
-				set_variable = { education_project_speed_modifier = education_project_temp }
+				set_variable = { POL_education_project_speed_modifier = education_project_temp }
 				clamp_variable = {
-					var = education_project_speed_modifier
+					var = POL_education_project_speed_modifier
 					max = 1
 				}
 				set_temp_variable = { education_influence_temp = education_effective_gdpc }
 				multiply_temp_variable = { education_influence_temp = 0.0025 }
-				set_variable = { education_influence_modifier = education_influence_temp }
+				set_variable = { POL_education_influence_modifier = education_influence_temp }
 				clamp_variable = {
-					var = education_influence_modifier
+					var = POL_education_influence_modifier
 					max = 0.5
 				}
-				add_to_variable = { education_interest_rate_modifier = 0.1 }
+				add_to_variable = { POL_education_interest_rate_modifier = 0.1 }
 				clamp_variable = {
-					var = education_interest_rate_modifier
+					var = POL_education_interest_rate_modifier
 					max = 0
 				}
 			}
@@ -415,9 +415,9 @@ on_actions = {
 				limit = { 
 					has_dynamic_modifier = POL_economy_modifier 
 				}
-				set_temp_variable = { stability_overflow_drift = economy_weekly_stability }
+				set_temp_variable = { stability_overflow_drift = POL_economy_weekly_stability }
 				multiply_temp_variable = { stability_overflow_drift = 4 }
-				add_to_variable = { economy_stability_modifier = stability_overflow_drift }
+				add_to_variable = { POL_economy_stability_modifier = stability_overflow_drift }
 				multiply_temp_variable = { stability_overflow_drift = -1 }
 				add_stability = stability_overflow_drift
 			}

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -63,7 +63,7 @@ country_event = {
 		}
 		IRQ = {
 			add_to_variable = {
-				civilian_aid_to_iraq_count = 1
+				IRQ_civilian_aid_to_iraq_count = 1
 				tooltip = industrial_factory_donations_tt
 			}
 		}
@@ -241,7 +241,7 @@ country_event = {
 			custom_effect_tooltip = will_receive_5_percent_construction_speed_TT
 			hidden_effect = {
 				add_to_variable = {
-					western_engineers_in_iraq_speed = 0.05
+					IRQ_western_engineers_in_iraq_speed = 0.05
 				}
 			}
 		}


### PR DESCRIPTION
### Changes
- Prefixes Poland's 33 dynamic modifier backing variables with `POL_` across the modifier file, the focus tree and the on_action, 236 references in all
- Prefixes Iraq's two backing variables with `IRQ_` across the modifier file, the focus tree and the events file
- Drops 30 redundant zero seeds, 29 in Poland and one in Iraq, since an unset variable already reads zero

Unprefixed names collide when another country sets the same name on a shared scope, and a civil war split-off keeps reading whatever those shared names hold.

### Verification
No other country writes any of these names today, so the rename is contained to the six files above and changes no behaviour.

Each zero seed was checked before removal rather than removed on sight. Poland's eighteen economy seeds sit in `POL_economy_initial_idea`, which has no prerequisites and is an ancestor of every focus that adds to those variables, so they always ran first. The remaining eleven back variables the monthly on_action overwrites outright with `set_variable`, never accumulates into. Iraq's two seeds sit in the same `completion_reward` that fires the only events which add to them, ahead of those calls.

`joined_iraqi_economic_union` is left alone: it is a country flag set on member nations rather than a backing variable, and a bare domain prefix is correct for an any-nation flag. Two `set_temp_variable` zero seeds in the Iraqi tree are also left, since temporaries are block scoped and do not carry over.

Closes #3231
Closes #3233