### PR TITLE
Fix Blank SCO Map Mode Colors (#3629)

### DIFF
--- a/common/map_modes/SCO_map_mode.txt
+++ b/common/map_modes/SCO_map_mode.txt
@@ -3,30 +3,30 @@ scripted_map_modes = {
 		top = {
 			type = country
 			color = {
-				FROM = {
-					is_in_array = { global.possible_sco_member_state = THIS.id }
-					if = { limit = { is_sco = yes }
-						set_temp_variable = { red = 1.000 }
-						set_temp_variable = { green = 0.450 }
-						set_temp_variable = { blue = 0.050 }
-					}
-					else_if = { limit = { has_idea = CHI_sco_observer }
-						set_temp_variable = { red = 0.650 }
-						set_temp_variable = { green = 0.350 }
-						set_temp_variable = { blue = 0.950 }
-					}
-					else_if = { limit = { has_idea = CHI_sco_dialogue_partner }
-						set_temp_variable = { red = 0.200 }
-						set_temp_variable = { green = 0.700 }
-						set_temp_variable = { blue = 0.850 }
-					}
-					else = {
-						set_temp_variable = { red = 1.000 }
-						set_temp_variable = { green = 0.900 }
-						set_temp_variable = { blue = 0.150 }
-						set_temp_variable = { alpha = 1 }
-					}
+				FROM = { is_in_array = { global.possible_sco_member_state = THIS.id } }
+
+				if = { limit = { FROM = { is_sco = yes } }
+					set_temp_variable = { red = 1.000 }
+					set_temp_variable = { green = 0.450 }
+					set_temp_variable = { blue = 0.050 }
 				}
+				else_if = { limit = { FROM = { has_idea = CHI_sco_observer } }
+					set_temp_variable = { red = 0.650 }
+					set_temp_variable = { green = 0.350 }
+					set_temp_variable = { blue = 0.950 }
+				}
+				else_if = { limit = { FROM = { has_idea = CHI_sco_dialogue_partner } }
+					set_temp_variable = { red = 0.200 }
+					set_temp_variable = { green = 0.700 }
+					set_temp_variable = { blue = 0.850 }
+				}
+				else = {
+					set_temp_variable = { red = 1.000 }
+					set_temp_variable = { green = 0.900 }
+					set_temp_variable = { blue = 0.150 }
+				}
+
+				set_temp_variable = { alpha = 1 }
 			}
 
 			targets = {

--- a/common/map_modes/SCO_map_mode.txt
+++ b/common/map_modes/SCO_map_mode.txt
@@ -3,8 +3,6 @@ scripted_map_modes = {
 		top = {
 			type = country
 			color = {
-				FROM = { is_in_array = { global.possible_sco_member_state = THIS.id } }
-
 				if = { limit = { FROM = { is_sco = yes } }
 					set_temp_variable = { red = 1.000 }
 					set_temp_variable = { green = 0.450 }
@@ -25,19 +23,12 @@ scripted_map_modes = {
 					set_temp_variable = { green = 0.900 }
 					set_temp_variable = { blue = 0.150 }
 				}
-
 				set_temp_variable = { alpha = 1 }
 			}
 
-			targets = {
-				target_array = global.possible_sco_member_state
-			}
+			targets = { target_array = global.possible_sco_member_state }
 		}
-
-		bottom = {
-			type = none
-		}
-
+		bottom = { type = none }
 		far_text = country
 		near_text = none
 		update_daily = no

--- a/localisation/english/MD_map_modes_l_english.yml
+++ b/localisation/english/MD_map_modes_l_english.yml
@@ -45,4 +45,4 @@
  MAPMODE_SCO_MAP_MODE: "SCO"
  MAPMODE_SCO_MAP_MODE_DESCRIPTION: "Shows member states, observers, and potential members of the Shanghai Cooperation Organisation."
  SCO_map_mode_tooltip: "Shanghai Cooperation Organisation"
- SCO_map_mode_tooltip_delayed: "Shows the current membership of the Shanghai Cooperation Organisation (SCO).\n\n§HColor Legend:§!\n§9Orange§! = SCO Member State\n§0Purple§! = Observer State\n§YYellow§! = Potential Member State\n\nUpdated weekly."
+ SCO_map_mode_tooltip_delayed: "Shows the current membership of the Shanghai Cooperation Organisation (SCO).\n\n§HColor Legend:§!\n§9Orange§! = SCO Member State\n§0Purple§! = Observer State\n§CCyan§! = Dialogue Partner\n§YYellow§! = Potential Member State\n\nUpdated weekly."


### PR DESCRIPTION
### Changes
- Fixes the SCO map mode drawing every country blank, so members, observers, dialogue partners and potential members render in their intended colors again
- Adds the missing dialogue partner entry to the SCO map mode color legend

Closes #3629