### PR TITLE
Fix Netherlands PvdA leadership outcome (#3500)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -441,6 +441,7 @@ v2.0.0
   - Raised the building slot ramp across every populated state category: state_01 to state_18 now scale from 4 to 62 base slots instead of 3 to 50, and MAX_SHARED_SLOTS is raised from 56 to 72 so railway and infrastructure modifiers still have headroom above the base. Only state_00, inhospitable and military base categories are unchanged, so this affects 1059 of 1250 states
 
  Bugfix:
+  - [HOL] Fixed the New Age of Social Democracy focus handing out a PvdA leader that contradicted the party's balance of power: every green and modernising focus and decision pushed the bar toward the Traditional Labor Base while every welfare and union one pushed it toward the Progressive Reformists, and a balance resting in the Progressive Leaning band completed no leader at all, dead-ending the branch. Asscher is now the traditional-labour outcome and Bos the centre one (Issue #3500)
   - Fixed the Renewable Energy Hotspot readout overlapping the bottom row of the state view building-slot grid whenever a state's grid is full
   - Fixed light-fighter doctrine bonuses displaying as generic "Fighter" bonuses (Issue #2745)
   - [ALG/KOR] Fixed the UN Security Council seat campaigns sharing lobbying flags, so Algeria's and Korea's bids could block each other and count each other's progress

--- a/common/decisions/netherlands.txt
+++ b/common/decisions/netherlands.txt
@@ -4028,7 +4028,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_modernize_party_policies"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.05
+				value = -0.05
 			}
 		}
 
@@ -4058,7 +4058,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_promote_urban_investments"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.05
+				value = -0.05
 			}
 		}
 
@@ -4093,7 +4093,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_focus_climate_policy"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.10
+				value = -0.1
 			}
 		}
 
@@ -4133,7 +4133,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_strengthen_union_influence"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.05
+				value = 0.05
 			}
 		}
 
@@ -4173,7 +4173,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_promote_rural_investments"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.05
+				value = 0.05
 			}
 		}
 
@@ -4214,7 +4214,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_climate_action_plan"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.05
+				value = -0.05
 			}
 		}
 
@@ -4244,7 +4244,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_social_housing_initiative"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.05
+				value = -0.05
 			}
 		}
 
@@ -4279,7 +4279,7 @@ HOL_pvda_balance_of_power_category = {
 			log = "[GetDateText]: [Root.GetName]: Decision HOL_pvda_private_energy_investments"
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.10
+				value = -0.1
 			}
 		}
 

