### PR TITLE
Keep Putin at the head of United Russia until the ladder passes him

### DIFF
--- a/common/scripted_effects/SOV_political_leaders.txt
+++ b/common/scripted_effects/SOV_political_leaders.txt
@@ -773,6 +773,11 @@ set_leader_SOV = {
 	else_if = { limit = { has_country_flag = set_Conservative }
 		if = { limit = { check_variable = { Conservative_leader = 0 } }
 			add_to_variable = { Conservative_leader = 1 }
+			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Conservative_leader = 1 } }
+			set_temp_variable = { b = 1 }
+		}
+		if = { limit = { check_variable = { Conservative_leader = 1 } NOT = { check_variable = { b = 1 } } }
+			add_to_variable = { Conservative_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
@@ -787,7 +792,7 @@ set_leader_SOV = {
 			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Conservative_leader = 1 } }
 			set_temp_variable = { b = 1 }
 		}
-		if = { limit = { check_variable = { Conservative_leader = 1 } NOT = { check_variable = { b = 1 } } }
+		if = { limit = { check_variable = { Conservative_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Conservative_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 
@@ -803,7 +808,7 @@ set_leader_SOV = {
 			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Conservative_leader = 1 } }
 			set_temp_variable = { b = 1 }
 		}
-		if = { limit = { check_variable = { Conservative_leader = 2 } NOT = { check_variable = { b = 1 } } }
+		if = { limit = { check_variable = { Conservative_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Conservative_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 
@@ -819,7 +824,7 @@ set_leader_SOV = {
 			if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = { Conservative_leader = 1 } }
 			set_temp_variable = { b = 1 }
 		}
-		if = { limit = { check_variable = { Conservative_leader = 3 } NOT = { check_variable = { b = 1 } } }
+		if = { limit = { check_variable = { Conservative_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Conservative_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 


### PR DESCRIPTION
### The bug

Reported from a 2000-start game: on 10 April 2004 Putin was replaced by an unfamiliar leader, with no change of government.

Traced against the save either side of the election. The election itself was correct — United Russia won on 55.0 percent against 32.4, `ruling_party` stayed `6`, `max_index_1` was `6`, and the election array was properly threshold-filtered. Nothing was voted out.

What happened is in the succession ladder:

1. United Russia wins, so `set_ruling_leader` raises `set_Conservative`
2. `set_leader_SOV` reads rung 0 of the Conservative ladder
3. Rung 0 was **Vyacheslav Volodin**, and Putin was not on the list at all
4. `kill_country_leader` then `create_country_leader` — the authored Putin, character 5157, is destroyed and a new character is created in his place

So the first election United Russia ever won removed Putin regardless of the result. In a 2000 start that is the March 2004 election, which he won with 71 percent, and he served until 2008.

### Changes

- Rung 0 keeps the leader already in place and only advances the counter, so Volodin follows Putin rather than replacing him
- The four existing rungs move up one: Volodin, Medvedev, Dyumin, Poklonskaya

Rung 0 deliberately does not recreate Putin. He is authored in `history/countries/SOV - Russia.txt` with `expire = "2028.3.1"` and six traits, none of which a `create_country_leader` copy would carry.

Volodin's block was written first and therefore had no `NOT = { check_variable = { b = 1 } }` guard. It needs one now that a rung runs ahead of it, or it fires in the same pass and kills Putin anyway.

### On `do_not_retire`

I first read the ladders' trailing `if = { limit = { has_country_flag = do_not_retire } subtract_from_variable = ... }` as a broken guard, on the theory that it is raised whenever a ruling party is re-elected. It is not. `change_ruling_party_effect` raises it only when `change_leader_temp = 1`, which focus trees and on_actions set deliberately, and which the election path never sets — the save from the game that prompted this carries no such flag. Content wraps it around specific operations in paired set/clear blocks, for instance South Korea's `disable_elections_with_no_leader_change` and Romania's forced `set_politics`, where the intent is that the rung is not consumed.

So the ladders are behaving as designed and nothing mod-wide needs changing here. Russia's fault was only that Putin was absent from his own party's ladder.
