### PR TITLE
Fix Aircraft Point Defense Laser Adding Armor (#3139)

### DIFF
--- a/common/units/equipment/modules/MD_plane_modules.txt
+++ b/common/units/equipment/modules/MD_plane_modules.txt
@@ -1862,7 +1862,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 		add_stats = {
 			reliability = -0.05
-		}	
+		}
 		multiply_stats = {
 			maximum_speed = 0.2
 			air_range = 0.1
@@ -1904,7 +1904,7 @@ equipment_modules = {
 		sfx = sfx_ui_sd_module_turret
 		add_stats = {
 			reliability = -0.1
-		}	
+		}
 		multiply_stats = {
 			maximum_speed = -0.1
 			air_defence = -0.1
@@ -5114,7 +5114,7 @@ equipment_modules = {
 			}
 			add_stats = {
 				air_bombing = 55
-				air_ground_attack = 39				
+				air_ground_attack = 39
 				naval_strike_attack = 25
 				air_defence = -15
 				weight = 10
@@ -8754,7 +8754,6 @@ equipment_modules = {
 
 		multiply_stats = {
 			air_defence = 0.02
-			armor_value = 0.05
 		}
 
 		build_cost_resources = {
@@ -8776,7 +8775,6 @@ equipment_modules = {
 
 		multiply_stats = {
 			air_defence = 0.02
-			armor_value = 0.05
 		}
 
 		build_cost_resources = {
@@ -8798,7 +8796,6 @@ equipment_modules = {
 
 		multiply_stats = {
 			air_defence = 0.03
-			armor_value = 0.05
 		}
 
 		build_cost_resources = {
@@ -8820,7 +8817,6 @@ equipment_modules = {
 
 		multiply_stats = {
 			air_defence = 0.03
-			armor_value = 0.05
 		}
 
 		build_cost_resources = {
@@ -8842,7 +8838,6 @@ equipment_modules = {
 
 		multiply_stats = {
 			air_defence = 0.04
-			armor_value = 0.05
 		}
 
 		build_cost_resources = {
@@ -8864,7 +8859,6 @@ equipment_modules = {
 
 		multiply_stats = {
 			air_defence = 0.04
-			armor_value = 0.05
 		}
 
 		build_cost_resources = {


### PR DESCRIPTION
### Changes
- Point Defense Laser modules no longer grant an armor bonus that aircraft cannot use, so the plane designer only shows the air defence they actually provide

Closes #3139