### PR TITLE
Fix Srpska Guard spawn and missing util_vehicle tech grants

### DIFF
--- a/common/ideas/Serbian.txt
+++ b/common/ideas/Serbian.txt
@@ -3337,4 +3337,14 @@ local_resources_chromium_factor = 0.10
 			}
 		}
 	}
+
+	hidden_ideas = {
+		SER_srpska_guard_allowance = {
+			picture = ser_defence_idea
+
+			modifier = {
+				special_forces_cap_flat = 6
+			}
+		}
+	}
 }

--- a/common/national_focus/05_serbia.txt
+++ b/common/national_focus/05_serbia.txt
@@ -5044,22 +5044,27 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -7.45 }
 			modify_treasury_effect = yes
 			hidden_effect = {
-				division_template = {
-					name = "Srpska Guard"
-					regiments = {
-						Special_Forces = { x = 0 y = 0 }
-						Special_Forces = { x = 0 y = 1 }
-						Special_Forces = { x = 0 y = 2 }
-						Special_Forces = { x = 0 y = 3 }
-						Special_Forces = { x = 1 y = 0 }
-						Special_Forces = { x = 1 y = 1 }
+				add_ideas = SER_srpska_guard_allowance
+				if = {
+					limit = { NOT = { has_template = "Srpska Guard" } }
+					division_template = {
+						name = "Srpska Guard"
+						is_locked = yes
+						regiments = {
+							Special_Forces = { x = 0 y = 0 }
+							Special_Forces = { x = 0 y = 1 }
+							Special_Forces = { x = 0 y = 2 }
+							Special_Forces = { x = 0 y = 3 }
+							Special_Forces = { x = 1 y = 0 }
+							Special_Forces = { x = 1 y = 1 }
+						}
+						priority = 2
 					}
-					priority = 2
 				}
 				capital_scope = {
 					create_unit = {
 						division = "name = \"Srpska Guard\" division_template = \"Srpska Guard\" start_experience_factor = 1.0"
-						owner = SER
+						owner = ROOT
 						count = 1
 					}
 				}

--- a/history/countries/ACE - Aceh.txt
+++ b/history/countries/ACE - Aceh.txt
@@ -31,6 +31,7 @@ capital = 622
 		infantry_weapons_1 = 1
 		combat_eng_equipment = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		##Industrial/Engineering
 		basic_computing = 1

--- a/history/countries/ADO - Andorra.txt
+++ b/history/countries/ADO - Andorra.txt
@@ -26,6 +26,7 @@ capital = 945
 		cnc_equipment_3 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 

--- a/history/countries/AFR - Armed Forces Revolutionary Council.txt
+++ b/history/countries/AFR - Armed Forces Revolutionary Council.txt
@@ -72,6 +72,7 @@ capital = 357
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/AGL - Angola.txt
+++ b/history/countries/AGL - Angola.txt
@@ -104,6 +104,7 @@ capital = 298
 
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		camouflage_1 = 1
 		camouflage_2 = 1
 		cnc_equipment_1 = 1

--- a/history/countries/ANJ - Anjouan.txt
+++ b/history/countries/ANJ - Anjouan.txt
@@ -25,6 +25,7 @@ capital = 1214
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/ASK - Alaska.txt
+++ b/history/countries/ASK - Alaska.txt
@@ -383,6 +383,7 @@ capital = 814
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 	}
 
 	set_popularities = {

--- a/history/countries/BAH - Bahamas.txt
+++ b/history/countries/BAH - Bahamas.txt
@@ -18,6 +18,7 @@ capital = 856
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		basic_computing = 1
 		integrated_circuit = 1
 		computing1 = 1

--- a/history/countries/BAL - Anti-Balaka.txt
+++ b/history/countries/BAL - Anti-Balaka.txt
@@ -40,6 +40,7 @@ capital = 922
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_Air_0 = 1
 		special_forces_tech_1 = 1
 		support_weapons = 1

--- a/history/countries/BAR - Barbados.txt
+++ b/history/countries/BAR - Barbados.txt
@@ -67,6 +67,7 @@ capital = 865
 		special_forces_tech_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/BHU - Bhutan.txt
+++ b/history/countries/BHU - Bhutan.txt
@@ -54,6 +54,7 @@ capital = 484
 
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/BLZ - Belize.txt
+++ b/history/countries/BLZ - Belize.txt
@@ -16,6 +16,7 @@ capital = 845
 		special_forces_tech_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/BNG - Bangsamoro.txt
+++ b/history/countries/BNG - Bangsamoro.txt
@@ -41,6 +41,7 @@ capital = 738
 		land_drone_equipment_type = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 
 		combat_eng_equipment = 1

--- a/history/countries/CAR - Central African Republic.txt
+++ b/history/countries/CAR - Central African Republic.txt
@@ -17,6 +17,7 @@ capital = 324
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 
 		basic_computing = 1

--- a/history/countries/CAT - Catalonia.txt
+++ b/history/countries/CAT - Catalonia.txt
@@ -32,6 +32,7 @@ capital = 91
 		stronghold_building_1 = 1
 		land_fort_building_1 = 1
 		construction2 = 1
+		util_vehicle_1 = 1
 	}
 
 	if = {

--- a/history/countries/CDI - Cote D'Ivoire.txt
+++ b/history/countries/CDI - Cote D'Ivoire.txt
@@ -115,6 +115,7 @@ capital = 352
 		combat_eng_equipment = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 
 		basic_computing = 1

--- a/history/countries/COM - Comoros.txt
+++ b/history/countries/COM - Comoros.txt
@@ -18,6 +18,7 @@ capital = 269
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/CRE - Crete.txt
+++ b/history/countries/CRE - Crete.txt
@@ -15,6 +15,7 @@ capital = 144
 		internet2 = 1
 		gprs = 1
 		fuel_silos = 1
+		util_vehicle_1 = 1
 	}
 
 	if = {

--- a/history/countries/CSA - Confederate States.txt
+++ b/history/countries/CSA - Confederate States.txt
@@ -316,6 +316,7 @@ capital = 792
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 	}
 
 	add_ideas = {

--- a/history/countries/DRC - Democratic Republic of the Congo.txt
+++ b/history/countries/DRC - Democratic Republic of the Congo.txt
@@ -130,6 +130,7 @@ capital = 302
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/EGU - Equatorial Guinea.txt
+++ b/history/countries/EGU - Equatorial Guinea.txt
@@ -15,6 +15,7 @@ capital = 319
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 
 		basic_computing = 1

--- a/history/countries/ERI - Eritrea.txt
+++ b/history/countries/ERI - Eritrea.txt
@@ -14,6 +14,7 @@ capital = 229
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		camouflage_1 = 1
 		camouflage_2 = 1

--- a/history/countries/FNC - Forces Nouvelles de Cote d'Ivoire.txt
+++ b/history/countries/FNC - Forces Nouvelles de Cote d'Ivoire.txt
@@ -98,6 +98,7 @@ capital = 353
 		combat_eng_equipment = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		Anti_Air_0 = 1
 		Rec_tank_0 = 1

--- a/history/countries/GAM - Gambia.txt
+++ b/history/countries/GAM - Gambia.txt
@@ -121,6 +121,7 @@ capital = 365
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/GLC - Great Lakes Confederation.txt
+++ b/history/countries/GLC - Great Lakes Confederation.txt
@@ -321,6 +321,7 @@ capital = 777
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 	}
 
 

--- a/history/countries/GNC - National Salvation Government - Libya.txt
+++ b/history/countries/GNC - National Salvation Government - Libya.txt
@@ -43,6 +43,7 @@ capital = 920
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/GUB - Guinea Bissau.txt
+++ b/history/countries/GUB - Guinea Bissau.txt
@@ -13,6 +13,7 @@ capital = 361
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/HAM - Hamas.txt
+++ b/history/countries/HAM - Hamas.txt
@@ -57,6 +57,7 @@ capital = 209
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/HAZ - Hazaristan.txt
+++ b/history/countries/HAZ - Hazaristan.txt
@@ -25,6 +25,7 @@ set_country_flag = disable_different_country_flag
 
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/JUB - Jubaland.txt
+++ b/history/countries/JUB - Jubaland.txt
@@ -52,6 +52,7 @@ capital = 581
 		cnc_equipment_1 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/KYR - Kyrgyzstan.txt
+++ b/history/countries/KYR - Kyrgyzstan.txt
@@ -18,6 +18,7 @@ capital = 720
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		body_armor_1 = 1
 		camouflage_1 = 1

--- a/history/countries/LES - Lesotho.txt
+++ b/history/countries/LES - Lesotho.txt
@@ -64,6 +64,7 @@ capital = 272
 		cnc_equipment_1 = 1
 		Heavy_Anti_tank_0 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		basic_computing = 1
 		integrated_circuit = 1
 		computing1 = 1

--- a/history/countries/LGN - Logone.txt
+++ b/history/countries/LGN - Logone.txt
@@ -36,6 +36,7 @@ capital = 921
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/LIC - Liechenstein.txt
+++ b/history/countries/LIC - Liechenstein.txt
@@ -95,6 +95,7 @@ oob = "GENERIC_OOB"
 		cnc_equipment_3 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 

--- a/history/countries/LKT - Lakota.txt
+++ b/history/countries/LKT - Lakota.txt
@@ -169,6 +169,7 @@ capital = 786
 				MBT_3 = 1
 				MBT_4 = 1
 				Early_APC = 1
+				util_vehicle_1 = 1
 				APC_1 = 1
 				APC_2 = 1
 				APC_3 = 1

--- a/history/countries/LOR - Luristan.txt
+++ b/history/countries/LOR - Luristan.txt
@@ -21,6 +21,7 @@ capital = 406
 
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/MLC - Movement for the Liberation of Congo.txt
+++ b/history/countries/MLC - Movement for the Liberation of Congo.txt
@@ -25,6 +25,7 @@ capital = 312
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/MLD - Maldives.txt
+++ b/history/countries/MLD - Maldives.txt
@@ -41,6 +41,7 @@ capital = 480
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/MLW - Malawi.txt
+++ b/history/countries/MLW - Malawi.txt
@@ -53,6 +53,7 @@ capital = 260
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/MNC - Monaco.txt
+++ b/history/countries/MNC - Monaco.txt
@@ -81,6 +81,7 @@ oob = "GENERIC_OOB"
 		land_drone_equipment_tech_2 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 

--- a/history/countries/MRT - Mauritius.txt
+++ b/history/countries/MRT - Mauritius.txt
@@ -68,6 +68,7 @@ capital = 270
 		integrated_transportation_system = 1
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		basic_computing = 1
 		integrated_circuit = 1
 		computing1 = 1

--- a/history/countries/MTE - Mayotte.txt
+++ b/history/countries/MTE - Mayotte.txt
@@ -26,6 +26,7 @@ oob = "GENERIC_OOB"
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/NCY - Northern Cyprus.txt
+++ b/history/countries/NCY - Northern Cyprus.txt
@@ -64,6 +64,7 @@ oob = "GENERIC_OOB"
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		body_armor_1 = 1
 

--- a/history/countries/NEN - New England.txt
+++ b/history/countries/NEN - New England.txt
@@ -317,6 +317,7 @@ capital = 767
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 	}
 
 	add_ideas = {

--- a/history/countries/NIC - Nicaragua.txt
+++ b/history/countries/NIC - Nicaragua.txt
@@ -121,6 +121,7 @@ capital = 849
 		cnc_equipment_1 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		Heavy_Anti_tank_0 = 1
 

--- a/history/countries/PAN - Panama.txt
+++ b/history/countries/PAN - Panama.txt
@@ -60,6 +60,7 @@ capital = 853
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		combat_eng_equipment = 1
 		camouflage_1 = 1

--- a/history/countries/PAP - Papua New Guinea.txt
+++ b/history/countries/PAP - Papua New Guinea.txt
@@ -61,6 +61,7 @@ capital = 730
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		combat_eng_equipment = 1
 

--- a/history/countries/RCD - Rally for Congolese Democracy.txt
+++ b/history/countries/RCD - Rally for Congolese Democracy.txt
@@ -61,6 +61,7 @@ capital = 310
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/ROJ - Rojava.txt
+++ b/history/countries/ROJ - Rojava.txt
@@ -42,6 +42,7 @@ capital = 193
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		fuel_silos = 1
 	}
 	if = {

--- a/history/countries/SAO - Sao Tome & Principe.txt
+++ b/history/countries/SAO - Sao Tome & Principe.txt
@@ -41,6 +41,7 @@ capital = 320
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/SAR - Sardinia.txt
+++ b/history/countries/SAR - Sardinia.txt
@@ -46,6 +46,7 @@ capital = 84
 		energy_efficiency2 = 1
 		fuel_efficiency = 1
 		construction1 = 1
+		util_vehicle_1 = 1
 	}
 
 	if = {

--- a/history/countries/SEL - Seleka.txt
+++ b/history/countries/SEL - Seleka.txt
@@ -40,6 +40,7 @@ capital = 325
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_Air_0 = 1
 
 		basic_computing = 1

--- a/history/countries/SIE - Sierra Leone.txt
+++ b/history/countries/SIE - Sierra Leone.txt
@@ -83,6 +83,7 @@ capital = 358
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/SMA - San Marino.txt
+++ b/history/countries/SMA - San Marino.txt
@@ -89,6 +89,7 @@ capital = 948
 		cnc_equipment_2 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 

--- a/history/countries/SNA - Somali National Alliance.txt
+++ b/history/countries/SNA - Somali National Alliance.txt
@@ -46,6 +46,7 @@ capital = 593
 		computing1 = 1
 
 		radar = 1
+		util_vehicle_1 = 1
 	}
 
 	if = {

--- a/history/countries/SUR - Suriname.txt
+++ b/history/countries/SUR - Suriname.txt
@@ -74,6 +74,7 @@ capital = 878
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 
 		basic_computing = 1

--- a/history/countries/SWA - Swaziland.txt
+++ b/history/countries/SWA - Swaziland.txt
@@ -72,6 +72,7 @@ capital = 271
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		combat_eng_equipment = 1
 		basic_computing = 1

--- a/history/countries/TAB - Tabaristan.txt
+++ b/history/countries/TAB - Tabaristan.txt
@@ -21,6 +21,7 @@ capital = 403
 
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/history/countries/TIM - East Timor.txt
+++ b/history/countries/TIM - East Timor.txt
@@ -38,6 +38,7 @@ capital = 734
 		land_drone_equipment_type = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		Heavy_Anti_tank_0 = 1
 

--- a/history/countries/TNZ - Tanzania.txt
+++ b/history/countries/TNZ - Tanzania.txt
@@ -83,6 +83,7 @@ capital = 255
 		cnc_equipment_1 = 1
 		land_drone_equipment_type = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		combat_eng_equipment = 1
 		SP_Anti_Air_0 = 1

--- a/history/countries/TOG - Togo.txt
+++ b/history/countries/TOG - Togo.txt
@@ -18,6 +18,7 @@ capital = 342
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		combat_eng_equipment = 1
 		basic_computing = 1

--- a/history/countries/TRI - Trinidad.txt
+++ b/history/countries/TRI - Trinidad.txt
@@ -33,6 +33,7 @@ capital = 869
 		cnc_equipment_1 = 1
 
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		Heavy_Anti_tank_0 = 1
 

--- a/history/countries/TTP - Pakistani Taliban.txt
+++ b/history/countries/TTP - Pakistani Taliban.txt
@@ -48,6 +48,7 @@ capital = 594
 		#Just to make templates work
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		night_vision_1 = 1
 
 		basic_computing = 1

--- a/history/countries/TUA - Tuaregs.txt
+++ b/history/countries/TUA - Tuaregs.txt
@@ -36,6 +36,7 @@ capital = 918
 		#For templates
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_Air_0 = 1
 		cnc_equipment_1 = 1
 

--- a/history/countries/UDT - Union of Deseret.txt
+++ b/history/countries/UDT - Union of Deseret.txt
@@ -51,6 +51,7 @@ capital = 805
 
 	set_technology = {
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Anti_tank_1 = 1
 		AT_upgrade_1 = 1
 		AT_upgrade_2 = 1

--- a/history/countries/UGA - Uganda.txt
+++ b/history/countries/UGA - Uganda.txt
@@ -128,6 +128,7 @@ capital = 249
 		infantry_weapons_1 = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		Heavy_Anti_tank_0 = 1
 		combat_eng_equipment = 1
 

--- a/history/countries/UNI - UNITA.txt
+++ b/history/countries/UNI - UNITA.txt
@@ -60,6 +60,7 @@ capital = 300
 		infantry_mass_assault = 1
 		infantry_weapons_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 		camouflage_1 = 1
 		camouflage_2 = 1
 		cnc_equipment_1 = 1

--- a/history/countries/VER - Cape Verde.txt
+++ b/history/countries/VER - Cape Verde.txt
@@ -80,6 +80,7 @@ capital = 398
 		combat_eng_equipment = 1
 		cnc_equipment_1 = 1
 		Anti_tank_0 = 1
+		util_vehicle_1 = 1
 
 		basic_computing = 1
 		integrated_circuit = 1

--- a/localisation/english/MD_focus_SER_VOJ_MNT_l_english.yml
+++ b/localisation/english/MD_focus_SER_VOJ_MNT_l_english.yml
@@ -562,6 +562,7 @@
  SER_zakup: "Purchases of Foreign Weapons"
  SER_zakup_desc: "We will purchase weapons for our police units"
  ##########Ideas##########
+ SER_srpska_guard_allowance: "Srpska Guard Establishment"
  SER_export_idea: "Yugoimport SDPR"
  SER_export_idea_desc: "Yugoimport SDPR  is a Serbian state-owned weapons manufacturer as well as intermediary company for the import and export of defense-related equipment."
  SER_military: "Reformed Serbian Army"


### PR DESCRIPTION
Closes #3772

**Bottom line:** Serbia's `SER_guard` no longer leaves a nameless ghost division in Belgrade, and 67 countries can finally fill the `util_vehicle_type` pool their support companies demand.

#### Why

- `SER_guard` built its division template unguarded and spawned the unit with a hardcoded `owner = SER`. When the template failed to register, `create_unit` fell through to `persistent.cpp: Malformed token: Srpska Guard` and dropped a template-less unit in province 11586.
- The issue's stated cause (same-block template registration timing) is disproved: `SER_kobra` and `CES_kaz_nat_gurad` use the identical `hidden_effect { division_template ... capital_scope { create_unit } }` shape and ran clean in the same save. Designer column height is also ruled out - vanilla ships a 6-tall effect template in `common/national_focus/siam.txt`, above its own maximum. The one remaining difference is that Srpska Guard is the only all-`Special_Forces` template, six battalions deep, under MD's tightened `SPECIAL_FORCES_CAP_BASE = 0.075` / `SPECIAL_FORCES_CAP_MIN = 6` (vanilla 0.05 / 24).
- `util_vehicle_1` is the sole source of `util_vehicle_1` / `heavy_util_vehicle_1`; there is no `create_equipment_variant` for them and no global startup grant. 67 country history files granted a tech that unlocks a util-consuming support company (`infantry_weapons_1` -> `combat_service_support_company` / `combat_maintenance_company`, `combat_eng_equipment` -> `L_Engi_Comp`, `Early_APC` -> `H_Engi_Comp`) without ever granting the vehicle tech, so the pool could never fill.
- The issue's Cote d'Ivoire analysis was off on one detail: `CDI_2000.txt` fields only `L_Inf_Bat` and `L_Recce_Comp`. CDI's empty pool comes from AI-designed templates, which is why the selection criterion here is "grants a tech unlocking a util consumer" rather than "its OOB already lists one".

#### How

- Wrapped the `Srpska Guard` template in a `NOT = { has_template = ... }` guard with `is_locked = yes`, matching `SER_kobra` and the canonical pattern in `05_algeria.txt` / `05_ukraine.txt`.
- Switched `owner = SER` to `owner = ROOT`. The tree is selected on `original_tag = SER`, which survives a civil-war split, so the hardcoded tag would have spawned the unit for the wrong country.
- Added hidden idea `SER_srpska_guard_allowance` (`special_forces_cap_flat = 6`), applied before the template is built so the six-battalion formation always fits the cap.
- Added `util_vehicle_1 = 1` to the first top-level `set_technology` block of 67 country history files, placed next to `Anti_tank_0` / `cnc_equipment_1` per existing convention. LKT takes it beside `Early_APC` in its non-NSB branch, the only place it has a util consumer.

#### Left out

- **BAY (Bavaria)** inherits the full German OOB but has no `set_technology` block at all; `util_vehicle_1` alone would not make that OOB fieldable, so it needs its own tech baseline.
- **Gating `common/ai_templates/MD_generic.txt`** behind `has_tech = util_vehicle_1` would stop the AI designing unfillable templates but permanently lock those countries out of motorised units. Granting the tech is the non-regressive fix.
- The multi-line `create_unit` division string at `common/national_focus/05_germany.txt:20706`, a real `parser.cpp` error in the same log but a separate bug.

#### Needs in-game confirmation

The Serbia root cause could not be settled statically. Play SER, complete `SER_guard`, and confirm `error.log` carries no `Malformed token: Srpska Guard` and the division spawns in the capital. Play CDI and confirm no `Trying to fill variant where none exist from type: util_vehicle_type`.