### PR TITLE
Rename Majlis election helpers and fold seat math

### DIFF
--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -6039,7 +6039,8 @@ PER_new_majlis = {
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_reschedule_session"
 			custom_effect_tooltip = PER_reschedule_session_TT
-			add_to_variable = { PER_session_var = -2 }
+			add_to_variable = { var = PER_session_var value = -2 }
+			clamp_variable = { var = PER_session_var min = 0 max = 48 }
 		}
 
 		ai_will_do = {

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -6039,13 +6039,7 @@ PER_new_majlis = {
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_reschedule_session"
 			custom_effect_tooltip = PER_reschedule_session_TT
-			set_variable = {
-				PER_session_var = {
-					value = PER_session_var
-					subtract = 2
-					clamp = { min = 0 max = 48 }
-				}
-			}
+			add_to_variable = { PER_session_var = -2 }
 		}
 
 		ai_will_do = {

--- a/common/decisions/Iran.txt
+++ b/common/decisions/Iran.txt
@@ -6039,8 +6039,13 @@ PER_new_majlis = {
 		remove_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_reschedule_session"
 			custom_effect_tooltip = PER_reschedule_session_TT
-			add_to_variable = { var = PER_session_var value = -2 }
-			clamp_variable = { var = PER_session_var min = 0 max = 48 }
+			set_variable = {
+				PER_session_var = {
+					value = PER_session_var
+					subtract = 2
+					clamp = { min = 0 max = 48 }
+				}
+			}
 		}
 
 		ai_will_do = {
@@ -6080,12 +6085,7 @@ PER_new_majlis = {
 	}
 	PER_accept_constitutionalists_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^0 > 1 }
 				check_variable = { PER_majlis_seats^2 > 1 }
@@ -6097,8 +6097,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_constitutionalists_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.10
 		}
 
@@ -6108,12 +6107,7 @@ PER_new_majlis = {
 	}
 	PER_accept_west_conservatives_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^1 > 1 }
 				check_variable = { PER_majlis_seats^14 > 1 }
@@ -6125,8 +6119,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_west_conservatives_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.11
 		}
 
@@ -6136,12 +6129,7 @@ PER_new_majlis = {
 	}
 	PER_accept_socialist_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^3 > 1 }
 				check_variable = { PER_majlis_seats^19 > 1 }
@@ -6153,8 +6141,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_socialist_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.12
 		}
 
@@ -6164,12 +6151,7 @@ PER_new_majlis = {
 	}
 	PER_accept_radical_leftist_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^4 > 1 }
 				check_variable = { PER_majlis_seats^5 > 1 }
@@ -6181,8 +6163,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_radical_leftist_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.14
 		}
 
@@ -6192,12 +6173,7 @@ PER_new_majlis = {
 	}
 	PER_accept_neo_islamist_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^6 > 1 }
 				check_variable = { PER_majlis_seats^7 > 1 }
@@ -6209,8 +6185,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_neo_islamist_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.15
 		}
 
@@ -6220,12 +6195,7 @@ PER_new_majlis = {
 	}
 	PER_accept_moderate_islamist_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^18 > 1 }
 				check_variable = { PER_majlis_seats^12 > 1 }
@@ -6237,8 +6207,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_moderate_islamist_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.16
 		}
 
@@ -6248,12 +6217,7 @@ PER_new_majlis = {
 	}
 	PER_accept_libertarian_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^13 > 1 }
 				check_variable = { PER_majlis_seats^16 > 1 }
@@ -6265,8 +6229,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_libertarian_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.17
 		}
 
@@ -6276,12 +6239,7 @@ PER_new_majlis = {
 	}
 	PER_accept_monarchist_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			OR = {
 				check_variable = { PER_majlis_seats^20 > 1 }
 				check_variable = { PER_majlis_seats^23 > 1 }
@@ -6293,8 +6251,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_monarchist_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.20
 		}
 
@@ -6304,12 +6261,7 @@ PER_new_majlis = {
 	}
 	PER_accept_green_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			check_variable = { PER_majlis_seats^17 > 1 }
 		}
 		icon = political_actions
