### PR TITLE
Remove empty space in helicopter tech tab

### DIFF
--- a/interface/countrytechtreeview.gui
+++ b/interface/countrytechtreeview.gui
@@ -2479,8 +2479,8 @@ guiTypes = {
 				name = "techtree_stripes"
 				position = { x = 0 y = 0 }
 				size = {
-					width = 2100 height = 1500
-					min = { width= 100%% height= 100%% }
+					width = 2100 height = 1120
+					min = { width= 100%% height= 1120 }
 				}
 				clipping = no
 				background = {


### PR DESCRIPTION
## After

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/5a79f48c-9713-43de-9733-07a9bea66fb8" />

## Before

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/f5d69c31-7856-4283-9df4-854490a661fa" />
