### PR TITLE
Make recce, SPAA, and heavy engineer support companies airdroppable for airborne units

### DIFF
--- a/common/units/MD_division_support.txt
+++ b/common/units/MD_division_support.txt
@@ -379,6 +379,7 @@ sub_units = {
 			defence = 0.15
 			movement = 0.05
 		}
+		can_be_parachuted = yes
 		same_support_type = engineer
 	}
 	communications_company = {

--- a/common/units/MD_regimental_support.txt
+++ b/common/units/MD_regimental_support.txt
@@ -684,6 +684,7 @@ sub_units = {
 		weight = 0.75
 
 		transport = medium_tank_aa_chassis
+		can_be_parachuted = yes
 	}
 
 	#Fire Support Elements
@@ -875,7 +876,7 @@ sub_units = {
 		}
 
 		group = support
-		allowed_battalion_groups = { mobile armor marine_infantry }
+		allowed_battalion_groups = { mobile armor marine_infantry airborne_infantry }
 
 		categories = {
 			category_support_battalions
@@ -910,6 +911,7 @@ sub_units = {
 		suppression = 0.5
 
 		transport = medium_tank_aa_chassis
+		can_be_parachuted = yes
 	}
 	air_assault_Arty_Battery = {
 		sprite = artillery
@@ -1289,7 +1291,7 @@ sub_units = {
 		}
 
 		group = support
-		allowed_battalion_groups = { mobile marine_infantry }
+		allowed_battalion_groups = { mobile marine_infantry airborne_infantry }
 
 		categories = {
 			category_all_recon
@@ -1360,7 +1362,7 @@ sub_units = {
 		}
 
 		group = support
-		allowed_battalion_groups = { armor marine_infantry }
+		allowed_battalion_groups = { armor marine_infantry airborne_infantry }
 
 		categories = {
 			category_all_recon
@@ -1431,7 +1433,7 @@ sub_units = {
 		}
 
 		group = support
-		allowed_battalion_groups = { armor marine_infantry }
+		allowed_battalion_groups = { armor marine_infantry airborne_infantry }
 
 		categories = {
 			category_all_recon
@@ -1505,7 +1507,7 @@ sub_units = {
 		}
 
 		group = support
-		allowed_battalion_groups = { armor }
+		allowed_battalion_groups = { armor airborne_infantry }
 
 		categories = {
 			category_all_recon


### PR DESCRIPTION
## Bottom line
Lets airborne (paratrooper) divisions use mech/armored recce, SPAA, and the heavy engineer support company, which they currently can't.

Closes #2845 

## What changed
- `H_Engi_Comp` (heavy engineer), `Light_SP_AA_Bat`, `SP_AA_Battery` (SPAA): added `can_be_parachuted = yes`
- `Mech_Recce_Comp`, `Arm_Recce_Comp`, `armor_Recce_Comp`, `Mot_Recce_Comp`, `SP_AA_Battery`: added `airborne_infantry` to `allowed_battalion_groups`

## Why this is the right fix
All the recce companies already had `can_be_parachuted = yes`. What actually kept them out of airborne divisions was `allowed_battalion_groups` \u2014 the mech/arm/motorized recce and armored SPAA listed only `armor`/`mobile`/`marine_infantry`, while only `L_Recce_Comp` (infantry recce) included `airborne_infantry`. So `can_be_parachuted` alone wouldn't have changed anything for the recce; the `allowed_battalion_groups` addition is what makes them selectable by airborne units.

## Out of scope / left as-is
- The engineer and light-infantry recce speeds (user mentioned them as a separate concern) were not touched.
- Airmobile (helicopter-assault) groups were not added; the fix targets paratrooper `airborne_infantry` units only. Say the word if airmobile should be included too.
- `SP_AA_Bat` (armored-division line SPAA) is a line battalion for armor, not a support company; left unchanged.

BLUF