### PR TITLE
Rebuild the Norway AI path game rule (#3162)

### DIFF
--- a/common/ai_strategy_plans/NRY_strategy_plans.txt
+++ b/common/ai_strategy_plans/NRY_strategy_plans.txt
@@ -1,10 +1,11 @@
-NRY_LABOUR_plan = {
+NRY_HISTORICAL_plan = {
 	allowed = { original_tag = NRY }
 	name = "Labour Norway"
 	desc = "Social democracy, welfare renewal and a Western foreign policy"
 
 	enable = {
-		has_global_flag = NRY_LABOUR_FOCUS_PATH
+		NRY_ai_historical_path = yes
+		NRY_ai_not_historical_path = no
 	}
 
 	abort = {
@@ -140,6 +141,31 @@ NRY_PROGRESS_plan = {
 	ai_strategy = { type = befriend id = "ENG" value = 75 }
 	ai_strategy = { type = befriend id = "ISR" value = 50 }
 	ai_strategy = { type = antagonize id = "SOV" value = 50 }
+
+	weight = {
+		factor = 1.0
+	}
+}
+
+NRY_unscripted_plan = {
+	allowed = { original_tag = NRY }
+	name = "An Undirected Norway"
+	desc = "No scripted path is set, so Norway builds and befriends on general principles only"
+
+	enable = {
+		NRY_ai_historical_path = no
+		NRY_ai_not_historical_path = no
+	}
+
+	abort = {
+		is_subject = yes
+	}
+
+	ai_strategy = { type = befriend id = "SWE" value = 75 }
+	ai_strategy = { type = befriend id = "DEN" value = 75 }
+	ai_strategy = { type = befriend id = "USA" value = 75 }
+	ai_strategy = { type = befriend id = "ENG" value = 50 }
+	ai_strategy = { type = befriend id = "GER" value = 50 }
 
 	weight = {
 		factor = 1.0

--- a/common/decisions/Norway.txt
+++ b/common/decisions/Norway.txt
@@ -401,3 +401,110 @@ NRY_norge_mining_decision_cat = {
 		}
 	}
 }
+
+NRY_ai_path_category = {
+
+	NRY_ai_rally_the_christian_democrats = {
+
+		icon = generic_decision
+
+		cost = 25
+
+		days_re_enable = 30
+
+		visible = { has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+
+		available = {
+			has_civil_war = no
+			check_variable = { party_pop_array^14 < 0.55 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_ai_rally_the_christian_democrats"
+			set_temp_variable = { party_index = 14 }
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			set_temp_variable = { temp_outlook_increase = 0.04 }
+			change_relative_party_popularity = yes
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	NRY_ai_christian_democrats_take_the_country = {
+
+		icon = generic_decision
+
+		cost = 150
+
+		days_re_enable = 180
+
+		visible = { has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+
+		available = {
+			has_civil_war = no
+			neutrality_neutral_conservatism_are_in_power = no
+			check_variable = { party_pop_array^14 > 0.5 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_ai_christian_democrats_take_the_country"
+			set_temp_variable = { rul_party_temp = 14 }
+			change_ruling_party_effect = yes
+			hidden_effect = { update_party_name = yes }
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	NRY_ai_rally_the_progress_party = {
+
+		icon = generic_decision
+
+		cost = 25
+
+		days_re_enable = 30
+
+		visible = { has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+
+		available = {
+			has_civil_war = no
+			check_variable = { party_pop_array^20 < 0.55 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_ai_rally_the_progress_party"
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			set_temp_variable = { temp_outlook_increase = 0.04 }
+			change_relative_party_popularity = yes
+		}
+
+		ai_will_do = { base = 100 }
+	}
+
+	NRY_ai_progress_party_takes_the_country = {
+
+		icon = generic_decision
+
+		cost = 150
+
+		days_re_enable = 180
+
+		visible = { has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+
+		available = {
+			has_civil_war = no
+			nationalist_right_wing_populists_are_in_power = no
+			check_variable = { party_pop_array^20 > 0.5 }
+		}
+
+		complete_effect = {
+			log = "[GetDateText]: [Root.GetName]: Decision NRY_ai_progress_party_takes_the_country"
+			set_temp_variable = { rul_party_temp = 20 }
+			change_ruling_party_effect = yes
+			hidden_effect = { update_party_name = yes }
+		}
+
+		ai_will_do = { base = 100 }
+	}
+}

--- a/common/decisions/categories/99_NOR_decision_categories.txt
+++ b/common/decisions/categories/99_NOR_decision_categories.txt
@@ -7,3 +7,20 @@ NRY_norge_mining_decision_cat = {
 	}
 	priority = 250
 }
+
+NRY_ai_path_category = {
+	allowed = {
+		is_ai = yes
+		original_tag = NRY
+	}
+
+	icon = GFX_decisions_category_political
+	priority = 100
+
+	visible = {
+		OR = {
+			has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH
+			has_global_flag = NRY_PROGRESS_FOCUS_PATH
+		}
+	}
+}

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -3908,29 +3908,24 @@ NRY_ai_behavior = {
 	name = "NRY_AI_BEHAVIOR"
 	group = "RULE_GROUP_AI_BEHAVIOR"
 	option = {
-		name = DEFAULT
-		text = "RULE_OPTION_DEFAULT"
-		desc = "RULE_OPTION_DEFAULT_AI_DESC"
-	}
-	option = {
-		name = LABOUR
-		text = "RULE_OPTION_NRY_LABOUR"
-		desc = "RULE_OPTION_NRY_LABOUR_AI_DESC"
+		name = HISTORICAL
+		text = "RULE_OPTION_NRY_HISTORICAL"
+		desc = "RULE_OPTION_NRY_HISTORICAL_DESC"
 	}
 	option = {
 		name = CHRISTIAN_PEOPLES
 		text = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES"
-		desc = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES_AI_DESC"
+		desc = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES_DESC"
 	}
 	option = {
 		name = PROGRESS
 		text = "RULE_OPTION_NRY_PROGRESS"
-		desc = "RULE_OPTION_NRY_PROGRESS_AI_DESC"
+		desc = "RULE_OPTION_NRY_PROGRESS_DESC"
 	}
 	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
 	}
 	default = {
 		name = NO_PATH

--- a/common/national_focus/05_norway.txt
+++ b/common/national_focus/05_norway.txt
@@ -507,7 +507,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -918,7 +924,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -1156,7 +1168,13 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+		}
 	}
 
 	focus = {
@@ -1654,7 +1672,13 @@ focus_tree = {
 			add_command_power = 25
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	# Naval Force
@@ -1684,6 +1708,10 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 			modifier = {
 				factor = 0
 				can_staff_an_dockyard = no
@@ -1736,7 +1764,17 @@ focus_tree = {
 			modify_treasury_effect = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1761,7 +1799,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1795,7 +1839,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	# Ground Force
@@ -1825,6 +1875,10 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
 			modifier = {
 				factor = 0
 				can_staff_an_arms_industry = no
@@ -1859,7 +1913,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1885,7 +1945,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1912,7 +1978,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	# Air Force
@@ -1937,7 +2009,13 @@ focus_tree = {
 			add_ideas = NRY_airforce
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -1984,6 +2062,10 @@ focus_tree = {
 		ai_will_do = {
 			base = 1
 			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+			modifier = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
@@ -2014,7 +2096,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2041,7 +2129,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2063,7 +2157,13 @@ focus_tree = {
 			add_ideas = NRY_cyber_defense
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	focus = {
@@ -2097,7 +2197,13 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 2
+				ai_is_threatened = yes
+			}
+		}
 	}
 
 	# Political Branches
@@ -2126,10 +2232,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				add = 25
-				has_global_flag = NRY_LABOUR_FOCUS_PATH
-			}
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
 		}
 	}
 
@@ -2154,7 +2258,11 @@ focus_tree = {
 			add_ideas = NRY_the_modern_welfare_state
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2178,7 +2286,11 @@ focus_tree = {
 			add_ideas = NRY_youth_wing_workers
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2251,6 +2363,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_offices = no
 			}
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
 		}
 	}
 
@@ -2299,6 +2413,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
 		}
 	}
 
@@ -2337,6 +2453,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
 		}
 	}
 
@@ -2364,7 +2482,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2390,7 +2512,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2426,7 +2552,11 @@ focus_tree = {
 			change_influence_percentage = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2450,7 +2580,11 @@ focus_tree = {
 			country_event = norway.91
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2509,7 +2643,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2562,7 +2700,15 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 0
+				has_active_mission = bankruptcy_incoming_collapse
+			}
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2613,7 +2759,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	focus = {
@@ -2639,7 +2789,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 NRY_ai_historical_path = yes }
+			modifier = { factor = 0 NRY_ai_not_historical_path = yes }
+		}
 	}
 
 	# Kristelig Folkeparti
@@ -2666,10 +2820,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				add = 25
-				has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH
-			}
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
 		}
 	}
 
@@ -2694,7 +2846,11 @@ focus_tree = {
 			country_event = norway.14
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2718,7 +2874,11 @@ focus_tree = {
 			add_ideas = NRY_restrictive_abortions
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2745,7 +2905,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2769,7 +2933,11 @@ focus_tree = {
 			increase_economic_growth = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2800,7 +2968,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2835,6 +3007,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
 		}
 	}
 
@@ -2863,7 +3037,11 @@ focus_tree = {
 			add_stability = -0.02
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2910,7 +3088,11 @@ focus_tree = {
 			add_stability = -0.01
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2934,7 +3116,11 @@ focus_tree = {
 			add_ideas = NRY_fair_refugee_distribution_idea
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2967,7 +3153,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -2991,7 +3181,11 @@ focus_tree = {
 			add_ideas = NRY_nato_drilling_idea
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -3043,6 +3237,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
 		}
 	}
 
@@ -3070,7 +3266,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	focus = {
@@ -3100,7 +3300,11 @@ focus_tree = {
 			change_relative_party_popularity = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_christian_peoples_path = yes }
+		}
 	}
 
 	# Fremskrisspartiset
@@ -3126,10 +3330,8 @@ focus_tree = {
 
 		ai_will_do = {
 			base = 1
-			modifier = {
-				add = 25
-				has_global_flag = NRY_PROGRESS_FOCUS_PATH
-			}
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
 		}
 	}
 
@@ -3179,6 +3381,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_offices = no
 			}
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
 		}
 	}
 
@@ -3214,6 +3418,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
 		}
 	}
 
@@ -3238,7 +3444,11 @@ focus_tree = {
 			add_ideas = NRY_abolish_inheritence_tax
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3266,7 +3476,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3290,7 +3504,11 @@ focus_tree = {
 			add_ideas = NRY_free_society
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3317,7 +3535,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3367,7 +3589,11 @@ focus_tree = {
 			recalculate_party = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3393,7 +3619,11 @@ focus_tree = {
 			add_ideas = NRY_lawful_society
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3419,7 +3649,11 @@ focus_tree = {
 			change_domestic_influence_percentage = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3446,7 +3680,11 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3474,7 +3712,11 @@ focus_tree = {
 			increase_centralization = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	focus = {
@@ -3521,6 +3763,8 @@ focus_tree = {
 				factor = 0
 				has_active_mission = bankruptcy_incoming_collapse
 			}
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
 		}
 	}
 
@@ -3571,6 +3815,8 @@ focus_tree = {
 				factor = 0
 				can_staff_an_dockyard = no
 			}
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
 		}
 	}
 
@@ -3599,7 +3845,11 @@ focus_tree = {
 			decrease_corruption = yes
 		}
 
-		ai_will_do = { base = 1 }
+		ai_will_do = {
+			base = 1
+			modifier = { factor = 25 has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+			modifier = { factor = 0 NRY_ai_not_progress_path = yes }
+		}
 	}
 
 	shared_focus = USoE001

--- a/common/on_actions/999_game_rules_on_actions.txt
+++ b/common/on_actions/999_game_rules_on_actions.txt
@@ -1731,20 +1731,11 @@ on_actions = {
 					limit = {
 						has_game_rule = {
 							rule = NRY_ai_behavior
-							option = RANDOM
-						}
-						NOT = {
-							OR = {
-								has_global_flag = NRY_LABOUR_FOCUS_PATH
-								has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH
-								has_global_flag = NRY_PROGRESS_FOCUS_PATH
-								has_global_flag = NRY_DEFAULT_FOCUS_PATH
-							}
+							option = RANDOM_PATH
 						}
 					}
 					random_list = {
-						10 = { set_global_flag = NRY_DEFAULT_FOCUS_PATH } #Default
-						30 = { set_global_flag = NRY_LABOUR_FOCUS_PATH }
+						40 = { set_global_flag = NRY_HISTORICAL_FOCUS_PATH }
 						30 = { set_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
 						30 = { set_global_flag = NRY_PROGRESS_FOCUS_PATH }
 					}
@@ -1753,10 +1744,10 @@ on_actions = {
 					limit = {
 						has_game_rule = {
 							rule = NRY_ai_behavior
-							option = LABOUR
+							option = HISTORICAL
 						}
 					}
-					set_global_flag = NRY_LABOUR_FOCUS_PATH
+					set_global_flag = NRY_HISTORICAL_FOCUS_PATH
 				}
 				if = {
 					limit = {
@@ -1779,29 +1770,23 @@ on_actions = {
 				if = {
 					limit = {
 						is_ai = yes
-						has_global_flag = NRY_LABOUR_FOCUS_PATH
-						NOT = { has_country_flag = NRY_ai_sentiment_granted }
+						has_global_flag = NRY_HISTORICAL_FOCUS_PATH
 					}
 					add_timed_idea = { idea = NRY_ai_labour_sentiment days = 1095 }
-					set_country_flag = NRY_ai_sentiment_granted
 				}
-				if = {
+				else_if = {
 					limit = {
 						is_ai = yes
 						has_global_flag = NRY_PROGRESS_FOCUS_PATH
-						NOT = { has_country_flag = NRY_ai_sentiment_granted }
 					}
 					add_timed_idea = { idea = NRY_ai_progress_sentiment days = 1095 }
-					set_country_flag = NRY_ai_sentiment_granted
 				}
-				if = {
+				else_if = {
 					limit = {
 						is_ai = yes
 						has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH
-						NOT = { has_country_flag = NRY_ai_sentiment_granted }
 					}
 					add_timed_idea = { idea = NRY_ai_christian_sentiment days = 1095 }
-					set_country_flag = NRY_ai_sentiment_granted
 				}
 			}
 

--- a/common/scripted_triggers/99_NRY_scripted_triggers.txt
+++ b/common/scripted_triggers/99_NRY_scripted_triggers.txt
@@ -1,0 +1,31 @@
+NRY_ai_historical_path = {
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = NRY_HISTORICAL_FOCUS_PATH
+	}
+}
+
+NRY_ai_not_historical_path = {
+	OR = {
+		has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH
+		has_global_flag = NRY_PROGRESS_FOCUS_PATH
+	}
+}
+
+NRY_ai_not_christian_peoples_path = {
+	NOT = { has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = NRY_HISTORICAL_FOCUS_PATH
+		has_global_flag = NRY_PROGRESS_FOCUS_PATH
+	}
+}
+
+NRY_ai_not_progress_path = {
+	NOT = { has_global_flag = NRY_PROGRESS_FOCUS_PATH }
+	OR = {
+		is_historical_focus_on = yes
+		has_global_flag = NRY_HISTORICAL_FOCUS_PATH
+		has_global_flag = NRY_CHRISTIAN_PEOPLES_FOCUS_PATH
+	}
+}

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -313,12 +313,12 @@
  RULE_OPTION_DEN_NATIONALIST_DESC: "The §8Danish People's Party§! takes the government it has only ever propped up and makes immigration and border control the whole of Danish politics. Denmark leaves the alliance and the Nordic Council, and begins pressing claims it has not raised since the Middle Ages."
 
  #Norway
- RULE_OPTION_NRY_LABOUR: "Labour Party"
- RULE_OPTION_NRY_LABOUR_AI_DESC: "Norway will keep the Labour Party in power, pursuing social democracy and close ties to NATO and the West."
- RULE_OPTION_NRY_CHRISTIAN_PEOPLES: "Christian People's Party"
- RULE_OPTION_NRY_CHRISTIAN_PEOPLES_AI_DESC: "Norway will rally behind the Christian People's Party, blending Christian social values with Nordic cooperation and development aid."
- RULE_OPTION_NRY_PROGRESS: "Progress Party"
- RULE_OPTION_NRY_PROGRESS_AI_DESC: "Norway will empower the Progress Party, pushing tax cuts, tighter immigration and an oil-funded state."
+ RULE_OPTION_NRY_HISTORICAL: "Historical"
+ RULE_OPTION_NRY_HISTORICAL_DESC: "The centre coalition gives way and §8Labour§! takes back the government, spending the oil fund on the welfare state and keeping Norway firmly inside the alliance. Oslo makes a career of peace talks and development aid while staying out of the Union its neighbours joined."
+ RULE_OPTION_NRY_CHRISTIAN_PEOPLES: "The Christian Centre"
+ RULE_OPTION_NRY_CHRISTIAN_PEOPLES_DESC: "The §8Christian People's Party§! keeps the premiership and writes family morals, development aid and a generous refugee quota into national policy. Norway drills with the alliance but holds Brussels at arm's length, taking in the migrants its southern neighbours cannot."
+ RULE_OPTION_NRY_PROGRESS: "Norway for the Norwegians"
+ RULE_OPTION_NRY_PROGRESS_DESC: "The §8Progress Party§! breaks out of opposition and spends the oil wealth on tax cuts, hospital wards and care for the elderly rather than on foreign aid. Norway centralises, hardens its immigration law and turns a colder face to the Nordic neighbours that once counted on it."
 
  #Greenland
  GRN_AI_BEHAVIOR: "@GRN Greenland"

--- a/localisation/english/replace/replaced_from_game_rules_l_english.yml
+++ b/localisation/english/replace/replaced_from_game_rules_l_english.yml
@@ -74,7 +74,7 @@
  RULE_OPTION_ALLOWED: "Allowed"
  SWE_AI_BEHAVIOR: "@SWE Kingdom of Sweden"
  DEN_AI_BEHAVIOR: "@DEN Denmark"
- NRY_AI_BEHAVIOR: "@NRY Kingdom of Norway"
+ NRY_AI_BEHAVIOR: "@NRY Norway"
  GRE_AI_BEHAVIOR: "@GRE Greece"
  HKG_AI_BEHAVIOR: "@HKG Hong Kong"
  BRA_AI_BEHAVIOR: "@BRA Brazil"


### PR DESCRIPTION
Part of #3162.

## Problem

`NRY_ai_behavior` was pre-standard and the tree was effectively unsteered:

- Options were `DEFAULT / LABOUR / CHRISTIAN_PEOPLES / PROGRESS / RANDOM / NO_PATH`. `DEFAULT` set no
  flag at all, and `RANDOM`'s list seeded `NRY_DEFAULT_FOCUS_PATH`, a flag nothing in the mod reads.
- Only **3 of 100 focuses** carried a path modifier, and all three used `add = 25`, which loses to any
  multiplicative modifier. The 44 political focuses below the three party roots sat at flat `base = 1`,
  so no rule state changed what the AI did.
- All four `_DESC` keys were one sentence; the header key read `@NRY Kingdom of Norway`.
- Every strategy plan was path-gated, so `NO_PATH` left Norway with no plan at all.

## The fork

The tree has exactly three political spines, each gated on a ruling party, plus a path-neutral trunk
of 41 economy and 15 military focuses:

| Spine | Root | `available` | Focuses |
|---|---|---|---|
| Labour (Ap) | `NRY_party_of_labour` | `western_social_democrats_are_in_power` | 14 |
| Christian People's (KrF) | `NRY_christan_peoples_party` | `neutrality_neutral_conservatism_are_in_power` | 15 |
| Progress (FrP) | `NRY_party_of_progress` | `nationalist_right_wing_populists_are_in_power` | 15 |

**Labour is the historical path** — Norway 2000-present is Stoltenberg and Støre — so `LABOUR` folds
into `HISTORICAL` rather than standing as a fourth option naming the same spine.

## Changes

**Rule and localisation.** `HISTORICAL` + `CHRISTIAN_PEOPLES` + `PROGRESS` + `RANDOM_PATH`, with
`NO_PATH` as the `default = { }` block. Historical displays as `"Historical"`; the two alt options get
player-facing names ("The Christian Centre", "Norway for the Norwegians") in place of the old bare
party labels. Every `_desc` is two sentences with `§8…§!` on party names. `RANDOM_PATH` and `NO_PATH`
reuse the shared `RULE_OPTION_MD_*` keys. Header key normalised to `@NRY Norway`.

**Wiring.** `NRY_LABOUR_FOCUS_PATH` → `NRY_HISTORICAL_FOCUS_PATH`; `NRY_DEFAULT_FOCUS_PATH` deleted.
`RANDOM_PATH` draws a three-bucket list that includes the historical bucket. The three sentiment
grants collapse to `if`/`else_if` and the `NRY_ai_sentiment_granted` bookkeeping country flag is gone.
`NO_PATH` gets no branch.

**Ownership.** New `common/scripted_triggers/99_NRY_scripted_triggers.txt` with four triggers, and all
44 political focuses re-owned through `apply_ai_path_weights.py` (multiplicative `factor = 25` boost,
`factor = 0` killswitch, both last in the block). The economy and military trunk stays path-neutral.

**Reachability.** Norway starts with KrF governing (`ruling_party = 14`, Bondevik) but `socialism` is
the largest party at 0.258, so Labour takes the 2001 election unaided and the historical path needs no
help. KrF loses that election and FrP is never in power, so both alt paths get an AI-only ramp pair in
a new `NRY_ai_path_category` — rally to 0.55, take the country above 0.5. `temp_outlook_increase` is
required for both: FrP is the only nationalist party, so it has no siblings to redistribute from, and
KrF has to clear socialism while the whole neutrality outlook is only 0.328. The takeovers deliberately
do **not** pass `disable_elections` — both fire only above 50% popularity in a country whose politics
should keep running, and the rally decision holds the party there.

**AI hardening.** `ai_is_threatened` weighting on the 15 military-spine focuses; bankruptcy guards on
the five spending focuses that had none (`NRY_packages_of_aid`, `NRY_renewable_investments`,
`NRY_contract_veidekke`, `NRY_haakonsvern_naval_base`, `NRY_statens_vangsen`). `NRY_unscripted_plan`
gives `NO_PATH` a working plan, in the `JAP_unscripted_plan` shape. No per-tag war brake was added:
the tree generates no wargoal and `MD_avoid_new_wars_when_outmatched` already covers the country.

## Deliberately not done

- **No historical government walker.** The report verdicts Norway's successor roster undated on every
  sub-ideology, so a walker would install the wrong person; the party is all the path can honestly
  steer.
- **No Conservative (Høyre) path.** Solberg's governments matter historically, but no such spine exists
  in the tree and adding one is new content, not a #3162 conversion.
- **`NRY_unscripted_plan` has no `focus_factors`** — the report lists this, and it is the point: under
  `NO_PATH` the AI picks freely, which is what the option's description promises.
- **No file reordering** — the alphabetical pass is a separate cross-cutting checklist item.

## Verification

- `ai_path_report.py --tag NRY` — rule, wiring, mechanics and government sections clean; 0 orphans and
  0 stranded focuses in all 8 state rows; no additive path modifiers; no unreferenced flags. `NO_PATH`
  with historical AI off leaves all 100 focuses live.
- `validate_focus_tree.py --path .` — NO ISSUES FOUND (unchanged).
- `validate_decisions.py` — identical to the pre-change baseline (283/7 errors, 455/3 warnings); no new
  group, and no `ai-only-decision-localisation` from the new AI-only category.
- `check_common_mistakes.py` — no Norway findings.
- Plan prerequisite closure re-checked for all four `ai_national_focuses` lists.
- No surviving reference to `NRY_LABOUR_FOCUS_PATH`, `NRY_DEFAULT_FOCUS_PATH`,
  `NRY_ai_sentiment_granted` or the old `_AI_DESC` keys outside non-English localisation, which is out
  of scope per `AGENTS.md`.
