### PR TITLE
Fix Saudi faction opinion event effects

### DIFF
--- a/events/SAU_events.txt
+++ b/events/SAU_events.txt
@@ -264,7 +264,8 @@ country_event = {
 		add_ideas = SAU_banking_649_secular
 		set_temp_variable = { treasury_change = 60 }
 		modify_treasury_effect = yes
-		add_to_variable = { wahabi_ulema_opinion = -15 }
+		set_temp_variable = { temp_opinion = -15 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = -0.03
 		add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -278,7 +279,8 @@ country_event = {
 		if = { limit = { has_idea = SAU_banking_649_secular } remove_ideas = SAU_banking_649_secular }
 		if = { limit = { has_idea = SAU_banking_649_hybrid } remove_ideas = SAU_banking_649_hybrid }
 		add_ideas = SAU_banking_649_islamic
-		add_to_variable = { wahabi_ulema_opinion = 15 }
+		set_temp_variable = { temp_opinion = 15 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.03
 		add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -319,7 +321,8 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		add_to_variable = { wahabi_ulema_opinion = -10 }
+		set_temp_variable = { temp_opinion = -10 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = -0.02
 		add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -333,7 +336,8 @@ country_event = {
 		if = { limit = { has_idea = SAU_banking_650_secular } remove_ideas = SAU_banking_650_secular }
 		if = { limit = { has_idea = SAU_banking_650_hybrid } remove_ideas = SAU_banking_650_hybrid }
 		add_ideas = SAU_banking_650_islamic
-		add_to_variable = { wahabi_ulema_opinion = 12 }
+		set_temp_variable = { temp_opinion = 12 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.04
 		add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -368,7 +372,8 @@ country_event = {
 		add_ideas = SAU_banking_651_secular
 		set_temp_variable = { treasury_change = 50 }
 		modify_treasury_effect = yes
-		add_to_variable = { wahabi_ulema_opinion = -12 }
+		set_temp_variable = { temp_opinion = -12 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = -0.03
 				add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -382,7 +387,8 @@ country_event = {
 		if = { limit = { has_idea = SAU_banking_651_secular } remove_ideas = SAU_banking_651_secular }
 		if = { limit = { has_idea = SAU_banking_651_hybrid } remove_ideas = SAU_banking_651_hybrid }
 		add_ideas = SAU_banking_651_islamic
-		add_to_variable = { wahabi_ulema_opinion = 12 }
+		set_temp_variable = { temp_opinion = 12 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.03
 		add_political_power = 30
 				add_power_balance_value = {
@@ -422,7 +428,8 @@ country_event = {
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = SAU }
 		change_influence_percentage = yes
-		add_to_variable = { wahabi_ulema_opinion = -10 }
+		set_temp_variable = { temp_opinion = -10 }
+		change_the_wahabi_ulema_opinion = yes
 				add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
 			value = 0.05
@@ -435,7 +442,8 @@ country_event = {
 		if = { limit = { has_idea = SAU_banking_652_secular } remove_ideas = SAU_banking_652_secular }
 		if = { limit = { has_idea = SAU_banking_652_hybrid } remove_ideas = SAU_banking_652_hybrid }
 		add_ideas = SAU_banking_652_islamic
-		add_to_variable = { wahabi_ulema_opinion = 12 }
+		set_temp_variable = { temp_opinion = 12 }
+		change_the_wahabi_ulema_opinion = yes
 		add_political_power = 50
 		add_stability = 0.02
 				add_power_balance_value = {
@@ -476,7 +484,8 @@ country_event = {
 		decrease_corruption = yes
 		set_temp_variable = { treasury_change = 30 }
 		modify_treasury_effect = yes
-		add_to_variable = { wahabi_ulema_opinion = -10 }
+		set_temp_variable = { temp_opinion = -10 }
+		change_the_wahabi_ulema_opinion = yes
 				add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
 			value = 0.01
@@ -489,7 +498,8 @@ country_event = {
 		if = { limit = { has_idea = SAU_banking_653_secular } remove_ideas = SAU_banking_653_secular }
 		if = { limit = { has_idea = SAU_banking_653_hybrid } remove_ideas = SAU_banking_653_hybrid }
 		add_ideas = SAU_banking_653_islamic
-		add_to_variable = { wahabi_ulema_opinion = 15 }
+		set_temp_variable = { temp_opinion = 15 }
+		change_the_wahabi_ulema_opinion = yes
 		add_political_power = 75
 		add_stability = 0.02
 				add_power_balance_value = {
@@ -522,7 +532,8 @@ country_event = {
 		if = { limit = { NOT = { has_idea = SAU_banking_system } } add_ideas = SAU_banking_system }
 		if = { limit = { has_idea = SAU_banking_654_pragmatic } remove_ideas = SAU_banking_654_pragmatic }
 		add_ideas = SAU_banking_654_strict
-		add_to_variable = { wahabi_ulema_opinion = 25 }
+		set_temp_variable = { temp_opinion = 25 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.05
 		add_political_power = 100
 		add_power_balance_value = {
@@ -536,7 +547,8 @@ country_event = {
 		if = { limit = { NOT = { has_idea = SAU_banking_system } } add_ideas = SAU_banking_system }
 		if = { limit = { has_idea = SAU_banking_654_strict } remove_ideas = SAU_banking_654_strict }
 		add_ideas = SAU_banking_654_pragmatic
-		add_to_variable = { wahabi_ulema_opinion = 10 }
+		set_temp_variable = { temp_opinion = 10 }
+		change_the_wahabi_ulema_opinion = yes
 		set_temp_variable = { treasury_change = 80 }
 		modify_treasury_effect = yes
 		add_political_power = 50
@@ -562,7 +574,8 @@ country_event = {
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = SAU }
 		change_influence_percentage = yes
-		add_to_variable = { wahabi_ulema_opinion = -25 }
+		set_temp_variable = { temp_opinion = -25 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = -0.05
 				add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -577,7 +590,8 @@ country_event = {
 		add_ideas = SAU_banking_655_gradual
 		set_temp_variable = { treasury_change = 80 }
 		modify_treasury_effect = yes
-		add_to_variable = { wahabi_ulema_opinion = -10 }
+		set_temp_variable = { temp_opinion = -10 }
+		change_the_wahabi_ulema_opinion = yes
 		add_political_power = 50
 				add_power_balance_value = {
 			id = SAU_modernisation_balance_of_power_category
@@ -597,14 +611,16 @@ country_event = {
 		name = SAU_events.370.a
 		log = "[GetDateText]: [This.GetName]: SAU_events.370.a executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = 0.015 }
-		add_to_variable = { wahabi_ulema_opinion = -5 }
+		set_temp_variable = { temp_opinion = -5 }
+		change_the_wahabi_ulema_opinion = yes
 		add_political_power = 25
 	}
 	option = {
 		name = SAU_events.370.b
 		log = "[GetDateText]: [This.GetName]: SAU_events.370.b executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = -0.015 }
-		add_to_variable = { wahabi_ulema_opinion = 5 }
+		set_temp_variable = { temp_opinion = 5 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.02
 	}
 }
@@ -620,14 +636,16 @@ country_event = {
 		name = SAU_events.371.a
 		log = "[GetDateText]: [This.GetName]: SAU_events.371.a executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = 0.015 }
-		add_to_variable = { wahabi_ulema_opinion = -8 }
+		set_temp_variable = { temp_opinion = -8 }
+		change_the_wahabi_ulema_opinion = yes
 		add_war_support = 0.02
 	}
 	option = {
 		name = SAU_events.371.b
 		log = "[GetDateText]: [This.GetName]: SAU_events.371.b executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = -0.01 }
-		add_to_variable = { wahabi_ulema_opinion = 8 }
+		set_temp_variable = { temp_opinion = 8 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.015
 	}
 }
@@ -643,7 +661,8 @@ country_event = {
 		name = SAU_events.372.a
 		log = "[GetDateText]: [This.GetName]: SAU_events.372.a executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = 0.01 }
-		add_to_variable = { wahabi_ulema_opinion = -5 }
+		set_temp_variable = { temp_opinion = -5 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = -0.01
 		add_political_power = 25
 	}
@@ -651,7 +670,8 @@ country_event = {
 		name = SAU_events.372.b
 		log = "[GetDateText]: [This.GetName]: SAU_events.372.b executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = -0.01 }
-		add_to_variable = { wahabi_ulema_opinion = 5 }
+		set_temp_variable = { temp_opinion = 5 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.02
 	}
 }
@@ -667,14 +687,16 @@ country_event = {
 		name = SAU_events.373.a
 		log = "[GetDateText]: [This.GetName]: SAU_events.373.a executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = 0.015 }
-		add_to_variable = { wahabi_ulema_opinion = -8 }
+		set_temp_variable = { temp_opinion = -8 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = 0.015
 	}
 	option = {
 		name = SAU_events.373.b
 		log = "[GetDateText]: [This.GetName]: SAU_events.373.b executed"
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = -0.015 }
-		add_to_variable = { wahabi_ulema_opinion = 8 }
+		set_temp_variable = { temp_opinion = 8 }
+		change_the_wahabi_ulema_opinion = yes
 		add_stability = -0.01
 	}
 }
@@ -843,7 +865,8 @@ country_event = {
 		add_manpower = 60000
 		add_stability = 0.05
 		add_equipment_to_stockpile = { type = infantry_weapons_type amount = 300 producer = SAU }
-		add_to_variable = { wahabi_ulema_opinion = 10 }
+		set_temp_variable = { temp_opinion = 10 }
+		change_the_wahabi_ulema_opinion = yes
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = -0.03 }
 		ai_chance = { factor = 5 }
 	}
@@ -984,7 +1007,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: SAU_events.341.c executed"
 		add_stability = 0.06
 		add_manpower = 40000
-		add_to_variable = { wahabi_ulema_opinion = 10 }
+		set_temp_variable = { temp_opinion = 10 }
+		change_the_wahabi_ulema_opinion = yes
 		add_power_balance_value = { id = SAU_modernisation_balance_of_power_category value = -0.02 }
 		ai_chance = { factor = 4 }
 	}


### PR DESCRIPTION
Closes #3304

**What**

- Route all 24 Wahhabi Ulema opinion changes in the affected Saudi events through the shared internal-faction effect.
- Preserve the existing event choices and numeric opinion inputs.

**Why**

Direct variable writes did not show the opinion change to players and bypassed normal clamping, autocrat handling, and immediate dynamic-modifier updates.

**How**

Each affected option now sets `temp_opinion` and calls `change_the_wahabi_ulema_opinion`, which owns the tooltip and faction update behavior.