### PR TITLE
Reorganize game rules: group table of contents, unified groups

### DIFF
--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -4,14 +4,13 @@
 # Groups, in file order:
 #
 #   Group                     Label                    Contents
-#   MD_RULES                  Millennium Dawn Options  General gameplay, performance and scenarios
+#   MD_RULES                  Millennium Dawn Options  Gameplay, performance, content and cheats
 #   MD_AI_RULES               AI Options               AI toggles and country AI paths
 #   MD_PEACE_DEALS            Peace Conferences        Peace conference behaviour
 #   MD_INFLUENCE_RULES        Influence System Options Influence spread, investment, coups
 #   MD_ORGANISATION_RULES     Organization Options     EU, NATO and CSTO
 #   MD_FORMABLE_RULES         Flags & Formable Nations Formables and flag visuals
-#   MD_RANDOM_RULES           Randomize Game Rules     Time for Chaos randomizers
-#   MD_CHEAT_RULES            Cheat Options            Cheat decisions and helpers
+#   MD_CUSTOM_SCENARIO_RULES  Custom Scenarios         Zombie mode, Event Horizon, Time for Chaos
 #   RULE_GROUP_*              (vanilla)                Unchanged base-game rules
 #
 # Keep like rules inside their group's section so the file stays sorted. The game rules
@@ -645,175 +644,68 @@ rule_disable_muslim_brotherhood_civil_war = {
 	}
 }
 
-# Custom Scenarios
-zombie_mode_enabled = {
-	name = "RULE_ZOMBIE_GAME_MODE"
+# Cheats
+allow_cheat_decisions = {
+	name = "RULE_ALLOW_CHEAT_DECISIONS"
 	group = "MD_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_ZOMBIE_GAME_MODE_NO_DESC"
-	}
+	icon = "GFX_production_licenses"
 	option = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_ZOMBIE_GAME_MODE_YES_DESC"
-		allow_achievements = no
+		desc = "RULE_YES_ALLOW_CHEAT_DECISIONS_DESC"
 	}
-}
-
-zombie_difficulty = {
-	name = "RULE_ZOMBIE_DIFFICULTY"
-	group = "MD_RULES"
-	icon = "GFX_wargoals"
 	default = {
-		name = "NORMAL"
-		text = "RULE_ZOMBIE_DIFFICULTY_NORMAL"
-		desc = "RULE_ZOMBIE_DIFFICULTY_NORMAL_DESC"
-	}
-	option = {
-		name = "HARD"
-		text = "RULE_ZOMBIE_DIFFICULTY_HARD"
-		desc = "RULE_ZOMBIE_DIFFICULTY_HARD_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = "EXTREME"
-		text = "RULE_ZOMBIE_DIFFICULTY_EXTREME"
-		desc = "RULE_ZOMBIE_DIFFICULTY_EXTREME_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = "INSANE"
-		text = "RULE_ZOMBIE_DIFFICULTY_INSANE"
-		desc = "RULE_ZOMBIE_DIFFICULTY_INSANE_DESC"
-		allow_achievements = no
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ALLOW_CHEAT_DECISIONS_DESC"
 	}
 }
 
-zombie_faction_joining_rules = {
-	name = "RULE_ZOMBIE_JOINING_FACTION_GAME_MODE"
-	group = "MD_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = normal
-		text = "RULE_ZOMBIE_JOINING_FACTION_NORMAL"
-		desc = "RULE_ZOMBIE_JOINING_FACTION_NORMAL_DESC"
-	}
-	option = {
-		name = no_majors
-		text = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS"
-		desc = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = all_majors
-		text = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS"
-		desc = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_spawn_location = {
-	name = "RULE_ZOMBIE_SPAWN_LOCATION"
-	group = "MD_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = INDIA
-		text = "RULE_ZOMBIE_SPAWN_INDIA"
-		desc = "RULE_ZOMBIE_SPAWN_INDIA_DESC"
-	}
-	option = {
-		name = AFRICA
-		text = "RULE_ZOMBIE_SPAWN_AFRICA"
-		desc = "RULE_ZOMBIE_SPAWN_AFRICA_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = EAST_ASIA
-		text = "RULE_ZOMBIE_SPAWN_EAST_ASIA"
-		desc = "RULE_ZOMBIE_SPAWN_EAST_ASIA_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = MULTIPLE
-		text = "RULE_ZOMBIE_SPAWN_MULTIPLE"
-		desc = "RULE_ZOMBIE_SPAWN_MULTIPLE_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_coalition_enabled = {
-	name = "RULE_ZOMBIE_COALITION_ENABLED"
-	group = "MD_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = YES
-		text = "RULE_ZOMBIE_COALITION_ENABLED_YES"
-		desc = "RULE_ZOMBIE_COALITION_ENABLED_YES_DESC"
-	}
-	option = {
-		name = NO
-		text = "RULE_ZOMBIE_COALITION_ENABLED_NO"
-		desc = "RULE_ZOMBIE_COALITION_ENABLED_NO_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_spawn_delay = {
-	name = "RULE_ZOMBIE_COALITION_DELAY"
-	group = "MD_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = NONE
-		text = "RULE_ZOMBIE_COALITION_DELAY_NONE"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_NONE_DESC"
-	}
-	option = {
-		name = ONE_YEAR
-		text = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = TWO_YEARS
-		text = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = THREE_YEARS
-		text = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS_DESC"
-		allow_achievements = no
-	}
-}
-
-rule_event_horizon_scenario = {
-	name = "RULE_EVENT_HORIZON_SCENARIO"
+allow_toggling_cheat_decisions = {
+	name = "RULE_ALLOW_TOGGLING_CHEAT_DECISIONS"
 	group = "MD_RULES"
 	icon = "GFX_production_licenses"
-
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
+	}
 	default = {
-		name = DEFAULT
-		text = "RULE_EVENT_HORIZON_DEFAULT"
-		desc = "RULE_EVENT_HORIZON_DEFAULT_DESC"
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
 	}
+}
+
+rule_disable_anti_bully = {
+	name = "RULE_DISABLE_ANTI_BULLY"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
 	option = {
-		name = BLITZ
-		text = "RULE_EVENT_HORIZON_BLITZ"
-		desc = "RULE_EVENT_HORIZON_BLITZ_DESC"
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ANTI_BULLY_DESC"
 	}
-	option = {
-		name = CASUAL
-		text = "RULE_EVENT_HORIZON_CASUAL"
-		desc = "RULE_EVENT_HORIZON_CASUAL_DESC"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ANTI_BULLY_DESC"
 	}
+}
+
+rule_player_instant_justification = {
+	name = "RULE_PLAYER_INSTANT_JUSTIFICATION"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
 	option = {
-		name = DELAYED
-		text = "RULE_EVENT_HORIZON_DELAYED"
-		desc = "RULE_EVENT_HORIZON_DELAYED_DESC"
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_PLAYER_INSTANT_JUSTIFICATION_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_PLAYER_INSTANT_JUSTIFICATION_DESC"
 	}
 }
 
@@ -4125,10 +4017,185 @@ allow_edgy_flags = {
 	}
 }
 
-# TIME FOR CHAOS
+# CUSTOM SCENARIOS
+
+# Zombie Mode
+zombie_mode_enabled = {
+	name = "RULE_ZOMBIE_GAME_MODE"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_ZOMBIE_GAME_MODE_NO_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_ZOMBIE_GAME_MODE_YES_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_difficulty = {
+	name = "RULE_ZOMBIE_DIFFICULTY"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = "NORMAL"
+		text = "RULE_ZOMBIE_DIFFICULTY_NORMAL"
+		desc = "RULE_ZOMBIE_DIFFICULTY_NORMAL_DESC"
+	}
+	option = {
+		name = "HARD"
+		text = "RULE_ZOMBIE_DIFFICULTY_HARD"
+		desc = "RULE_ZOMBIE_DIFFICULTY_HARD_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = "EXTREME"
+		text = "RULE_ZOMBIE_DIFFICULTY_EXTREME"
+		desc = "RULE_ZOMBIE_DIFFICULTY_EXTREME_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = "INSANE"
+		text = "RULE_ZOMBIE_DIFFICULTY_INSANE"
+		desc = "RULE_ZOMBIE_DIFFICULTY_INSANE_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_faction_joining_rules = {
+	name = "RULE_ZOMBIE_JOINING_FACTION_GAME_MODE"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = normal
+		text = "RULE_ZOMBIE_JOINING_FACTION_NORMAL"
+		desc = "RULE_ZOMBIE_JOINING_FACTION_NORMAL_DESC"
+	}
+	option = {
+		name = no_majors
+		text = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS"
+		desc = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = all_majors
+		text = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS"
+		desc = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_spawn_location = {
+	name = "RULE_ZOMBIE_SPAWN_LOCATION"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = INDIA
+		text = "RULE_ZOMBIE_SPAWN_INDIA"
+		desc = "RULE_ZOMBIE_SPAWN_INDIA_DESC"
+	}
+	option = {
+		name = AFRICA
+		text = "RULE_ZOMBIE_SPAWN_AFRICA"
+		desc = "RULE_ZOMBIE_SPAWN_AFRICA_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = EAST_ASIA
+		text = "RULE_ZOMBIE_SPAWN_EAST_ASIA"
+		desc = "RULE_ZOMBIE_SPAWN_EAST_ASIA_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = MULTIPLE
+		text = "RULE_ZOMBIE_SPAWN_MULTIPLE"
+		desc = "RULE_ZOMBIE_SPAWN_MULTIPLE_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_coalition_enabled = {
+	name = "RULE_ZOMBIE_COALITION_ENABLED"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = YES
+		text = "RULE_ZOMBIE_COALITION_ENABLED_YES"
+		desc = "RULE_ZOMBIE_COALITION_ENABLED_YES_DESC"
+	}
+	option = {
+		name = NO
+		text = "RULE_ZOMBIE_COALITION_ENABLED_NO"
+		desc = "RULE_ZOMBIE_COALITION_ENABLED_NO_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_spawn_delay = {
+	name = "RULE_ZOMBIE_COALITION_DELAY"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = NONE
+		text = "RULE_ZOMBIE_COALITION_DELAY_NONE"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_NONE_DESC"
+	}
+	option = {
+		name = ONE_YEAR
+		text = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = TWO_YEARS
+		text = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = THREE_YEARS
+		text = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS_DESC"
+		allow_achievements = no
+	}
+}
+
+# Event Horizon
+rule_event_horizon_scenario = {
+	name = "RULE_EVENT_HORIZON_SCENARIO"
+	group = "MD_CUSTOM_SCENARIO_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = DEFAULT
+		text = "RULE_EVENT_HORIZON_DEFAULT"
+		desc = "RULE_EVENT_HORIZON_DEFAULT_DESC"
+	}
+	option = {
+		name = BLITZ
+		text = "RULE_EVENT_HORIZON_BLITZ"
+		desc = "RULE_EVENT_HORIZON_BLITZ_DESC"
+	}
+	option = {
+		name = CASUAL
+		text = "RULE_EVENT_HORIZON_CASUAL"
+		desc = "RULE_EVENT_HORIZON_CASUAL_DESC"
+	}
+	option = {
+		name = DELAYED
+		text = "RULE_EVENT_HORIZON_DELAYED"
+		desc = "RULE_EVENT_HORIZON_DELAYED_DESC"
+	}
+}
+
+# Time for Chaos
 rule_randomize_ideologies = {
 	name = "RULE_RANDOM_IDEOLOGIES"
-	group = "MD_RANDOM_RULES"
+	group = "MD_CUSTOM_SCENARIO_RULES"
 	icon = "GFX_production_licenses"
 	default = {
 		name = no
@@ -4144,7 +4211,7 @@ rule_randomize_ideologies = {
 
 rule_randomize_religion = {
 	name = "RULE_RANDOM_RELIGION"
-	group = "MD_RANDOM_RULES"
+	group = "MD_CUSTOM_SCENARIO_RULES"
 	icon = "GFX_production_licenses"
 	default = {
 		name = no
@@ -4160,7 +4227,7 @@ rule_randomize_religion = {
 
 rule_randomize_internal_factions = {
 	name = "RULE_RANDOM_INTERNAL_FACTIONS"
-	group = "MD_RANDOM_RULES"
+	group = "MD_CUSTOM_SCENARIO_RULES"
 	icon = "GFX_production_licenses"
 	default = {
 		name = no
@@ -4171,71 +4238,6 @@ rule_randomize_internal_factions = {
 		name = yes
 		text = "RULE_OPTION_YES"
 		desc = "RULE_RANDOM_INTERNAL_FACTIONS_YES_DESC"
-	}
-}
-
-# CHEATS
-allow_cheat_decisions = {
-	name = "RULE_ALLOW_CHEAT_DECISIONS"
-	group = "MD_CHEAT_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ALLOW_CHEAT_DECISIONS_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ALLOW_CHEAT_DECISIONS_DESC"
-	}
-}
-
-allow_toggling_cheat_decisions = {
-	name = "RULE_ALLOW_TOGGLING_CHEAT_DECISIONS"
-	group = "MD_CHEAT_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
-	}
-}
-
-rule_disable_anti_bully = {
-	name = "RULE_DISABLE_ANTI_BULLY"
-	group = "MD_CHEAT_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ANTI_BULLY_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ANTI_BULLY_DESC"
-	}
-}
-
-rule_player_instant_justification = {
-	name = "RULE_PLAYER_INSTANT_JUSTIFICATION"
-	group = "MD_CHEAT_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_PLAYER_INSTANT_JUSTIFICATION_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_PLAYER_INSTANT_JUSTIFICATION_DESC"
 	}
 }
 

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -4,13 +4,12 @@
 # Groups, in file order:
 #
 #   Group                     Label                    Contents
-#   MD_RULES                  Millennium Dawn Options  General gameplay, performance and content
+#   MD_RULES                  Millennium Dawn Options  General gameplay, performance and scenarios
 #   MD_AI_RULES               AI Options               AI toggles and country AI paths
 #   MD_PEACE_DEALS            Peace Conferences        Peace conference behaviour
 #   MD_INFLUENCE_RULES        Influence System Options Influence spread, investment, coups
 #   MD_ORGANISATION_RULES     Organization Options     EU, NATO and CSTO
 #   MD_FORMABLE_RULES         Flags & Formable Nations Formables and flag visuals
-#   MD_CUSTOM_SCENARIO_RULES  Custom Scenarios         Zombie mode and Event Horizon
 #   MD_RANDOM_RULES           Randomize Game Rules     Time for Chaos randomizers
 #   MD_CHEAT_RULES            Cheat Options            Cheat decisions and helpers
 #   RULE_GROUP_*              (vanilla)                Unchanged base-game rules
@@ -18,6 +17,7 @@
 # Keep like rules inside their group's section so the file stays sorted. The game rules
 # screen filters on the group key set on each rule.
 #
+
 # MILLENNIUM DAWN OPTIONS
 allow_enable_world_war = {
 	name = "RULE_ALLOW_WORLD_WAR"
@@ -644,6 +644,179 @@ rule_disable_muslim_brotherhood_civil_war = {
 		desc = "RULE_NO_DISABLE_MUSLIM_BROTHERHOOD_CIVIL_WAR_DESC"
 	}
 }
+
+# Custom Scenarios
+zombie_mode_enabled = {
+	name = "RULE_ZOMBIE_GAME_MODE"
+	group = "MD_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_ZOMBIE_GAME_MODE_NO_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_ZOMBIE_GAME_MODE_YES_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_difficulty = {
+	name = "RULE_ZOMBIE_DIFFICULTY"
+	group = "MD_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = "NORMAL"
+		text = "RULE_ZOMBIE_DIFFICULTY_NORMAL"
+		desc = "RULE_ZOMBIE_DIFFICULTY_NORMAL_DESC"
+	}
+	option = {
+		name = "HARD"
+		text = "RULE_ZOMBIE_DIFFICULTY_HARD"
+		desc = "RULE_ZOMBIE_DIFFICULTY_HARD_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = "EXTREME"
+		text = "RULE_ZOMBIE_DIFFICULTY_EXTREME"
+		desc = "RULE_ZOMBIE_DIFFICULTY_EXTREME_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = "INSANE"
+		text = "RULE_ZOMBIE_DIFFICULTY_INSANE"
+		desc = "RULE_ZOMBIE_DIFFICULTY_INSANE_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_faction_joining_rules = {
+	name = "RULE_ZOMBIE_JOINING_FACTION_GAME_MODE"
+	group = "MD_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = normal
+		text = "RULE_ZOMBIE_JOINING_FACTION_NORMAL"
+		desc = "RULE_ZOMBIE_JOINING_FACTION_NORMAL_DESC"
+	}
+	option = {
+		name = no_majors
+		text = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS"
+		desc = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = all_majors
+		text = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS"
+		desc = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_spawn_location = {
+	name = "RULE_ZOMBIE_SPAWN_LOCATION"
+	group = "MD_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = INDIA
+		text = "RULE_ZOMBIE_SPAWN_INDIA"
+		desc = "RULE_ZOMBIE_SPAWN_INDIA_DESC"
+	}
+	option = {
+		name = AFRICA
+		text = "RULE_ZOMBIE_SPAWN_AFRICA"
+		desc = "RULE_ZOMBIE_SPAWN_AFRICA_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = EAST_ASIA
+		text = "RULE_ZOMBIE_SPAWN_EAST_ASIA"
+		desc = "RULE_ZOMBIE_SPAWN_EAST_ASIA_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = MULTIPLE
+		text = "RULE_ZOMBIE_SPAWN_MULTIPLE"
+		desc = "RULE_ZOMBIE_SPAWN_MULTIPLE_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_coalition_enabled = {
+	name = "RULE_ZOMBIE_COALITION_ENABLED"
+	group = "MD_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = YES
+		text = "RULE_ZOMBIE_COALITION_ENABLED_YES"
+		desc = "RULE_ZOMBIE_COALITION_ENABLED_YES_DESC"
+	}
+	option = {
+		name = NO
+		text = "RULE_ZOMBIE_COALITION_ENABLED_NO"
+		desc = "RULE_ZOMBIE_COALITION_ENABLED_NO_DESC"
+		allow_achievements = no
+	}
+}
+
+zombie_spawn_delay = {
+	name = "RULE_ZOMBIE_COALITION_DELAY"
+	group = "MD_RULES"
+	icon = "GFX_wargoals"
+	default = {
+		name = NONE
+		text = "RULE_ZOMBIE_COALITION_DELAY_NONE"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_NONE_DESC"
+	}
+	option = {
+		name = ONE_YEAR
+		text = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = TWO_YEARS
+		text = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = THREE_YEARS
+		text = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS"
+		desc = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS_DESC"
+		allow_achievements = no
+	}
+}
+
+rule_event_horizon_scenario = {
+	name = "RULE_EVENT_HORIZON_SCENARIO"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = DEFAULT
+		text = "RULE_EVENT_HORIZON_DEFAULT"
+		desc = "RULE_EVENT_HORIZON_DEFAULT_DESC"
+	}
+	option = {
+		name = BLITZ
+		text = "RULE_EVENT_HORIZON_BLITZ"
+		desc = "RULE_EVENT_HORIZON_BLITZ_DESC"
+	}
+	option = {
+		name = CASUAL
+		text = "RULE_EVENT_HORIZON_CASUAL"
+		desc = "RULE_EVENT_HORIZON_CASUAL_DESC"
+	}
+	option = {
+		name = DELAYED
+		text = "RULE_EVENT_HORIZON_DELAYED"
+		desc = "RULE_EVENT_HORIZON_DELAYED_DESC"
+	}
+}
+
 # AI OPTIONS
 rule_god_of_war = {
 	name = "RULE_GOD_OF_WAR"
@@ -3510,6 +3683,7 @@ VEN_ai_behavior = {
 		desc = "RULE_OPTION_MD_NO_PATH_DESC"
 	}
 }
+
 # PEACE CONFERENCES
 rule_md_annex = {
 	name = "RULE_ALLOW_MD_ANNEX"
@@ -3594,6 +3768,7 @@ allowed_CPD_AI = {
 		allow_achievements = yes
 	}
 }
+
 # INFLUENCE SYSTEM
 rule_spread_influence_amount_gain = {
 	name = "RULE_SPREAD_INFLUENCE_AMOUNT_GAIN"
@@ -3796,6 +3971,7 @@ rule_disable_western_outlook_features = {
 		desc = "RULE_YES_DISABLE_WESTERN_OUTLOOK_FEATURES"
 	}
 }
+
 # ORGANIZATIONS
 rule_disable_eu = {
 	name = "RULE_DISABLE_EU"
@@ -3914,6 +4090,7 @@ rule_disable_csto = {
 		desc = "RULE_NO_DISABLE_CSTO_DESC"
 	}
 }
+
 # FLAGS & FORMABLE NATIONS
 rule_disable_formable_nations = {
 	name = "RULE_DISABLE_FORMABLE_NATIONS"
@@ -3947,177 +4124,7 @@ allow_edgy_flags = {
 		allow_achievements = yes
 	}
 }
-# CUSTOM SCENARIOS
-zombie_mode_enabled = {
-	name = "RULE_ZOMBIE_GAME_MODE"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_ZOMBIE_GAME_MODE_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_ZOMBIE_GAME_MODE_YES_DESC"
-		allow_achievements = no
-	}
-}
 
-zombie_difficulty = {
-	name = "RULE_ZOMBIE_DIFFICULTY"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = "NORMAL"
-		text = "RULE_ZOMBIE_DIFFICULTY_NORMAL"
-		desc = "RULE_ZOMBIE_DIFFICULTY_NORMAL_DESC"
-	}
-	option = {
-		name = "HARD"
-		text = "RULE_ZOMBIE_DIFFICULTY_HARD"
-		desc = "RULE_ZOMBIE_DIFFICULTY_HARD_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = "EXTREME"
-		text = "RULE_ZOMBIE_DIFFICULTY_EXTREME"
-		desc = "RULE_ZOMBIE_DIFFICULTY_EXTREME_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = "INSANE"
-		text = "RULE_ZOMBIE_DIFFICULTY_INSANE"
-		desc = "RULE_ZOMBIE_DIFFICULTY_INSANE_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_faction_joining_rules = {
-	name = "RULE_ZOMBIE_JOINING_FACTION_GAME_MODE"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = normal
-		text = "RULE_ZOMBIE_JOINING_FACTION_NORMAL"
-		desc = "RULE_ZOMBIE_JOINING_FACTION_NORMAL_DESC"
-	}
-	option = {
-		name = no_majors
-		text = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS"
-		desc = "RULE_ZOMBIE_JOINING_FACTION_NO_MAJORS_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = all_majors
-		text = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS"
-		desc = "RULE_ZOMBIE_JOINING_FACTION_ALL_MAJORS_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_spawn_location = {
-	name = "RULE_ZOMBIE_SPAWN_LOCATION"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = INDIA
-		text = "RULE_ZOMBIE_SPAWN_INDIA"
-		desc = "RULE_ZOMBIE_SPAWN_INDIA_DESC"
-	}
-	option = {
-		name = AFRICA
-		text = "RULE_ZOMBIE_SPAWN_AFRICA"
-		desc = "RULE_ZOMBIE_SPAWN_AFRICA_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = EAST_ASIA
-		text = "RULE_ZOMBIE_SPAWN_EAST_ASIA"
-		desc = "RULE_ZOMBIE_SPAWN_EAST_ASIA_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = MULTIPLE
-		text = "RULE_ZOMBIE_SPAWN_MULTIPLE"
-		desc = "RULE_ZOMBIE_SPAWN_MULTIPLE_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_coalition_enabled = {
-	name = "RULE_ZOMBIE_COALITION_ENABLED"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = YES
-		text = "RULE_ZOMBIE_COALITION_ENABLED_YES"
-		desc = "RULE_ZOMBIE_COALITION_ENABLED_YES_DESC"
-	}
-	option = {
-		name = NO
-		text = "RULE_ZOMBIE_COALITION_ENABLED_NO"
-		desc = "RULE_ZOMBIE_COALITION_ENABLED_NO_DESC"
-		allow_achievements = no
-	}
-}
-
-zombie_spawn_delay = {
-	name = "RULE_ZOMBIE_COALITION_DELAY"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_wargoals"
-	default = {
-		name = NONE
-		text = "RULE_ZOMBIE_COALITION_DELAY_NONE"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_NONE_DESC"
-	}
-	option = {
-		name = ONE_YEAR
-		text = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_ONE_YEAR_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = TWO_YEARS
-		text = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_TWO_YEARS_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = THREE_YEARS
-		text = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS"
-		desc = "RULE_ZOMBIE_COALITION_DELAY_THREE_YEARS_DESC"
-		allow_achievements = no
-	}
-}
-
-rule_event_horizon_scenario = {
-	name = "RULE_EVENT_HORIZON_SCENARIO"
-	group = "MD_CUSTOM_SCENARIO_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = DEFAULT
-		text = "RULE_EVENT_HORIZON_DEFAULT"
-		desc = "RULE_EVENT_HORIZON_DEFAULT_DESC"
-	}
-	option = {
-		name = BLITZ
-		text = "RULE_EVENT_HORIZON_BLITZ"
-		desc = "RULE_EVENT_HORIZON_BLITZ_DESC"
-	}
-	option = {
-		name = CASUAL
-		text = "RULE_EVENT_HORIZON_CASUAL"
-		desc = "RULE_EVENT_HORIZON_CASUAL_DESC"
-	}
-	option = {
-		name = DELAYED
-		text = "RULE_EVENT_HORIZON_DELAYED"
-		desc = "RULE_EVENT_HORIZON_DELAYED_DESC"
-	}
-}
 # TIME FOR CHAOS
 rule_randomize_ideologies = {
 	name = "RULE_RANDOM_IDEOLOGIES"
@@ -4166,6 +4173,7 @@ rule_randomize_internal_factions = {
 		desc = "RULE_RANDOM_INTERNAL_FACTIONS_YES_DESC"
 	}
 }
