### PR TITLE
Fold ENG agitation clamps into per-region scripted effects

### DIFF
--- a/common/decisions/05_ENG_decisions.txt
+++ b/common/decisions/05_ENG_decisions.txt
@@ -70,11 +70,10 @@ decisions_ENG = {
 				}
 			}
 			newline = yes
-			add_to_variable = { ENG_north_irish_agitation = -2 }
 			NIR = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_north_irish_agitation = yes
 			}
-			ENG_var_cap = yes
 		}
 
 		ai_will_do = {
@@ -199,11 +198,10 @@ decisions_ENG = {
 			}
 			add_to_variable = { ENG_local_resources_factor = 0.015 tooltip = local_resources_factor_tt }
 			newline = yes
-			add_to_variable = { ENG_wales_agitation = -2 }
 			WAS = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_wales_agitation = yes
 			}
-			ENG_var_cap = yes
 			set_country_flag = ENG_clydach_nickel_decision_completed
 			clr_country_flag = ENG_active_resource_project
 		}
@@ -265,11 +263,10 @@ decisions_ENG = {
 			}
 			add_to_variable = { ENG_local_resources_factor = 0.015 tooltip = local_resources_factor_tt }
 			newline = yes
-			add_to_variable = { ENG_wales_agitation = -2 }
 			WAS = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_wales_agitation = yes
 			}
-			ENG_var_cap = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -8.50 }
 			modify_treasury_effect = yes
@@ -372,11 +369,10 @@ decisions_ENG = {
 			}
 			add_to_variable = { ENG_local_resources_factor = 0.015 tooltip = local_resources_factor_tt }
 			newline = yes
-			add_to_variable = { ENG_scottish_agitation = -2 }
 			SCO = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_scottish_agitation = yes
 			}
-			ENG_var_cap = yes
 			clr_country_flag = ENG_active_resource_project
 		}
 
@@ -427,11 +423,10 @@ decisions_ENG = {
 			}
 			add_to_variable = { ENG_local_resources_factor = 0.015 tooltip = local_resources_factor_tt }
 			newline = yes
-			add_to_variable = { ENG_scottish_agitation = -2 }
 			SCO = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_scottish_agitation = yes
 			}
-			ENG_var_cap = yes
 			clr_country_flag = ENG_active_resource_project
 		}
 
@@ -482,11 +477,10 @@ decisions_ENG = {
 			}
 			add_to_variable = { ENG_local_resources_factor = 0.015 tooltip = local_resources_factor_tt }
 			newline = yes
-			add_to_variable = { ENG_scottish_agitation = -2 }
 			SCO = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_scottish_agitation = yes
 			}
-			ENG_var_cap = yes
 			set_country_flag = ENG_cambo_offshore_decision_completed
 			clr_country_flag = ENG_active_resource_project
 		}
@@ -881,11 +875,10 @@ decisions_ENG = {
 				}
 			}
 			newline = yes
-			add_to_variable = { ENG_scottish_agitation = -2 }
 			SCO = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_scottish_agitation = yes
 			}
-			ENG_var_cap = yes
 			clr_country_flag = ENG_active_productivity_project
 		}
 
@@ -932,11 +925,10 @@ decisions_ENG = {
 			}
 			add_to_variable = { ENG_country_productivity_growth_modifier = 0.015 tooltip = country_productivity_growth_modifier_tt }
 			newline = yes
-			add_to_variable = { ENG_north_irish_agitation = -2 }
 			NIR = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_north_irish_agitation = yes
 			}
-			ENG_var_cap = yes
 			clr_country_flag = ENG_active_productivity_project
 			set_country_flag = ENG_expand_belfast_decision_done
 		}
@@ -1043,11 +1035,10 @@ decisions_ENG = {
 				add_extra_state_shared_building_slots = 3
 			}
 			newline = yes
-			add_to_variable = { ENG_north_irish_agitation = -2 }
 			NIR = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_north_irish_agitation = yes
 			}
-			ENG_var_cap = yes
 			clr_country_flag = ENG_active_productivity_project
 		}
 
@@ -3417,11 +3408,10 @@ ENG_devolved_matters = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_appease_scotland"
-			add_to_variable = { ENG_scottish_agitation = -2 }
 			SCO = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_scottish_agitation = yes
 			}
-			ENG_var_cap = yes
 		}
 
 		remove_effect = {
@@ -3469,11 +3459,10 @@ ENG_devolved_matters = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_appease_nireland"
-			add_to_variable = { ENG_north_irish_agitation = -2 }
 			NIR = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_north_irish_agitation = yes
 			}
