### PR TITLE
Flag major events fired inside every_country loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Every text-mode write in `tools/` must pass `newline=""`. Without it, Python's t
 
 ## Events
 
-- Always `is_triggered_only = yes`; log only if option has effects; `major = yes` for news only
+- Always `is_triggered_only = yes`; log only if option has effects; `major = yes` for news only. Never wrap a `major = yes` event in `every_country` / `every_other_country` (one fire already broadcasts)
 - Date-based events: owner-guard pattern in `common/scripted_effects/00_yearly_effects.txt`
 - `add_building_construction` for `naval_base` requires `province = XXXXX`
 - New subideology parties: register in `common/scripted_localisation/00_MD_politicsview_scripted_localisation.txt`

--- a/common/decisions/EU_voting_decisions.txt
+++ b/common/decisions/EU_voting_decisions.txt
@@ -1039,11 +1039,7 @@ EU_exit_category = {
 
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision EU_exit_three_month"
-			for_each_scope_loop = {
-				array = global.EU_member
-				tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
-				news_event = EU_news.22 ### Article 50 is revoked
-			}
+			news_event = EU_news.22 ### Article 50 is revoked
 		}
 
 		complete_effect = {

--- a/common/national_focus/05_afghanistan.txt
+++ b/common/national_focus/05_afghanistan.txt
@@ -3884,11 +3884,9 @@ focus_tree = {
 				add_political_power = 150
 			}
 			hidden_effect = {
-				every_other_country = {
-					news_event = {
-						id = AFG_news.9
-						hours = 2
-					}
+				news_event = {
+					id = AFG_news.9
+					hours = 2
 				}
 			}
 		}

--- a/common/national_focus/05_czech_republic.txt
+++ b/common/national_focus/05_czech_republic.txt
@@ -1206,17 +1206,7 @@ focus_tree = {
 					add_timed_idea = { idea = CZE_kscm_influences_communist_europe_idea days = 365 }
 				}
 			}
