### PR TITLE
Gate doctrine-exclusive naval hulls behind their doctrine

### DIFF
--- a/common/units/equipment/MD_mtg_ships.txt
+++ b/common/units/equipment/MD_mtg_ships.txt
@@ -6572,7 +6572,10 @@ equipments = {
 	patrol_boat = {
 		year = 1985
 		can_be_produced = {
-			has_doctrine = jeune_ecole
+			OR = {
+				has_doctrine = jeune_ecole
+				original_tag = HKG
+			}
 		}
 		is_archetype = yes
 		is_buildable = no

--- a/common/units/equipment/MD_mtg_ships.txt
+++ b/common/units/equipment/MD_mtg_ships.txt
@@ -1846,6 +1846,10 @@ equipments = {
 	heavy_frigate = {
 		year = 2010
 
+		can_be_produced = {
+			has_doctrine = frigate_capitals
+		}
+
 		is_archetype = yes
 		is_buildable = no
 		type = screen_ship
@@ -6567,6 +6571,9 @@ equipments = {
 #PATROL BOATS
 	patrol_boat = {
 		year = 1985
+		can_be_produced = {
+			has_doctrine = jeune_ecole
+		}
 		is_archetype = yes
 		is_buildable = no
 		type = screen_ship


### PR DESCRIPTION
**Bottom line:** patrol boats and heavy frigates can now only be produced while the unlocking doctrine is actually active, closing the switch-and-keep exploit in #576.

**Why**

- The engine reverts a doctrine's inline modifiers on a switch, but not anything inside `effect = { }` (`common/doctrines/grand_doctrines/_documentation.md:83`).
- `jeune_ecole` grants `patrol_boat_hull_1_tech` through `effect = { set_technology = ... }` (`common/doctrines/grand_doctrines/naval_doctrine.txt:303`), so the tech survives a switch.
- `frigate_capitals` grants the hidden `heavy_frigate` tech the same way (`common/doctrines/subdoctrines/sea/naval.txt:709`).
- The existing `allow = { has_doctrine = jeune_ecole }` on the five patrol boat hull techs only gates research, not ownership; `heavy_frigate` had no `allow` at all.

**How**

- `can_be_produced = { has_doctrine = jeune_ecole }` on the `patrol_boat` archetype; inherited by hulls 1-6.
- `can_be_produced = { has_doctrine = frigate_capitals }` on the `heavy_frigate` archetype.
- Hong Kong is exempted with `original_tag = HKG`. It is the only country that starts with `patrol_boat_hull_1_tech` in history and it holds no grand doctrine, so the gate would otherwise have stripped production of the boats it already fields.
- Non-destructive and reversible: research progress is untouched, and switching back restores production.

**Known limits**

- `module_heavy_frigate_upgrade_package` is a module and cannot take `can_be_produced`; its category still slots on plain `frigate` / `stealth_frigate`, so that half of the exploit stays open. Only a periodic tech-revocation pass would close it.
- Greece's `GRE_kimon_class_frigate` and the USA AI naval variants use the upgrade module on regular frigate hulls, so they are unaffected.
- The ~19 special-forces subdoctrine `set_technology` grants have the identical persistence bug and are out of scope here.

Closes #576