### PR TITLE
Reconnect two broken idea ladders

### DIFF
--- a/common/national_focus/05_sweden.txt
+++ b/common/national_focus/05_sweden.txt
@@ -16037,8 +16037,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SWE_kungliga"
 			swap_ideas = {
-				remove_idea = SWE_the_royals3
-				add_idea = SWE_the_royals4
+				remove_idea = SWE_the_royals4
+				add_idea = SWE_the_royals5
 			}
 		}
 

--- a/common/national_focus/Khanti-mansi.txt
+++ b/common/national_focus/Khanti-mansi.txt
@@ -1302,8 +1302,8 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 10 }
 			change_labour_unions_opinion = yes
 			swap_ideas = {
-				remove_idea = KHM_commies2
-				add_idea = KHM_commies3
+				remove_idea = KHM_commies1
+				add_idea = KHM_commies2
 			}
 		}
 


### PR DESCRIPTION
### The bug

Two focus trees have an idea ladder with a missing rung, so tiers that are fully authored can never be reached. Both were found by the same sweep and have the same shape: one focus repeats a swap its own prerequisite already performed, and the rung that should have advanced the ladder is absent.

**Sweden.** `SWE_kungliga` carries the same swap as `SWE_royal_council` — remove `SWE_the_royals3`, add `SWE_the_royals4` — and lists `SWE_royal_council` as a prerequisite, so it finds nothing to remove. Nothing else grants `SWE_the_royals5`, so the swaps beyond it are dead too.

| Swap | Before |
| --- | --- |
| `SWE_the_royals` → `2` → `3` → `4` | works |
| `3` → `4` again, in `SWE_kungliga` | **no-op** |
| `5` → `6`, `6` → `7` | **dead, royals5 never granted** |

**Khanti-Mansi.** `KHM_unions` advances `KHM_commies` to `KHM_commies1`, then `KHM_salary` and `KHM_housing` both remove `KHM_commies2` — and `KHM_housing` requires `KHM_salary`. Nothing moves a country from commies1 to commies2, and `KHM_commies2` is granted nowhere in the mod.

### Changes

- `SWE_kungliga` advances `SWE_the_royals4` to `SWE_the_royals5`
- `KHM_salary` advances `KHM_commies1` to `KHM_commies2`

Both restore the full run. The Khanti-Mansi order matches what the tree already enforces through its prerequisites: unions, salary, housing, then policies.

Between them that is six authored idea tiers — `SWE_the_royals5/6/7` and `KHM_commies2/3/4` — each with its own modifiers, that no playthrough could reach.

### How they were found

A sweep of all 3,209 `swap_ideas` removals across every focus tree for swaps whose removed idea a **mandatory prerequisite focus has already consumed**, with no `has_idea` guard. That is the shape of the Arms Against Tyranny branch of `HOL_asml_dutch_technological_dominance`, which #3390 had to fix, and the sweep rediscovers that one independently.

Eleven candidates came out. Nine are harmless and deliberately left alone: Belarus, Hezbollah's recon focus and Bosnia pair a dead swap with a second that does the real work; the Dutch financial sector and Rosatom ones are redundant but strand nothing, since no further tier exists; the rest sit behind `has_idea` guards. Only these two leave authored content unreachable.