@@ -6318,8 +6270,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_green_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.18
 		}
 
@@ -6329,12 +6280,7 @@ PER_new_majlis = {
 	}
 	PER_accept_corporate_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			check_variable = { PER_majlis_seats^15 > 1 }
 		}
 		icon = political_actions
@@ -6343,8 +6289,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_corporate_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.19
 		}
 
@@ -6354,12 +6299,7 @@ PER_new_majlis = {
 	}
 	PER_accept_ultra_nationalist_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			check_variable = { PER_majlis_seats^21 > 15 }
 		}
 		icon = political_actions
@@ -6368,8 +6308,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_ultra_nationalist_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.21
 		}
 
@@ -6379,12 +6318,7 @@ PER_new_majlis = {
 	}
 	PER_accept_artesh_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			emerging_hardline_shiite_are_in_power = no
-			emerging_moderate_shiite_are_in_power = no
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
+			PER_majlis_non_ir_proposal_visible = yes
 			check_variable = { PER_majlis_seats^22 > 1 }
 		}
 		icon = political_actions
@@ -6393,8 +6327,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_artesh_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.22
 		}
 
@@ -6405,14 +6338,7 @@ PER_new_majlis = {
 	# I.R.
 	PER_accept_reformists_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
-			OR = {
-				emerging_hardline_shiite_are_in_power = yes
-				emerging_moderate_shiite_are_in_power = yes
-			}
+			PER_majlis_ir_proposal_visible = yes
 			check_variable = { PER_majlis_seats^8 > 1 }
 		}
 		icon = political_actions
@@ -6421,8 +6347,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_reformists_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.23
 		}
 
@@ -6432,14 +6357,7 @@ PER_new_majlis = {
 	}
 	PER_accept_principalists_proposal = {
 		visible = {
-			has_country_flag = PER_debate_ongoing
-			NOT = {
-				has_country_flag = PER_doing_proposal
-			}
-			OR = {
-				emerging_hardline_shiite_are_in_power = yes
-				emerging_moderate_shiite_are_in_power = yes
-			}
+			PER_majlis_ir_proposal_visible = yes
 			check_variable = { PER_majlis_seats^9 > 1 }
 		}
 		icon = political_actions
@@ -6448,8 +6366,7 @@ PER_new_majlis = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision PER_accept_principalists_proposal"
-			set_country_flag = PER_doing_proposal
-			clr_country_flag = PER_debate_ongoing
+			PER_majlis_begin_proposal = yes
 			country_event = PER_majlis.24
 		}
 

--- a/common/on_actions/99_PER_on_actions.txt
+++ b/common/on_actions/99_PER_on_actions.txt
@@ -642,60 +642,8 @@ on_actions = {
 				PER = { add_to_faction = PAL }
 			}
 
