### PR TITLE
Ban available on slotless country ideas

### DIFF
--- a/.claude/docs/idea-reference.md
+++ b/.claude/docs/idea-reference.md
@@ -6,17 +6,17 @@ On-demand reference for idea structure and examples. For best practices, see AGE
 
 ```
 BRA_idea_higher_minimum_wage_1 = {
-	name = BRA_idea_higher_minimum_wage
-	allowed_civil_war = { always = yes }
+ name = BRA_idea_higher_minimum_wage
+ allowed_civil_war = { always = yes }
 
-	picture = gold
+ picture = gold
 
-	modifier = {
-		political_power_factor = 0.1
-		stability_factor = 0.05
-		consumer_goods_factor = 0.075
-		population_tax_income_multiplier_modifier = 0.05
-	}
+ modifier = {
+  political_power_factor = 0.1
+  stability_factor = 0.05
+  consumer_goods_factor = 0.075
+  population_tax_income_multiplier_modifier = 0.05
+ }
 }
 ```
 
@@ -26,6 +26,7 @@ BRA_idea_higher_minimum_wage_1 = {
 - Include `allowed_civil_war = { always = yes }` for civil war tags
 - Use `original_tag` not `tag` in `allowed` blocks
 - Drop the `allowed` block entirely in a category with no slot (`country`, `hidden_ideas`). Nothing picks from those, so `add_idea` is the only way in and it never consults `allowed` — the gate is dead either way. A category that has a slot draws from a pool `allowed` filters, so keep it there. Flagged by `validate_ideas.py` (`allowed-in-slotless-category`); `tools/standardization/strip_idea_allowed_gates.py` removes them in bulk
+- Drop the `available` block entirely in a category with no slot (`country`, `hidden_ideas`). Same reason: nothing picks from those, so `available` is never consulted. Use `cancel` if the idea should remove itself. Flagged by `validate_ideas.py` (`available-in-slotless-category`); the same stripper removes them in bulk
 - Remove `allowed = { always = no }` in the remaining categories (default, hurts performance)
 - Remove `cancel = { always = no }` (checked hourly, never true)
 - Remove empty `on_add = { log = "" }` unless actually doing something

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,8 @@ Every text-mode write in `tools/` must pass `newline=""`. Without it, Python's t
 
 ## Ideas
 
-- Always `picture = sprite_name` (no picture = blank icon); `original_tag` not `tag` in `allowed` blocks
-- Category-specific `allowed`-block scoping and removable defaults (`cancel`, `on_add`, `allowed_civil_war`): `.claude/docs/idea-reference.md`
+- Always `picture = sprite_name` (no picture = blank icon); `original_tag` not `tag` in `allowed` blocks; no `available` in `country`/`hidden_ideas`
+- Category-specific `allowed`/`available`-block scoping and removable defaults (`cancel`, `on_add`, `allowed_civil_war`): `.claude/docs/idea-reference.md`
 
 ## MIOs
 

--- a/common/ideas/!_generic_faction_goals.txt
+++ b/common/ideas/!_generic_faction_goals.txt
@@ -18,10 +18,6 @@ ideas = {
 		}
 		bosporus_controlled = {
 			picture = morale_bonus
-			available = {
-				155 = { is_controlled_by_ROOT_or_ally = yes }
-				934 = { is_controlled_by_ROOT_or_ally = yes }
-			}
 			modifier = {
 				navy_capital_ship_attack_factor = 0.05
 				navy_capital_ship_defence_factor = 0.10

--- a/common/ideas/05_japan.txt
+++ b/common/ideas/05_japan.txt
@@ -632,7 +632,6 @@ ideas = {
 			modifier = {
 				stability_factor = 0.05
 			}
-			available = { always = yes }
 		}
 
 		JAP_quantitative_oda_idea = {
@@ -640,7 +639,6 @@ ideas = {
 			modifier = {
 				production_speed_infrastructure_factor = 0.2
 			}
-			available = { always = yes }
 		}
 
 		JAP_qualitative_oda_idea = {
@@ -649,7 +647,6 @@ ideas = {
 				research_speed_factor = 0.05
 				productivity_growth_modifier = 0.2
 			}
-			available = { always = yes }
 		}
 
 		JAP_security_south_china_sea_idea = {
@@ -657,7 +654,6 @@ ideas = {
 			modifier = {
 				stability_factor = 0.05
 			}
-			available = { always = yes }
 		}
 
 		JAP_jap_education = {
@@ -665,7 +661,6 @@ ideas = {
 			modifier = {
 				stability_factor = 0.05
 			}
-			available = { always = yes }
 		}
 
 		JAP_jap_education_culture = {
@@ -673,7 +668,6 @@ ideas = {
 			modifier = {
 				stability_factor = 0.1
 			}
-			available = { always = yes }
 		}
 
 		JAP_dual_use_idea = {
@@ -681,7 +675,6 @@ ideas = {
 			modifier = {
 				research_speed_factor = 0.10
 			}
-			available = { always = yes }
 		}
 
 		JAP_disaster_countermeasure_cooperation_idea = {
@@ -690,7 +683,6 @@ ideas = {
 				repair_speed_infrastructure_factor = 0.3
 				repair_speed_industrial_complex_factor = 0.3
 			}
-			available = { always = yes }
 		}
 
 		JAP_tai_high_technology_idea = {
@@ -698,7 +690,6 @@ ideas = {
 			modifier = {
 				productivity_growth_modifier = 0.15
 			}
-			available = { always = yes }
 		}
 
 		JAP_tai_international_student_idea = {
@@ -706,7 +697,6 @@ ideas = {
 			modifier = {
 				research_speed_factor = 0.07
 			}
-			available = { always = yes }
 		}
 
 		JAP_chi_kor_intellectual_platform = {
@@ -714,7 +704,6 @@ ideas = {
 			modifier = {
 				stability_factor = 0.1
 			}
-			available = { always = yes }
 		}
 
 		JAP_chi_trade_support_idea = {
@@ -722,7 +711,6 @@ ideas = {
 			modifier = {
 				consumer_goods_factor = -0.05
 			}
-			available = { always = yes }
 		}
 
 		JAP_chi_advancement_companies_idea = {
@@ -730,7 +718,6 @@ ideas = {
 			modifier = {
 				productivity_growth_modifier = 0.15
 			}
-			available = { always = yes }
 		}
 
 		JAP_chi_kanji_idea = {
@@ -738,7 +725,6 @@ ideas = {
 			modifier = {
 				foreign_influence_defense_modifier = 0.20
 			}
-			available = { always = yes }
 		}
 
 		JAP_chi_temple_idea = {
@@ -746,7 +732,6 @@ ideas = {
 			modifier = {
 				tax_gain_multiplier_modifier = 0.03
 			}
-			available = { always = yes }
 		}
 
 		JAP_kor_accelerator_idea = {
@@ -754,7 +739,6 @@ ideas = {
 			modifier = {
 				production_speed_offices_factor = 0.15
 			}
-			available = { always = yes }
 		}
 
 		JAP_kor_local_companies_idea = {
@@ -762,7 +746,6 @@ ideas = {
 			modifier = {
 				production_speed_industrial_complex_factor = 0.15
 			}
-			available = { always = yes }
 		}
 
 		JAP_kor_aging_idea = {
@@ -770,7 +753,6 @@ ideas = {
 			modifier = {
 				monthly_population = 0.07
 			}
-			available = { always = yes }
 		}
 
 		JAP_sov_logistics_corridor_idea = {
@@ -778,7 +760,6 @@ ideas = {
 			modifier = {
 				production_speed_infrastructure_factor = 0.2
 			}
-			available = { always = yes }
 		}
 
 		JAP_sov_it_corridor_idea = {
@@ -786,7 +767,6 @@ ideas = {
 			modifier = {
 				production_speed_internet_station_factor = 0.2
 			}
-			available = { always = yes }
 		}
 
 		#territorial disputes
@@ -796,7 +776,6 @@ ideas = {
 				stability_factor = 0.05
 				agriculture_district_income_tax_modifier = 0.05
 			}
-			available = { always = yes }
 		}
 
 		JAP_territorial_disputes2 = {
@@ -806,7 +785,6 @@ ideas = {
 				stability_factor = 0.10
 				agriculture_district_income_tax_modifier = 0.10
 			}
-			available = { always = yes }
 		}
 
 		JAP_territorial_disputes3 = {
@@ -816,7 +794,6 @@ ideas = {
 				stability_factor = 0.15
 				agriculture_district_income_tax_modifier = 0.15
 			}
-			available = { always = yes }
 		}
 
 		JAP_territorial_disputes4 = {
@@ -826,7 +803,6 @@ ideas = {
 				stability_factor = 0.20
 				agriculture_district_income_tax_modifier = 0.20
 			}
-			available = { always = yes }
 		}
 
 		#Great East Japan Earthquake
@@ -836,7 +812,6 @@ ideas = {
 				production_speed_synthetic_refinery_factor = 0.2
 				custom_modifier_tooltip = JAP_focus_energy_TT
 			}
-			available = { always = yes }
 		}
 
 		JAP_focus_thermal_power_idea = {
@@ -845,7 +820,6 @@ ideas = {
 				production_speed_fossil_powerplant_factor = 0.2
 				custom_modifier_tooltip = JAP_focus_energy_TT
 			}
-			available = { always = yes }
 		}
 
 
@@ -965,14 +939,12 @@ ideas = {
 				production_speed_nuclear_reactor_factor = -0.25
 				stability_factor = -0.05
 			}
-			available = { always = yes }
 		}
 		JAP_shut_down_nuclear_plants = {
 			picture = antinuclear
 			modifier = {
 				stability_factor = 0.1
 			}
-			available = { always = yes }
 		}
 		JAP_nuclear_strict_examination = {
 			picture = GENERIC_protectionism
@@ -980,14 +952,12 @@ ideas = {
 				production_speed_nuclear_reactor_factor = -0.75
 				nuclear_energy_generation_modifier = -0.5
 			}
-			available = { always = yes }
 		}
 		JAP_continue_nuclear_plants = {
 			picture = nuclear_power
 			modifier = {
 				stability_factor = -0.1
 			}
-			available = { always = yes }
 		}
 
 		#monarchism

--- a/common/ideas/AIDS.txt
+++ b/common/ideas/AIDS.txt
@@ -5,10 +5,6 @@ ideas = {
 
 			picture = population_down
 
-			available = {
-				always = yes
-			}
-
 			modifier = {
 				conscription = -0.002
 				production_speed_buildings_factor = -0.10
@@ -21,10 +17,6 @@ ideas = {
 
 
 			picture = population_stagnation
-
-			available = {
-				always = yes
-			}
 
 			modifier = {
 				conscription = -0.004
@@ -39,10 +31,6 @@ ideas = {
 
 			picture = population_growth
 
-			available = {
-				always = yes
-			}
-
 			modifier = {
 				conscription = -0.006
 				production_speed_buildings_factor = -0.30
@@ -56,10 +44,6 @@ ideas = {
 
 			picture = population_rapid_growth
 
-			available = {
-				always = yes
-			}
-
 			modifier = {
 				conscription = -0.006
 				production_speed_buildings_factor = -0.40
@@ -72,10 +56,6 @@ ideas = {
 
 
 			picture = population_explosion
-
-			available = {
-				always = yes
-			}
 
 			modifier = {
 				conscription = -0.008

--- a/common/ideas/Cuban.txt
+++ b/common/ideas/Cuban.txt
@@ -247,10 +247,6 @@ ideas = {
 		CUB_idea_blockade1 = {
 
 			picture = CUB_eco_blockad
-			available = {
-				country_exists = USA
-			}
-
 			modifier = {
 				population_tax_income_multiplier_modifier = -0.15
 				agricolture_productivity_modifier = -0.25
@@ -518,13 +514,6 @@ ideas = {
 		CUB_cpc_idea1 = {
 
 			picture = cpczerocubaidea
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-					western_autocrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = -0.15
 				democratic_drift = 0.03
@@ -536,13 +525,6 @@ ideas = {
 		CUB_cpc_bad = {
 
 			picture = cpczerocubaidea
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-					western_autocrats_are_in_power = yes
-				}
-			}
 			modifier = {
 			political_power_factor = -0.1
 			democratic_drift = 0.02
@@ -554,13 +536,6 @@ ideas = {
 		CUB_cpc_good = {
 
 			picture = cpczerocubaidea
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-					western_autocrats_are_in_power = yes
-				}
-			}
 			modifier = {
 			democratic_drift = 0.01
 			political_power_factor = -0.02
@@ -570,12 +545,6 @@ ideas = {
 		CUB_idea_castroism = {
 
 			picture = castroismcubaidea
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				communism_drift = 0.02
@@ -616,12 +585,6 @@ ideas = {
 		CUB_communism_idea = {
 
 			picture = cubancommunismideapng
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-				}
-			}
 			modifier = {
 			communism_drift = 0.02
 			neutrality_drift = 0.02
@@ -652,9 +615,6 @@ ideas = {
 		CUB_castros_new_idea = {
 
 			picture = GENERIC_public_works
-			available = {
-				neutrality_neutral_communism_are_in_power = yes
-			}
 			modifier = {
 				political_power_factor = 0.01
 				conscription_factor = 0.02
@@ -665,9 +625,6 @@ ideas = {
 
 			name = CUB_castros_new_idea
 			picture = GENERIC_public_works
-			available = {
-				neutrality_neutral_communism_are_in_power = yes
-			}
 			modifier = {
 				political_power_factor = 0.05
 				conscription_factor = 0.03
@@ -681,9 +638,6 @@ ideas = {
 
 			name = CUB_castros_new_idea
 			picture = GENERIC_public_works
-			available = {
-				neutrality_neutral_communism_are_in_power = yes
-			}
 			modifier = {
 				political_power_factor = 0.05
 				conscription_factor = 0.03
@@ -700,13 +654,6 @@ ideas = {
 		CUB_rauls_four_reforms = {
 
 			picture = hyper_inflation5
-			available = {
-				OR = {
-				neutrality_neutral_communism_are_in_power = yes
-				western_autocrats_are_in_power = yes
-				emerging_communist_state_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.05
 				industrial_capacity_factory = 0.01
@@ -717,13 +664,6 @@ ideas = {
 
 			picture = hyper_inflation5
 			name = CUB_rauls_four_reforms
-			available = {
-				OR = {
-				neutrality_neutral_communism_are_in_power = yes
-				western_autocrats_are_in_power = yes
-				emerging_communist_state_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.05
 				industrial_capacity_factory = 0.03
@@ -738,13 +678,6 @@ ideas = {
 
 			picture = hyper_inflation5
 			name = CUB_rauls_four_reforms
-			available = {
-				OR = {
-				neutrality_neutral_communism_are_in_power = yes
-				western_autocrats_are_in_power = yes
-				emerging_communist_state_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.05
 				industrial_capacity_factory = 0.01
@@ -763,13 +696,6 @@ ideas = {
 		CUB_youth_castro_organisation = {
 
 			picture = communism9
-			available = {
-				OR = {
-				neutrality_neutral_communism_are_in_power = yes
-				western_autocrats_are_in_power = yes
-				emerging_communist_state_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.05
 				recruitable_population = 0.02
@@ -780,13 +706,6 @@ ideas = {
 		CUB_cdr = {
 
 			picture = political_violence
-			available = {
-				OR = {
-				neutrality_neutral_communism_are_in_power = yes
-				western_autocrats_are_in_power = yes
-				emerging_communist_state_are_in_power = yes
-				}
-			}
 			modifier = {
 			encryption_factor = 0.4
 			foreign_influence_defense_modifier = 0.08
@@ -796,12 +715,6 @@ ideas = {
 		CUB_anti_lgbtqa_idea = {
 
 			picture = antilgbtidea
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				democratic_drift = -0.02
@@ -909,10 +822,6 @@ ideas = {
 		CUB_constitution_democracy = {
 
 			picture = democraticreformsideacuba
-
-				available = {
-					western_autocrats_are_in_power = yes
-				}
 			modifier = {
 				democratic_drift = 0.03
 				neutrality_drift = 0.03
@@ -925,10 +834,6 @@ ideas = {
 		CUB_idea_democratic_reforms = {
 
 			picture = newdemocraticconsideacuba
-
-				available = {
-					western_autocrats_are_in_power = yes
-				}
 			modifier = {
 				democratic_drift = 0.05
 				communism_drift = -0.05
@@ -939,10 +844,6 @@ ideas = {
 		CUB_idea_democratic_reforms_continue = {
 
 			picture = newdemocraticconsideacuba
-
-				available = {
-					western_autocrats_are_in_power = yes
-				}
 			modifier = {
 				democratic_drift = 0.06
 				communism_drift = -0.06
@@ -953,10 +854,6 @@ ideas = {
 		CUB_new_cuba = {
 
 			picture = coninuedemocrairefromsideacuba
-
-				available = {
-					western_autocrats_are_in_power = yes
-				}
 			modifier = {
 				research_speed_factor = 0.05
 				tax_gain_multiplier_modifier = 0.05
@@ -969,14 +866,6 @@ ideas = {
 		CUB_pro_lgbtqa_idea = {
 
 			picture = pro-lgbtidea
-			available = {
-				OR = {
-				western_conservatism_are_in_power = yes
-				western_liberals_are_in_power = yes
-				western_social_democrats_are_in_power = yes
-				western_autocrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				democratic_drift = 0.02
@@ -988,12 +877,6 @@ ideas = {
 		CUB_pro_lgbt_idea_comu = {
 
 			picture = pro-lgbtidea
-			available = {
-				OR = {
-					emerging_communist_state_are_in_power = yes
-					neutrality_neutral_communism_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				democratic_drift = 0.02
@@ -1113,14 +996,6 @@ ideas = {
 		CUB_anti_lgbtqa_idea_nati = {
 
 			picture = antilgbtidea
-			available = {
-				OR = {
-					nationalist_military_junta_are_in_power = yes
-					nationalist_fascist_are_in_power = yes
-					nationalist_monarchists_are_in_power = yes
-					nationalist_right_wing_populists_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				democratic_drift = -0.02
@@ -1200,13 +1075,6 @@ ideas = {
 		CUB_idea_democrats_in_power = {
 
 			picture = CUB_democrats_in_power
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.01
 				bureaucracy_cost_multiplier_modifier = 0.1
@@ -1216,13 +1084,6 @@ ideas = {
 		CUB_idea_democrats_start_ref = {
 
 			picture = CUB_democrats_in_power
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.01
 				bureaucracy_cost_multiplier_modifier = 0.2
@@ -1233,13 +1094,6 @@ ideas = {
 		CUB_old_system_protests = {
 
 			picture = slightly_reformist
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 			consumer_goods_factor = 0.10
 			political_power_factor = -0.15
@@ -1254,13 +1108,6 @@ ideas = {
 		CUB_decommunisation = {
 
 			picture = communism
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 			communism_drift = -0.03
 			}
@@ -1268,13 +1115,6 @@ ideas = {
 		CUB_idea_democrats_ref = {
 
 			picture = CUB_democrats_in_power
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				bureaucracy_cost_multiplier_modifier = 0.015
@@ -1289,13 +1129,6 @@ ideas = {
 
 			name = CUB_idea_democrats_ref
 			picture = CUB_democrats_in_power
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.02
 				bureaucracy_cost_multiplier_modifier = 0.01
@@ -1313,13 +1146,6 @@ ideas = {
 
 			name = CUB_idea_democrats_ref
 			picture = CUB_democrats_in_power
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				political_power_factor = 0.04
 				democratic_drift = 0.05
@@ -1340,13 +1166,6 @@ ideas = {
 		CUB_idea_memory = {
 
 			picture = CUB_remember_batista
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				western_outlook_campaign_cost_modifier = -0.05
 				democratic_drift = 0.01
@@ -1356,13 +1175,6 @@ ideas = {
 
 			name = CUB_idea_memory
 			picture = CUB_remember_batista
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				western_outlook_campaign_cost_modifier = -0.05
 				democratic_drift = 0.01
@@ -1375,13 +1187,6 @@ ideas = {
 		CUB_idea_conf_one = {
 
 			picture = CUB_first_conf
-			available = {
-				OR = {
-					western_conservatism_are_in_power = yes
-					western_liberals_are_in_power = yes
-					western_social_democrats_are_in_power = yes
-				}
-			}
 			modifier = {
 				bureaucracy_cost_multiplier_modifier = 0.10
 				political_power_gain = -0.01

--- a/common/ideas/Kuban.txt
+++ b/common/ideas/Kuban.txt
@@ -439,9 +439,6 @@ ideas = {
 					emerging_communist_state_are_in_power = yes
 				}
 			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-			}
 			modifier = {
 				army_core_defence_factor = 0.1
 				army_core_attack_factor = 0.1

--- a/common/ideas/Ukrainian.txt
+++ b/common/ideas/Ukrainian.txt
@@ -345,10 +345,6 @@ ideas = {
 			picture = communism9
 			allowed_civil_war = { always = yes }
 			modifier = { communism_drift = 0.03 }
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
-			}
 		}
 		UKR_inner_policy_spu1 = {
 			name = UKR_inner_policy_spu
@@ -359,10 +355,6 @@ ideas = {
 				monthly_population = 0.01
 				drift_defence_factor = 0.05
 			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
-			}
 		}
 		UKR_inner_policy_spu2 = {
 			name = UKR_inner_policy_spu
@@ -372,10 +364,6 @@ ideas = {
 				communism_drift = 0.05
 				monthly_population = 0.01
 				drift_defence_factor = 0.08
-			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
 			}
 		}
 		UKR_inner_policy_spu3 = {
@@ -389,10 +377,6 @@ ideas = {
 				social_cost_multiplier_modifier = -0.06
 				education_cost_multiplier_modifier = -0.06
 				health_cost_multiplier_modifier = -0.06
-			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
 			}
 		}
 		UKR_inner_policy_spu4 = {
@@ -412,10 +396,6 @@ ideas = {
 				war_support_factor = 0.05
 				training_time_army_factor = -0.06
 			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
-			}
 		}
 		UKR_brotherhood_people = {
 			picture = communism11
@@ -425,10 +405,6 @@ ideas = {
 				political_power_factor = 0.15
 				drift_defence_factor = 0.15
 			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
-			}
 		}
 		UKR_social_reform = {
 			picture = communism10
@@ -437,10 +413,6 @@ ideas = {
 				social_cost_multiplier_modifier = -0.07
 				health_cost_multiplier_modifier = -0.07
 				consumer_goods_factor = 0.02
-			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
 			}
 		}
 		UKR_christian_communism = {
@@ -452,16 +424,11 @@ ideas = {
 				conscription_factor = 0.02
 				communism_drift = 0.03
 			}
-			available = {
-				emerging_communist_state_are_in_power = yes
-				NOT = { neutrality_neutral_social_in_power_or_coalition = yes }
-			}
 		}
 		UKR_inner_policy_cpu = {
 			picture = social_democracy
 			allowed_civil_war = { always = yes }
 			modifier = { neutrality_drift = 0.03 }
-			available = { neutrality_neutral_social_are_in_power = yes }
 		}
 		UKR_inner_policy_cpu1 = {
 			name = UKR_inner_policy_cpu
@@ -472,7 +439,6 @@ ideas = {
 				monthly_population = 0.02
 				social_cost_multiplier_modifier = -0.05
 			}
-			available = { neutrality_neutral_social_are_in_power = yes }
 		}
 		UKR_inner_policy_cpu2 = {
 			name = UKR_inner_policy_cpu
@@ -486,7 +452,6 @@ ideas = {
 				corporate_tax_income_multiplier_modifier = 0.10
 				stability_factor = -0.05
 			}
-			available = { neutrality_neutral_social_are_in_power = yes }
 		}
 		UKR_inner_policy_cpu3 = {
 			name = UKR_inner_policy_cpu
@@ -501,7 +466,6 @@ ideas = {
 				stability_factor = -0.05
 				consumer_goods_factor = 0.02
 			}
-			available = { neutrality_neutral_social_are_in_power = yes }
 		}
 		UKR_equal_rights_idea = {
 			picture = national_unity

--- a/tools/standardization/README.md
+++ b/tools/standardization/README.md
@@ -99,7 +99,7 @@ python3 standardize_ideas.py input.txt -o output.txt --backup --verbose
 
 Surgical sweeps for two gates that never fail. Unlike the standardizers above they rewrite only the blocks they remove, so the diff carries no reformatting.
 
-`strip_idea_allowed_gates.py` drops the `allowed` block from every idea in a category with no slot. Nothing picks from `country` or `hidden_ideas`, so `add_idea` is the only way in and it never consults `allowed`. Categories come from `common/idea_tags/`, so a new slotless one is covered without editing the script.
+`strip_idea_allowed_gates.py` drops `allowed` and `available` blocks from every idea in a category with no slot. Nothing picks from `country` or `hidden_ideas`, so `add_idea` is the only way in and it never consults either gate. Use `cancel` if the idea should remove itself. Categories come from `common/idea_tags/`, so a new slotless one is covered without editing the script.
 
 `strip_dynmod_tag_gates.py` drops `always = yes` and top-level `original_tag` / `tag` triggers from a dynamic modifier's `enable` block, removing the block when that empties it. `enable` is re-evaluated at runtime, so these cost something every pass. Only top-level triggers are touched: one inside `OR` / `NOT` is an alternative or an exclusion, and `country_exists`, `has_idea` and `has_completed_focus` stay, because those go false while the modifier is still attached. Every strip is reported — "only this country ever attaches it" is a claim about the rest of the repo that the script does not verify.
 

--- a/tools/standardization/strip_idea_allowed_gates.py
+++ b/tools/standardization/strip_idea_allowed_gates.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
 """
-Remove `allowed` blocks from ideas in slotless categories.
+Remove `allowed` and `available` blocks from ideas in slotless categories.
 
 An idea in a category with no slot (`country`, `hidden_ideas`) can only arrive
-through `add_idea`, which does not consult `allowed`, so the block is a gate on
-a pool the idea never enters. Categories are read from common/idea_tags/, so a
-new slotless category is covered without editing this script.
+through `add_idea`, which does not consult `allowed` or `available`, so either
+block is a gate on a pool the idea never enters. Use `cancel` if the idea
+should remove itself. Categories are read from common/idea_tags/, so a new
+slotless category is covered without editing this script.
 
 Rewrites in place, touching nothing but the blocks it removes.
 """
@@ -26,17 +27,17 @@ from shared_utils import (
     log_message,
 )
 
-_ALLOWED_OPEN_RE = re.compile(r"^(\s*)allowed\s*=\s*\{")
+_GATE_OPEN_RE = re.compile(r"^(\s*)(?:allowed|available)\s*=\s*\{")
 
 
 def strip_allowed_blocks(
     lines: list[str], slotless: frozenset
 ) -> tuple[list[str], int, int]:
-    """Drop every `allowed` block sitting directly inside a slotless-category idea.
+    """Drop every `allowed`/`available` block sitting directly inside a slotless idea.
 
     Returns the rewritten lines, the number of blocks removed, and the number
     skipped because their braces never balanced. Only the
-    ideas > category > idea nesting is touched, so an `allowed` somewhere
+    ideas > category > idea nesting is touched, so a gate somewhere
     unexpected is left alone rather than guessed at.
     """
     out: list[str] = []
@@ -48,7 +49,7 @@ def strip_allowed_blocks(
     while i < len(lines):
         code = common_utils.code_of_line(lines[i])
         opener = (
-            _ALLOWED_OPEN_RE.match(code)
+            _GATE_OPEN_RE.match(code)
             if len(stack) == 3 and stack[0] == "ideas" and stack[1] in slotless
             else None
         )
@@ -134,7 +135,7 @@ def main() -> int:
             continue
         if skipped:
             unbalanced += skipped
-            log_message("WARNING", f"{rel}: {skipped} allowed blocks never close")
+            log_message("WARNING", f"{rel}: {skipped} gate blocks never close")
         if removed:
             touched += 1
             total += removed
@@ -142,7 +143,7 @@ def main() -> int:
 
     verb = "would remove" if args.dry_run else "removed"
     level = "ERROR" if failed or unbalanced else "SUCCESS"
-    message = f"{verb} {total} allowed blocks across {touched} files"
+    message = f"{verb} {total} gate blocks across {touched} files"
     if failed:
         message += f"; {failed} files could not be read"
     log_message(level, message)

--- a/tools/tests/standardization/strip_idea_allowed_gates_test.py
+++ b/tools/tests/standardization/strip_idea_allowed_gates_test.py
@@ -1,8 +1,9 @@
-"""Tests for the slotless-category `allowed` stripper.
+"""Tests for the slotless-category `allowed`/`available` stripper.
 
 The blocks it removes are unreachable gates, but the ones it leaves alone are
-load-bearing: an `allowed` in a slotted category filters the pool that slot
-draws from, so removing it there would change what the player can pick.
+load-bearing: an `allowed` or `available` in a slotted category filters the
+pool that slot draws from, so removing it there would change what the player
+can pick.
 """
 
 from strip_idea_allowed_gates import process_file, strip_allowed_blocks
@@ -36,6 +37,63 @@ def test_removes_one_line_allowed_in_country():
     out, removed = _strip(text)
     assert removed == 1
     assert "allowed" not in out
+    assert "picture = gold" in out
+
+
+def test_removes_one_line_available_in_country():
+    text = "\n".join(
+        [
+            "ideas = {",
+            "\tcountry = {",
+            "\t\tFOO_idea = {",
+            "\t\t\tavailable = { always = yes }",
+            "\t\t\tpicture = gold",
+            "\t\t}",
+            "\t}",
+            "}",
+        ]
+    )
+    out, removed = _strip(text)
+    assert removed == 1
+    assert "available" not in out
+    assert "picture = gold" in out
+
+
+def test_keeps_available_in_slotted_category():
+    text = "\n".join(
+        [
+            "ideas = {",
+            "\ttank_manufacturer = {",
+            "\t\tFOO_designer = {",
+            "\t\t\tavailable = { original_tag = FOO }",
+            "\t\t}",
+            "\t}",
+            "}",
+        ]
+    )
+    out, removed = _strip(text)
+    assert removed == 0
+    assert "available = { original_tag = FOO }" in out
+
+
+def test_removes_allowed_and_available_together():
+    text = "\n".join(
+        [
+            "ideas = {",
+            "\tcountry = {",
+            "\t\tFOO_idea = {",
+            "\t\t\tallowed = { original_tag = FOO }",
+            "\t\t\tavailable = { always = yes }",
+            "\t\t\tpicture = gold",
+            "\t\t}",
+            "\t}",
+            "}",
+        ]
+    )
+    out, removed = _strip(text)
+    assert removed == 2
+    assert "allowed" not in out
+    assert "available" not in out
     assert "picture = gold" in out
 
 

--- a/tools/tests/validation/validate_ideas_slotless_available_test.py
+++ b/tools/tests/validation/validate_ideas_slotless_available_test.py
@@ -1,0 +1,171 @@
+"""Tests for the `available`-in-a-slotless-category check.
+
+`country` and `hidden_ideas` have no slot, so nothing ever picks from them and
+`add_idea` is the only way in. It does not consult `available`, which makes the
+block dead. A category that still has a slot draws from a pool `available`
+filters, so the block stays load-bearing there. Use `cancel` if the idea should
+remove itself.
+"""
+
+from validate_ideas import (
+    IdeaIssue,
+    Validator,
+    _parse_ideas_from_file,
+    _parse_ideas_from_text,
+)
+
+SLOTLESS = "available-in-slotless-category"
+SLOTLESS_CATEGORIES = frozenset({"country", "hidden_ideas"})
+
+
+def _issue_types(text):
+    _defined, issues = _parse_ideas_from_text(text, SLOTLESS_CATEGORIES)
+    return {i.issue_type for i in issues}
+
+
+def _wrap(body, category="country"):
+    return "ideas = {\n\t" + category + " = {\n" + body + "\n\t}\n}\n"
+
+
+def test_available_in_country_flagged():
+    text = _wrap(
+        "\t\tmy_idea = {\n"
+        "\t\t\tavailable = { emerging_communist_state_are_in_power = yes }\n"
+        "\t\t\tpicture = GFX_idea_x\n"
+        "\t\t}"
+    )
+    assert SLOTLESS in _issue_types(text)
+
+
+def test_available_in_hidden_ideas_flagged():
+    text = _wrap(
+        "\t\tmy_idea = {\n"
+        "\t\t\tavailable = {\n"
+        "\t\t\t\thas_country_flag = some_flag\n"
+        "\t\t\t}\n"
+        "\t\t\tpicture = GFX_idea_x\n"
+        "\t\t}",
+        category="hidden_ideas",
+    )
+    assert SLOTLESS in _issue_types(text)
+
+
+def test_available_in_slotted_category_not_flagged():
+    text = _wrap(
+        "\t\tmy_designer = {\n"
+        "\t\t\tavailable = { original_tag = ISR }\n"
+        "\t\t\tpicture = GFX_idea_x\n"
+        "\t\t}",
+        category="tank_manufacturer",
+    )
+    assert SLOTLESS not in _issue_types(text)
+
+
+def test_idea_without_available_not_flagged():
+    text = _wrap("\t\tmy_idea = {\n\t\t\tpicture = GFX_idea_x\n\t\t}")
+    assert SLOTLESS not in _issue_types(text)
+
+
+def test_cancel_alone_not_flagged():
+    text = _wrap(
+        "\t\tmy_idea = {\n"
+        "\t\t\tcancel = { always = yes }\n"
+        "\t\t\tpicture = GFX_idea_x\n"
+        "\t\t}"
+    )
+    assert SLOTLESS not in _issue_types(text)
+
+
+def test_always_yes_in_slotless_still_flagged():
+    text = _wrap(
+        "\t\tmy_idea = {\n"
+        "\t\t\tavailable = { always = yes }\n"
+        "\t\t\tpicture = GFX_idea_x\n"
+        "\t\t}"
+    )
+    assert _issue_types(text) == {SLOTLESS}
+
+
+def test_allowed_and_available_both_flagged_in_country():
+    text = _wrap(
+        "\t\tmy_idea = {\n"
+        "\t\t\tallowed = { original_tag = ISR }\n"
+        "\t\t\tavailable = { always = yes }\n"
+        "\t\t\tpicture = GFX_idea_x\n"
+        "\t\t}"
+    )
+    assert _issue_types(text) == {
+        "allowed-in-slotless-category",
+        SLOTLESS,
+    }
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        handle.write(text)
+
+
+def test_validator_uses_target_root_and_reports_error(tmp_path):
+    _write(
+        tmp_path / "common" / "idea_tags" / "00_idea.txt",
+        "idea_categories = {\n\tcustom_slotless = { type = national_spirit }\n}\n",
+    )
+    _write(
+        tmp_path / "common" / "ideas" / "test.txt",
+        _wrap(
+            "\t\tmy_idea = {\n\t\t\tavailable = { always = yes }\n\t\t}",
+            category="custom_slotless",
+        ),
+    )
+
+    validator = Validator(
+        str(tmp_path), use_colors=False, workers=1, unused_ideas=False
+    )
+    _defined, issues_by_file, _ideas_by_file = validator._parse_all_ideas()
+
+    assert {
+        issue.issue_type for issues in issues_by_file.values() for issue in issues
+    } == {SLOTLESS}
+    validator.validate_idea_quality(issues_by_file)
+    assert validator.errors_found == 1
+
+
+def test_category_set_is_part_of_parser_cache_key(tmp_path):
+    idea_file = tmp_path / "common" / "ideas" / "test.txt"
+    _write(
+        idea_file,
+        _wrap(
+            "\t\tmy_idea = {\n\t\t\tavailable = { always = yes }\n\t\t}",
+            category="custom_slotless",
+        ),
+    )
+
+    _defined, first = _parse_ideas_from_file(str(idea_file), str(tmp_path), frozenset())
+    _defined, second = _parse_ideas_from_file(
+        str(idea_file), str(tmp_path), frozenset({"custom_slotless"})
+    )
+
+    assert first == []
+    assert {issue.issue_type for issue in second} == {SLOTLESS}
+
+
+def test_staged_idea_tags_change_runs_full_quality_scan():
+    validator = Validator("/nonexistent", use_colors=False, workers=1)
+    validator.staged_only = True
+    validator.staged_files = ["common/idea_tags/00_idea.txt"]
+    issue = IdeaIssue("my_idea", "country", 1, SLOTLESS)
+    all_issues = {"common/ideas/test.txt": [issue]}
+    validator._parse_all_ideas = lambda: ({}, all_issues, {})
+    calls = []
+    validator.validate_idea_quality = lambda issues_by_file: calls.append(
+        issues_by_file
+    )
+    validator.validate_undefined_idea_refs = lambda defined_ideas: None
+    validator.validate_category_icon_frames = lambda: None
+    validator.validate_missing_icons = lambda defined_ideas: None
+    validator.validate_unused_ideas = lambda defined_ideas, ideas_by_file: None
+
+    validator.run_validations()
+
+    assert calls == [all_issues]

--- a/tools/validation/validate_ideas.py
+++ b/tools/validation/validate_ideas.py
@@ -118,6 +118,7 @@ _NAME_OVERRIDE_LINE = re.compile(r"^\s+name\s*=\s*([A-Za-z0-9_.]+)", re.MULTILIN
 _PICTURE_VALUE_LINE = re.compile(r"^\s+picture\s*=\s*([^\s#]+)", re.MULTILINE)
 _CANCEL_ALWAYS_NO = re.compile(r"\bcancel\s*=\s*\{\s*always\s*=\s*no\s*\}")
 _ALLOWED_BLOCK_START = re.compile(r"\ballowed\s*=\s*\{")
+_AVAILABLE_BLOCK_START = re.compile(r"\bavailable\s*=\s*\{")
 # `\btag` does not match inside `original_tag` (the preceding `_` is a word char),
 # so these two are disjoint. The capture spans 3+ chars so runtime civil-war
 # tags (`ISR_CW_0`) are caught, not just the 3-letter base tag.
@@ -326,7 +327,7 @@ def _parse_ideas_from_file(
     # per category set instead of replacing them in place.
     return disk_cache.per_file_cached_by_content(
         mod_path,
-        "ideas.defs.v4",
+        "ideas.defs.v5",
         filepath,
         f"{text}\x00{category_key}",
         lambda: _parse_ideas_from_text(text, slotless_categories),
@@ -449,6 +450,19 @@ def _parse_ideas_from_text(
                                 detail=detail,
                             )
                         )
+
+                if (
+                    category_name in slotless_categories
+                    and _AVAILABLE_BLOCK_START.search(idea_text)
+                ):
+                    issues.append(
+                        IdeaIssue(
+                            current_idea,
+                            cat,
+                            current_idea_line,
+                            "available-in-slotless-category",
+                        )
+                    )
 
                 if _on_add_is_log_only(idea_text):
                     issues.append(
@@ -809,7 +823,7 @@ class Validator(BaseValidator):
         self._log_section("Checking idea definition quality...")
 
         if not self.slotless_categories:
-            self.log("  No idea categories parsed — allowed-block check is off")
+            self.log("  No idea categories parsed — slotless-gate checks are off")
 
         idea_files = self._collect_files(["common/ideas/**/*.txt"])
 
@@ -854,6 +868,16 @@ class Validator(BaseValidator):
                         f"'{issue.idea_name}' has an allowed block in {issue.category}"
                         " (that category has no slot, so add_idea is the only way in"
                         " and the gate is never consulted — delete it)",
+                        Severity.ERROR,
+                    )
+                elif issue.issue_type == "available-in-slotless-category":
+                    _add(
+                        filepath,
+                        issue.line,
+                        f"'{issue.idea_name}' has an available block in {issue.category}"
+                        " (that category has no slot, so add_idea is the only way in"
+                        " and the gate is never consulted — delete it;"
+                        " use cancel if the idea should remove itself)",
                         Severity.ERROR,
                     )
                 elif issue.issue_type == "cancel-always-no":


### PR DESCRIPTION
## Bottom line

Country and hidden_ideas have no slot, so `available` is never consulted. The dead gates are gone, and `validate_ideas.py` now errors on new ones.

## Why

Those ideas are grant-only (`add_idea`). `available` filters a pool the player never picks from. Use `cancel` if an idea should remove itself.

## How

`available-in-slotless-category` is the sibling of `allowed-in-slotless-category`. `strip_idea_allowed_gates.py` now drops both keys.

BLUF