### PR TITLE
Fix AST, FRA, and LBA errors from the load log

### DIFF
--- a/common/national_focus/05_Australia.txt
+++ b/common/national_focus/05_Australia.txt
@@ -6000,15 +6000,15 @@ focus_tree = {
 			}
 		}
 	}
-	
+
 	focus = {
 		id = AST_new_columbo_plan
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY }
 		icon = focus_generic_university_2
 
-		x = 1
-		y = 1
-		relative_position_id = AST_indian_investments
+		x = 2
+		y = 4
+		relative_position_id = AST_sail_steady
 
 		cost = 5
 
@@ -10416,7 +10416,7 @@ focus_tree = {
 					limit = { has_country_flag = election_cooldown_ast }
 					country_event = { id = legislation_rudd_blocked.4 days = 3 }
 				}
-				
+
 			}
 		}
 

--- a/common/national_focus/05_france.txt
+++ b/common/national_focus/05_france.txt
@@ -4075,9 +4075,9 @@ focus_tree = {
 		id = FRA_leave_nato
 		icon = renounce_nato
 
-		x = 0
-		y = 1
-		relative_position_id = FRA_anti_usa
+		x = 2
+		y = 2
+		relative_position_id = FRA_sovereignism
 
 		cost = 8
 

--- a/common/national_focus/05_libya.txt
+++ b/common/national_focus/05_libya.txt
@@ -13463,11 +13463,11 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_end_of_gaddafi"
 			if = {
 				limit = { has_idea = LBA_general_peoples_congress }
-				remove_idea = LBA_general_peoples_congress
+				remove_ideas = LBA_general_peoples_congress
 			}
 			if = {
 				limit = { has_idea = LBA_empowered_revolutionary_committees }
-				remove_idea = LBA_empowered_revolutionary_committees
+				remove_ideas = LBA_empowered_revolutionary_committees
 			}
 		}
 
@@ -14847,7 +14847,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus LBA_emergency_privatisation"
-			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.075 multiply = 4 } }
+			set_temp_variable = { treasury_change = { value = gdp_total multiply = 0.3 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = LBA_emergency_privatisation_tt
 			add_to_variable = { lba_oil_nationalisation = -0.20 }

--- a/common/scripted_effects/99_FRA_scripted_effects.txt
+++ b/common/scripted_effects/99_FRA_scripted_effects.txt
@@ -1481,30 +1481,30 @@ FRA_corporate_history_2020 = {
 # Attaches only the ruling party's programme pools. The backing variables live on the country and
 # survive detachment, so a party's accumulated focus bonuses return intact when it regains power.
 FRA_update_party_programmes = {
-	remove_dynamic_modifier = { modifier = FRA_ps_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_ps_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_ps_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_udf_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_udf_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_udf_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_lr_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_lr_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_lr_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_rpf_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_rpf_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_rpf_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_fn_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_fn_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_fn_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_lfi_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_lfi_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_lfi_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_eelv_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_eelv_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_eelv_social_balance }
-	remove_dynamic_modifier = { modifier = FRA_pcf_political_balance }
-	remove_dynamic_modifier = { modifier = FRA_pcf_econ_policy }
-	remove_dynamic_modifier = { modifier = FRA_pcf_social_balance }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_ps_political_balance } } remove_dynamic_modifier = { modifier = FRA_ps_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_ps_econ_policy } } remove_dynamic_modifier = { modifier = FRA_ps_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_ps_social_balance } } remove_dynamic_modifier = { modifier = FRA_ps_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_udf_political_balance } } remove_dynamic_modifier = { modifier = FRA_udf_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_udf_econ_policy } } remove_dynamic_modifier = { modifier = FRA_udf_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_udf_social_balance } } remove_dynamic_modifier = { modifier = FRA_udf_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_lr_political_balance } } remove_dynamic_modifier = { modifier = FRA_lr_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_lr_econ_policy } } remove_dynamic_modifier = { modifier = FRA_lr_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_lr_social_balance } } remove_dynamic_modifier = { modifier = FRA_lr_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_rpf_political_balance } } remove_dynamic_modifier = { modifier = FRA_rpf_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_rpf_econ_policy } } remove_dynamic_modifier = { modifier = FRA_rpf_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_rpf_social_balance } } remove_dynamic_modifier = { modifier = FRA_rpf_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_fn_political_balance } } remove_dynamic_modifier = { modifier = FRA_fn_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_fn_econ_policy } } remove_dynamic_modifier = { modifier = FRA_fn_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_fn_social_balance } } remove_dynamic_modifier = { modifier = FRA_fn_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_lfi_political_balance } } remove_dynamic_modifier = { modifier = FRA_lfi_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_lfi_econ_policy } } remove_dynamic_modifier = { modifier = FRA_lfi_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_lfi_social_balance } } remove_dynamic_modifier = { modifier = FRA_lfi_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_eelv_political_balance } } remove_dynamic_modifier = { modifier = FRA_eelv_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_eelv_econ_policy } } remove_dynamic_modifier = { modifier = FRA_eelv_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_eelv_social_balance } } remove_dynamic_modifier = { modifier = FRA_eelv_social_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_pcf_political_balance } } remove_dynamic_modifier = { modifier = FRA_pcf_political_balance } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_pcf_econ_policy } } remove_dynamic_modifier = { modifier = FRA_pcf_econ_policy } }
+	if = { limit = { has_dynamic_modifier = { modifier = FRA_pcf_social_balance } } remove_dynamic_modifier = { modifier = FRA_pcf_social_balance } }
 	if = {
 		limit = { western_social_democrats_are_in_power = yes }
 		add_dynamic_modifier = { modifier = FRA_ps_econ_policy }
@@ -1579,8 +1579,8 @@ FRA_update_party_programmes = {
 	}
 	if = {
 		limit = { FRA_regime_restored = yes }
-		remove_dynamic_modifier = { modifier = FRA_political_balance }
-		remove_dynamic_modifier = { modifier = FRA_social_balance }
-		remove_dynamic_modifier = { modifier = FRA_6th_rep }
+		if = { limit = { has_dynamic_modifier = { modifier = FRA_political_balance } } remove_dynamic_modifier = { modifier = FRA_political_balance } }
+		if = { limit = { has_dynamic_modifier = { modifier = FRA_social_balance } } remove_dynamic_modifier = { modifier = FRA_social_balance } }
+		if = { limit = { has_dynamic_modifier = { modifier = FRA_6th_rep } } remove_dynamic_modifier = { modifier = FRA_6th_rep } }
 	}
 }


### PR DESCRIPTION
## Bottom line

Clears the Australia/France relative-position load errors, the Libya `remove_idea` and script-math failures, and the France party-programme `remove_dynamic_modifier` spam at 2000.1.1.

## Why

`relative_position_id` must name a focus already scripted in the same file. `remove_idea` is only valid inside `swap_ideas`. Two `multiply` keys in one math block default the value to 0. Removing a dynamic modifier the country does not have logs "modifier does not exist".

## How

`AST_new_columbo_plan` and `FRA_leave_nato` keep the same tree coords, retargeted at `AST_sail_steady` and `FRA_sovereignism`. Libya uses `remove_ideas` and a single `multiply = 0.3` (0.075 x 4). France only detaches programme modifiers that are actually attached.

Left alone: `TUR_great_east` exists (`turkey.txt:20577`) and the strategy-plan zeroes are valid. `context_type = diplomatic_action` is a known engine false positive. Loc collisions need `logs/text.log`.

BLUF