### PR TITLE
Streamline the performance guide

### DIFF
--- a/docs/src/content/tutorials/performance-guide.md
+++ b/docs/src/content/tutorials/performance-guide.md
@@ -5,27 +5,25 @@ permalink: /player-tutorials/performance-guide/
 version: "v2.0"
 ---
 
-# Performance Guide
-
-Millennium Dawn, by its nature, is a performance-intensive mod for Hearts of Iron IV due to its extended mechanics, numerous nations, and drive to deepen the Hearts of Iron IV experience. This guide seeks to help players make changes to the mod without losing meaningful content while delivering a solid experience. The team is striving to optimize the mod and the experience while providing the targeted gameplay; this is a focal point for the team. However, we are limited by the game engine and the interactions that Hearts of Iron IV allows.
+Millennium Dawn is a performance-intensive mod for Hearts of Iron IV. Its extended mechanics, numerous nations, and drive to deepen the experience demand more from your machine. The team is actively optimizing the mod, but we are limited by the game engine and what Hearts of Iron IV allows. This guide helps you tune the mod for a smoother experience without losing meaningful content.
 
 ## What this guide does not do
 
-This guide does not serve the following, nor will it recommend the following:
+This guide does not recommend:
 
 - Disabling the economic system
 - Disabling the influence system
-- Disabling the United Nation system
-- Changing anything that compromises the Millennium Dawn experience in any shape or form
+- Disabling the United Nations system
+- Removing core gameplay systems
 
-The mod is targeted at players looking for a deeper experience and a more geopolitically heavy game; without these systems to facilitate that aim, the mod falls flat. The guide's entire purpose is to deliver a more streamlined experience for your machine without compromising that aim. The recommendations are tailored to that aim, listed by impact with explanations as to why.
+These systems are central to Millennium Dawn's geopolitical gameplay. The recommendations below improve performance while keeping them enabled.
 
 **NOTE**
-If your computer has weak single-core performance and struggles with vanilla Hearts of Iron IV, you will struggle significantly more while playing Millennium Dawn. The development team is unable to fix this, as it must be handled by the Paradox Interactive development team.
+If your computer has weak single-core performance and struggles with vanilla Hearts of Iron IV, it will struggle significantly more with Millennium Dawn. The development team cannot fix this; it must be handled by the Paradox Interactive development team.
 
 ## Game Rules
 
-The most powerful tools for a Millennium Dawn player are the Game Rules in the "Select a Country" screen at the beginning of the game. Millennium Dawn provides you with multiple options to tailor your experience to your preference, but these are the game rules we recommend setting to preserve performance without losing any core gameplay.
+The most powerful tools for a Millennium Dawn player are the Game Rules in the "Select a Country" screen at the beginning of the game. Millennium Dawn offers multiple ways to tailor the experience, but these are the rules we recommend setting to preserve performance without losing any core gameplay.
 
 Recommended Game Rules:
 
@@ -37,20 +35,20 @@ Recommended Game Rules:
 
 ### Remove Nations: Tiny Nations (Microstates)
 
-The "Remove Nations - Tiny Nations (Microstates)" game rule removes nations such as Andorra, Vatican City, Nauru, St Kitts, and other small island nations included for immersion and historical accuracy. Removing them can yield a 5-6% performance improvement for weaker machines or for players who simply want the mod to run faster. The removal of these nations reduces overall calculations and makes each tick faster when the game runs "every country" or "every other country" calls.
+This rule removes nations such as Andorra, Vatican City, Nauru, St Kitts, and other small island nations included for immersion and historical accuracy. Removing them can yield a 5-6% performance improvement on weaker machines or for players who simply want the mod to run faster. Fewer nations means fewer calculations, so each tick, and every "every country" or "every other country" call, runs faster.
 
 ### Enable AI Division Limiter: Potato Edition
 
-The "Enable AI Division Limiter - Potato Edition" game rule enforces a stricter division limiter on the AI, which particularly improves late-game performance. Enabling this game rule reduces the number of divisions the AI produces in the later years of the mod, providing a more optimized experience at the cost of fewer units available for the AI to hold lines. This trade-off means the AI is slightly worse at handling situations with larger frontlines, multi-faceted attacks, or larger-scale conflicts, particularly during World War III.
+This rule enforces a stricter division limiter on the AI, which particularly improves late-game performance. It reduces the number of divisions the AI produces in the later years of the mod, trading some line-holding power for a more optimized run. The AI is slightly worse at handling larger frontlines, multi-faceted attacks, and large-scale conflicts, particularly during World War III.
 
 ### Disable GDP Graph: Yes
 
-Disabling the GDP Graph simply stops the game from calculating the needed frames for the GDP graph. The GDP graph is purely for display and player convenience; removing this feature comes at effectively no cost to the experience, although it removes historical data from the player's view.
+Disabling the GDP Graph stops the game from calculating the frames the graph needs. The GDP graph is purely for display and player convenience; turning it off comes at effectively no cost to the experience, though it removes historical data from the player's view.
 
 ### Enable Resource Storage System: No
 
-The Resource Storage System is relatively minor in the grand scheme of Millennium Dawn, but disabling it reduces computational overhead on the daily tick. It disables the ability for the player or AI to store resources, avoiding the computation of storage and relative consumption.
+The Resource Storage System is relatively minor in the grand scheme of Millennium Dawn, but disabling it reduces computational overhead on the daily tick. It removes the ability for the player or AI to store resources, avoiding the computation of storage and relative consumption.
 
 ### Enable MD Ledger: No
 
-The Ledger, much like the GDP Graph, is purely for display and provides long-form data and information about the world at large. Disabling the MD Ledger does not reduce the gameplay experience, but it does limit the easily accessible information provided to the player. It is recommended to turn this off to reduce the performance drain on monthly ticks, yielding around a 2-4% overall improvement.
+The Ledger, much like the GDP Graph, is purely for display and provides long-form data and information about the world at large. Disabling the MD Ledger does not reduce the gameplay experience; it only limits the easily accessible information provided to the player. Turning it off reduces the performance drain on monthly ticks, yielding around a 2-4% overall improvement.


### PR DESCRIPTION
## Bottom line
Remove the duplicate page title that fails the docs quality check and tighten the performance guide.

Keep all five game-rule recommendations and their trade-offs. Correct United Nations naming.

BLUF