### PR TITLE
Add military equipment guide

### DIFF
--- a/docs/src/content/tutorials/military-tutorial.md
+++ b/docs/src/content/tutorials/military-tutorial.md
@@ -1,8 +1,44 @@
 ---
 title: Military Tutorial
-description: How the military system works in Millennium Dawn, divisions, doctrines, command, and combat.
+description: How Millennium Dawn changes military equipment, production, and vehicle design from vanilla HOI4.
 permalink: /player-tutorials/military-tutorial/
 toc: off
 ---
 
-This page is being written. In the meantime, see the [Mechanics Guide](/player-tutorials/mechanics-guide/) for power ranking and bonuses, and the [EU Tutorial](/player-tutorials/eu-tutorial/) for coalition gameplay. The military system overview will land here once it's drafted.
+Millennium Dawn changes how you design, produce, and organize military equipment. This guide explains the major differences from vanilla Hearts of Iron IV.
+
+## Table of Contents
+
+- [Military Equipment and Production](#military-equipment-and-production)
+- [Armored Vehicles](#armored-vehicles)
+  - [Vehicle Roles](#vehicle-roles)
+
+---
+
+## Military Equipment and Production
+
+> ⚠️ **Important:** Millennium Dawn cannot be directly compared with vanilla HOI4 when it comes to military equipment and production. The equipment design and production structure is significantly different.
+
+Unlike vanilla HOI4, where a relatively small number of equipment types can cover most of your armed forces, Millennium Dawn lets you highly specialize your equipment. As a result, you will generally produce a much larger variety of equipment.
+
+Do not expect to build your military the same way as in vanilla HOI4. Equipment specialization and careful production planning are much more important in Millennium Dawn.
+
+---
+
+## Armored Vehicles
+
+Millennium Dawn uses a generalized armored fighting vehicle hull rather than separate hull families for every vehicle role.
+
+The modules you install determine what the vehicle becomes. Its weapon, armor, and specialized modules define its role and category. Most armaments are also categorized, making it easier to identify which type of vehicle a weapon is designed for.
+
+### Vehicle Roles
+
+Using the vehicle designer, you can create:
+
+- **APCs:** Armored Personnel Carriers
+- **IFVs:** Infantry Fighting Vehicles
+- **MBTs:** Main Battle Tanks
+- **LTs:** Light Tanks
+- **SPARTs:** Self-Propelled Artillery
+- **MLRS:** Multiple Launch Rocket Systems
+- **SPAAs:** Self-Propelled Anti-Aircraft Vehicles


### PR DESCRIPTION
### Changes

- Replaces the empty Military Tutorial placeholder with an introductory guide
- Explains how equipment specialization and production differ from vanilla HOI4
- Documents the generalized armored vehicle hull and its APC, IFV, MBT, light tank, SPART, MLRS, and SPAA roles
- Adds a manual Table of Contents

### Validation

- Markdownlint: 0 issues
- git diff --check: clean