### PR TITLE
Fix France MIO funding and Serbia focus tree overlaps (#3365, #3382)

### DIFF
--- a/common/national_focus/05_france.txt
+++ b/common/national_focus/05_france.txt
@@ -14132,10 +14132,22 @@ focus_tree = {
 			newline = yes
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				mio:FRA_nexter_manufacturer = { add_mio_funds = 250 }
+				if = {
+					limit = { has_country_flag = FRA_nexter_merge }
+					mio:FRA_knds_manufacturer = { add_mio_funds = 250 }
+				}
+				else = {
+					mio:FRA_nexter_manufacturer = { add_mio_funds = 250 }
+				}
 				mio:FRA_dassault_aviation_aircraft_manufacturer = { add_mio_funds = 250 }
 				mio:FRA_thales_manufacturer = { add_mio_funds = 250 }
-				mio:FRA_naval_group_naval_manufacturer = { add_mio_funds = 250 }
+				if = {
+					limit = { has_country_flag = FRA_naval_takeover }
+					mio:FRA_naval_group_naval_manufacturer = { add_mio_funds = 250 }
+				}
+				else = {
+					mio:FRA_dcn_manufacturer = { add_mio_funds = 250 }
+				}
 				mio:FRA_mbda_manufacturer = { add_mio_funds = 250 }
 				newline = yes
 			}
@@ -14300,9 +14312,18 @@ focus_tree = {
 			}
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
-				mio:FRA_nexter_manufacturer = {
-					add_mio_size = 2
-					add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
+				if = {
+					limit = { has_country_flag = FRA_nexter_merge }
+					mio:FRA_knds_manufacturer = {
+						add_mio_size = 2
+						add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
+					}
+				}
+				else = {
+					mio:FRA_nexter_manufacturer = {
+						add_mio_size = 2
+						add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
+					}
 				}
 			}
 			set_temp_variable = { temp_opinion = 5 }
@@ -14476,9 +14497,18 @@ focus_tree = {
 					add_mio_size = 2
 					add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
 				}
-				mio:FRA_naval_group_naval_manufacturer = {
-					add_mio_size = 2
-					add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
+				if = {
+					limit = { has_country_flag = FRA_naval_takeover }
+					mio:FRA_naval_group_naval_manufacturer = {
+						add_mio_size = 2
+						add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
+					}
+				}
+				else = {
+					mio:FRA_dcn_manufacturer = {
+						add_mio_size = 2
+						add_to_variable = { free_trait_picks = 2 tooltip = free_trait_picks_tt }
+					}
 				}
 			}
 			set_temp_variable = { temp_opinion = 5 }
@@ -14561,7 +14591,13 @@ focus_tree = {
 			if = {
 				limit = { has_dlc = "Arms Against Tyranny" }
 				mio:FRA_dassault_aviation_aircraft_manufacturer = { add_mio_funds = 250 }
-				mio:FRA_airbus_manufacturer = { add_mio_funds = 250 }
+				if = {
+					limit = { has_country_flag = FRA_airbus_change }
+					mio:FRA_airbus_manufacturer = { add_mio_funds = 250 }
+				}
+				else = {
+					mio:FRA_eurocopter_manufacturer = { add_mio_funds = 250 }
+				}
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = FRA_econ_policy }
 			add_to_variable = { FRA_econ_research = 0.08 tooltip = research_speed_factor_tt }

--- a/common/national_focus/05_serbia.txt
+++ b/common/national_focus/05_serbia.txt
@@ -2908,7 +2908,7 @@ focus_tree = {
 		id = SER_indian_arms_trade
 		icon = trade_with_russia
 
-		x = -1
+		x = 4
 		y = 1
 		relative_position_id = SER_non_aligned_partners
 
@@ -2983,7 +2983,7 @@ focus_tree = {
 		id = SER_belarusian_partnership
 		icon = blr_chinese_investments
 
-		x = 1
+		x = 2
 		y = 1
 		relative_position_id = SER_non_aligned_partners
 
@@ -3054,7 +3054,7 @@ focus_tree = {
 		id = SER_middle_east_exports
 		icon = ser_export
 
-		x = 0
+		x = 3
 		y = 2
 		relative_position_id = SER_non_aligned_partners
 
@@ -3945,7 +3945,7 @@ focus_tree = {
 		id = SER_orchestrate_referendum
 		icon = srpska_improve
 
-		x = 3
+		x = 5
 		y = 2
 		relative_position_id = SER_ratify_greater_serbia
 
@@ -4065,7 +4065,7 @@ focus_tree = {
 		id = SER_srpska_intervention
 		icon = ser_serbska
 
-		x = 5
+		x = 7
 		y = 2
 		relative_position_id = SER_ratify_greater_serbia
 
@@ -4137,7 +4137,7 @@ focus_tree = {
 		id = SER_integrate_bosnia
 		icon = ser_bosnia_integrate
 
-		x = 4
+		x = 6
 		y = 3
 		relative_position_id = SER_ratify_greater_serbia
 
@@ -5184,7 +5184,7 @@ focus_tree = {
 		id = SER_final_chapters_of_milosevic
 		icon = broken_serbia
 
-		x = 4
+		x = 8
 		y = 4
 		relative_position_id = SER_the_high_castle
 
@@ -5214,7 +5214,7 @@ focus_tree = {
 		id = SER_democratic_ascendant
 		icon = Serbia_dem
 
-		x = 18
+		x = 23
 		y = 5
 		relative_position_id = SER_the_high_castle
 


### PR DESCRIPTION
### Changes
- Fixed The Safran-GE Partnership handing funds to Airbus Group, which France cannot see until the 2014 rebranding, so the funds now go to Eurocopter until then
- Fixed the French Arms Industries and Thales Group focuses handing funds and size to Naval Group before the 2017 takeover makes it available, so they now go to DCN until then
- Fixed the French Arms Industries and Nexter focuses handing funds and size to Nexter after the KNDS merger replaces it, so they now go to KNDS from then on
- Fixed overlapping focuses in the Serbian tree: Middle Eastern Exports sat on top of The Sick Woman of the Coalition and Orchestrate a Referendum sat on top of the Smederevo Steelworks, so the non-aligned partners and Greater Serbia branches are respaced and every focus now has its own grid slot

Closes #3365
Closes #3382