### PR TITLE
Fix Doctrine Spirit Cancel (#3028)

### DIFF
--- a/.claude/docs/idea-reference.md
+++ b/.claude/docs/idea-reference.md
@@ -29,6 +29,7 @@ BRA_idea_higher_minimum_wage_1 = {
 - Drop the `available` block entirely in a category with no slot (`country`, `hidden_ideas`). Same reason: nothing picks from those, so `available` is never consulted. Use `cancel` if the idea should remove itself. Flagged by `validate_ideas.py` (`available-in-slotless-category`); the same stripper removes them in bulk
 - Keep `allowed = { always = no }` on slotted ideas that must not appear in the picker (religion, other laws). `add_idea` still applies them. Do not use it in slotless categories (`country`, `hidden_ideas`); that gate is dead and the validator flags it
 - Remove `cancel = { always = no }` (checked hourly, never true)
+- A slotted idea whose `available` can turn false mid-game needs a mirrored `cancel` with the negated condition. `available` gates picking only — the engine never strips an already-slotted idea when it goes false — and the spirit categories are `removal_cost = -1`, so the player cannot un-pick it either. `cancel` is checked hourly and frees the slot. Precedent: the doctrine-gated office core spirits in `common/ideas/zzz_{army,navy,air}_spirits.txt`
 - Remove empty `on_add = { log = "" }` unless actually doing something
 - Tiered ideas use suffix numbering: `TAG_idea_name_1`, `TAG_idea_name_2`, with shared `name = TAG_idea_name` for display
 - `name = X` redirects **both** name and description loc lookups — game reads `X` for the displayed name and `X_desc` for the tooltip body. The idea's own ID is no longer used for loc once `name =` is set.

--- a/common/ideas/zzz_air_spirits.txt
+++ b/common/ideas/zzz_air_spirits.txt
@@ -16,6 +16,7 @@ ideas = {
 			}
 			research_bonus = { CAT_large_plane = 0.15 }
 			available = { has_doctrine = strategic_destruction }
+			cancel = { NOT = { has_doctrine = strategic_destruction } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -28,6 +29,7 @@ ideas = {
 			}
 			research_bonus = { CAT_medium_plane = 0.15 }
 			available = { has_doctrine = air_battlefield_support }
+			cancel = { NOT = { has_doctrine = air_battlefield_support } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -40,6 +42,7 @@ ideas = {
 			}
 			research_bonus = { CAT_medium_plane = 0.15 }
 			available = { has_doctrine = air_supremacy }
+			cancel = { NOT = { has_doctrine = air_supremacy } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -52,6 +55,7 @@ ideas = {
 			}
 			research_bonus = { CAT_small_plane = 0.15 }
 			available = { has_doctrine = local_airspace_defense }
+			cancel = { NOT = { has_doctrine = local_airspace_defense } }
 			ai_will_do = { base = 1.5 }
 		}
 
@@ -67,6 +71,7 @@ ideas = {
 				CAT_medium_plane = 0.15
 			}
 			available = { has_doctrine = carrier_operations }
+			cancel = { NOT = { has_doctrine = carrier_operations } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -78,6 +83,7 @@ ideas = {
 			}
 			research_bonus = { CAT_heli = 0.15 }
 			available = { has_doctrine = heavy_gunships }
+			cancel = { NOT = { has_doctrine = heavy_gunships } }
 			ai_will_do = { base = 1 }
 		}
 

--- a/common/ideas/zzz_army_spirits.txt
+++ b/common/ideas/zzz_army_spirits.txt
@@ -263,6 +263,7 @@ ideas = {
 				experience_gain_army_factor = -0.10
 			}
 			available = { has_doctrine = combined_arms }
+			cancel = { NOT = { has_doctrine = combined_arms } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -276,6 +277,7 @@ ideas = {
 				experience_gain_army_factor = -0.10
 			}
 			available = { has_doctrine = shock_and_awe }
+			cancel = { NOT = { has_doctrine = shock_and_awe } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -288,6 +290,7 @@ ideas = {
 				unit_Mot_Inf_Bat_design_cost_factor = -0.50
 			}
 			available = { has_doctrine = defence_in_depth }
+			cancel = { NOT = { has_doctrine = defence_in_depth } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -309,6 +312,16 @@ ideas = {
 					has_doctrine = special_forces_ranger_focus
 				}
 			}
+			cancel = {
+				NOT = {
+					OR = {
+						has_doctrine = special_forces_mixed
+						has_doctrine = special_forces_marine_focus
+						has_doctrine = special_forces_airborne_focus
+						has_doctrine = special_forces_ranger_focus
+					}
+				}
+			}
 			ai_will_do = { base = 1 }
 		}
 
@@ -325,6 +338,7 @@ ideas = {
 				extra_paratrooper_supply_grace = 24
 			}
 			available = { has_doctrine = special_forces_airborne_focus }
+			cancel = { NOT = { has_doctrine = special_forces_airborne_focus } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -337,6 +351,7 @@ ideas = {
 				unit_Mot_Militia_Bat_design_cost_factor = -0.50
 			}
 			available = { has_doctrine = guerrilla_warfare }
+			cancel = { NOT = { has_doctrine = guerrilla_warfare } }
 			ai_will_do = { base = 1 }
 		}
 

--- a/common/ideas/zzz_navy_spirits.txt
+++ b/common/ideas/zzz_navy_spirits.txt
@@ -150,6 +150,7 @@ ideas = {
 			}
 			research_bonus = { CAT_corvette = 0.20 }
 			available = { has_doctrine = green_water }
+			cancel = { NOT = { has_doctrine = green_water } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -161,6 +162,7 @@ ideas = {
 			}
 			research_bonus = { CAT_frigate = 0.20 }
 			available = { has_doctrine = green_water }
+			cancel = { NOT = { has_doctrine = green_water } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -172,6 +174,7 @@ ideas = {
 			}
 			research_bonus = { CAT_corvette = 0.20 }
 			available = { has_doctrine = jeune_ecole }
+			cancel = { NOT = { has_doctrine = jeune_ecole } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -185,6 +188,7 @@ ideas = {
 			}
 			research_bonus = { CAT_cruiser = 0.20 }
 			available = { has_doctrine = blue_water }
+			cancel = { NOT = { has_doctrine = blue_water } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -197,6 +201,7 @@ ideas = {
 			}
 			research_bonus = { CAT_sub = 0.20 }
 			available = { has_doctrine = guerre_de_course }
+			cancel = { NOT = { has_doctrine = guerre_de_course } }
 			ai_will_do = { base = 1 }
 		}
 
@@ -209,6 +214,7 @@ ideas = {
 			}
 			research_bonus = { CAT_carrier = 0.20 }
 			available = { has_doctrine = blue_water }
+			cancel = { NOT = { has_doctrine = blue_water } }
 			ai_will_do = { base = 1 }
 		}
 


### PR DESCRIPTION
### Changes
- Doctrine-themed army, navy, and air office core spirits now clear themselves when a country switches away from the grand doctrine or subdoctrine they belong to, freeing the slot for a re-pick instead of paying out as a permanent legacy bonus

Closes #3028