### PR TITLE
Harvest doctrine folder cost factors in the modifier validator

### DIFF
--- a/common/ideas/05_netherlands.txt
+++ b/common/ideas/05_netherlands.txt
@@ -595,6 +595,7 @@ ideas = {
 				air_doctrine_cost_factor = 1.5
 				land_doctrine_cost_factor = 1.5
 				naval_doctrine_cost_factor = 1.5
+				equipment_doctrine_cost_factor = 1.5
 				special_forces_doctrine_cost_factor = 1.5
 			}
 			on_add = {
@@ -609,6 +610,7 @@ ideas = {
 				air_doctrine_cost_factor = 1
 				land_doctrine_cost_factor = 1
 				naval_doctrine_cost_factor = 1
+				equipment_doctrine_cost_factor = 1
 				special_forces_doctrine_cost_factor = 1
 			}
 			on_add = {
@@ -623,6 +625,7 @@ ideas = {
 				air_doctrine_cost_factor = 0.5
 				land_doctrine_cost_factor = 0.5
 				naval_doctrine_cost_factor = 0.5
+				equipment_doctrine_cost_factor = 0.5
 				special_forces_doctrine_cost_factor = 0.5
 			}
 			on_add = {

--- a/common/ideas/05_netherlands.txt
+++ b/common/ideas/05_netherlands.txt
@@ -595,7 +595,6 @@ ideas = {
 				air_doctrine_cost_factor = 1.5
 				land_doctrine_cost_factor = 1.5
 				naval_doctrine_cost_factor = 1.5
-				equipment_doctrine_cost_factor = 1.5
 				special_forces_doctrine_cost_factor = 1.5
 			}
 			on_add = {
@@ -610,7 +609,6 @@ ideas = {
 				air_doctrine_cost_factor = 1
 				land_doctrine_cost_factor = 1
 				naval_doctrine_cost_factor = 1
-				equipment_doctrine_cost_factor = 1
 				special_forces_doctrine_cost_factor = 1
 			}
 			on_add = {
@@ -625,7 +623,6 @@ ideas = {
 				air_doctrine_cost_factor = 0.5
 				land_doctrine_cost_factor = 0.5
 				naval_doctrine_cost_factor = 0.5
-				equipment_doctrine_cost_factor = 0.5
 				special_forces_doctrine_cost_factor = 0.5
 			}
 			on_add = {

--- a/tools/tests/validation/validate_modifiers_test.py
+++ b/tools/tests/validation/validate_modifiers_test.py
@@ -10,9 +10,12 @@ from validate_modifiers import (
     Validator,
     _check_file_for_unknown_modifiers,
     _extract_top_level_definition_blocks,
+    _harvest_doctrine_folder_cost_factors,
     _is_parametric_modifier,
     _load_documented_modifiers,
 )
+
+NEWLINE = chr(10)
 
 
 def _write_idea_file(tmp_path, modifier_body):
@@ -87,38 +90,64 @@ def test_parametric_modifier_families_exempt():
 
 
 def test_doctrine_cost_factor_is_not_a_parametric_family():
-    """Doctrine cost factors are a closed set of four, not an open family.
+    """Doctrine cost factors are harvested per folder, not matched by shape.
 
     A `<word>_doctrine_cost_factor` regex used to exempt the whole shape, which
-    whitelisted `equipment_doctrine_cost_factor` -- a name the engine does not
-    define, so it compiled silently and did nothing in three Netherlands ideas.
-    The four real categories are documented, so they need no pattern.
+    would have whitelisted a misspelled folder name. The real set is finite and
+    declared, so it is harvested from common/doctrines/folders/ instead.
     """
-    for valid in (
+    for name in (
         "air_doctrine_cost_factor",
         "land_doctrine_cost_factor",
         "naval_doctrine_cost_factor",
         "special_forces_doctrine_cost_factor",
+        "equipment_doctrine_cost_factor",
+        "equipmnt_doctrine_cost_factor",
     ):
-        assert not _is_parametric_modifier(valid), (
-            f"{valid} must come from the documentation, not a catch-all regex"
-        )
-    assert not _is_parametric_modifier("equipment_doctrine_cost_factor")
+        assert not _is_parametric_modifier(name), name
 
 
-def test_documented_doctrine_cost_factors_stay_known_good():
-    """The four real categories must survive without the catch-all pattern."""
-    documented, _ = _load_documented_modifiers(str(REPO_ROOT / _DOC_REL_PATH))
-    if not documented:
-        return  # documentation not checked out; covered by its own test
-    for valid in (
-        "air_doctrine_cost_factor",
+def test_doctrine_folder_cost_factors_are_harvested(tmp_path):
+    """Every declared folder generates one, including mod-defined folders.
+
+    MD declares its own `equipment` folder beside vanilla's four, so the shipped
+    vanilla documentation cannot cover the set: harvesting is what keeps
+    equipment_doctrine_cost_factor valid while a typo stays reportable.
+    """
+    folders = tmp_path / "common" / "doctrines" / "folders"
+    folders.mkdir(parents=True)
+    path = folders / "doctrine_folders.txt"
+    path.write_text(
+        "land = {"
+        + NEWLINE
+        + '	name = "land_doctrine_folder"'
+        + NEWLINE
+        + "}"
+        + NEWLINE
+        + "equipment = {"
+        + NEWLINE
+        + '	name = "equipment_doctrine_folder"'
+        + NEWLINE
+        + "}"
+        + NEWLINE,
+        encoding="utf-8",
+    )
+    harvested = _harvest_doctrine_folder_cost_factors([str(path)])
+    assert harvested == {
         "land_doctrine_cost_factor",
-        "naval_doctrine_cost_factor",
-        "special_forces_doctrine_cost_factor",
-    ):
-        assert valid in documented, valid
-    assert "equipment_doctrine_cost_factor" not in documented
+        "equipment_doctrine_cost_factor",
+    }
+
+
+def test_shipped_doctrine_folders_cover_the_netherlands_ideas():
+    """The five folders MD ships are exactly the five modifiers in use."""
+    shipped = REPO_ROOT / "common" / "doctrines" / "folders" / "doctrine_folders.txt"
+    if not shipped.exists():
+        return
+    harvested = _harvest_doctrine_folder_cost_factors([str(shipped)])
+    assert "equipment_doctrine_cost_factor" in harvested
+    for vanilla in ("air", "land", "naval", "special_forces"):
+        assert f"{vanilla}_doctrine_cost_factor" in harvested
 
 
 def test_shipped_doc_yields_concrete_names_and_families():

--- a/tools/tests/validation/validate_modifiers_test.py
+++ b/tools/tests/validation/validate_modifiers_test.py
@@ -86,6 +86,41 @@ def test_parametric_modifier_families_exempt():
     assert not _is_parametric_modifier("completely_fake_modifier_field")
 
 
+def test_doctrine_cost_factor_is_not_a_parametric_family():
+    """Doctrine cost factors are a closed set of four, not an open family.
+
+    A `<word>_doctrine_cost_factor` regex used to exempt the whole shape, which
+    whitelisted `equipment_doctrine_cost_factor` -- a name the engine does not
+    define, so it compiled silently and did nothing in three Netherlands ideas.
+    The four real categories are documented, so they need no pattern.
+    """
+    for valid in (
+        "air_doctrine_cost_factor",
+        "land_doctrine_cost_factor",
+        "naval_doctrine_cost_factor",
+        "special_forces_doctrine_cost_factor",
+    ):
+        assert not _is_parametric_modifier(valid), (
+            f"{valid} must come from the documentation, not a catch-all regex"
+        )
+    assert not _is_parametric_modifier("equipment_doctrine_cost_factor")
+
+
+def test_documented_doctrine_cost_factors_stay_known_good():
+    """The four real categories must survive without the catch-all pattern."""
+    documented, _ = _load_documented_modifiers(str(REPO_ROOT / _DOC_REL_PATH))
+    if not documented:
+        return  # documentation not checked out; covered by its own test
+    for valid in (
+        "air_doctrine_cost_factor",
+        "land_doctrine_cost_factor",
+        "naval_doctrine_cost_factor",
+        "special_forces_doctrine_cost_factor",
+    ):
+        assert valid in documented, valid
+    assert "equipment_doctrine_cost_factor" not in documented
+
+
 def test_shipped_doc_yields_concrete_names_and_families():
     """Guard the doc parse against a format change in the next refresh.
 

--- a/tools/validation/validate_modifiers.py
+++ b/tools/validation/validate_modifiers.py
@@ -394,6 +394,11 @@ def _load_documented_modifiers(
 
 _IDEA_SLOT_RE = re.compile(r"^\s*(?:character_)?slot\s*=\s*([A-Za-z][A-Za-z0-9_]*)")
 
+# Doctrine folders are declared as top-level `<id> = {` blocks. MD adds its own
+# `equipment` folder alongside vanilla's four, and the vanilla documentation
+# naturally lists only vanilla folders, so these must be harvested.
+_DOCTRINE_FOLDER_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)\s*=\s*\{")
+
 _BRACE_OR_ENABLE_RE = re.compile(r"\benable\s*=\s*\{|\{|\}")
 # The lookbehind keeps `tag` off the tail of `has_cosmetic_tag`; matching a
 # token rather than a whole line is what stops a gate hiding on a shared line.
@@ -490,6 +495,28 @@ def _harvest_idea_slot_cost_factors(idea_tags_files: List[str]) -> Set[str]:
             m = _IDEA_SLOT_RE.match(line)
             if m:
                 names.add(f"{m.group(1)}_cost_factor")
+    return names
+
+
+def _harvest_doctrine_folder_cost_factors(folder_files: List[str]) -> Set[str]:
+    """Every doctrine folder auto-generates a `<folder>_doctrine_cost_factor`.
+
+    MD declares its own `equipment` folder next to vanilla's land/naval/air/
+    special_forces, so the shipped vanilla documentation cannot cover the set.
+    Harvesting the declared ids keeps mod-defined folders valid while still
+    rejecting a misspelled folder name.
+    """
+    names: Set[str] = set()
+    for filepath in folder_files:
+        try:
+            with open(filepath, encoding="utf-8-sig") as fh:
+                content = fh.read()
+        except OSError:
+            continue
+        for line in content.splitlines():
+            m = _DOCTRINE_FOLDER_RE.match(line)
+            if m:
+                names.add(f"{m.group(1)}_doctrine_cost_factor")
     return names
 
 
@@ -701,6 +728,14 @@ class Validator(BaseValidator):
         slot_factors = _harvest_idea_slot_cost_factors(idea_tag_files)
         known_good |= slot_factors
 
+        # Engine-generated <folder>_doctrine_cost_factor from every doctrine
+        # folder, including MD's own `equipment` folder.
+        doctrine_folder_files = self._collect_files(
+            ["common/doctrines/folders/**/*.txt"], ignore_staged=True
+        )
+        doctrine_factors = _harvest_doctrine_folder_cost_factors(doctrine_folder_files)
+        known_good |= doctrine_factors
+
         # Engine-generated per-sub-unit modifiers (unit-keyed doc templates plus
         # modifier_army_sub_unit_*, doc-concrete for vanilla only) for MD's own
         # sub_units entries — the vanilla doc has no MD unit names to expand against.
@@ -733,6 +768,7 @@ class Validator(BaseValidator):
         self.log(
             f"  Known-good modifier set: {len(known_good)} names "
             f"({len(documented)} documented, {len(slot_factors)} slot cost factors, "
+            f"{len(doctrine_factors)} doctrine cost factors, "
             f"{len(sub_unit_modifiers)} MD sub-unit modifiers, "
             f"{len(operation_modifiers)} MD operation modifiers)"
         )

--- a/tools/validation/validate_modifiers.py
+++ b/tools/validation/validate_modifiers.py
@@ -109,7 +109,6 @@ _PARAMETRIC_MODIFIER_PATTERNS: Tuple[re.Pattern, ...] = tuple(
         r"^production_cost_max_[a-z][a-z0-9_]*$",
         # <Doctrine>-keyed (covers _mastery_gain and _track_mastery_gain)
         r"^[a-z][a-z0-9_]*_mastery_gain_factor$",
-        r"^[a-z][a-z0-9_]*_doctrine_cost_factor$",
         # <Ideology>-keyed
         r"^[a-z][a-z0-9_]*_drift(?:_from_guarantees)?$",
         r"^[a-z][a-z0-9_]*_acceptance$",


### PR DESCRIPTION
### Changes
- Derives `<folder>_doctrine_cost_factor` from `common/doctrines/folders/`, so MD's own `equipment` folder is recognised alongside vanilla's four.
- Stops `validate_modifiers.py` exempting `<word>_doctrine_cost_factor` by shape, so a misspelled folder name is reported instead of silently accepted.
- Adds regression coverage for the harvest, including that the five folders MD ships cover the five modifiers actually in use.

### What this started as, and why it changed
The PR originally deleted `equipment_doctrine_cost_factor` from three Dutch doctrine-change ideas as an undefined modifier. That was wrong. `common/doctrines/folders/doctrine_folders.txt` declares an `equipment` folder beside vanilla's `land`, `naval`, `air` and `special_forces`, and the engine generates a `<folder>_doctrine_cost_factor` for each one. The ideas were applying all five of their penalties correctly, and those lines are restored untouched.

The name looked undefined because the shipped vanilla documentation lists only vanilla's folders, so a doc-only known-good set cannot see a mod-declared fifth folder.

### Why harvest rather than restore the regex
`_PARAMETRIC_MODIFIER_PATTERNS` carried `r"^[a-z][a-z0-9_]*_doctrine_cost_factor$"`, which exempts the shape regardless of prefix: a misspelled folder would have passed just as silently as a correct one. The comment above that table rules out exactly this kind of catch-all, on the grounds that it would whitelist genuine typos.

Doctrine folders are declared, finite and greppable, so harvesting the ids gives the precision the regex was reaching for. It mirrors the existing `_harvest_idea_slot_cost_factors` path that derives `<slot>_cost_factor` from `common/idea_tags`.

Net effect: all five declared folders are known-good, and `equipmnt_doctrine_cost_factor` is now reported where previously it was not.

### Checks
`ruff check tools/` clean, formatting clean, and the modifier validator tests pass. The full suite's only failures are three pre-existing image-conversion tests that fail identically on a clean tree.