+
 # CHEATS
 allow_cheat_decisions = {
 	name = "RULE_ALLOW_CHEAT_DECISIONS"

--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -1,762 +1,24 @@
 #
-# List of options showing in the Game Rules screen
+# Millennium Dawn game rules
 #
-# format is:
-# rule_token = {
-#	name = "TEXT_KEY_FOR_NAME"
-#	required_dlc = "Name of the Required DLC"
-#	desc = "TEXT_KEY_FOR_LONG_DESC"
-#	group = "TEXT_KEY_FOR_GROUP"					# Used for filtering. A single rule can be in multiple groups
-#	icon = gfx_option_token							# Optional icon
-#	option = {										# Unless other specified, the first option is the default option
-#		name = option_token
-#		text = "TEXT_KEY_FOR_OPTION_NAME"
-#		allow_achievements = no						# Achievements cannot be earned if one or more game rules are set to an option that has this property set to no.
-#													# If not specified, this is set to yes for default options and no for all other options.
-#	}
-#	default = {										# Specify an option with the "default" token to override the behavior of treating the first option as the default.
-#		name = option_token
-#		text = "TEXT_KEY_FOR_OPTION_NAME"
-#		...
-#	}
-# }
-
-# AI RULES
-rule_god_of_war = {
-	name = "RULE_GOD_OF_WAR"
-	group = "MD_AI_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = no
-		text = "RULE_GOD_OF_WAR_NO"
-		desc = "RULE_GOD_OF_WAR_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_GOD_OF_WAR_YES"
-		desc = "RULE_GOD_OF_WAR_YES_DESC"
-		allow_achievements = yes
-	}
-}
-rule_ai_starting_political_power = {
-	name = "RULE_AI_STARTING_POLITICAL_POWER"
-	group = "MD_AI_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = no
-		text = "RULE_AI_STARTING_POLITICAL_POWER_NO"
-		desc = "RULE_AI_STARTING_POLITICAL_POWER_NO_DESC"
-	}
-	option = {
-		name = one
-		text = "RULE_AI_STARTING_POLITICAL_POWER_250"
-		desc = "RULE_AI_STARTING_POLITICAL_POWER_250_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = two
-		text = "RULE_AI_STARTING_POLITICAL_POWER_500"
-		desc = "RULE_AI_STARTING_POLITICAL_POWER_500_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = three
-		text = "RULE_AI_STARTING_POLITICAL_POWER_1000"
-		desc = "RULE_AI_STARTING_POLITICAL_POWER_1000_DESC"
-		allow_achievements = no
-	}
-}
-rule_enable_ai_debt_war = {
-	name = "RULE_DISABLE_AI_DEBT_WAR_TITLE"
-	group = "MD_AI_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = no
-		text = "RULE_ENABLE_AI_DEBT_WAR"
-		desc = "RULE_ENABLE_AI_DEBT_WAR_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_DISABLE_AI_DEBT_WAR"
-		desc = "RULE_DISABLE_AI_DEBT_WAR_DESC"
-	}
-}
-
-rule_disable_AI_using_freedom_cont_focus = {
-	name = "RULE_ENABLE_AI_FIGHTING_AUTONOMY_FOCUS"
-	group = "MD_AI_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = yes
-		text = "RULE_ENABLE_FIGHTING_AUTONOMY_FOCUS"
-		desc = "RULE_ENABLE_FIGHTING_AUTONOMY_FOCUS_DESC"
-	}
-	option = {
-		name = no
-		text = "RULE_DISABLE_FIGHTING_AUTONOMY_FOCUS"
-		desc = "RULE_DISABLE_FIGHTING_AUTONOMY_FOCUS_DESC"
-	}
-}
-
-rule_enable_AI_using_attaches = {
-	name = "RULE_ENABLE_AI_USING_ATTACHES"
-	group = "MD_AI_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_ENABLE_AI_USING_ATTACHES_YES_DESC"
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_ENABLE_AI_USING_ATTACHES_NO_DESC"
-	}
-}
-
-# PEACE DEAL RULES
-rule_md_annex = {
-	name = "RULE_ALLOW_MD_ANNEX"
-	group = "MD_PEACE_DEALS"
-	icon = "GFX_take_over_faction_leadership"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_MD_ANNEX_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_MD_ANNEX_YES_DESC"
-	}
-}
-allow_chaotic_PC = {
-	name = "RULE_ALLOW_CHAOTIC_PEACE_CONFERENCE"
-	group = "MD_PEACE_DEALS"
-	icon = "GFX_take_over_faction_leadership"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_CHAOTIC_PC_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_CHAOTIC_PC_YES_DESC"
-	}
-}
-allow_player_led_PC = {
-	name = "RULE_ALLOW_PLAYER_LED_PEACE_CONFERENCE"
-	group = "MD_PEACE_DEALS"
-	icon = "GFX_coups"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_PLAYER_LED_PC_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_PLAYER_LED_PC_YES_DESC"
-	}
-}
-allowed_CPD = {
-	name = "RULE_ALLOW_CONDITIONAL_PEACE_DEAL"
-	group = "MD_PEACE_DEALS"
-	icon = "GFX_take_over_faction_leadership"
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_CONDITIONAL_PEACE_DEAL_YES_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_CONDITIONAL_PEACE_DEAL_NO_DESC"
-		allow_achievements = yes
-	}
-}
-allowed_CPD_AI = {
-	name = "RULE_ALLOW_CPD_AI_OFFERS"
-	group = "MD_PEACE_DEALS"
-	icon = "GFX_take_over_faction_leadership"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_CPD_AI_OFFERS_NO_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_CPD_AI_OFFERS_YES_DESC"
-		allow_achievements = yes
-	}
-}
-
-# COUNTRY CONTENT
-rule_salafist_branch = {
-	name = "RULE_SALAFIST_BRANCH"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_SALAFIST_BRANCH_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_SALAFIST_BRANCH_DESC"
-	}
-}
-
-BLR_union_state_ai_behavior = {
-	name = "BLR_union_state_ai_behavior"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_kick_from_faction"
-	default = {
-		name = BLR_WONT_FOLLOW_UNION_STATE
-		text = "BLR_WONT_FOLLOW_UNION_STATE"
-		desc = "BLR_WONT_FOLLOW_UNION_STATE_DESC"
-	}
-	option = {
-		name = BLR_WILL_FOLLOW_UNION_STATE
-		text = "BLR_WILL_FOLLOW_UNION_STATE"
-		desc = "BLR_WILL_FOLLOW_UNION_STATE_DESC"
-	}
-	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
-	}
-}
-GEO_NATIONALIST_behavior = {
-	name = "GEO_NATIONALIST_behavior"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_kick_from_faction"
-	default = {
-		name = GEO_WILL_FOLLOW_OWN_WAY
-		text = "GEO_WILL_FOLLOW_OWN_WAY"
-		desc = "GEO_WILL_FOLLOW_OWN_WAY_DESC"
-	}
-	option = {
-		name = GEO_WILL_BE_PRO_ARMENIA
-		text = "GEO_WILL_BE_PRO_ARMENIA"
-		desc = "GEO_WILL_BE_PRO_ARMENIA_DESC"
-	}
-	option = {
-		name = GEO_WILL_BE_PRO_AZERI
-		text = "GEO_WILL_BE_PRO_AZERI"
-		desc = "GEO_WILL_BE_PRO_AZERI_DESC"
-	}
-	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
-	}
-}
-GEO_help_CHE_behavior = {
-	name = "GEO_help_CHE_behavior"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_kick_from_faction"
-	default = {
-		name = GEO_WONT_HELP
-		text = "GEO_WONT_HELP"
-		desc = "GEO_WONT_HELP_DESC"
-	}
-	option = {
-		name = GEO_WILL_HELP
-		text = "GEO_WILL_HELP"
-		desc = "GEO_WILL_HELP_DESC"
-	}
-	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
-	}
-}
-GEO_2008_war_behavior = {
-	name = "GEO_2008_war_behavior"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_kick_from_faction"
-	default = {
-		name = GEO_ATTACK_RUS
-		text = "GEO_ATTACK_RUS"
-		desc = "GEO_ATTACK_RUS_DESC"
-	}
-	option = {
-		name = GEO_WEAKBOY
-		text = "GEO_WEAKBOY"
-		desc = "GEO_WEAKBOY_DESC"
-	}
-	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
-	}
-}
-
-PMR_sub_behavior = {
-	name = "PMR_sub_behavior"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_kick_from_faction"
-	default = {
-		name = PMR_PASSIVE_DEFAULT
-		text = "PMR_PASSIVE_DEFAULT"
-		desc = "PMR_PASSIVE_DEFAULT_DESC"
-	}
-	option = {
-		name = PMR_SHERIFF
-		text = "PMR_SHERIFF"
-		desc = "PMR_SHERIFF_DESC"
-	}
-}
-
-# FLAGS & FORMABLES
-rule_disable_formable_nations = {
-	name = "RULE_DISABLE_FORMABLE_NATIONS"
-	group = "MD_FORMABLE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_FORMABLE_NATIONS_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_FORMABLE_NATIONS_DESC"
-	}
-}
-allow_edgy_flags = {
-	name = "RULE_ALLOW_EDGY_FLAGS"
-	group = "MD_FORMABLE_RULES"
-	icon = "GFX_leave_faction"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_ALLOW_EDGY_FLAGS_BLOCKED_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_ALLOW_EDGY_FLAGS_ALLOWED_DESC"
-		allow_achievements = yes
-	}
-}
-
-# ORGANISATION OPTIONS
-rule_disable_eu = {
-	name = "RULE_DISABLE_EU"
-	group = "MD_ORGANISATION_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_DISABLE_EU_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_DISABLE_EU_DESC"
-	}
-}
-
-rule_european_union_voting_limits = {
-	name = "RULE_EUROPEAN_VOTING_COOLDOWN_LIMIT"
-	group = "MD_ORGANISATION_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = one
-		text = "RULE_OPTION_EU_ONE"
-		desc = "RULE_OPTION_EU_ONE_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = sixty
-		text = "RULE_OPTION_EU_SIXTY"
-		desc = "RULE_OPTION_EU_SIXTY_DESC"
-	}
-	option = {
-		name = ninety
-		text = "RULE_OPTION_EU_NINETY"
-		desc = "RULE_OPTION_EU_NINETY_DESC"
-	}
-	default = {
-		name = one_hundred_twenty
-		text = "RULE_OPTION_EU_ONE_HUNDRED_TWENTY"
-		desc = "RULE_OPTION_EU_ONE_HUNDRED_TWENTY_DESC"
-	}
-	option = {
-		name = one_hundred_eighty
-		text = "RULE_OPTION_EU_ONE_HUNDRED_EIGHTY"
-		desc = "RULE_OPTION_EU_ONE_HUNDRED_EIGHTY_DESC"
-	}
-	option = {
-		name = two_hundred_ten
-		text = "RULE_OPTION_EU_TWO_HUNDRED_TEN"
-		desc = "RULE_OPTION_EU_TWO_HUNDRED_TEN_DESC"
-	}
-}
-
-rule_european_union_expansion_focus = {
-	name = "RULE_EU_EXPANSION_FOCUS"
-	group = "MD_ORGANISATION_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = default
-		text = "RULE_EU_EXP_NO"
-		desc = "RULE_EU_EXP_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_EU_EXP_YES"
-		desc = "RULE_EU_EXP_YES_DESC"
-		allow_achievements = yes
-	}
-}
-
-rule_enable_ai_european_union_end_game_paths = {
-	name = "RULE_AI_EU_END_GAME_PATHS"
-	group = "MD_ORGANISATION_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_AI_YES_EU_END_GAME_PATHS"
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_AI_NO_EU_END_GAME_PATHS"
-	}
-}
-
-rule_disable_nato = {
-	name = "RULE_DISABLE_NATO"
-	group = "MD_ORGANISATION_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_DISABLE_NATO_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_DISABLE_NATO_DESC"
-	}
-}
-
-
-rule_disable_csto = {
-	name = "RULE_DISABLE_CSTO"
-	group = "MD_ORGANISATION_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_DISABLE_CSTO_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_DISABLE_CSTO_DESC"
-	}
-}
-
-# INFLUENCE OPTIONS
-rule_spread_influence_amount_gain = {
-	name = "RULE_SPREAD_INFLUENCE_AMOUNT_GAIN"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = gain_0_5_percent_spread
-		text = "RULE_SPREAD_INFLUENCE_GAIN_0_5"
-		desc = "RULE_SPREAD_INFLUENCE_GAIN_0_5_DESC"
-	}
-	option = {
-		name = gain_1_percent_spread
-		text = "RULE_SPREAD_INFLUENCE_GAIN_1"
-		desc = "RULE_SPREAD_INFLUENCE_GAIN_1_DESC"
-	}
-	default = {
-		name = gain_1_5_percent_spread
-		text = "RULE_SPREAD_INFLUENCE_GAIN_1_5"
-		desc = "RULE_SPREAD_INFLUENCE_GAIN_1_5_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = gain_2_percent_spread
-		text = "RULE_SPREAD_INFLUENCE_GAIN_2"
-		desc = "RULE_SPREAD_INFLUENCE_GAIN_2_DESC"
-	}
-	option = {
-		name = gain_3_percent_spread
-		text = "RULE_SPREAD_INFLUENCE_GAIN_3"
-		desc = "RULE_SPREAD_INFLUENCE_GAIN_3_DESC"
-	}
-	option = {
-		name = gain_4_percent_spread
-		text = "RULE_SPREAD_INFLUENCE_GAIN_4"
-		desc = "RULE_SPREAD_INFLUENCE_GAIN_4_DESC"
-	}
-}
-rule_spread_influence_cooldown_limits = {
-	name = "RULE_SPREAD_INFLUENCE_AMOUNT_COOLDOWN"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = spread_influence_0_days
-		text = "RULE_SPREAD_INFLUENCE_0_COOLDOWN"
-		desc = "RULE_SPREAD_INFLUENCE_0_COOLDOWN_DESC"
-	}
-	option = {
-		name = spread_influence_14_days
-		text = "RULE_SPREAD_INFLUENCE_14_COOLDOWN"
-		desc = "RULE_SPREAD_INFLUENCE_14_COOLDOWN_DESC"
-	}
-	default = {
-		name = spread_influence_30_days
-		text = "RULE_SPREAD_INFLUENCE_30_COOLDOWN"
-		desc = "RULE_SPREAD_INFLUENCE_30_COOLDOWN_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = spread_influence_60_days
-		text = "RULE_SPREAD_INFLUENCE_60_COOLDOWN"
-		desc = "RULE_SPREAD_INFLUENCE_60_COOLDOWN_DESC"
-		allow_achievements = yes
-	}
-}
-rule_invest_influence_amount_gain = {
-	name = "RULE_INVEST_INFLUENCE_AMOUNT_GAIN"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = gain_0_5_percent_invest
-		text = "RULE_INVEST_DEFAULT_GAIN_0_5"
-		desc = "RULE_INVEST_DEFAULT_GAIN_0_5_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = gain_1_percent_invest
-		text = "RULE_INVEST_DEFAULT_GAIN_1"
-		desc = "RULE_INVEST_DEFAULT_GAIN_1_DESC"
-		allow_achievements = yes
-	}
-	default = {
-		name = gain_1_5_percent_invest
-		text = "RULE_INVEST_DEFAULT_GAIN_1_5"
-		desc = "RULE_INVEST_DEFAULT_GAIN_1_5_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = gain_2_percent_invest
-		text = "RULE_INVEST_DEFAULT_GAIN_2"
-		desc = "RULE_INVEST_DEFAULT_GAIN_2_DESC"
-	}
-}
-rule_influence_cooldown_limits = {
-	name = "RULE_INFLUENCE_COOLDOWN"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = day_0_cooldown
-		text = "RULE_0_DAY_INFLUENCE"
-		desc = "RULE_0_DAY_INFLUENCE_DESC"
-	}
-	default = {
-		name = day_14_cooldown
-		text = "RULE_14_DAY_INFLUENCE"
-		desc = "RULE_14_DAY_INFLUENCE_DESC"
-	}
-	option = {
-		name = day_30_cooldown
-		text = "RULE_30_DAY_INFLUENCE"
-		desc = "RULE_30_DAY_INFLUENCE_DESC"
-	}
-}
-rule_monthly_domestic_independence_tick = {
-	name = "RULE_MONTHLY_DOMESTIC_INFLUENCE_TICK"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_TICK_NO_DESC"
-	}
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_TICK_YES_DESC"
-		allow_achievements = yes
-	}
-}
-rule_monthly_domestic_independence_gain_amount = {
-	name = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = amount_05_gain
-		text = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_05"
-		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_05_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = amount_10_gain
-		text = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_10"
-		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_10_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = amount_15_gain
-		text = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_15"
-		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_15_DESC"
-		allow_achievements = yes
-	}
-}
-rule_disable_ai_influence_puppeting = {
-	name = "RULE_DISABLE_AI_INFLUENCE_PUPPETING"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_DISABLE_AI_INFLUENCE_PUPPETING_DESC"
-	}
-}
-rule_disable_coup_contest = {
-	name = "RULE_DISABLE_COUP_CONTEST"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_DISABLE_COUP_CONTEST_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_DISABLE_COUP_CONTEST_DESC"
-	}
-}
-rule_disable_western_outlook_features = {
-	name = "RULE_DISABLE_WESTERN_OUTLOOK_FEATURES"
-	group = "MD_INFLUENCE_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_DISABLE_WESTERN_OUTLOOK_FEATURES"
-	}
-}
-
-# OPTIMISATION AND PERFORMANCE
-allow_mp_optimizations = {
-	name = "RULE_ALLOW_MP_OPTIMIZATIONS"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ALLOW_MP_OPTIMIZATIONS_DESC"
-		allow_achievements = yes
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ALLOW_MP_OPTIMIZATIONS_DESC"
-		allow_achievements = yes
-	}
-}
-
-allow_division_limiter = {
-	name = "RULE_ENABLE_DIVISION_LIMITER"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_volunteers"
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ENABLE_DIVISION_LIMITER_DESC"
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ENABLE_DIVISION_LIMITER_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = potato_edition
-		text = "RULE_OPTION_POTATO_EDITION"
-		desc = "RULE_POTATO_EDITION_DIVISION_LIMITER_DESC"
-		allow_achievements = yes
-	}
-}
-
-disable_gdp_graph = {
-	name = "RULE_DISABLE_GDP_GRAPH"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_release_nations"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_RULE_DISABLE_GDP_GRAPH_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_RULE_DISABLE_GDP_GRAPH_DESC"
-		allow_achievements = yes
-	}
-}
-
-remove_micro_states = {
-	name = "RULE_REMOVE_MICRO_STATES"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_release_nations"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_RULE_REMOVE_MICRO_STATES_DESC"
-	}
-	option = {
-		name = tiny
-		text = "RULE_REMOVE_MICRO_STATES_TINY"
-		desc = "RULE_REMOVE_MICRO_STATES_TINY_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = smaller
-		text = "RULE_REMOVE_MICRO_STATES_SMALLER"
-		desc = "RULE_REMOVE_MICRO_STATES_SMALLER_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = insignificant
-		text = "RULE_REMOVE_MICRO_STATES_INSIGNIFICANT"
-		desc = "RULE_REMOVE_MICRO_STATES_INSIGNIFICANT_DESC"
-		allow_achievements = yes
-	}
-}
-
-# MISCELLANEOUS MD RULES
+# Groups, in file order:
+#
+#   Group                     Label                    Contents
+#   MD_RULES                  Millennium Dawn Options  General gameplay, performance and content
+#   MD_AI_RULES               AI Options               AI toggles and country AI paths
+#   MD_PEACE_DEALS            Peace Conferences        Peace conference behaviour
+#   MD_INFLUENCE_RULES        Influence System Options Influence spread, investment, coups
+#   MD_ORGANISATION_RULES     Organization Options     EU, NATO and CSTO
+#   MD_FORMABLE_RULES         Flags & Formable Nations Formables and flag visuals
+#   MD_CUSTOM_SCENARIO_RULES  Custom Scenarios         Zombie mode and Event Horizon
+#   MD_RANDOM_RULES           Randomize Game Rules     Time for Chaos randomizers
+#   MD_CHEAT_RULES            Cheat Options            Cheat decisions and helpers
+#   RULE_GROUP_*              (vanilla)                Unchanged base-game rules
+#
+# Keep like rules inside their group's section so the file stays sorted. The game rules
+# screen filters on the group key set on each rule.
+#
+# MILLENNIUM DAWN OPTIONS
 allow_enable_world_war = {
 	name = "RULE_ALLOW_WORLD_WAR"
 	group = "MD_RULES"
@@ -773,36 +35,20 @@ allow_enable_world_war = {
 	}
 }
 
