### PR TITLE
Remove dead MBS influence blocks and duplicate GFX_ukr_oun sprite

### DIFF
--- a/common/decisions/Gulf.txt
+++ b/common/decisions/Gulf.txt
@@ -2262,20 +2262,6 @@ gcc_decisions = {
 				country_event = SAU_GCC_CRISIS.27
 			}
 			if = {
-				limit = {
-					FROM = { tag = QAT }
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
-			if = {
 				limit = { has_idea = idea_gcc_member_state }
 				set_temp_variable = { temp_modify_gcc_unity = -25 }
 				modify_gcc_unity = yes
@@ -2314,19 +2300,6 @@ gcc_decisions = {
 				limit = { has_idea = idea_gcc_member_state }
 				set_temp_variable = { temp_modify_gcc_unity = 25 }
 				modify_gcc_unity = yes
-			}
-			if = {
-				limit = {
-					FROM = { tag = QAT }
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-				}
-				custom_effect_tooltip = MBS_weakened_tt
-				subtract_from_variable = { mbs = 1 }
 			}
 		}
 

--- a/common/national_focus/gulf.txt
+++ b/common/national_focus/gulf.txt
@@ -780,19 +780,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = -5 }
 			change_saudi_royal_family_opinion = yes
 			change_landowners_opinion = yes
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_diversify_the_economy executed"
 		}
 
@@ -2113,18 +2100,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_wahabi_ulema_opinion = yes
 			change_the_ulema_opinion = yes
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-				}
-				custom_effect_tooltip = MBS_weakened_tt
-				subtract_from_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_empower_the_mutaween executed"
 			unlock_decision_tooltip = GCC_discourage_female_representation
 			unlock_decision_tooltip = GCC_limit_female_employment
@@ -2163,19 +2138,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = -5 }
 			change_the_wahabi_ulema_opinion = yes
 			change_the_ulema_opinion = yes
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_weaken_the_mutaween executed"
 			unlock_decision_tooltip = GCC_encourage_female_representation
 			unlock_decision_tooltip = GCC_expand_female_employment
@@ -3890,19 +3852,6 @@ focus_tree = {
 			decrease_corruption = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_saudi_royal_family_opinion = yes
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_anti_corruption_drive executed"
 		}
 
@@ -3986,19 +3935,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = -5 }
 			change_the_wahabi_ulema_opinion = yes
 			change_the_ulema_opinion = yes
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_extend_control_over_the_ulema executed"
 		}
 
@@ -4089,19 +4025,6 @@ focus_tree = {
 			else_if = {
 				limit = { NOT = { has_government = neutrality } }
 				GCC_censored_nation_level_up = yes
-			}
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
 			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_centralize_power executed"
 		}
@@ -4240,19 +4163,6 @@ focus_tree = {
 				limit = { NOT = { has_government = neutrality } }
 				GCC_censored_nation_level_up = yes
 			}
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_a_cult_of_personality executed"
 		}
 
@@ -4300,19 +4210,6 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_saudi_royal_family_opinion = yes
 			custom_effect_tooltip = GCC_counter_terror_operations_tt
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_build_a_totalitarian_state executed"
 		}
 
@@ -7063,19 +6960,6 @@ focus_tree = {
 				limit = { original_tag = SAU }
 				news_event = { days = 1 id = SAU.1 }
 			}
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 		}
 
 		ai_will_do = {
@@ -8371,19 +8255,6 @@ focus_tree = {
 				set_temp_variable = { temp_modify_gcc_unity = -5 }
 				modify_gcc_unity = yes
 			}
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 		}
 
 		ai_will_do = { base = 1 }
@@ -8443,19 +8314,6 @@ focus_tree = {
 				set_temp_variable = { temp_modify_gcc_unity = -5 }
 				modify_gcc_unity = yes
 			}
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 			log = "[GetDateText]: [This.GetName]: focus GCC_combat_iranian_influence executed"
 		}
 
