### PR TITLE
Fix border conflict claim progress cleanup

### DIFF
--- a/common/scripted_effects/99_RAJ_scripted_effects.txt
+++ b/common/scripted_effects/99_RAJ_scripted_effects.txt
@@ -932,6 +932,7 @@ raj_chi_border_change_objective_progress = {
 }
 
 pak_raj_border_finish_outcome = {
+	clear_variable = pak_raj_border_objective_state
 	if = {
 		limit = {
 			NOT = { RAJ = { check_variable = { pak_raj_border_objective_state > 0 } } }
@@ -939,11 +940,10 @@ pak_raj_border_finish_outcome = {
 		}
 		clr_global_flag = GLOBAL_pak_raj_border_war_active
 	}
-	RAJ = { clear_variable = pak_raj_border_objective_state }
-	PAK = { clear_variable = pak_raj_border_objective_state }
 }
 
 raj_chi_border_finish_outcome = {
+	clear_variable = raj_chi_border_objective_state
 	if = {
 		limit = {
 			NOT = { RAJ = { check_variable = { raj_chi_border_objective_state > 0 } } }
@@ -951,8 +951,6 @@ raj_chi_border_finish_outcome = {
 		}
 		clr_global_flag = GLOBAL_raj_chi_border_war_active
 	}
-	RAJ = { clear_variable = raj_chi_border_objective_state }
-	CHI = { clear_variable = raj_chi_border_objective_state }
 }
 
 pak_raj_border_begin_claim = {


### PR DESCRIPTION
Closes #3471

**What**
- Preserve each participant's border-war objective until its own outcome resolves.
- Apply the correction to both Indo-Pakistani and Sino-Indian border conflicts.

**Why**
The first country to resolve an outcome cleared both objective-state variables. When the AI opponent resolved first, the player's later outcome had no target state, so the advertised claim-progress change was not applied.

**How**
Each finish helper now clears only the current country's objective, then removes the shared active flag after neither participant retains an objective.