-allow_enable_ledger = {
-	name = "RULE_ALLOW_ENABLE_LEDGER"
+allow_fictional_content = {
+	name = "RULE_FICTIONAL_CONTENT"
 	group = "MD_RULES"
 	icon = "GFX_production_licenses"
-	default = {
+	option = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_ALLOW_ENABLE_LEDGER_YES_DESC"
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_ALLOW_ENABLE_LEDGER_NO_DESC"
+		desc = "RULE_FICTIONAL_CONTENT_YES_DESC"
 		allow_achievements = yes
 	}
-}
-
-allow_colored_puppets = {
-	name = "RULE_ALLOW_PLAYER_COLORED_PUPPETS"
-	group = "MD_RULES"
-	icon = "GFX_production_licenses"
-	option = {
+	default = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_MD_COLORED_PUPPETS_NO_DESC"
-	}
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_MD_COLORED_PUPPETS_YES_DESC"
+		desc = "RULE_FICTIONAL_CONTENT_NO_DESC"
 		allow_achievements = yes
 	}
 }
@@ -847,38 +93,294 @@ rule_corporate_history = {
 	}
 }
 
-allow_carrier_only_raids = {
-	name = "RULE_CARRIER_ONLY_RAIDS"
+rule_futuristic_special_projects = {
+	name = "RULE_FUTURISTIC_SPECIAL_PROJECTS"
 	group = "MD_RULES"
-	icon = "GFX_production_licenses"
+	icon = "GFX_lend_lease"
 	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_CARRIER_ONLY_RAIDS_NO"
+		name = yes
+		text = "RULE_OPTION_ALLOWED"
+		desc = "RULE_ALLOWED_DISABLE_FUTURISTIC_SPECIAL_PROJECTS_DESC"
+		allow_achievements = yes
 	}
 	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_CARRIER_ONLY_RAIDS_YES"
+		name = no
+		text = "RULE_OPTION_DISABLED"
+		desc = "RULE_DISABLE_DISABLED_FUTURISTIC_SPECIAL_PROJECTS_DESC"
 		allow_achievements = yes
 	}
 }
 
-rule_raid_doctrine_reach = {
-	name = "RULE_RAID_DOCTRINE_REACH"
+rule_salafist_branch = {
+	name = "RULE_SALAFIST_BRANCH"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_SALAFIST_BRANCH_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_SALAFIST_BRANCH_DESC"
+	}
+}
+
+allow_colored_puppets = {
+	name = "RULE_ALLOW_PLAYER_COLORED_PUPPETS"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_OPTION_MD_COLORED_PUPPETS_NO_DESC"
+	}
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_OPTION_MD_COLORED_PUPPETS_YES_DESC"
+		allow_achievements = yes
+	}
+}
+
+allow_enable_ledger = {
+	name = "RULE_ALLOW_ENABLE_LEDGER"
 	group = "MD_RULES"
 	icon = "GFX_production_licenses"
 	default = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_RAID_DOCTRINE_REACH_YES"
-		allow_achievements = yes
+		desc = "RULE_ALLOW_ENABLE_LEDGER_YES_DESC"
 	}
 	option = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_RAID_DOCTRINE_REACH_NO"
+		desc = "RULE_ALLOW_ENABLE_LEDGER_NO_DESC"
 		allow_achievements = yes
+	}
+}
+
+allow_enable_help_gui = {
+	name = "RULE_ALLOW_HELP_GUI"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_ALLOW_HELP_GUI_YES"
+		allow_achievements = yes
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_ALLOW_HELP_GUI_NO"
+		allow_achievements = yes
+	}
+}
+
+# Performance & Multiplayer
+allow_mp_optimizations = {
+	name = "RULE_ALLOW_MP_OPTIMIZATIONS"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ALLOW_MP_OPTIMIZATIONS_DESC"
+		allow_achievements = yes
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ALLOW_MP_OPTIMIZATIONS_DESC"
+		allow_achievements = yes
+	}
+}
+
+rule_allow_MP_enhancements = {
+	name = "RULE_ALLOW_MP_ENHANCEMENTS"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NOT_ALLOW_MP_ENHANCEMENTS_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_ALLOW_MP_ENHANCEMENTS_DESC"
+	}
+}
+
+allow_division_limiter = {
+	name = "RULE_ENABLE_DIVISION_LIMITER"
+	group = "MD_RULES"
+	icon = "GFX_volunteers"
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ENABLE_DIVISION_LIMITER_DESC"
+	}
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ENABLE_DIVISION_LIMITER_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = potato_edition
+		text = "RULE_OPTION_POTATO_EDITION"
+		desc = "RULE_POTATO_EDITION_DIVISION_LIMITER_DESC"
+		allow_achievements = yes
+	}
+}
+
+disable_gdp_graph = {
+	name = "RULE_DISABLE_GDP_GRAPH"
+	group = "MD_RULES"
+	icon = "GFX_release_nations"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_RULE_DISABLE_GDP_GRAPH_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_RULE_DISABLE_GDP_GRAPH_DESC"
+		allow_achievements = yes
+	}
+}
+
+remove_micro_states = {
+	name = "RULE_REMOVE_MICRO_STATES"
+	group = "MD_RULES"
+	icon = "GFX_release_nations"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_RULE_REMOVE_MICRO_STATES_DESC"
+	}
+	option = {
+		name = tiny
+		text = "RULE_REMOVE_MICRO_STATES_TINY"
+		desc = "RULE_REMOVE_MICRO_STATES_TINY_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = smaller
+		text = "RULE_REMOVE_MICRO_STATES_SMALLER"
+		desc = "RULE_REMOVE_MICRO_STATES_SMALLER_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = insignificant
+		text = "RULE_REMOVE_MICRO_STATES_INSIGNIFICANT"
+		desc = "RULE_REMOVE_MICRO_STATES_INSIGNIFICANT_DESC"
+		allow_achievements = yes
+	}
+}
+
+rule_enable_resource_storage_system = {
+	name = "RULE_ENABLE_RESOURCE_STORAGE_SYSTEM"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_OPTION_ENABLE_RESOURCE_STORAGE_SYSTEM"
+	}
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_OPTION_DISABLE_RESOURCE_STORAGE_SYSTEM"
+	}
+}
+
+rule_disable_generals_getting_killed = {
+	name = "RULE_DISABLE_GENERALS_KILLED"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_ENABLE_GENERALS_KILLED_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_DISABLE_GENERALS_KILLED_DESC"
+	}
+}
+
+rule_free_factories_amount = {
+	name = "RULE_FREE_FACTORIES_AMOUNT"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = no
+		text = "RULE_FREE_FACTORIES_AMOUNT_OFF"
+		desc = "RULE_FREE_FACTORIES_AMOUNT_OFF_DESC"
+	}
+	option = {
+		name = one
+		text = "RULE_FREE_FACTORIES_AMOUNT_ONE"
+		desc = "RULE_FREE_FACTORIES_AMOUNT_ONE_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = two
+		text = "RULE_FREE_FACTORIES_AMOUNT_TWO"
+		desc = "RULE_FREE_FACTORIES_AMOUNT_TWO_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = three
+		text = "RULE_FREE_FACTORIES_AMOUNT_THREE"
+		desc = "RULE_FREE_FACTORIES_AMOUNT_THREE_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = five
+		text = "RULE_FREE_FACTORIES_AMOUNT_FIVE"
+		desc = "RULE_FREE_FACTORIES_AMOUNT_FIVE_DESC"
+		allow_achievements = no
+	}
+}
+
+# Economy
+rule_starting_debt_rule = {
+	name = "RULE_STARTING_DEBT_RULE"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = normal
+		text = "RULE_OPTION_NORMAL_DEBT"
+		desc = "RULE_STARTING_DEBT_NORMAL_RULE_DESC"
+	}
+	option = {
+		name = player_only
+		text = "RULE_OPTION_PLAYER_DEBT_ONLY"
+		desc = "RULE_STARTING_DEBT_PLAYER_ONLY_RULE_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = ai_only
+		text = "RULE_OPTION_AI_DEBT_ONLY"
+		desc = "RULE_STARTING_DEBT_AI_ONLY_RULE_DESC"
+	}
+	option = {
+		name = everyone
+		text = "RULE_OPTION_EVERYONE_DEBT"
+		desc = "RULE_STARTING_DEBT_EVERYONE_RULE_DESC"
 	}
 }
 
@@ -999,52 +501,6 @@ rule_income_per_gw_from_energy_load_sharing = {
 	}
 }
 
-allow_enable_help_gui = {
-	name = "RULE_ALLOW_HELP_GUI"
-	group = "MD_RULES"
-	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_ALLOW_HELP_GUI_YES"
-		allow_achievements = yes
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_ALLOW_HELP_GUI_NO"
-		allow_achievements = yes
-	}
-}
-
-rule_starting_debt_rule = {
-	name = "RULE_STARTING_DEBT_RULE"
-	group = "MD_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = normal
-		text = "RULE_OPTION_NORMAL_DEBT"
-		desc = "RULE_STARTING_DEBT_NORMAL_RULE_DESC"
-	}
-	option = {
-		name = player_only
-		text = "RULE_OPTION_PLAYER_DEBT_ONLY"
-		desc = "RULE_STARTING_DEBT_PLAYER_ONLY_RULE_DESC"
-		allow_achievements = no
-	}
-	option = {
-		name = ai_only
-		text = "RULE_OPTION_AI_DEBT_ONLY"
-		desc = "RULE_STARTING_DEBT_AI_ONLY_RULE_DESC"
-	}
-	option = {
-		name = everyone
-		text = "RULE_OPTION_EVERYONE_DEBT"
-		desc = "RULE_STARTING_DEBT_EVERYONE_RULE_DESC"
-	}
-}
-
 rule_internal_faction_tick_amount = {
 	name = "RULE_INTERNAL_FACTION_TICK_AMOUNT"
 	group = "MD_RULES"
@@ -1115,6 +571,43 @@ rule_enable_investment_collapse_lock = {
 	}
 }
 
