### PR TITLE
Gate Antarctica blizzard news to station owners

### DIFF
--- a/events/MD_Antarctica.txt
+++ b/events/MD_Antarctica.txt
@@ -217,6 +217,7 @@ country_event = {
 			limit = { has_dlc = "By Blood Alone" }
 			send_embargo = FROM
 		}
+		newline = yes
 		add_opinion_modifier = { target = FROM modifier = embargo }
 		reverse_add_opinion_modifier = { target = FROM modifier = embargo }
 		add_opinion_modifier = { target = FROM modifier = embargo_opinion }
@@ -235,7 +236,6 @@ country_event = {
 	}
 	option = {
 		name = MD_antarctica.7.b
-		log = "[GetDateText]: [This.GetName]: MD_antarctica.7.b executed"
 		ai_chance = {
 			base = 2
 			modifier = {
@@ -277,7 +277,6 @@ country_event = {
 
 	option = {
 		name = MD_antarctica.9.a
-		log = "[GetDateText]: [This.GetName]: MD_antarctica.9.a executed"
 		ai_chance = { base = 100 }
 	}
 }
@@ -292,7 +291,6 @@ country_event = {
 
 	option = {
 		name = MD_antarctica.10.a
-		log = "[GetDateText]: [This.GetName]: MD_antarctica.10.a executed"
 		ai_chance = { base = 100 }
 	}
 }
@@ -495,9 +493,7 @@ news_event = {
 	id = MD_antarctica_news.9
 	title = MD_antarctica_news.9.t
 	desc = MD_antarctica_news.9.d
-
 	picture = GFX_antarctica_blizzard_news
-
 	is_triggered_only = yes
 	trigger = { has_country_flag = antarctica_has_active_station }
 

--- a/events/MD_Antarctica.txt
+++ b/events/MD_Antarctica.txt
@@ -258,7 +258,10 @@ country_event = {
 	immediate = {
 		antarctica_trigger_blizzard_event = yes
 		hidden_effect = {
-			news_event = MD_antarctica_news.9
+			if = {
+				limit = { has_country_flag = antarctica_has_active_station }
+				news_event = MD_antarctica_news.9
+			}
 			country_event = { id = MD_antarctica.8 days = 300 random_days = 50 }
 		}
 	}
@@ -496,6 +499,7 @@ news_event = {
 	picture = GFX_antarctica_blizzard_news
 
 	is_triggered_only = yes
+	trigger = { has_country_flag = antarctica_has_active_station }
 
 	option = {
 		name = MD_antarctica_news.9.a


### PR DESCRIPTION
## Bottom line

Antarctica blizzard news (`MD_antarctica_news.9`) now only fires for countries with an active research station. The blizzard itself is unchanged.

## Why

The hidden scheduler (`MD_antarctica.8`) is parked on a random human player. That country was getting "Heavy Winds Across Antarctica" whether or not it had a base.

Closes #3261

BLUF