-			# For Election
-			if = {
-				limit = {
-					NOT = {
-						has_country_flag = PER_majles_abolished
-					}
-					check_variable = {
-						PER_election_var > 0
-					}
-				}
-				add_to_variable = { var = PER_election_var value = -1 }
-				clamp_variable = { var = PER_election_var min = 0 max = 48 }
-			}
-			if = {
-				limit = {
-					NOT = {
-						has_country_flag = PER_majles_abolished
-					}
-					check_variable = {
-						PER_election_var = 0
-					}
-				}
-				add_to_variable = { var = PER_election_var value = 48 }
-				clamp_variable = { var = PER_election_var min = 0 max = 48 }
-				country_event = {
-					id = PER_majlis.1
-					days = 18
-				}
-			}
-			if = {
-				limit = {
-					NOT = {
-						has_country_flag = PER_majles_abolished
-					}
-					check_variable = {
-						PER_election_var > 0
-					}
-				}
-				add_to_variable = { var = PER_session_var value = -1 }
-				clamp_variable = { var = PER_session_var min = 0 max = 48 }
-			}
-			if = {
-				limit = {
-					NOT = {
-						has_country_flag = PER_majles_abolished
-					}
-					check_variable = {
-						PER_session_var = 0
-					}
-				}
-				add_to_variable = { var = PER_session_var value = 18 }
-				clamp_variable = { var = PER_session_var min = 0 max = 48 }
-				country_event = PER_majlis.2
-			}
+			PER_majlis_monthly_tick = yes
+
 			# Jordan Shale Oil
 			if = {
 				limit = {

--- a/common/scripted_effects/99_PER_scripted_effects.txt
+++ b/common/scripted_effects/99_PER_scripted_effects.txt
@@ -1056,6 +1056,50 @@ PER_majlis_restore_banned_popularity = {
 	clear_array = PER_banned_pop_stash
 }
 
+PER_majlis_monthly_tick = {
+	if = {
+		limit = { NOT = { has_country_flag = PER_majles_abolished } }
+		if = {
+			limit = { check_variable = { PER_election_var > 0 } }
+			set_variable = {
+				PER_election_var = {
+					value = PER_election_var
+					subtract = 1
+					clamp = { min = 0 max = 48 }
+				}
+			}
+		}
+		if = {
+			limit = { check_variable = { PER_election_var = 0 } }
+			set_variable = { PER_election_var = 48 }
+			country_event = {
+				id = PER_majlis.1
+				days = 18
+			}
+		}
+		if = {
+			limit = { check_variable = { PER_election_var > 0 } }
+			set_variable = {
+				PER_session_var = {
+					value = PER_session_var
+					subtract = 1
+					clamp = { min = 0 max = 48 }
+				}
+			}
+		}
+		if = {
+			limit = { check_variable = { PER_session_var = 0 } }
+			set_variable = { PER_session_var = 18 }
+			country_event = PER_majlis.2
+		}
+	}
+}
+
+PER_majlis_begin_proposal = {
+	set_country_flag = PER_doing_proposal
+	clr_country_flag = PER_debate_ongoing
+}
+
 PER_clear_majles_flags = {
 	clr_country_flag = PER_removed_bureau_01
 	clr_country_flag = PER_removed_bureau_02
@@ -1085,21 +1129,12 @@ PER_centralized_change = {
 		if = {
 			limit = {
 				original_tag = PER
-				NOT = {
-					has_country_flag = PER_buru_cool_down
-				}
+				NOT = { has_country_flag = PER_buru_cool_down }
 			}
 			PER = {
 				random_list = {
-					40 = {
-						country_event = {
-							id = PER_majlis.31
-							days = 5
-						}
-					}
-					60 = {
-						PER_clear_majles_flags = yes
-					}
+					40 = { country_event = { id = PER_majlis.31 days = 5 } }
+					60 = { PER_clear_majles_flags = yes }
 				}
 			}
 		}
@@ -1111,21 +1146,12 @@ PER_police_change = {
 		if = {
 			limit = {
 				original_tag = PER
-				NOT = {
-					has_country_flag = PER_police_cool_down
-				}
+				NOT = { has_country_flag = PER_police_cool_down }
 			}
 			PER = {
 				random_list = {
-					40 = {
-						country_event = {
-							id = PER_majlis.32
-							days = 5
-						}
-					}
-					60 = {
-						PER_clear_majles_flags = yes
-					}
+					40 = { country_event = { id = PER_majlis.32 days = 5 } }
+					60 = { PER_clear_majles_flags = yes }
 				}
 			}
 		}
@@ -1137,21 +1163,12 @@ PER_education_change = {
 		if = {
 			limit = {
 				original_tag = PER
-				NOT = {
-					has_country_flag = PER_edu_cool_down
-				}
+				NOT = { has_country_flag = PER_edu_cool_down }
 			}
 			PER = {
 				random_list = {
-					40 = {
-						country_event = {
-							id = PER_majlis.33
-							days = 5
-						}
-					}
-					60 = {
-						PER_clear_majles_flags = yes
-					}
+					40 = { country_event = { id = PER_majlis.33 days = 5 } }
+					60 = { PER_clear_majles_flags = yes }
 				}
 			}
 		}
@@ -1163,21 +1180,12 @@ PER_health_change = {
 		if = {
 			limit = {
 				original_tag = PER
-				NOT = {
-					has_country_flag = PER_health_cool_down
-				}
+				NOT = { has_country_flag = PER_health_cool_down }
 			}
 			PER = {
 				random_list = {
-					40 = {
-						country_event = {
-							id = PER_majlis.34
-							days = 5
-						}
-					}
-					60 = {
-						PER_clear_majles_flags = yes
-					}
+					40 = { country_event = { id = PER_majlis.34 days = 5 } }
+					60 = { PER_clear_majles_flags = yes }
 				}
 			}
 		}
@@ -1189,21 +1197,12 @@ PER_social_change = {
 		if = {
 			limit = {
 				original_tag = PER
-				NOT = {
-					has_country_flag = PER_social_cool_down
-				}
+				NOT = { has_country_flag = PER_social_cool_down }
 			}
 			PER = {
 				random_list = {
-					40 = {
-						country_event = {
-							id = PER_majlis.35
-							days = 5
-						}
-					}
-					60 = {
-						PER_clear_majles_flags = yes
-					}
+					40 = { country_event = { id = PER_majlis.35 days = 5 } }
+					60 = { PER_clear_majles_flags = yes }
 				}
 			}
 		}

--- a/common/scripted_effects/99_PER_scripted_effects.txt
+++ b/common/scripted_effects/99_PER_scripted_effects.txt
@@ -898,7 +898,7 @@ PER_minister_clear = {
 	}
 }
 
-# New Majlis Shit (Dread gave me permission to use some parts of the code from AoN)
+# Ban stash is required: find_highest_in_array cannot skip banned slots.
 PER_majlis_duopoly = {
 	find_highest_in_array = {
 		array = party_pop_array
@@ -1056,6 +1056,7 @@ PER_majlis_restore_banned_popularity = {
 	clear_array = PER_banned_pop_stash
 }
 
+# Flag is PER_majles_abolished (e). Do not rename it to majlis.
 PER_majlis_monthly_tick = {
 	if = {
 		limit = { NOT = { has_country_flag = PER_majles_abolished } }

--- a/common/scripted_effects/99_PER_scripted_effects.txt
+++ b/common/scripted_effects/99_PER_scripted_effects.txt
@@ -900,7 +900,6 @@ PER_minister_clear = {
 
 # New Majlis Shit (Dread gave me permission to use some parts of the code from AoN)
 PER_majlis_duopoly = {
-	# this finds the most popular party
 	find_highest_in_array = {
 		array = party_pop_array
 		value = popular_1_temp
@@ -908,7 +907,6 @@ PER_majlis_duopoly = {
 	}
 	set_variable = { popular_index_1 = popular_index_1_temp }
 	set_variable = { party_pop_array^popular_index_1 = -2 }
-	# this finds the second most popular party
 	find_highest_in_array = {
 		array = party_pop_array
 		value = popular_2_temp
@@ -922,52 +920,46 @@ PER_majlis_elections = {
 	custom_effect_tooltip = PER_majlis_TT
 	set_variable = { PER_majlis_total_seats = 0 }
 	set_variable = { PER_majlis_seats_INDEPENDENT = 0 }
-	PER_testing = yes
+	PER_majlis_stash_banned_popularity = yes
 	if = {
 		limit = { NOT = { has_completed_focus = PER_weaken_guardian_council } }
 		PER_majlis_duopoly = yes
-
 		for_each_loop = {
 			array = party_pop_array
 			value = v
 			index = i
 			set_variable = { PER_majlis_seats^i = 0 }
-		}
-
-		for_each_loop = {
-			array = party_pop_array
-			value = v
-			index = i
-
-			set_variable = { PER_majlis_seats^i = 0 }
-
 			if = {
 				limit = { check_variable = { party_pop_array^i = party_pop_array^popular_index_1 } }
-				set_temp_variable = { PER_majlis_popularity^i = party_pop_array^popular_index_1 }
-				set_variable = { PER_majlis_seats^i = PER_majlis_popularity^popular_index_1 }
-				multiply_variable = { PER_majlis_seats^i = 1 } # gives an 50% boost to seats
-				multiply_variable = { PER_majlis_seats^i = 290 }
-				round_variable = PER_majlis_seats^i
+				set_variable = {
+					PER_majlis_seats^i = {
+						value = party_pop_array^popular_index_1
+						multiply = 290
+						round = yes
+					}
+				}
 			}
 			else_if = {
 				limit = { check_variable = { party_pop_array^i = party_pop_array^popular_index_2 } }
-				set_temp_variable = { PER_majlis_popularity^i = party_pop_array^popular_index_2 }
-				set_variable = { PER_majlis_seats^i = PER_majlis_popularity^popular_index_2 }
-				multiply_variable = { PER_majlis_seats^i = 1.1 } # gives a 25% disadvantage to seats
-				multiply_variable = { PER_majlis_seats^i = 290 }
-				round_variable = PER_majlis_seats^i
+				set_variable = {
+					PER_majlis_seats^i = {
+						value = party_pop_array^popular_index_2
+						multiply = 1.1
+						multiply = 290
+						round = yes
+					}
+				}
 			}
-
 			else_if = {
 				limit = { check_variable = { party_pop_array^i > 0.05 } }
-				set_temp_variable = { PER_majlis_popularity^i = party_pop_array^i }
-				set_variable = { PER_majlis_seats^i = PER_majlis_popularity^i }
-				multiply_variable = { PER_majlis_seats^i = 0.2 }
-				multiply_variable = { PER_majlis_seats^i = 290 }
-				round_variable = PER_majlis_seats^i
-			}
-			set_temp_variable = {
-				PER_majlis_seats = x
+				set_variable = {
+					PER_majlis_seats^i = {
+						value = party_pop_array^i
+						multiply = 0.2
+						multiply = 290
+						round = yes
+					}
+				}
 			}
 			add_to_variable = { PER_majlis_total_seats = PER_majlis_seats^i }
 		}
@@ -978,100 +970,87 @@ PER_majlis_elections = {
 			array = party_pop_array
 			value = v
 			index = i
-
 			set_variable = { PER_majlis_seats^i = 0 }
-
 			if = {
 				limit = { check_variable = { party_pop_array^i > 0.005 } }
-				set_temp_variable = { PER_majlis_popularity^i = party_pop_array^i }
-				set_variable = { PER_majlis_seats^i = PER_majlis_popularity^i }
-				multiply_variable = { PER_majlis_seats^i = 290 }
-				round_variable = PER_majlis_seats^i
+				set_variable = {
+					PER_majlis_seats^i = {
+						value = party_pop_array^i
+						multiply = 290
+						round = yes
+					}
+				}
 			}
 			add_to_variable = { PER_majlis_total_seats = PER_majlis_seats^i }
 		}
-
 		PER_majlis_correct_seats = yes
 	}
-	set_variable = { PER_majlis_seats_INDEPENDENT = 290 }
-	subtract_from_variable = { PER_majlis_seats_INDEPENDENT = PER_majlis_total_seats }
+	set_variable = {
+		PER_majlis_seats_INDEPENDENT = {
+			value = 290
+			subtract = PER_majlis_total_seats
+		}
+	}
 	add_to_variable = { PER_majlis_total_seats = PER_majlis_seats_INDEPENDENT }
-	PER_testing2 = yes
+	PER_majlis_restore_banned_popularity = yes
 }
 
 PER_majlis_correct_seats = {
 	for_each_loop = {
 		array = party_pop_array
-		value = PER_majlis_total_seats_temp_allocation
+		value = v
 		index = i
-		# break = PER_majlis_no_more_seats
-
 		if = {
-			limit = {
-				check_variable = { PER_majlis_total_seats < 291 }
-				check_variable = { PER_majlis_seats^i > 1 }
+			limit = { check_variable = { PER_majlis_seats^i > 1 } }
+			if = {
+				limit = { check_variable = { PER_majlis_total_seats < 291 } }
+				set_temp_variable = {
+					PER_majlis_total_seats_temp = {
+						value = 291
+						subtract = PER_majlis_total_seats
+					}
+				}
 			}
-			set_temp_variable = { PER_majlis_total_seats_temp = PER_majlis_total_seats }
-			log = "[?PER_majlis_total_seats_temp]"
-			subtract_from_temp_variable = { PER_majlis_total_seats_temp = 291 }
-			log = "[?PER_majlis_total_seats_temp]"
-			multiply_temp_variable = { PER_majlis_total_seats_temp = -1 }
-			log = "[?PER_majlis_total_seats_temp]"
+			else = {
+				set_temp_variable = {
+					PER_majlis_total_seats_temp = {
+						value = PER_majlis_total_seats
+						subtract = 289
+					}
+				}
+			}
 			set_temp_variable_to_random = {
 				var = PER_majlis_total_seats_temp_allocation
 				max = PER_majlis_total_seats_temp
 				integer = yes
 			}
-			log = "[?PER_majlis_total_seats_temp_allocation]"
 			add_to_variable = { PER_majlis_seats^i = PER_majlis_total_seats_temp_allocation }
-			log = "[?PER_majlis_total_seats_temp_allocation]"
 			add_to_variable = { PER_majlis_total_seats = PER_majlis_total_seats_temp_allocation }
-			log = "[?PER_majlis_total_seats_temp_allocation]"
 		}
-		else_if = {
-			limit = {
-				check_variable = { PER_majlis_total_seats > 289 }
-				check_variable = { PER_majlis_seats^i > 1 }
-			}
-			set_temp_variable = { PER_majlis_total_seats_temp = PER_majlis_total_seats }
-			log = "[?PER_majlis_total_seats_temp]"
-			subtract_from_temp_variable = { PER_majlis_total_seats_temp = 289 }
-			log = "[?PER_majlis_total_seats_temp]"
-			set_temp_variable_to_random = {
-				var = PER_majlis_total_seats_temp_allocation
-				max = PER_majlis_total_seats_temp
-				integer = yes
-			}
-			log = "[?PER_majlis_total_seats_temp_allocation]"
-			add_to_variable = { PER_majlis_seats^i = PER_majlis_total_seats_temp_allocation }
-			log = "[?PER_majlis_total_seats_temp_allocation]"
-			add_to_variable = { PER_majlis_total_seats = PER_majlis_total_seats_temp_allocation }
-			log = "[?PER_majlis_total_seats_temp_allocation]"
-		}
+	}
+}
 
-		else = { set_temp_variable = { PER_majlis_no_more_seats = 1 } }
-	}
-}
-PER_testing = {
-	for_loop_effect = {
-		start = 0
-		end = 24
+PER_majlis_stash_banned_popularity = {
+	for_each_loop = {
+		array = party_pop_array
 		value = v
+		index = i
 		if = {
-			limit = { check_variable = { party_banned_array^v = 1 } }
-			set_variable = { PER_banned_pop_stash^v = party_pop_array^v }
-			set_variable = { party_pop_array^v = 0 }
+			limit = { check_variable = { party_banned_array^i = 1 } }
+			set_variable = { PER_banned_pop_stash^i = v }
+			set_variable = { party_pop_array^i = 0 }
 		}
 	}
 }
-PER_testing2 = {
-	for_loop_effect = {
-		start = 0
-		end = 24
+
+PER_majlis_restore_banned_popularity = {
+	for_each_loop = {
+		array = party_pop_array
 		value = v
+		index = i
 		if = {
-			limit = { check_variable = { party_banned_array^v = 1 } }
-			set_variable = { party_pop_array^v = PER_banned_pop_stash^v }
+			limit = { check_variable = { party_banned_array^i = 1 } }
+			set_variable = { party_pop_array^i = PER_banned_pop_stash^i }
 		}
 	}
 	clear_array = PER_banned_pop_stash

--- a/common/scripted_effects/99_PER_scripted_effects.txt
+++ b/common/scripted_effects/99_PER_scripted_effects.txt
@@ -919,7 +919,6 @@ PER_majlis_duopoly = {
 PER_majlis_elections = {
 	custom_effect_tooltip = PER_majlis_TT
 	set_variable = { PER_majlis_total_seats = 0 }
-	set_variable = { PER_majlis_seats_INDEPENDENT = 0 }
 	PER_majlis_stash_banned_popularity = yes
 	if = {
 		limit = { NOT = { has_completed_focus = PER_weaken_guardian_council } }
@@ -928,7 +927,6 @@ PER_majlis_elections = {
 			array = party_pop_array
 			value = v
 			index = i
-			set_variable = { PER_majlis_seats^i = 0 }
 			if = {
 				limit = { check_variable = { party_pop_array^i = party_pop_array^popular_index_1 } }
 				set_variable = {
@@ -961,16 +959,15 @@ PER_majlis_elections = {
 					}
 				}
 			}
+			else = { set_variable = { PER_majlis_seats^i = 0 } }
 			add_to_variable = { PER_majlis_total_seats = PER_majlis_seats^i }
 		}
-		PER_majlis_correct_seats = yes
 	}
 	else = {
 		for_each_loop = {
 			array = party_pop_array
 			value = v
 			index = i
-			set_variable = { PER_majlis_seats^i = 0 }
 			if = {
 				limit = { check_variable = { party_pop_array^i > 0.005 } }
 				set_variable = {
@@ -981,10 +978,11 @@ PER_majlis_elections = {
 					}
 				}
 			}
+			else = { set_variable = { PER_majlis_seats^i = 0 } }
 			add_to_variable = { PER_majlis_total_seats = PER_majlis_seats^i }
 		}
-		PER_majlis_correct_seats = yes
 	}
+	PER_majlis_correct_seats = yes
 	set_variable = {
 		PER_majlis_seats_INDEPENDENT = {
 			value = 290

--- a/common/scripted_localisation/99_PER_scripted_localisation.txt
+++ b/common/scripted_localisation/99_PER_scripted_localisation.txt
@@ -2046,7 +2046,6 @@ defined_text = {
 	}
 }
 
-# New Majlis Shit
 defined_text = { # 0
 	name = PER_majlis_0
 	text = {
@@ -2215,7 +2214,7 @@ defined_text = { # 23
 		localization_key = PER_majlis_party_23
 	}
 }
-defined_text = { # INDEPENDENTS (FAILSAFE BECAUSE I AM DUM)
+defined_text = {
 	name = PER_majlis_IND_MP
 	text = {
 		trigger = { check_variable = { ROOT.PER_majlis_seats_INDEPENDENT > 0 } }

--- a/common/scripted_triggers/99_PER_scripted_triggers.txt
+++ b/common/scripted_triggers/99_PER_scripted_triggers.txt
@@ -229,3 +229,19 @@ PER_ai_not_artesh_path = {
 		PER_ai_path_selected = yes
 	}
 }
+
+PER_majlis_non_ir_proposal_visible = {
+	has_country_flag = PER_debate_ongoing
+	NOT = { has_country_flag = PER_doing_proposal }
+	emerging_hardline_shiite_are_in_power = no
+	emerging_moderate_shiite_are_in_power = no
+}
+
+PER_majlis_ir_proposal_visible = {
+	has_country_flag = PER_debate_ongoing
+	NOT = { has_country_flag = PER_doing_proposal }
+	OR = {
+		emerging_hardline_shiite_are_in_power = yes
+		emerging_moderate_shiite_are_in_power = yes
+	}
+}

--- a/docs/src/content/countries/iran.md
+++ b/docs/src/content/countries/iran.md
@@ -173,11 +173,28 @@ Therefore:
 
 Note: If The Breaking Point is triggered while the protest event chain is active, the protests will subside, but the revolution event chain will still begin without any issues, so you can continue playing without concern.
 
-###　Majles
-The Iranian parliament. Elections and debates are held at regular intervals. When a debate concludes, the parties in parliament can assign missions. Completing these missions grants rewards, while failure results in penalties.
+### Majles
 
-Examples of missions obtained through debates Mission:
-Network infrastructure level 2 or higher in four specific states Reward for completion: Office districts +2, Thermal power plants +1 (funds are taken from the national treasury) On failure: Office districts -2
+The Iranian parliament has 290 seats. At game start the Reformists hold 200, the Followers of
+Principle hold 65, and independents hold 5.
+
+The first election arrives shortly after game start, then about every four years. The first debate
+is a few months in, then about every 18 months. Decisions can dissolve parliament early or pull the
+next debate forward by two months.
+
+Banned parties win no seats. Those seats go to independents. While the Guardian Council is strong,
+the two most popular legal parties take most of the chamber, and other legal parties above 5%
+popularity get a reduced share. Completing Undermine the Guardian Council switches allocation to a
+straight popularity split (parties under 0.5% get nothing).
+
+When a debate starts, parties with seats can offer missions. Finish them for rewards. Let the
+21-day timer expire and you lose 100 Political Power, plus the mission's failure effect.
+
+Changing bureaucracy, police, education, health, or welfare laws can provoke a Majles objection.
+
+Example debate mission: network infrastructure level 2 or higher in four specific states.
+Completion: Office districts +2, thermal power plants +1 (paid from the treasury). Failure: Office
+districts -2.
 
 ## National Focus
 

--- a/events/Iran.txt
+++ b/events/Iran.txt
@@ -3704,27 +3704,20 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: PER_majlis.1.a executed"
 		PER_majlis_elections = yes
 		if = {
-			limit = {
-				has_country_flag = PER_stop_elections
-			}
+			limit = { has_country_flag = PER_stop_elections }
 			clr_country_flag = PER_stop_elections
 		}
 		if = {
 			limit = {
-				NOT = {
-					OR = {
-						emerging_hardline_shiite_are_in_power = yes
-						emerging_moderate_shiite_are_in_power = yes
-					}
-				}
+				emerging_hardline_shiite_are_in_power = no
+				emerging_moderate_shiite_are_in_power = no
 			}
 			country_event = {
 				id = PER_majlis.401
 				days = 3
 			}
 		}
-		add_to_variable = { var = PER_election_var value = 48 }
-		clamp_variable = { var = PER_election_var min = 0 max = 48 }
+		set_variable = { PER_election_var = 48 }
 		ai_chance = {
 			base = 1
 		}
@@ -3755,8 +3748,13 @@ country_event = {
 		name = PER_majlis.2.b
 		log = "[GetDateText]: [This.GetName]: PER_majlis.2.b executed"
 		custom_effect_tooltip = PER_session_extended_TT
-		add_to_variable = { var = PER_session_var value = 3 }
-		clamp_variable = { var = PER_session_var min = 0 max = 48 }
+		set_variable = {
+			PER_session_var = {
+				value = PER_session_var
+				add = 3
+				clamp = { min = 0 max = 48 }
+			}
+		}
 		ai_chance = {
 			base = 5
 		}


### PR DESCRIPTION
## Bottom line

Rename the Majlis election helpers and streamline the rest of the parliament loop. Seat math, the monthly tick, and debate proposals share one path each. Closes #3463.

## How

- `PER_testing`/`PER_testing2` are `PER_majlis_stash_banned_popularity` / `PER_majlis_restore_banned_popularity`. Seat counts round in one expression.
- `on_monthly_PER` calls `PER_majlis_monthly_tick` once instead of four abolished-gated ifs.
- Debate decisions share `PER_majlis_non_ir_proposal_visible` / `PER_majlis_ir_proposal_visible` and `PER_majlis_begin_proposal`.

BLUF