+# Military
+allow_carrier_only_raids = {
+	name = "RULE_CARRIER_ONLY_RAIDS"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_CARRIER_ONLY_RAIDS_NO"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_CARRIER_ONLY_RAIDS_YES"
+		allow_achievements = yes
+	}
+}
+
+rule_raid_doctrine_reach = {
+	name = "RULE_RAID_DOCTRINE_REACH"
+	group = "MD_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_RAID_DOCTRINE_REACH_YES"
+		allow_achievements = yes
+	}
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_RAID_DOCTRINE_REACH_NO"
+		allow_achievements = yes
+	}
+}
+
+# Country Content
 rule_syria_arab_spring_choice = {
 	name = "RULE_SYRIA_ARAB_SPRING_CHOICE"
 	group = "MD_RULES"
@@ -1151,520 +644,149 @@ rule_disable_muslim_brotherhood_civil_war = {
 		desc = "RULE_NO_DISABLE_MUSLIM_BROTHERHOOD_CIVIL_WAR_DESC"
 	}
 }
-
-rule_futuristic_special_projects = {
-	name = "RULE_FUTURISTIC_SPECIAL_PROJECTS"
-	group = "MD_RULES"
-	icon = "GFX_lend_lease"
-	default = {
-		name = yes
-		text = "RULE_OPTION_ALLOWED"
-		desc = "RULE_ALLOWED_DISABLE_FUTURISTIC_SPECIAL_PROJECTS_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_DISABLED"
-		desc = "RULE_DISABLE_DISABLED_FUTURISTIC_SPECIAL_PROJECTS_DESC"
-		allow_achievements = yes
-	}
-}
-allow_fictional_content = {
-	name = "RULE_FICTIONAL_CONTENT"
-	group = "MD_RULES"
+# AI OPTIONS
+rule_god_of_war = {
+	name = "RULE_GOD_OF_WAR"
+	group = "MD_AI_RULES"
 	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_FICTIONAL_CONTENT_YES_DESC"
-		allow_achievements = yes
-	}
+
 	default = {
 		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_FICTIONAL_CONTENT_NO_DESC"
+		text = "RULE_GOD_OF_WAR_NO"
+		desc = "RULE_GOD_OF_WAR_NO_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_GOD_OF_WAR_YES"
+		desc = "RULE_GOD_OF_WAR_YES_DESC"
 		allow_achievements = yes
 	}
 }
 
-# CHEATS
-allow_cheat_decisions = {
-	name = "RULE_ALLOW_CHEAT_DECISIONS"
-	group = "MD_CHEAT_RULES"
+rule_ai_starting_political_power = {
+	name = "RULE_AI_STARTING_POLITICAL_POWER"
+	group = "MD_AI_RULES"
 	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ALLOW_CHEAT_DECISIONS_DESC"
-	}
+
 	default = {
 		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ALLOW_CHEAT_DECISIONS_DESC"
+		text = "RULE_AI_STARTING_POLITICAL_POWER_NO"
+		desc = "RULE_AI_STARTING_POLITICAL_POWER_NO_DESC"
+	}
+	option = {
+		name = one
+		text = "RULE_AI_STARTING_POLITICAL_POWER_250"
+		desc = "RULE_AI_STARTING_POLITICAL_POWER_250_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = two
+		text = "RULE_AI_STARTING_POLITICAL_POWER_500"
+		desc = "RULE_AI_STARTING_POLITICAL_POWER_500_DESC"
+		allow_achievements = no
+	}
+	option = {
+		name = three
+		text = "RULE_AI_STARTING_POLITICAL_POWER_1000"
+		desc = "RULE_AI_STARTING_POLITICAL_POWER_1000_DESC"
+		allow_achievements = no
 	}
 }
-allow_toggling_cheat_decisions = {
-	name = "RULE_ALLOW_TOGGLING_CHEAT_DECISIONS"
-	group = "MD_CHEAT_RULES"
+
+rule_enable_ai_debt_war = {
+	name = "RULE_DISABLE_AI_DEBT_WAR_TITLE"
+	group = "MD_AI_RULES"
 	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
-	}
+
 	default = {
 		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
+		text = "RULE_ENABLE_AI_DEBT_WAR"
+		desc = "RULE_ENABLE_AI_DEBT_WAR_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_DISABLE_AI_DEBT_WAR"
+		desc = "RULE_DISABLE_AI_DEBT_WAR_DESC"
 	}
 }
-rule_disable_anti_bully = {
-	name = "RULE_DISABLE_ANTI_BULLY"
-	group = "MD_CHEAT_RULES"
+
+rule_disable_AI_using_freedom_cont_focus = {
+	name = "RULE_ENABLE_AI_FIGHTING_AUTONOMY_FOCUS"
+	group = "MD_AI_RULES"
 	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ANTI_BULLY_DESC"
-	}
+
 	default = {
+		name = yes
+		text = "RULE_ENABLE_FIGHTING_AUTONOMY_FOCUS"
+		desc = "RULE_ENABLE_FIGHTING_AUTONOMY_FOCUS_DESC"
+	}
+	option = {
 		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ANTI_BULLY_DESC"
+		text = "RULE_DISABLE_FIGHTING_AUTONOMY_FOCUS"
+		desc = "RULE_DISABLE_FIGHTING_AUTONOMY_FOCUS_DESC"
 	}
 }
-rule_player_instant_justification = {
-	name = "RULE_PLAYER_INSTANT_JUSTIFICATION"
-	group = "MD_CHEAT_RULES"
+
+rule_enable_AI_using_attaches = {
+	name = "RULE_ENABLE_AI_USING_ATTACHES"
+	group = "MD_AI_RULES"
 	icon = "GFX_production_licenses"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_PLAYER_INSTANT_JUSTIFICATION_DESC"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_PLAYER_INSTANT_JUSTIFICATION_DESC"
-	}
-}
-# VANILLA
-allow_wargoals = {
-	name = "RULE_ALLOW_WARGOALS"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_wargoals"
-	option = {
-		name = "ALWAYS_FREE"
-		text = RULE_OPTION_ALWAYS_FREE
-		desc = "RULE_ALLOW_WARGOALS_ALWAYS_FREE_DESC"
-	}
-	default = {
-		name = "LIMITED"
-		text = "RULE_OPTION_LIMITED"
-		desc = "RULE_ALLOW_WARGOALS_LIMITED_DESC"
-	}
-	option = {
-		name = "FREE_25"
-		text = RULE_OPTION_FREE_25
-		desc = "RULE_ALLOW_WARGOALS_FREE_25_DESC"
-	}
-	option = {
-		name = "FREE_50"
-		text = RULE_OPTION_FREE_50
-		desc = "RULE_ALLOW_WARGOALS_FREE_50_DESC"
-	}
-	option = {
-		name = "FREE_75"
-		text = RULE_OPTION_FREE_75
-		desc = "RULE_ALLOW_WARGOALS_FREE_75_DESC"
-	}
-	option = {
-		name = "FREE_100"
-		text = RULE_OPTION_FREE_100
-		desc = "RULE_ALLOW_WARGOALS_FREE_100_DESC"
-	}
-	option = {
-		name = "FOCUSES_ONLY"
-		text = RULE_OPTION_FOCUSES_ONLY
-		desc = "RULE_ALLOW_WARGOALS_FOCUSES_ONLY_DESC"
-	}
-}
-allow_access = {
-	name = "RULE_ALLOW_MILITARY_ACCESS"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_military_access_docking_rights"
-	default = {
-		name = "FREE"
-		text = RULE_OPTION_FREE
-		desc = "RULE_ALLOW_ACCESS_FREE_DESC"
-	}
-	option = {
-		name = "SAME_IDEOLOGY"
-		text = "RULE_OPTION_SAME_IDEOLOGY"
-		desc = "RULE_ALLOW_ACCESS_SAME_IDEOLOGY_DESC"
-	}
-	option = {
-		name = "BLOCKED"
-		text = RULE_OPTION_BLOCKED
-		desc = "RULE_ALLOW_ACCESS_BLOCKED_DESC"
-	}
-}
-allow_release_nations = {
-	name = "RULE_ALLOW_RELEASE_NATIONS"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_release_nations"
-	default = {
-		name = "FREE"
-		text = RULE_OPTION_FREE
-		desc = "RULE_ALLOW_RELEASE_NATIONS_FREE_DESC"
-	}
-	option = {
-		name = "PEACE_ONLY"
-		text = "RULE_OPTION_PEACE_ONLY"
-		desc = "RULE_ALLOW_RELEASE_NATIONS_PEACE_ONLY_DESC"
-	}
-	option = {
-		name = "BLOCKED"
-		text = RULE_OPTION_BLOCKED
-		desc = "RULE_ALLOW_RELEASE_NATIONS_BLOCKED_DESC"
-	}
-}
-allow_licensing = {
-	name = "RULE_ALLOW_LICENSING"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_production_licenses"
-	option = {
-		name = "FREE"
-		text = "RULE_OPTION_FREE"
-		desc = "RULE_ALLOW_LICENSING_FREE_DESC"
-	}
-	option = {
-		name = SAME_IDEOLOGY
-		text = "RULE_OPTION_SAME_IDEOLOGY"
-		desc = "RULE_ALLOW_LICENSING_SAME_IDEOLOGY_DESC"
-	}
-	option = {
-		name = SAME_FACTION
-		text = "RULE_OPTION_SAME_FACTION"
-		desc = "RULE_ALLOW_LICENSING_SAME_FACTION_DESC"
-	}
-	option = {
-		name = BLOCKED
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_LICENSING_BLOCKED_DESC"
-	}
-}
-allow_lend_lease = {
-	name = "RULE_ALLOW_LEND_LEASE"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_lend_lease"
-	option = {
-		name = "FREE"
-		text = "RULE_OPTION_FREE"
-		desc = "RULE_ALLOW_LEND_LEASE_FREE_DESC"
-	}
-	default = {
-		name = "LIMITED"
-		text = "RULE_OPTION_LIMITED"
-		desc = "RULE_ALLOW_LEND_LEASE_LIMITED_DESC"
-	}
-	option = {
-		name = SAME_IDEOLOGY
-		text = "RULE_OPTION_SAME_IDEOLOGY"
-		desc = "RULE_ALLOW_LEND_LEASE_SAME_IDEOLOGY_DESC"
-	}
-	option = {
-		name = SAME_FACTION
-		text = "RULE_OPTION_SAME_FACTION"
-		desc = "RULE_ALLOW_LEND_LEASE_SAME_FACTION_DESC"
-	}
-	option = {
-		name = BLOCKED
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_LEND_LEASE_BLOCKED_DESC"
-	}
-}
-allow_volunteers = {
-	name = "RULE_ALLOW_VOLUNTEERS"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_volunteers"
-	option = {
-		name = "ALWAYS_FREE"
-		text = "RULE_OPTION_FREE"
-		desc = "RULE_ALLOW_VOLUNTEERS_FREE_DESC"
-	}
-	default = {
-		name = "LIMITED"
-		text = "RULE_OPTION_LIMITED"
-		desc = "RULE_ALLOW_VOLUNTEERS_LIMITED_DESC"
-	}
-	option = {
-		name = SAME_IDEOLOGY
-		text = "RULE_OPTION_SAME_IDEOLOGY"
-		desc = "RULE_ALLOW_VOLUNTEERS_SAME_IDEOLOGY_DESC"
-	}
-	option = {
-		name = BLOCKED
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_VOLUNTEERS_BLOCKED_DESC"
-	}
-}
-allow_recall_intervention_forces = {
-	name = "RULE_ALLOW_RECALL_INTERVENTION_FORCES"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_volunteers"
+
 	default = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_ALLOW_INTERVENTION_FORCES"
+		desc = "RULE_ENABLE_AI_USING_ATTACHES_YES_DESC"
 	}
 	option = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_ALLOW_INTERVENTION_FORCES"
-		allow_achievements = yes
+		desc = "RULE_ENABLE_AI_USING_ATTACHES_NO_DESC"
 	}
 }
