### PR TITLE
Give every icon definition a real value

### DIFF
--- a/common/scripted_effects/CAS_political_leaders.txt
+++ b/common/scripted_effects/CAS_political_leaders.txt
@@ -241,7 +241,7 @@ set_leader_CAS = {
 
 			create_country_leader = {
 				name = "David I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_020.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -258,7 +258,7 @@ set_leader_CAS = {
 
 			create_country_leader = {
 				name = "Alfred II"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_021.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -275,7 +275,7 @@ set_leader_CAS = {
 
 			create_country_leader = {
 				name = "Charlie I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_022.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -292,7 +292,7 @@ set_leader_CAS = {
 
 			create_country_leader = {
 				name = "Alfred I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_023.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -309,7 +309,7 @@ set_leader_CAS = {
 
 			create_country_leader = {
 				name = "Timothy I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_024.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist

--- a/common/scripted_effects/CSA_political_leaders.txt
+++ b/common/scripted_effects/CSA_political_leaders.txt
@@ -10,7 +10,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "Sir Charles Hatt IV"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_025.dds"
 				ideology = Western_Autocracy
 				traits = {
 					western_Western_Autocracy
@@ -27,7 +27,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "Sir Richard Hatt"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_026.dds"
 				ideology = Western_Autocracy
 				traits = {
 					western_Western_Autocracy
@@ -488,7 +488,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "Joseph I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_027.dds"
 				ideology = Nat_Autocracy
 				traits = {
 					nationalist_Monarchist
@@ -505,7 +505,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "John II"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_028.dds"
 				ideology = Nat_Autocracy
 				traits = {
 					nationalist_Monarchist
@@ -522,7 +522,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "Andrew I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_029.dds"
 				ideology = Nat_Autocracy
 				traits = {
 					nationalist_Monarchist
@@ -539,7 +539,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "John I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_030.dds"
 				ideology = Nat_Autocracy
 				traits = {
 					nationalist_Monarchist
@@ -556,7 +556,7 @@ set_leader_CSA = {
 
 			create_country_leader = {
 				name = "Terry I"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_031.dds"
 				ideology = Nat_Autocracy
 				traits = {
 					nationalist_Monarchist

--- a/common/scripted_effects/FIJ_political_leaders.txt
+++ b/common/scripted_effects/FIJ_political_leaders.txt
@@ -212,7 +212,7 @@ set_leader_FIJ = {
 
 			create_country_leader = {
 				name = "Sakeasi Butadroka"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/southeastasian_002.dds"
 				ideology = Nat_Populism
 				traits = {
 					nationalist_Nat_Populism

--- a/common/scripted_effects/USB_political_leaders.txt
+++ b/common/scripted_effects/USB_political_leaders.txt
@@ -128,7 +128,7 @@ set_leader_USB = {
 
 			create_country_leader = {
 				name = "Elijah F. Sommers"
-				picture = ""
+				picture = "gfx/leaders/generic_politicians/white_032.dds"
 				ideology = Autocracy
 				traits = {
 					emerging_Autocracy

--- a/interface/factions/countryfactionview.gui
+++ b/interface/factions/countryfactionview.gui
@@ -672,7 +672,7 @@ guiTypes = {
 					iconType = {
 						name = "goal_icon"
 						position = { x=24 y= 18 }
-						quadTextureSprite = ""
+						quadTextureSprite = "GFX_tiled_window_transparent"
 						alwaystransparent = yes
 					}
 
@@ -982,7 +982,7 @@ guiTypes = {
 					iconType = {
 						name = "goal_icon"
 						position = { x=24 y= 18 }
-						quadTextureSprite = ""
+						quadTextureSprite = "GFX_tiled_window_transparent"
 						alwaystransparent = yes
 					}
 
@@ -1275,7 +1275,7 @@ guiTypes = {
 		iconType = {
 			name ="icon"
 			position = { x= 10 y = 8 }
-			spriteType = ""
+			spriteType = "GFX_tiled_window_transparent"
 		}
 
 		gridBoxType = {
@@ -1658,7 +1658,7 @@ guiTypes = {
 			name ="type_icon"
 			position = { x= 5 y = 6 }
 			alwaystransparent = yes
-			spriteType = ""
+			spriteType = "GFX_tiled_window_transparent"
 		}
 	}
 

--- a/interface/inner_circles/ENG_inner_circle_scripted_gui.gui
+++ b/interface/inner_circles/ENG_inner_circle_scripted_gui.gui
@@ -166,7 +166,7 @@ guiTypes = {
 				#PORTRAIT
 				iconType = {
 					name ="ascended_advisor_1_portrait"
-					spriteType = ""
+					spriteType = "GFX_tiled_window_transparent"
 					orientation = upper_left
 					position = { x=7	 y=6 }
 					scale = 0.5
@@ -247,7 +247,7 @@ guiTypes = {
 				#PORTRAIT
 				iconType = {
 					name ="ascended_advisor_2_portrait"
-					spriteType = ""
+					spriteType = "GFX_tiled_window_transparent"
 					orientation = upper_left
 					position = { x=7	 y=6 }
 					scale = 0.5
@@ -327,7 +327,7 @@ guiTypes = {
 				#PORTRAIT
 				iconType = {
 					name ="ascended_advisor_3_portrait"
-					spriteType = ""
+					spriteType = "GFX_tiled_window_transparent"
 					orientation = upper_left
 					position = { x=7	 y=6 }
 					scale = 0.5

--- a/interface/military_raids/country_raids_view.gui
+++ b/interface/military_raids/country_raids_view.gui
@@ -715,14 +715,14 @@ guiTypes = {
 		iconType = {
 			name = "unit_picture"
 			position = { x = 35 y = 88 }
-			spriteType = ""
+			spriteType = "GFX_tiled_window_transparent"
 		}
 
 		iconType = {
 			name = "target_picture"
 			position = { x = -170 y = 75 }
 			orientation = upper_right
-			spriteType = ""
+			spriteType = "GFX_tiled_window_transparent"
 		}
 
 		instantTextboxType = {


### PR DESCRIPTION
### Changes
- Replaces nine empty `.gui` sprite declarations with `GFX_tiled_window_transparent`, which is invisible and resolves.
- Gives fourteen `create_country_leader` calls a real portrait instead of `picture = ""`.

### Why the warnings only appear on a loaded save
This is the second half of #3262: `icon_entry.cpp` logs `Icon definition "" does neither look like a file path nor a GFX entry` 2327 times when loading a save and never on a new game. There are two sources, and between them they explain that split.

**Nine `.gui` icons** declared an empty sprite and are filled at runtime: three advisor portraits in the England inner circle, the unit and target pictures in the raids view, and four faction goal icons. Those windows only populate once a save actually has factions and raids in it, and a GUI element is re-evaluated continuously, which is where the volume comes from.

Empty is not the convention here. 124 declarations across `interface/` already use `GFX_tiled_window_transparent` for exactly this, so these now match. It is transparent, so there is no visual change; the sprite is still assigned at runtime as before.

**Fourteen `create_country_leader` calls** passed `picture = ""`. Omitting the field is not an alternative: all 3567 such calls in the repo set it. These leaders are created by succession and election effects during play rather than at startup, which is the other half of why a new game is quiet.

They now point at `gfx/leaders/generic_politicians`, which MD already uses for country leaders elsewhere and which holds 354 portraits with only 13 currently referenced.

### One judgement call worth reviewing
Thirteen of the fourteen are fictional alt-history figures in Cascadia, the Confederate States and USB, so generic art is a straightforward fit. The fourteenth, Sakeasi Butadroka of Fiji, was a real politician. He is given a generic portrait so the warning stops, but that is explicitly a placeholder and anyone with better source material should swap the file.

### Deliberately not changed
`text= ""` in `countryfactionview.gui` is a text field, not an icon, and never reaches `icon_entry.cpp`.

Closes #3262

### Checks
`validate_gfx_references` and `validate_style` clean, `check_common_mistakes` passes on all seven files, and no empty `icon` or `picture` assignment remains anywhere in `common/` or `interface/`. Every assigned portrait was confirmed to exist on disk.