### PR TITLE
Build slots 72 bug fixes

### DIFF
--- a/interface/MD_energy_scripted.gui
+++ b/interface/MD_energy_scripted.gui
@@ -33,13 +33,13 @@ guiTypes = {
 		iconType = {
 			name ="energy_icon"
 			spriteType = "GFX_modifiers_energy"
-			position = { x = 144 y = 321 }
+			position = { x = 140 y = 321 }
 			scale = 0.8
 		}
 
 		instantTextBoxType = {
 			name = "state_renewable_text"
-			position = { x = 170 y = 324 }
+			position = { x = 166 y = 324 }
 			font = "hoi_18mbs"
 			format = left
 			maxWidth = 280

--- a/interface/countrystateview.gui
+++ b/interface/countrystateview.gui
@@ -147,7 +147,7 @@ guiTypes = {
 
 			gridBoxType = {
 				name = "state_shared_slot_building_entries"
-				position = { x = 100 y = 335 }
+				position = { x = 102 y = 335 }
 				size = { width = 480 height = 90%% }
 				format = "UPPER_LEFT"
 				slotsize = { width = 34 height = 28 }
@@ -9868,14 +9868,14 @@ guiTypes = {
 
 		buttonType = {
 			name = "building_picture"
-			position = { x = 3 y = 0 }
+			position = { x = 4 y = 0 }
 			quadTextureSprite = "GFX_buildings_strip"
 			scale = 0.60
 		}
 
 		iconType = {
 			name = "building_status_overlay"
-			position = { x = 3 y = 0 }
+			position = { x = 4 y = 0 }
 			quadTextureSprite = "GFX_building_status_overlay"
 			alwaystransparent = yes
 			scale = 0.86
@@ -9891,7 +9891,7 @@ guiTypes = {
 		iconType = {
 			name = "damage_bar"
 			spriteType = "GFX_damage_bar_slim"
-			position = { x=6 y=26 }
+			position = { x=4 y=22 }
 			rotation = 1.5708
 		}
 	}

--- a/interface/countrystateview.gui
+++ b/interface/countrystateview.gui
@@ -9876,9 +9876,9 @@ guiTypes = {
 		iconType = {
 			name = "building_status_overlay"
 			position = { x = 3 y = 0 }
-			quadTextureSprite = "GFX_buildings_strip"
+			quadTextureSprite = "GFX_building_status_overlay"
 			alwaystransparent = yes
-			scale = 0.60
+			scale = 0.86
 		}
 
 		buttonType = {


### PR DESCRIPTION
### Changes

Follow-up to #3479, cleaning up the state view at the new slot size.

- Fixes an old bug where a building under construction showed the wrong icon, always the same building, whatever was actually being built. `building_status_overlay` was bound to `GFX_buildings_strip`, but the game sets that element's frame from the slot's *status*, so it indexed into the building icon strip instead. Vanilla and MD's own construction/diplomacy/intel views all use `GFX_building_status_overlay` here; the state view was the only place it was wrong. Scale goes to `0.86` because that sprite is 32x32 against 46x46 icon frames (`46 * 0.60 / 32`), so it covers the icon 1:1.
- Recenters the `state_shared_slot_building_entries` grid in its panel.
- Centers the building icon in its slot.
- Moves the damage bar into the slot row instead of overlapping the icon above it.
- Moves `energy_icon` and `state_renewable_text` left to clear the grid.

No slot values, defines or state categories touched.

Old look:
<img width="447" height="724" alt="Screenshot 2026-09-04 090040" src="https://github.com/user-attachments/assets/42d9f25b-7364-4e3b-8c6e-267493595262" />

New look:
<img width="450" height="720" alt="Screenshot 2026-09-05 202439" src="https://github.com/user-attachments/assets/6529b5d6-0ca6-4e1d-bf57-9a3c9aa194cb" />