-			every_country = {
-				limit = {
-					OR = {
-						capital_scope = {
-							is_on_continent = europe
-						}
-						has_government = communism
-					}
-				}
-				news_event = CZE_news.4
-			}
+			news_event = CZE_news.4
 		}
 
 		ai_will_do = {

--- a/events/05_china.txt
+++ b/events/05_china.txt
@@ -6043,13 +6043,7 @@ country_event = {
 	option = {
 		name = CHI_foreign.200.c
 		log = "[GetDateText]: [This.GetName]: CHI_foreign.200.c executed"
-		every_country = {
-			limit = {
-				NOT = { original_tag = JAP }
-				NOT = { original_tag = CHI }
-			}
-			news_event = { id = CHI_foreign.203 days = 1 }
-		}
+		news_event = { id = CHI_foreign.203 days = 1 }
 		if = {
 			limit = {
 				any_of_scopes = {

--- a/events/05_china.txt
+++ b/events/05_china.txt
@@ -6278,6 +6278,10 @@ news_event = {
 	desc = CHI_foreign.203.d
 	is_triggered_only = yes
 	major = yes
+	trigger = {
+		NOT = { original_tag = JAP }
+		NOT = { original_tag = CHI }
+	}
 
 	#picture = x TODO
 	option = {

--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -1300,10 +1300,7 @@ country_event = {
 			limit = { country_exists = FRA }
 			FRA = { country_event = { id = ENG_military.051 days = 3 } }
 		}
-		every_country = {
-			limit = { is_ai = no }
-			news_event = { id = ENG_military.054 days = 1 }
-		}
+		news_event = { id = ENG_military.054 days = 1 }
 		newline = yes
 		set_temp_variable = { treasury_change = -20 }
 		modify_treasury_effect = yes

--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -1396,9 +1396,11 @@ news_event = {
 	title = ENG_military.054.t
 	desc = ENG_military.054.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 	major = yes
+	trigger = {
+		is_ai = no
+	}
 
 	option = {
 		name = ENG_military.054.a

--- a/events/Afghanistan.txt
+++ b/events/Afghanistan.txt
@@ -3290,11 +3290,9 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: AFG_news.11.a executed"
 		add_command_power = -5
 		hidden_effect = {
-			every_other_country = {
-				news_event = {
-					id = AFG_news.12
-					hours = 1
-				}
+			news_event = {
+				id = AFG_news.12
+				hours = 1
 			}
 		}
 		ai_chance = {

--- a/events/Czech Republic.txt
+++ b/events/Czech Republic.txt
@@ -3381,6 +3381,14 @@ news_event = {
 	picture = GFX_news_market_crash
 	is_triggered_only = yes
 	major = yes
+	trigger = {
+		OR = {
+			capital_scope = {
+				is_on_continent = europe
+			}
+			has_government = communism
+		}
+	}
 
 	option = {
 		name = CZE_news.4.o1

--- a/events/EU_news.txt
+++ b/events/EU_news.txt
@@ -179,6 +179,7 @@ news_event = {
 	trigger = {
 		has_idea = EU_member
 	}
+
 	option = {
 		name = EU_news.22.a
 	}

--- a/events/Philippines.txt
+++ b/events/Philippines.txt
@@ -77,7 +77,7 @@ country_event = { # Edsa Dos, Erap Resigns
 		set_temp_variable = { rul_party_temp = 1 }
 		change_ruling_party_effect = yes
 		add_timed_idea = { idea = PHI_edsa_dos_recovery_spirit days = 365 }
-		every_country = { news_event = { id = PHI_news.1 days = 1 } }
+		news_event = { id = PHI_news.1 days = 1 }
 		country_event = { id = PHI.3 days = 5 } # Fires the Arroyo inaguration event
 	}
 }
@@ -128,7 +128,7 @@ country_event = { # Estrada Survives EDSA DOS
 		set_temp_variable = { party_popularity_increase = 0.06 }
 		set_temp_variable = { temp_outlook_increase = 0.06 }
 		change_relative_party_popularity = yes
-		every_country = { news_event = { hours = 2 id = PHI_news.2 } }
+		news_event = { hours = 2 id = PHI_news.2 }
 	}
 }
 

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -30277,10 +30277,7 @@ country_event = {
 			add_to_variable = { USA_aukus_accept_count = 1 }
 			if = {
 				limit = { check_variable = { USA_aukus_accept_count > 1 } }
-				every_country = {
-					limit = { is_ai = no }
-					news_event = { id = department_of_state.101 days = 1 }
-				}
+				news_event = { id = department_of_state.101 days = 1 }
 			}
 		}
 		add_opinion_modifier = {

--- a/tools/tests/validation/validate_events_major_in_loop_test.py
+++ b/tools/tests/validation/validate_events_major_in_loop_test.py
@@ -1,0 +1,242 @@
+"""Tests for validate_events.py: major = yes events fired inside an
+every_*/for_each_* iterator.
+
+A major event already broadcasts to every country on each fire. Inside an
+iterating scope that becomes one broadcast per iteration. Unlike
+fire_only_once, a pinned ROOT/TAG scope does not exempt it: the same global
+broadcast still repeats. Non-major news_event fires inside every_country are
+the per-country notification pattern and are not flagged.
+"""
+
+from validate_events import (
+    _parse_event_metadata,
+    scan_major_event_in_loop,
+)
+
+
+def _major_block(eid, extra="major = yes\n"):
+    return (
+        f"news_event = {{\n"
+        f"\tid = {eid}\n"
+        f"\tis_triggered_only = yes\n"
+        f"\t{extra}"
+        f"\toption = {{ name = {eid}.a }}\n"
+        f"}}\n"
+    )
+
+
+def _scan(tmp_path, body, ids=("foo.1",)):
+    call = tmp_path / "common" / "f.txt"
+    call.parent.mkdir(parents=True, exist_ok=True)
+    call.write_text(body, encoding="utf-8")
+    return scan_major_event_in_loop((str(call), frozenset(ids), str(tmp_path)))
+
+
+def test_major_news_inside_every_country_flagged(tmp_path):
+    res = _scan(
+        tmp_path, "x = {\n\tevery_country = {\n\t\tnews_event = foo.1\n\t}\n}\n"
+    )
+    assert len(res) == 1
+    assert "foo.1" in res[0]
+    assert "major event" in res[0]
+
+
+def test_major_country_event_inside_every_country_flagged(tmp_path):
+    res = _scan(
+        tmp_path, "x = {\n\tevery_country = {\n\t\tcountry_event = foo.1\n\t}\n}\n"
+    )
+    assert len(res) == 1
+
+
+def test_non_major_news_inside_every_country_not_flagged(tmp_path):
+    res = _scan(
+        tmp_path,
+        "x = {\n\tevery_country = {\n\t\tnews_event = foo.1\n\t}\n}\n",
+        ids=(),
+    )
+    assert res == []
+
+
+def test_every_other_country_flagged(tmp_path):
+    res = _scan(
+        tmp_path, "x = {\n\tevery_other_country = {\n\t\tnews_event = foo.1\n\t}\n}\n"
+    )
+    assert len(res) == 1
+
+
+def test_every_state_flagged(tmp_path):
+    res = _scan(tmp_path, "x = {\n\tevery_state = {\n\t\tnews_event = foo.1\n\t}\n}\n")
+    assert len(res) == 1
+
+
+def test_for_each_scope_loop_flagged(tmp_path):
+    res = _scan(
+        tmp_path,
+        "x = {\n"
+        "\tfor_each_scope_loop = {\n"
+        "\t\tarray = global.bloc\n"
+        "\t\tnews_event = { id = foo.1 days = 1 }\n"
+        "\t}\n"
+        "}\n",
+    )
+    assert len(res) == 1
+
+
+def test_id_not_first_arg_still_extracted(tmp_path):
+    res = _scan(
+        tmp_path,
+        "x = {\n"
+        "\tevery_country = {\n"
+        "\t\tnews_event = { hours = 2 id = foo.1 }\n"
+        "\t}\n"
+        "}\n",
+    )
+    assert len(res) == 1
+    assert "foo.1" in res[0]
+
+
+def test_random_country_single_pick_not_flagged(tmp_path):
+    res = _scan(
+        tmp_path, "x = {\n\trandom_country = {\n\t\tnews_event = foo.1\n\t}\n}\n"
+    )
+    assert res == []
+
+
+def test_pinned_root_scope_still_flagged(tmp_path):
+    res = _scan(
+        tmp_path,
+        "x = {\n"
+        "\tevery_country = {\n"
+        "\t\tROOT = {\n"
+        "\t\t\tnews_event = foo.1\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n",
+    )
+    assert len(res) == 1
+
+
+def test_pinned_tag_scope_still_flagged(tmp_path):
+    res = _scan(
+        tmp_path,
+        "x = {\n"
+        "\tevery_country = {\n"
+        "\t\tPHI = {\n"
+        "\t\t\tnews_event = { id = foo.1 days = 1 }\n"
+        "\t\t}\n"
+        "\t}\n"
+        "}\n",
+    )
+    assert len(res) == 1
+
+
+def test_literal_brace_in_quoted_log_does_not_desync(tmp_path):
+    res = _scan(
+        tmp_path,
+        "x = {\n"
+        "\tevery_country = {\n"
+        '\t\tlog = "unbalanced brace } inside a string"\n'
+        "\t\tnews_event = foo.1\n"
+        "\t}\n"
+        "}\n",
+    )
+    assert len(res) == 1
+
+
+def test_worker_returns_empty_for_an_unreadable_file(tmp_path):
+    args = (str(tmp_path / "common" / "gone.txt"), frozenset({"foo.1"}), str(tmp_path))
+    assert scan_major_event_in_loop(args) == []
+
+
+def test_worker_short_circuits_files_with_no_event_calls(tmp_path):
+    call = tmp_path / "common" / "fx.txt"
+    call.parent.mkdir(parents=True)
+    call.write_text(
+        "fx = {\n\tevery_country = { add_political_power = 5 }\n}\n",
+        encoding="utf-8",
+    )
+    assert (
+        scan_major_event_in_loop((str(call), frozenset({"foo.1"}), str(tmp_path))) == []
+    )
+
+
+def test_parse_metadata_major_yes():
+    meta, _ = _parse_event_metadata(_major_block("foo.1"), "Ev.txt")
+    assert meta[0]["is_major"] is True
+
+
+def test_parse_metadata_strips_commented_major():
+    meta, _ = _parse_event_metadata(
+        _major_block("foo.1", extra="#major = yes\n"), "Ev.txt"
+    )
+    assert meta[0]["is_major"] is False
+
+
+def test_parse_metadata_is_major_trigger_is_not_event_major():
+    text = (
+        "country_event = {\n"
+        "\tid = foo.1\n"
+        "\tis_triggered_only = yes\n"
+        "\toption = {\n"
+        "\t\tname = foo.1.a\n"
+        "\t\ttrigger = { is_major = yes }\n"
+        "\t}\n"
+        "}\n"
+    )
+    meta, _ = _parse_event_metadata(text, "Ev.txt")
+    assert meta[0]["is_major"] is False
+
+
+def test_major_lookup_full_repo_in_staged_mode(tmp_path):
+    from validate_events import Validator as EventsValidator
+
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    (events_dir / "def.txt").write_text(
+        "add_namespace = foo\n" + _major_block("foo.1"),
+        encoding="utf-8",
+    )
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    caller = common_dir / "caller.txt"
+    caller.write_text(
+        "x = {\n\tevery_country = {\n\t\tnews_event = foo.1\n\t}\n}\n",
+        encoding="utf-8",
+    )
+
+    v = EventsValidator(mod_path=str(tmp_path), use_colors=False, workers=1)
+    v.staged_only = True
+    v.staged_files = [str(caller)]
+    v.validate_major_event_in_loop()
+    assert v.errors_found >= 1, (
+        "major definition in an unstaged file must still be looked up — "
+        "staged mode used to scan only staged event files and miss it, "
+        "silently passing the in-loop broadcast bug at commit time"
+    )
+
+
+def test_major_check_short_circuits_without_declarations(tmp_path, monkeypatch):
+    from validate_events import Validator as EventsValidator
+
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    (events_dir / "Ev.txt").write_text(
+        "add_namespace = foo\n" + _major_block("foo.1", extra=""),
+        encoding="utf-8",
+    )
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    (common_dir / "caller.txt").write_text(
+        "x = {\n\tevery_country = {\n\t\tnews_event = foo.1\n\t}\n}\n",
+        encoding="utf-8",
+    )
+
+    v = EventsValidator(mod_path=str(tmp_path), use_colors=False, workers=1)
+    v._get_major_event_ids()
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("scanned for in-loop fires with no major events")
+
+    monkeypatch.setattr(v, "_pool_map", _fail)
+    v.validate_major_event_in_loop()
+    assert v._issues == []

--- a/tools/validation/validate_events.py
+++ b/tools/validation/validate_events.py
@@ -438,23 +438,43 @@ _RE_FOF_TOKEN = re.compile(
 )
 
 
-def _fof_stack_flags(stack: List[str]) -> bool:
-    """Walk scope frames innermost-first; True iff the nearest loop/pin frame is
-    an iterator. A "pinned" scope switch fixes the recipient, so it shields an
-    outer iterator (dedup idiom); "other" frames (incl. random_*) are
-    transparent, so a random pick nested inside an iterator is still flagged."""
+_FOF_IN_LOOP_MSG = (
+    "fire_only_once event {eid} fired inside"
+    " an every_*/for_each_* iterator (only the first"
+    " recipient gets it; drop fire_only_once or fire it"
+    " outside the loop)"
+)
+_MAJOR_IN_LOOP_MSG = (
+    "major event {eid} fired inside an every_*/for_each_*"
+    " iterator (each iteration broadcasts to every country;"
+    " fire it once outside the loop)"
+)
+
+
+def _loop_stack_flags(stack: List[str], pinned_shields: bool) -> bool:
+    """True iff the nearest loop/pin frame is an iterator.
+
+    pinned_shields: a ROOT/TAG switch fixes the recipient, which is a
+    fire_only_once dedup idiom. Major events still broadcast once per
+    iteration even when pinned, so they pass False.
+    """
     for kind in reversed(stack):
         if kind == "iter":
             return True
-        if kind == "pinned":
+        if kind == "pinned" and pinned_shields:
             return False
     return False
 
 
-def scan_fire_only_once_in_loop(args: Tuple[str, frozenset, str]) -> List[str]:
-    """Pool worker: flag fire_only_once events fired inside an iterator."""
-    filename, fire_only_once_ids, mod_path = args
-    if not fire_only_once_ids or _should_skip(filename):
+def _scan_tracked_events_in_loop(
+    args: Tuple[str, frozenset, str],
+    *,
+    pinned_shields: bool,
+    message: str,
+) -> List[str]:
+    """Flag tracked event IDs fired inside an every_*/for_each_* iterator."""
+    filename, tracked_ids, mod_path = args
+    if not tracked_ids or _should_skip(filename):
         return []
     try:
         text = Path(filename).read_text(encoding="utf-8-sig", errors="replace")
@@ -474,17 +494,11 @@ def scan_fire_only_once_in_loop(args: Tuple[str, frozenset, str]) -> List[str]:
     def _flag(eid: str, pos: int) -> None:
         line = cleaned.count("\n", 0, pos) + 1
         rel = os.path.relpath(filename, mod_path)
-        findings.append(
-            f"{rel}:{line} - fire_only_once event {eid} fired inside"
-            f" an every_*/for_each_* iterator (only the first"
-            f" recipient gets it; drop fire_only_once or fire it"
-            f" outside the loop)"
-        )
+        findings.append(f"{rel}:{line} - {message.format(eid=eid)}")
 
     # Stack of scope frames: "iter" (every_/for_each_), "pinned"
     # (fixed-recipient scope switch), or "other" (limit / if / random_* /
-    # completion_reward / the event-call block / ...). An event call is flagged
-    # when the nearest enclosing loop/pin frame is an iterator (_fof_stack_flags).
+    # completion_reward / the event-call block / ...).
     stack: List[str] = []
     for m in _RE_FOF_TOKEN.finditer(cleaned):
         tok = m.group(0)
@@ -503,13 +517,31 @@ def scan_fire_only_once_in_loop(args: Tuple[str, frozenset, str]) -> List[str]:
             body, _ = extract_block_from_text(cleaned, m.end() - 1)
             idm = _RE_FOF_ID.search(body)
             eid = idm.group(1) if idm else None
-            if eid and eid in fire_only_once_ids and _fof_stack_flags(stack[:-1]):
+            if (
+                eid
+                and eid in tracked_ids
+                and _loop_stack_flags(stack[:-1], pinned_shields)
+            ):
                 _flag(eid, m.start())
         elif _RE_FOF_EVENT_SHORT.match(tok):
             eid = tok.split("=", 1)[1].strip()
-            if eid in fire_only_once_ids and _fof_stack_flags(stack):
+            if eid in tracked_ids and _loop_stack_flags(stack, pinned_shields):
                 _flag(eid, m.start())
     return findings
+
+
+def scan_fire_only_once_in_loop(args: Tuple[str, frozenset, str]) -> List[str]:
+    """Pool worker: flag fire_only_once events fired inside an iterator."""
+    return _scan_tracked_events_in_loop(
+        args, pinned_shields=True, message=_FOF_IN_LOOP_MSG
+    )
+
+
+def scan_major_event_in_loop(args: Tuple[str, frozenset, str]) -> List[str]:
+    """Pool worker: flag major events fired inside an iterator."""
+    return _scan_tracked_events_in_loop(
+        args, pinned_shields=False, message=_MAJOR_IN_LOOP_MSG
+    )
 
 
 def process_txt_for_long_form_events(args: Tuple[str, str]) -> List[str]:
@@ -616,6 +648,11 @@ def scan_probability_rolled_fires(args: Tuple[str, frozenset]) -> Set[str]:
     return ids
 
 
+# `is_major = yes` is a country trigger ("this is a major power") and must
+# not count as the event-level `major = yes` broadcast flag.
+_RE_MAJOR_YES = re.compile(r"(?<![A-Za-z0-9_])major\s*=\s*yes")
+
+
 def _parse_event_metadata(text: str, basename: str) -> Tuple[List[dict], Set[str]]:
     namespaces: Set[str] = set(_ADD_NAMESPACE_PATTERN.findall(text))
     meta: List[dict] = []
@@ -640,6 +677,7 @@ def _parse_event_metadata(text: str, basename: str) -> Tuple[List[dict], Set[str
                 "is_hidden": "hidden = yes" in body_nc,
                 "is_triggered_only": "is_triggered_only = yes" in body_nc,
                 "fire_only_once": "fire_only_once = yes" in body_nc,
+                "is_major": bool(_RE_MAJOR_YES.search(body_nc)),
                 "has_mtth": "mean_time_to_happen" in body_nc,
                 "option_count": len(_OPTION_BLOCK_PATTERN.findall(body)),
                 "title_desc_refs": [
@@ -660,6 +698,7 @@ class Validator(BaseValidator):
         self._random_events_cache: Optional[set] = None
         self._probability_rolled_cache: Optional[set] = None
         self._fire_only_once_ids_cache: Optional[set] = None
+        self._major_event_ids_cache: Optional[set] = None
         self._fire_scan_args_cache: Optional[List[Tuple[str, frozenset]]] = None
         self._fires_cache: Optional[List[Tuple[str, str, int]]] = None
         self._typed_fires_cache: Optional[List[Tuple[str, str, str, int]]] = None
@@ -669,8 +708,8 @@ class Validator(BaseValidator):
         """Parse all event files and return (event_metadata_list, declared_namespaces).
 
         Each metadata dict has: id (or None for malformed blocks), type, file,
-        is_hidden, is_triggered_only, fire_only_once, has_mtth, option_count,
-        title_desc_refs.
+        is_hidden, is_triggered_only, fire_only_once, is_major, has_mtth,
+        option_count, title_desc_refs.
         """
         if self._meta_cache is not None:
             return self._meta_cache
@@ -846,6 +885,38 @@ class Validator(BaseValidator):
             ids.update(ev["id"] for ev in file_meta if ev["fire_only_once"])
 
         self._fire_only_once_ids_cache = ids
+        return ids
+
+    def _get_major_event_ids(self) -> set:
+        """Return IDs of events declared ``major = yes``.
+
+        Lookup pass: must scan the full repo even in staged mode. Otherwise a
+        staged caller that fires an existing major event whose definition
+        lives in an unstaged file drops out of the ID set, and the in-loop
+        broadcast bug commits silently.
+        """
+        if self._major_event_ids_cache is not None:
+            return self._major_event_ids_cache
+
+        files = self._collect_files(["events/**/*.txt"], ignore_staged=True)
+        ids: set = set()
+        for filepath in files:
+            text = FileOpener.open_text_file(
+                filepath, lowercase=False, strip_comments_flag=True
+            )
+            if not text:
+                continue
+            basename = os.path.basename(filepath)
+            file_meta, _ = disk_cache.per_file_cached_by_content(
+                self.mod_path,
+                "events.metadata",
+                filepath,
+                text,
+                lambda: _parse_event_metadata(text, basename),
+            )
+            ids.update(ev["id"] for ev in file_meta if ev["is_major"] and ev["id"])
+
+        self._major_event_ids_cache = ids
         return ids
 
     def validate_unsupported_title_desc(self):
@@ -1473,6 +1544,47 @@ class Validator(BaseValidator):
             category="fire-only-once-in-loop",
         )
 
+    def validate_major_event_in_loop(self):
+        """Flag major events fired inside an every_*/for_each_* iterator.
+
+        A ``major = yes`` event already broadcasts to every country on each
+        fire. Inside an iterating scope that becomes one broadcast per
+        iteration (N countries, N popups; worse in MP). A pinned ROOT/TAG
+        scope does not exempt it: the same global broadcast still repeats.
+        Non-major news_event fires inside every_country are the per-country
+        notification pattern and are not flagged.
+        """
+        self._log_section("Checking for major events fired inside iterators...")
+
+        major_ids = frozenset(self._get_major_event_ids())
+        if not major_ids:
+            self.log("  No major events defined — skipping")
+            self._report(
+                [],
+                "✓ No major events fired inside iterators",
+                "major events fired inside iterators (each iteration broadcasts to every country):",
+                category="major-event-in-loop",
+            )
+            return
+
+        txt_files = self._collect_files(
+            ["common/**/*.txt", "events/**/*.txt", "history/**/*.txt"]
+        )
+        args_list = [(f, major_ids, self.mod_path) for f in txt_files]
+        all_results = self._pool_map(scan_major_event_in_loop, args_list, chunksize=30)
+        results = [r for file_res in all_results for r in file_res]
+
+        # ERROR: the 9-site pre-existing backlog was cleared.
+        self._report(
+            results,
+            "✓ No major events fired inside iterators",
+            "major events fired inside every_*/for_each_* iterators"
+            " (each iteration broadcasts to every country; fire the event"
+            " once outside the loop):",
+            Severity.ERROR,
+            category="major-event-in-loop",
+        )
+
     def run_validations(self):
         self.validate_unsupported_title_desc()
         self.validate_missing_triggered_only()
@@ -1490,6 +1602,7 @@ class Validator(BaseValidator):
         self.validate_undefined_event_fires()
         self.validate_event_pictures()
         self.validate_fire_only_once_in_loop()
+        self.validate_major_event_in_loop()
 
 
 if __name__ == "__main__":

--- a/tools/validation/validate_events.py
+++ b/tools/validation/validate_events.py
@@ -10,7 +10,7 @@ import re
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -855,17 +855,7 @@ class Validator(BaseValidator):
         self._probability_rolled_cache = ids
         return ids
 
-    def _get_fire_only_once_ids(self) -> set:
-        """Return IDs of events declared ``fire_only_once = yes``.
-
-        Lookup pass: must scan the full repo even in staged mode. Otherwise a
-        staged caller that fires an existing fire_only_once event whose
-        definition lives in an unstaged file drops out of the ID set, and the
-        real in-loop / multi-caller bug commits silently.
-        """
-        if self._fire_only_once_ids_cache is not None:
-            return self._fire_only_once_ids_cache
-
+    def _collect_event_ids_where(self, predicate: Callable[[dict], bool]) -> set:
         files = self._collect_files(["events/**/*.txt"], ignore_staged=True)
         ids: set = set()
         for filepath in files:
@@ -882,10 +872,23 @@ class Validator(BaseValidator):
                 text,
                 lambda: _parse_event_metadata(text, basename),
             )
-            ids.update(ev["id"] for ev in file_meta if ev["fire_only_once"])
-
-        self._fire_only_once_ids_cache = ids
+            ids.update(ev["id"] for ev in file_meta if predicate(ev))
         return ids
+
+    def _get_fire_only_once_ids(self) -> set:
+        """Return IDs of events declared ``fire_only_once = yes``.
+
+        Lookup pass: must scan the full repo even in staged mode. Otherwise a
+        staged caller that fires an existing fire_only_once event whose
+        definition lives in an unstaged file drops out of the ID set, and the
+        real in-loop / multi-caller bug commits silently.
+        """
+        if self._fire_only_once_ids_cache is not None:
+            return self._fire_only_once_ids_cache
+        self._fire_only_once_ids_cache = self._collect_event_ids_where(
+            lambda ev: bool(ev["fire_only_once"])
+        )
+        return self._fire_only_once_ids_cache
 
     def _get_major_event_ids(self) -> set:
         """Return IDs of events declared ``major = yes``.
@@ -897,27 +900,10 @@ class Validator(BaseValidator):
         """
         if self._major_event_ids_cache is not None:
             return self._major_event_ids_cache
-
-        files = self._collect_files(["events/**/*.txt"], ignore_staged=True)
-        ids: set = set()
-        for filepath in files:
-            text = FileOpener.open_text_file(
-                filepath, lowercase=False, strip_comments_flag=True
-            )
-            if not text:
-                continue
-            basename = os.path.basename(filepath)
-            file_meta, _ = disk_cache.per_file_cached_by_content(
-                self.mod_path,
-                "events.metadata",
-                filepath,
-                text,
-                lambda: _parse_event_metadata(text, basename),
-            )
-            ids.update(ev["id"] for ev in file_meta if ev["is_major"] and ev["id"])
-
-        self._major_event_ids_cache = ids
-        return ids
+        self._major_event_ids_cache = self._collect_event_ids_where(
+            lambda ev: bool(ev["is_major"] and ev["id"])
+        )
+        return self._major_event_ids_cache
 
     def validate_unsupported_title_desc(self):
         self._log_section(


### PR DESCRIPTION
## Bottom line

`validate_events` now errors when a `major = yes` event is fired from `every_country` or another iterating `every_` / `for_each_` scope. That wrap broadcasts the news popup once per country, which is the PHI_news.2 spam. The nine existing sites fire the event once.

## Why

`major = yes` already shows the event to every country. Looping the fire repeats it. Non-major `news_event` inside `every_country` is left alone. That is the per-country notification pattern (elections, bankruptcy).

BLUF