### PR TITLE
Give Japan a five-path country AI path game rule (#3162)

### DIFF
--- a/common/ai_strategy/JAP.txt
+++ b/common/ai_strategy/JAP.txt
@@ -88,7 +88,7 @@ JAP_no_war_if_at_war = {
 JAP_historical_no_offensive_wars = {
 	allowed = { original_tag = JAP }
 	enable = {
-		has_global_flag = JAP_HISTORICAL_AI_FOCUS
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 		has_war = no
 	}
 	abort_when_not_enabled = yes
@@ -178,7 +178,7 @@ JAP_empire_naval_breakdown = {
 JAP_empire_naval_arms_race_vs_CHI = {
 	allowed = { original_tag = JAP }
 	enable = {
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 		country_exists = CHI
 		naval_strength_ratio = { tag = CHI ratio < 1.2 }
 	}
@@ -191,7 +191,7 @@ JAP_empire_naval_arms_race_vs_CHI = {
 JAP_empire_naval_arms_race_vs_USA = {
 	allowed = { original_tag = JAP }
 	enable = {
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 		country_exists = USA
 		naval_strength_ratio = { tag = CHI ratio > 1.2 }
 		naval_strength_ratio = { tag = USA ratio < 1.5 }
@@ -205,7 +205,7 @@ JAP_empire_naval_arms_race_vs_USA = {
 JAP_empire_industrial_base = {
 	allowed = { original_tag = JAP }
 	enable = {
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 		has_completed_focus = JAP_formalize_national_defense
 	}
 	abort_when_not_enabled = yes
@@ -462,4 +462,30 @@ JAP_empire_blitz_china = {
 
 	ai_strategy = { type = invade id = "CHI" value = 400 }
 	ai_strategy = { type = conquer id = "CHI" value = 400 }
+}
+
+JAP_hold_off_new_wars_while_losing = {
+	allowed = { original_tag = JAP }
+	enable = {
+		has_war = yes
+		surrender_progress > 0.15
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = { type = declare_war id = "CHI" value = -4000 }
+	ai_strategy = { type = declare_war id = "NKO" value = -4000 }
+	ai_strategy = { type = declare_war id = "KOR" value = -4000 }
+	ai_strategy = { type = declare_war id = "TAI" value = -4000 }
+	ai_strategy = { type = declare_war id = "AST" value = -4000 }
+	ai_strategy = { type = declare_war id = "NZL" value = -4000 }
+	ai_strategy = { type = declare_war id = "PHI" value = -4000 }
+	ai_strategy = { type = declare_war id = "MAY" value = -4000 }
+	ai_strategy = { type = declare_war id = "IND" value = -4000 }
+	ai_strategy = { type = declare_war id = "VIE" value = -4000 }
+	ai_strategy = { type = declare_war id = "CBD" value = -4000 }
+	ai_strategy = { type = declare_war id = "LAO" value = -4000 }
+	ai_strategy = { type = declare_war id = "BRM" value = -4000 }
+	ai_strategy = { type = declare_war id = "SOV" value = -4000 }
+	ai_strategy = { type = declare_war id = "RAJ" value = -4000 }
+	ai_strategy = { type = declare_war id = "SIN" value = -4000 }
 }

--- a/common/ai_strategy/JAP.txt
+++ b/common/ai_strategy/JAP.txt
@@ -88,7 +88,8 @@ JAP_no_war_if_at_war = {
 JAP_historical_no_offensive_wars = {
 	allowed = { original_tag = JAP }
 	enable = {
-		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		JAP_ai_historical_path = yes
+		JAP_ai_not_historical_path = no
 		has_war = no
 	}
 	abort_when_not_enabled = yes
@@ -219,6 +220,7 @@ JAP_empire_indochina = {
 	allowed = { original_tag = JAP }
 	enable = {
 		has_completed_focus = JAP_reclaim_indochina
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -237,6 +239,7 @@ JAP_empire_myanmar = {
 	allowed = { original_tag = JAP }
 	enable = {
 		has_completed_focus = JAP_reclaim_myanmar
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -253,6 +256,7 @@ JAP_empire_pacific_islands = {
 	allowed = { original_tag = JAP }
 	enable = {
 		has_completed_focus = JAP_reclaim_the_pacific
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -275,6 +279,7 @@ JAP_empire_south_china_sea = {
 	allowed = { original_tag = JAP }
 	enable = {
 		has_completed_focus = JAP_reclaim_south_chinese_sea
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -295,6 +300,7 @@ JAP_empire_korea = {
 			has_completed_focus = JAP_reclaim_north_korea
 			has_completed_focus = JAP_reclaim_south_korea
 		}
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -308,6 +314,7 @@ JAP_empire_australia = {
 	allowed = { original_tag = JAP }
 	enable = {
 		has_completed_focus = JAP_reclaim_australia
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -321,6 +328,7 @@ JAP_empire_taiwan = {
 	allowed = { original_tag = JAP }
 	enable = {
 		has_completed_focus = JAP_reclaim_taiwan
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -333,6 +341,7 @@ JAP_empire_china = {
 	enable = {
 		has_completed_focus = JAP_fight_china_again
 		naval_strength_ratio = { tag = CHI ratio > 1.5 }
+		NOT = { surrender_progress > 0.15 }
 	}
 	abort_when_not_enabled = yes
 
@@ -462,30 +471,4 @@ JAP_empire_blitz_china = {
 
 	ai_strategy = { type = invade id = "CHI" value = 400 }
 	ai_strategy = { type = conquer id = "CHI" value = 400 }
-}
-
-JAP_hold_off_new_wars_while_losing = {
-	allowed = { original_tag = JAP }
-	enable = {
-		has_war = yes
-		surrender_progress > 0.15
-	}
-	abort_when_not_enabled = yes
-
-	ai_strategy = { type = declare_war id = "CHI" value = -4000 }
-	ai_strategy = { type = declare_war id = "NKO" value = -4000 }
-	ai_strategy = { type = declare_war id = "KOR" value = -4000 }
-	ai_strategy = { type = declare_war id = "TAI" value = -4000 }
-	ai_strategy = { type = declare_war id = "AST" value = -4000 }
-	ai_strategy = { type = declare_war id = "NZL" value = -4000 }
-	ai_strategy = { type = declare_war id = "PHI" value = -4000 }
-	ai_strategy = { type = declare_war id = "MAY" value = -4000 }
-	ai_strategy = { type = declare_war id = "IND" value = -4000 }
-	ai_strategy = { type = declare_war id = "VIE" value = -4000 }
-	ai_strategy = { type = declare_war id = "CBD" value = -4000 }
-	ai_strategy = { type = declare_war id = "LAO" value = -4000 }
-	ai_strategy = { type = declare_war id = "BRM" value = -4000 }
-	ai_strategy = { type = declare_war id = "SOV" value = -4000 }
-	ai_strategy = { type = declare_war id = "RAJ" value = -4000 }
-	ai_strategy = { type = declare_war id = "SIN" value = -4000 }
 }

--- a/common/ai_strategy_plans/JAP_strategy_plans.txt
+++ b/common/ai_strategy_plans/JAP_strategy_plans.txt
@@ -4,11 +4,8 @@ JAP_HISTORICAL_plan = {
 	desc = "US-anchored alliance, export economy, Article Nine reinterpreted but never rewritten"
 
 	enable = {
-		OR = {
-			is_historical_focus_on = yes
-			has_global_flag = JAP_HISTORICAL_AI_FOCUS
-		}
-		NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+		JAP_ai_historical_path = yes
+		JAP_ai_not_historical_path = no
 	}
 
 	abort = {
@@ -219,32 +216,7 @@ JAP_HISTORICAL_plan = {
 	}
 
 	focus_factors = {
-		JAP_restore_imperial_household = 0
-		JAP_reinstate_former_imperial_houses = 0
-		JAP_male_line_succession_act = 0
-
-		JAP_left = 0
-		JAP_principle_of_no_armed_forces = 0
-		JAP_abrogating_us_japan_security_treaty = 0
 		JAP_dissolving_sdf = 0
-		JAP_exclusive_defense = 0
-
-		JAP_forced_mergers = 0
-		JAP_active_public_investment = 0
-		JAP_japan_belongs_to_the_japanese = 0
-		JAP_open_japan = 0
-		JAP_career_first_model = 0
-		JAP_cultural_change = 0
-		JAP_keiretsu_pact = 0
-		JAP_cool_japan_doctrine = 0
-		JAP_nuclear_phaseout = 0
-		JAP_revitalize_rural_communities = 0
-		JAP_keiretsu_supplier_network = 0
-		JAP_hydrogen_society = 0
-		JAP_station_city_model = 0
-		JAP_foundry_partnership = 0
-		JAP_away_dependence = 0
-		JAP_dprk_conditional_engagement = 0
 	}
 
 	ai_strategy = {
@@ -329,7 +301,7 @@ JAP_FOCUS_MONARCHY = {
 	desc = "The imperial household is restored and Japan reclaims its place in East Asia"
 
 	enable = {
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 	}
 
 	abort = {
@@ -576,44 +548,7 @@ JAP_FOCUS_MONARCHY = {
 	}
 
 	focus_factors = {
-		JAP_left = 0
-		JAP_principle_of_no_armed_forces = 0
-		JAP_abrogating_us_japan_security_treaty = 0
 		JAP_dissolving_sdf = 0
-		JAP_exclusive_defense = 0
-		JAP_leading_disarmament = 0
-		JAP_restricting_arms_exports = 0
-
-		JAP_imperial_audience = 0
-
-		JAP_controlled_downsize = 0
-		JAP_complete_downsizing = 0
-		JAP_corporate_laws = 0
-		JAP_cultural_change = 0
-		JAP_womenomics = 0
-		JAP_open_japan = 0
-		JAP_multicultural_society = 0
-		JAP_guest_worker_system = 0
-		JAP_state_family_mandate = 0
-		JAP_family_first_model = 0
-		JAP_career_first_model = 0
-		JAP_active_public_investment = 0
-		JAP_cool_japan_doctrine = 0
-		JAP_foundry_partnership = 0
-		JAP_nuclear_phaseout = 0
-		JAP_hydrogen_society = 0
-		JAP_keiretsu_supplier_network = 0
-		JAP_revitalize_rural_communities = 0
-		JAP_regional_line_preservation = 0
-
-		JAP_dprk_conditional_engagement = 0
-		JAP_dprk_normalization_framework = 0
-		JAP_dprk_support_unification = 0
-		JAP_friendship_asean = 0
-		JAP_informal_cooperation = 0
-		JAP_history_education = 0
-		JAP_approaching_russia = 0
-		JAP_enhancement_exercises = 0
 	}
 
 	ai_strategy = {
@@ -704,6 +639,304 @@ JAP_FOCUS_MONARCHY = {
 	ai_strategy = {
 		type = force_build_armies
 		value = 100
+	}
+
+	weight = {
+		factor = 1.0
+	}
+}
+
+JAP_NORMAL_NATION_plan = {
+	allowed = { original_tag = JAP }
+	name = "A Normal Nation"
+	desc = "Article Nine is rewritten and the Self-Defense Forces become a standing military inside the American alliance"
+
+	enable = {
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+	}
+
+	abort = {
+		is_subject = yes
+	}
+
+	focus_factors = {
+		JAP_dissolving_sdf = 0
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = USA
+		value = 200
+	}
+	ai_strategy = {
+		type = befriend
+		id = KOR
+		value = 90
+	}
+	ai_strategy = {
+		type = befriend
+		id = AST
+		value = 70
+	}
+	ai_strategy = {
+		type = befriend
+		id = TAI
+		value = 60
+	}
+	ai_strategy = {
+		type = befriend
+		id = PHI
+		value = 50
+	}
+	ai_strategy = {
+		type = befriend
+		id = IND
+		value = 40
+	}
+	ai_strategy = {
+		type = antagonize
+		id = NKO
+		value = 80
+	}
+	ai_strategy = {
+		type = antagonize
+		id = CHI
+		value = 50
+	}
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 60
+	}
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 50
+	}
+	ai_strategy = {
+		type = building_target
+		id = dockyard
+		value = 50
+	}
+	ai_strategy = {
+		type = building_target
+		id = microchip_plant
+		value = 50
+	}
+	ai_strategy = {
+		type = building_target
+		id = nuclear_reactor
+		value = 20
+	}
+
+	weight = {
+		factor = 1.0
+	}
+}
+
+JAP_SOCIAL_DEMOCRACY_plan = {
+	allowed = { original_tag = JAP }
+	name = "The Second Postwar"
+	desc = "The opposition governs on disclosure, labour law and an open door while the alliance holds"
+
+	enable = {
+		has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+	}
+
+	abort = {
+		is_subject = yes
+	}
+
+	focus_factors = {
+		JAP_dissolving_sdf = 0
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = USA
+		value = 150
+	}
+	ai_strategy = {
+		type = befriend
+		id = KOR
+		value = 110
+	}
+	ai_strategy = {
+		type = befriend
+		id = CHI
+		value = 70
+	}
+	ai_strategy = {
+		type = befriend
+		id = PHI
+		value = 50
+	}
+	ai_strategy = {
+		type = befriend
+		id = VIE
+		value = 40
+	}
+	ai_strategy = {
+		type = befriend
+		id = IND
+		value = 40
+	}
+	ai_strategy = {
+		type = antagonize
+		id = NKO
+		value = 30
+	}
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 70
+	}
+	ai_strategy = {
+		type = building_target
+		id = microchip_plant
+		value = 60
+	}
+	ai_strategy = {
+		type = building_target
+		id = dockyard
+		value = 20
+	}
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 10
+	}
+
+	weight = {
+		factor = 1.0
+	}
+}
+
+JAP_PACIFIST_plan = {
+	allowed = { original_tag = JAP }
+	name = "The Peace Constitution"
+	desc = "Article Nine is taken literally, the bases close and Japan disarms"
+
+	enable = {
+		has_global_flag = JAP_PACIFIST_FOCUS_PATH
+	}
+
+	abort = {
+		is_subject = yes
+	}
+
+	focus_factors = {
+		JAP_dissolving_sdf = 0
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = KOR
+		value = 120
+	}
+	ai_strategy = {
+		type = befriend
+		id = CHI
+		value = 100
+	}
+	ai_strategy = {
+		type = befriend
+		id = NKO
+		value = 50
+	}
+	ai_strategy = {
+		type = befriend
+		id = VIE
+		value = 50
+	}
+	ai_strategy = {
+		type = befriend
+		id = PHI
+		value = 40
+	}
+	ai_strategy = {
+		type = befriend
+		id = IND
+		value = 40
+	}
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 80
+	}
+	ai_strategy = {
+		type = building_target
+		id = microchip_plant
+		value = 60
+	}
+	ai_strategy = {
+		type = building_target
+		id = nuclear_reactor
+		value = 5
+	}
+
+	weight = {
+		factor = 1.0
+	}
+}
+
+JAP_unscripted_plan = {
+	allowed = { original_tag = JAP }
+	name = "An Undirected Japan"
+	desc = "No scripted path is set, so Japan builds and befriends on general principles only"
+
+	enable = {
+		JAP_ai_historical_path = no
+		JAP_ai_not_historical_path = no
+	}
+
+	abort = {
+		is_subject = yes
+	}
+
+	focus_factors = {
+		JAP_dissolving_sdf = 0
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = USA
+		value = 120
+	}
+	ai_strategy = {
+		type = befriend
+		id = KOR
+		value = 60
+	}
+	ai_strategy = {
+		type = befriend
+		id = AST
+		value = 50
+	}
+	ai_strategy = {
+		type = befriend
+		id = PHI
+		value = 40
+	}
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 60
+	}
+	ai_strategy = {
+		type = building_target
+		id = microchip_plant
+		value = 50
+	}
+	ai_strategy = {
+		type = building_target
+		id = dockyard
+		value = 30
+	}
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 12
 	}
 
 	weight = {

--- a/common/decisions/05_japan.txt
+++ b/common/decisions/05_japan.txt
@@ -35,7 +35,7 @@ JAP_territorial_disputes = {
 
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -75,7 +75,7 @@ JAP_territorial_disputes = {
 
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -115,7 +115,7 @@ JAP_territorial_disputes = {
 
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -155,7 +155,7 @@ JAP_territorial_disputes = {
 
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -1402,11 +1402,11 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -1440,11 +1440,11 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -1476,11 +1476,11 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -1512,7 +1512,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1520,7 +1520,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1528,7 +1528,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1537,17 +1538,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1579,7 +1584,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1587,7 +1592,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1595,7 +1600,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1604,17 +1610,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1646,7 +1656,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1654,7 +1664,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1662,7 +1672,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1671,17 +1682,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1713,7 +1728,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1721,7 +1736,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1729,7 +1744,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1738,17 +1754,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1780,7 +1800,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1788,7 +1808,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1796,7 +1816,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1805,17 +1826,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1847,7 +1872,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1855,7 +1880,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1863,7 +1888,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1872,17 +1898,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1914,7 +1944,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1922,7 +1952,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1930,7 +1960,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -1939,17 +1970,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -1978,7 +2013,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -1986,7 +2021,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -1994,7 +2029,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2003,17 +2039,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2042,7 +2082,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2050,7 +2090,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2058,7 +2098,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2067,17 +2108,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2106,7 +2151,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2114,7 +2159,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2122,7 +2167,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2131,17 +2177,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2183,7 +2233,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2191,7 +2241,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2199,7 +2249,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2208,17 +2259,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2257,7 +2312,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2265,7 +2320,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2273,7 +2328,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2282,17 +2338,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2319,7 +2379,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2327,7 +2387,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2335,7 +2395,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2344,17 +2405,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2381,7 +2446,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2389,7 +2454,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2397,7 +2462,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2406,17 +2472,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2443,7 +2513,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2451,7 +2521,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2459,7 +2529,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2468,17 +2539,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2505,7 +2580,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2513,7 +2588,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2521,7 +2596,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2530,17 +2606,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2572,7 +2652,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2580,7 +2660,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2588,7 +2668,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2597,17 +2678,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2636,7 +2721,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2644,7 +2729,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2652,7 +2737,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2661,17 +2747,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2700,7 +2790,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2708,7 +2798,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2716,7 +2806,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2725,17 +2816,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -2764,7 +2859,7 @@ JAP_article_nine_balance_of_power_category = {
 			base = 10
 			modifier = {
 				add = 40
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < -0.20
@@ -2772,7 +2867,7 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				power_balance_value = {
 					id = JAP_article_nine
 					value < 0.20
@@ -2780,7 +2875,8 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
+				JAP_ai_rearmament_path = no
 				power_balance_value = {
 					id = JAP_article_nine
 					value > 0.55
@@ -2789,17 +2885,21 @@ JAP_article_nine_balance_of_power_category = {
 			}
 			modifier = {
 				add = 35
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				JAP_article_nine_hard_threat = yes
 			}
 			modifier = {
 				add = 20
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_restrained_defence_path = yes
 				has_war = yes
 			}
 			modifier = {
 				add = 60
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				JAP_ai_rearmament_path = yes
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = JAP_PACIFIST_FOCUS_PATH
 			}
 		}
 	}
@@ -3350,7 +3450,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3386,7 +3486,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3422,7 +3522,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3552,7 +3652,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3625,7 +3725,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3676,7 +3776,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3744,7 +3844,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3817,7 +3917,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3890,7 +3990,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 
@@ -3963,7 +4063,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4035,7 +4135,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4107,7 +4207,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4179,7 +4279,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4251,7 +4351,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4323,7 +4423,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4367,7 +4467,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4411,7 +4511,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4456,7 +4556,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4501,7 +4601,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4546,7 +4646,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4591,7 +4691,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4636,7 +4736,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4683,7 +4783,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4728,7 +4828,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4773,7 +4873,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4818,7 +4918,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4864,7 +4964,7 @@ JAP_military_decision_category = {
 			base = 1
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -4909,7 +5009,7 @@ JAP_military_decision_category = {
 			base = 0
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				naval_strength_ratio = { tag = USA ratio > 1.2 }
 			}
 		}
@@ -4951,7 +5051,7 @@ JAP_military_decision_category = {
 			base = 0
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				naval_strength_ratio = { tag = FRA ratio > 1.2 }
 			}
 		}
@@ -4989,7 +5089,7 @@ JAP_military_decision_category = {
 			base = 0
 			modifier = {
 				add = 30
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				naval_strength_ratio = { tag = ENG ratio > 1.2 }
 			}
 		}
@@ -6718,7 +6818,7 @@ JAP_zombie_investigation_category = {
 			base = 1
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_historical_path = yes
 				check_variable = { JAP_zombie_case_files < 10 }
 			}
 		}
@@ -7908,7 +8008,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -7963,7 +8067,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8018,7 +8126,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8077,7 +8189,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8136,7 +8252,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8195,7 +8315,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8254,7 +8378,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8313,7 +8441,11 @@ JAP_reactor_restart_category = {
 			base = 10
 			modifier = {
 				add = 15
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				JAP_ai_conservative_path = yes
+			}
+			modifier = {
+				factor = 0
+				JAP_ai_left_path = yes
 			}
 			modifier = {
 				factor = 0
@@ -8870,7 +9002,7 @@ JAP_ai_path_category = {
 
 		fire_only_once = yes
 
-		visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+		visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 
 		available = {
 			nationalist_monarchists_are_in_power = no
@@ -8896,7 +9028,7 @@ JAP_ai_path_category = {
 
 		days_re_enable = 30
 
-		visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+		visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 
 		available = {
 			nationalist_monarchists_are_in_power = no
@@ -8921,7 +9053,7 @@ JAP_ai_path_category = {
 
 		days_re_enable = 180
 
-		visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+		visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 
 		available = {
 			nationalist_monarchists_are_in_power = no
@@ -8933,6 +9065,105 @@ JAP_ai_path_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision JAP_restore_the_imperial_prerogative"
 			set_temp_variable = { rul_party_temp = 23 }
 			set_temp_variable = { disable_elections = 1 }
+			change_ruling_party_effect = yes
+			hidden_effect = { update_party_name = yes }
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	JAP_build_the_democratic_party = {
+		icon = GFX_decision_JAP_civic_faction
+
+		cost = 25
+
+		days_re_enable = 30
+
+		visible = { has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH }
+
+		available = {
+			western_liberals_are_in_power = no
+			check_variable = { party_pop_array^2 < 0.45 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_build_the_democratic_party"
+			set_temp_variable = { party_index = 2 }
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			change_relative_party_popularity = yes
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	JAP_democrats_take_the_diet = {
+		icon = GFX_decision_JAP_civic_faction
+
+		cost = 150
+
+		days_re_enable = 180
+
+		visible = { has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH }
+
+		available = {
+			western_liberals_are_in_power = no
+			has_civil_war = no
+			check_variable = { party_pop_array^2 > 0.4 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_democrats_take_the_diet"
+			set_temp_variable = { rul_party_temp = 2 }
+			change_ruling_party_effect = yes
+			hidden_effect = { update_party_name = yes }
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	JAP_build_the_social_democrats = {
+		icon = GFX_decision_JAP_civic_faction
+
+		cost = 25
+
+		days_re_enable = 30
+
+		visible = { has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+
+		available = {
+			neutrality_neutral_social_are_in_power = no
+			check_variable = { party_pop_array^18 < 0.35 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_build_the_social_democrats"
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			set_temp_variable = { temp_outlook_increase = 0.04 }
+			change_relative_party_popularity = yes
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	JAP_social_democrats_take_the_diet = {
+		icon = GFX_decision_JAP_civic_faction
+
+		cost = 150
+
+		days_re_enable = 180
+
+		visible = { has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+
+		available = {
+			neutrality_neutral_social_are_in_power = no
+			has_civil_war = no
+			check_variable = { party_pop_array^18 > 0.3 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision JAP_social_democrats_take_the_diet"
+			set_temp_variable = { rul_party_temp = 18 }
 			change_ruling_party_effect = yes
 			hidden_effect = { update_party_name = yes }
 		}

--- a/common/decisions/categories/99_JAP_decision_categories.txt
+++ b/common/decisions/categories/99_JAP_decision_categories.txt
@@ -164,5 +164,11 @@ JAP_ai_path_category = {
 	}
 	icon = GFX_decisions_category_political
 	priority = 100
-	visible = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+	visible = {
+		OR = {
+			has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+			has_global_flag = JAP_PACIFIST_FOCUS_PATH
+			has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+		}
+	}
 }

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -2968,19 +2968,34 @@ JAP_ai_behavior = {
 	name = "JAP_AI_BEHAVIOR"
 	group = "RULE_GROUP_AI_BEHAVIOR"
 	option = {
-		name = JAP_HISTORICAL
+		name = HISTORICAL
 		text = "RULE_OPTION_JAP_HISTORICAL"
 		desc = "RULE_OPTION_JAP_HISTORICAL_DESC"
 	}
 	option = {
-		name = JAP_RETURN_OF_THE_EMPIRE
+		name = NORMAL_NATION
+		text = "RULE_OPTION_JAP_NORMAL_NATION"
+		desc = "RULE_OPTION_JAP_NORMAL_NATION_DESC"
+	}
+	option = {
+		name = SOCIAL_DEMOCRACY
+		text = "RULE_OPTION_JAP_SOCIAL_DEMOCRACY"
+		desc = "RULE_OPTION_JAP_SOCIAL_DEMOCRACY_DESC"
+	}
+	option = {
+		name = PACIFIST
+		text = "RULE_OPTION_JAP_PACIFIST"
+		desc = "RULE_OPTION_JAP_PACIFIST_DESC"
+	}
+	option = {
+		name = RETURN_OF_THE_EMPIRE
 		text = "RULE_OPTION_JAP_RETURN_OF_THE_EMPIRE"
 		desc = "RULE_OPTION_JAP_RETURN_OF_THE_EMPIRE_DESC"
 	}
 	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
 	}
 	default = {
 		name = NO_PATH

--- a/common/national_focus/05_japan.txt
+++ b/common/national_focus/05_japan.txt
@@ -97,14 +97,8 @@ focus_tree = {
 					check_variable = { ruling_party = 20 }
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -135,7 +129,11 @@ focus_tree = {
 			add_dynamic_modifier = { modifier = JAP_transparency_and_audit_reform_modifier }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -170,7 +168,11 @@ focus_tree = {
 			add_to_variable = { JAP_transparency_and_audit_reform_tax_gain_multiplier_modifier = 0.03 tooltip = tax_gain_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -203,7 +205,11 @@ focus_tree = {
 			add_to_variable = { JAP_transparency_and_audit_reform_bureaucracy_cost_multiplier_modifier = -0.10 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -237,7 +243,11 @@ focus_tree = {
 			add_to_variable = { JAP_transparency_and_audit_reform_political_power_factor = 0.03 tooltip = political_power_factor_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -271,7 +281,11 @@ focus_tree = {
 			add_to_variable = { JAP_transparency_and_audit_reform_productivity_growth_modifier = 0.10 tooltip = productivity_growth_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -308,7 +322,11 @@ focus_tree = {
 			add_to_variable = { JAP_transparency_and_audit_reform_foreign_influence_defense_modifier = 0.05 tooltip = foreign_influence_defense_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -339,7 +357,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -373,7 +395,11 @@ focus_tree = {
 			add_to_variable = { JAP_protecting_human_rights_migration_rate_value_factor = 0.10 tooltip = migration_rate_value_factor_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -407,7 +433,11 @@ focus_tree = {
 			add_to_variable = { JAP_protecting_human_rights_productivity_growth_modifier = 0.10 tooltip = productivity_growth_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -441,7 +471,11 @@ focus_tree = {
 			add_to_variable = { JAP_protecting_human_rights_productivity_growth_modifier = 0.15 tooltip = productivity_growth_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -474,7 +508,11 @@ focus_tree = {
 			change_labour_unions_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -509,7 +547,11 @@ focus_tree = {
 			change_labour_unions_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -549,7 +591,11 @@ focus_tree = {
 			change_small_medium_business_owners_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -589,7 +635,11 @@ focus_tree = {
 			change_small_medium_business_owners_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -630,7 +680,11 @@ focus_tree = {
 			change_small_medium_business_owners_opinion = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -662,7 +716,11 @@ focus_tree = {
 			add_dynamic_modifier = { modifier = JAP_redistribution_modifier }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -699,7 +757,11 @@ focus_tree = {
 			add_to_variable = { JAP_redistribution_health_cost_multiplier_modifier = 0.05 tooltip = health_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -735,7 +797,11 @@ focus_tree = {
 			add_to_variable = { JAP_redistribution_health_cost_multiplier_modifier = 0.05 tooltip = health_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -771,7 +837,11 @@ focus_tree = {
 			add_to_variable = { JAP_redistribution_social_cost_multiplier_modifier = 0.05 tooltip = social_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -806,7 +876,11 @@ focus_tree = {
 			add_to_variable = { JAP_redistribution_education_cost_multiplier_modifier = 0.05 tooltip = education_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -837,10 +911,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_pacifist_path = yes }
 		}
 	}
 
@@ -875,10 +947,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_pacifist_path = yes }
 		}
 	}
 
@@ -918,14 +988,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_pacifist_path = yes }
 		}
 	}
 
@@ -969,14 +1033,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_pacifist_path = yes }
 		}
 	}
 
@@ -1029,7 +1087,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 0 }
+		ai_will_do = {
+			base = 0
+			modifier = { factor = 25 has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_pacifist_path = yes }
+		}
 	}
 
 	focus = {
@@ -1069,13 +1131,8 @@ focus_tree = {
 					check_variable = { ruling_party = 5 }
 				}
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -1140,6 +1197,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -1223,6 +1282,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -1306,6 +1367,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -1384,6 +1447,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -1440,14 +1505,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_historical_path = yes }
+			modifier = { factor = 0 JAP_ai_not_historical_path = yes }
 		}
 	}
 
@@ -1524,16 +1583,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -1585,7 +1639,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1638,7 +1696,11 @@ focus_tree = {
 			add_to_variable = { JAP_prioritizing_order_police_cost_multiplier_modifier = -0.10 tooltip = police_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1693,7 +1755,11 @@ focus_tree = {
 			add_to_variable = { JAP_prioritizing_order_police_cost_multiplier_modifier = 0.05 tooltip = police_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1748,7 +1814,11 @@ focus_tree = {
 			add_to_variable = { JAP_prioritizing_order_police_cost_multiplier_modifier = 0.05 tooltip = police_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1803,7 +1873,11 @@ focus_tree = {
 			add_to_variable = { JAP_prioritizing_order_political_power_factor = -0.05 tooltip = political_power_factor_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1855,7 +1929,11 @@ focus_tree = {
 			add_dynamic_modifier = { modifier = JAP_strengthening_cabinet_modifier }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1909,7 +1987,11 @@ focus_tree = {
 			add_to_variable = { JAP_strengthening_cabinet_bureaucracy_cost_multiplier_modifier = -0.05 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -1964,7 +2046,11 @@ focus_tree = {
 			add_to_variable = { JAP_strengthening_cabinet_bureaucracy_cost_multiplier_modifier = -0.05 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2018,7 +2104,11 @@ focus_tree = {
 			add_to_variable = { JAP_strengthening_cabinet_productivity_growth_modifier = 0.10 tooltip = productivity_growth_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2078,6 +2168,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -2142,6 +2234,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -2198,6 +2292,8 @@ focus_tree = {
 				is_historical_focus_on = yes
 				date > 2005.03.27
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -2264,11 +2360,8 @@ focus_tree = {
 				is_historical_focus_on = yes
 				date > 2005.06.04
 			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				date < 2005.06.05
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -2325,7 +2418,12 @@ focus_tree = {
 			add_to_variable = { JAP_regulatory_reform_stability_factor = -0.05 tooltip = stability_factor_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 0 date < 2005.06.05 }
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2397,7 +2495,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2459,7 +2561,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2516,7 +2622,11 @@ focus_tree = {
 			add_to_variable = { JAP_regulatory_reform_production_speed_buildings_factor = 0.05 tooltip = production_speed_buildings_factor_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2569,7 +2679,11 @@ focus_tree = {
 			add_to_variable = { JAP_regulatory_reform_research_speed_factor = 0.10 tooltip = research_speed_factor_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2623,7 +2737,11 @@ focus_tree = {
 			add_to_variable = { JAP_regulatory_reform_receiving_investment_cost_modifier = 0.40 tooltip = receiving_investment_cost_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2678,7 +2796,11 @@ focus_tree = {
 			add_to_variable = { JAP_regulatory_reform_foreign_influence_monthly_domestic_independence_gain_modifier = 0.20 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2727,7 +2849,11 @@ focus_tree = {
 			add_dynamic_modifier = { modifier = JAP_patriotic_education_modifier }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2780,7 +2906,11 @@ focus_tree = {
 			add_to_variable = { JAP_patriotic_education_research_speed_factor = 0.10 tooltip = research_speed_factor_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2834,7 +2964,11 @@ focus_tree = {
 			add_to_variable = { JAP_patriotic_education_foreign_influence_monthly_domestic_independence_gain_modifier = 0.15 tooltip = foreign_influence_monthly_domestic_independence_gain_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2888,7 +3022,11 @@ focus_tree = {
 			add_to_variable = { JAP_patriotic_education_foreign_influence_defense_modifier = 0.15 tooltip = foreign_influence_defense_modifier_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -2942,7 +3080,11 @@ focus_tree = {
 			add_to_variable = { JAP_patriotic_education_monthly_population = 0.05 tooltip = monthly_population_tt }
 		}
 
-		ai_will_do = { base = 8 }
+		ai_will_do = {
+			base = 8
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	#Economic Tree
@@ -3125,14 +3267,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -3174,10 +3310,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 12
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -3210,7 +3344,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -3241,7 +3379,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -3273,7 +3415,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -3305,7 +3451,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -3343,7 +3493,11 @@ focus_tree = {
 			unlock_decision_tooltip = JAP_retirement_reform_decision
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -3390,7 +3544,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -3437,19 +3595,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -3476,7 +3623,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_office_park_income_tax_modifier = 0.05 tooltip = office_park_income_tax_modifier_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -3502,7 +3653,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_production_speed_industrial_complex_factor = 0.05 tooltip = production_speed_industrial_complex_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -3529,7 +3684,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_research_speed_factor = 0.03 tooltip = research_speed_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -3561,7 +3720,11 @@ focus_tree = {
 			change_industrial_conglomerates_opinion = yes
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -3602,7 +3765,11 @@ focus_tree = {
 			change_industrial_conglomerates_opinion = yes
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -3656,7 +3823,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_foreign_influence_modifier = 0.05 tooltip = foreign_influence_modifier_tt }
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -3762,14 +3933,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 5
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -3807,13 +3972,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 5
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -3842,7 +4002,9 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+		}
 	}
 
 	focus = {
@@ -3870,7 +4032,9 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+		}
 	}
 
 	focus = {
@@ -4070,19 +4234,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4138,6 +4291,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4204,6 +4359,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4260,6 +4417,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4317,6 +4476,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4377,10 +4538,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4442,10 +4601,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 30 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4512,10 +4669,8 @@ focus_tree = {
 				factor = 3
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -4570,14 +4725,6 @@ focus_tree = {
 			modifier = {
 				factor = 3
 				has_western_aligned_government = yes
-			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
 			}
 		}
 	}
@@ -4923,14 +5070,8 @@ focus_tree = {
 				factor = 3
 				has_western_aligned_government = yes
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -4998,14 +5139,8 @@ focus_tree = {
 				factor = 3
 				has_western_aligned_government = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5139,14 +5274,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5227,6 +5356,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5314,6 +5445,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5381,6 +5514,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5464,10 +5599,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 30 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5548,10 +5681,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5626,6 +5757,8 @@ focus_tree = {
 				factor = 0.25
 				has_nationalist_government = yes
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5730,13 +5863,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_agriculture_district = no
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -5792,14 +5920,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_agriculture_district = no
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -5827,7 +5949,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_energy_use_modifier_agriculture_district = -0.05 tooltip = energy_use_modifier_agriculture_district_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -5861,7 +5985,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_agriculture_district_income_tax_modifier = 0.05 tooltip = agriculture_district_income_tax_modifier_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -6137,13 +6263,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 8
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -6184,14 +6305,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_industrial_complex = no
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -6225,7 +6340,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_civilian_industry_tax_modifier = 0.075 tooltip = civilian_industry_tax_modifier_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -6259,7 +6376,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_production_speed_offices_factor = 0.05 tooltip = production_speed_offices_factor_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -6288,7 +6407,9 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -6335,13 +6456,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_industrial_complex = no
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -6374,14 +6490,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 8
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -6488,7 +6598,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_consumer_goods_factor = -0.05 tooltip = consumer_goods_factor_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -6515,7 +6627,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_foreign_influence_modifier = 0.05 tooltip = foreign_influence_modifier_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -6836,13 +6950,8 @@ focus_tree = {
 				factor = 3
 				is_historical_focus_on = yes
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -6941,14 +7050,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 8
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -7001,6 +7104,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -7046,7 +7151,11 @@ focus_tree = {
 			country_event = { id = Japan_economy.32 days = 5 }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -7087,7 +7196,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_production_factory_max_efficiency_factor = 0.03 tooltip = production_factory_max_efficiency_factor_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -7129,6 +7242,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -7169,7 +7284,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_consumer_goods_factor = -0.08 tooltip = consumer_goods_factor_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -7212,7 +7331,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_renewable_infra_cost_multiplier_modifier = -0.10 tooltip = renewable_infra_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -7338,7 +7461,9 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -7845,19 +7970,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -7905,14 +8019,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -8002,7 +8110,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_return_on_investment_modifier = 0.015 tooltip = return_on_investment_modifier_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -8037,7 +8147,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_productivity_growth_modifier = 0.05 tooltip = productivity_growth_modifier_tt }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+		}
 	}
 
 	focus = {
@@ -8125,10 +8237,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 6
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
 		}
 	}
 
@@ -8312,23 +8420,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 4
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 JAP_ai_autonomy_path = yes }
+			modifier = { factor = 0 JAP_ai_not_autonomy_path = yes }
 		}
 	}
 
@@ -8365,6 +8458,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_autonomy_path = yes }
+			modifier = { factor = 0 JAP_ai_not_autonomy_path = yes }
 		}
 	}
 
@@ -8444,6 +8539,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_autonomy_path = yes }
+			modifier = { factor = 0 JAP_ai_not_autonomy_path = yes }
 		}
 	}
 
@@ -8478,6 +8575,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_autonomy_path = yes }
+			modifier = { factor = 0 JAP_ai_not_autonomy_path = yes }
 		}
 	}
 
@@ -8513,6 +8612,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_autonomy_path = yes }
+			modifier = { factor = 0 JAP_ai_not_autonomy_path = yes }
 		}
 	}
 
@@ -8541,7 +8642,11 @@ focus_tree = {
 			unlock_decision_category_tooltip = JAP_base_okinawa_decision
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_autonomy_path = yes }
+			modifier = { factor = 0 JAP_ai_not_autonomy_path = yes }
+		}
 	}
 
 	focus = {
@@ -8580,17 +8685,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 4
 			modifier = {
-				factor = 150
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_us_alliance_path = yes }
+			modifier = { factor = 0 JAP_ai_not_us_alliance_path = yes }
 		}
 	}
 
@@ -8626,7 +8725,11 @@ focus_tree = {
 			effect_tooltip = { USA = { add_ideas = JAP_jap_education } }
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_us_alliance_path = yes }
+			modifier = { factor = 0 JAP_ai_not_us_alliance_path = yes }
+		}
 	}
 
 	focus = {
@@ -8667,7 +8770,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_us_alliance_path = yes }
+			modifier = { factor = 0 JAP_ai_not_us_alliance_path = yes }
+		}
 	}
 
 	focus = {
@@ -8707,6 +8814,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_us_alliance_path = yes }
+			modifier = { factor = 0 JAP_ai_not_us_alliance_path = yes }
 		}
 	}
 
@@ -8751,6 +8860,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_us_alliance_path = yes }
+			modifier = { factor = 0 JAP_ai_not_us_alliance_path = yes }
 		}
 	}
 
@@ -8791,10 +8902,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 6
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
 		}
 	}
 
@@ -9072,13 +9179,6 @@ focus_tree = {
 		ai_will_do = {
 			base = 4
 			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
@@ -9346,14 +9446,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 4
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -9392,10 +9486,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 6
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -9428,10 +9520,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 6
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -9461,10 +9551,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 6
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
 		}
 	}
 
@@ -9548,10 +9634,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 4
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-			}
 		}
 	}
 
@@ -10077,10 +10159,6 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 6
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
 		}
 	}
 
@@ -11840,18 +11918,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 6
 			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				JAP_article_nine_hard_threat = no
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -11891,6 +11962,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -11932,6 +12005,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -11972,6 +12047,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12020,13 +12097,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 6
 			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12064,6 +12139,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12111,6 +12188,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12150,6 +12229,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12192,6 +12273,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12228,6 +12311,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12263,6 +12348,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12298,6 +12385,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12330,6 +12419,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12393,6 +12484,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12432,6 +12525,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12472,6 +12567,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12517,6 +12614,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12548,6 +12647,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12584,6 +12685,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12625,6 +12728,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12669,6 +12774,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12721,6 +12828,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12775,6 +12884,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12823,6 +12934,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12876,6 +12989,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -12946,6 +13061,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -13004,6 +13121,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -13051,6 +13170,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -13108,6 +13229,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -13156,6 +13279,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
 		}
 	}
 
@@ -13178,7 +13303,11 @@ focus_tree = {
 			activate_mission = JAP_establish_asteroid_mining_network_mission
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
+		}
 	}
 
 	focus = {
@@ -13207,7 +13336,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
+		}
 	}
 
 	focus = {
@@ -13242,7 +13375,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 6 }
+		ai_will_do = {
+			base = 6
+			modifier = { factor = 25 JAP_ai_rearmament_path = yes }
+			modifier = { factor = 0 JAP_ai_not_rearmament_path = yes }
+		}
 	}
 
 	focus = {
@@ -13268,19 +13405,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13309,19 +13435,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13365,19 +13480,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13411,7 +13515,11 @@ focus_tree = {
 			add_to_variable = { JAP_political_power_factor_monarchist = 0.05 tooltip = political_power_factor_tt }
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -13481,10 +13589,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13516,10 +13622,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13553,10 +13657,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 30 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13596,10 +13698,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13654,6 +13754,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13731,13 +13833,11 @@ focus_tree = {
 				can_staff_an_dockyard = no
 			}
 			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13781,13 +13881,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13829,6 +13927,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13878,6 +13978,8 @@ focus_tree = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13917,22 +14019,11 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
-			modifier = {
 				factor = 2
 				ai_is_threatened = yes
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -13970,19 +14061,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14017,19 +14097,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14078,19 +14147,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14132,19 +14190,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14193,19 +14240,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14276,19 +14312,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14332,19 +14357,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14392,19 +14406,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14452,19 +14455,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14519,19 +14511,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14580,19 +14561,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14620,19 +14590,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -14706,14 +14665,6 @@ focus_tree = {
 					neutrality_neutral_communism_are_in_power = yes
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
 		}
 	}
 
@@ -14749,14 +14700,8 @@ focus_tree = {
 					western_liberals_are_in_power = yes
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -14797,19 +14742,8 @@ focus_tree = {
 					neutrality_neutral_oligarch_are_in_power = yes
 				}
 			}
-			modifier = {
-				factor = 150
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
-			}
-			modifier = {
-				factor = 0
-				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
-			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -15049,7 +14983,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_civilian_factories_productivity = 0.02 tooltip = civilian_factories_productivity_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15083,7 +15021,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15125,6 +15067,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -15154,7 +15098,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_research_speed_factor = 0.02 tooltip = research_speed_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15184,7 +15132,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_production_factory_max_efficiency_factor = 0.03 tooltip = production_factory_max_efficiency_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15218,7 +15170,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15265,7 +15221,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15305,7 +15265,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -15349,6 +15313,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -15398,6 +15364,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -15433,7 +15401,11 @@ focus_tree = {
 			add_to_variable = { JAP_demographic_pressure_health_cost_multiplier_modifier = 0.02 tooltip = health_cost_multiplier_modifier_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -15483,6 +15455,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
 		}
 	}
 
@@ -15538,7 +15512,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+			modifier = { factor = 0 JAP_ai_not_empire_path = yes }
+		}
 	}
 
 	focus = {
@@ -15671,14 +15649,8 @@ focus_tree = {
 					nationalist_monarchists_are_in_power = yes
 				}
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -15719,6 +15691,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -15747,7 +15721,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_office_park_income_tax_modifier = 0.03 tooltip = office_park_income_tax_modifier_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15780,7 +15758,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15808,7 +15790,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_agricolture_productivity_modifier = 0.03 tooltip = agricolture_productivity_modifier_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15837,7 +15823,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_trade_opinion_factor = 0.03 tooltip = trade_opinion_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15872,7 +15862,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
+		}
 	}
 
 	focus = {
@@ -15917,13 +15911,8 @@ focus_tree = {
 					neutrality_neutral_communism_are_in_power = yes
 				}
 			}
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -15964,6 +15953,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -15996,7 +15987,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_office_park_income_tax_modifier = 0.05 tooltip = office_park_income_tax_modifier_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -16028,7 +16023,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_trade_opinion_factor = 0.05 tooltip = trade_opinion_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	focus = {
@@ -16068,6 +16067,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -16107,7 +16108,11 @@ focus_tree = {
 			add_to_variable = { JAP_economy_international_market_income_modifier = 0.03 tooltip = international_market_income_modifier_tt }
 		}
 
-		ai_will_do = { base = 20 }
+		ai_will_do = {
+			base = 20
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
+		}
 	}
 
 	# Electronics and the Model Competition
@@ -16228,13 +16233,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				factor = 150
-				OR = {
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_conservative_path = yes }
+			modifier = { factor = 0 JAP_ai_not_conservative_path = yes }
 		}
 	}
 
@@ -16285,14 +16285,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_microchip_plant = no
 			}
-			modifier = {
-				factor = 0
-				OR = {
-					is_historical_focus_on = yes
-					has_global_flag = JAP_HISTORICAL_AI_FOCUS
-					has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
-				}
-			}
+			modifier = { factor = 25 JAP_ai_left_path = yes }
+			modifier = { factor = 0 JAP_ai_not_left_path = yes }
 		}
 	}
 
@@ -16324,7 +16318,9 @@ focus_tree = {
 			add_to_variable = { JAP_economy_production_speed_microchip_plant_factor = 0.05 tooltip = production_speed_microchip_plant_factor_tt }
 		}
 
-		ai_will_do = { base = 12 }
+		ai_will_do = {
+			base = 12
+		}
 	}
 
 	focus = {
@@ -16552,6 +16548,14 @@ focus_tree = {
 			modifier = {
 				factor = 0
 				can_staff_an_industrial_complex = no
+			}
+			modifier = {
+				factor = 3
+				OR = {
+					has_idea = JAP_model_competition_1
+					has_idea = JAP_model_competition_2
+					has_idea = JAP_model_competition_3
+				}
 			}
 		}
 	}

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -4609,31 +4609,61 @@ on_actions = {
 					limit = {
 						has_game_rule = {
 							rule = JAP_ai_behavior
-							option = RANDOM
+							option = RANDOM_PATH
 						}
 					}
 					random_list = {
-						60 = { set_global_flag = JAP_HISTORICAL_AI_FOCUS }
-						40 = { set_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+						35 = { set_global_flag = JAP_HISTORICAL_FOCUS_PATH }
+						20 = { set_global_flag = JAP_NORMAL_NATION_FOCUS_PATH }
+						20 = { set_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH }
+						10 = { set_global_flag = JAP_PACIFIST_FOCUS_PATH }
+						15 = { set_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 					}
 				}
 				if = {
 					limit = {
 						has_game_rule = {
 							rule = JAP_ai_behavior
-							option = JAP_HISTORICAL
+							option = HISTORICAL
 						}
 					}
-					set_global_flag = JAP_HISTORICAL_AI_FOCUS
+					set_global_flag = JAP_HISTORICAL_FOCUS_PATH
 				}
 				if = {
 					limit = {
 						has_game_rule = {
 							rule = JAP_ai_behavior
-							option = JAP_RETURN_OF_THE_EMPIRE
+							option = NORMAL_NATION
 						}
 					}
-					set_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+					set_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = JAP_ai_behavior
+							option = SOCIAL_DEMOCRACY
+						}
+					}
+					set_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = JAP_ai_behavior
+							option = PACIFIST
+						}
+					}
+					set_global_flag = JAP_PACIFIST_FOCUS_PATH
+				}
+				if = {
+					limit = {
+						has_game_rule = {
+							rule = JAP_ai_behavior
+							option = RETURN_OF_THE_EMPIRE
+						}
+					}
+					set_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				}
 			}
 

--- a/common/scripted_effects/00_yearly_effects.txt
+++ b/common/scripted_effects/00_yearly_effects.txt
@@ -98,6 +98,7 @@ MD_event_on_startup_events = {
 		country_event = { id = japan_classic.15 days = 91 }
 		country_event = { id = japan_classic.18 days = 134 }
 		country_event = { id = JAP_historical.121006001 days = 279 }
+		country_event = { id = JAP_ai.4 days = 95 }
 	}
 	KOR = { country_event = { id = korea.19 days = 72 } }
 	LBA = { country_event = { id = LibyaRandomEvents.1 days = 120 random_days = 90 } }
@@ -259,6 +260,7 @@ trigger_year_2001_events = {
 		country_event = { id = JAP_historical.9130901001 days = 244 }
 		country_event = { id = JAP_historical.131201001 days = 335 }
 		JAP_corporate_history_2001 = yes
+		country_event = { id = JAP_ai.4 days = 116 }
 	}
 	JUB = { country_event = { id = somalia.5 days = 170 random_days = 20 } }
 	KAZ = { if = { limit = { is_subject = no } country_event = { id = centralkaz.3 days = 348 } } }
@@ -839,6 +841,7 @@ trigger_year_2006_events = {
 		country_event = { id = JAP_historical.20060926 days = 268 }
 		country_event = { id = JAP_historical.20030926 days = 268 }
 		JAP_corporate_history_2006 = yes
+		country_event = { id = JAP_ai.4 days = 269 }
 	}
 	KUW = { news_event = { id = kuwait_royal.1 days = 16 } }
 	LIT = { country_event = { id = lithuania.1 days = 120 random_days = 90 } }
@@ -970,6 +973,7 @@ trigger_year_2007_events = {
 		country_event = { id = JAP_historical.190325001 days = 84 }
 		country_event = { id = JAP_historical.190716001 days = 196 }
 		country_event = { id = JAP_historical.20030926 days = 268 }
+		country_event = { id = JAP_ai.4 days = 269 }
 	}
 	LIT = { country_event = { id = lithuania.10 days = 60 random_days = 120 } }
 	MAL = {
@@ -1067,6 +1071,7 @@ trigger_year_2008_events = {
 		country_event = { id = JAP_historical.20080924 days = 267 }
 		country_event = { id = JAP_historical.200614001 days = 165 }
 		country_event = { id = JAP_historical.20030926 days = 268 }
+		country_event = { id = JAP_ai.4 days = 267 }
 	}
 	MAL = { country_event = { id = mali.12 days = 335 random_days = 10 } }
 	NGR = { country_event = { id = mali.27 days = 152 random_days = 15 } }
@@ -1166,6 +1171,7 @@ trigger_year_2009_events = {
 	JAP = {
 		country_event = { id = JAP_historical.210811001 days = 223 }
 		country_event = { id = JAP_historical.20090808 days = 219 }
+		country_event = { id = JAP_ai.4 days = 259 }
 	}
 	MAL = { country_event = { id = mali.15 days = 31 random_days = 10 } }
 	NIG = {
@@ -1234,6 +1240,7 @@ trigger_year_2010_events = {
 	}
 	JAP = {
 		country_event = { id = JAP_historical.20090808 days = 219 }
+		country_event = { id = JAP_ai.4 days = 159 }
 	}
 	KOS = { country_event = { id = kosovo.11 days = 202 } }
 	KYR = { if = { limit = { has_country_leader = { name = "Kurmanbek Bakiyev" ruling_only = yes } } country_event = { id = centralkyr.14 days = 94 } } }
@@ -1309,6 +1316,7 @@ trigger_year_2011_events = {
 	JAP = {
 		country_event = { id = JAP_historical.20110311 days = 69 hours = 15 }
 		country_event = { id = JAP_historical.20090808 days = 219 }
+		country_event = { id = JAP_ai.4 days = 245 }
 	}
 	MAL = {
 		country_event = { id = mali.17 days = 212 random_days = 20 }
@@ -1391,6 +1399,7 @@ trigger_year_2012_events = {
 		country_event = { id = JAP_historical.20090808 days = 219 }
 		country_event = { id = JAP_historical.20120928 days = 271 }
 		JAP_corporate_history_2012 = yes
+		country_event = { id = JAP_ai.4 days = 360 }
 	}
 	MAL = {
 		country_event = { id = mali.22 days = 5 random_days = 10 }
@@ -2013,6 +2022,7 @@ trigger_year_2020_events = {
 		country_event = { id = JAP_historical.20170925 days = 267 }
 		country_event = { id = JAP_historical.20180507 days = 126 }
 		country_event = { id = JAP_historical.20190401 days = 90 }
+		country_event = { id = JAP_ai.4 days = 259 }
 	}
 	KOR = {
 		if = { limit = { country_exists = CHI has_country_flag = KOR_agreed_to_return_cpv_remains } news_event = { id = korea.31 days = 270 } }
@@ -2060,6 +2070,7 @@ trigger_year_2021_events = {
 		country_event = { id = JAP_historical.20170925 days = 267 }
 		country_event = { id = JAP_historical.20180507 days = 126 }
 		country_event = { id = JAP_historical.20190401 days = 90 }
+		country_event = { id = JAP_ai.4 days = 277 }
 	}
 	PER = { country_event = { id = PER_election_events.7 days = 90 } }
 	RAJ = {
@@ -2189,6 +2200,7 @@ trigger_year_2024_events = {
 	JAP = {
 		country_event = { id = JAP_historical.20220710 days = 190 }
 		JAP_corporate_history_2024 = yes
+		country_event = { id = JAP_ai.4 days = 274 }
 	}
 	SIN = { country_event = { id = singapore.128 days = 136 } }
 	TAI = { TAI_foxconn_milestone_2024 = yes }
@@ -2218,6 +2230,7 @@ trigger_year_2025_events = {
 	JAP = {
 		country_event = { id = JAP_historical.20220710 days = 190 }
 		JAP_corporate_history_2025 = yes
+		country_event = { id = JAP_ai.4 days = 294 }
 	}
 	PER = { country_event = { id = PER_election_events.71 days = 90 } }
 	SIA = {

--- a/common/scripted_triggers/99_JAP_scripted_triggers.txt
+++ b/common/scripted_triggers/99_JAP_scripted_triggers.txt
@@ -93,3 +93,118 @@ JAP_nintendo_outcome_settled = {
 		has_idea = JAP_nintendo_open_developer_commonwealth
 	}
 }
+
+JAP_ai_historical_path = {
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_historical_path = {
+	OR = {
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+		has_global_flag = JAP_PACIFIST_FOCUS_PATH
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+	}
+}
+
+JAP_ai_left_path = {
+	OR = {
+		has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+		has_global_flag = JAP_PACIFIST_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_left_path = {
+	NOT = { JAP_ai_left_path = yes }
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+	}
+}
+
+JAP_ai_conservative_path = {
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_conservative_path = {
+	JAP_ai_left_path = yes
+}
+
+JAP_ai_rearmament_path = {
+	OR = {
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_rearmament_path = {
+	NOT = { JAP_ai_rearmament_path = yes }
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		JAP_ai_left_path = yes
+	}
+}
+
+JAP_ai_us_alliance_path = {
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_us_alliance_path = {
+	JAP_ai_autonomy_path = yes
+}
+
+JAP_ai_autonomy_path = {
+	OR = {
+		has_global_flag = JAP_PACIFIST_FOCUS_PATH
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_autonomy_path = {
+	NOT = { JAP_ai_autonomy_path = yes }
+	JAP_ai_us_alliance_path = yes
+}
+
+JAP_ai_not_pacifist_path = {
+	NOT = { has_global_flag = JAP_PACIFIST_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
+	}
+}
+
+JAP_ai_not_empire_path = {
+	NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+		has_global_flag = JAP_NORMAL_NATION_FOCUS_PATH
+		JAP_ai_left_path = yes
+	}
+}
+
+JAP_ai_restrained_defence_path = {
+	OR = {
+		JAP_ai_historical_path = yes
+		has_global_flag = JAP_SOCIAL_DEMOCRACY_FOCUS_PATH
+	}
+}

--- a/events/05_japan.txt
+++ b/events/05_japan.txt
@@ -10632,7 +10632,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}
@@ -10672,7 +10673,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}
@@ -10712,7 +10714,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}
@@ -10752,7 +10755,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}
@@ -10794,7 +10798,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}
@@ -10835,7 +10840,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}
@@ -10878,7 +10884,8 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
+				JAP_ai_historical_path = yes
+				JAP_ai_not_historical_path = no
 			}
 		}
 	}

--- a/events/05_japan.txt
+++ b/events/05_japan.txt
@@ -246,7 +246,7 @@ country_event = {
 			base = 5
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				naval_strength_ratio = { tag = CHI ratio > 1.5 }
 			}
 			modifier = {
@@ -256,7 +256,7 @@ country_event = {
 			modifier = {
 				factor = 0
 				JAP_article_nine_hard_threat = no
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 			}
 			modifier = {
 				factor = 2
@@ -291,7 +291,7 @@ country_event = {
 			modifier = {
 				factor = 0
 				JAP_article_nine_hard_threat = no
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 			}
 			modifier = {
 				factor = 2
@@ -315,7 +315,7 @@ country_event = {
 			base = 20
 			modifier = {
 				factor = 10
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 			}
 			modifier = {
 				factor = 2
@@ -467,15 +467,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: japan_classic.16.o1 executed"
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		change_relative_party_popularity = yes
-		create_country_leader = {
-			name = "Yoshiro Mori"
-			picture = "yoshiro_mori.dds"
-			ideology = conservatism
-			traits = {
-				western_conservatism
-				career_politician
-			}
-		}
+		set_variable = { conservatism_leader = 1 }
+		set_ruling_leader = yes
+		set_leader = yes
 	}
 }
 
@@ -520,11 +514,11 @@ country_event = {
 			 modifier = {
 				factor = 0
 				is_historical_focus_on = yes
-				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS }
+				NOT = { has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH }
 			 }
 			 modifier = {
 				factor = 999
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			 }
 		}
 	}
@@ -560,7 +554,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 999
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -790,15 +784,9 @@ country_event = {
 	option = {
 		name = JAP_historical.20010426.oA
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20010426.oA executed"
-		create_country_leader = {
-			name = "Junichiro Koizumi"
-			picture = "junichiro_koizumi.dds"
-			ideology = conservatism
-			traits = {
-				western_conservatism
-				mediafuror
-			}
-		}
+		set_variable = { conservatism_leader = 2 }
+		set_ruling_leader = yes
+		set_leader = yes
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		change_relative_party_popularity = yes
 		set_country_flag = JAP_KOIZUMI_HISTRICAL_APPEARANCE
@@ -1325,15 +1313,9 @@ country_event = {
 	option = {
 		name = JAP_historical.20060926.oB
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20060926.oB executed"
-		create_country_leader = {
-			name = "Shinzo Abe"
-			picture = "Shinzo_Abe.dds"
-			ideology = conservatism
-			traits = {
-				western_conservatism
-				abenomics
-			}
-		}
+		set_variable = { conservatism_leader = 3 }
+		set_ruling_leader = yes
+		set_leader = yes
 		set_country_flag = JAP_ABE_FIRST_HISTRICAL_APPEARANCE
 		ai_chance = {
 			base = 10
@@ -1625,15 +1607,9 @@ country_event = {
 	option = {
 		name = JAP_historical.20070926.oB
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070926.oB executed"
-		create_country_leader = {
-			name = "Yasuo Fukuda"
-			picture = "yasuo_fukuda.dds"
-			ideology = conservatism
-			traits = {
-				western_conservatism
-				capable
-			}
-		}
+		set_variable = { conservatism_leader = 4 }
+		set_ruling_leader = yes
+		set_leader = yes
 		set_country_flag = JAP_FUKUDA_HISTRICAL_APPEARANCE
 		ai_chance = {
 			base = 10
@@ -1732,15 +1708,9 @@ country_event = {
 	option = {
 		name = JAP_historical.20080924.oB
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20080924.oB executed"
-		create_country_leader = {
-			name = "Taro Aso"
-			picture = "taro_aso.dds"
-			ideology = conservatism
-			traits = {
-				western_conservatism
-				political_dancer
-			}
-		}
+		set_variable = { conservatism_leader = 5 }
+		set_ruling_leader = yes
+		set_leader = yes
 		ai_chance = {
 			base = 10
 		}
@@ -2802,7 +2772,7 @@ country_event = {
 		ai_chance = {
 			base = 1
 			modifier = {
-				is_historical_focus_on = yes
+				JAP_ai_historical_path = yes
 				factor = 0
 			}
 		}
@@ -3031,7 +3001,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -3062,7 +3032,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -3101,7 +3071,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -3135,7 +3105,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -3161,7 +3131,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 			}
 		}
 	}
@@ -5716,7 +5686,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SOV ratio > 2 }
 			}
 		}
@@ -6385,7 +6355,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KOR ratio > 2 }
 			}
 		}
@@ -6400,7 +6370,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KOR ratio > 2 }
 			}
 		}
@@ -6489,7 +6459,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = NKO ratio > 2 }
 			}
 		}
@@ -6504,7 +6474,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = NKO ratio > 2 }
 			}
 		}
@@ -6603,7 +6573,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = TAI ratio > 2 }
 			}
 		}
@@ -6618,7 +6588,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = TAI ratio > 2 }
 			}
 		}
@@ -6708,7 +6678,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = PHI ratio > 2 }
 			}
 		}
@@ -6723,7 +6693,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = PHI ratio > 2 }
 			}
 		}
@@ -6824,7 +6794,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = MAY ratio > 2 }
 			}
 		}
@@ -6839,7 +6809,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = MAY ratio > 2 }
 			}
 		}
@@ -6939,7 +6909,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = IND ratio > 2 }
 			}
 		}
@@ -6954,7 +6924,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = IND ratio > 2 }
 			}
 		}
@@ -7070,7 +7040,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = VIE ratio > 2 }
 			}
 		}
@@ -7085,7 +7055,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = VIE ratio > 2 }
 			}
 		}
@@ -7201,7 +7171,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = CBD ratio > 2 }
 			}
 		}
@@ -7216,7 +7186,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = CBD ratio > 2 }
 			}
 		}
@@ -7332,7 +7302,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = LAO ratio > 2 }
 			}
 		}
@@ -7347,7 +7317,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = LAO ratio > 2 }
 			}
 		}
@@ -7463,7 +7433,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = AST ratio > 2 }
 			}
 		}
@@ -7478,7 +7448,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = AST ratio > 2 }
 			}
 		}
@@ -7594,7 +7564,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = NZL ratio > 2 }
 			}
 		}
@@ -7609,7 +7579,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = NZL ratio > 2 }
 			}
 		}
@@ -7725,7 +7695,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = BRM ratio > 2 }
 			}
 		}
@@ -7740,7 +7710,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = BRM ratio > 2 }
 			}
 		}
