### PR TITLE
Harden Comoros AI paths (issue #3162)

### DIFF
--- a/.claude/docs/ai-strategy-reference.md
+++ b/.claude/docs/ai-strategy-reference.md
@@ -209,7 +209,7 @@ MD_avoid_new_wars_when_outmatched = {
 }
 ```
 
-Omitting `allowed` applies a strategy to every country (precedent: `save_pp_for_laws`, `AI_generic_office_construction`, `default_area_priority`). Do not re-add per-tag `*_cancel_war_*` blocks.
+Omitting `allowed` applies a strategy to every country (precedent: `save_pp_for_laws`, `AI_generic_office_construction`, `default_area_priority`). Do not re-add per-tag `*_cancel_war_*` blocks, and do not write a per-tag `TAG_avoid_starting_wars` on a plain `enemies_strength_ratio` gate — anything stricter than `> 0.75` is already covered by the mod-wide block and does nothing. A per-tag brake earns its place only on a gate the strength ratio cannot express, such as `BLR`/`SOV` firing on NATO/EU-aligned enemies at any strength.
 
 **Ratio direction differs between the two triggers.** `strength_ratio = { tag = X ratio < 1 }` means the scope country is weaker than X. `enemies_strength_ratio` rises as the scope country's enemies get stronger — MD's peace-deal triggers read `> 1.7` as losing and `> 2.0` as massively outgunned (`common/scripted_triggers/00_peace_deal_triggers.txt`).
 

--- a/common/ai_strategy/CHI.txt
+++ b/common/ai_strategy/CHI.txt
@@ -836,17 +836,6 @@ CHI_support_north_korea = {
 	ai_strategy = { type = contain id = "KOR" value = 25 }
 }
 
-CHI_avoid_starting_wars = {
-	allowed = { original_tag = CHI }
-	enable = {
-		has_war = yes
-		enemies_strength_ratio > 1.5
-	}
-	abort_when_not_enabled = yes
-
-	ai_strategy = { type = avoid_starting_wars value = -200 }
-}
-
 CHI_avoid_unready_war_with_TAI = {
 	allowed = { original_tag = CHI }
 	enable = {

--- a/common/ai_strategy/COM.txt
+++ b/common/ai_strategy/COM.txt
@@ -1,14 +1,3 @@
-COM_avoid_starting_wars = {
-	allowed = { original_tag = COM }
-	enable = {
-		has_war = yes
-		enemies_strength_ratio > 1.5
-	}
-	abort_when_not_enabled = yes
-
-	ai_strategy = { type = avoid_starting_wars value = -200 }
-}
-
 COM_avoid_unready_war_with_FRA = {
 	allowed = { original_tag = COM }
 	enable = {

--- a/common/ai_strategy/COM.txt
+++ b/common/ai_strategy/COM.txt
@@ -1,0 +1,37 @@
+COM_avoid_starting_wars = {
+	allowed = { original_tag = COM }
+	enable = {
+		has_war = yes
+		enemies_strength_ratio > 1.5
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = avoid_starting_wars value = -200 }
+}
+
+COM_avoid_unready_war_with_FRA = {
+	allowed = { original_tag = COM }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		NOT = { strength_ratio = { tag = FRA ratio > 1.2 } }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = FRA value = -4000 }
+	ai_strategy = { type = conquer id = FRA value = -4000 }
+}
+
+COM_prepare_war_with_FRA = {
+	allowed = { original_tag = COM }
+	enable = {
+		has_wargoal_against = FRA
+		NOT = { has_war_with = FRA }
+		strength_ratio = { tag = FRA ratio > 1.2 }
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = prepare_for_war id = FRA value = 200 }
+	ai_strategy = { type = declare_war id = FRA value = 200 }
+	ai_strategy = { type = conquer id = FRA value = 200 }
+}

--- a/common/ai_strategy_plans/COM_strategy_plans.txt
+++ b/common/ai_strategy_plans/COM_strategy_plans.txt
@@ -1,0 +1,563 @@
+COM_HISTORICAL_plan = {
+	allowed = { original_tag = COM }
+	name = "The Union of the Comoros"
+	desc = "Comoros writes the federal constitution, gives each island its own president, lets the African Union retake Anjouan and hands the union presidency on at the ballot box."
+
+	enable = { has_global_flag = COM_HISTORICAL_FOCUS_PATH }
+
+	abort = { is_subject = yes }
+
+	ai_national_focuses = {
+		COM_comorian_politics
+		COM_introduce_democracy
+		COM_convention_renewal_party
+		COM_the_constitutional_referendum
+		COM_kickstart_economy
+		COM_a_federal_union
+		COM_army
+		COM_our_own_path
+		COM_Loi_des_competences
+		COM_social_democracy_in_africa
+		COM_operation_democracy_in_comoros
+		COM_greater_inter_island_cooperation
+		COM_naval_treaty_with_france
+		COM_a_common_destiny
+	}
+
+	focus_factors = {
+		COM_convention_renewal_party = 100
+		COM_social_democracy_in_africa = 100
+		COM_a_true_democracy = 100
+		COM_subsidies_for_education = 100
+		COM_social_agenda = 100
+		COM_stabilizing_society = 100
+		COM_assembly_of_union = 100
+		COM_purging_dissidents = 100
+		COM_our_partnership = 100
+		COM_the_constitutional_referendum = 100
+		COM_a_federal_union = 100
+		COM_Loi_des_competences = 100
+		COM_operation_democracy_in_comoros = 100
+		COM_greater_inter_island_cooperation = 100
+		COM_a_common_destiny = 100
+		COM_our_own_path = 100
+		COM_naval_treaty_with_france = 100
+		COM_befriend_the_west = 100
+		COM_buy_missile_defences = 100
+		COM_tighter_edf_cooperation = 100
+		COM_non_nato_ally = 100
+
+		COM_orange_party = 0
+		COM_radical_stance_on_trafficking = 0
+		COM_efficient_governmental_apparatus = 0
+		COM_meritocracy = 0
+		COM_push_it_to_the_limit = 0
+		COM_absolute_employment = 0
+		COM_balancing = 0
+		COM_state_run_capitalism = 0
+		COM_daudouism = 0
+		COM_inclusive_government = 0
+		COM_maintain_dictatorship = 0
+		COM_draw_closer_to_the_au = 0
+		COM_ohada = 0
+		COM_form_tanzancom = 0
+		COM_influence_of_islam = 0
+		COM_closer_ties_with_arab_league = 0
+		COM_seek_help_from_the_saudis = 0
+		COM_foreign_jihadists = 0
+		COM_pan_arabism = 0
+		COM_befriend_baath = 0
+		COM_ayatollah_sambi = 0
+		COM_militarism_baath = 0
+		COM_clearing_the_nomenclature = 0
+		COM_nationalization_of_capital = 0
+		COM_our_will_to_expand = 0
+		COM_declare_islamic_republic = 0
+		COM_the_warrior_king = 0
+		COM_the_consolidation_of_power = 0
+		COM_legitimize_our_rule = 0
+		COM_declare_the_state_of_pmcs = 0
+		COM_a_rifle_for_hire = 0
+		COM_expanded_regional_operations = 0
+		COM_expanded_global_operations = 0
+		COM_african_mercenaries = 0
+		COM_invite_the_pmcs = 0
+		COM_reform_defunct_pmc_units = 0
+		COM_mission_from_unrec = 0
+		COM_centralize_power = 0
+		COM_claim_banc_du_geyser = 0
+		COM_claim_the_glorioso_islands = 0
+		COM_no_more_coups = 0
+		COM_the_zanzibar_agreement = 0
+		COM_rejoin_france = 0
+		COM_antagonize_france = 0
+		COM_anti_colonialist_propaganda = 0
+		COM_demand_mayotte = 0
+		COM_naval_treaty_with_china = 0
+		COM_befriend_the_east = 0
+		COM_buy_missile_defences_rus = 0
+		COM_tighter_chi_cooperation = 0
+		COM_anti_nato_ally = 0
+	}
+
+	weight = { factor = 1.0 }
+}
+
+COM_MILITARY_DICTATORSHIP_plan = {
+	allowed = { original_tag = COM }
+	name = "The Colonel Stays"
+	desc = "Azali Assoumani keeps the presidency he took in uniform, folds the islands back under Moroni and drops the rotation before it can reach them."
+
+	enable = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+
+	abort = { is_subject = yes }
+
+	ai_national_focuses = {
+		COM_comorian_politics
+		COM_introduce_democracy
+		COM_convention_renewal_party
+		COM_the_constitutional_referendum
+		COM_kickstart_economy
+		COM_maintain_dictatorship
+		COM_army
+		COM_our_own_path
+		COM_centralize_power
+		COM_draw_closer_to_the_au
+		COM_naval_treaty_with_china
+		COM_ohada
+		COM_claim_banc_du_geyser
+		COM_form_tanzancom
+	}
+
+	focus_factors = {
+		COM_convention_renewal_party = 100
+		COM_maintain_dictatorship = 100
+		COM_draw_closer_to_the_au = 100
+		COM_ohada = 100
+		COM_form_tanzancom = 100
+		COM_stabilizing_society = 100
+		COM_assembly_of_union = 100
+		COM_purging_dissidents = 100
+		COM_our_partnership = 100
+		COM_the_constitutional_referendum = 100
+		COM_centralize_power = 100
+		COM_claim_banc_du_geyser = 100
+		COM_claim_the_glorioso_islands = 100
+		COM_no_more_coups = 100
+		COM_a_common_destiny = 100
+		COM_the_zanzibar_agreement = 100
+		COM_antagonize_france = 100
+		COM_anti_colonialist_propaganda = 100
+		COM_our_own_path = 100
+		COM_naval_treaty_with_china = 100
+		COM_befriend_the_east = 100
+		COM_buy_missile_defences_rus = 100
+		COM_tighter_chi_cooperation = 100
+		COM_anti_nato_ally = 100
+
+		COM_social_democracy_in_africa = 0
+		COM_a_true_democracy = 0
+		COM_subsidies_for_education = 0
+		COM_social_agenda = 0
+		COM_orange_party = 0
+		COM_radical_stance_on_trafficking = 0
+		COM_efficient_governmental_apparatus = 0
+		COM_meritocracy = 0
+		COM_push_it_to_the_limit = 0
+		COM_absolute_employment = 0
+		COM_balancing = 0
+		COM_state_run_capitalism = 0
+		COM_daudouism = 0
+		COM_inclusive_government = 0
+		COM_influence_of_islam = 0
+		COM_closer_ties_with_arab_league = 0
+		COM_seek_help_from_the_saudis = 0
+		COM_foreign_jihadists = 0
+		COM_pan_arabism = 0
+		COM_befriend_baath = 0
+		COM_ayatollah_sambi = 0
+		COM_militarism_baath = 0
+		COM_clearing_the_nomenclature = 0
+		COM_nationalization_of_capital = 0
+		COM_our_will_to_expand = 0
+		COM_declare_islamic_republic = 0
+		COM_the_warrior_king = 0
+		COM_the_consolidation_of_power = 0
+		COM_legitimize_our_rule = 0
+		COM_declare_the_state_of_pmcs = 0
+		COM_a_rifle_for_hire = 0
+		COM_expanded_regional_operations = 0
+		COM_expanded_global_operations = 0
+		COM_african_mercenaries = 0
+		COM_invite_the_pmcs = 0
+		COM_reform_defunct_pmc_units = 0
+		COM_mission_from_unrec = 0
+		COM_a_federal_union = 0
+		COM_Loi_des_competences = 0
+		COM_operation_democracy_in_comoros = 0
+		COM_greater_inter_island_cooperation = 0
+		COM_rejoin_france = 0
+		COM_demand_mayotte = 0
+		COM_naval_treaty_with_france = 0
+		COM_befriend_the_west = 0
+		COM_buy_missile_defences = 0
+		COM_tighter_edf_cooperation = 0
+		COM_non_nato_ally = 0
+	}
+
+	weight = { factor = 1.0 }
+}
+
+COM_ORANGE_PARTY_plan = {
+	allowed = { original_tag = COM }
+	name = "The Orange Ascendancy"
+	desc = "Mohamed Daoudou's Orange Party takes Moroni and runs the islands as a merit-picked technocracy. Trafficking is broken, the ministries are professionalised and Comoros sells itself to Western capital."
+
+	enable = { has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+
+	abort = { is_subject = yes }
+
+	ai_national_focuses = {
+		COM_comorian_politics
+		COM_introduce_democracy
+		COM_kickstart_economy
+		COM_orange_party
+		COM_the_constitutional_referendum
+		COM_radical_stance_on_trafficking
+		COM_army
+		COM_our_own_path
+		COM_meritocracy
+		COM_efficient_governmental_apparatus
+		COM_naval_treaty_with_france
+		COM_centralize_power
+		COM_push_it_to_the_limit
+		COM_daudouism
+	}
+
+	focus_factors = {
+		COM_orange_party = 100
+		COM_radical_stance_on_trafficking = 100
+		COM_efficient_governmental_apparatus = 100
+		COM_meritocracy = 100
+		COM_push_it_to_the_limit = 100
+		COM_absolute_employment = 100
+		COM_daudouism = 100
+		COM_inclusive_government = 100
+		COM_the_constitutional_referendum = 100
+		COM_centralize_power = 100
+		COM_claim_banc_du_geyser = 100
+		COM_claim_the_glorioso_islands = 100
+		COM_no_more_coups = 100
+		COM_a_common_destiny = 100
+		COM_the_zanzibar_agreement = 100
+		COM_our_own_path = 100
+		COM_naval_treaty_with_france = 100
+		COM_befriend_the_west = 100
+		COM_buy_missile_defences = 100
+		COM_tighter_edf_cooperation = 100
+		COM_non_nato_ally = 100
+
+		COM_balancing = 0
+		COM_state_run_capitalism = 0
+		COM_convention_renewal_party = 0
+		COM_social_democracy_in_africa = 0
+		COM_a_true_democracy = 0
+		COM_subsidies_for_education = 0
+		COM_social_agenda = 0
+		COM_stabilizing_society = 0
+		COM_assembly_of_union = 0
+		COM_purging_dissidents = 0
+		COM_our_partnership = 0
+		COM_maintain_dictatorship = 0
+		COM_draw_closer_to_the_au = 0
+		COM_ohada = 0
+		COM_form_tanzancom = 0
+		COM_influence_of_islam = 0
+		COM_closer_ties_with_arab_league = 0
+		COM_seek_help_from_the_saudis = 0
+		COM_foreign_jihadists = 0
+		COM_pan_arabism = 0
+		COM_befriend_baath = 0
+		COM_ayatollah_sambi = 0
+		COM_militarism_baath = 0
+		COM_clearing_the_nomenclature = 0
+		COM_nationalization_of_capital = 0
+		COM_our_will_to_expand = 0
+		COM_declare_islamic_republic = 0
+		COM_the_warrior_king = 0
+		COM_the_consolidation_of_power = 0
+		COM_legitimize_our_rule = 0
+		COM_declare_the_state_of_pmcs = 0
+		COM_a_rifle_for_hire = 0
+		COM_expanded_regional_operations = 0
+		COM_expanded_global_operations = 0
+		COM_african_mercenaries = 0
+		COM_invite_the_pmcs = 0
+		COM_reform_defunct_pmc_units = 0
+		COM_mission_from_unrec = 0
+		COM_a_federal_union = 0
+		COM_Loi_des_competences = 0
+		COM_operation_democracy_in_comoros = 0
+		COM_greater_inter_island_cooperation = 0
+		COM_rejoin_france = 0
+		COM_antagonize_france = 0
+		COM_anti_colonialist_propaganda = 0
+		COM_demand_mayotte = 0
+		COM_naval_treaty_with_china = 0
+		COM_befriend_the_east = 0
+		COM_buy_missile_defences_rus = 0
+		COM_tighter_chi_cooperation = 0
+		COM_anti_nato_ally = 0
+	}
+
+	weight = { factor = 1.0 }
+}
+
+COM_ISLAMIC_REPUBLIC_plan = {
+	allowed = { original_tag = COM }
+	name = "An Arabic Republic"
+	desc = "The mosques carry Ahmed Abdallah Mohamed Sambi into Moroni and Comoros remakes itself as an Arab republic. It nationalises the ports, courts Damascus and Baghdad and turns its back on Paris."
+
+	enable = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+
+	abort = { is_subject = yes }
+
+	ai_national_focuses = {
+		COM_comorian_politics
+		COM_introduce_democracy
+		COM_kickstart_economy
+		COM_influence_of_islam
+		COM_the_constitutional_referendum
+		COM_befriend_baath
+		COM_army
+		COM_our_own_path
+		COM_ayatollah_sambi
+		COM_clearing_the_nomenclature
+		COM_naval_treaty_with_china
+		COM_centralize_power
+		COM_nationalization_of_capital
+		COM_declare_islamic_republic
+	}
+
+	focus_factors = {
+		COM_influence_of_islam = 100
+		COM_befriend_baath = 100
+		COM_ayatollah_sambi = 100
+		COM_militarism_baath = 100
+		COM_clearing_the_nomenclature = 100
+		COM_nationalization_of_capital = 100
+		COM_our_will_to_expand = 100
+		COM_declare_islamic_republic = 100
+		COM_the_constitutional_referendum = 100
+		COM_centralize_power = 100
+		COM_claim_banc_du_geyser = 100
+		COM_claim_the_glorioso_islands = 100
+		COM_no_more_coups = 100
+		COM_a_common_destiny = 100
+		COM_the_zanzibar_agreement = 100
+		COM_antagonize_france = 100
+		COM_anti_colonialist_propaganda = 100
+		COM_our_own_path = 100
+		COM_naval_treaty_with_china = 100
+		COM_befriend_the_east = 100
+		COM_buy_missile_defences_rus = 100
+		COM_tighter_chi_cooperation = 100
+		COM_anti_nato_ally = 100
+
+		COM_closer_ties_with_arab_league = 0
+		COM_seek_help_from_the_saudis = 0
+		COM_foreign_jihadists = 0
+		COM_pan_arabism = 0
+		COM_convention_renewal_party = 0
+		COM_social_democracy_in_africa = 0
+		COM_a_true_democracy = 0
+		COM_subsidies_for_education = 0
+		COM_social_agenda = 0
+		COM_stabilizing_society = 0
+		COM_assembly_of_union = 0
+		COM_purging_dissidents = 0
+		COM_our_partnership = 0
+		COM_orange_party = 0
+		COM_radical_stance_on_trafficking = 0
+		COM_efficient_governmental_apparatus = 0
+		COM_meritocracy = 0
+		COM_push_it_to_the_limit = 0
+		COM_absolute_employment = 0
+		COM_balancing = 0
+		COM_state_run_capitalism = 0
+		COM_daudouism = 0
+		COM_inclusive_government = 0
+		COM_maintain_dictatorship = 0
+		COM_draw_closer_to_the_au = 0
+		COM_ohada = 0
+		COM_form_tanzancom = 0
+		COM_the_warrior_king = 0
+		COM_the_consolidation_of_power = 0
+		COM_legitimize_our_rule = 0
+		COM_declare_the_state_of_pmcs = 0
+		COM_a_rifle_for_hire = 0
+		COM_expanded_regional_operations = 0
+		COM_expanded_global_operations = 0
+		COM_african_mercenaries = 0
+		COM_invite_the_pmcs = 0
+		COM_reform_defunct_pmc_units = 0
+		COM_mission_from_unrec = 0
+		COM_a_federal_union = 0
+		COM_Loi_des_competences = 0
+		COM_operation_democracy_in_comoros = 0
+		COM_greater_inter_island_cooperation = 0
+		COM_rejoin_france = 0
+		COM_demand_mayotte = 0
+		COM_naval_treaty_with_france = 0
+		COM_befriend_the_west = 0
+		COM_buy_missile_defences = 0
+		COM_tighter_edf_cooperation = 0
+		COM_non_nato_ally = 0
+	}
+
+	weight = { factor = 1.0 }
+}
+
+COM_WARRIOR_KING_plan = {
+	allowed = { original_tag = COM }
+	name = "The Warrior King"
+	desc = "Robert Denard comes back to the islands one last time and the Presidential Guard hands him the palace. Comoros stops being a country with an army and becomes an army with a flag to rent."
+
+	enable = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
+
+	abort = { is_subject = yes }
+
+	ai_national_focuses = {
+		COM_comorian_politics
+		COM_kickstart_economy
+		COM_army
+		COM_the_constitutional_referendum
+		COM_the_warrior_king
+		COM_african_mercenaries
+		COM_the_consolidation_of_power
+		COM_legitimize_our_rule
+		COM_declare_the_state_of_pmcs
+		COM_invite_the_pmcs
+		COM_centralize_power
+		COM_a_rifle_for_hire
+		COM_expanded_regional_operations
+		COM_expanded_global_operations
+	}
+
+	focus_factors = {
+		COM_the_warrior_king = 100
+		COM_the_consolidation_of_power = 100
+		COM_legitimize_our_rule = 100
+		COM_declare_the_state_of_pmcs = 100
+		COM_a_rifle_for_hire = 100
+		COM_expanded_regional_operations = 100
+		COM_expanded_global_operations = 100
+		COM_african_mercenaries = 100
+		COM_invite_the_pmcs = 100
+		COM_reform_defunct_pmc_units = 100
+		COM_the_constitutional_referendum = 100
+		COM_centralize_power = 100
+		COM_claim_banc_du_geyser = 100
+		COM_claim_the_glorioso_islands = 100
+		COM_no_more_coups = 100
+		COM_antagonize_france = 100
+		COM_anti_colonialist_propaganda = 100
+		COM_naval_treaty_with_china = 100
+		COM_befriend_the_east = 100
+		COM_buy_missile_defences_rus = 100
+		COM_tighter_chi_cooperation = 100
+		COM_anti_nato_ally = 100
+
+		COM_our_own_path = 0
+		COM_mission_from_unrec = 0
+		COM_convention_renewal_party = 0
+		COM_social_democracy_in_africa = 0
+		COM_a_true_democracy = 0
+		COM_subsidies_for_education = 0
+		COM_social_agenda = 0
+		COM_stabilizing_society = 0
+		COM_assembly_of_union = 0
+		COM_purging_dissidents = 0
+		COM_our_partnership = 0
+		COM_orange_party = 0
+		COM_radical_stance_on_trafficking = 0
+		COM_efficient_governmental_apparatus = 0
+		COM_meritocracy = 0
+		COM_push_it_to_the_limit = 0
+		COM_absolute_employment = 0
+		COM_balancing = 0
+		COM_state_run_capitalism = 0
+		COM_daudouism = 0
+		COM_inclusive_government = 0
+		COM_maintain_dictatorship = 0
+		COM_draw_closer_to_the_au = 0
+		COM_ohada = 0
+		COM_form_tanzancom = 0
+		COM_influence_of_islam = 0
+		COM_closer_ties_with_arab_league = 0
+		COM_seek_help_from_the_saudis = 0
+		COM_foreign_jihadists = 0
+		COM_pan_arabism = 0
+		COM_befriend_baath = 0
+		COM_ayatollah_sambi = 0
+		COM_militarism_baath = 0
+		COM_clearing_the_nomenclature = 0
+		COM_nationalization_of_capital = 0
+		COM_our_will_to_expand = 0
+		COM_declare_islamic_republic = 0
+		COM_a_federal_union = 0
+		COM_Loi_des_competences = 0
+		COM_operation_democracy_in_comoros = 0
+		COM_greater_inter_island_cooperation = 0
+		COM_a_common_destiny = 0
+		COM_the_zanzibar_agreement = 0
+		COM_rejoin_france = 0
+		COM_demand_mayotte = 0
+		COM_naval_treaty_with_france = 0
+		COM_befriend_the_west = 0
+		COM_buy_missile_defences = 0
+		COM_tighter_edf_cooperation = 0
+		COM_non_nato_ally = 0
+	}
+
+	weight = { factor = 1.0 }
+}
+
+COM_no_scripted_path = {
+	allowed = { original_tag = COM }
+	name = "Comoros"
+	desc = "Behaviour when no scripted path is set"
+
+	enable = {
+		original_tag = COM
+		NOT = { has_global_flag = COM_HISTORICAL_FOCUS_PATH }
+		NOT = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+		NOT = { has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+		NOT = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+		NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
+	}
+
+	abort = { is_subject = yes }
+
+	ai_national_focuses = {
+		COM_comorian_politics
+		COM_kickstart_economy
+		COM_introduce_democracy
+		COM_army
+		COM_our_own_path
+		COM_the_constitutional_referendum
+		COM_expand_moroni
+		COM_agricultural_developments
+		COM_naval_treaty_with_france
+		COM_expand_on_anjouan
+		COM_modernize_the_patrol_boats
+		COM_ministry_of_economy
+	}
+
+	focus_factors = {
+		COM_rejoin_france = 0
+		COM_demand_mayotte = 0
+	}
+
+	weight = { factor = 1.0 }
+}

--- a/common/decisions/05_comoros_decisions.txt
+++ b/common/decisions/05_comoros_decisions.txt
@@ -1,4 +1,59 @@
 # Author(s): AngriestBird
+COM_ai_path_category = {
+
+	COM_build_the_orange_movement = {
+
+		icon = GFX_decision_generic_political_discourse
+
+		cost = 25
+
+		days_re_enable = 30
+
+		visible = { has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+
+		available = {
+			western_conservatism_are_in_power = no
+			check_variable = { party_pop_array^1 < 0.45 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision COM_build_the_orange_movement"
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			change_relative_party_popularity = yes
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	COM_carry_the_baath_message = {
+
+		icon = GFX_decision_generic_political_discourse
+
+		cost = 25
+
+		days_re_enable = 30
+
+		visible = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+
+		available = {
+			nationalist_military_junta_are_in_power = no
+			check_variable = { party_pop_array^22 < 0.50 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision COM_carry_the_baath_message"
+			set_temp_variable = { party_index = 22 }
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			set_temp_variable = { temp_outlook_increase = 0.04 }
+			change_relative_party_popularity = yes
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+}
+
 COM_comorian_political_decisions = {
 	COM_disband_the_presidential_guard_decision = {
 		icon = x

--- a/common/decisions/categories/99_BLR_decision_categories.txt
+++ b/common/decisions/categories/99_BLR_decision_categories.txt
@@ -193,12 +193,14 @@ BLR_advanced_industry_category = {
 }
 
 BLR_ai_path_category = {
-	allowed = {	original_tag = BLR }
+	allowed = {
+		is_ai = yes
+		original_tag = BLR
+	}
 	icon = GFX_decisions_category_political
 	priority = 100
 
 	visible = {
-		is_ai = yes
 		OR = {
 			has_global_flag = BLR_EUROPEAN_BELARUS_FOCUS_PATH
 			has_global_flag = BLR_POPULAR_FRONT_FOCUS_PATH

--- a/common/decisions/categories/99_BOT_decision_categories.txt
+++ b/common/decisions/categories/99_BOT_decision_categories.txt
@@ -1,12 +1,12 @@
 BOT_ai_path_category = {
-	allowed = { original_tag = BOT }
+	allowed = {
+		is_ai = yes
+		original_tag = BOT
+	}
 	icon = GFX_decisions_category_political
 	priority = 100
 
-	visible = {
-		is_ai = yes
-		has_global_flag = BOT_KGOSIKGOLO_FOCUS_PATH
-	}
+	visible = { has_global_flag = BOT_KGOSIKGOLO_FOCUS_PATH }
 }
 
 BOT_anti_poaching_decisions = {

--- a/common/decisions/categories/99_BUL_decision_categories.txt
+++ b/common/decisions/categories/99_BUL_decision_categories.txt
@@ -42,13 +42,15 @@ BUL_tourism_development_category = {
 }
 
 BUL_ai_path_category = {
-	allowed = { original_tag = BUL }
+	allowed = {
+		is_ai = yes
+		original_tag = BUL
+	}
 
 	icon = GFX_decisions_category_political
 	priority = 100
 
 	visible = {
-		is_ai = yes
 		OR = {
 			has_global_flag = BUL_TSARIST_RESTORATION_FOCUS_PATH
 			has_global_flag = BUL_RED_BALKAN_FOCUS_PATH

--- a/common/decisions/categories/99_CAN_decision_categories.txt
+++ b/common/decisions/categories/99_CAN_decision_categories.txt
@@ -38,13 +38,13 @@ CAN_war_decisions = {
 }
 
 CAN_ai_path_category = {
-	allowed = { original_tag = CAN }
+	allowed = {
+		is_ai = yes
+		original_tag = CAN
+	}
 
 	icon = GFX_decisions_category_political
 	priority = 100
 
-	visible = {
-		is_ai = yes
-		has_global_flag = CAN_NATIONALIST_FOCUS_PATH
-	}
+	visible = { has_global_flag = CAN_NATIONALIST_FOCUS_PATH }
 }

--- a/common/decisions/categories/99_COM_decision_categories.txt
+++ b/common/decisions/categories/99_COM_decision_categories.txt
@@ -1,12 +1,14 @@
 # Author(s): AngriestBird
 COM_ai_path_category = {
-	allowed = { original_tag = COM }
+	allowed = {
+		is_ai = yes
+		original_tag = COM
+	}
 	icon = GFX_decisions_category_political
 
 	priority = 100
 
 	visible = {
-		is_ai = yes
 		OR = {
 			has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH
 			has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH

--- a/common/decisions/categories/99_COM_decision_categories.txt
+++ b/common/decisions/categories/99_COM_decision_categories.txt
@@ -1,4 +1,19 @@
 # Author(s): AngriestBird
+COM_ai_path_category = {
+	allowed = { original_tag = COM }
+	icon = GFX_decisions_category_political
+
+	priority = 100
+
+	visible = {
+		is_ai = yes
+		OR = {
+			has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH
+			has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH
+		}
+	}
+}
+
 COM_comorian_political_decisions = {
 	allowed = { original_tag = COM }
 	icon = GFX_decision_category_generic_political_actions

--- a/common/decisions/categories/99_HOL_decisions_categories.txt
+++ b/common/decisions/categories/99_HOL_decisions_categories.txt
@@ -163,11 +163,13 @@ HOL_future_air_defender_program = {
 }
 
 HOL_ai_path_category = {
-	allowed = { original_tag = HOL }
+	allowed = {
+		is_ai = yes
+		original_tag = HOL
+	}
 	icon = decision_category_generic_propaganda
 	priority = 100
 	visible = {
-		is_ai = yes
 		OR = {
 			has_global_flag = HOL_WESTERN_MONARCHY_AI_FOCUS
 			has_global_flag = HOL_NATIONALIST_MONARCHY_AI_FOCUS

--- a/common/decisions/categories/99_ITA_decision_categories.txt
+++ b/common/decisions/categories/99_ITA_decision_categories.txt
@@ -73,12 +73,14 @@ ITA_italian_space_decision_category = {
 }
 
 ITA_ai_path_category = {
-	allowed = { original_tag = ITA }
+	allowed = {
+		is_ai = yes
+		original_tag = ITA
+	}
 	icon = GFX_decisions_category_political
 	priority = 100
 
 	visible = {
-		is_ai = yes
 		OR = {
 			has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
 			has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS

--- a/common/decisions/categories/99_JAP_decision_categories.txt
+++ b/common/decisions/categories/99_JAP_decision_categories.txt
@@ -158,11 +158,11 @@ JAP_seismic_retrofit_category = {
 }
 
 JAP_ai_path_category = {
-	allowed = { original_tag = JAP }
+	allowed = {
+		is_ai = yes
+		original_tag = JAP
+	}
 	icon = GFX_decisions_category_political
 	priority = 100
-	visible = {
-		is_ai = yes
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-	}
+	visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
 }

--- a/common/decisions/categories/united_kingdom_categories.txt
+++ b/common/decisions/categories/united_kingdom_categories.txt
@@ -75,8 +75,8 @@ ENG_ai_path_category = {
 	icon = decision_category_generic_propaganda
 
 	allowed = {
-		original_tag = ENG
 		is_ai = yes
+		original_tag = ENG
 	}
 	priority = 100
 

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -2120,32 +2120,42 @@ CHI_ai_behavior = {
 }
 
 COM_ai_behavior = {
-	name = "COM_ai_behavior"
+	name = "COM_AI_BEHAVIOR"
 	group = "RULE_GROUP_AI_BEHAVIOR"
 	default = {
-		name = DEFAULT
-		text = "RULE_OPTION_DEFAULT"
-		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+		name = HISTORICAL
+		text = "RULE_OPTION_COM_HISTORICAL"
+		desc = "RULE_OPTION_COM_HISTORICAL_DESC"
 	}
 	option = {
-		name = COM_DEMOCRACY
-		text = "RULE_OPTION_COM_DEMOCRACY"
-		desc = "RULE_OPTION_COM_DEMOCRACY_DESC"
-	}
-	option = {
-		name = COM_WARRIOR_KING
-		text = "RULE_OPTION_COM_WARRIOR_KING"
-		desc = "RULE_OPTION_COM_WARRIOR_KING_DESC"
-	}
-	option = {
-		name = COM_MILITARY_DICTATORSHIP
+		name = MILITARY_DICTATORSHIP
 		text = "RULE_OPTION_COM_MILITARY_DICTATORSHIP"
 		desc = "RULE_OPTION_COM_MILITARY_DICTATORSHIP_DESC"
 	}
 	option = {
-		name = COM_ISLAMISM
-		text = "RULE_OPTION_COM_ISLAMISM"
-		desc = "RULE_OPTION_COM_ISLAMISM_DESC"
+		name = ORANGE_PARTY
+		text = "RULE_OPTION_COM_ORANGE_PARTY"
+		desc = "RULE_OPTION_COM_ORANGE_PARTY_DESC"
+	}
+	option = {
+		name = ISLAMIC_REPUBLIC
+		text = "RULE_OPTION_COM_ISLAMIC_REPUBLIC"
+		desc = "RULE_OPTION_COM_ISLAMIC_REPUBLIC_DESC"
+	}
+	option = {
+		name = WARRIOR_KING
+		text = "RULE_OPTION_COM_WARRIOR_KING"
+		desc = "RULE_OPTION_COM_WARRIOR_KING_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	option = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
 	}
 }
 

--- a/common/national_focus/05_comoros.txt
+++ b/common/national_focus/05_comoros.txt
@@ -194,6 +194,7 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
 			}
 			modifier = {
 				factor = 0
@@ -349,6 +350,10 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -374,7 +379,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 10 }
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -535,6 +546,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -634,7 +649,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 10 }
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -821,6 +842,10 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 		}
 	}
 
@@ -940,6 +965,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
 			}
 		}
 	}
@@ -1766,7 +1795,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 10 }
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1896,7 +1931,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 10 }
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2904,6 +2945,9 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
 			}
 		}
 	}
@@ -3058,6 +3102,9 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+				NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
 			}
 		}
 	}
@@ -3111,6 +3158,9 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+				NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
 			}
 		}
 	}
@@ -3366,6 +3416,10 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+				NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
 			}
 		}
 	}

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -1495,6 +1495,69 @@ on_actions = {
 				}
 			}
 
+			COM = {
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = COM_ai_behavior
+							option = RANDOM_PATH
+						}
+					}
+					random_list = {
+						40 = { set_global_flag = COM_HISTORICAL_FOCUS_PATH }
+						20 = { set_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+						15 = { set_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+						15 = { set_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+						10 = { set_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
+					}
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = COM_ai_behavior
+							option = HISTORICAL
+						}
+					}
+					set_global_flag = COM_HISTORICAL_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = COM_ai_behavior
+							option = MILITARY_DICTATORSHIP
+						}
+					}
+					set_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = COM_ai_behavior
+							option = ORANGE_PARTY
+						}
+					}
+					set_global_flag = COM_ORANGE_PARTY_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = COM_ai_behavior
+							option = ISLAMIC_REPUBLIC
+						}
+					}
+					set_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = COM_ai_behavior
+							option = WARRIOR_KING
+						}
+					}
+					set_global_flag = COM_WARRIOR_KING_FOCUS_PATH
+				}
+			}
+
 			BRM = {
 				if = {
 					limit = {

--- a/events/Italy.txt
+++ b/events/Italy.txt
@@ -4788,14 +4788,12 @@ country_event = {
 			}
 			modifier = {
 				add = 100
-				has_game_rule = {
-					rule = COM_ai_behavior
-					option = COM_WARRIOR_KING
-				}
+				has_global_flag = COM_WARRIOR_KING_FOCUS_PATH
 			}
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
 			}
 		}
 	}

--- a/events/comoros.txt
+++ b/events/comoros.txt
@@ -25,6 +25,13 @@ country_event = {
 		set_temp_variable = { influence_target = COM }
 		change_influence_percentage = yes
 		add_ideas = shia_movement
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 20
+				has_government = communism
+			}
+		}
 		hidden_effect = {
 			create_country_leader = {
 				name = "Ahmed Abdallah Mohamed Sambi"
@@ -51,6 +58,13 @@ country_event = {
 		set_temp_variable = { influence_target = COM }
 		change_influence_percentage = yes
 		add_ideas = baath_movement
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 20
+				has_government = nationalist
+			}
+		}
 		hidden_effect = {
 			create_country_leader = {
 				name = "Said Ahmed Said Ali"
@@ -93,6 +107,15 @@ country_event = {
 
 		ai_chance = {
 			base = 50
+			modifier = {
+				factor = 0
+				OR = {
+					has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH
+					has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH
+					has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH
+					has_global_flag = COM_WARRIOR_KING_FOCUS_PATH
+				}
+			}
 		}
 	}
 
@@ -110,6 +133,14 @@ country_event = {
 			modifier = {
 				factor = 0
 				is_historical_focus_on = yes
+				NOT = { has_global_flag = COM_MILITARY_DICTATORSHIP_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ORANGE_PARTY_FOCUS_PATH }
+				NOT = { has_global_flag = COM_ISLAMIC_REPUBLIC_FOCUS_PATH }
+				NOT = { has_global_flag = COM_WARRIOR_KING_FOCUS_PATH }
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = COM_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -831,10 +862,7 @@ country_event = {
 				25 = {
 					modifier = {
 						factor = 0
-						has_game_rule = {
-							rule = COM_ai_behavior
-							option = COM_WARRIOR_KING
-						}
+						has_global_flag = COM_WARRIOR_KING_FOCUS_PATH
 					}
 					country_event = { id = comoros.30 random_days = 30 }
 				}
@@ -845,10 +873,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 100
-				has_game_rule = {
-					rule = COM_ai_behavior
-					option = COM_WARRIOR_KING
-				}
+				has_global_flag = COM_WARRIOR_KING_FOCUS_PATH
 			}
 		}
 	}
@@ -868,10 +893,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 0
-				has_game_rule = {
-					rule = COM_ai_behavior
-					option = COM_WARRIOR_KING
-				}
+				has_global_flag = COM_WARRIOR_KING_FOCUS_PATH
 			}
 		}
 	}
@@ -891,10 +913,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 0
-				has_game_rule = {
-					rule = COM_ai_behavior
-					option = COM_WARRIOR_KING
-				}
+				has_global_flag = COM_WARRIOR_KING_FOCUS_PATH
 			}
 		}
 	}
@@ -920,6 +939,10 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.15 }
 		change_relative_party_popularity = yes
 
+		if = {
+			limit = { is_ai = yes }
+			set_temp_variable = { disable_elections = 1 }
+		}
 		set_temp_variable = { rul_party_temp = 22 }
 		change_ruling_party_effect = yes
 		create_country_leader = {
@@ -993,7 +1016,7 @@ country_event = {
 	# The Results Are In
 	option = {
 		name = comoros.31.a
-		log = "[GetDateText]: [This.GetName]: comoros.30.a executed"
+		log = "[GetDateText]: [This.GetName]: comoros.31.a executed"
 		if = { limit = { check_variable = { COM_federalist_constitutional_support > COM_anti_federalist_constitutional_support } }
 			set_country_flag = COM_pro_federalist
 		}

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -406,15 +406,17 @@
  RULE_OPTION_MULTIPOLAR_GREECE_DESC: "Greece will remain a republic but turn away from the Western bloc, courting Russia, China, and Iran before anchoring itself in BRICS and leaving the Western institutions behind."
 
  # Comoros
- COM_ai_behavior: "@COM Comoros"
- RULE_OPTION_COM_DEMOCRACY: "Democracy Route"
- RULE_OPTION_COM_DEMOCRACY_DESC: ""
+ COM_AI_BEHAVIOR: "@COM Comoros"
+ RULE_OPTION_COM_HISTORICAL: "The Union of the Comoros"
+ RULE_OPTION_COM_HISTORICAL_DESC: "Azali Assoumani trades the uniform for the ballot box, the islands each get a president and the union presidency rotates between them, and African Union troops take Anjouan back from its colonel. The §8Convention for the Renewal of the Comoros§! wins and then loses power peacefully, and the archipelago finally stops overthrowing itself."
+ RULE_OPTION_COM_MILITARY_DICTATORSHIP: "The Colonel Stays"
+ RULE_OPTION_COM_MILITARY_DICTATORSHIP_DESC: "Azali keeps the presidency he took in uniform, pulls the islands back under Moroni and lets the rotation die before it reaches anyone else. Comoros drifts out of the French orbit and looks to Beijing and the African Union for the recognition Paris no longer offers."
+ RULE_OPTION_COM_ORANGE_PARTY: "The Orange Ascendancy"
+ RULE_OPTION_COM_ORANGE_PARTY_DESC: "Mohamed Daoudou's §8Orange Party§! takes Moroni and runs the archipelago as a merit-picked technocracy, breaking the trafficking rings and professionalising the ministries. Comoros sells itself to Western capital as the one Indian Ocean microstate whose paperwork can be trusted."
+ RULE_OPTION_COM_ISLAMIC_REPUBLIC: "An Arabic Republic"
+ RULE_OPTION_COM_ISLAMIC_REPUBLIC_DESC: "The mosque committees carry Ahmed Abdallah Mohamed Sambi into the presidency and the §8Ba'athist movement§! remakes the islands as an Arab republic. The ports are nationalised, Damascus and Baghdad replace Paris, and the Comoros becomes an Arab League voice in the Mozambique Channel."
  RULE_OPTION_COM_WARRIOR_KING: "The Warrior King"
- RULE_OPTION_COM_WARRIOR_KING_DESC: ""
- RULE_OPTION_COM_MILITARY_DICTATORSHIP: "Military Dictatorship"
- RULE_OPTION_COM_MILITARY_DICTATORSHIP_DESC: ""
- RULE_OPTION_COM_ISLAMISM: "Islamism"
- RULE_OPTION_COM_ISLAMISM_DESC: ""
+ RULE_OPTION_COM_WARRIOR_KING_DESC: "Robert Denard returns to the islands one last time and the §8Presidential Guard§! hands him the palace without a shot. Comoros stops being a country with an army and becomes an army with a flag to rent, selling its mercenaries across Africa."
 
  #Canada
  RULE_OPTION_CAN_HISTORICAL: "Historical"


### PR DESCRIPTION
Part of #3162.

## What changed

**Rule** — `COM_ai_behavior` now reads `HISTORICAL` (default) / `MILITARY_DICTATORSHIP` / `ORANGE_PARTY` / `ISLAMIC_REPUBLIC` / `WARRIOR_KING` / `RANDOM_PATH` / `NO_PATH`. `DEFAULT` and `COM_DEMOCRACY` are gone; the header key is `COM_AI_BEHAVIOR` (was the lowercase rule id) and all five descs are written (they were empty strings).

**Wiring** — there was no `COM = { }` block in `999_game_rules_on_actions.txt`, so no option ever set a flag and only `COM_WARRIOR_KING` did anything at all. Added one setting `COM_<PATH>_FOCUS_PATH` global flags, with the historical bucket in the `RANDOM_PATH` list. All five previous raw `has_game_rule` reads (comoros.27 ×4, italy_md.70 ×1) now read the flag.

**Path selection** — new `common/ai_strategy_plans/COM_strategy_plans.txt`: six plans carrying the killswitch matrix in `focus_factors`, so the 119-focus tree needed almost no edits. `COM_no_scripted_path` deliberately carries a two-entry `focus_factors` block (CHI's has none) so NO_PATH cannot end the campaign either.

**Reachability fixes**

- `COM_orange_party` needed `western_conservatism_are_in_power`, but its own reward is what creates the conservative leader and grows party 1 — chicken and egg. Comoros starts socialism-ruling with conservatism at 0.20 and **no drift ideas**, so it never wins an election. 12 focuses were permanently dead.
- `COM_influence_of_islam` needed `communism/nationalist/fascism > 0.4`; all three start at 0 and the only drift sources are handed out by `COM_ayatollah_sambi`, three levels inside the branch. ~15 focuses were permanently dead.
- Both are now reached through the house ramp pattern (`BOT_ai_path_category`): a new AI-only `COM_ai_path_category` with one decision each, walking `party_pop_array^1` / `^22` via `change_relative_party_popularity` so the party wins the 2003.2 election. The Orange ramp deliberately omits `temp_outlook_increase` — with it, party 1 caps at exactly 0.45, a tie with socialism it can never break.
- `italy_md.70.o2` gave `add = 100` for the Comoros rule and then `factor = 0 is_historical_focus_on = yes`, so under default settings Italy never released Denard and the Warrior King path could not happen. The killswitch is now exempted by the path flag.
- `comoros.28` left elections on with party 22 at 0.15, so an AI Denard lost the 2003 election and all seven Warrior King focuses went permanently unavailable. It now passes `disable_elections` for an AI Comoros; a human keeps their elections.
- `comoros.4` option b (anti-federalist) was zeroed whenever historical AI was on, and both referendum campaign decisions are `base = 0`, so `COM_centralize_power` was unreachable and four of five paths dead-ended at the referendum. Both options are now weighted per path.
- Five `factor = 0 is_historical_focus_on = yes` killswitches in the tree would have zeroed a path's own focuses through the `focus_factors` multiplier (`10 × 0 × 100 = 0`). Each now carries `NOT = { has_global_flag = ... }` for the paths that own it.

**AI hardening**

- `COM_social_democracy_in_africa` and `COM_maintain_dictatorship` are mutex, share the identical `available`, and both sat at `base = 10` — the fork resolved by file order. The plans decide it now.
- `ai_is_threatened` factor 2 on eight combat-capacity focuses; the tree had no threat term anywhere.
- New `common/ai_strategy/COM.txt`: the paired `avoid_unready_war_with_FRA` / `prepare_war_with_FRA` readiness gate. `comoros.12` is a flat coin flip that can hand an AI Comoros a `take_core_state` wargoal on France with no focus involved.
- `COM_rejoin_france` (turns Comoros into a French overseas department) and `COM_demand_mayotte` (hopeless war with France) are zeroed in **all six** plans.
- `comoros.1` had no `ai_chance` on either option; `comoros.31.a` logged `comoros.30.a`.

## Review follow-ups

- The per-tag losing-war brake is gone. `MD_avoid_new_wars_when_outmatched` already carries the same `avoid_starting_wars value = -200` on a looser gate (`enemies_strength_ratio > 0.75`) with no `allowed` block, so a `> 1.5` per-tag copy can never fire when the mod-wide rule is not already firing. `CHI_avoid_starting_wars` (identical, merged in #3327) goes with it; `BLR`/`SOV` keep theirs, which gate on NATO/EU-aligned enemies at any strength. `.claude/docs/ai-strategy-reference.md` now says so next to the `*_cancel_war_*` rule.
- `is_ai = yes` moved out of the category `visible` block and into `allowed` on every `*_ai_path_category` (COM, BLR, BOT, BUL, CAN, HOL, ITA, JAP; ENG already had it), so a human never evaluates the category or its decisions past game start. Validator AI-only detection is unchanged: `_AI_GATE_FIELDS` reads `visible`/`available`/`allowed` alike, so the categories stay loc-exempt.

## What to test

- Start as an observer with each of the five options and confirm Comoros reaches its branch root: federal union + Operation Democracy in Comoros (historical), Maintain a Military Dictatorship + Centralize Power, Orange Party → Daoudouism, Influence of Islam → Declare an Arabic Republic, Denard's coup → Declare the State of PMCs.
- Orange Party and Islamic Republic: the party ramp should flip the government at the February 2003 election. Check the decisions fire (AI-only category, invisible to a human) and stop once the party is in power.
- Warrior King: with historical AI on (the default), Italy should still release Denard, the coup should land in 2001-2002, and the junta should survive past February 2003.
- `RANDOM_PATH` can roll historical; `NO_PATH` leaves no path flag set, Comoros picks focuses freely, and it can still not reach `COM_rejoin_france` or `COM_demand_mayotte`.
- Rename of the rule's option names invalidates the Comoros rule selection in existing saves (same as the China PR).

## Deliberately not fixed

- The four `has_government = fascism` focuses on the Arab League / jihadist spur stay human-only. Their rewards do `add_popularity = { ideology = fascism }` and `set_cosmetic_tag = COM_AUTH_S_fascism`; firing them under a nationalist government is a content change, not AI hardening, and a fascism ramp cannot coexist with the nationalist one.
- `COM_trade_deals_with_tanzania` checks `country_exists = SIN` (copy-paste from the Singapore focus).
- `99_COM_on_actions.txt:15` `add_to_variable = { COM.COM_volunteer_nation_total = 0 }` is a no-op.

## Validation

`validate_focus_tree` (exit 0, still zero issues repo-wide), `validate_variables`, `validate_on_actions` clean. `validate_decisions` / `validate_events` / `validate_localisation` unchanged from baseline — no COM entries in any warning group, and no `ai-only-decision-localisation` findings (the AI-only category correctly carries no loc keys). `check_common_mistakes --mode staged` passed. `pre-commit` is not installed in this environment; CI hooks have not been run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


