### PR TITLE
Unlock SRA Creating a Federal Government after USA collapse

### DIFF
--- a/events/United States.txt
+++ b/events/United States.txt
@@ -12738,7 +12738,10 @@ country_event = {
 		name = USA_collapse_event.9.o1
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.9.o1 executed"
 		CSA = {
-			country_event = USA_collapse_event.23
+			country_event = {
+				id = USA_collapse_event.23
+				days = 2
+			}
 		}
 		every_unit_leader = {
 			limit = { has_trait = southern_soldier }
@@ -12786,7 +12789,10 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.9.o2 executed"
 		CSA = {
 			change_tag_from = USA
-			country_event = USA_collapse_event.23
+			country_event = {
+				id = USA_collapse_event.23
+				days = 2
+			}
 		}
 		every_unit_leader = {
 			limit = { has_trait = southern_soldier }

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -12494,12 +12494,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.7.o1
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.7.o1 executed"
-		CAS = {
-			country_event = {
-				id = USA_collapse_event.30
-				days = 2
-			}
-		}
 		every_unit_leader = {
 			limit = { has_trait = cascadian_soldier }
 			set_nationality = CAS
@@ -12537,6 +12531,7 @@ country_event = {
 			CAS = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_collapse_event.30 days = 2 }
 			}
 		}
 		ai_chance = { base = 30 }
@@ -12547,10 +12542,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.7.o2 executed"
 		CAS = {
 			change_tag_from = USA
-			country_event = {
-				id = USA_collapse_event.30
-				days = 2
-			}
 		}
 		every_unit_leader = {
 			limit = { has_trait = cascadian_soldier }
@@ -12589,6 +12580,7 @@ country_event = {
 			CAS = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_collapse_event.30 days = 2 }
 			}
 		}
 	}
@@ -12737,12 +12729,6 @@ country_event = {
 	option = {
 		name = USA_collapse_event.9.o1
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.9.o1 executed"
-		CSA = {
-			country_event = {
-				id = USA_collapse_event.23
-				days = 2
-			}
-		}
 		every_unit_leader = {
 			limit = { has_trait = southern_soldier }
 			set_nationality = CSA
@@ -12779,6 +12765,7 @@ country_event = {
 			CSA = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_collapse_event.23 days = 2 }
 			}
 		}
 		ai_chance = { base = 30 }
@@ -12789,10 +12776,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.9.o2 executed"
 		CSA = {
 			change_tag_from = USA
-			country_event = {
-				id = USA_collapse_event.23
-				days = 2
-			}
 		}
 		every_unit_leader = {
 			limit = { has_trait = southern_soldier }
@@ -12830,6 +12813,7 @@ country_event = {
 			CSA = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_collapse_event.23 days = 2 }
 			}
 		}
 	}
@@ -13489,10 +13473,6 @@ country_event = {
 				inherit_technology = PREV
 				transfer_state = 784
 				transfer_state = 785
-				country_event = {
-					id = LKT_collapse_event.1
-					days = 3
-				}
 			}
 		}
 	}
@@ -13536,6 +13516,7 @@ country_event = {
 			LKT = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = LKT_collapse_event.1 days = 3 }
 			}
 		}
 		ai_chance = { base = 30 }
@@ -13581,6 +13562,7 @@ country_event = {
 			LKT = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = LKT_collapse_event.1 days = 3 }
 			}
 		}
 	}
@@ -14024,16 +14006,11 @@ country_event = {
 			id = USA_collapse_event.20
 			days = 1
 		}
-		USB = {
-			country_event = {
-				id = USA_collapse_event.19
-				days = 3
-			}
-		}
 		hidden_effect = {
 			USB = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_collapse_event.19 days = 3 }
 			}
 		}
 		ai_chance = { base = 30 }
@@ -16606,10 +16583,7 @@ country_event = {
 		name = USA_crisis_event.1110.o1
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1110.o1 executed"
 		TEX = {
-			country_event = {
-				id = USA_crisis_event.1120
-				days = 4
-			}
+			country_event = { id = USA_crisis_event.1120 days = 4 }
 		}
 		country_event = {
 			id = USA_crisis_event.1111
@@ -16650,6 +16624,7 @@ country_event = {
 			TEX = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1120 days = 4 }
 			}
 		}
 	}
@@ -16659,10 +16634,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1110.o2 executed"
 		TEX = {
 			change_tag_from = USA
-			country_event = {
-				id = USA_crisis_event.1120
-				days = 4
-			}
 		}
 		country_event = {
 			id = USA_crisis_event.1111
@@ -16703,6 +16674,7 @@ country_event = {
 			TEX = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1120 days = 4 }
 			}
 		}
 	}