-allow_forcing_a_white_peace = {
-	name = "RULE_ALLOW_FORCING_A_WHITE_PEACE"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_volunteers"
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_YES_FORCING_A_WHITE_PEACE"
-	}
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_NO_FORCING_A_WHITE_PEACE"
-		allow_achievements = yes
-	}
-}
-allow_guarantees = {
-	name = "RULE_ALLOW_GUARANTEES"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_guarantee_independence"
-	option = {
-		name = "ALWAYS_FREE"
-		text = "RULE_OPTION_FREE"
-		desc = "RULE_ALLOW_GUARANTEES_FREE_DESC"
-	}
-	default = {
-		name = "LIMITED"
-		text = "RULE_OPTION_LIMITED"
-		desc = "RULE_ALLOW_GUARANTEES_LIMITED_DESC"
-	}
-	option = {
-		name = SAME_IDEOLOGY
-		text = "RULE_OPTION_SAME_IDEOLOGY"
-		desc = "RULE_ALLOW_GUARANTEES_SAME_IDEOLOGY_DESC"
-	}
-	option = {
-		name = BLOCKED
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_GUARANTEES_BLOCKED_DESC"
-	}
-}
-allow_revoke_guarantees = {
-	name = "RULE_ALLOW_REVOKE_GUARANTEES"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_revoke_guarantees"
-	default = {
-		name = "ALLOWED"
-		text = "RULE_OPTION_ALLOWED"
-		desc = "RULE_ALLOW_REVOKE_GUARANTEES_ALLOWED_DESC"
-	}
-	option = {
-		name = "BLOCKED"
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_REVOKE_GUARANTEES_BLOCKED_DESC"
-	}
-}
-allow_leave_faction = {
-	name = "RULE_ALLOW_LEAVE_FACTION"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_leave_faction"
-	default = {
-		name = "ALLOWED"
-		text = "RULE_OPTION_ALLOWED"
-		desc = "RULE_ALLOW_LEAVE_FACTION_ALLOWED_DESC"
-	}
-	option = {
-		name = "BLOCKED"
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_LEAVE_FACTION_BLOCKED_DESC"
-	}
-}
-allow_kick_faction = {
-	name = "RULE_ALLOW_KICK_FACTION"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+
+# Country AI Paths
+AFG_northern_alliance_uprising = {
+	name = "RULE_AFG_NORTHERN_ALLIANCE_UPRISING"
+	group = "MD_AI_RULES"
 	icon = "GFX_kick_from_faction"
-	option = {
-		name = "ALLOWED"
-		text = "RULE_OPTION_ALLOWED"
-		desc = "RULE_ALLOW_KICK_FACTION_ALLOWED_DESC"
-	}
-	option = {
-		name = "BLOCKED"
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_KICK_FACTION_BLOCKED_DESC"
-	}
-}
-allow_take_over_faction = {
-	name = "RULE_ALLOW_TAKE_OVER_FACTION"
-	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
-	icon = "GFX_take_over_faction_leadership"
-	option = {
-		name = "ALLOWED"
-		text = "RULE_OPTION_ALLOWED"
-		desc = "RULE_ALLOW_TAKE_OVER_FACTION_ALLOWED_DESC"
-	}
-	option = {
-		name = "BLOCKED"
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_TAKE_OVER_FACTION_BLOCKED_DESC"
-	}
-}
-obsolete_focus_branches_visibility = {
-	name = "OBSOLETE_FOCUS_BRANCHES_VISIBILITY"
-	group = "RULE_GROUP_GENERAL_UI"
+
 	default = {
-		name = HIDE
-		text = "RULE_OPTION_HIDE"
-		desc = "RULE_OPTION_HIDE_DESC"
-	}
-	option = {
-		name = SHOW
-		text = "RULE_OPTION_SHOW"
-		desc = "RULE_OPTION_SHOW_DESC_DESC"
-		allow_achievements = yes
-	}
-}
-# COVERT ACTIONS
-allow_coups = {
-	name = "RULE_ALLOW_COUPS"
-	group = "RULE_GROUP_COVERT_ACTIONS"
-	icon = "GFX_coups"
-	default = {
-		name = BLOCKED
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_COUPS_BLOCKED_DESC"
-	}
-	option = {
-		name = AI_ONLY
-		text = "RULE_OPTION_AI_ONLY"
-		desc = "RULE_ALLOW_COUPS_AI_ONLY_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = FREE
-		text = "RULE_OPTION_FREE"
-		desc = "RULE_ALLOW_COUPS_FREE_DESC"
-	}
-}
-allow_party_boosting = {
-	name = "RULE_ALLOW_PARTY_BOOSTING"
-	group = "RULE_GROUP_COVERT_ACTIONS"
-	icon = "GFX_boosting_party_popularity"
-	option = {
-		name = FREE
-		text = "RULE_OPTION_FREE"
-		desc = "RULE_ALLOW_PARTY_BOOSTING_FREE_DESC"
-	}
-	option = {
-		name = AI_ONLY
-		text = "RULE_OPTION_AI_ONLY"
-		desc = "RULE_ALLOW_PARTY_BOOSTING_AI_ONLY_DESC"
-		allow_achievements = yes
-	}
-	option = {
-		name = PLAYER_ONLY
-		text = "RULE_OPTION_PLAYER_ONLY"
-		desc = "RULE_ALLOW_PARTY_BOOSTING_PLAYER_ONLY_DESC"
-	}
-	option = {
-		name = BLOCKED
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_PARTY_BOOSTING_BLOCKED_DESC"
-	}
-}
-# MILITARY RULES
-allow_paratroopers = {
-	name = "RULE_ALLOW_PARATROOPERS"
-	group = "RULE_GROUP_GAMEPLAY"
-	icon = "GFX_paradrops"
-	option = {
 		name = yes
-		text = "RULE_OPTION_ALLOWED"
-		desc = "RULE_ALLOW_PARATROOPERS_ALLOWED_DESC"
+		text = "RULE_OPTION_YES"
+		desc = "RULE_AFG_NORTHERN_ALLIANCE_UPRISING_ALLOWED_DESC"
 	}
 	option = {
 		name = no
-		text = "RULE_OPTION_BLOCKED"
-		desc = "RULE_ALLOW_PARATROOPERS_BLOCKED_DESC"
+		text = "RULE_OPTION_NO"
+		desc = "RULE_AFG_NORTHERN_ALLIANCE_UPRISING_BLOCKED_DESC"
 	}
 }
-# CONSTRUCTION RULES
-maximum_fort_level = {
-	name = "RULE_MAXIMUM_FORT_LEVEL"
-	group = "RULE_GROUP_GAMEPLAY"
-	icon = "GFX_maximum_fort_level"
-	option = {
-		name = normal
-		text = "RULE_OPTION_NORMAL"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_NORMAL_DESC"
+
+AFG_taliban_insurgency_intensity = {
+	name = "RULE_AFG_TALIBAN_INSURGENCY_INTENSITY"
+	group = "MD_AI_RULES"
+	icon = "GFX_production_licenses"
+
+	default = {
+		name = DEFAULT
+		text = "RULE_AFG_TALIBAN_INSURGENCY_DEFAULT"
+		desc = "RULE_AFG_TALIBAN_INSURGENCY_DEFAULT_DESC"
 	}
 	option = {
-		name = level_1
-		text = "RULE_OPTION_1"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+		name = WEAK
+		text = "RULE_AFG_TALIBAN_INSURGENCY_WEAK"
+		desc = "RULE_AFG_TALIBAN_INSURGENCY_WEAK_DESC"
 	}
 	option = {
-		name = level_2
-		text = "RULE_OPTION_2"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_3
-		text = "RULE_OPTION_3"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_4
-		text = "RULE_OPTION_4"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_5
-		text = "RULE_OPTION_5"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_6
-		text = "RULE_OPTION_6"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_7
-		text = "RULE_OPTION_7"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_8
-		text = "RULE_OPTION_8"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
-	}
-	option = {
-		name = level_9
-		text = "RULE_OPTION_9"
-		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+		name = RELENTLESS
+		text = "RULE_AFG_TALIBAN_INSURGENCY_RELENTLESS"
+		desc = "RULE_AFG_TALIBAN_INSURGENCY_RELENTLESS_DESC"
 	}
 }
-# AI FOCUS BEHAVIOUR
+
 ALG_ai_behavior = {
 	name = "ALG_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_ALG_HISTORICAL"
@@ -1709,7 +831,7 @@ ALG_ai_behavior = {
 
 ARM_ai_behavior = {
 	name = "ARM_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_ARM_HISTORICAL"
@@ -1769,7 +891,7 @@ ARM_ai_behavior = {
 
 BHR_ai_behavior = {
 	name = "BHR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_BHR_HISTORICAL"
@@ -1799,7 +921,7 @@ BHR_ai_behavior = {
 
 BLR_ai_behavior = {
 	name = "BLR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_BLR_HISTORICAL"
@@ -1847,9 +969,30 @@ BLR_ai_behavior = {
 	}
 }
 
+BLR_union_state_ai_behavior = {
+	name = "BLR_union_state_ai_behavior"
+	group = "MD_AI_RULES"
+	icon = "GFX_kick_from_faction"
+	default = {
+		name = BLR_WONT_FOLLOW_UNION_STATE
+		text = "BLR_WONT_FOLLOW_UNION_STATE"
+		desc = "BLR_WONT_FOLLOW_UNION_STATE_DESC"
+	}
+	option = {
+		name = BLR_WILL_FOLLOW_UNION_STATE
+		text = "BLR_WILL_FOLLOW_UNION_STATE"
+		desc = "BLR_WILL_FOLLOW_UNION_STATE_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_DESC"
+	}
+}
+
 BOS_ai_behavior = {
 	name = "BOS_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 
 	option = {
 		name = HISTORICAL
@@ -1890,7 +1033,7 @@ BOS_ai_behavior = {
 
 BOT_ai_behavior = {
 	name = "BOT_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 
 	option = {
 		name = HISTORICAL
@@ -1921,7 +1064,7 @@ BOT_ai_behavior = {
 
 BRA_ai_behavior = {
 	name = "BRA_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_BRA_HISTORICAL"
@@ -1971,7 +1114,7 @@ BRA_ai_behavior = {
 
 BRM_ai_behavior = {
 	name = "BRM_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_BRM_HISTORICAL"
@@ -1999,9 +1142,39 @@ BRM_ai_behavior = {
 	}
 }
 
+BUL_ai_behavior = {
+	name = "BUL_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_BUL_HISTORICAL"
+		desc = "RULE_OPTION_BUL_HISTORICAL_DESC"
+	}
+	option = {
+		name = TSARIST_RESTORATION
+		text = "RULE_OPTION_BUL_TSARIST_RESTORATION"
+		desc = "RULE_OPTION_BUL_TSARIST_RESTORATION_DESC"
+	}
+	option = {
+		name = RED_BALKAN
+		text = "RULE_OPTION_BUL_RED_BALKAN"
+		desc = "RULE_OPTION_BUL_RED_BALKAN_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 CAN_ai_behavior = {
 	name = "CAN_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_CAN_HISTORICAL"
@@ -2041,7 +1214,7 @@ CAN_ai_behavior = {
 
 CAS_ai_behavior = {
 	name = "CAS_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -2071,7 +1244,7 @@ CAS_ai_behavior = {
 
 CHE_ai_behavior = {
 	name = "CHE_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_CHE_HISTORICAL"
@@ -2111,7 +1284,7 @@ CHE_ai_behavior = {
 
 CHI_ai_behavior = {
 	name = "CHI_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_CHI_HISTORICAL"
@@ -2141,7 +1314,7 @@ CHI_ai_behavior = {
 
 COM_ai_behavior = {
 	name = "COM_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_COM_HISTORICAL"
@@ -2179,9 +1352,49 @@ COM_ai_behavior = {
 	}
 }
 
+CSA_ai_behavior = {
+	name = "CSA_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = A_SOUTHERN_AMERICA_PATH
+		text = "RULE_OPTION_A_SOUTHERN_AMERICA_PATH"
+		desc = "RULE_OPTION_A_SOUTHERN_AMERICA_PATH_AI_DESC"
+	}
+	option = {
+		name = GOLDEN_CIRCLE_PATH
+		text = "RULE_OPTION_GOLDEN_CIRCLE_PATH"
+		desc = "RULE_OPTION_GOLDEN_CIRCLE_PATH_AI_DESC"
+	}
+	option = {
+		name = SOUTHERN_ARCADIA_PATH
+		text = "RULE_OPTION_SOUTHERN_ARCADIA_PATH"
+		desc = "RULE_OPTION_SOUTHERN_ARCADIA_PATH_AI_DESC"
+	}
+	option = {
+		name = THE_FLORIDA_UPRISING_PATH
+		text = "RULE_OPTION_THE_FLORIDA_UPRISING_PATH"
+		desc = "RULE_OPTION_THE_FLORIDA_UPRISING_PATH_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 CUB_ai_behavior = {
 	name = "CUB_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_CUB_HISTORICAL"
@@ -2224,49 +1437,9 @@ CUB_ai_behavior = {
 	}
 }
 
-CSA_ai_behavior = {
-	name = "CSA_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = DEFAULT
-		text = "RULE_OPTION_DEFAULT"
-		desc = "RULE_OPTION_DEFAULT_AI_DESC"
-	}
-	option = {
-		name = A_SOUTHERN_AMERICA_PATH
-		text = "RULE_OPTION_A_SOUTHERN_AMERICA_PATH"
-		desc = "RULE_OPTION_A_SOUTHERN_AMERICA_PATH_AI_DESC"
-	}
-	option = {
-		name = GOLDEN_CIRCLE_PATH
-		text = "RULE_OPTION_GOLDEN_CIRCLE_PATH"
-		desc = "RULE_OPTION_GOLDEN_CIRCLE_PATH_AI_DESC"
-	}
-	option = {
-		name = SOUTHERN_ARCADIA_PATH
-		text = "RULE_OPTION_SOUTHERN_ARCADIA_PATH"
-		desc = "RULE_OPTION_SOUTHERN_ARCADIA_PATH_AI_DESC"
-	}
-	option = {
-		name = THE_FLORIDA_UPRISING_PATH
-		text = "RULE_OPTION_THE_FLORIDA_UPRISING_PATH"
-		desc = "RULE_OPTION_THE_FLORIDA_UPRISING_PATH_AI_DESC"
-	}
-	option = {
-		name = RANDOM
-		text = "RULE_OPTION_RANDOM"
-		desc = "RULE_OPTION_RANDOM_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
 CZE_ai_behavior = {
 	name = "CZE_AI_BEHAVIOR_MD"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_CZE_HISTORICAL"
@@ -2299,9 +1472,94 @@ CZE_ai_behavior = {
 	}
 }
 
+DEN_ai_behavior = {
+	name = "DEN_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_DEN_HISTORICAL"
+		desc = "RULE_OPTION_DEN_HISTORICAL_DESC"
+	}
+	option = {
+		name = EUROPEAN_UNION
+		text = "RULE_OPTION_DEN_EUROPEAN_UNION"
+		desc = "RULE_OPTION_DEN_EUROPEAN_UNION_DESC"
+	}
+	option = {
+		name = EUROSCEPTIC
+		text = "RULE_OPTION_DEN_EUROSCEPTIC"
+		desc = "RULE_OPTION_DEN_EUROSCEPTIC_DESC"
+	}
+	option = {
+		name = SOCIALIST
+		text = "RULE_OPTION_DEN_SOCIALIST"
+		desc = "RULE_OPTION_DEN_SOCIALIST_DESC"
+	}
+	option = {
+		name = MONARCHIST
+		text = "RULE_OPTION_DEN_MONARCHIST"
+		desc = "RULE_OPTION_DEN_MONARCHIST_DESC"
+	}
+	option = {
+		name = NATIONALIST
+		text = "RULE_OPTION_DEN_NATIONALIST"
+		desc = "RULE_OPTION_DEN_NATIONALIST_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
+EGY_ai_behavior = {
+	name = "EGY_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_EGY_HISTORICAL"
+		desc = "RULE_OPTION_EGY_HISTORICAL_DESC"
+	}
+	option = {
+		name = BROTHERHOOD
+		text = "RULE_OPTION_EGY_BROTHERHOOD"
+		desc = "RULE_OPTION_EGY_BROTHERHOOD_DESC"
+	}
+	option = {
+		name = PAN_ARAB
+		text = "RULE_OPTION_EGY_PAN_ARAB"
+		desc = "RULE_OPTION_EGY_PAN_ARAB_DESC"
+	}
+	option = {
+		name = SALAFIST
+		text = "RULE_OPTION_EGY_SALAFIST"
+		desc = "RULE_OPTION_EGY_SALAFIST_DESC"
+	}
+	option = {
+		name = COPTIC
+		text = "RULE_OPTION_EGY_COPTIC"
+		desc = "RULE_OPTION_EGY_COPTIC_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 ENG_ai_behavior = {
 	name = "BRI_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = ENG_HISTORICAL
 		text = "RULE_OPTION_ENG_HISTORICAL"
@@ -2331,7 +1589,7 @@ ENG_ai_behavior = {
 
 EST_ai_behavior = {
 	name = "EST_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_EST_HISTORICAL"
@@ -2369,9 +1627,39 @@ EST_ai_behavior = {
 	}
 }
 
+ETH_ai_behavior = {
+	name = "ETH_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_ETH_HISTORICAL"
+		desc = "RULE_OPTION_ETH_HISTORICAL_DESC"
+	}
+	option = {
+		name = MONARCHIST_RESTORATION
+		text = "RULE_OPTION_ETH_MONARCHIST_RESTORATION"
+		desc = "RULE_OPTION_ETH_MONARCHIST_RESTORATION_DESC"
+	}
+	option = {
+		name = DERG_RESTORATION
+		text = "RULE_OPTION_ETH_DERG_RESTORATION"
+		desc = "RULE_OPTION_ETH_DERG_RESTORATION_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 FIJ_ai_behavior = {
 	name = "FIJ_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_FIJ_HISTORICAL"
@@ -2421,7 +1709,7 @@ FIJ_ai_behavior = {
 
 FRA_ai_behavior = {
 	name = "FRA_AI_BEHAVIOR_MD"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_FRA_HISTORICAL"
@@ -2486,7 +1774,7 @@ FRA_ai_behavior = {
 
 GEO_ai_behavior = {
 	name = "GEO_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_GEO_HISTORICAL"
@@ -2539,9 +1827,77 @@ GEO_ai_behavior = {
 	}
 }
 
+GEO_2008_war_behavior = {
+	name = "GEO_2008_war_behavior"
+	group = "MD_AI_RULES"
+	icon = "GFX_kick_from_faction"
+	default = {
+		name = GEO_ATTACK_RUS
+		text = "GEO_ATTACK_RUS"
+		desc = "GEO_ATTACK_RUS_DESC"
+	}
+	option = {
+		name = GEO_WEAKBOY
+		text = "GEO_WEAKBOY"
+		desc = "GEO_WEAKBOY_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_DESC"
+	}
+}
+
+GEO_NATIONALIST_behavior = {
+	name = "GEO_NATIONALIST_behavior"
+	group = "MD_AI_RULES"
+	icon = "GFX_kick_from_faction"
+	default = {
+		name = GEO_WILL_FOLLOW_OWN_WAY
+		text = "GEO_WILL_FOLLOW_OWN_WAY"
+		desc = "GEO_WILL_FOLLOW_OWN_WAY_DESC"
+	}
+	option = {
+		name = GEO_WILL_BE_PRO_ARMENIA
+		text = "GEO_WILL_BE_PRO_ARMENIA"
+		desc = "GEO_WILL_BE_PRO_ARMENIA_DESC"
+	}
+	option = {
+		name = GEO_WILL_BE_PRO_AZERI
+		text = "GEO_WILL_BE_PRO_AZERI"
+		desc = "GEO_WILL_BE_PRO_AZERI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_DESC"
+	}
+}
+
+GEO_help_CHE_behavior = {
+	name = "GEO_help_CHE_behavior"
+	group = "MD_AI_RULES"
+	icon = "GFX_kick_from_faction"
+	default = {
+		name = GEO_WONT_HELP
+		text = "GEO_WONT_HELP"
+		desc = "GEO_WONT_HELP_DESC"
+	}
+	option = {
+		name = GEO_WILL_HELP
+		text = "GEO_WILL_HELP"
+		desc = "GEO_WILL_HELP_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_DESC"
+	}
+}
+
 GER_ai_behavior = {
 	name = "GER_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_GER_HISTORICAL"
@@ -2589,154 +1945,9 @@ GER_ai_behavior = {
 	}
 }
 
-ETH_ai_behavior = {
-	name = "ETH_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_ETH_HISTORICAL"
-		desc = "RULE_OPTION_ETH_HISTORICAL_DESC"
-	}
-	option = {
-		name = MONARCHIST_RESTORATION
-		text = "RULE_OPTION_ETH_MONARCHIST_RESTORATION"
-		desc = "RULE_OPTION_ETH_MONARCHIST_RESTORATION_DESC"
-	}
-	option = {
-		name = DERG_RESTORATION
-		text = "RULE_OPTION_ETH_DERG_RESTORATION"
-		desc = "RULE_OPTION_ETH_DERG_RESTORATION_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
-EGY_ai_behavior = {
-	name = "EGY_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_EGY_HISTORICAL"
-		desc = "RULE_OPTION_EGY_HISTORICAL_DESC"
-	}
-	option = {
-		name = BROTHERHOOD
-		text = "RULE_OPTION_EGY_BROTHERHOOD"
-		desc = "RULE_OPTION_EGY_BROTHERHOOD_DESC"
-	}
-	option = {
-		name = PAN_ARAB
-		text = "RULE_OPTION_EGY_PAN_ARAB"
-		desc = "RULE_OPTION_EGY_PAN_ARAB_DESC"
-	}
-	option = {
-		name = SALAFIST
-		text = "RULE_OPTION_EGY_SALAFIST"
-		desc = "RULE_OPTION_EGY_SALAFIST_DESC"
-	}
-	option = {
-		name = COPTIC
-		text = "RULE_OPTION_EGY_COPTIC"
-		desc = "RULE_OPTION_EGY_COPTIC_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
-BUL_ai_behavior = {
-	name = "BUL_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_BUL_HISTORICAL"
-		desc = "RULE_OPTION_BUL_HISTORICAL_DESC"
-	}
-	option = {
-		name = TSARIST_RESTORATION
-		text = "RULE_OPTION_BUL_TSARIST_RESTORATION"
-		desc = "RULE_OPTION_BUL_TSARIST_RESTORATION_DESC"
-	}
-	option = {
-		name = RED_BALKAN
-		text = "RULE_OPTION_BUL_RED_BALKAN"
-		desc = "RULE_OPTION_BUL_RED_BALKAN_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
-MNT_ai_behavior = {
-	name = "MNT_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_MNT_HISTORICAL"
-		desc = "RULE_OPTION_MNT_HISTORICAL_DESC"
-	}
-	option = {
-		name = EUROPEAN_REFORM
-		text = "RULE_OPTION_MNT_EUROPEAN_REFORM"
-		desc = "RULE_OPTION_MNT_EUROPEAN_REFORM_DESC"
-	}
-	option = {
-		name = SERBIAN_UNION
-		text = "RULE_OPTION_MNT_SERBIAN_UNION"
-		desc = "RULE_OPTION_MNT_SERBIAN_UNION_DESC"
-	}
-	option = {
-		name = MONARCHIST_RESTORATION
-		text = "RULE_OPTION_MNT_MONARCHIST_RESTORATION"
-		desc = "RULE_OPTION_MNT_MONARCHIST_RESTORATION_DESC"
-	}
-	option = {
-		name = NEUTRAL_HARBOUR
-		text = "RULE_OPTION_MNT_NEUTRAL_HARBOUR"
-		desc = "RULE_OPTION_MNT_NEUTRAL_HARBOUR_DESC"
-	}
-	option = {
-		name = SOCIALIST_REVIVAL
-		text = "RULE_OPTION_MNT_SOCIALIST_REVIVAL"
-		desc = "RULE_OPTION_MNT_SOCIALIST_REVIVAL_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
 GRE_ai_behavior = {
 	name = "GRE_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_GRE_HISTORICAL"
@@ -2769,28 +1980,23 @@ GRE_ai_behavior = {
 	}
 }
 
-HKG_ai_behavior = {
-	name = "HKG_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+GRN_ai_behavior = {
+	name = "GRN_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
-		text = "RULE_OPTION_HKG_HISTORICAL"
-		desc = "RULE_OPTION_HKG_HISTORICAL_DESC"
+		text = "RULE_OPTION_GRN_HISTORICAL"
+		desc = "RULE_OPTION_GRN_HISTORICAL_DESC"
 	}
 	option = {
-		name = INDEPENDENCE
-		text = "RULE_OPTION_HKG_INDEPENDENCE"
-		desc = "RULE_OPTION_HKG_INDEPENDENCE_DESC"
+		name = SCANDINAVIAN_SERENITY
+		text = "RULE_OPTION_GRN_SCANDINAVIAN_SERENITY"
+		desc = "RULE_OPTION_GRN_SCANDINAVIAN_SERENITY_DESC"
 	}
 	option = {
-		name = BRITISH
-		text = "RULE_OPTION_HKG_BRITISH"
-		desc = "RULE_OPTION_HKG_BRITISH_DESC"
-	}
-	option = {
-		name = CITY_STATE
-		text = "RULE_OPTION_HKG_CITY_STATE"
-		desc = "RULE_OPTION_HKG_CITY_STATE_DESC"
+		name = CONTINENTAL_HEGEMONY
+		text = "RULE_OPTION_GRN_CONTINENTAL_HEGEMONY"
+		desc = "RULE_OPTION_GRN_CONTINENTAL_HEGEMONY_DESC"
 	}
 	option = {
 		name = RANDOM_PATH
@@ -2806,7 +2012,7 @@ HKG_ai_behavior = {
 
 HEZ_ai_behavior = {
 	name = "HEZ_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_HEZ_HISTORICAL"
@@ -2839,9 +2045,44 @@ HEZ_ai_behavior = {
 	}
 }
 
+HKG_ai_behavior = {
+	name = "HKG_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HKG_HISTORICAL"
+		desc = "RULE_OPTION_HKG_HISTORICAL_DESC"
+	}
+	option = {
+		name = INDEPENDENCE
+		text = "RULE_OPTION_HKG_INDEPENDENCE"
+		desc = "RULE_OPTION_HKG_INDEPENDENCE_DESC"
+	}
+	option = {
+		name = BRITISH
+		text = "RULE_OPTION_HKG_BRITISH"
+		desc = "RULE_OPTION_HKG_BRITISH_DESC"
+	}
+	option = {
+		name = CITY_STATE
+		text = "RULE_OPTION_HKG_CITY_STATE"
+		desc = "RULE_OPTION_HKG_CITY_STATE_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 HOL_ai_behavior = {
 	name = "HOL_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_HOL_HISTORICAL"
@@ -2879,44 +2120,9 @@ HOL_ai_behavior = {
 	}
 }
 
-ITA_ai_behavior = {
-	name = "ITA_AI_BEHAVIOR_MD"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_ITA_HISTORICAL"
-		desc = "RULE_OPTION_ITA_HISTORICAL_DESC"
-	}
-	option = {
-		name = ROMAN_RESTORATION
-		text = "RULE_OPTION_ITA_ROMAN_RESTORATION"
-		desc = "RULE_OPTION_ITA_ROMAN_RESTORATION_DESC"
-	}
-	option = {
-		name = MARCH_ON_ROME
-		text = "RULE_OPTION_ITA_MARCH_ON_ROME"
-		desc = "RULE_OPTION_ITA_MARCH_ON_ROME_DESC"
-	}
-	option = {
-		name = EASTERN_TURN
-		text = "RULE_OPTION_ITA_EASTERN_TURN"
-		desc = "RULE_OPTION_ITA_EASTERN_TURN_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
 IND_ai_behavior = {
 	name = "IND_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_IND_HISTORICAL"
@@ -2961,7 +2167,7 @@ IND_ai_behavior = {
 
 IRQ_ai_behavior = {
 	name = "IRQ_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_IRQ_HISTORICAL"
@@ -3006,7 +2212,7 @@ IRQ_ai_behavior = {
 
 ISR_ai_behavior = {
 	name = "ISR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_ISR_HISTORICAL"
@@ -3044,9 +2250,44 @@ ISR_ai_behavior = {
 	}
 }
 
+ITA_ai_behavior = {
+	name = "ITA_AI_BEHAVIOR_MD"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_ITA_HISTORICAL"
+		desc = "RULE_OPTION_ITA_HISTORICAL_DESC"
+	}
+	option = {
+		name = ROMAN_RESTORATION
+		text = "RULE_OPTION_ITA_ROMAN_RESTORATION"
+		desc = "RULE_OPTION_ITA_ROMAN_RESTORATION_DESC"
+	}
+	option = {
+		name = MARCH_ON_ROME
+		text = "RULE_OPTION_ITA_MARCH_ON_ROME"
+		desc = "RULE_OPTION_ITA_MARCH_ON_ROME_DESC"
+	}
+	option = {
+		name = EASTERN_TURN
+		text = "RULE_OPTION_ITA_EASTERN_TURN"
+		desc = "RULE_OPTION_ITA_EASTERN_TURN_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 JAP_ai_behavior = {
 	name = "JAP_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_JAP_HISTORICAL"
@@ -3086,7 +2327,7 @@ JAP_ai_behavior = {
 
 LBA_ai_behavior = {
 	name = "LBA_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_LBA_HISTORICAL"
@@ -3141,7 +2382,7 @@ LBA_ai_behavior = {
 
 LKT_ai_behavior = {
 	name = "LKT_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3169,9 +2410,54 @@ LKT_ai_behavior = {
 	}
 }
 
+MNT_ai_behavior = {
+	name = "MNT_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_MNT_HISTORICAL"
+		desc = "RULE_OPTION_MNT_HISTORICAL_DESC"
+	}
+	option = {
+		name = EUROPEAN_REFORM
+		text = "RULE_OPTION_MNT_EUROPEAN_REFORM"
+		desc = "RULE_OPTION_MNT_EUROPEAN_REFORM_DESC"
+	}
+	option = {
+		name = SERBIAN_UNION
+		text = "RULE_OPTION_MNT_SERBIAN_UNION"
+		desc = "RULE_OPTION_MNT_SERBIAN_UNION_DESC"
+	}
+	option = {
+		name = MONARCHIST_RESTORATION
+		text = "RULE_OPTION_MNT_MONARCHIST_RESTORATION"
+		desc = "RULE_OPTION_MNT_MONARCHIST_RESTORATION_DESC"
+	}
+	option = {
+		name = NEUTRAL_HARBOUR
+		text = "RULE_OPTION_MNT_NEUTRAL_HARBOUR"
+		desc = "RULE_OPTION_MNT_NEUTRAL_HARBOUR_DESC"
+	}
+	option = {
+		name = SOCIALIST_REVIVAL
+		text = "RULE_OPTION_MNT_SOCIALIST_REVIVAL"
+		desc = "RULE_OPTION_MNT_SOCIALIST_REVIVAL_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 NEN_ai_behavior = {
 	name = "NEN_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3201,7 +2487,7 @@ NEN_ai_behavior = {
 
 NIG_ai_behavior = {
 	name = "NIG_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_NIG_HISTORICAL"
@@ -3236,7 +2522,7 @@ NIG_ai_behavior = {
 
 NKO_ai_behavior = {
 	name = "NKO_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_NKO_HISTORICAL"
@@ -3264,9 +2550,39 @@ NKO_ai_behavior = {
 	}
 }
 
+NRY_ai_behavior = {
+	name = "NRY_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_NRY_HISTORICAL"
+		desc = "RULE_OPTION_NRY_HISTORICAL_DESC"
+	}
+	option = {
+		name = CHRISTIAN_PEOPLES
+		text = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES"
+		desc = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES_DESC"
+	}
+	option = {
+		name = PROGRESS
+		text = "RULE_OPTION_NRY_PROGRESS"
+		desc = "RULE_OPTION_NRY_PROGRESS_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 PER_ai_behavior = {
 	name = "PER_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_PER_HISTORICAL"
@@ -3346,7 +2662,7 @@ PER_ai_behavior = {
 
 PMR_ai_behavior = {
 	name = "PMR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_PMR_HISTORICAL"
@@ -3394,9 +2710,25 @@ PMR_ai_behavior = {
 	}
 }
 
+PMR_sub_behavior = {
+	name = "PMR_sub_behavior"
+	group = "MD_AI_RULES"
+	icon = "GFX_kick_from_faction"
+	default = {
+		name = PMR_PASSIVE_DEFAULT
+		text = "PMR_PASSIVE_DEFAULT"
+		desc = "PMR_PASSIVE_DEFAULT_DESC"
+	}
+	option = {
+		name = PMR_SHERIFF
+		text = "PMR_SHERIFF"
+		desc = "PMR_SHERIFF_DESC"
+	}
+}
+
 POL_ai_behavior = {
 	name = "POL_AI_BEHAVIOR_MD"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_POL_HISTORICAL"
@@ -3449,9 +2781,49 @@ POL_ai_behavior = {
 	}
 }
 
+RAJ_ai_behavior = {
+	name = "RAJ_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_RAJ_HISTORICAL"
+		desc = "RULE_OPTION_RAJ_HISTORICAL_DESC"
+	}
+	option = {
+		name = GREATER_INDIA
+		text = "RULE_OPTION_RAJ_GREATER_INDIA"
+		desc = "RULE_OPTION_RAJ_GREATER_INDIA_DESC"
+	}
+	option = {
+		name = RED_REPUBLIC
+		text = "RULE_OPTION_RAJ_RED_REPUBLIC"
+		desc = "RULE_OPTION_RAJ_RED_REPUBLIC_DESC"
+	}
+	option = {
+		name = PEOPLES_FRONT
+		text = "RULE_OPTION_RAJ_PEOPLES_FRONT"
+		desc = "RULE_OPTION_RAJ_PEOPLES_FRONT_DESC"
+	}
+	option = {
+		name = WESTERN_ALIGNMENT
+		text = "RULE_OPTION_RAJ_WESTERN_ALIGNMENT"
+		desc = "RULE_OPTION_RAJ_WESTERN_ALIGNMENT_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 ROM_ai_behavior = {
 	name = "ROM_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_ROM_HISTORICAL"
@@ -3494,64 +2866,9 @@ ROM_ai_behavior = {
 	}
 }
 
-SOV_ai_behavior = {
-	name = "SOV_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_SOV_HISTORICAL"
-		desc = "RULE_OPTION_SOV_HISTORICAL_DESC"
-	}
-	option = {
-		name = OLIGARCHS
-		text = "RULE_OPTION_SOV_OLIGARCHS"
-		desc = "RULE_OPTION_SOV_OLIGARCHS_DESC"
-	}
-	option = {
-		name = LIBERAL_REFORM
-		text = "RULE_OPTION_SOV_LIBERAL_REFORM"
-		desc = "RULE_OPTION_SOV_LIBERAL_REFORM_DESC"
-	}
-	option = {
-		name = COMMUNIST_REVIVAL
-		text = "RULE_OPTION_SOV_COMMUNIST_REVIVAL"
-		desc = "RULE_OPTION_SOV_COMMUNIST_REVIVAL_DESC"
-	}
-	option = {
-		name = NATIONALIST
-		text = "RULE_OPTION_SOV_NATIONALIST"
-		desc = "RULE_OPTION_SOV_NATIONALIST_DESC"
-	}
-	option = {
-		name = NATIONAL_BOLSHEVIK
-		text = "RULE_OPTION_SOV_NATIONAL_BOLSHEVIK"
-		desc = "RULE_OPTION_SOV_NATIONAL_BOLSHEVIK_DESC"
-	}
-	option = {
-		name = MEDVEDEV_HARDLINE
-		text = "RULE_OPTION_SOV_MEDVEDEV_HARDLINE"
-		desc = "RULE_OPTION_SOV_MEDVEDEV_HARDLINE_DESC"
-	}
-	option = {
-		name = MEDVEDEV_LIBERAL
-		text = "RULE_OPTION_SOV_MEDVEDEV_LIBERAL"
-		desc = "RULE_OPTION_SOV_MEDVEDEV_LIBERAL_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
 SAU_ai_behavior = {
 	name = "SAU_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = HISTORICAL
 		text = "RULE_OPTION_SAU_HISTORICAL"
@@ -3604,39 +2921,9 @@ SAU_ai_behavior = {
 	}
 }
 
-SOL_ai_behavior = {
-	name = "SOL_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = SOL_DYNAMIC
-		text = "RULE_OPTION_SOL_DYNAMIC"
-		desc = "RULE_OPTION_SOL_DYNAMIC_AI_DESC"
-	}
-	option = {
-		name = SOL_AUSTRALIAN_PEACE
-		text = "RULE_OPTION_AUSTRALIAN_PEACE"
-		desc = "RULE_OPTION_AUSTRALIAN_PEACE_AI_DESC"
-	}
-	option = {
-		name = SOL_SOLOMON_BILL_FAILS_RASTA_COUP
-		text = "RULE_OPTION_SOLOMON_BILL_FAILS_RASTA_COUP"
-		desc = "RULE_OPTION_SOLOMON_BILL_FAILS_RASTA_COUP_AI_DESC"
-	}
-	option = {
-		name = SOL_AST_REJECTS_TEE_REBEL
-		text = "RULE_OPTION_AST_REJECTS_TEE_REBEL"
-		desc = "RULE_OPTION_AST_REJECTS_TEE_REBEL_AI_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
 SER_ai_behavior = {
 	name = "SER_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3681,7 +2968,7 @@ SER_ai_behavior = {
 
 SIA_ai_behavior = {
 	name = "SIA_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3716,7 +3003,7 @@ SIA_ai_behavior = {
 
 SIN_ai_behavior = {
 	name = "SIN_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3749,9 +3036,94 @@ SIN_ai_behavior = {
 	}
 }
 
+SOL_ai_behavior = {
+	name = "SOL_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = SOL_DYNAMIC
+		text = "RULE_OPTION_SOL_DYNAMIC"
+		desc = "RULE_OPTION_SOL_DYNAMIC_AI_DESC"
+	}
+	option = {
+		name = SOL_AUSTRALIAN_PEACE
+		text = "RULE_OPTION_AUSTRALIAN_PEACE"
+		desc = "RULE_OPTION_AUSTRALIAN_PEACE_AI_DESC"
+	}
+	option = {
+		name = SOL_SOLOMON_BILL_FAILS_RASTA_COUP
+		text = "RULE_OPTION_SOLOMON_BILL_FAILS_RASTA_COUP"
+		desc = "RULE_OPTION_SOLOMON_BILL_FAILS_RASTA_COUP_AI_DESC"
+	}
+	option = {
+		name = SOL_AST_REJECTS_TEE_REBEL
+		text = "RULE_OPTION_AST_REJECTS_TEE_REBEL"
+		desc = "RULE_OPTION_AST_REJECTS_TEE_REBEL_AI_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
+SOV_ai_behavior = {
+	name = "SOV_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_SOV_HISTORICAL"
+		desc = "RULE_OPTION_SOV_HISTORICAL_DESC"
+	}
+	option = {
+		name = OLIGARCHS
+		text = "RULE_OPTION_SOV_OLIGARCHS"
+		desc = "RULE_OPTION_SOV_OLIGARCHS_DESC"
+	}
+	option = {
+		name = LIBERAL_REFORM
+		text = "RULE_OPTION_SOV_LIBERAL_REFORM"
+		desc = "RULE_OPTION_SOV_LIBERAL_REFORM_DESC"
+	}
+	option = {
+		name = COMMUNIST_REVIVAL
+		text = "RULE_OPTION_SOV_COMMUNIST_REVIVAL"
+		desc = "RULE_OPTION_SOV_COMMUNIST_REVIVAL_DESC"
+	}
+	option = {
+		name = NATIONALIST
+		text = "RULE_OPTION_SOV_NATIONALIST"
+		desc = "RULE_OPTION_SOV_NATIONALIST_DESC"
+	}
+	option = {
+		name = NATIONAL_BOLSHEVIK
+		text = "RULE_OPTION_SOV_NATIONAL_BOLSHEVIK"
+		desc = "RULE_OPTION_SOV_NATIONAL_BOLSHEVIK_DESC"
+	}
+	option = {
+		name = MEDVEDEV_HARDLINE
+		text = "RULE_OPTION_SOV_MEDVEDEV_HARDLINE"
+		desc = "RULE_OPTION_SOV_MEDVEDEV_HARDLINE_DESC"
+	}
+	option = {
+		name = MEDVEDEV_LIBERAL
+		text = "RULE_OPTION_SOV_MEDVEDEV_LIBERAL"
+		desc = "RULE_OPTION_SOV_MEDVEDEV_LIBERAL_DESC"
+	}
+	option = {
+		name = RANDOM_PATH
+		text = "RULE_OPTION_MD_RANDOM_PATH"
+		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
+	}
+	default = {
+		name = NO_PATH
+		text = "RULE_OPTION_MD_NO_PATH"
+		desc = "RULE_OPTION_MD_NO_PATH_DESC"
+	}
+}
+
 SPR_ai_behavior = {
 	name = "SPR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3801,7 +3173,7 @@ SPR_ai_behavior = {
 
 SWE_ai_behavior = {
 	name = "SWE_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -3834,114 +3206,9 @@ SWE_ai_behavior = {
 	}
 }
 
-DEN_ai_behavior = {
-	name = "DEN_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_DEN_HISTORICAL"
-		desc = "RULE_OPTION_DEN_HISTORICAL_DESC"
-	}
-	option = {
-		name = EUROPEAN_UNION
-		text = "RULE_OPTION_DEN_EUROPEAN_UNION"
-		desc = "RULE_OPTION_DEN_EUROPEAN_UNION_DESC"
-	}
-	option = {
-		name = EUROSCEPTIC
-		text = "RULE_OPTION_DEN_EUROSCEPTIC"
-		desc = "RULE_OPTION_DEN_EUROSCEPTIC_DESC"
-	}
-	option = {
-		name = SOCIALIST
-		text = "RULE_OPTION_DEN_SOCIALIST"
-		desc = "RULE_OPTION_DEN_SOCIALIST_DESC"
-	}
-	option = {
-		name = MONARCHIST
-		text = "RULE_OPTION_DEN_MONARCHIST"
-		desc = "RULE_OPTION_DEN_MONARCHIST_DESC"
-	}
-	option = {
-		name = NATIONALIST
-		text = "RULE_OPTION_DEN_NATIONALIST"
-		desc = "RULE_OPTION_DEN_NATIONALIST_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
-GRN_ai_behavior = {
-	name = "GRN_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_GRN_HISTORICAL"
-		desc = "RULE_OPTION_GRN_HISTORICAL_DESC"
-	}
-	option = {
-		name = SCANDINAVIAN_SERENITY
-		text = "RULE_OPTION_GRN_SCANDINAVIAN_SERENITY"
-		desc = "RULE_OPTION_GRN_SCANDINAVIAN_SERENITY_DESC"
-	}
-	option = {
-		name = CONTINENTAL_HEGEMONY
-		text = "RULE_OPTION_GRN_CONTINENTAL_HEGEMONY"
-		desc = "RULE_OPTION_GRN_CONTINENTAL_HEGEMONY_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
-NRY_ai_behavior = {
-	name = "NRY_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_NRY_HISTORICAL"
-		desc = "RULE_OPTION_NRY_HISTORICAL_DESC"
-	}
-	option = {
-		name = CHRISTIAN_PEOPLES
-		text = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES"
-		desc = "RULE_OPTION_NRY_CHRISTIAN_PEOPLES_DESC"
-	}
-	option = {
-		name = PROGRESS
-		text = "RULE_OPTION_NRY_PROGRESS"
-		desc = "RULE_OPTION_NRY_PROGRESS_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
 SWI_ai_behavior = {
 	name = "SWI_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = RANDOM
 		text = "RULE_OPTION_RANDOM"
@@ -3966,7 +3233,7 @@ SWI_ai_behavior = {
 
 SYR_ai_behavior = {
 	name = "SYR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -4011,7 +3278,7 @@ SYR_ai_behavior = {
 
 TUR_ai_behavior = {
 	name = "TUR_AI_BEHAVIOR_MD"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = TUR_HISTORICAL
 		text = "RULE_OPTION_TUR_HISTORICAL"
@@ -4056,7 +3323,7 @@ TUR_ai_behavior = {
 
 UKR_ai_behavior = {
 	name = "UKR_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -4111,7 +3378,7 @@ UKR_ai_behavior = {
 
 USA_ai_behavior = {
 	name = "USA_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -4171,7 +3438,7 @@ USA_ai_behavior = {
 
 USB_ai_behavior = {
 	name = "USB_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = DEFAULT
 		text = "RULE_OPTION_DEFAULT"
@@ -4211,7 +3478,7 @@ USB_ai_behavior = {
 
 VEN_ai_behavior = {
 	name = "VEN_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
+	group = "MD_AI_RULES"
 	option = {
 		name = VEN_CHAVISMO_CONTINUES
 		text = "RULE_VEN_CHAVISMO_CONTINUES"
@@ -4243,178 +3510,444 @@ VEN_ai_behavior = {
 		desc = "RULE_OPTION_MD_NO_PATH_DESC"
 	}
 }
-RAJ_ai_behavior = {
-	name = "RAJ_AI_BEHAVIOR"
-	group = "RULE_GROUP_AI_BEHAVIOR"
-	option = {
-		name = HISTORICAL
-		text = "RULE_OPTION_RAJ_HISTORICAL"
-		desc = "RULE_OPTION_RAJ_HISTORICAL_DESC"
-	}
-	option = {
-		name = GREATER_INDIA
-		text = "RULE_OPTION_RAJ_GREATER_INDIA"
-		desc = "RULE_OPTION_RAJ_GREATER_INDIA_DESC"
-	}
-	option = {
-		name = RED_REPUBLIC
-		text = "RULE_OPTION_RAJ_RED_REPUBLIC"
-		desc = "RULE_OPTION_RAJ_RED_REPUBLIC_DESC"
-	}
-	option = {
-		name = PEOPLES_FRONT
-		text = "RULE_OPTION_RAJ_PEOPLES_FRONT"
-		desc = "RULE_OPTION_RAJ_PEOPLES_FRONT_DESC"
-	}
-	option = {
-		name = WESTERN_ALIGNMENT
-		text = "RULE_OPTION_RAJ_WESTERN_ALIGNMENT"
-		desc = "RULE_OPTION_RAJ_WESTERN_ALIGNMENT_DESC"
-	}
-	option = {
-		name = RANDOM_PATH
-		text = "RULE_OPTION_MD_RANDOM_PATH"
-		desc = "RULE_OPTION_MD_RANDOM_PATH_DESC"
-	}
-	default = {
-		name = NO_PATH
-		text = "RULE_OPTION_MD_NO_PATH"
-		desc = "RULE_OPTION_MD_NO_PATH_DESC"
-	}
-}
-
-
-# TIME FOR CHAOS
-rule_randomize_ideologies = {
-	name = "RULE_RANDOM_IDEOLOGIES"
-	group = "MD_RANDOM_RULES"
-	icon = "GFX_production_licenses"
+# PEACE CONFERENCES
+rule_md_annex = {
+	name = "RULE_ALLOW_MD_ANNEX"
+	group = "MD_PEACE_DEALS"
+	icon = "GFX_take_over_faction_leadership"
 	default = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_RANDOM_IDEOLOGIES_NO_DESC"
+		desc = "RULE_OPTION_MD_ANNEX_NO_DESC"
 	}
 	option = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_RANDOM_IDEOLOGIES_YES_DESC"
+		desc = "RULE_OPTION_MD_ANNEX_YES_DESC"
 	}
 }
-rule_randomize_religion = {
-	name = "RULE_RANDOM_RELIGION"
-	group = "MD_RANDOM_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_RANDOM_RELIGION_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_RANDOM_RELIGION_YES_DESC"
-	}
-}
-rule_randomize_internal_factions = {
-	name = "RULE_RANDOM_INTERNAL_FACTIONS"
-	group = "MD_RANDOM_RULES"
-	icon = "GFX_production_licenses"
-	default = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_RANDOM_INTERNAL_FACTIONS_NO_DESC"
-	}
-	option = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_RANDOM_INTERNAL_FACTIONS_YES_DESC"
-	}
-}
-rule_disable_generals_getting_killed = {
-	name = "RULE_DISABLE_GENERALS_KILLED"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_production_licenses"
 
+allow_chaotic_PC = {
+	name = "RULE_ALLOW_CHAOTIC_PEACE_CONFERENCE"
+	group = "MD_PEACE_DEALS"
+	icon = "GFX_take_over_faction_leadership"
 	default = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_ENABLE_GENERALS_KILLED_DESC"
+		desc = "RULE_OPTION_CHAOTIC_PC_NO_DESC"
 	}
 	option = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_DISABLE_GENERALS_KILLED_DESC"
+		desc = "RULE_OPTION_CHAOTIC_PC_YES_DESC"
 	}
 }
-rule_free_factories_amount = {
-	name = "RULE_FREE_FACTORIES_AMOUNT"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_production_licenses"
 
+allow_player_led_PC = {
+	name = "RULE_ALLOW_PLAYER_LED_PEACE_CONFERENCE"
+	group = "MD_PEACE_DEALS"
+	icon = "GFX_coups"
 	default = {
 		name = no
-		text = "RULE_FREE_FACTORIES_AMOUNT_OFF"
-		desc = "RULE_FREE_FACTORIES_AMOUNT_OFF_DESC"
+		text = "RULE_OPTION_NO"
+		desc = "RULE_OPTION_PLAYER_LED_PC_NO_DESC"
 	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_OPTION_PLAYER_LED_PC_YES_DESC"
+	}
+}
+
+allowed_CPD = {
+	name = "RULE_ALLOW_CONDITIONAL_PEACE_DEAL"
+	group = "MD_PEACE_DEALS"
+	icon = "GFX_take_over_faction_leadership"
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_OPTION_CONDITIONAL_PEACE_DEAL_YES_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_OPTION_CONDITIONAL_PEACE_DEAL_NO_DESC"
+		allow_achievements = yes
+	}
+}
+
+allowed_CPD_AI = {
+	name = "RULE_ALLOW_CPD_AI_OFFERS"
+	group = "MD_PEACE_DEALS"
+	icon = "GFX_take_over_faction_leadership"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_OPTION_CPD_AI_OFFERS_NO_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_OPTION_CPD_AI_OFFERS_YES_DESC"
+		allow_achievements = yes
+	}
+}
+# INFLUENCE SYSTEM
+rule_spread_influence_amount_gain = {
+	name = "RULE_SPREAD_INFLUENCE_AMOUNT_GAIN"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = gain_0_5_percent_spread
+		text = "RULE_SPREAD_INFLUENCE_GAIN_0_5"
+		desc = "RULE_SPREAD_INFLUENCE_GAIN_0_5_DESC"
+	}
+	option = {
+		name = gain_1_percent_spread
+		text = "RULE_SPREAD_INFLUENCE_GAIN_1"
+		desc = "RULE_SPREAD_INFLUENCE_GAIN_1_DESC"
+	}
+	default = {
+		name = gain_1_5_percent_spread
+		text = "RULE_SPREAD_INFLUENCE_GAIN_1_5"
+		desc = "RULE_SPREAD_INFLUENCE_GAIN_1_5_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = gain_2_percent_spread
+		text = "RULE_SPREAD_INFLUENCE_GAIN_2"
+		desc = "RULE_SPREAD_INFLUENCE_GAIN_2_DESC"
+	}
+	option = {
+		name = gain_3_percent_spread
+		text = "RULE_SPREAD_INFLUENCE_GAIN_3"
+		desc = "RULE_SPREAD_INFLUENCE_GAIN_3_DESC"
+	}
+	option = {
+		name = gain_4_percent_spread
+		text = "RULE_SPREAD_INFLUENCE_GAIN_4"
+		desc = "RULE_SPREAD_INFLUENCE_GAIN_4_DESC"
+	}
+}
+
+rule_spread_influence_cooldown_limits = {
+	name = "RULE_SPREAD_INFLUENCE_AMOUNT_COOLDOWN"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = spread_influence_0_days
+		text = "RULE_SPREAD_INFLUENCE_0_COOLDOWN"
+		desc = "RULE_SPREAD_INFLUENCE_0_COOLDOWN_DESC"
+	}
+	option = {
+		name = spread_influence_14_days
+		text = "RULE_SPREAD_INFLUENCE_14_COOLDOWN"
+		desc = "RULE_SPREAD_INFLUENCE_14_COOLDOWN_DESC"
+	}
+	default = {
+		name = spread_influence_30_days
+		text = "RULE_SPREAD_INFLUENCE_30_COOLDOWN"
+		desc = "RULE_SPREAD_INFLUENCE_30_COOLDOWN_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = spread_influence_60_days
+		text = "RULE_SPREAD_INFLUENCE_60_COOLDOWN"
+		desc = "RULE_SPREAD_INFLUENCE_60_COOLDOWN_DESC"
+		allow_achievements = yes
+	}
+}
+
+rule_invest_influence_amount_gain = {
+	name = "RULE_INVEST_INFLUENCE_AMOUNT_GAIN"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = gain_0_5_percent_invest
+		text = "RULE_INVEST_DEFAULT_GAIN_0_5"
+		desc = "RULE_INVEST_DEFAULT_GAIN_0_5_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = gain_1_percent_invest
+		text = "RULE_INVEST_DEFAULT_GAIN_1"
+		desc = "RULE_INVEST_DEFAULT_GAIN_1_DESC"
+		allow_achievements = yes
+	}
+	default = {
+		name = gain_1_5_percent_invest
+		text = "RULE_INVEST_DEFAULT_GAIN_1_5"
+		desc = "RULE_INVEST_DEFAULT_GAIN_1_5_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = gain_2_percent_invest
+		text = "RULE_INVEST_DEFAULT_GAIN_2"
+		desc = "RULE_INVEST_DEFAULT_GAIN_2_DESC"
+	}
+}
+
+rule_influence_cooldown_limits = {
+	name = "RULE_INFLUENCE_COOLDOWN"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = day_0_cooldown
+		text = "RULE_0_DAY_INFLUENCE"
+		desc = "RULE_0_DAY_INFLUENCE_DESC"
+	}
+	default = {
+		name = day_14_cooldown
+		text = "RULE_14_DAY_INFLUENCE"
+		desc = "RULE_14_DAY_INFLUENCE_DESC"
+	}
+	option = {
+		name = day_30_cooldown
+		text = "RULE_30_DAY_INFLUENCE"
+		desc = "RULE_30_DAY_INFLUENCE_DESC"
+	}
+}
+
+rule_monthly_domestic_independence_tick = {
+	name = "RULE_MONTHLY_DOMESTIC_INFLUENCE_TICK"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_TICK_NO_DESC"
+	}
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_TICK_YES_DESC"
+		allow_achievements = yes
+	}
+}
+
+rule_monthly_domestic_independence_gain_amount = {
+	name = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = amount_05_gain
+		text = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_05"
+		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_05_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = amount_10_gain
+		text = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_10"
+		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_10_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = amount_15_gain
+		text = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_15"
+		desc = "RULE_MONTHLY_DOMESTIC_INFLUENCE_GAIN_AMOUNT_15_DESC"
+		allow_achievements = yes
+	}
+}
+
+rule_disable_ai_influence_puppeting = {
+	name = "RULE_DISABLE_AI_INFLUENCE_PUPPETING"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_DISABLE_AI_INFLUENCE_PUPPETING_DESC"
+	}
+}
+
+rule_disable_coup_contest = {
+	name = "RULE_DISABLE_COUP_CONTEST"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_DISABLE_COUP_CONTEST_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_DISABLE_COUP_CONTEST_DESC"
+	}
+}
+
+rule_disable_western_outlook_features = {
+	name = "RULE_DISABLE_WESTERN_OUTLOOK_FEATURES"
+	group = "MD_INFLUENCE_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_DISABLE_WESTERN_OUTLOOK_FEATURES"
+	}
+}
+# ORGANIZATIONS
+rule_disable_eu = {
+	name = "RULE_DISABLE_EU"
+	group = "MD_ORGANISATION_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_DISABLE_EU_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_DISABLE_EU_DESC"
+	}
+}
+
+rule_european_union_voting_limits = {
+	name = "RULE_EUROPEAN_VOTING_COOLDOWN_LIMIT"
+	group = "MD_ORGANISATION_RULES"
+	icon = "GFX_production_licenses"
 	option = {
 		name = one
-		text = "RULE_FREE_FACTORIES_AMOUNT_ONE"
-		desc = "RULE_FREE_FACTORIES_AMOUNT_ONE_DESC"
+		text = "RULE_OPTION_EU_ONE"
+		desc = "RULE_OPTION_EU_ONE_DESC"
 		allow_achievements = no
 	}
 	option = {
-		name = two
-		text = "RULE_FREE_FACTORIES_AMOUNT_TWO"
-		desc = "RULE_FREE_FACTORIES_AMOUNT_TWO_DESC"
-		allow_achievements = no
+		name = sixty
+		text = "RULE_OPTION_EU_SIXTY"
+		desc = "RULE_OPTION_EU_SIXTY_DESC"
 	}
 	option = {
-		name = three
-		text = "RULE_FREE_FACTORIES_AMOUNT_THREE"
-		desc = "RULE_FREE_FACTORIES_AMOUNT_THREE_DESC"
-		allow_achievements = no
+		name = ninety
+		text = "RULE_OPTION_EU_NINETY"
+		desc = "RULE_OPTION_EU_NINETY_DESC"
+	}
+	default = {
+		name = one_hundred_twenty
+		text = "RULE_OPTION_EU_ONE_HUNDRED_TWENTY"
+		desc = "RULE_OPTION_EU_ONE_HUNDRED_TWENTY_DESC"
 	}
 	option = {
-		name = five
-		text = "RULE_FREE_FACTORIES_AMOUNT_FIVE"
-		desc = "RULE_FREE_FACTORIES_AMOUNT_FIVE_DESC"
-		allow_achievements = no
+		name = one_hundred_eighty
+		text = "RULE_OPTION_EU_ONE_HUNDRED_EIGHTY"
+		desc = "RULE_OPTION_EU_ONE_HUNDRED_EIGHTY_DESC"
+	}
+	option = {
+		name = two_hundred_ten
+		text = "RULE_OPTION_EU_TWO_HUNDRED_TEN"
+		desc = "RULE_OPTION_EU_TWO_HUNDRED_TEN_DESC"
 	}
 }
-rule_allow_MP_enhancements = {
-	name = "RULE_ALLOW_MP_ENHANCEMENTS"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_production_licenses"
 
+rule_european_union_expansion_focus = {
+	name = "RULE_EU_EXPANSION_FOCUS"
+	group = "MD_ORGANISATION_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = default
+		text = "RULE_EU_EXP_NO"
+		desc = "RULE_EU_EXP_NO_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_EU_EXP_YES"
+		desc = "RULE_EU_EXP_YES_DESC"
+		allow_achievements = yes
+	}
+}
+
+rule_enable_ai_european_union_end_game_paths = {
+	name = "RULE_AI_EU_END_GAME_PATHS"
+	group = "MD_ORGANISATION_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_AI_YES_EU_END_GAME_PATHS"
+	}
+	option = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_AI_NO_EU_END_GAME_PATHS"
+	}
+}
+
+rule_disable_nato = {
+	name = "RULE_DISABLE_NATO"
+	group = "MD_ORGANISATION_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_DISABLE_NATO_DESC"
+	}
 	default = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_NOT_ALLOW_MP_ENHANCEMENTS_DESC"
+		desc = "RULE_NO_DISABLE_NATO_DESC"
+	}
+}
+
+rule_disable_csto = {
+	name = "RULE_DISABLE_CSTO"
+	group = "MD_ORGANISATION_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_DISABLE_CSTO_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_DISABLE_CSTO_DESC"
+	}
+}
+# FLAGS & FORMABLE NATIONS
+rule_disable_formable_nations = {
+	name = "RULE_DISABLE_FORMABLE_NATIONS"
+	group = "MD_FORMABLE_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_FORMABLE_NATIONS_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_FORMABLE_NATIONS_DESC"
+	}
+}
+
+allow_edgy_flags = {
+	name = "RULE_ALLOW_EDGY_FLAGS"
+	group = "MD_FORMABLE_RULES"
+	icon = "GFX_leave_faction"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_ALLOW_EDGY_FLAGS_BLOCKED_DESC"
 	}
 	option = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_ALLOW_MP_ENHANCEMENTS_DESC"
+		desc = "RULE_ALLOW_EDGY_FLAGS_ALLOWED_DESC"
+		allow_achievements = yes
 	}
 }
-
-rule_enable_resource_storage_system = {
-	name = "RULE_ENABLE_RESOURCE_STORAGE_SYSTEM"
-	group = "MD_OPTIMISATION_RULES"
-	icon = "GFX_production_licenses"
-
-	default = {
-		name = yes
-		text = "RULE_OPTION_YES"
-		desc = "RULE_OPTION_ENABLE_RESOURCE_STORAGE_SYSTEM"
-	}
-	option = {
-		name = no
-		text = "RULE_OPTION_NO"
-		desc = "RULE_OPTION_DISABLE_RESOURCE_STORAGE_SYSTEM"
-	}
-}
-
+# CUSTOM SCENARIOS
 zombie_mode_enabled = {
 	name = "RULE_ZOMBIE_GAME_MODE"
 	group = "MD_CUSTOM_SCENARIO_RULES"
@@ -4585,42 +4118,549 @@ rule_event_horizon_scenario = {
 		desc = "RULE_EVENT_HORIZON_DELAYED_DESC"
 	}
 }
-
-AFG_taliban_insurgency_intensity = {
-	name = "RULE_AFG_TALIBAN_INSURGENCY_INTENSITY"
-	group = "MD_FOCUS_TREE_RULES"
+# TIME FOR CHAOS
+rule_randomize_ideologies = {
+	name = "RULE_RANDOM_IDEOLOGIES"
+	group = "MD_RANDOM_RULES"
 	icon = "GFX_production_licenses"
-
 	default = {
-		name = DEFAULT
-		text = "RULE_AFG_TALIBAN_INSURGENCY_DEFAULT"
-		desc = "RULE_AFG_TALIBAN_INSURGENCY_DEFAULT_DESC"
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_RANDOM_IDEOLOGIES_NO_DESC"
 	}
 	option = {
-		name = WEAK
-		text = "RULE_AFG_TALIBAN_INSURGENCY_WEAK"
-		desc = "RULE_AFG_TALIBAN_INSURGENCY_WEAK_DESC"
-	}
-	option = {
-		name = RELENTLESS
-		text = "RULE_AFG_TALIBAN_INSURGENCY_RELENTLESS"
-		desc = "RULE_AFG_TALIBAN_INSURGENCY_RELENTLESS_DESC"
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_RANDOM_IDEOLOGIES_YES_DESC"
 	}
 }
 
-AFG_northern_alliance_uprising = {
-	name = "RULE_AFG_NORTHERN_ALLIANCE_UPRISING"
-	group = "MD_FOCUS_TREE_RULES"
-	icon = "GFX_kick_from_faction"
+rule_randomize_religion = {
+	name = "RULE_RANDOM_RELIGION"
+	group = "MD_RANDOM_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_RANDOM_RELIGION_NO_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_RANDOM_RELIGION_YES_DESC"
+	}
+}
 
+rule_randomize_internal_factions = {
+	name = "RULE_RANDOM_INTERNAL_FACTIONS"
+	group = "MD_RANDOM_RULES"
+	icon = "GFX_production_licenses"
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_RANDOM_INTERNAL_FACTIONS_NO_DESC"
+	}
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_RANDOM_INTERNAL_FACTIONS_YES_DESC"
+	}
+}
+# CHEATS
+allow_cheat_decisions = {
+	name = "RULE_ALLOW_CHEAT_DECISIONS"
+	group = "MD_CHEAT_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ALLOW_CHEAT_DECISIONS_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ALLOW_CHEAT_DECISIONS_DESC"
+	}
+}
+
+allow_toggling_cheat_decisions = {
+	name = "RULE_ALLOW_TOGGLING_CHEAT_DECISIONS"
+	group = "MD_CHEAT_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ALLOW_TOGGLING_CHEAT_DECISIONS_DESC"
+	}
+}
+
+rule_disable_anti_bully = {
+	name = "RULE_DISABLE_ANTI_BULLY"
+	group = "MD_CHEAT_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_ANTI_BULLY_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_ANTI_BULLY_DESC"
+	}
+}
+
+rule_player_instant_justification = {
+	name = "RULE_PLAYER_INSTANT_JUSTIFICATION"
+	group = "MD_CHEAT_RULES"
+	icon = "GFX_production_licenses"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_PLAYER_INSTANT_JUSTIFICATION_DESC"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_PLAYER_INSTANT_JUSTIFICATION_DESC"
+	}
+}
+
+# VANILLA RULES
+# Vanilla rules keep their original group keys so base-game localisation applies.
+
+# Foreign Policy
+allow_wargoals = {
+	name = "RULE_ALLOW_WARGOALS"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_wargoals"
+	option = {
+		name = "ALWAYS_FREE"
+		text = RULE_OPTION_ALWAYS_FREE
+		desc = "RULE_ALLOW_WARGOALS_ALWAYS_FREE_DESC"
+	}
+	default = {
+		name = "LIMITED"
+		text = "RULE_OPTION_LIMITED"
+		desc = "RULE_ALLOW_WARGOALS_LIMITED_DESC"
+	}
+	option = {
+		name = "FREE_25"
+		text = RULE_OPTION_FREE_25
+		desc = "RULE_ALLOW_WARGOALS_FREE_25_DESC"
+	}
+	option = {
+		name = "FREE_50"
+		text = RULE_OPTION_FREE_50
+		desc = "RULE_ALLOW_WARGOALS_FREE_50_DESC"
+	}
+	option = {
+		name = "FREE_75"
+		text = RULE_OPTION_FREE_75
+		desc = "RULE_ALLOW_WARGOALS_FREE_75_DESC"
+	}
+	option = {
+		name = "FREE_100"
+		text = RULE_OPTION_FREE_100
+		desc = "RULE_ALLOW_WARGOALS_FREE_100_DESC"
+	}
+	option = {
+		name = "FOCUSES_ONLY"
+		text = RULE_OPTION_FOCUSES_ONLY
+		desc = "RULE_ALLOW_WARGOALS_FOCUSES_ONLY_DESC"
+	}
+}
+
+allow_access = {
+	name = "RULE_ALLOW_MILITARY_ACCESS"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_military_access_docking_rights"
+	default = {
+		name = "FREE"
+		text = RULE_OPTION_FREE
+		desc = "RULE_ALLOW_ACCESS_FREE_DESC"
+	}
+	option = {
+		name = "SAME_IDEOLOGY"
+		text = "RULE_OPTION_SAME_IDEOLOGY"
+		desc = "RULE_ALLOW_ACCESS_SAME_IDEOLOGY_DESC"
+	}
+	option = {
+		name = "BLOCKED"
+		text = RULE_OPTION_BLOCKED
+		desc = "RULE_ALLOW_ACCESS_BLOCKED_DESC"
+	}
+}
+
+allow_release_nations = {
+	name = "RULE_ALLOW_RELEASE_NATIONS"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_release_nations"
+	default = {
+		name = "FREE"
+		text = RULE_OPTION_FREE
+		desc = "RULE_ALLOW_RELEASE_NATIONS_FREE_DESC"
+	}
+	option = {
+		name = "PEACE_ONLY"
+		text = "RULE_OPTION_PEACE_ONLY"
+		desc = "RULE_ALLOW_RELEASE_NATIONS_PEACE_ONLY_DESC"
+	}
+	option = {
+		name = "BLOCKED"
+		text = RULE_OPTION_BLOCKED
+		desc = "RULE_ALLOW_RELEASE_NATIONS_BLOCKED_DESC"
+	}
+}
+
+allow_licensing = {
+	name = "RULE_ALLOW_LICENSING"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_production_licenses"
+	option = {
+		name = "FREE"
+		text = "RULE_OPTION_FREE"
+		desc = "RULE_ALLOW_LICENSING_FREE_DESC"
+	}
+	option = {
+		name = SAME_IDEOLOGY
+		text = "RULE_OPTION_SAME_IDEOLOGY"
+		desc = "RULE_ALLOW_LICENSING_SAME_IDEOLOGY_DESC"
+	}
+	option = {
+		name = SAME_FACTION
+		text = "RULE_OPTION_SAME_FACTION"
+		desc = "RULE_ALLOW_LICENSING_SAME_FACTION_DESC"
+	}
+	option = {
+		name = BLOCKED
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_LICENSING_BLOCKED_DESC"
+	}
+}
+
+allow_lend_lease = {
+	name = "RULE_ALLOW_LEND_LEASE"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_lend_lease"
+	option = {
+		name = "FREE"
+		text = "RULE_OPTION_FREE"
+		desc = "RULE_ALLOW_LEND_LEASE_FREE_DESC"
+	}
+	default = {
+		name = "LIMITED"
+		text = "RULE_OPTION_LIMITED"
+		desc = "RULE_ALLOW_LEND_LEASE_LIMITED_DESC"
+	}
+	option = {
+		name = SAME_IDEOLOGY
+		text = "RULE_OPTION_SAME_IDEOLOGY"
+		desc = "RULE_ALLOW_LEND_LEASE_SAME_IDEOLOGY_DESC"
+	}
+	option = {
+		name = SAME_FACTION
+		text = "RULE_OPTION_SAME_FACTION"
+		desc = "RULE_ALLOW_LEND_LEASE_SAME_FACTION_DESC"
+	}
+	option = {
+		name = BLOCKED
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_LEND_LEASE_BLOCKED_DESC"
+	}
+}
+
+allow_volunteers = {
+	name = "RULE_ALLOW_VOLUNTEERS"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_volunteers"
+	option = {
+		name = "ALWAYS_FREE"
+		text = "RULE_OPTION_FREE"
+		desc = "RULE_ALLOW_VOLUNTEERS_FREE_DESC"
+	}
+	default = {
+		name = "LIMITED"
+		text = "RULE_OPTION_LIMITED"
+		desc = "RULE_ALLOW_VOLUNTEERS_LIMITED_DESC"
+	}
+	option = {
+		name = SAME_IDEOLOGY
+		text = "RULE_OPTION_SAME_IDEOLOGY"
+		desc = "RULE_ALLOW_VOLUNTEERS_SAME_IDEOLOGY_DESC"
+	}
+	option = {
+		name = BLOCKED
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_VOLUNTEERS_BLOCKED_DESC"
+	}
+}
+
+allow_recall_intervention_forces = {
+	name = "RULE_ALLOW_RECALL_INTERVENTION_FORCES"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_volunteers"
 	default = {
 		name = yes
 		text = "RULE_OPTION_YES"
-		desc = "RULE_AFG_NORTHERN_ALLIANCE_UPRISING_ALLOWED_DESC"
+		desc = "RULE_YES_ALLOW_INTERVENTION_FORCES"
 	}
 	option = {
 		name = no
 		text = "RULE_OPTION_NO"
-		desc = "RULE_AFG_NORTHERN_ALLIANCE_UPRISING_BLOCKED_DESC"
+		desc = "RULE_NO_ALLOW_INTERVENTION_FORCES"
+		allow_achievements = yes
+	}
+}
+
+allow_forcing_a_white_peace = {
+	name = "RULE_ALLOW_FORCING_A_WHITE_PEACE"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_volunteers"
+	option = {
+		name = yes
+		text = "RULE_OPTION_YES"
+		desc = "RULE_YES_FORCING_A_WHITE_PEACE"
+	}
+	default = {
+		name = no
+		text = "RULE_OPTION_NO"
+		desc = "RULE_NO_FORCING_A_WHITE_PEACE"
+		allow_achievements = yes
+	}
+}
+
+allow_guarantees = {
+	name = "RULE_ALLOW_GUARANTEES"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_guarantee_independence"
+	option = {
+		name = "ALWAYS_FREE"
+		text = "RULE_OPTION_FREE"
+		desc = "RULE_ALLOW_GUARANTEES_FREE_DESC"
+	}
+	default = {
+		name = "LIMITED"
+		text = "RULE_OPTION_LIMITED"
+		desc = "RULE_ALLOW_GUARANTEES_LIMITED_DESC"
+	}
+	option = {
+		name = SAME_IDEOLOGY
+		text = "RULE_OPTION_SAME_IDEOLOGY"
+		desc = "RULE_ALLOW_GUARANTEES_SAME_IDEOLOGY_DESC"
+	}
+	option = {
+		name = BLOCKED
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_GUARANTEES_BLOCKED_DESC"
+	}
+}
+
+allow_revoke_guarantees = {
+	name = "RULE_ALLOW_REVOKE_GUARANTEES"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_revoke_guarantees"
+	default = {
+		name = "ALLOWED"
+		text = "RULE_OPTION_ALLOWED"
+		desc = "RULE_ALLOW_REVOKE_GUARANTEES_ALLOWED_DESC"
+	}
+	option = {
+		name = "BLOCKED"
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_REVOKE_GUARANTEES_BLOCKED_DESC"
+	}
+}
+
+allow_leave_faction = {
+	name = "RULE_ALLOW_LEAVE_FACTION"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_leave_faction"
+	default = {
+		name = "ALLOWED"
+		text = "RULE_OPTION_ALLOWED"
+		desc = "RULE_ALLOW_LEAVE_FACTION_ALLOWED_DESC"
+	}
+	option = {
+		name = "BLOCKED"
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_LEAVE_FACTION_BLOCKED_DESC"
+	}
+}
+
+allow_kick_faction = {
+	name = "RULE_ALLOW_KICK_FACTION"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_kick_from_faction"
+	option = {
+		name = "ALLOWED"
+		text = "RULE_OPTION_ALLOWED"
+		desc = "RULE_ALLOW_KICK_FACTION_ALLOWED_DESC"
+	}
+	option = {
+		name = "BLOCKED"
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_KICK_FACTION_BLOCKED_DESC"
+	}
+}
+
+allow_take_over_faction = {
+	name = "RULE_ALLOW_TAKE_OVER_FACTION"
+	group = "RULE_GROUP_GENERAL_FOREIGN_POLICY"
+	icon = "GFX_take_over_faction_leadership"
+	option = {
+		name = "ALLOWED"
+		text = "RULE_OPTION_ALLOWED"
+		desc = "RULE_ALLOW_TAKE_OVER_FACTION_ALLOWED_DESC"
+	}
+	option = {
+		name = "BLOCKED"
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_TAKE_OVER_FACTION_BLOCKED_DESC"
+	}
+}
+
+# UI
+obsolete_focus_branches_visibility = {
+	name = "OBSOLETE_FOCUS_BRANCHES_VISIBILITY"
+	group = "RULE_GROUP_GENERAL_UI"
+	default = {
+		name = HIDE
+		text = "RULE_OPTION_HIDE"
+		desc = "RULE_OPTION_HIDE_DESC"
+	}
+	option = {
+		name = SHOW
+		text = "RULE_OPTION_SHOW"
+		desc = "RULE_OPTION_SHOW_DESC_DESC"
+		allow_achievements = yes
+	}
+}
+
+# Covert Actions
+allow_coups = {
+	name = "RULE_ALLOW_COUPS"
+	group = "RULE_GROUP_COVERT_ACTIONS"
+	icon = "GFX_coups"
+	default = {
+		name = BLOCKED
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_COUPS_BLOCKED_DESC"
+	}
+	option = {
+		name = AI_ONLY
+		text = "RULE_OPTION_AI_ONLY"
+		desc = "RULE_ALLOW_COUPS_AI_ONLY_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = FREE
+		text = "RULE_OPTION_FREE"
+		desc = "RULE_ALLOW_COUPS_FREE_DESC"
+	}
+}
+
+allow_party_boosting = {
+	name = "RULE_ALLOW_PARTY_BOOSTING"
+	group = "RULE_GROUP_COVERT_ACTIONS"
+	icon = "GFX_boosting_party_popularity"
+	option = {
+		name = FREE
+		text = "RULE_OPTION_FREE"
+		desc = "RULE_ALLOW_PARTY_BOOSTING_FREE_DESC"
+	}
+	option = {
+		name = AI_ONLY
+		text = "RULE_OPTION_AI_ONLY"
+		desc = "RULE_ALLOW_PARTY_BOOSTING_AI_ONLY_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = PLAYER_ONLY
+		text = "RULE_OPTION_PLAYER_ONLY"
+		desc = "RULE_ALLOW_PARTY_BOOSTING_PLAYER_ONLY_DESC"
+	}
+	option = {
+		name = BLOCKED
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_PARTY_BOOSTING_BLOCKED_DESC"
+	}
+}
+
+# Gameplay
+allow_paratroopers = {
+	name = "RULE_ALLOW_PARATROOPERS"
+	group = "RULE_GROUP_GAMEPLAY"
+	icon = "GFX_paradrops"
+	option = {
+		name = yes
+		text = "RULE_OPTION_ALLOWED"
+		desc = "RULE_ALLOW_PARATROOPERS_ALLOWED_DESC"
+	}
+	option = {
+		name = no
+		text = "RULE_OPTION_BLOCKED"
+		desc = "RULE_ALLOW_PARATROOPERS_BLOCKED_DESC"
+	}
+}
+
+maximum_fort_level = {
+	name = "RULE_MAXIMUM_FORT_LEVEL"
+	group = "RULE_GROUP_GAMEPLAY"
+	icon = "GFX_maximum_fort_level"
+	option = {
+		name = normal
+		text = "RULE_OPTION_NORMAL"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_NORMAL_DESC"
+	}
+	option = {
+		name = level_1
+		text = "RULE_OPTION_1"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_2
+		text = "RULE_OPTION_2"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_3
+		text = "RULE_OPTION_3"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_4
+		text = "RULE_OPTION_4"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_5
+		text = "RULE_OPTION_5"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_6
+		text = "RULE_OPTION_6"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_7
+		text = "RULE_OPTION_7"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_8
+		text = "RULE_OPTION_8"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
+	}
+	option = {
+		name = level_9
+		text = "RULE_OPTION_9"
+		desc = "RULE_MAXIMUM_FORT_LEVEL_DESC"
 	}
 }

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -6,8 +6,7 @@
  MD_INFLUENCE_RULES: "Influence System Options"
  MD_ORGANISATION_RULES: "Organization Options"
  MD_FORMABLE_RULES: "Flags & Formable Nations"
- MD_RANDOM_RULES: "Randomize Game Rules"
- MD_CHEAT_RULES: "Cheat Options"
+ MD_CUSTOM_SCENARIO_RULES: "Custom Scenarios"
 
  # AI RULES
  RULE_HARD_AI_ECONOMIC: "Economic AI"

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -6,7 +6,6 @@
  MD_INFLUENCE_RULES: "Influence System Options"
  MD_ORGANISATION_RULES: "Organization Options"
  MD_FORMABLE_RULES: "Flags & Formable Nations"
- MD_CUSTOM_SCENARIO_RULES: "Custom Scenarios"
  MD_RANDOM_RULES: "Randomize Game Rules"
  MD_CHEAT_RULES: "Cheat Options"
 

--- a/localisation/english/MD_game_rules_l_english.yml
+++ b/localisation/english/MD_game_rules_l_english.yml
@@ -1,17 +1,14 @@
 ﻿l_english:
 
+ MD_RULES: "Millennium Dawn Options"
  MD_AI_RULES: "AI Options"
  MD_PEACE_DEALS: "Peace Conferences"
- MD_FOCUS_TREE_RULES: "Focus Tree Options"
- MD_FORMABLE_RULES: "Flags & Formable Nations"
- MD_ORGANISATION_RULES: "Organization Options"
  MD_INFLUENCE_RULES: "Influence System Options"
- MD_OPTIMISATION_RULES: "Optimization & Performance"
- MD_NUCLEAR_RULES: "Nuclear Rules"
- MD_RULES: "Miscellaneous Rules"
- MD_CHEAT_RULES: "Cheat Options"
- MD_RANDOM_RULES: "Randomize Game Rules"
+ MD_ORGANISATION_RULES: "Organization Options"
+ MD_FORMABLE_RULES: "Flags & Formable Nations"
  MD_CUSTOM_SCENARIO_RULES: "Custom Scenarios"
+ MD_RANDOM_RULES: "Randomize Game Rules"
+ MD_CHEAT_RULES: "Cheat Options"
 
  # AI RULES
  RULE_HARD_AI_ECONOMIC: "Economic AI"


### PR DESCRIPTION
## Bottom line
Reorganizes `common/game_rules/00_game_rules.txt` so like rules sit together, with a table of contents at the top and the two most overlapping MD groups merged into one.

## Why
The file grew by accretion: optimization rules were split across two places, per-country behaviour rules lived under a focus-tree group, and the country AI path rules were unsorted. New users had no way to see what was in the rules screen without scrolling 4600 lines.

## How
- Replaced the vanilla format-doc comment with a group table (in file order) and section headers that match it.
- Merged `MD_OPTIMISATION_RULES` into `MD_RULES` (`Millennium Dawn Options`), clustered into General / Performance & Multiplayer / Economy / Military / Country Content.
- Unified AI rules under `MD_AI_RULES` (`AI Options`): the five MD AI toggles, all country `*_ai_behavior` path rules, and the per-country behaviour rules (`BLR_union_state`, `GEO_*`, `PMR_sub`, `AFG_*`) that were under `MD_FOCUS_TREE_RULES`. Country rules are sorted A-Z by tag with sub-behaviours directly under their country. `rule_salafist_branch` moved to the general group and `MD_FOCUS_TREE_RULES` was dissolved.
- Vanilla rules stay under their original `RULE_GROUP_*` keys so base-game localisation applies, collected in one section at the bottom.
- English localisation: renamed the `MD_RULES` label, dropped the now-unused `MD_OPTIMISATION_RULES`/`MD_FOCUS_TREE_RULES` keys plus the stale `MD_NUCLEAR_RULES`, and ordered the group block to match the file.

Rule tokens are untouched, so every `has_game_rule` reference and save keeps working. Script-verified that all 158 rules survived, none duplicated, and no stale group keys remain.