### PR TITLE
Bring Italy's AI paths onto the #3162 standard (#3162)

### DIFF
--- a/common/ai_strategy/ITA.txt
+++ b/common/ai_strategy/ITA.txt
@@ -228,7 +228,7 @@ ITA_army_doctrine = {
 ITA_roman_conquest_TUN = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_african_coast
 		country_exists = TUN
 		strength_ratio = { tag = TUN ratio > 1.5 }
@@ -241,7 +241,7 @@ ITA_roman_conquest_TUN = {
 ITA_roman_conquest_LBA = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_african_coast
 		country_exists = LBA
 		strength_ratio = { tag = LBA ratio > 1.5 }
@@ -254,7 +254,7 @@ ITA_roman_conquest_LBA = {
 ITA_roman_conquest_ALG = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_african_coast
 		country_exists = ALG
 		strength_ratio = { tag = ALG ratio > 1.5 }
@@ -267,7 +267,7 @@ ITA_roman_conquest_ALG = {
 ITA_roman_conquest_MOR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_african_coast
 		country_exists = MOR
 		strength_ratio = { tag = MOR ratio > 1.5 }
@@ -280,7 +280,7 @@ ITA_roman_conquest_MOR = {
 ITA_roman_conquest_EGY = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_african_coast
 		country_exists = EGY
 		strength_ratio = { tag = EGY ratio > 1.5 }
@@ -293,7 +293,7 @@ ITA_roman_conquest_EGY = {
 ITA_roman_conquest_ISR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = ISR
 		strength_ratio = { tag = ISR ratio > 1.5 }
@@ -306,7 +306,7 @@ ITA_roman_conquest_ISR = {
 ITA_roman_conquest_LEB = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = LEB
 		strength_ratio = { tag = LEB ratio > 1.5 }
@@ -319,7 +319,7 @@ ITA_roman_conquest_LEB = {
 ITA_roman_conquest_SYR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = SYR
 		strength_ratio = { tag = SYR ratio > 1.5 }
@@ -332,7 +332,7 @@ ITA_roman_conquest_SYR = {
 ITA_roman_conquest_JOR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = JOR
 		strength_ratio = { tag = JOR ratio > 1.5 }
@@ -345,7 +345,7 @@ ITA_roman_conquest_JOR = {
 ITA_roman_conquest_PAL = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = PAL
 		strength_ratio = { tag = PAL ratio > 1.5 }
@@ -358,7 +358,7 @@ ITA_roman_conquest_PAL = {
 ITA_roman_conquest_IRQ = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = IRQ
 		strength_ratio = { tag = IRQ ratio > 1.5 }
@@ -371,7 +371,7 @@ ITA_roman_conquest_IRQ = {
 ITA_roman_conquest_KUW = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = KUW
 		strength_ratio = { tag = KUW ratio > 1.5 }
@@ -384,7 +384,7 @@ ITA_roman_conquest_KUW = {
 ITA_roman_conquest_KUR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = KUR
 		strength_ratio = { tag = KUR ratio > 1.5 }
@@ -397,7 +397,7 @@ ITA_roman_conquest_KUR = {
 ITA_roman_conquest_PUK = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = PUK
 		strength_ratio = { tag = PUK ratio > 1.5 }
@@ -410,7 +410,7 @@ ITA_roman_conquest_PUK = {
 ITA_roman_conquest_HEZ = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_retake_levant
 		country_exists = HEZ
 		strength_ratio = { tag = HEZ ratio > 1.5 }
@@ -423,7 +423,7 @@ ITA_roman_conquest_HEZ = {
 ITA_roman_conquest_SLV = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = SLV
 		strength_ratio = { tag = SLV ratio > 1.5 }
@@ -436,7 +436,7 @@ ITA_roman_conquest_SLV = {
 ITA_roman_conquest_CRO = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = CRO
 		strength_ratio = { tag = CRO ratio > 1.5 }
@@ -449,7 +449,7 @@ ITA_roman_conquest_CRO = {
 ITA_roman_conquest_BOS = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = BOS
 		strength_ratio = { tag = BOS ratio > 1.5 }
@@ -462,7 +462,7 @@ ITA_roman_conquest_BOS = {
 ITA_roman_conquest_SER = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = SER
 		strength_ratio = { tag = SER ratio > 1.5 }
@@ -475,7 +475,7 @@ ITA_roman_conquest_SER = {
 ITA_roman_conquest_MNT = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = MNT
 		strength_ratio = { tag = MNT ratio > 1.5 }
@@ -488,7 +488,7 @@ ITA_roman_conquest_MNT = {
 ITA_roman_conquest_KOS = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = KOS
 		strength_ratio = { tag = KOS ratio > 1.5 }
@@ -501,7 +501,7 @@ ITA_roman_conquest_KOS = {
 ITA_roman_conquest_FYR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = FYR
 		strength_ratio = { tag = FYR ratio > 1.5 }
@@ -514,7 +514,7 @@ ITA_roman_conquest_FYR = {
 ITA_roman_conquest_ALB = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = ALB
 		strength_ratio = { tag = ALB ratio > 1.5 }
@@ -527,7 +527,7 @@ ITA_roman_conquest_ALB = {
 ITA_roman_conquest_GRE = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = GRE
 		strength_ratio = { tag = GRE ratio > 1.5 }
@@ -540,7 +540,7 @@ ITA_roman_conquest_GRE = {
 ITA_roman_conquest_BUL = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = BUL
 		strength_ratio = { tag = BUL ratio > 1.5 }
@@ -553,7 +553,7 @@ ITA_roman_conquest_BUL = {
 ITA_roman_conquest_ROM = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = ROM
 		strength_ratio = { tag = ROM ratio > 1.5 }
@@ -566,7 +566,7 @@ ITA_roman_conquest_ROM = {
 ITA_roman_conquest_HUN = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_balkans
 		country_exists = HUN
 		strength_ratio = { tag = HUN ratio > 1.5 }
@@ -579,7 +579,7 @@ ITA_roman_conquest_HUN = {
 ITA_roman_conquest_TUR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = TUR
 		strength_ratio = { tag = TUR ratio > 1.5 }
@@ -592,7 +592,7 @@ ITA_roman_conquest_TUR = {
 ITA_roman_conquest_CYP = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = CYP
 		naval_strength_ratio = { tag = CYP ratio > 1.5 }
@@ -605,7 +605,7 @@ ITA_roman_conquest_CYP = {
 ITA_roman_conquest_NCY = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = NCY
 		naval_strength_ratio = { tag = NCY ratio > 1.5 }
@@ -618,7 +618,7 @@ ITA_roman_conquest_NCY = {
 ITA_roman_conquest_GEO = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = GEO
 		strength_ratio = { tag = GEO ratio > 1.5 }
@@ -631,7 +631,7 @@ ITA_roman_conquest_GEO = {
 ITA_roman_conquest_ABK = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = ABK
 		strength_ratio = { tag = ABK ratio > 1.5 }
@@ -644,7 +644,7 @@ ITA_roman_conquest_ABK = {
 ITA_roman_conquest_SOO = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = SOO
 		strength_ratio = { tag = SOO ratio > 1.5 }
@@ -657,7 +657,7 @@ ITA_roman_conquest_SOO = {
 ITA_roman_conquest_ARM = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = ARM
 		strength_ratio = { tag = ARM ratio > 1.5 }
@@ -670,7 +670,7 @@ ITA_roman_conquest_ARM = {
 ITA_roman_conquest_AZE = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_anatolia
 		country_exists = AZE
 		strength_ratio = { tag = AZE ratio > 1.5 }
@@ -683,7 +683,7 @@ ITA_roman_conquest_AZE = {
 ITA_roman_conquest_FRA = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_strike_gaul
 		country_exists = FRA
 		strength_ratio = { tag = FRA ratio > 1.5 }
@@ -696,7 +696,7 @@ ITA_roman_conquest_FRA = {
 ITA_roman_conquest_BEL = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_strike_gaul
 		country_exists = BEL
 		strength_ratio = { tag = BEL ratio > 1.5 }
@@ -709,7 +709,7 @@ ITA_roman_conquest_BEL = {
 ITA_roman_conquest_LUX = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_strike_gaul
 		country_exists = LUX
 		strength_ratio = { tag = LUX ratio > 1.5 }
@@ -722,7 +722,7 @@ ITA_roman_conquest_LUX = {
 ITA_roman_conquest_SPR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_iberia
 		country_exists = SPR
 		strength_ratio = { tag = SPR ratio > 1.5 }
@@ -735,7 +735,7 @@ ITA_roman_conquest_SPR = {
 ITA_roman_conquest_POR = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_iberia
 		country_exists = POR
 		strength_ratio = { tag = POR ratio > 1.5 }
@@ -748,7 +748,7 @@ ITA_roman_conquest_POR = {
 ITA_roman_conquest_CAT = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_iberia
 		country_exists = CAT
 		strength_ratio = { tag = CAT ratio > 1.5 }
@@ -761,7 +761,7 @@ ITA_roman_conquest_CAT = {
 ITA_roman_conquest_ENG = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_britannia
 		country_exists = ENG
 		naval_strength_ratio = { tag = ENG ratio > 1.5 }
@@ -774,7 +774,7 @@ ITA_roman_conquest_ENG = {
 ITA_roman_conquest_WAS = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_britannia
 		country_exists = WAS
 		naval_strength_ratio = { tag = WAS ratio > 1.5 }
@@ -787,7 +787,7 @@ ITA_roman_conquest_WAS = {
 ITA_roman_conquest_SWI = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_alps
 		country_exists = SWI
 		strength_ratio = { tag = SWI ratio > 1.5 }
@@ -800,7 +800,7 @@ ITA_roman_conquest_SWI = {
 ITA_roman_conquest_AUS = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_recover_alps
 		country_exists = AUS
 		strength_ratio = { tag = AUS ratio > 1.5 }
@@ -813,7 +813,7 @@ ITA_roman_conquest_AUS = {
 ITA_roman_conquest_GER = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_attack_germany
 		country_exists = GER
 		strength_ratio = { tag = GER ratio > 1.5 }
@@ -826,7 +826,7 @@ ITA_roman_conquest_GER = {
 ITA_roman_conquest_SOV = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_crush_third_rome
 		country_exists = SOV
 		strength_ratio = { tag = SOV ratio > 1.5 }
@@ -839,7 +839,7 @@ ITA_roman_conquest_SOV = {
 ITA_roman_conquest_CHI = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_attack_china
 		country_exists = CHI
 		strength_ratio = { tag = CHI ratio > 1.5 }
@@ -852,7 +852,7 @@ ITA_roman_conquest_CHI = {
 ITA_roman_conquest_USA = {
 	allowed = { original_tag = ITA }
 	enable = {
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 		has_completed_focus = ITA_attack_on_america
 		country_exists = USA
 		naval_strength_ratio = { tag = USA ratio > 1.5 }

--- a/common/ai_strategy_plans/ITA_strategy_plans.txt
+++ b/common/ai_strategy_plans/ITA_strategy_plans.txt
@@ -5,13 +5,8 @@ ITA_historical_plan = {
 
 	enable = {
 		original_tag = ITA
-		OR = {
-			is_historical_focus_on = yes
-			has_global_flag = ITA_HISTORICAL_AI_FOCUS
-		}
-		NOT = { has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS }
-		NOT = { has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS }
-		NOT = { has_global_flag = ITA_EASTERN_TURN_AI_FOCUS }
+		ITA_ai_historical_path = yes
+		ITA_ai_not_historical_path = no
 	}
 
 	abort = {
@@ -49,8 +44,6 @@ ITA_historical_plan = {
 		ITA_right_wing_populism = 0
 	}
 
-	# Keep small, as it is used as a factor for some things (such as research needs)
-	# Recommended around 1.0. Useful for relation between plans
 	weight = {
 		factor = 1.0
 		modifier = {
@@ -66,7 +59,7 @@ ITA_roman_restoration_plan = {
 
 	enable = {
 		original_tag = ITA
-		has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 	}
 
 	abort = {
@@ -128,7 +121,7 @@ ITA_march_on_rome_plan = {
 
 	enable = {
 		original_tag = ITA
-		has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
+		has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH
 	}
 
 	abort = {
@@ -187,7 +180,7 @@ ITA_eastern_turn_plan = {
 
 	enable = {
 		original_tag = ITA
-		has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
+		has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH
 	}
 
 	abort = {

--- a/common/decisions/Italy.txt
+++ b/common/decisions/Italy.txt
@@ -8934,12 +8934,7 @@ ITA_ai_path_category = {
 
 		fire_only_once = yes
 
-		visible = {
-			OR = {
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-				has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-			}
-		}
+		visible = { ITA_ai_nationalist_path = yes }
 
 		available = {
 			nationalist_right_wing_populists_are_in_power = no
@@ -8965,12 +8960,7 @@ ITA_ai_path_category = {
 
 		days_re_enable = 30
 
-		visible = {
-			OR = {
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-				has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-			}
-		}
+		visible = { ITA_ai_nationalist_path = yes }
 
 		available = {
 			nationalist_right_wing_populists_are_in_power = no
@@ -8996,12 +8986,7 @@ ITA_ai_path_category = {
 
 		days_re_enable = 180
 
-		visible = {
-			OR = {
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-				has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-			}
-		}
+		visible = { ITA_ai_nationalist_path = yes }
 
 		available = {
 			nationalist_right_wing_populists_are_in_power = no
@@ -9028,7 +9013,7 @@ ITA_ai_path_category = {
 
 		fire_only_once = yes
 
-		visible = { has_global_flag = ITA_EASTERN_TURN_AI_FOCUS }
+		visible = { has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH }
 
 		available = { emerging_communist_state_are_in_power = no }
 
@@ -9047,7 +9032,7 @@ ITA_ai_path_category = {
 
 		days_re_enable = 30
 
-		visible = { has_global_flag = ITA_EASTERN_TURN_AI_FOCUS }
+		visible = { has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH }
 
 		available = {
 			emerging_communist_state_are_in_power = no
@@ -9073,7 +9058,7 @@ ITA_ai_path_category = {
 
 		days_re_enable = 180
 
-		visible = { has_global_flag = ITA_EASTERN_TURN_AI_FOCUS }
+		visible = { has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH }
 
 		available = {
 			emerging_communist_state_are_in_power = no

--- a/common/decisions/categories/99_ITA_decision_categories.txt
+++ b/common/decisions/categories/99_ITA_decision_categories.txt
@@ -80,11 +80,5 @@ ITA_ai_path_category = {
 	icon = GFX_decisions_category_political
 	priority = 100
 
-	visible = {
-		OR = {
-			has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-			has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-		}
-	}
+	visible = { ITA_ai_not_historical_path = yes }
 }

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -2728,29 +2728,29 @@ ITA_ai_behavior = {
 	name = "ITA_AI_BEHAVIOR_MD"
 	group = "RULE_GROUP_AI_BEHAVIOR"
 	option = {
-		name = ITA_HISTORICAL
+		name = HISTORICAL
 		text = "RULE_OPTION_ITA_HISTORICAL"
 		desc = "RULE_OPTION_ITA_HISTORICAL_DESC"
 	}
 	option = {
-		name = ITA_ROMAN_RESTORATION
+		name = ROMAN_RESTORATION
 		text = "RULE_OPTION_ITA_ROMAN_RESTORATION"
 		desc = "RULE_OPTION_ITA_ROMAN_RESTORATION_DESC"
 	}
 	option = {
-		name = ITA_MARCH_ON_ROME
+		name = MARCH_ON_ROME
 		text = "RULE_OPTION_ITA_MARCH_ON_ROME"
 		desc = "RULE_OPTION_ITA_MARCH_ON_ROME_DESC"
 	}
 	option = {
-		name = ITA_EASTERN_TURN
+		name = EASTERN_TURN
 		text = "RULE_OPTION_ITA_EASTERN_TURN"
 		desc = "RULE_OPTION_ITA_EASTERN_TURN_DESC"
 	}
 	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
 	}
 	default = {
 		name = NO_PATH

--- a/common/national_focus/05_italy.txt
+++ b/common/national_focus/05_italy.txt
@@ -111,32 +111,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 10
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = {
-					OR = {
-						has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-						has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-						has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-					}
-				}
-			}
-			modifier = {
 				factor = 4
 				has_east_aligned_government = yes
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -183,10 +162,6 @@ focus_tree = {
 		ai_will_do = {
 			base = 10
 			modifier = {
-				factor = 4
-				is_historical_focus_on = yes
-			}
-			modifier = {
 				factor = 0.25
 				has_east_aligned_government = yes
 			}
@@ -194,18 +169,8 @@ focus_tree = {
 				factor = 4
 				has_west_aligned_government = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -236,10 +201,6 @@ focus_tree = {
 		ai_will_do = {
 			base = 40
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
 				factor = 0.25
 				has_east_aligned_government = yes
 			}
@@ -247,15 +208,7 @@ focus_tree = {
 				factor = 0.25
 				has_west_aligned_government = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -339,6 +292,8 @@ focus_tree = {
 					check_variable = { ruling_party = 20 }
 				}
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -422,6 +377,8 @@ focus_tree = {
 					check_variable = { ruling_party = 7 }
 				}
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -459,6 +416,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -509,6 +468,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 40
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -538,7 +499,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_befriend_israel_TT
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -602,7 +567,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -691,6 +660,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -780,6 +751,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -850,6 +823,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -879,7 +854,11 @@ focus_tree = {
 			custom_effect_tooltip = mafia_strength_decrease_tt
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -913,6 +892,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -947,6 +928,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -999,6 +982,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -1087,6 +1072,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 40
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -1149,6 +1136,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -1201,6 +1190,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -1266,6 +1257,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -1300,6 +1293,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -1352,6 +1347,8 @@ focus_tree = {
 				factor = mafia_strength_ai_factor_var
 				has_idea = ITA_mafia
 			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -1440,6 +1437,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 40
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -1467,7 +1466,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_attempt_join_sco_accept_tt
 		}
 
-		ai_will_do = { base = 30 }
+		ai_will_do = {
+			base = 30
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -1509,7 +1512,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 30 }
+		ai_will_do = {
+			base = 30
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 ##INDUSTRIAL FOCUS##
@@ -3236,30 +3243,8 @@ focus_tree = {
 					check_variable = { ruling_party = 23 } #Monarchist
 				}
 			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = {
-					OR = {
-						has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-						has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					}
-				}
-			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -3283,15 +3268,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 40
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
 		}
 	}
 
@@ -3332,30 +3308,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 320
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = {
-					OR = {
-						has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-						has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					}
-				}
-			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -3428,10 +3382,6 @@ focus_tree = {
 			}
 			modifier = {
 				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
-				factor = 0
 				has_stability < 0.5
 			}
 			modifier = {
@@ -3442,15 +3392,7 @@ focus_tree = {
 				factor = 0
 				check_variable = { stability_protests_counter < -5 }
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -3499,18 +3441,8 @@ focus_tree = {
 					check_variable = { ruling_party = 21 }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
 		}
 	}
 
@@ -3562,18 +3494,8 @@ focus_tree = {
 					check_variable = { ruling_party = 23 }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -3618,15 +3540,7 @@ focus_tree = {
 				factor = 4
 				check_variable = { ruling_party = 23 }
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -3687,11 +3601,6 @@ focus_tree = {
 		ai_will_do = {
 			base = 160
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS }
-			}
-			modifier = {
 				factor = 4
 				OR = {
 					western_autocrats_are_in_power = yes
@@ -3700,18 +3609,8 @@ focus_tree = {
 					check_variable = { ruling_party = 15 }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -3735,15 +3634,7 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 160
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -3793,15 +3684,7 @@ focus_tree = {
 				factor = 4
 				check_variable = { ruling_party = 15 }
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -3849,15 +3732,7 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 160
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -3889,18 +3764,8 @@ focus_tree = {
 					check_variable = { ruling_party = 13 }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -3948,15 +3813,7 @@ focus_tree = {
 				factor = 42
 				western_autocrats_are_in_power = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -4004,15 +3861,7 @@ focus_tree = {
 				factor = 2
 				check_variable = { ruling_party = 7 }
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -4059,18 +3908,8 @@ focus_tree = {
 				factor = 2
 				check_variable = { ruling_party = 13 }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -4143,6 +3982,7 @@ focus_tree = {
 				factor = 0
 				can_staff_an_industrial_complex = no
 			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -4221,6 +4061,7 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -4333,6 +4174,7 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -4365,7 +4207,10 @@ focus_tree = {
 			add_ideas = ITA_royal_family
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -4402,7 +4247,11 @@ focus_tree = {
 
 		completion_reward = { log = "[GetDateText]: [Root.GetName]: Focus ITA_restore_hegemony" }
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
+		}
 	}
 
 	focus = {
@@ -4467,10 +4316,8 @@ focus_tree = {
 					}
 				}
 			}
-			modifier = {
-				factor = 4
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
+			modifier = { factor = 4 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -4532,6 +4379,8 @@ focus_tree = {
 					}
 				}
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -4568,7 +4417,11 @@ focus_tree = {
 			add_ideas = ITA_economic_freedoms
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
+		}
 	}
 
 	focus = {
@@ -4606,7 +4459,11 @@ focus_tree = {
 			add_to_variable = { ITA_bureaucracy_cost_multiplier_modifier_var = 0.1 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
+		}
 	}
 
 	focus = {
@@ -4644,7 +4501,11 @@ focus_tree = {
 			add_to_variable = { ITA_bureaucracy_cost_multiplier_modifier_var = 0.2 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
+		}
 	}
 
 	focus = {
@@ -4687,6 +4548,8 @@ focus_tree = {
 				factor = 8
 				has_war = yes
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -4727,18 +4590,8 @@ focus_tree = {
 				factor = 8
 				check_variable = { ruling_party = 21 }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
 		}
 	}
 
@@ -4775,7 +4628,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
+		}
 	}
 
 	focus = {
@@ -4861,6 +4718,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
 		}
 	}
 
@@ -4891,7 +4750,11 @@ focus_tree = {
 			add_to_variable = { ITA_conscription_var = 0.02 tooltip = conscription_tt }
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
+		}
 	}
 
 	focus = {
@@ -4965,6 +4828,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
 		}
 	}
 
@@ -5008,7 +4873,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 80 }
+		ai_will_do = {
+			base = 80
+			modifier = { factor = 25 has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+			modifier = { factor = 0 ITA_ai_not_march_path = yes }
+		}
 	}
 
 	focus = {
@@ -5051,7 +4920,10 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 80 }
+		ai_will_do = {
+			base = 80
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 #TERRITORIAL CLAIMS
@@ -5079,30 +4951,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 160
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = {
-					OR = {
-						has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-						has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					}
-				}
-			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5162,20 +5012,8 @@ focus_tree = {
 				factor = 0
 				SLV = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5235,20 +5073,8 @@ focus_tree = {
 				factor = 0
 				CRO = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5308,20 +5134,8 @@ focus_tree = {
 				factor = 0
 				SWI = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5373,20 +5187,8 @@ focus_tree = {
 				factor = 0
 				FRA = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5467,20 +5269,8 @@ focus_tree = {
 				factor = 0
 				FRA = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5532,20 +5322,8 @@ focus_tree = {
 				factor = 0
 				FRA = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5597,20 +5375,8 @@ focus_tree = {
 				factor = 0
 				GRE = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5754,20 +5520,8 @@ focus_tree = {
 					}
 				}
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5817,20 +5571,8 @@ focus_tree = {
 				factor = 0
 				ALB = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 #reclaim colonies
@@ -5857,20 +5599,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 20
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5942,6 +5672,8 @@ focus_tree = {
 				factor = 0
 				EGY = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -5996,6 +5728,8 @@ focus_tree = {
 				factor = 0
 				SAU = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6083,6 +5817,8 @@ focus_tree = {
 				factor = 0
 				UAE = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6155,6 +5891,8 @@ focus_tree = {
 					SYR = { strength_ratio = { tag = ITA ratio > 1 } }
 				}
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6209,6 +5947,8 @@ focus_tree = {
 				factor = 0
 				PER = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6276,6 +6016,8 @@ focus_tree = {
 				factor = 0
 				TUN = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6339,6 +6081,8 @@ focus_tree = {
 				factor = 0
 				LBA = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6389,6 +6133,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6454,6 +6200,8 @@ focus_tree = {
 				factor = 0
 				ERI = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6537,6 +6285,8 @@ focus_tree = {
 				factor = 0
 				SOM = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6609,6 +6359,8 @@ focus_tree = {
 				factor = 0
 				ETH = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -6642,18 +6394,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 80
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -6803,18 +6545,8 @@ focus_tree = {
 					ALG = { strength_ratio = { tag = ITA ratio > 1 } }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -6931,18 +6663,8 @@ focus_tree = {
 					SYR = { strength_ratio = { tag = ITA ratio > 1 } }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7080,18 +6802,8 @@ focus_tree = {
 					SER = { strength_ratio = { tag = ITA ratio > 1 } }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7164,18 +6876,8 @@ focus_tree = {
 				factor = 0
 				TUR = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7261,18 +6963,8 @@ focus_tree = {
 				factor = 0
 				FRA = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7355,18 +7047,8 @@ focus_tree = {
 				factor = 0
 				SPR = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7429,18 +7111,8 @@ focus_tree = {
 				factor = 0
 				ENG = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7506,18 +7178,8 @@ focus_tree = {
 					SWI = { strength_ratio = { tag = ITA ratio > 1 } }
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7579,18 +7241,8 @@ focus_tree = {
 				factor = 0
 				GER = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 #dismantle rivals
@@ -7659,18 +7311,8 @@ focus_tree = {
 				factor = 0
 				GER = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7737,18 +7379,8 @@ focus_tree = {
 				factor = 0
 				SOV = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7813,18 +7445,8 @@ focus_tree = {
 				factor = 0
 				CHI = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7883,18 +7505,8 @@ focus_tree = {
 				factor = 0
 				USA = { strength_ratio = { tag = ITA ratio > 1 } }
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -7930,7 +7542,11 @@ focus_tree = {
 			add_to_variable = { ITA_justify_war_goal_time_var = -0.75 tooltip = justify_war_goal_time_tt }
 		}
 
-		ai_will_do = { base = 5 }
+		ai_will_do = {
+			base = 5
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
+		}
 	}
 
 #DEMOCRATIC PARTIES FOCUS
@@ -7970,18 +7586,8 @@ focus_tree = {
 				factor = party_pop_array^4
 				always = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8027,18 +7633,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8084,18 +7680,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8141,18 +7727,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8191,18 +7767,8 @@ focus_tree = {
 				factor = party_pop_array^19
 				always = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8248,18 +7814,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8305,18 +7861,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8362,18 +7908,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -8425,15 +7961,7 @@ focus_tree = {
 				factor = party_pop_array^18
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -8477,7 +8005,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_giuseppe_civati_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8520,7 +8051,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_roberto_speranza_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8563,7 +8097,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_nicola_fratoianni_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8601,15 +8138,7 @@ focus_tree = {
 				factor = party_pop_array^17
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -8653,7 +8182,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_alfonso_pecoraro_scanio_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8696,7 +8228,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_grazia_francescato_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8739,7 +8274,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_angelo_bonelli_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8790,15 +8328,7 @@ focus_tree = {
 				factor = party_pop_array^5
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -8842,7 +8372,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_luigi_di_maio_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8885,7 +8418,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_giuseppe_conte_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8928,7 +8464,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_alessandro_di_battista_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -8966,18 +8505,8 @@ focus_tree = {
 				factor = party_pop_array^3
 				always = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -9021,7 +8550,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_giuliano_amato_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -9064,7 +8597,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_romano_prodi_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -9107,7 +8644,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_enrico_letta_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -9145,15 +8686,7 @@ focus_tree = {
 				factor = party_pop_array^2
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -9197,7 +8730,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_benedetto_della_vedova_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9240,7 +8776,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_matteo_renzi_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9283,7 +8822,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_carlo_calenda_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9321,18 +8863,8 @@ focus_tree = {
 				factor = party_pop_array^1
 				always = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
 		}
 	}
 
@@ -9376,7 +8908,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_stefano_parisi_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -9419,7 +8955,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_mara_carfagna_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -9462,7 +9002,11 @@ focus_tree = {
 			custom_effect_tooltip = ITA_michela_vittoria_brambilla_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 ITA_ai_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -9500,15 +9044,7 @@ focus_tree = {
 				factor = party_pop_array^14
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -9552,7 +9088,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_roberto_calderoli_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9595,7 +9134,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_roberto_maroni_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9638,7 +9180,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_giancarlo_giorgetti_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9676,15 +9221,7 @@ focus_tree = {
 				factor = party_pop_array^16
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -9728,7 +9265,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_oscar_giannino_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9771,7 +9311,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_michele_boldrin_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9814,7 +9357,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_marco_cappato_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9865,15 +9411,7 @@ focus_tree = {
 				factor = party_pop_array^6
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -9917,7 +9455,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_lorenzo_fontana_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -9960,7 +9501,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_andrea_crippa_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -10003,7 +9547,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_riccardo_molinari_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -10041,20 +9588,8 @@ focus_tree = {
 				factor = party_pop_array^20
 				always = yes
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -10100,20 +9635,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -10159,20 +9682,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -10218,20 +9729,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -10270,15 +9769,7 @@ focus_tree = {
 				factor = party_pop_array^21
 				always = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -10322,7 +9813,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_attilio_carelli_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -10365,7 +9859,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_roberto_fiore_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -10408,7 +9905,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_simone_di_stefano_TT
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 #POLICIES
@@ -12464,29 +11964,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1000
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = {
-					OR = {
-						has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-						has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-						has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-					}
-				}
-			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
+			modifier = { factor = 25 ITA_ai_not_historical_path = yes }
+			modifier = { factor = 0 ITA_ai_historical_path = yes }
 		}
 	}
 
@@ -12511,10 +11990,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 20
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
 		}
 	}
 
@@ -12999,6 +12474,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -13182,6 +12659,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_arms_industry = no
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -14529,13 +14008,6 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
 		}
 	}
 
@@ -14591,13 +14063,6 @@ focus_tree = {
 			modifier = {
 				factor = 2
 				ai_is_threatened = yes
-			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
 			}
 		}
 	}
@@ -16000,14 +15465,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
-			modifier = {
-				factor = 4
-				has_global_flag = ITA_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
+			modifier = { factor = 25 ITA_ai_not_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_eastern_path = yes }
 		}
 	}
 
@@ -16070,26 +15529,11 @@ focus_tree = {
 				always = yes
 			}
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = ITA_EASTERN_TURN_AI_FOCUS }
-			}
-			modifier = {
-				factor = 150
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -16135,17 +15579,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
+			modifier = { factor = 4 ITA_ai_not_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_eastern_path = yes }
 		}
 	}
 
@@ -16288,23 +15723,11 @@ focus_tree = {
 				has_active_mission = bankruptcy_incoming_collapse
 			}
 			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_not_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_nationalist_path = yes }
 		}
 	}
 
@@ -16347,6 +15770,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_not_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_nationalist_path = yes }
 		}
 	}
 
@@ -16393,6 +15818,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_not_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_nationalist_path = yes }
 		}
 	}
 
@@ -16432,6 +15859,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_not_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_nationalist_path = yes }
 		}
 	}
 
@@ -16473,6 +15902,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_not_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_nationalist_path = yes }
 		}
 	}
 
@@ -16516,16 +15947,6 @@ focus_tree = {
 				always = yes
 			}
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = {
-					OR = {
-						has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-						has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					}
-				}
-			}
-			modifier = {
 				factor = 2
 				OR = {
 					has_completed_focus = ITA_seize_power
@@ -16545,23 +15966,11 @@ focus_tree = {
 				has_active_mission = bankruptcy_incoming_collapse
 			}
 			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -16604,6 +16013,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -16647,6 +16058,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -16686,6 +16099,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -16725,6 +16140,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
 		}
 	}
 
@@ -17554,13 +16971,6 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
 		}
 	}
 
@@ -17602,13 +17012,6 @@ focus_tree = {
 			modifier = {
 				factor = 2
 				ai_is_threatened = yes
-			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
 			}
 		}
 	}
@@ -18168,14 +17571,6 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
 		}
 	}
 
@@ -18437,10 +17832,6 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
-			modifier = {
-				factor = 4
-				has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-			}
 		}
 	}
 
@@ -18482,6 +17873,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -18523,6 +17916,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -18564,6 +17959,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -18605,6 +18002,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -18646,6 +18045,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 ITA_ai_roman_path = yes }
+			modifier = { factor = 0 ITA_ai_not_roman_path = yes }
 		}
 	}
 
@@ -19078,15 +18479,7 @@ focus_tree = {
 				factor = 0.5
 				nationalist_right_wing_populists_are_in_power_or_coalition = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -19116,15 +18509,6 @@ focus_tree = {
 			modifier = {
 				factor = 0.5
 				has_statalist_government_or_in_coalition = yes
-			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
 			}
 		}
 	}
@@ -19479,6 +18863,7 @@ focus_tree = {
 				factor = 0
 				check_variable = { drift_switch_var_base > 0.35 }
 			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -19511,7 +18896,10 @@ focus_tree = {
 			add_ideas = ITA_bloated_local_administrations
 		}
 
-		ai_will_do = { base = 80 }
+		ai_will_do = {
+			base = 80
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -19557,6 +18945,7 @@ focus_tree = {
 				factor = 0
 				check_variable = { drift_switch_var_base > 0.35 }
 			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -19586,7 +18975,10 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 40 }
+		ai_will_do = {
+			base = 40
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
+		}
 	}
 
 	focus = {
@@ -19664,6 +19056,7 @@ focus_tree = {
 				factor = 0
 				check_variable = { drift_switch_var_base > 0.35 }
 			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -19712,23 +19105,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
 				factor = 400
 				50_percent_government_popularity = yes
 				neutrality_neutral_conservatism_are_in_power = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -19894,23 +19275,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
 				factor = 400
 				50_percent_government_popularity = yes
 				neutrality_neutral_conservatism_are_in_power = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -20102,23 +19471,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
 				factor = 400
 				50_percent_government_popularity = yes
 				neutrality_neutral_conservatism_are_in_power = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -20683,9 +20040,9 @@ focus_tree = {
 		}
 
 		ai_will_do = {
-			base = 0
+			base = 80
 			modifier = {
-				add = 80
+				factor = 4
 				has_statalist_government = yes
 			}
 		}
@@ -21734,14 +21091,8 @@ focus_tree = {
 					has_government = communism
 				}
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
+			modifier = { factor = 4 ITA_ai_not_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_eastern_path = yes }
 		}
 	}
 
@@ -21779,10 +21130,8 @@ focus_tree = {
 				factor = 40
 				has_government = communism
 			}
-			modifier = {
-				factor = 4
-				has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-			}
+			modifier = { factor = 4 ITA_ai_eastern_path = yes }
+			modifier = { factor = 0 ITA_ai_not_eastern_path = yes }
 		}
 	}
 
@@ -22662,13 +22011,6 @@ focus_tree = {
 				factor = 0
 				has_antistatalist_government_or_in_coalition = yes
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-				}
-			}
 		}
 	}
 
@@ -22698,13 +22040,6 @@ focus_tree = {
 				factor = 0
 				has_statalist_government_or_in_coalition = yes
 			}
-			modifier = {
-				factor = 4
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
 		}
 	}
 
@@ -22728,7 +22063,11 @@ focus_tree = {
 			custom_effect_tooltip = exploit_talk_shows_TT
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 ITA_ai_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_not_nationalist_path = yes }
+		}
 	}
 
 	focus = {
@@ -22761,6 +22100,8 @@ focus_tree = {
 				factor = 0
 				check_variable = { drift_switch_var_base < -0.35 }
 			}
+			modifier = { factor = 25 ITA_ai_not_nationalist_path = yes }
+			modifier = { factor = 0 ITA_ai_nationalist_path = yes }
 		}
 	}
 
@@ -23266,19 +22607,7 @@ focus_tree = {
 				factor = influence_array_val^0
 				check_variable = { influence_array^0 = HLS }
 			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -23343,19 +22672,7 @@ focus_tree = {
 				factor = influence_array_val^0
 				check_variable = { influence_array^0 = HLS }
 			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -24292,15 +23609,7 @@ focus_tree = {
 					check_variable = { ruling_party = 15 }
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -24354,15 +23663,7 @@ focus_tree = {
 					check_variable = { ruling_party = 21 }
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -24439,15 +23740,7 @@ focus_tree = {
 					}
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 
@@ -24492,15 +23785,7 @@ focus_tree = {
 					check_variable = { ruling_party = 23 }
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					has_global_flag = ITA_HISTORICAL_AI_FOCUS
-					has_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
-					has_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
-					has_global_flag = ITA_EASTERN_TURN_AI_FOCUS
-				}
-			}
+			modifier = { factor = 0 ITA_ai_not_unclaimed_path = yes }
 		}
 	}
 

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -3130,50 +3130,50 @@ on_actions = {
 					limit = {
 						has_game_rule = {
 							rule = ITA_ai_behavior
-							option = ITA_HISTORICAL
+							option = HISTORICAL
 						}
 					}
-					set_global_flag = ITA_HISTORICAL_AI_FOCUS
+					set_global_flag = ITA_HISTORICAL_FOCUS_PATH
 				}
 				if = {
 					limit = {
 						has_game_rule = {
 							rule = ITA_ai_behavior
-							option = ITA_ROMAN_RESTORATION
+							option = ROMAN_RESTORATION
 						}
 					}
-					set_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS
+					set_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
 				}
 				if = {
 					limit = {
 						has_game_rule = {
 							rule = ITA_ai_behavior
-							option = ITA_MARCH_ON_ROME
+							option = MARCH_ON_ROME
 						}
 					}
-					set_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS
+					set_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH
 				}
 				if = {
 					limit = {
 						has_game_rule = {
 							rule = ITA_ai_behavior
-							option = ITA_EASTERN_TURN
+							option = EASTERN_TURN
 						}
 					}
-					set_global_flag = ITA_EASTERN_TURN_AI_FOCUS
+					set_global_flag = ITA_EASTERN_TURN_FOCUS_PATH
 				}
 				if = {
 					limit = {
 						has_game_rule = {
 							rule = ITA_ai_behavior
-							option = RANDOM
+							option = RANDOM_PATH
 						}
 					}
 					random_list = {
-						45 = { set_global_flag = ITA_HISTORICAL_AI_FOCUS }
-						25 = { set_global_flag = ITA_ROMAN_RESTORATION_AI_FOCUS }
-						15 = { set_global_flag = ITA_MARCH_ON_ROME_AI_FOCUS }
-						15 = { set_global_flag = ITA_EASTERN_TURN_AI_FOCUS }
+						45 = { set_global_flag = ITA_HISTORICAL_FOCUS_PATH }
+						25 = { set_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH }
+						15 = { set_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+						15 = { set_global_flag = ITA_EASTERN_TURN_FOCUS_PATH }
 					}
 				}
 			}

--- a/common/scripted_triggers/99_ITA_scripted_triggers.txt
+++ b/common/scripted_triggers/99_ITA_scripted_triggers.txt
@@ -1,5 +1,83 @@
 #Simone-Traiano
 
+ITA_ai_path_selected = {
+	OR = {
+		has_global_flag = ITA_HISTORICAL_FOCUS_PATH
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
+		has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH
+		has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH
+	}
+}
+
+ITA_ai_historical_path = {
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = ITA_HISTORICAL_FOCUS_PATH
+	}
+}
+
+ITA_ai_not_historical_path = {
+	OR = {
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
+		has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH
+		has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH
+	}
+}
+
+ITA_ai_roman_path = {
+	has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
+}
+
+ITA_ai_not_roman_path = {
+	NOT = { has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		ITA_ai_path_selected = yes
+	}
+}
+
+ITA_ai_not_march_path = {
+	NOT = { has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		ITA_ai_path_selected = yes
+	}
+}
+
+ITA_ai_eastern_path = {
+	has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH
+}
+
+ITA_ai_not_eastern_path = {
+	NOT = { has_global_flag = ITA_EASTERN_TURN_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		ITA_ai_path_selected = yes
+	}
+}
+
+ITA_ai_nationalist_path = {
+	OR = {
+		has_global_flag = ITA_ROMAN_RESTORATION_FOCUS_PATH
+		has_global_flag = ITA_MARCH_ON_ROME_FOCUS_PATH
+	}
+}
+
+ITA_ai_not_nationalist_path = {
+	NOT = { ITA_ai_nationalist_path = yes }
+	OR = {
+		is_historical_focus_on = yes
+		ITA_ai_path_selected = yes
+	}
+}
+
+ITA_ai_not_unclaimed_path = {
+	OR = {
+		is_historical_focus_on = yes
+		ITA_ai_path_selected = yes
+	}
+}
+
 has_statalist_government_or_in_coalition = {
 	custom_trigger_tooltip = {
 		tooltip = has_statalist_government_or_in_coalition_TT

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -250,15 +250,15 @@
  RULE_OPTION_FRA_EMPIRE_DESC: "A Bonapartist coup ends the Republic and proclaims a new French Empire. The Empire pursues continental ambitions that set it against Germany and Britain alike."
 
  #Italy
- ITA_AI_BEHAVIOR_MD: "@ITA Italian Republic"
- RULE_OPTION_ITA_HISTORICAL: "The Second Republic"
- RULE_OPTION_ITA_HISTORICAL_DESC: "Power alternates between the §CWestern§! centre-left and centre-right, and Italy stays anchored in NATO and the European Union. The AI spends the game on the mafia, the debt, the southern question and its own administration rather than on its borders."
+ ITA_AI_BEHAVIOR_MD: "@ITA Italy"
+ RULE_OPTION_ITA_HISTORICAL: "Historical"
+ RULE_OPTION_ITA_HISTORICAL_DESC: "Power alternates between the §8Partito Democratico§! and the §8Forza Italia§! bloc, and Italy stays anchored in NATO and the European Union. Its governments spend themselves on organised crime, public debt, the southern question and their own administration rather than on the country's borders."
  RULE_OPTION_ITA_ROMAN_RESTORATION: "Restoration of the Roman Empire"
- RULE_OPTION_ITA_ROMAN_RESTORATION_DESC: "A §8national-populist§! movement grows until it carries an election, dissolves parliament and crowns an emperor over a restored Rome. The AI then claims the old provinces one by one, from the African coast to Britannia."
+ RULE_OPTION_ITA_ROMAN_RESTORATION_DESC: "§8Fratelli d'Italia§! and the national right grow until they carry an election, dissolve parliament and crown an emperor over a restored Rome. Italy then claims the old imperial provinces one by one, from the African coast to Britannia."
  RULE_OPTION_ITA_MARCH_ON_ROME: "A Second March on Rome"
  RULE_OPTION_ITA_MARCH_ON_ROME_DESC: "The same movement takes power but keeps the republic, installing a §8fascist§! government in Rome. Italy presses its irredentist claims on the Adriatic and the Alps without reaching for the empire."
  RULE_OPTION_ITA_EASTERN_TURN: "Turn to the East"
- RULE_OPTION_ITA_EASTERN_TURN_DESC: "The §GItalian left§! rebuilds itself around the old communist parties and pulls the country out of NATO. Italy courts Moscow and Beijing and seeks a place in the Shanghai Cooperation Organisation."
+ RULE_OPTION_ITA_EASTERN_TURN_DESC: "§8Rifondazione Comunista§! and the §8Partito dei Comunisti Italiani§! rebuild the Italian left and pull the country out of NATO. Italy courts Moscow and Beijing and seeks a place in the Shanghai Cooperation Organisation."
 
  #Taiwan
  ROC_AI_BEHAVIOR: "@TAI Republic of China"

--- a/tools/analysis/ai_path_report.py
+++ b/tools/analysis/ai_path_report.py
@@ -61,7 +61,7 @@ BOOKMARK_DATES = ((2016, 1, 2), (2017, 1, 1))
 TIMELINE_MIN_DATES = 3
 DAYS_PER_MONTH = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
 
-_STATEMENT = re.compile(r"([A-Za-z_][A-Za-z0-9_.:]*)\s*=\s*")
+_STATEMENT = re.compile(r"([A-Za-z_][A-Za-z0-9_.:]*)\s*[=<>]\s*")
 _FOCUS_START = re.compile(r"^[ \t]*(focus|shared_focus|joint_focus)\s*=\s*\{", re.M)
 _ID_LINE = re.compile(r"^[ \t]*id\s*=\s*(\S+)", re.M)
 _LOC_KEY = re.compile(r'^\s*([A-Za-z_][A-Za-z0-9_]*):\s*\d*\s*"(.*)"\s*$')

--- a/tools/tests/ai_path_report_test.py
+++ b/tools/tests/ai_path_report_test.py
@@ -30,6 +30,13 @@ class TestStatements:
         keys = [key for key, _, _ in report.iter_statements(body)]
         assert keys == ["a", "d"]
 
+    def test_comparison_operators_are_yielded(self):
+        body = "has_stability > 0.66 threat < 0.4"
+        assert list(report.iter_statements(body)) == [
+            ("has_stability", "0.66", None),
+            ("threat", "0.4", None),
+        ]
+
 
 class TestEvaluator:
     def test_flag_predicate(self):
@@ -45,6 +52,10 @@ class TestEvaluator:
 
     def test_unknown_trigger_never_counts_as_a_kill(self):
         expr = parse("has_government = democratic")
+        assert report.evaluate(expr, None, True, {}) is None
+
+    def test_comparison_only_body_never_counts_as_a_kill(self):
+        expr = parse("has_stability > 0.66")
         assert report.evaluate(expr, None, True, {}) is None
 
     def test_not_wrapped_flag_is_an_exemption(self):


### PR DESCRIPTION
## Summary

`ITA_ai_behavior` kept a pre-standard shape: tag-prefixed option names (`ITA_HISTORICAL`, …), a `RANDOM` option, `"The Second Republic"` where the historical option's text must read `Historical`, and `ITA_<PATH>_AI_FOCUS` flags.

That flag suffix made the tooling blind to Italy. `is_path_flag()` (`tools/analysis/ai_path_report.py:187`) and `is_path_modifier()` (`tools/standardization/apply_ai_path_weights.py:130`) both match only `_FOCUS_PATH`, so the report claimed *0 path flags, 0 owned / 470 path-neutral* for a tree carrying 367 path-flag references — none of its ownership, orphan or mutex analysis had ever run against the real tree.

## Changes

- **Flags** renamed `ITA_<PATH>_AI_FOCUS` → `ITA_<PATH>_FOCUS_PATH` across the focus tree, `ai_strategy/ITA.txt`, the strategy plans, the AI ramp decisions and its category.
- **Rule** rewritten to `HISTORICAL` / `ROMAN_RESTORATION` / `MARCH_ON_ROME` / `EASTERN_TURN` / `RANDOM_PATH`, with the existing `default = { name = NO_PATH }` last. The `RANDOM_PATH` bucket list already included the historical path and is unchanged (45/25/15/15).
- **Localisation**: header normalised to `@ITA Italy`, the historical option's text is now literally `Historical` with the Second Republic history moved into its `_desc`, `§8` highlighting corrected onto real party names, all four descs two sentences and about Italy rather than "the AI". `RANDOM_PATH` / `NO_PATH` use the shared `RULE_OPTION_MD_*` keys.
- **Scripted triggers**: eleven `ITA_ai_*_path` triggers. The historical spine now gates on `ITA_ai_historical_path` (which ORs `is_historical_focus_on = yes`), so it is boosted under `NO_PATH` with historical AI on instead of sitting unweighted.
- **Weights**: 186 focuses re-owned through `apply_ai_path_weights.py`, each group derived from the prerequisite graph rather than from the old modifiers. Every spine no option claims — the eight non-flagship party chains, the Savoy monarchy sub-tree, the Roman senate constitution, the separatist arm, the papal endpoint and the four democratic-restoration focuses — is now explicitly zeroed whenever a path is selected, instead of being stranded behind a dead parent.
- The three nationalist-path `visible` blocks in `common/decisions/Italy.txt` and the AI category's gate collapse onto the new triggers.

## Two bugs found on the way

- `ITA_classical_education` scored `base = 0` with an `add = 80` modifier — it could never beat its mutex sibling's `base = 120`, so the whole six-focus classical-education chain was dead for the AI. Now `base = 80` with a multiplicative statalist bonus, preserving the original intent.
- `ai_path_report.py`'s statement regex only matched `key =`, so a modifier whose body was a lone `has_stability > 0.66` parsed to an empty `AND` and evaluated `TRUE` — inventing five phantom killswitches and ten phantom orphans. Widened to `[=<>]` so comparisons parse to UNKNOWN, with two regression tests.

## Deliberately not done

- **No historical government walker.** The report verdicts an *undated successor roster*: fifteen sub-ideologies, zero dated entries. The existing AI ramp decisions already deliver the party, and a walker over an undated roster would install the wrong person.
- **No per-tag war brake.** `MD_avoid_new_wars_while_losing` (`common/ai_strategy/MD_war_declaration_ai.txt:30`) already fires on exactly the `surrender_progress > 0.15` gate an `ITA_cancel_war_*` block would use, so a per-tag copy would be dead code.
- **No new path options.** The unclaimed spines were each checked: neutrality is three focuses, the separatist arm tag-switches Italy out of existence, and `ITA_seize_power` hands most of the country to rebels. They stay unclaimed and zeroed in every plan.

## Verification

| Check | Result |
| --- | --- |
| `ai_path_report.py --tag ITA` | rule/wiring **clean**; **0 orphans, 0 stranded in all ten states**; 0 path-relevant mutex ties; no additive path modifiers; no unused flags |
| `validate_focus_tree.py --path .` | no issues |
| `validate_decisions.py` | 283 errors / 458 warnings — unchanged from the pre-change baseline |
| `python -m pytest` | no new failures; the four remaining are pre-existing Windows symlink-privilege and Pillow environment failures, identical on `main` |
| `precommit_validate.py` | all eight validators ok |
| `ruff` / `black` | clean |

Part of #3162.
