### PR TITLE
Rebalance naval reactor cost scaling

### DIFF
--- a/common/units/equipment/modules/MD_ship_modules.txt
+++ b/common/units/equipment/modules/MD_ship_modules.txt
@@ -1241,7 +1241,7 @@ equipment_modules = {
 		multiply_stats = {
 			build_cost_ic = 0.24
 			sub_visibility = -0.04
-			fuel_consumption = 0.4
+			fuel_consumption = 0.05
 		}
 
 		dismantle_cost_ic = 72

--- a/common/units/equipment/modules/MD_ship_modules.txt
+++ b/common/units/equipment/modules/MD_ship_modules.txt
@@ -1264,19 +1264,20 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 15
 			naval_range = 20000
+			build_cost_ic = 800
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.20
+			build_cost_ic = 0.15
 			fuel_consumption = -1.0
 			sub_visibility = 0.25
 		}
 
-		dismantle_cost_ic = 48
+		dismantle_cost_ic = 100
 
 		can_convert_from = {
 			module_category = module_sub_power_source_category
-			convert_cost_ic = 480
+			convert_cost_ic = 1000
 		}
 
 		critical_parts = { damaged_reactor }
@@ -1288,24 +1289,25 @@ equipment_modules = {
 		parent = module_sub_early_reactor_power
 		add_stats = {
 			naval_speed = 16
-			naval_range = 20000
+			naval_range = 22000
+			build_cost_ic = 950
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.25
+			build_cost_ic = 0.145
 			fuel_consumption = -1.0
 			sub_visibility = 0.2
 		}
 
-		dismantle_cost_ic = 64
+		dismantle_cost_ic = 150
 
 		can_convert_from = {
 			module_category = module_sub_power_source_category
-			convert_cost_ic = 640
+			convert_cost_ic = 1500
 		}
 		can_convert_from = {
 			module = module_sub_early_reactor_power
-			convert_cost_ic = 400
+			convert_cost_ic = 1000
 		}
 
 		critical_parts = { damaged_reactor }
@@ -1317,24 +1319,25 @@ equipment_modules = {
 		parent = module_sub_adv_reactor_power
 		add_stats = {
 			naval_speed = 17
-			naval_range = 20000
+			naval_range = 24000
+			build_cost_ic = 1100
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.30
+			build_cost_ic = 0.14
 			fuel_consumption = -1.0
 			sub_visibility = 0.15
 		}
 
-		dismantle_cost_ic = 80
+		dismantle_cost_ic = 200
 
 		can_convert_from = {
 			module_category = module_sub_power_source_category
-			convert_cost_ic = 800
+			convert_cost_ic = 2000
 		}
 		can_convert_from = {
 			module = module_sub_adv_reactor_power
-			convert_cost_ic = 480
+			convert_cost_ic = 1250
 		}
 
 		critical_parts = { damaged_reactor }
@@ -1346,24 +1349,25 @@ equipment_modules = {
 		parent = module_sub_mod_reactor_power
 		add_stats = {
 			naval_speed = 18
-			naval_range = 20000
+			naval_range = 26000
+			build_cost_ic = 1250
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.35
+			build_cost_ic = 0.135
 			fuel_consumption = -1.0
 			sub_visibility = 0.1
 		}
 
-		dismantle_cost_ic = 96
+		dismantle_cost_ic = 250
 
 		can_convert_from = {
 			module_category = module_sub_power_source_category
-			convert_cost_ic = 960
+			convert_cost_ic = 2500
 		}
 		can_convert_from = {
 			module = module_sub_mod_reactor_power
-			convert_cost_ic = 560
+			convert_cost_ic = 1500
 		}
 
 		critical_parts = { damaged_reactor }
@@ -1375,24 +1379,25 @@ equipment_modules = {
 		parent = module_sub_mod_reactor_power
 		add_stats = {
 			naval_speed = 19
-			naval_range = 20000
+			naval_range = 28000
+			build_cost_ic = 1400
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.28
+			build_cost_ic = 0.13
 			fuel_consumption = -1.0
 			sub_visibility = 0.05
 		}
 
-		dismantle_cost_ic = 112
+		dismantle_cost_ic = 300
 
 		can_convert_from = {
 			module_category = module_sub_power_source_category
-			convert_cost_ic = 1120
+			convert_cost_ic = 3000
 		}
 		can_convert_from = {
 			module = module_sub_mod_reactor_power
-			convert_cost_ic = 640
+			convert_cost_ic = 1750
 		}
 
 		critical_parts = { damaged_reactor }
@@ -1404,23 +1409,24 @@ equipment_modules = {
 		parent = module_sub_fut_reactor_power2
 		add_stats = {
 			naval_speed = 20
-			naval_range = 20000
+			naval_range = 30000
+			build_cost_ic = 1550
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.32
+			build_cost_ic = 0.125
 			fuel_consumption = -1.0
 		}
 
-		dismantle_cost_ic = 128
+		dismantle_cost_ic = 350
 
 		can_convert_from = {
 			module_category = module_sub_power_source_category
-			convert_cost_ic = 1280
+			convert_cost_ic = 3500
 		}
 		can_convert_from = {
 			module = module_sub_fut_reactor_power2
-			convert_cost_ic = 720
+			convert_cost_ic = 2000
 		}
 
 		critical_parts = { damaged_reactor }

--- a/common/units/equipment/modules/MD_ship_modules.txt
+++ b/common/units/equipment/modules/MD_ship_modules.txt
@@ -707,10 +707,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 22
 			naval_range = 21500
-			build_cost_ic = 1000
+			build_cost_ic = 1150
 		}
 		multiply_stats = {
-			build_cost_ic = 0.19
+			build_cost_ic = 0.155
 			fuel_consumption = -1.0
 		}
 
@@ -735,10 +735,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 23
 			naval_range = 23000
-			build_cost_ic = 1000
+			build_cost_ic = 1300
 		}
 		multiply_stats = {
-			build_cost_ic = 0.22
+			build_cost_ic = 0.15
 			fuel_consumption = -1.0
 		}
 
@@ -763,10 +763,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 24
 			naval_range = 24500
-			build_cost_ic = 1000
+			build_cost_ic = 1450
 		}
 		multiply_stats = {
-			build_cost_ic = 0.25
+			build_cost_ic = 0.145
 			fuel_consumption = -1.0
 		}
 
@@ -815,11 +815,11 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 20
 			naval_range = 22000
-			build_cost_ic = 2000
+			build_cost_ic = 2250
 		}
 
 		multiply_stats = {
-			build_cost_ic = 0.17
+			build_cost_ic = 0.145
 			fuel_consumption = -1.0
 		}
 
@@ -844,10 +844,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 21
 			naval_range = 24000
-			build_cost_ic = 2000
+			build_cost_ic = 2500
 		}
 		multiply_stats = {
-			build_cost_ic = 0.19
+			build_cost_ic = 0.14
 			fuel_consumption = -1.0
 		}
 
