### PR TITLE
Optimize USA resource prospecting checks

### DIFF
--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -16,15 +16,9 @@ USA_american_economic_decisions_category = {
 				tooltip = USA_has_wall_street_faction_TT
 				has_idea = wall_street
 			}
-			any_owned_state = {
-				has_resources_amount = {
-					resource = steel
-					amount > 5
-				}
-				custom_trigger_tooltip = {
-					tooltip = USA_not_expanded_states_resources_three_times_TT
-					check_variable = { USA_steel_expansion_count < 3 }
-				}
+			custom_trigger_tooltip = {
+				tooltip = USA_not_expanded_states_resources_three_times_TT
+				check_variable = { USA_can_expand_steel_resources = 1 }
 			}
 			congress_low_support_trigger = yes
 		}
@@ -94,15 +88,9 @@ USA_american_economic_decisions_category = {
 				tooltip = USA_has_wall_street_faction_TT
 				has_idea = wall_street
 			}
-			any_owned_state = {
-				has_resources_amount = {
-					resource = aluminium
-					amount > 4
-				}
-				custom_trigger_tooltip = {
-					tooltip = USA_not_expanded_states_resources_three_times_TT
-					check_variable = { USA_aluminium_expansion_count < 3 }
-				}
+			custom_trigger_tooltip = {
+				tooltip = USA_not_expanded_states_resources_three_times_TT
+				check_variable = { USA_can_expand_aluminium_resources = 1 }
 			}
 		}
 
@@ -170,15 +158,9 @@ USA_american_economic_decisions_category = {
 				tooltip = USA_has_wall_street_faction_TT
 				has_idea = wall_street
 			}
-			any_owned_state = {
-				has_resources_amount = {
-					resource = tungsten
-					amount > 4
-				}
-				custom_trigger_tooltip = {
-					tooltip = USA_not_expanded_states_resources_three_times_TT
-					check_variable = { USA_tungsten_expansion_count < 3 }
-				}
+			custom_trigger_tooltip = {
+				tooltip = USA_not_expanded_states_resources_three_times_TT
+				check_variable = { USA_can_expand_tungsten_resources = 1 }
 			}
 		}
 

--- a/common/on_actions/99_USA_on_actions.txt
+++ b/common/on_actions/99_USA_on_actions.txt
@@ -7,6 +7,45 @@ on_actions = {
 			150 = wot.22
 		}
 		effect = {
+			set_variable = { USA_can_expand_steel_resources = 0 }
+			set_variable = { USA_can_expand_aluminium_resources = 0 }
+			set_variable = { USA_can_expand_tungsten_resources = 0 }
+			every_owned_state = {
+				if = {
+					limit = {
+						ROOT = { check_variable = { USA_can_expand_steel_resources = 0 } }
+						has_resources_amount = {
+							resource = steel
+							amount > 5
+						}
+						check_variable = { USA_steel_expansion_count < 3 }
+					}
+					ROOT = { set_variable = { USA_can_expand_steel_resources = 1 } }
+				}
+				if = {
+					limit = {
+						ROOT = { check_variable = { USA_can_expand_aluminium_resources = 0 } }
+						has_resources_amount = {
+							resource = aluminium
+							amount > 4
+						}
+						check_variable = { USA_aluminium_expansion_count < 3 }
+					}
+					ROOT = { set_variable = { USA_can_expand_aluminium_resources = 1 } }
+				}
+				if = {
+					limit = {
+						ROOT = { check_variable = { USA_can_expand_tungsten_resources = 0 } }
+						has_resources_amount = {
+							resource = tungsten
+							amount > 4
+						}
+						check_variable = { USA_tungsten_expansion_count < 3 }
+					}
+					ROOT = { set_variable = { USA_can_expand_tungsten_resources = 1 } }
+				}
+			}
+
 			# The shelterer can be annexed with bin Laden still at large; without this the manhunt stalls forever
 			if = {
 				limit = {


### PR DESCRIPTION
## Bottom line
Cache USA resource-prospecting eligibility weekly, replacing three every-tick owned-state scans with country-variable checks.

## Why
The aluminium availability trigger measured 2.488 ms across 10 calls. Steel and tungsten used the same pattern.

## How
One `on_weekly_USA` pass refreshes the exact state eligibility for steel, aluminium, and tungsten. Completion retains its state-level validation.

Closes #3302

BLUF