### PR TITLE
Apply the currency adjustment where debt_rate is set

### DIFF
--- a/common/scripted_effects/00_currency_effects.txt
+++ b/common/scripted_effects/00_currency_effects.txt
@@ -253,8 +253,10 @@ calculate_currency_strength = {
 # ── Income stream multipliers ─────────────────────────────────────────────────
 
 # Runs in ingame_update_setup (00_money_system.txt) after income is computed.
-# Both streams scale by 1/currency_strength: a weak currency (< 1.0) boosts
-# foreign-earned income locally, a strong one suppresses it.
+# Income scales by 1/currency_strength: a weak currency (< 1.0) boosts
+# foreign-earned income locally, a strong one suppresses it. The matching
+# adjustment for debt lives in calculate_interest_rate, which sets debt_rate
+# after this effect runs.
 apply_currency_multipliers = {
 	set_temp_variable = {
 		inv_factor = {
@@ -273,25 +275,6 @@ apply_currency_multipliers = {
 	multiply_variable = { rubber_exports = inv_factor }
 	multiply_variable = { microchip_exports = inv_factor }
 	multiply_variable = { composite_exports = inv_factor }
-
-	# Only debt denominated in an external reserve currency takes the exchange hit.
-	if = {
-		limit = {
-			OR = {
-				has_idea = us_dollar
-				has_idea = euro
-				has_idea = chinese_yuan
-				has_idea = chinese_yuan_2
-				has_idea = chinese_yuan_3
-				has_idea = russia_rouble
-				has_idea = japanese_yen
-				has_idea = british_pound
-				has_idea = swiss_frank
-				has_idea = gulden
-			}
-		}
-		multiply_variable = { debt_rate = inv_factor }
-	}
 }
 
 # ── Seigniorage income ────────────────────────────────────────────────────────

--- a/common/scripted_effects/00_money_system.txt
+++ b/common/scripted_effects/00_money_system.txt
@@ -2437,6 +2437,28 @@ calculate_interest_rate = {
 		#Calculate weekly debt rate based on interest (52 weeks in a year)
 		set_variable = { debt_rate = { value = debt multiply = 0.00019 multiply = interest_rate } }
 
+		# Only debt denominated in an external reserve currency takes the exchange hit.
+		# Must follow the set_variable above: applied before it, the adjustment is
+		# overwritten and never reaches the player.
+		if = {
+			limit = {
+				OR = {
+					has_idea = us_dollar
+					has_idea = euro
+					has_idea = chinese_yuan
+					has_idea = chinese_yuan_2
+					has_idea = chinese_yuan_3
+					has_idea = russia_rouble
+					has_idea = japanese_yen
+					has_idea = british_pound
+					has_idea = swiss_frank
+					has_idea = gulden
+				}
+			}
+			set_temp_variable = { debt_fx_factor = { value = 1 divide = currency_strength } }
+			multiply_variable = { debt_rate = debt_fx_factor }
+		}
+
 		#If interest rate is really high, add additional modifier
 		if = { limit = { check_variable = { interest_rate > 14.999 } }
 			if = {


### PR DESCRIPTION
### Changes
- Debt denominated in a foreign reserve currency now actually takes the exchange-rate hit, so Interest on Debt moves with currency strength instead of ignoring it

### The bug

`apply_currency_multipliers` ended with:

```
multiply_variable = { debt_rate = inv_factor }
```

but it runs earlier in `ingame_update_setup` than `calculate_interest_rate`, which sets the same variable outright:

```
set_variable = { debt_rate = { value = debt multiply = 0.00019 multiply = interest_rate } }
```

So the adjustment was computed and then overwritten on every economic update. The comment said only reserve-currency debt takes the exchange hit; in practice no debt ever did.

### The fix

The block moved into `calculate_interest_rate`, immediately after the `set_variable` that derives `debt_rate`.

This also corrects nine call sites that never had the adjustment at all: `calculate_interest_rate` is called from the Belarus and India focus trees and from `00_economic_system_utilities.txt`, none of which go through `apply_currency_multipliers`.

Set-then-multiply now happens inside one effect, so repeat calls are idempotent. `currency_strength` is clamped to 0.15-2.0 in `clamp_currency_strength`, so the divide cannot hit zero.

Found while investigating #3325. It is not the reported refresh-button symptom: every other variable in that path is reset before being multiplied, so nothing there compounds per click. That report is still open.
