### PR TITLE
Fix the three Test Suite quality gates red since #3683

### DIFF
--- a/.github/actions/setup-md-python/action.yml
+++ b/.github/actions/setup-md-python/action.yml
@@ -16,7 +16,9 @@ runs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6
       with:
         python-version: "3.x"
-        cache: pip
+        # The pip cache hashes a dependency manifest that sparse checkouts
+        # without pyproject.toml do not have, and install: false caches nothing.
+        cache: ${{ inputs.install == 'true' && 'pip' || '' }}
     - name: Install Python dependencies
       if: inputs.install == 'true'
       shell: bash

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -863,6 +863,10 @@ jobs:
       - name: Set up Python
         id: setup-python
         uses: ./.github/actions/setup-md-python
+        with:
+          # The report tooling is stdlib-only and the sparse checkout has no
+          # pyproject.toml, so there is nothing to install or cache.
+          install: "false"
 
       - name: Download all validation results
         id: download-results

--- a/tools/assets/generate_background_thumbnails.py
+++ b/tools/assets/generate_background_thumbnails.py
@@ -114,7 +114,9 @@ def thumbnail_for(source: Path) -> Path:
 
 def render_thumbnail(dds: types.ModuleType, source: Path) -> bytes:
     with Image.open(source) as image:
-        thumbnail = image.convert("RGB").resize(THUMBNAIL_SIZE, Image.LANCZOS)
+        thumbnail = image.convert("RGB").resize(
+            THUMBNAIL_SIZE, Image.Resampling.LANCZOS
+        )
     raw = thumbnail.tobytes()
     pixels = [
         (raw[i + 2], raw[i + 1], raw[i], 255) for i in range(0, len(raw), 3)

--- a/tools/tests/report_lib/checks_api_test.py
+++ b/tools/tests/report_lib/checks_api_test.py
@@ -319,6 +319,13 @@ def _error_issues(count):
     ]
 
 
+def _post_single_run(monkeypatch, outcomes, run=None):
+    """Post one run (default: 1 error) through a scripted transport."""
+    run = run or _run_with_issues(_error_issues(1))
+    calls = _transport(monkeypatch, outcomes)
+    return calls, post_checks("owner", "repo", "sha1", [run], "token")
+
+
 def test_fallback_job_maps_batch_and_standalone_names():
     assert _fallback_job("events") == "Mod tests (core)"
     assert _fallback_job("focus-tree") == "Mod tests (targeted-b)"
@@ -461,8 +468,7 @@ def test_post_checks_patches_the_existing_job_check_run(monkeypatch):
 
 
 def test_post_checks_posts_when_existing_check_run_rejects_patch(monkeypatch):
-    run = _run_with_issues(_error_issues(1))
-    calls = _transport(
+    calls, results = _post_single_run(
         monkeypatch,
         [
             _Resp(b'{"check_runs": [{"id": 9, "name": "Mod tests (core)"}]}'),
@@ -470,8 +476,6 @@ def test_post_checks_posts_when_existing_check_run_rejects_patch(monkeypatch):
             _Resp(b'{"id": 11}'),
         ],
     )
-
-    results = post_checks("owner", "repo", "sha1", [run], "token")
 
     assert results == [("Mod tests (core)", True, "check #11")]
     assert [c[0] for c in calls] == ["GET", "PATCH", "POST"]
@@ -481,15 +485,14 @@ def test_post_checks_posts_when_existing_check_run_rejects_patch(monkeypatch):
 def test_post_checks_posts_when_no_check_run_matches_the_job(monkeypatch):
     run = _run_with_issues([])
     run.name, run.title = "events", "Events"
-    calls = _transport(
+    calls, results = _post_single_run(
         monkeypatch,
         [
             _Resp(b'{"check_runs": [{"id": 5, "name": "Unrelated job"}]}'),
             _Resp(b'{"id": 11}'),
         ],
+        run,
     )
-
-    results = post_checks("owner", "repo", "sha1", [run], "token")
 
     assert results == [("Mod tests (core)", True, "check #11")]
     assert [c[0] for c in calls] == ["GET", "POST"]


### PR DESCRIPTION
## Bottom line
Every PR run since #3683 fails three gates that the fold introduced or re-surfaced. This fixes all three; #3655 and later PRs go green once this merges.

## Why
- pylint: `Image.LANCZOS` in generate_background_thumbnails.py is invisible to astroid (Pillow sets the resampling constants through a setattr loop), so pylint's no-member fired on Linux. `Image.Resampling.LANCZOS` is statically visible and the same value.
- jscpd: two post_checks tests in checks_api_test.py shared a 56-token window over the zero-duplication threshold. Extracted `_post_single_run` so the scripted transport plus post_checks call lives in one place.
- Test suite report job: its sparse checkout has no pyproject.toml, so the unconditional `cache: pip` inside setup-md-python aborted with 'No file matched'. The report tooling is stdlib-only, so the job now passes `install: false` and the action gates the pip cache on `install == 'true'` (nothing to cache otherwise; the file-paths job benefits too).
- generate_background_thumbnails.py also gains the executable bit the shebang hook wants; every other standalone tool script is 755.

## How
Verified locally: pylint/ruff/black/mypy clean, jscpd 0 clones, full pytest 4482 passed 2 skipped, all pre-commit hooks pass.

BLUF