### PR TITLE
Let UK truck MIOs boost heavy utility vehicles

### DIFF
--- a/common/military_industrial_organization/organizations/MD_ENG_organizations.txt
+++ b/common/military_industrial_organization/organizations/MD_ENG_organizations.txt
@@ -6,7 +6,7 @@ ENG_supacat_utility_manufacturer = {
 
 	task_capacity = 3
 
-	equipment_type = { util_vehicle_type }
+	equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 	research_categories = { CAT_util }
 
@@ -541,6 +541,7 @@ ENG_rheinmetall_manufacturer = {
 
 	equipment_type = {
 		util_vehicle_type
+		heavy_util_vehicle_type
 		medium_tank_chassis
 		medium_tank_amphibious_chassis
 		medium_tank_flame_chassis
@@ -1202,7 +1203,7 @@ ENG_rheinmetall_manufacturer = {
 
 		position = { x = 7 y = 0 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = {
 			maximum_speed = 0.03
@@ -1230,7 +1231,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = -1 y = 1 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = { fuel_consumption = -0.01 }
 
@@ -1257,7 +1258,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = 0 y = 1 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = {
 			defense = 0.03
@@ -1285,7 +1286,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = 1 y = 1 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = { maximum_speed = 0.05 }
 
@@ -1310,7 +1311,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = 0 y = 2 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = { defense = 0.05 }
 
@@ -1338,7 +1339,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = 1 y = 2 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = {
 			defense = 0.03
@@ -1369,7 +1370,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = -1 y = 2 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		production_bonus = { production_resource_need_factor = -0.05 }
 
@@ -1417,7 +1418,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = 1 y = 3 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		production_bonus = {
 			production_efficiency_gain_factor = 0.04
@@ -1445,7 +1446,7 @@ ENG_rheinmetall_manufacturer = {
 		relative_position_id = ENG_rheinmetall_mio_trait_hx_tactical_truck_family
 		position = { x = 0 y = 4 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = {
 			reliability = 0.03
@@ -1473,6 +1474,7 @@ ENG_general_dynamics_manufacturer = {
 
 	equipment_type = {
 		util_vehicle_type
+		heavy_util_vehicle_type
 		medium_tank_flame_chassis
 	}
 
@@ -1860,7 +1862,7 @@ ENG_general_dynamics_manufacturer = {
 
 		position = { x = 8 y = 0 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = {
 			defense = 0.085
@@ -1888,7 +1890,7 @@ ENG_general_dynamics_manufacturer = {
 		relative_position_id = ENG_general_dynamics_mio_trait_protected_mobility_modular_body
 		position = { x = -1 y = 1 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = {
 			maximum_speed = 0.09
@@ -1916,7 +1918,7 @@ ENG_general_dynamics_manufacturer = {
 		relative_position_id = ENG_general_dynamics_mio_trait_protected_mobility_modular_body
 		position = { x = 1 y = 1 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = { defense = 0.12 }
 
@@ -1941,7 +1943,7 @@ ENG_general_dynamics_manufacturer = {
 		relative_position_id = ENG_general_dynamics_mio_trait_protected_mobility_modular_body
 		position = { x = -1 y = 2 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = { fuel_consumption = -0.10 }
 
@@ -1966,7 +1968,7 @@ ENG_general_dynamics_manufacturer = {
 		relative_position_id = ENG_general_dynamics_mio_trait_protected_mobility_modular_body
 		position = { x = 1 y = 2 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		equipment_bonus = { build_cost_ic = -0.10 }
 
@@ -2021,7 +2023,7 @@ ENG_general_dynamics_manufacturer = {
 		relative_position_id = ENG_general_dynamics_mio_trait_protected_mobility_modular_body
 		position = { x = 1 y = 3 }
 
-		limit_to_equipment_type = { util_vehicle_type }
+		limit_to_equipment_type = { util_vehicle_type heavy_util_vehicle_type }
 
 		production_bonus = { production_efficiency_gain_factor = 0.12 }
 


### PR DESCRIPTION
## Bottom line
UK Supacat, Rheinmetall, and General Dynamics can now assign to heavy utility vehicles and apply the same production and equipment bonuses they already give regular utility.

## Why
Those three MIOs were util-only. Heavy util lines (Mastiff, Ridgeback, and similar) could not use them, so regular utility stayed the only incentivized option.

Closes #2117

BLUF