-			ENG_var_cap = yes
 		}
 
 		remove_effect = {
@@ -3522,11 +3511,10 @@ ENG_devolved_matters = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision ENG_appease_wales"
-			add_to_variable = { ENG_wales_agitation = -2 }
 			WAS = {
-				custom_effect_tooltip = ENG_decrease_agitation_2_alt_TT
+				set_temp_variable = { ENG_agitation_change = -2 }
+				ENG_change_wales_agitation = yes
 			}
-			ENG_var_cap = yes
 		}
 
 		remove_effect = {

--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -8067,7 +8067,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -8123,7 +8124,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_north_irish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_north_irish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_north_irish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -8220,7 +8222,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -9233,7 +9236,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_wales_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_wales_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9294,7 +9298,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9349,7 +9354,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9422,7 +9428,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9498,7 +9505,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9551,7 +9559,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9615,7 +9624,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_wales_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_wales_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9684,7 +9694,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_wales_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_wales_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -9889,7 +9900,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 		}
 
@@ -9960,7 +9972,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -10033,7 +10046,8 @@ focus_tree = {
 				set_temp_variable = { ENG_agitation_change = -1 }
 				ENG_change_scottish_agitation = yes
 				newline = yes
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -11417,18 +11431,18 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_scottish_dependency = yes
 			}
 			newline = yes
 			NIR = {
-				add_to_variable = { ENG_north_irish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_north_irish_dependency = yes
 			}
 			newline = yes
 			WAS = {
-				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_dependency_change = 1 }
+				ENG_change_wales_dependency = yes
 			}
 			newline = yes
 			set_temp_variable = { treasury_change = needed_money }

