### PR TITLE
Fix Chinese Yuan reserve currency tiers (#3716, #3715)

### DIFF
--- a/common/ideas/AA_law_expanded_economics.txt
+++ b/common/ideas/AA_law_expanded_economics.txt
@@ -872,6 +872,7 @@ ideas = {
 		}
 		chinese_yuan_2 = {
 			name = chinese_yuan
+			picture = chinese_yuan
 			modifier = {
 				custom_modifier_tooltip = cny_reserve_users_tt
 				resource_trade_cost_bonus_per_factory = 1
@@ -946,6 +947,7 @@ ideas = {
 		}
 		chinese_yuan_3 = {
 			name = chinese_yuan
+			picture = chinese_yuan
 			modifier = {
 				custom_modifier_tooltip = cny_reserve_users_tt
 				resource_trade_cost_bonus_per_factory = 1

--- a/common/national_focus/03_china_north_korea_joint.txt
+++ b/common/national_focus/03_china_north_korea_joint.txt
@@ -447,10 +447,8 @@ joint_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus CHI_NKO_yuan_settlement"
 		if = {
 			limit = { original_tag = NKO }
-			swap_ideas = {
-				remove_idea = no_foreign_reserve
-				add_idea = chinese_yuan
-			}
+			remove_ideas = no_foreign_reserve
+			adopt_chinese_yuan_reserve = yes
 			newline = yes
 		}
 		custom_effect_tooltip = {

--- a/common/national_focus/05_china.txt
+++ b/common/national_focus/05_china.txt
@@ -1431,15 +1431,23 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_yuan_internationalisation"
+			every_country = {
+				limit = {
+					OR = {
+						has_idea = chinese_yuan
+						has_idea = chinese_yuan_2
+					}
+				}
+				if = {
+					limit = { has_idea = chinese_yuan_2 }
+					swap_ideas = { remove_idea = chinese_yuan_2 add_idea = chinese_yuan_3 }
+				}
+				else = {
+					swap_ideas = { remove_idea = chinese_yuan add_idea = chinese_yuan_3 }
+				}
+			}
 			if = {
-				limit = { has_idea = chinese_yuan_2 }
-				swap_ideas = { remove_idea = chinese_yuan_2 add_idea = chinese_yuan_3 }
-			}
-			else_if = {
-				limit = { has_idea = chinese_yuan }
-				swap_ideas = { remove_idea = chinese_yuan add_idea = chinese_yuan_3 }
-			}
-			else = {
+				limit = { NOT = { has_idea = chinese_yuan_3 } }
 				add_ideas = chinese_yuan_3
 			}
 		}
@@ -16820,7 +16828,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus CHI_Renminbi_Internationalization"
 			add_ideas = rmb_reserve_currency
-			if = {
+			every_country = {
 				limit = { has_idea = chinese_yuan }
 				swap_ideas = { remove_idea = chinese_yuan add_idea = chinese_yuan_2 }
 			}

--- a/common/on_actions/MD_on_actions.txt
+++ b/common/on_actions/MD_on_actions.txt
@@ -1357,7 +1357,7 @@ on_actions = {
 						}
 					}
 				}
-				add_ideas = chinese_yuan
+				adopt_chinese_yuan_reserve = yes
 			}
 			else_if = {
 				limit = {

--- a/common/scripted_effects/00_currency_effects.txt
+++ b/common/scripted_effects/00_currency_effects.txt
@@ -441,6 +441,22 @@ calculate_reserve_roi_bonus = {
 	}
 }
 
+# The visible yuan tier tracks China's internationalisation focuses, so any later
+# grant must match the tier the law list is currently showing.
+adopt_chinese_yuan_reserve = {
+	if = {
+		limit = { CHI = { has_completed_focus = CHI_yuan_internationalisation } }
+		add_ideas = chinese_yuan_3
+	}
+	else_if = {
+		limit = { CHI = { has_completed_focus = CHI_Renminbi_Internationalization } }
+		add_ideas = chinese_yuan_2
+	}
+	else = {
+		add_ideas = chinese_yuan
+	}
+}
+
 clamp_currency_strength = {
 	clamp_variable = { var = currency_strength min = 0.15 max = 2.0 }
 }

--- a/common/scripted_effects/00_currency_effects.txt
+++ b/common/scripted_effects/00_currency_effects.txt
@@ -441,8 +441,6 @@ calculate_reserve_roi_bonus = {
 	}
 }
 
-# The visible yuan tier tracks China's internationalisation focuses, so any later
-# grant must match the tier the law list is currently showing.
 adopt_chinese_yuan_reserve = {
 	if = {
 		limit = { CHI = { has_completed_focus = CHI_yuan_internationalisation } }


### PR DESCRIPTION
### Changes
- Yuan holders now move up with China when it completes Renminbi Internationalization or Yuan Internationalisation, instead of being left on a hidden tier that displayed as Domestic Reserve
- Countries granted the yuan after those focuses (AI joining China's faction, the China/North Korea yuan settlement focus) now receive the tier China has actually reached
- The upgraded Chinese Yuan tiers show the yuan icon in the reserve currency law list instead of a missing texture

Closes #3716
Closes #3715