### PR TITLE
Fix Taiwan embargo tooltip and US withdrawal effects (#3639, #3638)

### DIFF
--- a/common/ai_strategy/USA.txt
+++ b/common/ai_strategy/USA.txt
@@ -881,6 +881,7 @@ USA_taiwan_relations = {
 	allowed = { tag = USA }
 	enable = {
 		country_exists = TAI
+		NOT = { has_country_flag = USA_withdrew_support_TAI }
 		CHI = { has_government = communism }
 		TAI = {
 			OR = {

--- a/common/decisions/NATO.txt
+++ b/common/decisions/NATO.txt
@@ -2124,23 +2124,10 @@ generic_coalition_politics_decisions = {
 
 		complete_effect = {
 			log = "[GetDateText]: [Root.GetName]: Decision denounce_Status_As_Major_Non_NATO_Ally"
-			remove_ideas = Major_Non_NATO_Ally
-			clr_country_flag = Major_Non_NATO_Ally
-			remove_from_tech_sharing_group = Major_Non_NATO_Ally_Share
+			NATO_major_non_nato_ally_leave = yes
 
 			USA = {
 				add_opinion_modifier = { target = PREV modifier = left_alliance }
-			}
-
-			every_other_country = {
-				limit = {
-					has_opinion_modifier = Major_Non_NATO_Ally
-				}
-
-				remove_opinion_modifier = { target = PREV modifier = Major_Non_NATO_Ally }
-				hidden_effect = {
-					PREV = { remove_opinion_modifier = { target = PREV modifier = Major_Non_NATO_Ally } }
-				}
 			}
 		}
 		ai_will_do = { base = 0 }

--- a/common/decisions/USA.txt
+++ b/common/decisions/USA.txt
@@ -8295,6 +8295,7 @@ USA_foreign_policy = {
 		visible = {
 			country_exists = TAI
 			NOT = { has_war_with = TAI }
+			NOT = { has_country_flag = USA_withdrew_support_TAI }
 			CHI = {
 				has_completed_focus = CHI_TAI_cross_strait_policy
 				OR = {
@@ -8337,6 +8338,7 @@ USA_foreign_policy = {
 		visible = {
 			country_exists = TAI
 			NOT = { has_war_with = TAI }
+			NOT = { has_country_flag = USA_withdrew_support_TAI }
 			CHI = {
 				has_completed_focus = CHI_TAI_cross_strait_policy
 				has_country_flag = CHI_adiz_incursion_active
@@ -8372,6 +8374,7 @@ USA_foreign_policy = {
 		visible = {
 			country_exists = TAI
 			NOT = { has_war_with = TAI }
+			NOT = { has_country_flag = USA_withdrew_support_TAI }
 			CHI = {
 				has_completed_focus = CHI_TAI_cross_strait_policy
 				has_country_flag = CHI_blockade_sim_active
@@ -8411,6 +8414,7 @@ USA_foreign_policy = {
 		visible = {
 			country_exists = TAI
 			NOT = { has_war_with = TAI }
+			NOT = { has_country_flag = USA_withdrew_support_TAI }
 			CHI = { has_country_flag = CHI_TAI_maritime_zone_active }
 		}
 
@@ -8443,6 +8447,7 @@ USA_foreign_policy = {
 		visible = {
 			country_exists = TAI
 			NOT = { has_war_with = TAI }
+			NOT = { has_country_flag = USA_withdrew_support_TAI }
 			CHI = { has_completed_focus = CHI_TAI_cross_strait_policy }
 		}
 

--- a/common/national_focus/05_china.txt
+++ b/common/national_focus/05_china.txt
@@ -29148,19 +29148,22 @@ focus_tree = {
 			add_to_variable = { CHI_taiwan_us_support = -3 tooltip = CHI_taiwan_us_support_tt }
 			clamp_variable = { var = CHI_taiwan_us_support min = 0 max = 100 }
 			newline = yes
-			every_other_country = {
-				limit = {
-					is_in_array = { recognised_countries = TAI }
-					exists = yes
-					NOT = { original_tag = CHI }
-					NOT = { original_tag = TAI }
-				}
-				if = {
-					limit = { ROOT = { has_dlc = "By Blood Alone" } }
-					ROOT = { send_embargo = PREV }
-				}
-				else = {
-					add_ideas = CHI_recognition_embargo
+			custom_effect_tooltip = CHI_TAI_intl_org_blockade_embargo_tt
+			hidden_effect = {
+				every_other_country = {
+					limit = {
+						is_in_array = { recognised_countries = TAI }
+						exists = yes
+						NOT = { original_tag = CHI }
+						NOT = { original_tag = TAI }
+					}
+					if = {
+						limit = { ROOT = { has_dlc = "By Blood Alone" } }
+						ROOT = { send_embargo = PREV }
+					}
+					else = {
+						add_ideas = CHI_recognition_embargo
+					}
 				}
 			}
 			newline = yes

--- a/common/on_actions/99_CHI_on_actions.txt
+++ b/common/on_actions/99_CHI_on_actions.txt
@@ -100,6 +100,7 @@ on_actions = {
 					limit = {
 						has_country_flag = CHI_harris_us_support_floor
 						check_variable = { CHI_taiwan_us_support < 40 }
+						NOT = { USA = { has_country_flag = USA_withdrew_support_TAI } }
 					}
 					set_variable = { CHI_taiwan_us_support = 40 }
 				}

--- a/common/scripted_effects/01_NATO_effects.txt
+++ b/common/scripted_effects/01_NATO_effects.txt
@@ -415,6 +415,25 @@ NATO_major_non_nato_ally_join = {
 	}
 }
 
+# Effect: NATO_major_non_nato_ally_leave
+# Purpose: Mirror of NATO_major_non_nato_ally_join — revokes the idea, flag and Major_Non_NATO_Ally_Share tech group, and clears the mutual opinion modifiers the join granted. Sweeps every country rather than global.nato_members so members that have since left NATO are cleaned up too.
+NATO_major_non_nato_ally_leave = {
+	remove_ideas = Major_Non_NATO_Ally
+	clr_country_flag = Major_Non_NATO_Ally
+	remove_from_tech_sharing_group = Major_Non_NATO_Ally_Share
+
+	every_other_country = {
+		limit = {
+			has_opinion_modifier = Major_Non_NATO_Ally
+		}
+
+		remove_opinion_modifier = { target = PREV modifier = Major_Non_NATO_Ally }
+		hidden_effect = {
+			PREV = { remove_opinion_modifier = { target = PREV modifier = Major_Non_NATO_Ally } }
+		}
+	}
+}
+
 # Effect: NATO_coup_response_pulse
 # Purpose: Fires the NATO-coup dilemma (department_of_state.233) on the current NATO faction leader when ROOT (the coup mastermind) successfully overthrows a NATO member (FROM). Picks the first eligible leader from global.nato_members so the content works whether the USA still leads NATO or another member has taken over. Sets a 365-day per-leader cooldown so the same leader isn't spammed by repeated coups. Skips ROOT if it is democratic, is the USA itself, or is not one of the designated hostile sponsors (CHI / SOV / PER). Skips entirely when NATO is disabled by game rule or has no members yet.
 NATO_coup_response_pulse = {

--- a/events/05_china.txt
+++ b/events/05_china.txt
@@ -1050,13 +1050,19 @@ country_event = {
 		}
 		add_to_variable = { CHI_network_border_control_multiplier_modifier = 0.03 tooltip = border_control_multiplier_modifier_tt }
 		add_war_support = 0.05
+		custom_effect_tooltip = CHI_taiwan_us_support_collapse_tt
+		hidden_effect = { set_variable = { CHI_taiwan_us_support = 0 } }
 		TAI = {
 			add_timed_idea = {
 				idea = TAI_isolated_from_us
 				days = 1825
 			}
+			NATO_major_non_nato_ally_leave = yes
+			country_event = { id = china_sar.049 days = 1 }
 		}
 		USA = {
+			set_country_flag = USA_withdrew_support_TAI
+			diplomatic_relation = { country = TAI relation = guarantee active = no }
 			add_opinion_modifier = { target = CHI modifier = chi_usa_pressure_campaign }
 		}
 		ai_chance = { base = 10 }
@@ -1084,6 +1090,20 @@ country_event = {
 		ai_chance = { base = 10 }
 	}
 }
+
+country_event = {
+	id = china_sar.049
+	title = china_sar.049.t
+	desc = china_sar.049.d
+	picture = GFX_CHI_event_american_chinese_flag
+	is_triggered_only = yes
+	minor_flavor = yes
+
+	option = {
+		name = china_sar.049.a
+	}
+}
+
 country_event = {
 	id = china_sar.034
 	title = china_sar.034.t

--- a/localisation/english/MD_focus_CHI_l_english.yml
+++ b/localisation/english/MD_focus_CHI_l_english.yml
@@ -4752,6 +4752,7 @@
  CHI_TAI_intl_org_blockade: "International Organisation Blockade"
  CHI_TAI_intl_org_blockade_desc: "China leverages its permanent seat on the UN Security Council and its growing weight in multilateral institutions to block Taiwan's participation in international organisations. Observer status applications are vetoed and informal participation channels are closed."
  CHI_TAI_intl_org_blockade_tt: "[TAI.GetNameWithFlag] gains a dynamic modifier that penalises it based on its level of international recognition."
+ CHI_TAI_intl_org_blockade_embargo_tt: "Every country that still recognises [TAI.GetNameWithFlag] is placed under a §Ytrade embargo§!."
 
  CHI_TAI_economic_leverage: "Economic Leverage Campaign"
  CHI_TAI_economic_leverage_desc: "Beijing weaponises its position as the world's largest trading nation, applying targeted economic pressure on American industries and political constituencies that support Taiwan. The campaign exploits commercial dependence to erode the political will behind US security guarantees."

--- a/localisation/english/MD_focus_CHI_l_english.yml
+++ b/localisation/english/MD_focus_CHI_l_english.yml
@@ -4815,6 +4815,7 @@
  CHI_taiwan_us_support: "§Y[USA.GetFlag][USA.GetAdjectiveCap] Support§! for §Y[TAI.GetNameWithFlag]§!"
  CHI_taiwan_us_support_tt: "$CHI_taiwan_us_support$: $RIGHT|-=0$"
  CHI_taiwan_us_support_display: "$CHI_taiwan_us_support$: [?CHI_taiwan_us_support|0]"
+ CHI_taiwan_us_support_collapse_tt: "$CHI_taiwan_us_support$ collapses to §Y0§!"
  CHI_taiwan_strait_tension: "[TAI.GetNameWithFlag] Strait Tension"
  CHI_taiwan_strait_tension_tt: "$CHI_taiwan_strait_tension$: $RIGHT|+=0$"
  CHI_taiwan_strait_tension_display: "$CHI_taiwan_strait_tension$: [?CHI_taiwan_strait_tension|0]"
@@ -4921,6 +4922,10 @@
  china_sar.033.t: "Washington Reaffirms Its Commitment"
  china_sar.033.d: "The United States has rejected China's pressure campaign and publicly reaffirmed its commitment to Taiwan's security. The administration has announced a new arms package for Taipei and convened emergency consultations with Japan and Australia. Beijing's campaign has failed, and has hardened opposition in Washington."
  china_sar.033.a: "A setback, but not a defeat. We will reassess our approach."
+
+ china_sar.049.t: "Washington Withdraws Its Guarantee"
+ china_sar.049.d: "The United States has notified Taipei that its security guarantee is no longer in force and that Taiwan's designation as a Major Non-NATO Ally has been rescinded. Arms transfers are suspended, joint exercises cancelled, and liaison staffing cut back to a token presence. Taiwan now stands without its principal security guarantor."
+ china_sar.049.a: "We will have to defend ourselves."
 
  china_sar.001.t: "Proposal: Cross-Strait Services Trade Agreement"
  china_sar.001.d: "Beijing has put forward the Cross-Strait Services Trade Agreement, opening major service sectors on both sides to freer trade and investment. The proposal would grant mainland firms access to Taiwan's banking, healthcare, and retail sectors. Supporters argue it would deepen economic integration; critics warn it hands Beijing structural leverage over Taiwan's economy."


### PR DESCRIPTION
### Changes
- International Organisation Blockade no longer claims to embargo one arbitrary country in its effect tooltip; it now shows a single line covering every nation that still recognises Taiwan
- Washington Steps Back from Taiwan now actually withdraws US backing: the independence guarantee is broken, Taiwan loses its Major Non-NATO Ally status (idea, flag, tech sharing group and opinion modifiers), and American support for Taiwan drops to zero
- The US AI no longer re-issues the guarantee after backing down, the five American Taiwan support decisions are withdrawn, and the presidential support floor no longer restores support the following month
- Taiwan is notified when Washington revokes the guarantee

Closes #3639
Closes #3638