### PR TITLE
Write sham-election popularity to the ruling party's slot

### DIFF
--- a/common/scripted_effects/00_MD_politicsview_scripted_effects.txt
+++ b/common/scripted_effects/00_MD_politicsview_scripted_effects.txt
@@ -580,8 +580,7 @@ hold_elections = {
 	else = {
 		# Should set the main election value and ignore the election threshold
 		if = { limit = { has_variable = ruling_party }
-			# deliberately slot 0, not ^ruling_party: preserves pre-conversion behaviour, see #3369
-		set_variable = { party_pop_elect_array^0 = party_pop_array^0 }
+			set_variable = { party_pop_elect_array^ruling_party = party_pop_array^ruling_party }
 		}
 	}
 	calculate_banned_parties = yes
@@ -613,8 +612,7 @@ recalculate_party_strength = {
 	else = {
 		# Should set the main election value and ignore the election threshold
 		if = { limit = { has_variable = ruling_party }
-			# deliberately slot 0, not ^ruling_party: preserves pre-conversion behaviour, see #3369
-		set_variable = { party_pop_elect_array^0 = party_pop_array^0 }
+			set_variable = { party_pop_elect_array^ruling_party = party_pop_array^ruling_party }
 		}
 	}
 	update_majority_threshold = yes


### PR DESCRIPTION
## Bottom line
When all parties are banned, sham-election popularity is written to the ruling party's elect slot instead of always writing Western Autocracy at index 0.

## Why
The pre-#3363 loop over the one-element `ruling_party` array used loop index `i`, which is always 0. `hold_elections` then zeros slot 0 if Western Autocracy is banned, so the ruling slot never refreshes.

Closes #3369

BLUF