@@ -16734,10 +16706,7 @@ country_event = {
 			days = 1
 		}
 		TEX = {
-			country_event = {
-				id = USA_crisis_event.1112
-				days = 7
-			}
+			country_event = { id = USA_crisis_event.1112 days = 7 }
 		}
 	}
 }
@@ -16786,26 +16755,17 @@ country_event = {
 			}
 		}
 		TEX = {
-			country_event = {
-				id = USA_crisis_event.1115
-				days = 7
-			}
+			country_event = { id = USA_crisis_event.1115 days = 7 }
 		}
 		CSA = {
 			change_tag_from = TEX
-			country_event = {
-				id = USA_crisis_event.1121
-				days = 3
-			}
-			country_event = {
-				id = USA_crisis_event.1128
-				days = 1
-			}
 		}
 		hidden_effect = {
 			CSA = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1121 days = 3 }
+				country_event = { id = USA_crisis_event.1128 days = 1 }
 			}
 		}
 	}
@@ -16820,25 +16780,16 @@ country_event = {
 			}
 		}
 		TEX = {
-			country_event = {
-				id = USA_crisis_event.1115
-				days = 7
-			}
+			country_event = { id = USA_crisis_event.1115 days = 7 }
 		}
 		CSA = {
-			country_event = {
-				id = USA_crisis_event.1121
-				days = 3
-			}
-			country_event = {
-				id = USA_crisis_event.1128
-				days = 1
-			}
 		}
 		hidden_effect = {
 			CSA = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1121 days = 3 }
+				country_event = { id = USA_crisis_event.1128 days = 1 }
 			}
 		}
 	}
@@ -16995,10 +16946,7 @@ country_event = {
 			}
 		}
 		TEX = {
-			country_event = {
-				id = USA_crisis_event.1117
-				days = 7
-			}
+			country_event = { id = USA_crisis_event.1117 days = 7 }
 		}
 		hidden_effect = {
 			LKT = {
@@ -17018,21 +16966,13 @@ country_event = {
 			}
 		}
 		TEX = {
-			country_event = {
-				id = USA_crisis_event.1117
-				days = 7
-			}
-		}
-		LKT = {
-			country_event = {
-				id = USA_crisis_event.1122
-				days = 5
-			}
+			country_event = { id = USA_crisis_event.1117 days = 7 }
 		}
 		hidden_effect = {
 			LKT = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1122 days = 5 }
 			}
 		}
 	}
@@ -17155,10 +17095,6 @@ country_event = {
 		name = USA_crisis_event.1117.o2
 		log = "[GetDateText]: [This.GetName]: USA_crisis_event.1117.o2 executed"
 		NEN = {
-			country_event = {
-				id = USA_crisis_event.1123
-				days = 2
-			}
 		}
 		USA = {
 			country_event = {
@@ -17170,6 +17106,7 @@ country_event = {
 			NEN = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1123 days = 2 }
 			}
 		}
 	}
@@ -18143,6 +18080,7 @@ country_event = {
 			CAL = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1135 days = 1 }
 			}
 		}
 		USA = {
@@ -18154,12 +18092,6 @@ country_event = {
 				id = USA_crisis_event.1137
 				days = 3
 			}
-		}
-		CAL = {
-			country_event = {
-					id = USA_crisis_event.1135
-					days = 1
-				}
 		}
 	}
 }
@@ -18313,6 +18245,7 @@ country_event = {
 			GLC = {
 				set_country_flag = { flag = disabled_protests_system days = 1095 value = 1 }
 				ingame_startup_nations_effect = yes
+				country_event = { id = USA_crisis_event.1138 days = 1 }
 			}
 		}
 		USA = {
@@ -18320,12 +18253,6 @@ country_event = {
 				id = USA_crisis_event.1139
 				days = 7
 			}
-		}
-		GLC = {
-			country_event = {
-					id = USA_crisis_event.1138
-					days = 1
-				}
 		}
 	}
 }


### PR DESCRIPTION
## Bottom line

SRA (CSA) never got `USA_collapse_event.23` after the 2003 railroad-strike collapse, so `the_dust_settles` was never set and `CSA_focus_creating_a_federal_government` stayed locked. The event now waits 2 days, same as Cascadia and the Free States.

## Why

Event 9 creates CSA in `immediate`, then both options fired event 23 in the same hour. HOI4 drops country events sent to a nation that just spawned. Cascadia (`USA_collapse_event.30`, 2 days) and Free States (`USA_collapse_event.19`, 3 days) already delay their unlock events; CSA was the odd one out.

After the delay, CSA exists, "Southern Problems" can fire, and the first focus becomes available.

BLUF