### PR TITLE
Route the compare fallback through the ImageMagick resolver

### DIFF
--- a/docs/src/content/resources/art-standards.md
+++ b/docs/src/content/resources/art-standards.md
@@ -72,7 +72,7 @@ DO NOT: GFX_Germany_Icon_Name
 
 ## Converting
 
-`tools/assets/md_art_convert.py` writes the formats above so you don’t have to remember the flags. It needs ImageMagick on PATH.
+`tools/assets/md_art_convert.py` writes the formats above so you don’t have to remember the flags. It needs ImageMagick on PATH; on Windows install ImageMagick 7, since the `convert` already on PATH there is the NTFS conversion utility rather than ImageMagick.
 
 ```bash
 # Event pictures, 217x163 for a country event or 397x153 for a news event

--- a/tools/assets/md_art_convert.py
+++ b/tools/assets/md_art_convert.py
@@ -111,7 +111,7 @@ def pixels_match(a: Path, b: Path) -> bool:
     if Path(argv[0]).stem.lower() == "magick":
         argv.append("compare")
     else:
-        argv = [shutil.which("compare") or "compare"]
+        argv = [_which_imagemagick("compare")]
     result = subprocess.run(
         argv + ["-metric", "AE", str(a), str(b), "null:"],
         capture_output=True,

--- a/tools/tests/assets_coverage_test.py
+++ b/tools/tests/assets_coverage_test.py
@@ -177,6 +177,17 @@ def test_pixels_match_uses_compare_binary(monkeypatch):
     assert recorded["argv"][0] == "/usr/bin/compare"
 
 
+def test_pixels_match_names_imagemagick_when_compare_is_missing(monkeypatch):
+    _trust_resolved_binaries(monkeypatch)
+    monkeypatch.setattr(
+        md_art_convert.shutil,
+        "which",
+        lambda name: "/usr/bin/convert" if name == "convert" else None,
+    )
+    with pytest.raises(SystemExit, match="ImageMagick not found"):
+        md_art_convert.pixels_match(Path("a.png"), Path("b.png"))
+
+
 def test_fixed_size_counts_a_verify_mismatch(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(md_art_convert, "image_size", lambda _path: (2, 2))
     monkeypatch.setattr(md_art_convert, "write_dds", lambda *_args, **_kwargs: None)


### PR DESCRIPTION
### Changes

Follow-up to #3438, which moved `imagemagick()` and `image_size()` onto `_which_imagemagick` so a missing or counterfeit binary exits naming ImageMagick instead of raising a bare `TypeError` out of `pathlib`. One call site was missed.

`pixels_match` still resolves the standalone comparator by hand:

```python
argv = [shutil.which("compare") or "compare"]
```

That else-branch runs whenever the resolver settled on the legacy `convert` rather than `magick`. Two problems, both the ones #3438 set out to remove:

- With no `compare` on PATH the `or "compare"` fallback hands `subprocess` a bare string, so the verify step dies with `FileNotFoundError: [WinError 2]` — the same "looks like a code bug, never mentions the dependency" failure #3438 fixed elsewhere.
- It is the last lookup that skips the `-version` probe, so a `compare` that is not ImageMagick gets driven anyway. On Windows the `convert` shadowing that motivated the probe is the well-known case, but the probe exists precisely because a name on PATH proves nothing.

Routing it through `_which_imagemagick("compare")` fixes both and drops the hand-rolled lookup.

`--no-verify` is not a workaround here: verification is on by default and is what stops a bad conversion reaching the branch.

**Also:** one sentence in `docs/src/content/resources/art-standards.md` telling Windows contributors to install ImageMagick 7, since the `convert` already on their PATH is the NTFS conversion utility.

### Testing

`test_pixels_match_names_imagemagick_when_compare_is_missing` covers the branch: a real `convert`, no `compare`, expect `SystemExit` naming ImageMagick. It fails on `main` with `FileNotFoundError`.

- `python -m pytest` — 4162 passed, 8 skipped
- `python -m black tools/...` and `python -m ruff check tools` — clean

Verified on Windows without ImageMagick installed, which is what surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
