### PR TITLE
Fix Gulf coalition election flow

### DIFF
--- a/common/decisions/Gulf.txt
+++ b/common/decisions/Gulf.txt
@@ -841,57 +841,6 @@ gulf_society = {
 
 shia_decisions = {
 
-	# The politics view is the only route out of set_partyall_banned, and the AI cannot use it.
-	BHR_legalise_the_opposition = {
-
-		icon = GFX_decision_generic_political_discourse
-
-		allowed = { original_tag = BHR }
-
-		visible = {
-			is_ai = yes
-			has_completed_focus = GCC_free_and_fair_elections
-			OR = {
-				AND = {
-					has_global_flag = BHR_DAY_OF_RAGE_FOCUS_PATH
-					OR = {
-						has_country_flag = party7_banned
-						has_country_flag = party9_banned
-					}
-				}
-				AND = {
-					has_global_flag = BHR_CROWNED_DEMOCRACY_FOCUS_PATH
-					OR = {
-						has_country_flag = party2_banned
-						has_country_flag = party3_banned
-					}
-				}
-			}
-		}
-
-		cost = 75
-
-		days_remove = 30
-
-		remove_effect = {
-			log = "[GetDateText]: [Root.GetName]: Decision BHR_legalise_the_opposition"
-			if = {
-				limit = { has_global_flag = BHR_DAY_OF_RAGE_FOCUS_PATH }
-				clr_country_flag = party7_banned
-				clr_country_flag = party9_banned
-			}
-			else = {
-				clr_country_flag = party2_banned
-				clr_country_flag = party3_banned
-			}
-			clr_country_flag = partyall_banned
-			recalculate_party = yes
-			add_stability = 0.02
-		}
-
-		ai_will_do = { base = 10 }
-	}
-
 	encourage_shia_immigration = {
 
 		icon = GFX_decision_infiltrate_state

--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -2667,6 +2667,8 @@ focus_tree = {
 
 		completion_reward = {
 			enable_elections_with_no_leader_change = yes
+			set_country_flag = free_allow_parties
+			set_partyall_allowed = yes
 			if = {
 				limit = { original_tag = BHR }
 				swap_ideas = {

--- a/common/scripted_effects/00_MD_politicsview_scripted_effects.txt
+++ b/common/scripted_effects/00_MD_politicsview_scripted_effects.txt
@@ -2456,37 +2456,35 @@ unban_party_scripted_call = {
 
 set_partyall_banned = {
 	set_country_flag = partyall_banned
-
-	if = { limit = { NOT = { has_country_flag = free_ban_parties } }
-		set_temp_variable = { pp_cost = 0 }
-		for_loop_effect = {
-			end = 24
-			value = ban_i
-			if = {
-				limit = {
-					NOT = {
-						AND = {
-							has_variable = ruling_party
-							check_variable = { ruling_party = ban_i }
-						}
+	set_temp_variable = { pp_cost = 0 }
+	for_loop_effect = {
+		end = 24
+		value = ban_i
+		if = {
+			limit = {
+				NOT = {
+					AND = {
+						has_variable = ruling_party
+						check_variable = { ruling_party = ban_i }
 					}
-					NOT = { is_in_array = { gov_coalition_array = ban_i } }
 				}
-				set_temp_variable = { ban_flag_index = ban_i }
-				add_to_temp_variable = { ban_flag_index = 1 }
-				meta_effect = {
-					text = {
-						if = {
-							limit = { NOT = { has_country_flag = party[v]_banned } }
-							add_to_temp_variable = { pp_cost = 10 }
-							set_country_flag = party[v]_banned
-						}
+				NOT = { is_in_array = { gov_coalition_array = ban_i } }
+			}
+			set_temp_variable = { ban_flag_index = ban_i }
+			add_to_temp_variable = { ban_flag_index = 1 }
+			meta_effect = {
+				text = {
+					if = {
+						limit = { NOT = { has_country_flag = party[v]_banned } }
+						add_to_temp_variable = { pp_cost = 10 }
+						set_country_flag = party[v]_banned
 					}
-					v = "[?ban_flag_index|.0]"
 				}
+				v = "[?ban_flag_index|.0]"
 			}
 		}
-
+	}
+	if = { limit = { NOT = { has_country_flag = free_ban_parties } }
 		multiply_temp_variable = { pp_cost = -1 }
 		add_political_power = pp_cost
 	}
@@ -2498,30 +2496,28 @@ set_partyall_banned = {
 
 set_partyall_allowed = {
 	clr_country_flag = partyall_banned
-
-	if = { limit = { NOT = { has_country_flag = free_allow_parties } }
-		set_temp_variable = { pp_cost = 0 }
-		for_loop_effect = {
-			end = 24
-			value = unban_i
-			set_temp_variable = { unban_flag_index = unban_i }
-			add_to_temp_variable = { unban_flag_index = 1 }
-			meta_effect = {
-				text = {
-					if = { limit = { has_country_flag = party[v]_banned }
-						add_to_temp_variable = { pp_cost = 10 }
-						clr_country_flag = party[v]_banned
-					}
+	set_temp_variable = { pp_cost = 0 }
+	for_loop_effect = {
+		end = 24
+		value = unban_i
+		set_temp_variable = { unban_flag_index = unban_i }
+		add_to_temp_variable = { unban_flag_index = 1 }
+		meta_effect = {
+			text = {
+				if = { limit = { has_country_flag = party[v]_banned }
+					add_to_temp_variable = { pp_cost = 10 }
+					clr_country_flag = party[v]_banned
 				}
-				v = "[?unban_flag_index|.0]"
 			}
+			v = "[?unban_flag_index|.0]"
 		}
-
+	}
+	if = { limit = { NOT = { has_country_flag = free_allow_parties } }
 		multiply_temp_variable = { pp_cost = -1 }
 		add_political_power = pp_cost
 	}
 
-	clr_country_flag = free_ban_parties
+	clr_country_flag = free_allow_parties
 	custom_effect_tooltip = set_partyall_allowed_tt
 	update_dirty_politicsview_expanded = yes
 }

--- a/common/scripted_guis/00_MD_politicsview_scripted_guis.txt
+++ b/common/scripted_guis/00_MD_politicsview_scripted_guis.txt
@@ -246,6 +246,7 @@ scripted_gui = {
 						salafist_caliphate_are_in_power = yes
 						has_country_flag = generic_election_killswitch
 						has_country_flag = hold_reelections_flag
+						has_country_flag = partyall_banned
 					}
 				}
 

--- a/history/countries/ALG - Algeria.txt
+++ b/history/countries/ALG - Algeria.txt
@@ -318,22 +318,6 @@ set_research_slots = 4
 	### Ruling Party
 	set_variable = { ruling_party = 7 }
 
-	#1997 election results
-	set_variable = { party_pop_elect_array^1 = 0 } #conservatism - ANR
-	set_variable = { party_pop_elect_array^2 = 0.337 } #liberalism - RND
-	set_variable = { party_pop_elect_array^3 = 0 } #socialist - MPA
-	set_variable = { party_pop_elect_array^6 = 0 } #Conservative - FNA
-	set_variable = { party_pop_elect_array^7 = 0.143 } #Autocracy - FLN
-	set_variable = { party_pop_elect_array^11 = 0 } #Caliphate - Salafist Group for Preaching and Combat
-	set_variable = { party_pop_elect_array^12 = 0.148 } #Neutral_Muslim_Brotherhood - Movement of Society for Peace
-	set_variable = { party_pop_elect_array^13 = 0 } #Neutral_Autocracy - Islah/MRN
-	set_variable = { party_pop_elect_array^14 = 0.087 } #Neutral_conservatism - Nahda/MRI
-	set_variable = { party_pop_elect_array^18 = 0.05 } #neutral_Social - FFS
-	set_variable = { party_pop_elect_array^19 = 0.019 } #Neutral_Communism - Worker's Party
-	set_variable = { party_pop_elect_array^20 = 0 } #Nat_Populism - FJD
-	set_variable = { party_pop_elect_array^21 = 0 } #Nat_Fascism - New Dawn
-	set_variable = { party_pop_elect_array^22 = 0 } #Nat_Autocracy - Algerian People's National Armed Forces
-
 	startup_politics = yes
 
 	### Banned Parties & Balance

--- a/history/countries/BAY - Bavaria.txt
+++ b/history/countries/BAY - Bavaria.txt
@@ -110,16 +110,6 @@ capital = 43
 	# GOVERNMENT
 	set_variable = { ruling_party = 1 } #socialist
 
-	# 1998 STATE ELECTION
-	set_variable = { party_pop_elect_array^1 = 0.529 } # CSU
-	set_variable = { party_pop_elect_array^2 = 0.017 } # FPD
-	set_variable = { party_pop_elect_array^3 = 0.287 } # SPD
-	set_variable = { party_pop_elect_array^6 = 0.006 } # BfB
-	set_variable = { party_pop_elect_array^13 = 0.008 } # BP
-	set_variable = { party_pop_elect_array^14 = 0.04 } # FW
-	set_variable = { party_pop_elect_array^17 = 0.075 } # GRÜNE
-	set_variable = { party_pop_elect_array^20 = 0.036 } # REP
-	set_variable = { party_pop_elect_array^21 = 0.002 } # REP
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/BOT - Botswana.txt
+++ b/history/countries/BOT - Botswana.txt
@@ -173,9 +173,6 @@ capital = 287
 
 	add_to_array = { gov_coalition_array = 16 }
 
-	set_variable = { party_pop_elect_array^14 = 0.429 } #Neutral_conservatism
-	set_variable = { party_pop_elect_array^16 = 0.143 } #Neutral_Libertarian
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/DEN - Denmark.txt
+++ b/history/countries/DEN - Denmark.txt
@@ -672,17 +672,6 @@ capital = 4
 	add_to_array = { gov_coalition_array = 14 } #Neutral_conservatism
 	add_to_array = { gov_coalition_array = 16 } #Neutral_Libertarian
 
-	###1998 election results###
-	set_variable = { party_pop_elect_array^1 = 0.089 } #conservatism
-	set_variable = { party_pop_elect_array^2 = 0.241 } #liberalism
-	set_variable = { party_pop_elect_array^3 = 0.359 } #socialism
-	set_variable = { party_pop_elect_array^5 = 0.027 } #anarchist_communism
-	set_variable = { party_pop_elect_array^14 = 0.043 } #Neutral_conservatism
-	set_variable = { party_pop_elect_array^16 = 0.039 } #Neutral_Libertarian
-	set_variable = { party_pop_elect_array^18 = 0.076 } #neutral_Social
-	set_variable = { party_pop_elect_array^20 = 0.074 } #Nat_Populism
-	set_variable = { party_pop_elect_array^21 = 0.024 } #Nat_Fascism
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/FIN - Finland.txt
+++ b/history/countries/FIN - Finland.txt
@@ -589,7 +589,7 @@ capital = 102
 	set_variable = { party_pop_elect_array^16 = 0.012 } #Neutral_Libertarian
 	set_variable = { party_pop_elect_array^17 = 0.073 } #Neutral_green
 	set_variable = { party_pop_elect_array^18 = 0.109 } #neutral_Social
-	set_variable = { party_pop_elect_array^18 = 0.008 } #Neutral_Communism
+	set_variable = { party_pop_elect_array^19 = 0.008 } #Neutral_Communism
 	set_variable = { party_pop_elect_array^20 = 0.010 } #Nat_Populism
 
 	startup_politics = yes

--- a/history/countries/FIN - Finland.txt
+++ b/history/countries/FIN - Finland.txt
@@ -579,19 +579,6 @@ capital = 102
 	add_to_array = { gov_coalition_array = 17 } #Neutral_green
 	add_to_array = { gov_coalition_array = 18 } #neutral_Social
 
-	#1998 election results
-	set_variable = { party_pop_elect_array^1 = 0.042 } #conservatism
-	set_variable = { party_pop_elect_array^2 = 0.210 } #liberalism
-	set_variable = { party_pop_elect_array^3 = 0.229 } #socialism
-	set_variable = { party_pop_elect_array^4 = 0.001 } #Communist-State
-	set_variable = { party_pop_elect_array^14 = 0.224 } #Neutral_conservatism
-	set_variable = { party_pop_elect_array^15 = 0.051 } #oligarchism
-	set_variable = { party_pop_elect_array^16 = 0.012 } #Neutral_Libertarian
-	set_variable = { party_pop_elect_array^17 = 0.073 } #Neutral_green
-	set_variable = { party_pop_elect_array^18 = 0.109 } #neutral_Social
-	set_variable = { party_pop_elect_array^19 = 0.008 } #Neutral_Communism
-	set_variable = { party_pop_elect_array^20 = 0.010 } #Nat_Populism
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/GAH - Ghana.txt
+++ b/history/countries/GAH - Ghana.txt
@@ -159,15 +159,6 @@ capital = 346
 	### Ruling Party
 	set_variable = { ruling_party = 3 }
 
-	#1996 election results
-	set_variable = { party_pop_elect_array^1 = 0.338 } #conservatism - NPP
-	set_variable = { party_pop_elect_array^3 = 0.53 } #socialist - NDC
-	set_variable = { party_pop_elect_array^4 = 0.067 } #Communist-State - CPP
-	set_variable = { party_pop_elect_array^5 = 0.001 } #anarchist_communism - DPP
-	set_variable = { party_pop_elect_array^17 = 0 } #Neutral_green - GCPP
-	set_variable = { party_pop_elect_array^18 = 0.001 } #neutral_Social - EGLE
-	set_variable = { party_pop_elect_array^19 = 0.033 } #Neutral_Communism - PNC
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/GER - Germany.txt
+++ b/history/countries/GER - Germany.txt
@@ -2107,13 +2107,6 @@ capital = 45
 	set_variable = { ruling_party = 3 } #socialist
 	add_to_array = { gov_coalition_array = 17 } #Neutral_green
 
-	#1998 election results
-	set_variable = { party_pop_elect_array^1 = 0.352 } #conservatism - CDU
-	set_variable = { party_pop_elect_array^16 = 0.062 } #liberalism - FPD
-	set_variable = { party_pop_elect_array^3 = 0.409 } #socialist - SPD
-	set_variable = { party_pop_elect_array^5 = 0.069 } #anarchist_communism
-	set_variable = { party_pop_elect_array^17 = 0.067 } #Neutral_green - Die Grune
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/GUA - Guatemala.txt
+++ b/history/countries/GUA - Guatemala.txt
@@ -202,12 +202,6 @@ capital = 841
 	### Ruling Party
 	set_variable = { ruling_party = 21 }
 
-	#1999 election results
-	set_variable = { party_pop_elect_array^1 = 0.269 } #conservatism - PAN
-	set_variable = { party_pop_elect_array^5 = 0.11 } #anarchist_communism - ANN
-	set_variable = { party_pop_elect_array^20 = 0.01 } #Nat_Populism - MLN
-	set_variable = { party_pop_elect_array^21 = 0.421 } #Nat_Fascism - FRG
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/GUY - Guyana.txt
+++ b/history/countries/GUY - Guyana.txt
@@ -155,12 +155,6 @@ capital = 877
 	set_variable = { party_pop_array^18 = 0.012 } #neutral_Social - WPA
 	set_variable = { party_pop_array^19 = 0.009 } #Neutral_Communism - GAP
 
-	#1997 election results
-	set_variable = { party_pop_elect_array^1 = 0.015 } #conservatism - TUF
-	set_variable = { party_pop_elect_array^3 = 0.405 } #socialism - PNC
-	set_variable = { party_pop_elect_array^5 = 0.553 } #anarchist_communism - PPP
-	set_variable = { party_pop_elect_array^18 = 0.012 } #neutral_Social - WPA
-
 	### Ruling Party
 	set_variable = { ruling_party = 5 }
 

--- a/history/countries/HZG - Herzegovinian.txt
+++ b/history/countries/HZG - Herzegovinian.txt
@@ -165,8 +165,6 @@ capital = 129
 
 	set_variable = { ruling_party = 6 } #Conservative
 
-	set_variable = { party_pop_elect_array^20 = 0.334 } #Conservative
-
 	startup_politics = yes
 
 

--- a/history/countries/NRY - Norway.txt
+++ b/history/countries/NRY - Norway.txt
@@ -307,7 +307,7 @@ capital = 32
 	### Non-Aligned (neutrality) ###: Neutral_Muslim_Brotherhood(12) Neutral_Autocracy(13) Neutral_conservatism(14) oligarchism(15) Neutral_Libertarian(16) Neutral_green(17) neutral_Social(18) Neutral_Communism(19)
 	### Nationalist (nationalist) ###: Nat_Populism(20) Nat_Fascism(21) Nat_Autocracy(22) Monarchist(23)
 
-	# All their definitions are stored in arrays - (party_pop_array) stores current popularities, (party_pop_elect_array) stores popularities at the previous election, (ruling_party) stores the ID of the governing party, (gov_coalition_array) stores the ID's of it's coalition partners. If party_pop_elect_array entries are not set for a party, it will take values from party_pop_array for this purpose. If no popularities are set at all, the game will give them failsafe values based on ruling outlook, geography and religion.
+	# All their definitions are stored in arrays - (party_pop_array) stores current popularities, (party_pop_elect_array) starts from party_pop_array and stores later election results, (ruling_party) stores the ID of the governing party, (gov_coalition_array) stores the ID's of it's coalition partners. If no popularities are set at all, the game will give them failsafe values based on ruling outlook, geography and religion.
 	# Please note that the main ruling party should NOT be also added to gov_coalition_array. Upon startup, parties are recalculated to conform to outlook popularities. This means that if the sum of popularity of say the western parties don't match the popularity of the democratic entry in set_politics = {}, or add up to 100, they will appear a bit different in-game, but there is no harm in this in general.
 	# Before any array values can be set for both 2000 and 2017, one must first use the scripted function start_politics_input = yes
 	# after input is finished, set startup_politics = yes
@@ -346,13 +346,6 @@ capital = 32
 	add_to_array = { gov_coalition_array = 1 } #conservatism
 	add_to_array = { gov_coalition_array = 2 } #liberalism
 	add_to_array = { gov_coalition_array = 15 } #oligarchism
-
-	#optional: special custom values representing % of votes in last election
-
-	set_variable = { party_pop_elect_array^1 = 0.143 } #conservatism
-	set_variable = { party_pop_elect_array^2 = 0.045 } #liberalism
-	set_variable = { party_pop_elect_array^14 = 0.137 } #Neutral_conservatism
-	set_variable = { party_pop_elect_array^15 = 0.079 } #oligarchism
 
 	startup_politics = yes
 

--- a/history/countries/POL - Poland.txt
+++ b/history/countries/POL - Poland.txt
@@ -737,13 +737,6 @@ capital = 114
 	}
 
 	start_politics_input = yes
-	set_variable = { party_pop_elect_array^3 = 0.272 }
-	set_variable = { party_pop_elect_array^2 = 0.134 }
-	set_variable = { party_pop_elect_array^6 = 0.023 }
-	set_variable = { party_pop_elect_array^1 = 0.338 }
-	set_variable = { party_pop_elect_array^20 = 0.083 }
-	set_variable = { party_pop_elect_array^15 = 0.073 }
-	set_variable = { party_pop_elect_array^18 = 0.047 }
 	set_variable = { ruling_party = 1 }
 	add_to_array = { gov_coalition_array = 2 }
 	set_variable = { party_pop_array^3 = 0.41 }

--- a/history/countries/RSK - Republika Srpska.txt
+++ b/history/countries/RSK - Republika Srpska.txt
@@ -179,8 +179,6 @@ capital = 1054
 
 	set_variable = { ruling_party = 6 } #Conservative
 
-	set_variable = { party_pop_elect_array^20 = 0.334 } #Conservative
-
 	startup_politics = yes
 
 

--- a/history/countries/SER - Serbia.txt
+++ b/history/countries/SER - Serbia.txt
@@ -638,10 +638,6 @@ capital = 131
 	add_to_array = { gov_coalition_array = 5 } #anarchist_communism
 	add_to_array = { gov_coalition_array = 21 } #Nat_Fascism
 
-	set_variable = { party_pop_elect_array^20 = 0.334 } #Nat_Populism
-	set_variable = { party_pop_elect_array^5 = 0.078 } #anarchist_communism
-	set_variable = { party_pop_elect_array^21 = 0.354 } #Nat_Fascism
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/SOV - Russia.txt
+++ b/history/countries/SOV - Russia.txt
@@ -5707,15 +5707,6 @@ capital = 652
 	add_to_array = { gov_coalition_array = 0 }
 	add_to_array = { gov_coalition_array = 15 }
 
-	#1999 parliament election results and some from 1996 pres elections
-	set_variable = { party_pop_elect_array^1 = 0.085 } #conservatism
-	set_variable = { party_pop_elect_array^2 = 0.075 } #liberalism - yabloko
-	set_variable = { party_pop_elect_array^6 = 0.396 } #Conservative - fatherland and Unity parties
-	set_variable = { party_pop_elect_array^15 = 0 } #oligarchism
-	set_variable = { party_pop_elect_array^4 = 0.262 } #Communist-State
-	set_variable = { party_pop_elect_array^20 = 0.060 } #Nat_Populism
-	#election noteable for high % independents elected
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/SWE - Sweden.txt
+++ b/history/countries/SWE - Sweden.txt
@@ -1659,15 +1659,6 @@ capital = 34
 	#Government:
 	set_variable = { ruling_party = 3 } #socialist
 
-	#1998 election results
-	set_variable = { party_pop_elect_array^1 = 0.229 } #conservatism
-	set_variable = { party_pop_elect_array^2 = 0.047 } #liberalism
-	set_variable = { party_pop_elect_array^3 = 0.364 } #socialist
-	set_variable = { party_pop_elect_array^5 = 0.120 } #anarchist_communism
-	set_variable = { party_pop_elect_array^14 = 0.118 } #Neutral_conservatism
-	set_variable = { party_pop_elect_array^15 = 0.051 } #oligarchism
-	set_variable = { party_pop_elect_array^17 = 0.045 } #Neutral_green
-
 	startup_politics = yes
 
 	create_country_leader = {

--- a/history/countries/TOG - Togo.txt
+++ b/history/countries/TOG - Togo.txt
@@ -168,9 +168,6 @@ capital = 342
 	set_variable = { party_pop_array^13 = 0.415 } #Neutral_Autocracy - Rally of the Togolese People
 	set_variable = { party_pop_array^18 = 0.287 } #neutral_Social - Action Committee for Renewal
 
-	#1999 election results
-	set_variable = { party_pop_elect_array^13 = 0.975 } #Neutral_Autocracy - RTP
-
 	### Ruling Party
 	set_variable = { ruling_party = 13 }
 

--- a/history/countries/TUR - Turkey.txt
+++ b/history/countries/TUR - Turkey.txt
@@ -832,11 +832,6 @@ capital = 159
 	add_to_array = { gov_coalition_array = 16 }
 	add_to_array = { gov_coalition_array = 20 }
 
-	#Previous elections (1999) - put all other politics info above
-	set_variable = { party_pop_elect_array^3 = 0.222 } #conservatism
-	set_variable = { party_pop_elect_array^16 = 0.132 } #Neutral_Libertarian
-	set_variable = { party_pop_elect_array^20 = 0.18 } #Nat_Populism
-
 	startup_politics = yes
 
 	recruit_character = TUR_bulent_ecevit

--- a/history/countries/USA - USA.txt
+++ b/history/countries/USA - USA.txt
@@ -4972,7 +4972,7 @@ capital = 1182
 	# Non-Aligned (neutrality) ###: Neutral_Muslim_Brotherhood(12) Neutral_Autocracy(13) Neutral_conservatism(14) oligarchism(15) Neutral_Libertarian(16) Neutral_green(17) neutral_Social(18) Neutral_Communism(19)
 	# Nationalist (nationalist) ###: Nat_Populism(20) Nat_Fascism(21) Nat_Autocracy(22) Monarchist(23)
 
-	# All their definitions are stored in arrays - (party_pop_array) stores current popularities, (party_pop_elect_array) stores popularities at the previous election, (ruling_party) stores the ID of the governing party, (gov_coalition_array) stores the ID's of it's coalition partners. If party_pop_elect_array entries are not set for a party, it will take values from party_pop_array for this purpose. If no popularities are set at all, the game will give them failsafe values based on ruling outlook, geography and religion.
+	# All their definitions are stored in arrays - (party_pop_array) stores current popularities, (party_pop_elect_array) starts from party_pop_array and stores later election results, (ruling_party) stores the ID of the governing party, (gov_coalition_array) stores the ID's of it's coalition partners. If no popularities are set at all, the game will give them failsafe values based on ruling outlook, geography and religion.
 	# Please note that the main ruling party should NOT be also added to gov_coalition_array. Upon startup, parties are recalculated to conform to outlook popularites. This means that if the sum of popularity of say the western parties don't match the popularity of the democratic entry in set_politics = {}, or add up to 100, they will appear a bit different ingame, but there is no harm in this in general.
 	# Before any array values can be set for both 2000 and 2017, one must first use the scripted function start_politics_input = yes
 	# after intput is finished, set startup_politics = yes
@@ -5010,13 +5010,6 @@ capital = 1182
 	set_variable = { ruling_party = 2 } #democrat
 	add_to_array = { gov_coalition_array = 3 } #democrat progressives
 	add_to_array = { gov_coalition_array = 18 } #democratic socialist fringes
-
-	#1996 elections estimated - only over threshold added
-	set_variable = { party_pop_elect_array^1 = 0.407 } #repubs
-	set_variable = { party_pop_elect_array^2 = 0.437 } #dem libs
-	set_variable = { party_pop_elect_array^3 = 0.055 } #soc. dem
-	set_variable = { party_pop_elect_array^13 = 0.084 } #reform party
-	set_variable = { party_pop_elect_array^14 = 0.0 } #N/A cons cons
 
 	startup_politics = yes
 

--- a/history/countries/ZAM - Zambia.txt
+++ b/history/countries/ZAM - Zambia.txt
@@ -153,19 +153,6 @@ capital = 292
 	### Ruling Party
 	set_variable = { ruling_party = 3 }
 
-	#1996 election results
-	set_variable = { party_pop_elect_array^0 = 0 } #Western_Autocracy - Party for Poor People
-	set_variable = { party_pop_elect_array^1 = 0.138 } #conservatism - ZADECO
-	set_variable = { party_pop_elect_array^2 = 0 } #liberalism - UPND
-	set_variable = { party_pop_elect_array^3 = 0.609 } #socialist - MMD
-	set_variable = { party_pop_elect_array^5 = 0 } #anarchist_communism - UNIP
-	set_variable = { party_pop_elect_array^6 = 0 } #Conservative - Heritage
-	set_variable = { party_pop_elect_array^14 = 0 } #Neutral_conservatism - NAREP
-	set_variable = { party_pop_elect_array^17 = 0 } #Neutral_green - FDD
-	set_variable = { party_pop_elect_array^18 = 0 } #neutral_Social - PF
-	set_variable = { party_pop_elect_array^19 = 0 } #Neutral_Communism - Rainbow Party
-	set_variable = { party_pop_elect_array^20 = 0.071 } #Nat_Populism - NP
-
 	startup_politics = yes
 
 	create_country_leader = {


### PR DESCRIPTION
## Bottom line

Make Gulf free-and-fair elections legalize all parties so extraordinary elections can produce coalition invitations. Initialize every country's election snapshot from current party popularity.

## Why

- Free party-ban exemptions skipped the flag changes instead of only skipping the political-power cost.
- Gulf countries could enable elections while every opposition party remained banned.
- Only 20 country histories overrode initial election results, creating inconsistent startup behavior and extra maintenance.

## How

- Apply free party legalization when completing GCC_free_and_fair_elections.
- Restore the free ban and legalization helpers so they change flags and only exempt the cost.
- Block extraordinary elections while the one-party-state flag remains active.
- Remove the superseded Bahrain AI workaround.
- Remove historical election snapshots so startup uses current eligible party popularity for every country.

BLUF