### PR TITLE
Add country-specific train equipment names for 19 nations

### DIFF
--- a/localisation/english/equipment_l_english.yml
+++ b/localisation/english/equipment_l_english.yml
@@ -8,6 +8,83 @@
  train_equipment_4: "Train 2075"
  train_equipment_desc: "Just a train, really."
 
+############################################Country-Specific Trains############################################
+ HOL_train_equipment_1: "NS 1600"
+ HOL_train_equipment_2: "NS Vectron"
+ HOL_train_equipment_3: "Stadler Eurorail"
+
+ GER_train_equipment_1: "BR 218"
+ GER_train_equipment_2: "BR 152"
+ GER_train_equipment_3: "BR 193 Vectron"
+
+ USA_train_equipment_1: "EMD SD40-2"
+ USA_train_equipment_2: "GE ES44AC Evolution"
+ USA_train_equipment_3: "Wabtec FLXdrive"
+
+ CHI_train_equipment_1: "Shaoshan SS4"
+ CHI_train_equipment_2: "HXD1 Harmony"
+ CHI_train_equipment_3: "CR400AF Fuxing"
+
+ RUS_train_equipment_1: "VL80S"
+ RUS_train_equipment_2: "2ES10 Granit"
+ RUS_train_equipment_3: "3ES8 Granit"
+
+ JAP_train_equipment_1: "JNR EF66"
+ JAP_train_equipment_2: "EF210 Eco-Power Momotaro"
+ JAP_train_equipment_3: "EH800"
+
+ RAJ_train_equipment_1: "WDM-2"
+ RAJ_train_equipment_2: "WAG-9"
+ RAJ_train_equipment_3: "WAG-12B Prima T8"
+
+ ENG_train_equipment_1: "Class 43 InterCity 125"
+ ENG_train_equipment_2: "Class 66"
+ ENG_train_equipment_3: "Class 93 Stadler"
+
+ FRA_train_equipment_1: "BB 22200"
+ FRA_train_equipment_2: "Alstom Prima BB 27000"
+ FRA_train_equipment_3: "Alstom Prima H4"
+
+ ITA_train_equipment_1: "E.656 Caimano"
+ ITA_train_equipment_2: "ETR 500 Frecciarossa"
+ ITA_train_equipment_3: "ETR 1000 Frecciarossa"
+
+ BRA_train_equipment_1: "GE U20C"
+ BRA_train_equipment_2: "GE Dash 9-44CW"
+ BRA_train_equipment_3: "Wabtec ES58ACi"
+
+ CAN_train_equipment_1: "MLW M-636"
+ CAN_train_equipment_2: "EMD SD70M-2"
+ CAN_train_equipment_3: "CPKC Hydrogen Locomotive"
+
+ TUR_train_equipment_1: "TCDD DE24000"
+ TUR_train_equipment_2: "TCDD E68000"
+ TUR_train_equipment_3: "TÜRASAŞ Milli Elektrikli Tren"
+
+ POL_train_equipment_1: "EU07"
+ POL_train_equipment_2: "Newag E6ACT Dragon"
+ POL_train_equipment_3: "Newag Dragon 2"
+
+ SPR_train_equipment_1: "RENFE Class 269"
+ SPR_train_equipment_2: "Stadler Euro4000"
+ SPR_train_equipment_3: "Stadler Euro6000"
+
+ AST_train_equipment_1: "81 Class"
+ AST_train_equipment_2: "NR Class"
+ AST_train_equipment_3: "Rio Tinto AutoHaul"
+
+ KOR_train_equipment_1: "Korail Class 8000"
+ KOR_train_equipment_2: "Korail Class 8200"
+ KOR_train_equipment_3: "KTX-Eum"
+
+ IND_train_equipment_1: "CC201"
+ IND_train_equipment_2: "CC206"
+ IND_train_equipment_3: "KCIC400AF Whoosh"
+
+ MEX_train_equipment_1: "GE C30-7"
+ MEX_train_equipment_2: "EMD SD70ACe"
+ MEX_train_equipment_3: "Alstom X'trapolis Tren Maya"
+
 ############################################Generic Equipment############################################
  infantry_weapons_type: "Small Arms"
  infantry_weapons_type_desc: "Small Arms represent the equipment employed by Rifle Squads, such as Assault Rifles, Marksman Rifles, Sniper Rifles, Grenade-Launchers, Recoilless Rifles, Light Machine Guns and Body Armor."


### PR DESCRIPTION
### Changes
- Adds unique locomotive names to the first three train equipment tiers for the Netherlands, Germany, the United States, China, Russia, Japan, India, the United Kingdom, France, Italy, Brazil, Canada, Turkey, Poland, Spain, Australia, South Korea, Indonesia and Mexico
- Nations without their own entries keep the generic train names, and the fourth train tier is unchanged everywhere