@@ -7856,7 +7826,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KAC ratio > 2 }
 			}
 		}
@@ -7871,7 +7841,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KAC ratio > 2 }
 			}
 		}
@@ -7976,7 +7946,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = WAA ratio > 2 }
 			}
 		}
@@ -7991,7 +7961,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = WAA ratio > 2 }
 			}
 		}
@@ -8097,7 +8067,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SHN ratio > 2 }
 			}
 		}
@@ -8112,7 +8082,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SHN ratio > 2 }
 			}
 		}
@@ -8218,7 +8188,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KAR ratio > 2 }
 			}
 		}
@@ -8233,7 +8203,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KAR ratio > 2 }
 			}
 		}
@@ -8339,7 +8309,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = PAU ratio > 2 }
 			}
 		}
@@ -8354,7 +8324,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = PAU ratio > 2 }
 			}
 		}
@@ -8460,7 +8430,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = MIC ratio > 2 }
 			}
 		}
@@ -8475,7 +8445,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = MIC ratio > 2 }
 			}
 		}
@@ -8581,7 +8551,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = NAU ratio > 2 }
 			}
 		}
@@ -8596,7 +8566,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = NAU ratio > 2 }
 			}
 		}
@@ -8702,7 +8672,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KIR ratio > 2 }
 			}
 		}
