### PR TITLE
Fix milestone focus gates, MIO layouts and validator output

### DIFF
--- a/common/military_industrial_organization/organizations/MD_FRA_organizations.txt
+++ b/common/military_industrial_organization/organizations/MD_FRA_organizations.txt
@@ -5380,7 +5380,7 @@ FRA_dcn_manufacturer = {
 			FRA_ng_cherbourg_modernization
 		}
 
-		position = { x = -1 y = 5 }
+		position = { x = -1 y = 6 }
 		relative_position_id = FRA_dcn_surface_heritage
 
 		limit_to_equipment_type = { helicopter_operator }
@@ -5473,7 +5473,7 @@ FRA_dcn_manufacturer = {
 			FRA_dcn_foudre_lsd
 		}
 
-		position = { x = 0 y = 6 }
+		position = { x = 0 y = 7 }
 		relative_position_id = FRA_dcn_surface_heritage
 
 		production_bonus = { production_resource_penalty_factor = -0.10 }
@@ -5517,7 +5517,7 @@ FRA_dcn_manufacturer = {
 
 		all_parents = { FRA_dcn_brest_yard }
 
-		position = { x = 1 y = 0 }
+		position = { x = 1 y = 1 }
 		relative_position_id = FRA_dcn_brest_yard
 
 		production_bonus = { production_cost_factor = -0.05 }
@@ -5645,7 +5645,7 @@ FRA_naval_group_naval_manufacturer = {
 			FRA_dcn_brest_yard
 		}
 
-		position = { x = 0 y = 5 }
+		position = { x = 0 y = 7 }
 		relative_position_id = FRA_ng_industrial_reform_2017
 
 		organization_modifier = { military_industrial_organization_funds_gain = 0.10 }
@@ -5662,7 +5662,7 @@ FRA_naval_group_naval_manufacturer = {
 
 		all_parents = { FRA_ng_export_office_global }
 
-		position = { x = 0 y = 6 }
+		position = { x = 0 y = 8 }
 		relative_position_id = FRA_ng_industrial_reform_2017
 
 		organization_modifier = {
@@ -5898,7 +5898,7 @@ FRA_naval_group_naval_manufacturer = {
 			FRA_ng_industrial_capstone
 		}
 
-		position = { x = 0 y = 1 }
+		position = { x = 0 y = 2 }
 		relative_position_id = FRA_dcn_sawari_heritage
 
 		limit_to_equipment_type = { carrier }
@@ -5922,7 +5922,7 @@ FRA_naval_group_naval_manufacturer = {
 			FRA_ng_industrial_capstone
 		}
 
-		position = { x = 0 y = 1 }
+		position = { x = 0 y = 3 }
 		relative_position_id = FRA_dcn_force_de_frappe
 
 		organization_modifier = {

--- a/common/military_industrial_organization/organizations/MD_GER_organizations.txt
+++ b/common/military_industrial_organization/organizations/MD_GER_organizations.txt
@@ -11992,7 +11992,7 @@ GER_thyssenkrupp_marine_naval_manufacturer = {
 
 		all_parents = { GER_mio_trait_thyssenkrupp_integrated_combat_suite }
 
-		position = { x = 1 y = 0 }
+		position = { x = 1 y = 2 }
 		relative_position_id = GER_mio_trait_thyssenkrupp_integrated_combat_suite
 
 		limit_to_equipment_type = {

--- a/common/military_industrial_organization/organizations/MD_ITA_organizations.txt
+++ b/common/military_industrial_organization/organizations/MD_ITA_organizations.txt
@@ -3072,7 +3072,7 @@ ITA_alenia_aeronautica = {
 		}
 
 		relative_position_id = ITA_alenia_aeronautica_trait_g91_gina
-		position = { x = 0 y = 8 }
+		position = { x = 0 y = 10 }
 
 		limit_to_equipment_type = { mio_cat_eq_only_all_medium_aircraft }
 
@@ -3605,7 +3605,7 @@ ITA_alenia_aeronautica = {
 		}
 
 		relative_position_id = ITA_alenia_aeronautica_trait_g222_legacy
-		position = { x = 0 y = 7 }
+		position = { x = 0 y = 10 }
 
 		organization_modifier = { military_industrial_organization_research_bonus = 0.08 }
 

--- a/common/military_industrial_organization/organizations/MD_TAI_organizations.txt
+++ b/common/military_industrial_organization/organizations/MD_TAI_organizations.txt
@@ -85,7 +85,7 @@ TAI_tsmc_manufacturer = {
 		all_parents = { TAI_tsmc_established_research_department }
 
 		relative_position_id = TAI_tsmc_established_research_department
-		position = { x = 1 y = 0 }
+		position = { x = 1 y = 1 }
 
 		organization_modifier = { military_industrial_organization_research_bonus = 0.025 }
 
@@ -314,7 +314,7 @@ TAI_tsmc_manufacturer = {
 		all_parents = { TAI_tsmc_efficient_company_structure }
 
 		relative_position_id = TAI_tsmc_efficient_company_structure
-		position = { x = -1 y = 0 }
+		position = { x = -1 y = 1 }
 
 		organization_modifier = {
 			military_industrial_organization_size_up_requirement = -0.05
@@ -946,7 +946,7 @@ TAI_tsmc_manufacturer = {
 		}
 
 		relative_position_id = TAI_tsmc_early_90nm_production
-		position = { x = 0 y = 1 }
+		position = { x = 0 y = 2 }
 
 		on_complete = {
 			expenditure_large_for_mio_upgrade = yes

--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -104,7 +104,12 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			OR = {
+				has_country_flag = fiji_2000_coups_over
+				has_country_flag = fiji_post_coup_political_shift
+			}
+		}
 
 		bypass = {
 			OR = {

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -26582,7 +26582,19 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_ISRPALSTUFF FOCUS_FILTER_INSURGENCY }
 
-		available = { always = no }
+		available = {
+			country_exists = PAL
+			PAL = {
+				NOT = { has_war_with = ISR }
+				OR = {
+					AND = {
+						NOT = { has_government = democratic }
+						neutrality_neutral_social_in_power_or_coalition = no
+					}
+					has_war_support < 0.25
+				}
+			}
+		}
 
 		bypass = {
 			country_exists = PAL

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -2704,7 +2704,12 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_WAR_SUPPORT }
 
-		available = { always = no }
+		available = {
+			OR = {
+				has_idea = NIG_joint_task_force_idea
+				has_country_flag = NIG_niger_delta_resolved
+			}
+		}
 
 		bypass = {
 			OR = {
@@ -2799,7 +2804,12 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_EXPENDITURE }
 
-		available = { always = no }
+		available = {
+			OR = {
+				has_country_flag = NIG_negotiating_with_militants
+				has_country_flag = NIG_amnesty_succeeded
+			}
+		}
 
 		bypass = {
 			OR = {

--- a/common/national_focus/05_sahrawi.txt
+++ b/common/national_focus/05_sahrawi.txt
@@ -448,7 +448,7 @@ shared_focus = {
 
 	search_filters = { FOCUS_FILTER_INTERNAL_AFFAIRS }
 
-	available = { always = no }
+	available = { has_full_control_of_state = 373 }
 
 	bypass = { has_full_control_of_state = 373 }
 

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -31,7 +31,12 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			custom_trigger_tooltip = {
+				tooltip = TT_DEATH_OF_HAFEZ
+				has_country_flag = Syria_Hafez_dead
+			}
+		}
 
 		bypass = {
 			custom_trigger_tooltip = {

--- a/common/national_focus/05_usa.txt
+++ b/common/national_focus/05_usa.txt
@@ -385,7 +385,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2001.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2000_republicans
+			}
+			western_liberals_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2001.1.20
@@ -923,7 +929,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2001.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2000_democrats
+			}
+			western_conservatism_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2001.1.20
@@ -1391,7 +1403,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2005.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2004_republicans
+			}
+			western_liberals_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2005.1.20
@@ -1773,7 +1791,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2005.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2004_democrats
+			}
+			western_conservatism_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2005.1.20
@@ -2322,7 +2346,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2009.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2008_republicans
+			}
+			western_liberals_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2009.1.20
@@ -2761,7 +2791,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2009.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2008_democrats
+			}
+			western_conservatism_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2009.1.20
@@ -3241,7 +3277,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2013.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2012_republicans
+			}
+			western_liberals_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2013.1.20
@@ -3747,7 +3789,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2013.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2012_democrats
+			}
+			western_conservatism_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2013.1.20
@@ -4258,7 +4306,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
-		available = { always = no }
+		available = {
+			date > 2017.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2016_republican_victory
+			}
+			western_liberals_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2017.1.20
@@ -4533,7 +4587,13 @@ focus_tree = {
 
 		search_filters = { FOCUS_FILTER_STABILITY }
 
-		available = { always = no }
+		available = {
+			date > 2017.1.20
+			NOT = {
+				has_completed_focus = USA_focus_2016_democrat_victory
+			}
+			western_conservatism_are_in_power = yes
+		}
 
 		bypass = {
 			date > 2017.1.20

--- a/tools/tests/validation/run_all_validators_test.py
+++ b/tools/tests/validation/run_all_validators_test.py
@@ -457,3 +457,31 @@ def test_main_stays_quiet_when_the_cache_is_fresh(tmp_path, monkeypatch, capsys)
     assert exc.value.code == 0
     assert "Pruned stale" not in stdout
     assert "cleared and rebuilding" not in stdout
+
+
+@pytest.mark.parametrize("format_", ["text", "json"])
+def test_main_prints_unicode_with_windows_pipe_encoding(tmp_path, monkeypatch, format_):
+    buffers = [io.BytesIO(), io.BytesIO()]
+    streams = [io.TextIOWrapper(buffer, encoding="cp1252") for buffer in buffers]
+    monkeypatch.setattr(sys, "stdout", streams[0])
+    monkeypatch.setattr(sys, "stderr", streams[1])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["runner", "--path", str(tmp_path), "--format", format_, "--no-color"],
+    )
+    monkeypatch.setattr(
+        runner, "discover_validators", lambda: [("stub", "validate_stub.py", "Stub")]
+    )
+    monkeypatch.setattr(runner, "launch_validator", _launcher_with([]))
+
+    with pytest.raises(SystemExit) as exc:
+        runner.main()
+
+    for stream in streams:
+        stream.flush()
+    output = [buffer.getvalue().decode("utf-8") for buffer in buffers]
+    assert exc.value.code == 0
+    assert "✓ Stub" in output[format_ == "json"]
+    if format_ == "json":
+        assert json.loads(output[0])["total_errors"] == 0

--- a/tools/validation/run_all_validators.py
+++ b/tools/validation/run_all_validators.py
@@ -302,6 +302,11 @@ def _persist_sidecars(output_dir: str, persist_dir: str) -> None:
 
 
 def main():
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            reconfigure(encoding="utf-8", errors="replace")
+
     parser = argparse.ArgumentParser(description="Run all MD validators in parallel")
     parser.add_argument("--staged", action="store_true")
     parser.add_argument("--strict", action="store_true")


### PR DESCRIPTION
Match 16 milestone focus availability conditions to their bypass conditions, reposition MIO traits while preserving prerequisites, and make validator output safe for Windows UTF-8 pipes. Includes runner regression tests.

The Ukrainian KhTZ cycle and other deferred MIO/math findings are excluded.

Part 1 of 4 replacing #3792. Merge order: remaining fixes → events → localisation → standardization. This PR targets `main` so its diff contains only this category.

Verification: the completed stack exactly preserves all 105 files changed by the combined PR while retaining updated main, including the other developer’s China work. Relevant runner, localisation and standardization tests: 474 passed. Diff checks passed. The earlier full Windows suite had five failures in unchanged hook/executable checks; splitting introduces no further code changes.

Stack: [rest](https://github.com/MillenniumDawn/Millennium-Dawn/pull/3797) → [events](https://github.com/MillenniumDawn/Millennium-Dawn/pull/3798) → [localisation](https://github.com/MillenniumDawn/Millennium-Dawn/pull/3799) → [standardization](https://github.com/MillenniumDawn/Millennium-Dawn/pull/3800)
