### PR TITLE
Tie unemployment national spirits into the unemployment mechanic

### DIFF
--- a/common/ideas/05_japan.txt
+++ b/common/ideas/05_japan.txt
@@ -361,6 +361,8 @@ ideas = {
 			picture = hyper_inflation2
 
 			modifier = {
+				civ_facs_worker_requirement_modifier = -0.08
+				offices_worker_requirement_modifier = -0.08
 				production_speed_buildings_factor = -0.20
 				civilian_factories_productivity = -0.10
 				stability_factor = -0.15

--- a/common/ideas/German.txt
+++ b/common/ideas/German.txt
@@ -199,6 +199,9 @@ ideas = {
 			picture = poor_economy
 			allowed_civil_war = { always = yes }
 			modifier = {
+				civ_facs_worker_requirement_modifier = -0.04
+				mil_facs_worker_requirement_modifier = -0.04
+				offices_worker_requirement_modifier = -0.04
 				civilian_factories_productivity = -0.03
 				military_factories_productivity = -0.03
 				dockyard_productivity = -0.03

--- a/common/ideas/estonia.txt
+++ b/common/ideas/estonia.txt
@@ -29,6 +29,7 @@ ideas = {
 				stability_factor = -0.10
 				production_speed_buildings_factor = -0.10
 				tax_gain_multiplier_modifier = -0.05
+				buildings_worker_requirement_modifier = -0.08
 				high_unemployment_threshold_modifier = 0.03
 			}
 		}
@@ -261,6 +262,8 @@ local_resources_chromium_factor = 0.10
 				political_power_gain = -0.10
 				stability_factor = -0.075
 				production_speed_infrastructure_factor = -0.06
+				buildings_worker_requirement_modifier = -0.05
+				agriculture_district_worker_requirement_modifier = -0.10
 			}
 		}
 		EST_taxed_alc_consumpt = {
@@ -277,6 +280,7 @@ local_resources_chromium_factor = 0.10
 				political_power_gain = -0.10
 				stability_factor = -0.15
 				production_speed_infrastructure_factor = -0.06
+				buildings_worker_requirement_modifier = 0.05
 				high_unemployment_threshold_modifier = 0.05
 			}
 		}

--- a/localisation/english/MD_focus_EST_l_english.yml
+++ b/localisation/english/MD_focus_EST_l_english.yml
@@ -660,7 +660,7 @@ l_english:
  EST_full_eco: "Squirrel Paradise"
  EST_full_eco_desc: ""
  EST_fighting_unemployment_idea: "Fighting Unemployment"
- EST_fighting_unemployment_idea_desc: ""
+ EST_fighting_unemployment_idea_desc: "An active labour market policy has replaced the passive payment of benefits. Retraining programmes, wage subsidies for employers who take on the long-term unemployed, and public works schemes in the worst affected counties are drawing idle workers back into the economy. The programme is expensive and its results will take years to show, but every job it creates is one fewer household dependent on the state."
  EST_tax_breaks_idea: "Tax breaks"
  EST_tax_breaks_idea_desc: ""
  EST_immigration_con: "Confronting Immigration"


### PR DESCRIPTION
Closes #803

**Bottom line**
- Unemployment-themed national spirits now actually move the unemployment system instead of being flavour text with unrelated maluses.

**Why**
- MD computes unemployment as leftover workforce: `workforce_total` is drawn down by each sector's worker requirement, and the remainder becomes `total_unemployed` (`common/scripted_effects/00_money_system.txt:5165-6066`).
- A negative `*_worker_requirement_modifier` cuts labour demand and therefore raises unemployment. This is the lever AngriestBird pointed at in the issue, and the shape the `employment_pressure` law group already uses.
- Several unemployment spirits carried none of that, so a country could display an "Unemployment Crisis" while simultaneously being short of workers.

**How**
- `GER_idea_unemployment_crisis2`: added a scaled-down demand cut (-0.04 civ/mil/offices). Previously the softened post-focus version had zero labour-market effect, so completing *Ein Aktives Deutschland* made the modelled unemployment vanish outright rather than ease.
- `JAP_liquidation_wave`: added -0.08 civ facs and offices worker requirement. Its description already says "unemployment surges" and it lowers the tolerance threshold, but nothing drove the rate up.
- `EST_crippling_unemployment`: added `buildings_worker_requirement_modifier = -0.08`.
- `EST_rural_unemployment`: added `buildings_worker_requirement_modifier = -0.05` and `agriculture_district_worker_requirement_modifier = -0.10`.
- `EST_fighting_unemployment`: added `buildings_worker_requirement_modifier = 0.05`, positive so the activation policy absorbs workers and the rate falls.
- Filled the empty `EST_fighting_unemployment_idea_desc` tooltip.
- No existing modifier was altered or removed; the change is additive only.
- `GER_idea_unemployment_crisis` and `ITA_unemployment_wave` already carried the lever and are untouched.