@@ -8717,7 +8687,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = KIR ratio > 2 }
 			}
 		}
@@ -8823,7 +8793,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = MAR ratio > 2 }
 			}
 		}
@@ -8838,7 +8808,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = MAR ratio > 2 }
 			}
 		}
@@ -8944,7 +8914,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = TUL ratio > 2 }
 			}
 		}
@@ -8959,7 +8929,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = TUL ratio > 2 }
 			}
 		}
@@ -9066,7 +9036,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SOL ratio > 2 }
 			}
 		}
@@ -9081,7 +9051,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SOL ratio > 2 }
 			}
 		}
@@ -9188,7 +9158,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = PAP ratio > 2 }
 			}
 		}
@@ -9203,7 +9173,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = PAP ratio > 2 }
 			}
 		}
@@ -9309,7 +9279,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = VAN ratio > 2 }
 			}
 		}
@@ -9324,7 +9294,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = VAN ratio > 2 }
 			}
 		}
@@ -9430,7 +9400,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = FIJ ratio > 2 }
 			}
 		}
@@ -9445,7 +9415,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = FIJ ratio > 2 }
 			}
 		}
@@ -9551,7 +9521,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SAM ratio > 2 }
 			}
 		}
@@ -9566,7 +9536,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = SAM ratio > 2 }
 			}
 		}