@@ -872,10 +872,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 22
 			naval_range = 26000
-			build_cost_ic = 2000
+			build_cost_ic = 2750
 		}
 		multiply_stats = {
-			build_cost_ic = 0.21
+			build_cost_ic = 0.135
 			fuel_consumption = -1.0
 		}
 
@@ -900,10 +900,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 23
 			naval_range = 28000
-			build_cost_ic = 2000
+			build_cost_ic = 3000
 		}
 		multiply_stats = {
-			build_cost_ic = 0.23
+			build_cost_ic = 0.13
 			fuel_consumption = -1.0
 		}
 
@@ -928,10 +928,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 24
 			naval_range = 30000
-			build_cost_ic = 2000
+			build_cost_ic = 3250
 		}
 		multiply_stats = {
-			build_cost_ic = 0.25
+			build_cost_ic = 0.125
 			fuel_consumption = -1.0
 		}
 
@@ -983,10 +983,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 23
 			naval_range = 32500
-			build_cost_ic = 1600
+			build_cost_ic = 1850
 		}
 		multiply_stats = {
-			build_cost_ic = 0.27
+			build_cost_ic = 0.245
 			fuel_consumption = -1.0
 			reliability = 0.06
 		}
@@ -1011,10 +1011,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 24
 			naval_range = 35000