@@ -8491,19 +8349,6 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus GCC_confront_iranian_partners executed"
 			unlock_decision_tooltip = GCC_blockade
 			custom_effect_tooltip = GCC_confront_iranian_partners_tt
-			if = {
-				limit = {
-					tag = SAU
-					check_variable = { ruling_party = 10 }
-					has_country_leader = {
-						name = "Salman bin Abdulaziz Al-Saud"
-						ruling_only = yes
-					}
-					NOT = { has_country_flag = SAU_mbs_punished }
-				}
-				custom_effect_tooltip = MBS_strengthened_tt
-				add_to_variable = { mbs = 1 }
-			}
 		}
 
 		ai_will_do = {

--- a/interface/MD_eventpictures.gfx
+++ b/interface/MD_eventpictures.gfx
@@ -12868,10 +12868,6 @@ spriteTypes = {
 		textureFile = "gfx/event_pictures/americas/_generic_americas/cartels_caught.dds"
 	}
 	spriteType = {
-		name = "GFX_ukr_oun"
-		textureFile = "gfx/event_pictures/europe/ukraine - UKR/ukr_oun.dds"
-	}
-	spriteType = {
 		name = "GFX_event_shooting_down_santa"
 		texturefile = "gfx/event_pictures/generic/events/event_shooting_down_santa.dds"
 	}

--- a/localisation/english/MD_middle_east_content_l_english.yml
+++ b/localisation/english/MD_middle_east_content_l_english.yml
@@ -327,8 +327,6 @@
  GCC_exploit_authority_tt: "Is the top influencer in every GCC member state"
  GCC_exploit_authority1_tt: "Has more than §Y50%§! influence in every GCC member state"
  GCC_increase_autonomy_tt: "Will no longer be able to align with foreign powers.\n"
- MBS_strengthened_tt: "Will strengthen §YMohammed bin Salman§!."
- MBS_weakened_tt: "Will weaken §YMohammed bin Salman§!."
  has_repressive_government_tt: "Has §YRepressive§! or §YTotalitarian§! Government\n"
  has_not_repressive_government_tt: "Has §YReformist§! or §YLiberal§! Government\n"
  remove_demographics_idea_tt: "Remove §Y[ROOT.GetAdjective] Demographics§!\n"


### PR DESCRIPTION
@
Fixes two branch-check findings on `main`.

## Dead MBS influence blocks

`common/national_focus/gulf.txt` (11 focuses) and `common/decisions/Gulf.txt` (GCC_blockade / GCC_drop_the_blockade) carried an `if` block gated on `NOT = { has_country_flag = SAU_mbs_punished }` — a flag nothing in the repo ever sets. Its body wrote a bare `mbs` country variable that no script, GUI or loc string ever reads, so the block only rendered a tooltip ("Will strengthen Mohammed bin Salman") for an effect the game never applied. The crown prince race (`SAU_mbs_points` / `SAU_add_heir_points` in `common/scripted_effects/SAU_scripted_effects.txt`) superseded this mechanic. The last writer of the flag was dropped in #3736, which introduced the new heir system but left these reads behind.

All 14 blocks removed, along with the now-unused `MBS_strengthened_tt` / `MBS_weakened_tt` English loc keys. No gameplay change — every surrounding effect is untouched.

## Duplicate GFX_ukr_oun

`interface/MD_eventpictures.gfx` defined `GFX_ukr_oun` over the Ukrainian party icon of the same name in `interface/MD_parties_icons.gfx`, with a different texture. The event picture is already exposed as `GFX_ukr_oun_event` (same texturefile, four blocks above), and load order meant the parties file already won, so the duplicate was inert. Removed it; the party icon keeps the conventional `GFX_ukr_<party>` name.

## Testing

- `validate_variables.py` — no issues found
- `validate_gfx_references.py` — no issues found
- Brace balance verified on both edited script files; deletions only (188 lines), no reformatting

No changelog entry (dead-code and sprite cleanup).
@