@@ -9672,7 +9642,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = TON ratio > 2 }
 			}
 		}
@@ -9687,7 +9657,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = TON ratio > 2 }
 			}
 		}
@@ -9801,7 +9771,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = USA ratio > 2 }
 			}
 		}
@@ -9816,7 +9786,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = USA ratio > 2 }
 			}
 		}
@@ -9924,7 +9894,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = FRA ratio > 2 }
 			}
 		}
@@ -9939,7 +9909,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = FRA ratio > 2 }
 			}
 		}
@@ -10041,7 +10011,7 @@ country_event = {
 			base = 0
 			modifier = {
 				add = 100
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = ENG ratio > 2 }
 			}
 		}
@@ -10056,7 +10026,7 @@ country_event = {
 			base = 100
 			modifier = {
 				factor = 0
-				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+				has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 				strength_ratio = { tag = ENG ratio > 2 }
 			}
 		}
@@ -10662,7 +10632,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -10702,7 +10672,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -10742,7 +10712,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -10782,7 +10752,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -10824,7 +10794,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -10865,7 +10835,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -10908,7 +10878,7 @@ country_event = {
 			base = 8
 			modifier = {
 				factor = 2
-				has_global_flag = JAP_HISTORICAL_AI_FOCUS
+				has_global_flag = JAP_HISTORICAL_FOCUS_PATH
 			}
 		}
 	}