--- a/common/national_focus/05_united_kingdom.txt
+++ b/common/national_focus/05_united_kingdom.txt
@@ -8064,8 +8064,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -8120,8 +8120,8 @@ focus_tree = {
 			activate_mission = ENG_invest_northern_ireland_mission
 			newline = yes
 			NIR = {
-				add_to_variable = { ENG_north_irish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_north_irish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_north_irish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -8217,8 +8217,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9230,8 +9230,8 @@ focus_tree = {
 			}
 			newline = yes
 			WAS = {
-				add_to_variable = { ENG_wales_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_wales_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9291,8 +9291,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9346,8 +9346,8 @@ focus_tree = {
 			custom_effect_tooltip = ENG_refine_natural_bauxite_tt
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9419,8 +9419,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9495,8 +9495,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9548,8 +9548,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9612,8 +9612,8 @@ focus_tree = {
 			}
 			newline = yes
 			WAS = {
-				add_to_variable = { ENG_wales_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_wales_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9681,8 +9681,8 @@ focus_tree = {
 			add_to_variable = { ENG_industrial_capacity_dockyard = 0.10 tooltip = industrial_capacity_dockyard_tt }
 			newline = yes
 			WAS = {
-				add_to_variable = { ENG_wales_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_wales_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_wales_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9886,8 +9886,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -9957,8 +9957,8 @@ focus_tree = {
 			add_to_variable = { ENG_industrial_capacity_factory = 0.10 tooltip = industrial_capacity_factory_tt }
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -10030,8 +10030,8 @@ focus_tree = {
 			}
 			newline = yes
 			SCO = {
-				add_to_variable = { ENG_scottish_agitation = -1 tooltip = ENG_decrease_agitation_alt_TT }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = -1 }
+				ENG_change_scottish_agitation = yes
 				newline = yes
 				add_to_variable = { ENG_scottish_dependency = 1 tooltip = ENG_increase_dependence_alt_TT }
 			}
@@ -22570,10 +22570,9 @@ focus_tree = {
 			modify_treasury_effect = yes
 			newline = yes
 			SCO = {
-				custom_effect_tooltip = ENG_decrease_agitation_5_alt_TT
+				set_temp_variable = { ENG_agitation_change = -5 }
+				ENG_change_scottish_agitation = yes
 			}
-			add_to_variable = { ENG_scottish_agitation = -5 }
-			ENG_var_cap = yes
 			newline = yes
 			set_temp_variable = { temp_productivity_change = 50 }
 			every_core_state = {

--- a/common/on_actions/99_ENG_on_actions.txt
+++ b/common/on_actions/99_ENG_on_actions.txt
@@ -13,7 +13,8 @@ on_actions = {
 				}
 				set_temp_variable = { ENG_agitation_change = 0.15 }
 				ENG_change_north_irish_agitation = yes
-				add_to_variable = { var = ENG_north_irish_nationalists value = 1 }
+				set_temp_variable = { ENG_nationalists_change = 1 }
+				ENG_change_north_irish_nationalists = yes
 				if = {
 					limit = {
 						NOT = {
@@ -22,8 +23,6 @@ on_actions = {
 					}
 					add_ideas = ENG_the_dissident_campaign_hidden_idea
 				}
-
-				ENG_var_cap = yes
 			}
 			if = {
 				limit = {

--- a/common/on_actions/99_ENG_on_actions.txt
+++ b/common/on_actions/99_ENG_on_actions.txt
@@ -11,7 +11,8 @@ on_actions = {
 						}
 					}
 				}
-				add_to_variable = { var = ENG_north_irish_agitation value = 0.15 }
+				set_temp_variable = { ENG_agitation_change = 0.15 }
+				ENG_change_north_irish_agitation = yes
 				add_to_variable = { var = ENG_north_irish_nationalists value = 1 }
 				if = {
 					limit = {
@@ -39,8 +40,8 @@ on_actions = {
 					}
 					remove_ideas = ENG_the_dissident_campaign_hidden_idea
 				}
-				add_to_variable = { var = ENG_north_irish_agitation value = 0.15 }
-				ENG_var_cap = yes
+				set_temp_variable = { ENG_agitation_change = 0.15 }
+				ENG_change_north_irish_agitation = yes
 			}
 			#-----------# "Good Friday End" #-----------#
 			if = {

--- a/common/scripted_effects/99_ENG_scripted_effects..txt
+++ b/common/scripted_effects/99_ENG_scripted_effects..txt
@@ -139,7 +139,8 @@ ENG_advance_moon_base = {
 # English seats: (Take Party Popularity variable) (if minor -, if major +) ( random variable selected from range of 0-10)
 # (Take Party Popularity of Labour,Tories,LibDems,Greens) (then Combine) (then add Nationalist Percentage) (remainder randomly distributed)
 # FUTURE ADDITIONS: Good to get UI to expand to states within England
-# Expects temp var: ENG_dependency_change (signed).
+# Parameters:
+# - ENG_dependency_change: signed amount
 ENG_change_scottish_dependency = {
 	custom_effect_tooltip = ENG_dependency_change_tt
 	hidden_effect = {
@@ -147,6 +148,8 @@ ENG_change_scottish_dependency = {
 	}
 }
 
+# Parameters:
+# - ENG_dependency_change: signed amount
 ENG_change_north_irish_dependency = {
 	custom_effect_tooltip = ENG_dependency_change_tt
 	hidden_effect = {
@@ -154,6 +157,8 @@ ENG_change_north_irish_dependency = {
 	}
 }
 
+# Parameters:
+# - ENG_dependency_change: signed amount
 ENG_change_wales_dependency = {
 	custom_effect_tooltip = ENG_dependency_change_tt
 	hidden_effect = {
@@ -171,7 +176,8 @@ ENG_lower_dependence_1 = {
 	}
 }
 
-# Expects temp var: ENG_agitation_change (signed).
+# Parameters:
+# - ENG_agitation_change: signed amount
 ENG_change_scottish_agitation = {
 	custom_effect_tooltip = ENG_agitation_change_tt
 	hidden_effect = {
@@ -179,6 +185,8 @@ ENG_change_scottish_agitation = {
 	}
 }
 
+# Parameters:
+# - ENG_agitation_change: signed amount
 ENG_change_north_irish_agitation = {
 	custom_effect_tooltip = ENG_agitation_change_tt
 	hidden_effect = {
@@ -187,6 +195,8 @@ ENG_change_north_irish_agitation = {
 	}
 }
 
+# Parameters:
+# - ENG_agitation_change: signed amount
 ENG_change_wales_agitation = {
 	custom_effect_tooltip = ENG_agitation_change_tt
 	hidden_effect = {
@@ -291,7 +301,8 @@ ENG_north_irish_agitation_change_check = {
 }
 
 
-# Expects temp var: ENG_nationalists_change (signed).
+# Parameters:
+# - ENG_nationalists_change: signed amount
 ENG_change_north_irish_nationalists = {
 	custom_effect_tooltip = ENG_nationalists_change_tt
 	hidden_effect = {

--- a/common/scripted_effects/99_ENG_scripted_effects..txt
+++ b/common/scripted_effects/99_ENG_scripted_effects..txt
@@ -139,32 +139,59 @@ ENG_advance_moon_base = {
 # English seats: (Take Party Popularity variable) (if minor -, if major +) ( random variable selected from range of 0-10)
 # (Take Party Popularity of Labour,Tories,LibDems,Greens) (then Combine) (then add Nationalist Percentage) (remainder randomly distributed)
 # FUTURE ADDITIONS: Good to get UI to expand to states within England
+# Expects temp var: ENG_dependency_change (signed).
+ENG_change_scottish_dependency = {
+	custom_effect_tooltip = ENG_dependency_change_tt
+	hidden_effect = {
+		set_variable = { ROOT.ENG_scottish_dependency = { value = ROOT.ENG_scottish_dependency add = ENG_dependency_change clamp = { min = 0 max = 100 } } }
+	}
+}
+
+ENG_change_north_irish_dependency = {
+	custom_effect_tooltip = ENG_dependency_change_tt
+	hidden_effect = {
+		set_variable = { ROOT.ENG_north_irish_dependency = { value = ROOT.ENG_north_irish_dependency add = ENG_dependency_change clamp = { min = 0 max = 100 } } }
+	}
+}
+
+ENG_change_wales_dependency = {
+	custom_effect_tooltip = ENG_dependency_change_tt
+	hidden_effect = {
+		set_variable = { ROOT.ENG_wales_dependency = { value = ROOT.ENG_wales_dependency add = ENG_dependency_change clamp = { min = 0 max = 100 } } }
+	}
+}
+
 ENG_lower_dependence_1 = {
 	custom_effect_tooltip = ENG_lower_dependence_1_TT
-	add_to_variable = { ENG_scottish_dependency = -1 }
-	add_to_variable = { ENG_north_irish_dependency = -1 }
-	add_to_variable = { ENG_wales_dependency = -1 }
+	hidden_effect = {
+		set_temp_variable = { ENG_dependency_change = -1 }
+		ENG_change_scottish_dependency = yes
+		ENG_change_north_irish_dependency = yes
+		ENG_change_wales_dependency = yes
+	}
 }
-# Lower dependence + agitation
-# Increase Dependence
-# Increase Agitation
+
 # Expects temp var: ENG_agitation_change (signed).
 ENG_change_scottish_agitation = {
-	add_to_variable = { var = ROOT.ENG_scottish_agitation value = ENG_agitation_change tooltip = ENG_agitation_change_tt }
-	clamp_variable = { var = ROOT.ENG_scottish_agitation min = 0 max = 100 }
+	custom_effect_tooltip = ENG_agitation_change_tt
+	hidden_effect = {
+		set_variable = { ROOT.ENG_scottish_agitation = { value = ROOT.ENG_scottish_agitation add = ENG_agitation_change clamp = { min = 0 max = 100 } } }
+	}
 }
 
 ENG_change_north_irish_agitation = {
-	add_to_variable = { var = ROOT.ENG_north_irish_agitation value = ENG_agitation_change tooltip = ENG_agitation_change_tt }
-	clamp_variable = { var = ROOT.ENG_north_irish_agitation min = 0 max = 100 }
+	custom_effect_tooltip = ENG_agitation_change_tt
 	hidden_effect = {
+		set_variable = { ROOT.ENG_north_irish_agitation = { value = ROOT.ENG_north_irish_agitation add = ENG_agitation_change clamp = { min = 0 max = 100 } } }
 		ROOT = { ENG_north_irish_agitation_change_check = yes }
 	}
 }
 
 ENG_change_wales_agitation = {
-	add_to_variable = { var = ROOT.ENG_wales_agitation value = ENG_agitation_change tooltip = ENG_agitation_change_tt }
-	clamp_variable = { var = ROOT.ENG_wales_agitation min = 0 max = 100 }
+	custom_effect_tooltip = ENG_agitation_change_tt
+	hidden_effect = {
+		set_variable = { ROOT.ENG_wales_agitation = { value = ROOT.ENG_wales_agitation add = ENG_agitation_change clamp = { min = 0 max = 100 } } }
+	}
 }
 
 ENG_increase_agitation_2 = {
@@ -264,13 +291,20 @@ ENG_north_irish_agitation_change_check = {
 }
 
 
-ENG_var_cap = {
-	clamp_variable = { var = ENG_scottish_dependency min = 0 max = 100 }
-	clamp_variable = { var = ENG_scottish_nationalists min = 0 max = 100 }
-	clamp_variable = { var = ENG_north_irish_dependency min = 0 max = 100 }
-	clamp_variable = { var = ENG_north_irish_nationalists min = 0 max = 100 }
-	clamp_variable = { var = ENG_wales_dependency min = 0 max = 100 }
-	clamp_variable = { var = ENG_wales_nationalists min = 0 max = 100 }
+# Expects temp var: ENG_nationalists_change (signed).
+ENG_change_north_irish_nationalists = {
+	custom_effect_tooltip = ENG_nationalists_change_tt
+	hidden_effect = {
+		set_variable = { ROOT.ENG_north_irish_nationalists = { value = ROOT.ENG_north_irish_nationalists add = ENG_nationalists_change clamp = { min = 0 max = 100 } } }
+	}
+}
+
+ENG_clamp_nationalists = {
+	hidden_effect = {
+		set_variable = { ROOT.ENG_scottish_nationalists = { value = ROOT.ENG_scottish_nationalists clamp = { min = 0 max = 100 } } }
+		set_variable = { ROOT.ENG_north_irish_nationalists = { value = ROOT.ENG_north_irish_nationalists clamp = { min = 0 max = 100 } } }
+		set_variable = { ROOT.ENG_wales_nationalists = { value = ROOT.ENG_wales_nationalists clamp = { min = 0 max = 100 } } }
+	}
 }
 
 update_eng_devolution_dirty_variable = {

--- a/common/scripted_effects/99_ENG_scripted_effects..txt
+++ b/common/scripted_effects/99_ENG_scripted_effects..txt
@@ -148,11 +148,33 @@ ENG_lower_dependence_1 = {
 # Lower dependence + agitation
 # Increase Dependence
 # Increase Agitation
+# Expects temp var: ENG_agitation_change (signed).
+ENG_change_scottish_agitation = {
+	add_to_variable = { var = ROOT.ENG_scottish_agitation value = ENG_agitation_change tooltip = ENG_agitation_change_tt }
+	clamp_variable = { var = ROOT.ENG_scottish_agitation min = 0 max = 100 }
+}
+
+ENG_change_north_irish_agitation = {
+	add_to_variable = { var = ROOT.ENG_north_irish_agitation value = ENG_agitation_change tooltip = ENG_agitation_change_tt }
+	clamp_variable = { var = ROOT.ENG_north_irish_agitation min = 0 max = 100 }
+	hidden_effect = {
+		ROOT = { ENG_north_irish_agitation_change_check = yes }
+	}
+}
+
+ENG_change_wales_agitation = {
+	add_to_variable = { var = ROOT.ENG_wales_agitation value = ENG_agitation_change tooltip = ENG_agitation_change_tt }
+	clamp_variable = { var = ROOT.ENG_wales_agitation min = 0 max = 100 }
+}
+
 ENG_increase_agitation_2 = {
 	custom_effect_tooltip = ENG_increase_agitation_2_TT
-	add_to_variable = { ENG_scottish_agitation = 2 }
-	add_to_variable = { ENG_north_irish_agitation = 2 }
-	add_to_variable = { ENG_wales_agitation = 2 }
+	hidden_effect = {
+		set_temp_variable = { ENG_agitation_change = 2 }
+		ENG_change_scottish_agitation = yes
+		ENG_change_north_irish_agitation = yes
+		ENG_change_wales_agitation = yes
+	}
 }
 
 ENG_north_irish_agitation_change_check = {
@@ -243,81 +265,12 @@ ENG_north_irish_agitation_change_check = {
 
 
 ENG_var_cap = {
-	if = {
-		limit = { check_variable = { ENG_scottish_agitation > 100 } }
-		set_variable = { ENG_scottish_agitation = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_scottish_dependency > 100 } }
-		set_variable = { ENG_scottish_dependency = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_scottish_nationalists > 100 } }
-		set_variable = { ENG_scottish_nationalists = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_scottish_agitation < 0 } }
-		set_variable = { ENG_scottish_agitation = 0 }
-	}
-	if = {
-		limit = { check_variable = { ENG_scottish_dependency < 0 } }
-		set_variable = { ENG_scottish_dependency = 0 }
-	}
-	if = {
-		limit = { check_variable = { ENG_scottish_nationalists < 0 } }
-		set_variable = { ENG_scottish_nationalists = 0 }
-	}
-	# Ireland
-	ENG_north_irish_agitation_change_check = yes
-	if = {
-		limit = { check_variable = { ENG_north_irish_agitation > 100 } }
-		set_variable = { ENG_north_irish_agitation = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_north_irish_dependency > 100 } }
-		set_variable = { ENG_north_irish_dependency = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_north_irish_nationalists > 100 } }
-		set_variable = { ENG_north_irish_nationalists = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_north_irish_agitation < 0 } }
-		set_variable = { ENG_north_irish_agitation = 0 }
-	}
-	if = {
-		limit = { check_variable = { ENG_north_irish_dependency < 0 } }
-		set_variable = { ENG_north_irish_dependency = 0 }
-	}
-	if = {
-		limit = { check_variable = { ENG_north_irish_nationalists < 0 } }
-		set_variable = { ENG_north_irish_nationalists = 0 }
-	}
-	# Wales
-	if = {
-		limit = { check_variable = { ENG_wales_agitation > 100 } }
-		set_variable = { ENG_wales_agitation = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_wales_dependency > 100 } }
-		set_variable = { ENG_wales_dependency = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_wales_nationalists > 100 } }
-		set_variable = { ENG_wales_nationalists = 100 }
-	}
-	if = {
-		limit = { check_variable = { ENG_wales_agitation < 0 } }
-		set_variable = { ENG_wales_agitation = 0 }
-	}
-	if = {
-		limit = { check_variable = { ENG_wales_dependency < 0 } }
-		set_variable = { ENG_wales_dependency = 0 }
-	}
-	if = {
-		limit = { check_variable = { ENG_wales_nationalists < 0 } }
-		set_variable = { ENG_wales_nationalists = 0 }
-	}
+	clamp_variable = { var = ENG_scottish_dependency min = 0 max = 100 }
+	clamp_variable = { var = ENG_scottish_nationalists min = 0 max = 100 }
+	clamp_variable = { var = ENG_north_irish_dependency min = 0 max = 100 }
+	clamp_variable = { var = ENG_north_irish_nationalists min = 0 max = 100 }
+	clamp_variable = { var = ENG_wales_dependency min = 0 max = 100 }
+	clamp_variable = { var = ENG_wales_nationalists min = 0 max = 100 }
 }
 
 update_eng_devolution_dirty_variable = {

--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -2459,7 +2459,6 @@ country_event = {
 		name = devolution.1.a
 		log = "[GetDateText]: [This.GetName]: devolution.1.a executed"
 		ENG_lower_dependence_1 = yes
-		ENG_var_cap = yes
 		ai_chance = {
 			base = 1
 		}
@@ -2510,9 +2509,8 @@ country_event = {
 	option = {
 		name = devolution.2.a
 		log = "[GetDateText]: [This.GetName]: devolution.2.a executed"
-		add_to_variable = { ENG_scottish_dependency = -1 }
-		custom_effect_tooltip = ENG_decrease_dependence_1_alt_TT
-		ENG_var_cap = yes
+		set_temp_variable = { ENG_dependency_change = -1 }
+		ENG_change_scottish_dependency = yes
 		ai_chance = {
 			base = 1
 		}
@@ -2544,9 +2542,8 @@ country_event = {
 	option = {
 		name = devolution.3.a
 		log = "[GetDateText]: [This.GetName]: devolution.3.a executed"
-		add_to_variable = { ENG_north_irish_dependency = -1 }
-		custom_effect_tooltip = ENG_decrease_dependence_1_alt_TT
-		ENG_var_cap = yes
+		set_temp_variable = { ENG_dependency_change = -1 }
+		ENG_change_north_irish_dependency = yes
 		ai_chance = {
 			base = 1
 		}
@@ -2578,9 +2575,8 @@ country_event = {
 	option = {
 		name = devolution.4.a
 		log = "[GetDateText]: [This.GetName]: devolution.4.a executed"
-		add_to_variable = { ENG_wales_dependency = -1 }
-		custom_effect_tooltip = ENG_decrease_dependence_1_alt_TT
-		ENG_var_cap = yes
+		set_temp_variable = { ENG_dependency_change = -1 }
+		ENG_change_wales_dependency = yes
 		ai_chance = {
 			base = 1
 		}
@@ -3254,7 +3250,7 @@ country_event = {
 			}
 
 		}
-		ENG_var_cap = yes
+		ENG_clamp_nationalists = yes
 		ai_chance = {
 			base = 1
 		}
@@ -6371,10 +6367,9 @@ country_event = {
 	option = {
 		name = british_flavor.5.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.5.a executed"
-		add_to_variable = { ENG_scottish_dependency = -2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_decrease_dependence_2_alt_TT
+			set_temp_variable = { ENG_dependency_change = -2 }
+			ENG_change_scottish_dependency = yes
 		}
 		ai_chance = {
 			base = 1
@@ -6587,10 +6582,9 @@ country_event = {
 	option = {
 		name = british_flavor.11.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.11.b executed"
-		add_to_variable = { ENG_scottish_dependency = -2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_decrease_dependence_2_alt_TT
+			set_temp_variable = { ENG_dependency_change = -2 }
+			ENG_change_scottish_dependency = yes
 		}
 		ai_chance = {
 			base = 1
@@ -6623,10 +6617,9 @@ country_event = {
 	option = {
 		name = british_flavor.12.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.12.b executed"
-		add_to_variable = { ENG_scottish_dependency = -2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_decrease_dependence_2_alt_TT
+			set_temp_variable = { ENG_dependency_change = -2 }
+			ENG_change_scottish_dependency = yes
 		}
 		ai_chance = {
 			base = 1

--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -2469,7 +2469,6 @@ country_event = {
 		name = devolution.1.b
 		log = "[GetDateText]: [This.GetName]: devolution.1.b executed"
 		ENG_increase_agitation_2 = yes
-		ENG_var_cap = yes
 		ai_chance = {
 			base = 1
 		}
@@ -2522,9 +2521,8 @@ country_event = {
 	option = {
 		name = devolution.2.b
 		log = "[GetDateText]: [This.GetName]: devolution.2.b executed"
-		add_to_variable = { ENG_scottish_agitation = 1 }
-		custom_effect_tooltip = ENG_increase_agitation_1_alt_TT
-		ENG_var_cap = yes
+		set_temp_variable = { ENG_agitation_change = 1 }
+		ENG_change_scottish_agitation = yes
 		ai_chance = {
 			base = 1
 		}
@@ -2557,9 +2555,8 @@ country_event = {
 	option = {
 		name = devolution.3.b
 		log = "[GetDateText]: [This.GetName]: devolution.3.b executed"
-		add_to_variable = { ENG_north_irish_agitation = 1 }
-		custom_effect_tooltip = ENG_increase_agitation_1_alt_TT
-		ENG_var_cap = yes
+		set_temp_variable = { ENG_agitation_change = 1 }
+		ENG_change_north_irish_agitation = yes
 		ai_chance = {
 			base = 1
 		}
@@ -2592,9 +2589,8 @@ country_event = {
 	option = {
 		name = devolution.4.b
 		log = "[GetDateText]: [This.GetName]: devolution.4.b executed"
-		add_to_variable = { ENG_wales_agitation = 1 }
-		custom_effect_tooltip = ENG_increase_agitation_1_alt_TT
-		ENG_var_cap = yes
+		set_temp_variable = { ENG_agitation_change = 1 }
+		ENG_change_wales_agitation = yes
 		ai_chance = {
 			base = 1
 		}
@@ -6310,10 +6306,9 @@ country_event = {
 	option = {
 		name = british_flavor.3.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.3.a executed"
-		add_to_variable = { ENG_scottish_agitation = 2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_increase_agitation_2_alt_TT
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_scottish_agitation = yes
 		}
 		ai_chance = {
 			base = 1
@@ -6389,9 +6384,10 @@ country_event = {
 	option = {
 		name = british_flavor.5.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.5.b executed"
-		add_to_variable = { ENG_scottish_agitation = 2 }
-		ENG_var_cap = yes
-		SCO = { custom_effect_tooltip = ENG_increase_agitation_2_alt_TT }
+		SCO = {
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_scottish_agitation = yes
+		}
 		newline = yes
 		custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
@@ -6457,10 +6453,9 @@ country_event = {
 	option = {
 		name = british_flavor.7.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.7.a executed"
-		add_to_variable = { ENG_north_irish_agitation = 2 }
-		ENG_var_cap = yes
 		NIR = {
-			custom_effect_tooltip = ENG_increase_agitation_2_alt_TT
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_north_irish_agitation = yes
 		}
 		ai_chance = {
 			base = 1
@@ -6495,10 +6490,9 @@ country_event = {
 	option = {
 		name = british_flavor.8.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.8.b executed"
-		add_to_variable = { ENG_wales_agitation = 2 }
-		ENG_var_cap = yes
 		WAS = {
-			custom_effect_tooltip = ENG_increase_agitation_2_alt_TT
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_wales_agitation = yes
 		}
 		ai_chance = {
 			base = 1
@@ -6577,10 +6571,9 @@ country_event = {
 	option = {
 		name = british_flavor.11.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.11.a executed"
-		add_to_variable = { ENG_scottish_agitation = 2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_increase_agitation_2_alt_TT
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_scottish_agitation = yes
 		}
 		newline = yes
 		set_temp_variable = { party_index = 1 }
@@ -6618,10 +6611,9 @@ country_event = {
 	option = {
 		name = british_flavor.12.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.12.a executed"
-		add_to_variable = { ENG_scottish_agitation = 2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_increase_agitation_2_alt_TT
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_scottish_agitation = yes
 		}
 		ai_chance = {
 			base = 1
@@ -6653,10 +6645,9 @@ country_event = {
 	option = {
 		name = british_flavor.13.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.13.a executed"
-		add_to_variable = { ENG_north_irish_agitation = 4 }
-		ENG_var_cap = yes
 		NIR = {
-			custom_effect_tooltip = ENG_increase_agitation_4_alt_TT
+			set_temp_variable = { ENG_agitation_change = 4 }
+			ENG_change_north_irish_agitation = yes
 		}
 		ai_chance = {
 			base = 1
@@ -7029,10 +7020,9 @@ country_event = {
 	option = {
 		name = british_flavor.18.a
 		log = "[GetDateText]: [This.GetName]: british_flavor.18.a executed"
-		add_to_variable = { ENG_scottish_agitation = 2 }
-		ENG_var_cap = yes
 		SCO = {
-			custom_effect_tooltip = ENG_increase_agitation_2_alt_TT
+			set_temp_variable = { ENG_agitation_change = 2 }
+			ENG_change_scottish_agitation = yes
 		}
 		ai_chance = {
 			base = 1

--- a/localisation/english/MD_focus_ENG_l_english.yml
+++ b/localisation/english/MD_focus_ENG_l_english.yml
@@ -1844,6 +1844,8 @@
  ENG_decrease_agitation_alt_TT: "Will lower the §Hagitation§! by $RIGHT|-=0$"
  ENG_decrease_agitation_2_alt_TT: "Will lower the §Hagitation§! of this §Hconstituent§! by §H2§!"
  ENG_decrease_agitation_5_alt_TT: "Will lower the §Hagitation§! of this §Hconstituent§! by §H5§!"
+ ENG_agitation_change: "§HAgitation§!"
+ ENG_agitation_change_tt: "$ENG_agitation_change$: $RIGHT|-=0$"
 
  ENG_lower_dependence_1_TT: "Will lower the §HDependency§! of all §HConstituents§! by §H1§!"
 

--- a/localisation/english/MD_focus_ENG_l_english.yml
+++ b/localisation/english/MD_focus_ENG_l_english.yml
@@ -1845,7 +1845,11 @@
  ENG_decrease_agitation_2_alt_TT: "Will lower the §Hagitation§! of this §Hconstituent§! by §H2§!"
  ENG_decrease_agitation_5_alt_TT: "Will lower the §Hagitation§! of this §Hconstituent§! by §H5§!"
  ENG_agitation_change: "§HAgitation§!"
- ENG_agitation_change_tt: "$ENG_agitation_change$: $RIGHT|-=0$"
+ ENG_agitation_change_tt: "$ENG_agitation_change$: [?ENG_agitation_change|=-0]"
+ ENG_dependency_change: "§HDependency§!"
+ ENG_dependency_change_tt: "$ENG_dependency_change$: [?ENG_dependency_change|=+0]"
+ ENG_nationalists_change: "§HNationalists§!"
+ ENG_nationalists_change_tt: "$ENG_nationalists_change$: [?ENG_nationalists_change|=-0]"
 
  ENG_lower_dependence_1_TT: "Will lower the §HDependency§! of all §HConstituents§! by §H1§!"
 

--- a/tools/tests/validation/validate_scripted_params_test.py
+++ b/tools/tests/validation/validate_scripted_params_test.py
@@ -99,6 +99,29 @@ def test_contract_parser_reads_parameter_after_header(tmp_path):
     }
 
 
+def test_validator_enforces_uppercase_effect_and_parameter_names(tmp_path):
+    effect_path = tmp_path / "common" / "scripted_effects" / "test_effect.txt"
+    caller_path = tmp_path / "events" / "test_event.txt"
+    _write(
+        effect_path,
+        "# Parameters:\n"
+        "# - ENG_agitation_change: signed amount\n"
+        "ENG_change_scottish_agitation = {\n}\n",
+    )
+    _write(caller_path, "ENG_change_scottish_agitation = yes\n")
+
+    validator = vsp.Validator(str(tmp_path), use_colors=False, workers=1)
+    validator.run_validations()
+
+    issues = [
+        issue
+        for issue in validator._issues
+        if issue.category == "missing-required-param"
+    ]
+    assert len(issues) == 1
+    assert "ENG_agitation_change" in issues[0].message
+
+
 @pytest.mark.parametrize(
     "caller_dir",
     [

--- a/tools/validation/validate_scripted_params.py
+++ b/tools/validation/validate_scripted_params.py
@@ -112,7 +112,7 @@ SCOPE_CHANGING_KEYWORDS: Set[str] = {
 _SET_TEMP_RE = re.compile(
     r"\bset_temp_variable\s*=\s*\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([^}]+?)\s*\}",
 )
-_CALL_RE = re.compile(r"\b([a-z][a-z0-9_]*)\s*=\s*yes\b")
+_CALL_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9_]*)\s*=\s*yes\b")
 _KW_OPEN_RE = re.compile(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*\{")
 
 
@@ -257,7 +257,7 @@ def _parse_effect_contracts_from_file(
 
                 # "# set_temp_variable = { param_name = ... }"
                 stv_m = re.search(
-                    r"set_temp_variable\s*=\s*\{\s*([a-z][a-z0-9_]*)\s*=", inner
+                    r"set_temp_variable\s*=\s*\{\s*([A-Za-z][A-Za-z0-9_]*)\s*=", inner
                 )
                 if stv_m:
                     pname = stv_m.group(1)
@@ -269,7 +269,7 @@ def _parse_effect_contracts_from_file(
                     continue
 
                 # "# - param_name: ..." or "# - param_name - ..."
-                plain_m = re.match(r"^[-\*]?\s*([a-z][a-z0-9_]*)\s*[-:]", inner)
+                plain_m = re.match(r"^[-\*]?\s*([A-Za-z][A-Za-z0-9_]*)\s*[-:]", inner)
                 if plain_m:
                     pname = plain_m.group(1)
                     skip_words = {
@@ -301,7 +301,7 @@ def _parse_effect_contracts_from_file(
             while k < len(lines) and not lines[k].strip():
                 k += 1
             if k < len(lines):
-                def_m = re.match(r"^([a-z][a-z0-9_]*)\s*=\s*\{", lines[k].strip())
+                def_m = re.match(r"^([A-Za-z][A-Za-z0-9_]*)\s*=\s*\{", lines[k].strip())
                 if def_m and (params_required or params_optional):
                     eff_name = def_m.group(1)
                     if eff_name not in HARDCODED_CONTRACTS:


### PR DESCRIPTION
## Bottom line
UK devolution vars now mutate through ROOT-scoped change effects that add and clamp 0-100 in one set_variable. ENG_var_cap is gone.

## Why
Call sites mixed add_to_variable with a blanket cap, often from SCO/NIR/WAS, so the write and the clamp could hit the wrong country.

## How
Signed temps ENG_agitation_change, ENG_dependency_change, and ENG_nationalists_change. Election nationalist drift is ENG_clamp_nationalists.

BLUF