-			build_cost_ic = 1600
+			build_cost_ic = 2100
 		}
 		multiply_stats = {
-			build_cost_ic = 0.29
+			build_cost_ic = 0.24
 			fuel_consumption = -1.0
 			reliability = 0.08
 		}
@@ -1039,10 +1039,10 @@ equipment_modules = {
 		add_stats = {
 			naval_speed = 25
 			naval_range = 37500
-			build_cost_ic = 1600
+			build_cost_ic = 2350
 		}
 		multiply_stats = {
-			build_cost_ic = 0.31
+			build_cost_ic = 0.235
 			fuel_consumption = -1.0
 			reliability = 0.1
 		}


### PR DESCRIPTION
Closes #3137

The submarine nuclear reactors were never brought onto the model the surface reactors got in #2827. Doing that surfaced a second problem the surface pass itself carries, so this fixes both.

#### Submarine nuclear reactors

The six sub reactors had no flat `build_cost_ic` adder at all, a non-monotonic multiplier ramp (`0.20 / 0.25 / 0.30 / 0.35 / 0.28 / 0.32` — tier 5 was cheaper than tier 4), and a flat `naval_range = 20000` on every tier. Since the sub hull contributes `@attack_sub_range = 0`, that flat value was a hard cap: a tier 6 reactor cost 60% more than tier 1 for +5 kn and zero extra range.

- Flat `build_cost_ic` adder of `800 → 1550` (+150/tier) now carries the tier progression.
- Hull multiplier falls `0.15 → 0.125` instead of climbing.
- `naval_range` progresses `20000 → 30000` (+2000/tier), closing on the same ceiling as the heavy surface line.
- `dismantle_cost_ic` `100 → 350` and conversion costs rescaled to the surface line at half scale.
- Speed, `sub_visibility`, `fuel_consumption` and parent links unchanged.

Cost on an attack sub goes `1272 → 1944` across the line; tier 1 now sits at 40% of the hull cost, matching the ratio the rebalanced destroyer reactor sits at on its own hull (39%). The old 20% was the anomaly.

#### Surface, light and fusion reactors

On a ship module, `multiply_stats = { build_cost_ic = X }` scales the **whole ship's** cost. Every reactor line ramped that multiplier *upward* with tech tier (heavy `0.15→0.25`, light `0.16→0.25`, fusion `0.25→0.31`), which reads as "a more advanced reactor makes the entire hull a larger percentage more expensive". A newer reactor is more power-dense and more compact, so its burden per ton of boat should fall — the reactor unit getting pricier is what the flat adder is for.

Inverted on all 14 modules: the multiplier now declines `0.005` per tier and the flat adder carries the progression. Speed, range, reliability, dismantle and conversion costs are untouched, so #2827's tuning stands.

Each category's flat step is sized so total cost still rises on the largest hull that can mount it — otherwise the top tier would be strictly cheaper *and* better, a dominant module with no trade-off. Verified monotonic on attack sub, SSBN, corvette, frigate, destroyer, carrier and battleship.

#### Fixes

- `module_sub_diesel_electric_power7` carried `fuel_consumption = 0.4` against a tier 1-6 ramp of `0.3` down to `0.07`, making the top diesel engine thirstier than the starting one. Set to `0.05`. Kept as its own commit.

#### Notes for reviewers

- No localisation changes. The existing designer hints ("costs more IC and is generally easier to detect than diesel-electric propulsion" / "extremely expensive to build") stay accurate.
- Cost figures above assume `multiply_stats` applies to the hull archetype's `build_cost_ic`. If it applies to the running total instead, the absolute numbers shift but the direction of the fix and the monotonicity guarantees hold — the flat step exceeds the multiplier drop on every hull either way.
- Not touched, but noted: there is still no submarine fusion engine; the four fusion modules lack `sfx = sfx_ui_sd_module_engine` that every other engine has, and all four still `can_convert_from = module_surface_adv_reactor_power` rather than the newer reactors.