@@ -11099,7 +11069,7 @@ country_event = {
 
 	trigger = {
 		is_ai = yes
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 		nationalist_monarchists_are_in_power = no
 		has_civil_war = no
 	}
@@ -11114,6 +11084,103 @@ country_event = {
 }
 
 country_event = {
+	id = JAP_ai.4
+	is_triggered_only = yes
+	hidden = yes
+
+	trigger = {
+		is_ai = yes
+		has_civil_war = no
+		JAP_ai_historical_path = yes
+		JAP_ai_not_historical_path = no
+		NOT = { has_country_flag = generic_election_killswitch }
+	}
+
+	immediate = {
+		log = "[GetDateText]: [This.GetName]: JAP_ai.4 executed"
+		if = {
+			limit = { date > 2025.10.21 }
+			set_variable = { conservatism_leader = 11 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2024.10.1 }
+			set_variable = { conservatism_leader = 10 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2021.10.4 }
+			set_variable = { conservatism_leader = 9 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2020.9.16 }
+			set_variable = { conservatism_leader = 8 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2012.12.26 }
+			set_variable = { conservatism_leader = 7 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2011.9.2 }
+			set_variable = { liberalism_leader = 7 }
+			set_temp_variable = { rul_party_temp = 2 }
+		}
+		else_if = {
+			limit = { date > 2010.6.8 }
+			set_variable = { liberalism_leader = 6 }
+			set_temp_variable = { rul_party_temp = 2 }
+		}
+		else_if = {
+			limit = { date > 2009.9.16 }
+			set_variable = { liberalism_leader = 5 }
+			set_temp_variable = { rul_party_temp = 2 }
+		}
+		else_if = {
+			limit = { date > 2008.9.24 }
+			set_variable = { conservatism_leader = 5 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2007.9.26 }
+			set_variable = { conservatism_leader = 4 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2006.9.26 }
+			set_variable = { conservatism_leader = 3 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2001.4.26 }
+			set_variable = { conservatism_leader = 2 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else_if = {
+			limit = { date > 2000.4.5 }
+			set_variable = { conservatism_leader = 1 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+		else = {
+			set_variable = { conservatism_leader = 0 }
+			set_temp_variable = { rul_party_temp = 1 }
+		}
+
+		if = {
+			limit = { NOT = { check_variable = { ruling_party = rul_party_temp } } }
+			change_ruling_party_effect = yes
+			set_elections_48_months = yes
+		}
+		else = {
+			set_ruling_leader = yes
+			set_leader = yes
+		}
+	}
+}
+
+country_event = {
 	id = JAP_ai.2
 	is_triggered_only = yes
 	hidden = yes
@@ -11121,7 +11188,7 @@ country_event = {
 
 	trigger = {
 		is_ai = yes
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 		nationalist_monarchists_are_in_power = no
 		has_civil_war = no
 	}
@@ -11143,7 +11210,7 @@ country_event = {
 
 	trigger = {
 		is_ai = yes
-		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS
+		has_global_flag = JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH
 		nationalist_monarchists_are_in_power = no
 		has_civil_war = no
 	}

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -272,10 +272,16 @@
  RULE_OPTION_TAI_ROAD_TO_SPLIT_AI_DESC: "The two sides of the Taiwan Strait are governed separately and are not subordinate to each other. What is the Republic of China?"
 
  #Japan
- RULE_OPTION_JAP_HISTORICAL: "The Postwar Consensus"
- RULE_OPTION_JAP_HISTORICAL_DESC: "The Liberal Democrats keep the Diet, the alliance with Washington holds, and the Self-Defense Forces are normalised only as far as a hostile neighbourhood forces them to be. Japan writes off its bad loans, legislates against the birthrate collapse and the karoshi crisis, and leaves Article Nine standing."
+ RULE_OPTION_JAP_HISTORICAL: "Historical"
+ RULE_OPTION_JAP_HISTORICAL_DESC: "The §8Liberal Democrats§! keep the Diet, the alliance with Washington holds, and the Self-Defense Forces are normalised only as far as a hostile neighbourhood forces them to be. Japan writes off its bad loans, legislates against the birthrate collapse and the karoshi crisis, and leaves Article Nine standing."
+ RULE_OPTION_JAP_NORMAL_NATION: "A Normal Nation"
+ RULE_OPTION_JAP_NORMAL_NATION_DESC: "The §8Liberal Democrats§! spend down the Article Nine consensus until the Self-Defense Forces are written into the constitution as an army like any other. Japan rearms inside the American alliance and begins answering Beijing and Pyongyang on its own account."
+ RULE_OPTION_JAP_SOCIAL_DEMOCRACY: "The Second Postwar"
+ RULE_OPTION_JAP_SOCIAL_DEMOCRACY_DESC: "The §8Democratic Party§! breaks the conservative hold on the Diet and governs on disclosure, labour law and an open door for foreign workers. Japan spends its strength on the birthrate, the salaryman and the corruption that outlived the bubble rather than on the region."
+ RULE_OPTION_JAP_PACIFIST: "The Peace Constitution"
+ RULE_OPTION_JAP_PACIFIST_DESC: "The §8Social Democrats§! take the Diet on the promise that Article Nine means what it says, and the arms exports, the bases and finally the Self-Defense Forces are wound up. Japan tears up the security treaty with Washington and stands disarmed between China and the Koreas."
  RULE_OPTION_JAP_RETURN_OF_THE_EMPIRE: "The Return of the Empire"
- RULE_OPTION_JAP_RETURN_OF_THE_EMPIRE_DESC: "A monarchist movement grows out of the right until the throne is restored to power and Article Nine is struck out. Japan rearms behind a blue-water fleet and reclaims the Kurils, Korea, Taiwan and the old sphere in the Pacific by force."
+ RULE_OPTION_JAP_RETURN_OF_THE_EMPIRE_DESC: "The §8Restoration Party§! grows out of the nationalist right until the throne is restored to power and Article Nine is struck out. Japan rearms behind a blue-water fleet and reclaims the Kurils, Korea, Taiwan and the old sphere in the Pacific by force."
 
  #Myanmar
  BRM_AI_BEHAVIOR: "@BRM Union of Myanmar"

--- a/tools/analysis/ai_path_report.py
+++ b/tools/analysis/ai_path_report.py
@@ -59,6 +59,7 @@ GUARD_TOKENS = (
 )
 
 BOOKMARK_DATES = ((2016, 1, 2), (2017, 1, 1))
+START_YEAR = 2000
 TIMELINE_MIN_DATES = 3
 DAYS_PER_MONTH = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
 
@@ -1474,22 +1475,27 @@ def parse_leader_roster(text: str, tag: str) -> Dict[str, List[Leader]]:
 def _parse_roster_branch(block: str, subideology: str) -> List[Leader]:
     declared = re.compile(re.escape(subideology) + r"_leader\s*=\s*(\d+)")
     leaders: List[Leader] = []
-    for key, _, entry in iter_statements(block):
-        if key != "if" or entry is None:
-            continue
-        create = _block_of(entry, "create_country_leader")
-        if create is None:
-            continue
-        name = re.search(r'name\s*=\s*"([^"]*)"', create)
-        index = declared.search(_block_of(entry, "limit") or "")
-        until = _ROSTER_DATE.search(entry)
-        leaders.append(
-            Leader(
-                name=name.group(1) if name else "?",
-                index=int(index.group(1)) if index else len(leaders),
-                until=_parse_date(until.group(1)) if until else None,
+
+    def walk(scope: str) -> None:
+        for key, _, entry in iter_statements(scope):
+            if key not in ("if", "else_if") or entry is None:
+                continue
+            create = _block_of(entry, "create_country_leader")
+            if create is None:
+                walk(entry)
+                continue
+            name = re.search(r'name\s*=\s*"([^"]*)"', create)
+            index = declared.search(_block_of(entry, "limit") or "")
+            until = _ROSTER_DATE.search(entry)
+            leaders.append(
+                Leader(
+                    name=name.group(1) if name else "?",
+                    index=int(index.group(1)) if index else len(leaders),
+                    until=_parse_date(until.group(1)) if until else None,
+                )
             )
-        )
+
+    walk(block)
     return leaders
 
 
@@ -1501,7 +1507,15 @@ def parse_year_schedule(text: str, tag: str) -> List[Tuple[int, str, int]]:
         r"country_event\s*=\s*\{[^{}]*?\bid\s*=\s*([A-Za-z0-9_.]+)"
         r"[^{}]*?\bdays\s*=\s*(\d+)"
     )
-    for match in re.finditer(r"^trigger_year_(\d{4})_events\s*=\s*\{", text, re.M):
+    blocks = [
+        (int(match.group(1)), match)
+        for match in re.finditer(r"^trigger_year_(\d{4})_events\s*=\s*\{", text, re.M)
+    ]
+    blocks += [
+        (START_YEAR, match)
+        for match in re.finditer(r"^MD_event_on_startup_events\s*=\s*\{", text, re.M)
+    ]
+    for year, match in blocks:
         start = text.index("{", match.start())
         close = find_matching_brace(text, start)
         if close == -1:
@@ -1513,9 +1527,7 @@ def parse_year_schedule(text: str, tag: str) -> List[Tuple[int, str, int]]:
             if inner_close == -1:
                 continue
             for event in fire.finditer(body[inner + 1 : inner_close]):
-                entries.append(
-                    (int(match.group(1)), event.group(1), int(event.group(2)))
-                )
+                entries.append((year, event.group(1), int(event.group(2))))
     return entries
 
 

--- a/tools/tests/ai_path_report_test.py
+++ b/tools/tests/ai_path_report_test.py
@@ -408,6 +408,20 @@ class TestYearSchedule:
             (2022, "denmark_md.400", 298),
         ]
 
+    def test_the_startup_block_is_read_as_the_mod_start_year(self):
+        text = (
+            "MD_event_on_startup_events = {\n"
+            "\tDEN = { country_event = { id = denmark_md.400 days = 94 } }\n"
+            "}\n"
+            "trigger_year_2001_events = {\n"
+            "\tDEN = { country_event = { id = denmark_md.400 days = 158 } }\n"
+            "}\n"
+        )
+        assert report.parse_year_schedule(text, "DEN") == [
+            (2001, "denmark_md.400", 158),
+            (report.START_YEAR, "denmark_md.400", 94),
+        ]
+
 
 class TestWalker:
     def setup_method(self):


### PR DESCRIPTION
Closes part of #3162 (Japan).

Japan had a two-option rule (`JAP_HISTORICAL` / `JAP_RETURN_OF_THE_EMPIRE`) whose flags nothing in the focus tree read. `ai_path_report.py --tag JAP` reported **0 owned / 365 path-neutral**, **63 orphaned focuses** under historical AI, and three coherent spines that no option claimed:

- the **left / social-democratic spine** (`JAP_left`, `JAP_information_disclosure`, `JAP_management_documents` plus ~63 descendants), zeroed at the roots by a killswitch and by both strategy plans while its descendants kept positive weight;
- the **pacifist / Article 9 tail** (`JAP_leading_disarmament` to `JAP_principle_of_no_armed_forces` to `JAP_abrogating_us_japan_security_treaty`), zeroed by both plans;
- the **remilitarisation spine** (32 focuses behind `power_balance_value > 0.70`), which the Article Nine decision ladder caps the historical AI out of at 0.55, so only the Empire path could ever revise Article 9.

## The option set

| `name =` | text | owns |
|---|---|---|
| `HISTORICAL` | Historical | LDP, US alliance, Article Nine stands |
| `NORMAL_NATION` | A Normal Nation | Article Nine rewritten, SDF becomes a standing military, still democratic and US-aligned |
| `SOCIAL_DEMOCRACY` | The Second Postwar | disclosure, labour law, redistribution, open immigration |
| `PACIFIST` | The Peace Constitution | arms-export ban, no armed forces, treaty abrogation |
| `RETURN_OF_THE_EMPIRE` | The Return of the Empire | imperial restoration and the conquest tail |
| `RANDOM_PATH` | shared key | `random_list` over all five |
| `NO_PATH` | shared key | `default = { }`, last, sets nothing |

Each path's branch root is reachable by something its AI can satisfy. HISTORICAL and NORMAL_NATION start from the LDP already in power (NORMAL_NATION's gate is the Article Nine balance, opened below); SOCIAL_DEMOCRACY and PACIFIST get AI-only ramps; RETURN_OF_THE_EMPIRE keeps its existing monarchist ramp.

## Changes

**Rule and loc.** Option names unprefixed, `RANDOM` becomes `RANDOM_PATH` on the shared `RULE_OPTION_MD_*` keys, `NO_PATH` kept as the `default = { }` block last. `RULE_OPTION_JAP_HISTORICAL` now reads literally `"Historical"` (it was `"The Postwar Consensus"`, which moved into the desc). Every `_desc` is two sentences with the party names highlighted. The `@JAP Japan` header key already existed and is unchanged. The file is **not** reordered, since that is a separate cross-cutting item.

**Flags.** `JAP_HISTORICAL_AI_FOCUS` to `JAP_HISTORICAL_FOCUS_PATH`, `JAP_RETURN_OF_THE_EMPIRE_AI_FOCUS` to `JAP_RETURN_OF_THE_EMPIRE_FOCUS_PATH`, plus `JAP_NORMAL_NATION_FOCUS_PATH`, `JAP_SOCIAL_DEMOCRACY_FOCUS_PATH` and `JAP_PACIFIST_FOCUS_PATH`. Roughly 300 references across decisions, events, the tree, `ai_strategy` and the plans.

**Tree ownership.** 15 scripted path triggers and 211 focuses re-owned across eight groups (`historical`, `conservative`, `rearmament`, `us_alliance`, `autonomy`, `left`, `pacifist`, `empire`), written by `apply_ai_path_weights.py`. Ownership is assigned by single-group reachability from each spine's seeds: any focus reachable from two paths' seeds stays path-neutral, which is what keeps the shared electronics chain and the middle side of every three-way mutex alive in every state. 154 focuses stay path-neutral, including the economy, army and equipment trunk.

**Party ramps** in `JAP_ai_path_category` (`is_ai = yes`, no loc): the DPJ (index 2, inside the incumbent's own group, so `party_popularity_increase` only) and the SDP (index 18, a different group from the incumbent, so both temp vars, mirroring the existing monarchist ramp). Neither disables elections; the takeover decision re-enables every 180 days instead.

**Article Nine ladder.** The 20 rearmament decisions now push for `JAP_ai_rearmament_path` (NORMAL_NATION plus EMPIRE) rather than the empire flag alone, the 0.55 cap no longer applies to a rearmament path, and PACIFIST zeroes them outright. The capped historical ladder now also covers SOCIAL_DEMOCRACY and `NO_PATH` with historical AI on. The reactor-restart nudges follow `JAP_ai_conservative_path` and are zeroed for the left paths, matching `JAP_nuclear_phaseout`'s ownership in the tree.

**Plans.** Three thin path plans plus `JAP_unscripted_plan` for the `NO_PATH` with historical-AI-off state, which previously enabled **no plan at all**. Both existing plans keep their `ai_national_focuses` lists; their `focus_factors` collapse to `JAP_dissolving_sdf = 0`, since the tree now owns the killswitching and the old lists had begun to contradict it.

**AI hardening.** `JAP_no_war_if_at_war` switches off permanently once `JAP_imperial_war_cabinet` completes, after which the empire chain keeps pushing `antagonize` and `prepare_for_war` with no check on whether Japan is losing. The eight `JAP_empire_*` pre-war blocks now gate on `NOT = { surrender_progress > 0.15 }`, which lifts that pressure for every target the chain can reach rather than for a hand-maintained list; the mod-wide `MD_avoid_new_wars_while_losing` already supplies the targetless declaration penalty on the same threshold, so no per-tag brake is added. The `JAP_empire_blitz_*` blocks are untouched — they gate on `has_war_with` and steer an existing war rather than start a new one. `JAP_historical_no_offensive_wars` enables on the `JAP_ai_historical_path` / `JAP_ai_not_historical_path` pair rather than the raw `JAP_HISTORICAL_FOCUS_PATH` flag, so the default `NO_PATH` plus historical AI state keeps its offensive-war suppression; the seven `Japan_economy` option `ai_chance` nudges that read the same raw flag take the pair too. `JAP_electronics_superpower` gets a real weighting modifier for the `JAP_model_competition` malus it cures. `Japan.101` keys its `ai_chance` on `JAP_ai_historical_path` rather than `is_historical_focus_on`.

**Historical government walker.** `JAP_ai.4` (hidden, `is_ai = yes`, no loc) asserts both the ruling party and the roster index at thirteen dates, scheduled from `00_yearly_effects.txt`. Japan sets no `term_limit`, so nothing rotated its Prime Minister. The walker covers the 2009-2012 DPJ interregnum, which is why explicit index assertion matters: conservatism index 6 is Sadakazu Tanigaki, LDP president but never Prime Minister, so the walker steps 5 (Aso) to 7 (Abe's return) while the ruling party sits on liberalism. The five flavour events that installed Prime Ministers with inline `create_country_leader` (`japan_classic.16`, `JAP_historical.20010426`, `.20060926`, `.20070926`, `.20080924`) now assert the roster index and call `set_ruling_leader` / `set_leader` instead. The roster entries are byte-identical to the data they inlined, so nothing player-visible changes, and the pointer stops desyncing.

**Tooling.** `ai_path_report.py` could not read Japan's roster shape: `_parse_roster_branch` only looked at the top level of a sub-ideology branch and only at `if`, so Japan's date-wrapped, `else_if`-chained roster parsed as zero entries and every walker branch was reported OUT OF RANGE. It now recurses and accepts `else_if`. `parse_year_schedule` also reads `MD_event_on_startup_events` as the mod start year, so events dispatched at startup are no longer reported as unscheduled. One regression test added; `python -m pytest` is green (4135 passed, 22 skipped).

## Verification

- `ai_path_report.py --tag JAP`: rule and wiring **clean**; **0 orphans and 0 stranded focuses in all twelve states**; 0 mutex ties, down from 3 intra-path ties broken with boost overrides; no additive path modifiers; no unreferenced flags; every one of the 15 triggers has callers.
- `government` section: every scheduled date resolves to the person history had (Koizumi, Abe, Fukuda, Aso, Hatoyama, Kan, Noda, Abe, Suga, Kishida, Ishiba, Takaichi). No `change_leader_temp`, no unbounded party change. Two notes remain by design. The tool's blanket "walker over an undated roster" advice stands because Japan's roster carries no per-entry end-of-tenure dates, but it **is** a historically ordered sequence, which is exactly what the explicit index assertion relies on. The final `else` fallback branch is unscheduled, which the bounded-chain shape requires.
- `mechanics` section: no AI-untakeable cure. Every remaining flag on the section attaches to the two cost-shaped keys **seeded negative** in the history file, `JAP_transparency_and_audit_reform_corruption_cost_factor` and `JAP_regulatory_reform_bureaucracy_cost_multiplier_modifier` — bonus ramps, not burdens, so their "every cure is dead" states and the three flat-base cure lines (`JAP_independent_audits`, `JAP_eliminating_amakudari`, `JAP_disclosure_of_political_funding`) are by design and no AI cure route was added for them. The `nothing relieves` line lists four entries and all four are judged **not** burdens: `JAP_ykk_group` is +2.5% civilian factory productivity plus research bonuses, and `JAP_political_modifier`, `JAP_economy_modifier` and `JAP_jsw_steel_modifier` are added in history with their backing variables unset, so they apply nothing until a focus fills them.
- Validators run against `3cb87fe`: `validate_focus_tree.py --path .` clean; `validate_decisions.py` 290 errors / 459 warnings, identical to the pre-change baseline; `validate_common_mistakes.py`, `validate_localisation.py`, `validate_variables.py`, `validate_simplifications.py` and `check_common_mistakes.py` clean; `validate_events.py` zero warnings for `05_japan.txt`. The review-fix commit on top only swaps trigger references inside `enable` and `ai_chance` blocks and deletes one strategy block; CI's validation report covers it.

Stale checklist annotations corrected while here: nothing outside `00_game_rules.txt` and `999_game_rules_on_actions.txt` reads `JAP_ai_behavior` (`events/05_japan.txt` does not), and no `set_country_flag` path flag remained.