--- a/common/national_focus/05_netherlands.txt
+++ b/common/national_focus/05_netherlands.txt
@@ -17913,7 +17913,7 @@ focus_tree = {
 			}
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18021,7 +18021,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -18130,7 +18130,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -18175,7 +18175,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -18221,7 +18221,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -18265,7 +18265,7 @@ focus_tree = {
 			}
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18313,7 +18313,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -18358,7 +18358,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -18447,7 +18447,7 @@ focus_tree = {
 			}
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18486,7 +18486,7 @@ focus_tree = {
 			}
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18538,7 +18538,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18581,7 +18581,7 @@ focus_tree = {
 			}
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18622,7 +18622,7 @@ focus_tree = {
 				limit = {
 					is_power_balance_in_range = {
 						id = HOL_pvda_balance_of_power_category
-						range < HOL_pvda_progressive_reformists_bop_left_medium_range
+						range < HOL_pvda_progressive_reformists_bop_left_low_range
 					}
 				}
 				complete_national_focus = HOL_samsom
@@ -18631,22 +18631,12 @@ focus_tree = {
 				limit = {
 					is_power_balance_in_range = {
 						id = HOL_pvda_balance_of_power_category
-						range > HOL_pvda_progressive_reformists_bop_left_medium_range
-					}
-					is_power_balance_in_range = {
-						id = HOL_pvda_balance_of_power_category
-						range < HOL_pvda_traditional_labor_base_bop_right_medium_range
+						range > HOL_pvda_traditional_labor_base_bop_right_low_range
 					}
 				}
 				complete_national_focus = HOL_asscher
 			}
-			else_if = {
-				limit = {
-					is_power_balance_in_range = {
-						id = HOL_pvda_balance_of_power_category
-						range > HOL_pvda_progressive_reformists_bop_left_medium_range
-					}
-				}
+			else = {
 				complete_national_focus = HOL_bos
 			}
 		}
@@ -18703,7 +18693,7 @@ focus_tree = {
 			western_social_democrats_are_in_power = yes
 			is_power_balance_in_range = {
 				id = HOL_pvda_balance_of_power_category
-				range < HOL_pvda_progressive_reformists_bop_left_medium_range
+				range < HOL_pvda_progressive_reformists_bop_left_low_range
 			}
 		}
 
@@ -18755,7 +18745,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18790,7 +18780,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18825,7 +18815,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18857,7 +18847,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -18973,7 +18963,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -19036,7 +19026,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -19103,7 +19093,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -19117,9 +19107,20 @@ focus_tree = {
 		id = HOL_asscher
 		icon = dutch_Asscher
 
-		x = 0
+		x = 6
 		y = 1
 		relative_position_id = HOL_new_socialist_age
+		offset = {
+			x = -6
+			y = 0
+			trigger = {
+				has_game_rule = {
+					rule = obsolete_focus_branches_visibility
+					option = HIDE
+				}
+				has_completed_focus = HOL_asscher
+			}
+		}
 
 		cost = 1
 
@@ -19148,11 +19149,7 @@ focus_tree = {
 			western_social_democrats_are_in_power = yes
 			is_power_balance_in_range = {
 				id = HOL_pvda_balance_of_power_category
-				range > HOL_pvda_progressive_reformists_bop_left_medium_range
-			}
-			is_power_balance_in_range = {
-				id = HOL_pvda_balance_of_power_category
-				range < HOL_pvda_traditional_labor_base_bop_right_medium_range
+				range > HOL_pvda_traditional_labor_base_bop_right_low_range
 			}
 		}
 
@@ -19218,7 +19215,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -19292,7 +19289,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -19420,7 +19417,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -19552,7 +19549,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.15
+				value = 0.15
 			}
 		}
 		ai_will_do = {
@@ -19592,7 +19589,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {
@@ -19639,20 +19636,9 @@ focus_tree = {
 		id = HOL_bos
 		icon = dutch_bos
 
-		x = 6
+		x = 0
 		y = 1
 		relative_position_id = HOL_new_socialist_age
-		offset = {
-			x = -6
-			y = 0
-			trigger = {
-				has_game_rule = {
-					rule = obsolete_focus_branches_visibility
-					option = HIDE
-				}
-				has_completed_focus = HOL_bos
-			}
-		}
 
 		cost = 1
 
@@ -19679,9 +19665,17 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			is_power_balance_in_range = {
-				id = HOL_pvda_balance_of_power_category
-				range > HOL_pvda_traditional_labor_base_bop_right_low_range
+			NOT = {
+				is_power_balance_in_range = {
+					id = HOL_pvda_balance_of_power_category
+					range < HOL_pvda_progressive_reformists_bop_left_low_range
+				}
+			}
+			NOT = {
+				is_power_balance_in_range = {
+					id = HOL_pvda_balance_of_power_category
+					range > HOL_pvda_traditional_labor_base_bop_right_low_range
+				}
 			}
 		}
 
@@ -19904,7 +19898,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = -0.1
+				value = 0.1
 			}
 		}
 		ai_will_do = {
@@ -20027,7 +20021,7 @@ focus_tree = {
 			newline = yes
 			add_power_balance_value = {
 				id = HOL_pvda_balance_of_power_category
-				value = 0.1
+				value = -0.1
 			}
 		}
 		ai_will_do = {


### PR DESCRIPTION
### Changes
- The New Age of Social Democracy focus now always produces a PvdA leader; a balance of power resting in the Progressive Leaning band previously completed nothing and dead-ended the branch
- PvdA balance of power now moves the way its labels say: green and modernising focuses and decisions shift the bar toward the Progressive Reformists, welfare and union ones toward the Traditional Labor Base
- Asscher is now the traditional-labour outcome and Bos the centre outcome, and the two branches swap places so the tree still reads progressive to traditional from left to right

Closes #3500