### PR TITLE
Standardize event files — batch 04/14

### DIFF
--- a/events/Algeria.txt
+++ b/events/Algeria.txt
@@ -542,9 +542,7 @@ news_event = {
 
 	trigger = { date > 2011.07.30 }
 
-	option = {
-		name = alg_politics_news.1.a
-	}
+	option = { name = alg_politics_news.1.a }
 }
 country_event = {
 	id = ALG_faction.1
@@ -1143,9 +1141,7 @@ country_event = {
 		name = algerian.1.b
 		log = "[GetDateText]: [This.GetName]: algerian.1.b executed"
 		ALG = { country_event = { id = algerian.5 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1157,9 +1153,7 @@ country_event = {
 
 	option = {
 		name = algerian.4.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1171,9 +1165,7 @@ country_event = {
 
 	option = {
 		name = algerian.5.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #Investments
@@ -1240,9 +1232,7 @@ country_event = {
 		name = algeria_invest.1.b
 		log = "[GetDateText]: [This.GetName]: algeria_invest.1.b executed"
 		ALG = { country_event = { id = algeria_invest.3 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1254,9 +1244,7 @@ country_event = {
 
 	option = {
 		name = algeria_invest.2.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1268,9 +1256,7 @@ country_event = {
 
 	option = {
 		name = algeria_invest.3.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #USA Investments
@@ -1339,9 +1325,7 @@ country_event = {
 		name = algeria_invest.4.b
 		log = "[GetDateText]: [This.GetName]: algeria_invest.4.b executed"
 		ALG = { country_event = { id = algeria_invest.6 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1353,9 +1337,7 @@ country_event = {
 
 	option = {
 		name = algeria_invest.5.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1367,9 +1349,7 @@ country_event = {
 
 	option = {
 		name = algeria_invest.6.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #Russian Investments
@@ -1446,9 +1426,7 @@ country_event = {
 		name = algeria_invest.7.b
 		log = "[GetDateText]: [This.GetName]: algeria_invest.7.b executed"
 		ALG = { country_event = { id = algeria_invest.9 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1460,9 +1438,7 @@ country_event = {
 
 	option = {
 		name = algeria_invest.8.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1474,9 +1450,7 @@ country_event = {
 
 	option = {
 		name = algeria_invest.9.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #Algeris Metro
@@ -1495,9 +1469,7 @@ country_event = {
 		set_temp_variable = { influence_target = ALG }
 		change_influence_percentage = yes
 		add_dynamic_modifier = { modifier = ALG_algiers_metro }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1519,9 +1491,7 @@ country_event = {
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = ALG }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1539,9 +1509,7 @@ country_event = {
 			modifier = large_decrease
 		}
 		add_political_power = -100
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1556,9 +1524,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: algeria_invest.12.a executed"
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Desertification increases
@@ -1584,9 +1550,7 @@ country_event = {
 	picture = GFX_amazon_rainforest_drought
 	is_triggered_only = yes
 
-	option = {
-		name = ALG_pulse.2.a
-	}
+	option = { name = ALG_pulse.2.a }
 }
 
 # Desertification decreases
@@ -1624,9 +1588,7 @@ country_event = {
 		set_temp_variable = { tag_index = ALG }
 		set_temp_variable = { influence_target = TUA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1641,9 +1603,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Secret support to tuareg leaders
@@ -1658,9 +1618,7 @@ country_event = {
 
 	option = {
 		name = Algeria.237.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -2032,9 +1990,7 @@ news_event = {
 	picture = GFX_UN_event_global
 	is_triggered_only = yes
 
-	option = {
-		name = AlgeriaFocusNews.100.a
-	}
+	option = { name = AlgeriaFocusNews.100.a }
 }
 
 news_event = {
@@ -2044,9 +2000,7 @@ news_event = {
 	picture = GFX_news_arab_spring
 	is_triggered_only = yes
 
-	option = {
-		name = AlgeriaFocusNews.101.a
-	}
+	option = { name = AlgeriaFocusNews.101.a }
 }
 
 news_event = {
@@ -2056,9 +2010,7 @@ news_event = {
 	picture = GFX_UN_event_global_2
 	is_triggered_only = yes
 
-	option = {
-		name = AlgeriaFocusNews.102.a
-	}
+	option = { name = AlgeriaFocusNews.102.a }
 }
 
 news_event = {
@@ -2069,9 +2021,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = AlgeriaFocusNews.103.a
-	}
+	option = { name = AlgeriaFocusNews.103.a }
 }
 
 news_event = {
@@ -2081,9 +2031,7 @@ news_event = {
 	picture = GFX_trade_agreement
 	is_triggered_only = yes
 
-	option = {
-		name = AlgeriaFocusNews.104.a
-	}
+	option = { name = AlgeriaFocusNews.104.a }
 }
 
 news_event = {
@@ -2093,9 +2041,7 @@ news_event = {
 	picture = GFX_trade_agreement
 	is_triggered_only = yes
 
-	option = {
-		name = AlgeriaFocusNews.105.a
-	}
+	option = { name = AlgeriaFocusNews.105.a }
 }
 
 news_event = {
@@ -2105,9 +2051,7 @@ news_event = {
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
-	option = {
-		name = AlgeriaFocusNews.106.a
-	}
+	option = { name = AlgeriaFocusNews.106.a }
 }
 news_event = {
 	id = algeria_morocco.1
@@ -2155,16 +2099,12 @@ news_event = {
 
 	option = {
 		name = algeria.7.a
-		trigger = {
-			tag = ALG
-		}
+		trigger = { tag = ALG }
 	}
 
 	option = {
 		name = algeria.7.b
-		trigger = {
-			NOT = { tag = ALG }
-		}
+		trigger = { NOT = { tag = ALG } }
 	}
 }
 country_event = {
@@ -2325,9 +2265,7 @@ country_event = {
 		date > 2005.01.01
 	}
 
-	option = {
-		name = alg_generals.1.a
-	}
+	option = { name = alg_generals.1.a }
 }
 country_event = {
 	id = alg_generals.2
@@ -2342,9 +2280,7 @@ country_event = {
 		date > 2008.01.01
 	}
 
-	option = {
-		name = alg_generals.2.a
-	}
+	option = { name = alg_generals.2.a }
 }
 country_event = {
 	id = alg_generals.3
@@ -2359,9 +2295,7 @@ country_event = {
 		date > 2015.01.01
 	}
 
-	option = {
-		name = alg_generals.3.a
-	}
+	option = { name = alg_generals.3.a }
 }
 
 
@@ -2618,27 +2552,21 @@ country_event = {
 	option = {
 		name = AlgeriaPoliticalEvents.20.a
 		log = "[GetDateText]: [This.GetName]: AlgeriaPoliticalEvents.20.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_political_power = 50
 	}
 
 	option = {
 		name = AlgeriaPoliticalEvents.20.b
 		log = "[GetDateText]: [This.GetName]: AlgeriaPoliticalEvents.20.b executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_stability = 0.05
 	}
 
 	option = {
 		name = AlgeriaPoliticalEvents.20.c
 		log = "[GetDateText]: [This.GetName]: AlgeriaPoliticalEvents.20.c executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_popularity = { ideology = fascism popularity = 0.05 }
 	}
 }
@@ -2951,9 +2879,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = algeria_elections.2024.a
-	}
+	option = { name = algeria_elections.2024.a }
 }
 country_event = {
 	id = algeria_reforms.1
@@ -2979,9 +2905,7 @@ country_event = {
 	option = {
 		name = algeria_reforms.1.b
 		log = "[GetDateText]: [This.GetName]: algeria_reforms.1.b executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_political_power = -50
 		add_popularity = { ideology = democratic popularity = 0.05 }
 	}
@@ -3130,15 +3054,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_government = ROOT
-				}
+				ALG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability > 0.5
-				}
+				ALG = { has_stability > 0.5 }
 			}
 			modifier = {
 				factor = 2
@@ -3160,9 +3080,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				ALG = {
-					has_stability < 0.2
-				}
+				ALG = { has_stability < 0.2 }
 			}
 		}
 	}
@@ -3186,15 +3104,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_government = ROOT
-				}
+				ALG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability > 0.6
-				}
+				ALG = { has_stability > 0.6 }
 			}
 			modifier = {
 				factor = 2
@@ -3216,9 +3130,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				ALG = {
-					has_stability < 0.3
-				}
+				ALG = { has_stability < 0.3 }
 			}
 		}
 	}
@@ -3248,15 +3160,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_government = ROOT
-				}
+				ALG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability > 0.75
-				}
+				ALG = { has_stability > 0.75 }
 			}
 			modifier = {
 				factor = 2
@@ -3278,9 +3186,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				ALG = {
-					has_stability < 0.5
-				}
+				ALG = { has_stability < 0.5 }
 			}
 		}
 	}
@@ -3299,9 +3205,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability < 0.1
-				}
+				ALG = { has_stability < 0.1 }
 			}
 			modifier = {
 				factor = 2
@@ -3323,9 +3227,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 10
-				ALG = {
-					has_war = yes
-				}
+				ALG = { has_war = yes }
 			}
 		}
 	}
@@ -3341,9 +3243,7 @@ country_event = {
 
 	option = {
 		name = AlgeriaInvestment.2.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3357,9 +3257,7 @@ country_event = {
 
 	option = {
 		name = AlgeriaInvestment.3.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3373,9 +3271,7 @@ country_event = {
 
 	option = {
 		name = AlgeriaInvestment.4.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3391,9 +3287,7 @@ country_event = {
 		name = AlgeriaInvestment.5.a
 		log = "[GetDateText]: [This.GetName]: AlgeriaInvestment.5.a executed"
 		add_political_power = -10
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3423,15 +3317,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_government = ROOT
-				}
+				ALG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability > 0.5
-				}
+				ALG = { has_stability > 0.5 }
 			}
 			modifier = {
 				factor = 2
@@ -3453,9 +3343,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				ALG = {
-					has_stability < 0.2
-				}
+				ALG = { has_stability < 0.2 }
 			}
 		}
 	}
@@ -3479,15 +3367,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_government = ROOT
-				}
+				ALG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability > 0.6
-				}
+				ALG = { has_stability > 0.6 }
 			}
 			modifier = {
 				factor = 2
@@ -3509,9 +3393,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				ALG = {
-					has_stability < 0.3
-				}
+				ALG = { has_stability < 0.3 }
 			}
 		}
 	}
@@ -3530,9 +3412,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				ALG = {
-					has_stability < 0.1
-				}
+				ALG = { has_stability < 0.1 }
 			}
 			modifier = {
 				factor = 2
@@ -3554,21 +3434,15 @@ country_event = {
 			}
 			modifier = {
 				factor = 10
-				ALG = {
-					has_idea = corruption_level_10
-				}
+				ALG = { has_idea = corruption_level_10 }
 			}
 			modifier = {
 				factor = 10
-				ALG = {
-					has_idea = corruption_level_09
-				}
+				ALG = { has_idea = corruption_level_09 }
 			}
 			modifier = {
 				factor = 10
-				ALG = {
-					has_war = yes
-				}
+				ALG = { has_war = yes }
 			}
 		}
 	}
@@ -3587,9 +3461,7 @@ country_event = {
 		set_temp_variable = { receiver_nation = FROM.id }
 		set_temp_variable = { sender_nation = ROOT.id }
 		set_improved_trade_agreement = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3614,9 +3486,7 @@ country_event = {
 				days = 2
 			}
 		}
-		hidden_effect = {
-			subtract_from_variable = { CHI_chinese_aggression = 1 }
-		}
+		hidden_effect = { subtract_from_variable = { CHI_chinese_aggression = 1 } }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -3629,21 +3499,15 @@ country_event = {
 			}
 			modifier = {
 				factor = 2
-				ALG = {
-					has_government = communism
-				}
+				ALG = { has_government = communism }
 			}
 			modifier = {
 				factor = 0
-				ALG = {
-					has_war = yes
-				}
+				ALG = { has_war = yes }
 			}
 			modifier = {
 				factor = 0
-				check_variable = {
-					debt > 10000
-				}
+				check_variable = { debt > 10000 }
 			}
 			modifier = {
 				factor = 2
@@ -3668,9 +3532,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				check_variable = {
-					uighur_threat > 80
-				}
+				check_variable = { uighur_threat > 80 }
 			}
 			modifier = {
 				factor = 2
@@ -3695,9 +3557,7 @@ country_event = {
 		name = Algeria.12.a
 		log = "[GetDateText]: [This.GetName]: Algeria.12.a executed"
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3715,9 +3575,7 @@ country_event = {
 		add_political_power = -20
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4261,9 +4119,7 @@ country_event = {
 		name = algeria_news.6.a
 		log = "[GetDateText]: [This.GetName]: algeria_news.6.a executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 7 }
-			}
+			limit = { check_variable = { ruling_party = 7 } }
 			set_temp_variable = { add_col_one = 2 }
 			add_coalition_members_effect = yes
 			set_temp_variable = { add_col_one = 12 }
@@ -4772,9 +4628,7 @@ country_event = {
 
 	trigger = { has_country_flag = ALG_civil_war_triggered }
 
-	option = {
-		name = alg.450.a
-	}
+	option = { name = alg.450.a }
 }
 #2003 Sahara hostage crisis
 country_event = {
@@ -4791,9 +4645,7 @@ country_event = {
 		no_jihadist_government = yes
 	}
 
-	option = {
-		name = "ALG_terror_2003_hostage_option"
-	}
+	option = { name = "ALG_terror_2003_hostage_option" }
 }
 # 2007 Algiers Bombings
 country_event = {
@@ -4965,9 +4817,7 @@ country_event = {
 		no_jihadist_government = yes
 	}
 
-	option = {
-		name = ALG_terror_generic_option
-	}
+	option = { name = ALG_terror_generic_option }
 }
 
 # Year 2002 - Hammam Righa Bombing
@@ -4985,9 +4835,7 @@ country_event = {
 		no_jihadist_government = yes
 	}
 
-	option = {
-		name = ALG_terror_generic_option
-	}
+	option = { name = ALG_terror_generic_option }
 }
 
 # Year 2002 - Larbaa Bombing
@@ -5005,9 +4853,7 @@ country_event = {
 		no_jihadist_government = yes
 	}
 
-	option = {
-		name = ALG_terror_generic_option
-	}
+	option = { name = ALG_terror_generic_option }
 }
 
 # Year 2002 - M'Sila Bombing
@@ -5025,9 +4871,7 @@ country_event = {
 		no_jihadist_government = yes
 	}
 
-	option = {
-		name = ALG_terror_generic_option
-	}
+	option = { name = ALG_terror_generic_option }
 }
 
 # Year 2003 - Tizi Ouzou Bombing
@@ -5106,20 +4950,14 @@ country_event = {
 	option = {
 		name = nuclear_algeria.1.a
 		log = "[GetDateText]: [This.GetName]: nuclear_algeria.1.a executed"
-		trigger = {
-			NOT = {
-				has_war_with = CHI
-			}
-		}
+		trigger = { NOT = { has_war_with = CHI } }
 		CHI = {
 			country_event = {
 				id = nuclear_algeria.2
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5139,11 +4977,7 @@ country_event = {
 		set_temp_variable = { influence_target = ALG }
 		change_influence_percentage = yes
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = CHI
-				}
-			}
+			limit = { ROOT = { original_tag = CHI } }
 			custom_effect_tooltip = ALG_missile_chi_TT
 			ALG = {
 				country_event = {
@@ -5152,27 +4986,17 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = nuclear_algeria.2.b
 		log = "[GetDateText]: [This.GetName]: nuclear_algeria.2.b executed"
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = CHI
-				}
-			}
-			ALG = {
-				set_country_flag = CHI_rejected_ALG
-			}
+			limit = { ROOT = { original_tag = CHI } }
+			ALG = { set_country_flag = CHI_rejected_ALG }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
@@ -5190,19 +5014,11 @@ country_event = {
 		name = nuclear_algeria.4.a
 		log = "[GetDateText]: [This.GetName]: nuclear_algeria.4.a executed"
 		if = {
-			limit = {
-				has_tech = reactor1
-			}
+			limit = { has_tech = reactor1 }
 			set_technology = { reactor2 = 1 }
 		}
-		else = {
-			ALG = {
-				set_technology = { reactor1 = 1 }
-			}
-		}
-		ai_chance = {
-			base = 10
-		}
+		else = { ALG = { set_technology = { reactor1 = 1 } } }
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5219,9 +5035,7 @@ country_event = {
 		name = nuclear_algeria.6.a
 		log = "[GetDateText]: [This.GetName]: nuclear_algeria.6.a executed"
 		if = {
-			limit = {
-				has_dlc = "Gotterdammerung"
-			}
+			limit = { has_dlc = "Gotterdammerung" }
 			send_equipment = {
 				type = guided_missile_equipment_1
 				amount = 400
@@ -5255,9 +5069,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -5269,9 +5081,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
@@ -5291,9 +5101,7 @@ country_event = {
 		effect_tooltip = {
 			CHI = {
 				if = {
-					limit = {
-						has_dlc = "Gotterdammerung"
-					}
+					limit = { has_dlc = "Gotterdammerung" }
 					send_equipment = {
 						type = guided_missile_equipment_1
 						amount = 400
@@ -5321,9 +5129,7 @@ country_event = {
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = ALG }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5337,9 +5143,7 @@ country_event = {
 	# Okay
 	option = {
 		name = nuclear_algeria.8.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5368,9 +5172,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -11.5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -5378,9 +5180,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:algerian_focus.171.b executed"
 		set_temp_variable = { percent_change = 5 }
 		change_domestic_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -5408,9 +5208,7 @@ country_event = {
 		add_to_variable = { ALG_sanction_improve_relations_maintain_cost_factor = 0.1 tooltip = improve_relations_maintain_cost_factor_tt }
 		add_to_variable = { ALG_sanction_productivity_growth_modifier = -0.05 tooltip = productivity_growth_modifier_tt }
 		add_to_variable = { ALG_sanction_stability_factor = -0.05 tooltip = stability_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5438,9 +5236,7 @@ country_event = {
 		add_to_variable = { ALG_sanction_improve_relations_maintain_cost_factor = -0.1 tooltip = improve_relations_maintain_cost_factor_tt }
 		add_to_variable = { ALG_sanction_productivity_growth_modifier = 0.05 tooltip = productivity_growth_modifier_tt }
 		add_to_variable = { ALG_sanction_stability_factor = 0.05 tooltip = stability_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5454,9 +5250,7 @@ country_event = {
 	# Good
 	option = {
 		name = nuclear_algeria.28.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5769,9 +5563,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = alg_news_non_aligned.1.a
-	}
+	option = { name = alg_news_non_aligned.1.a }
 }
 country_event = {
 	id = alg_news_non_aligned.2
@@ -5781,9 +5573,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = alg_news_non_aligned.2.a
-	}
+	option = { name = alg_news_non_aligned.2.a }
 }
 country_event = {
 	id = alg_news_non_aligned.3
@@ -5793,9 +5583,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = alg_news_non_aligned.3.a
-	}
+	option = { name = alg_news_non_aligned.3.a }
 }
 country_event = {
 	id = alg_news_non_aligned.4
@@ -5805,9 +5593,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = alg_news_non_aligned.4.a
-	}
+	option = { name = alg_news_non_aligned.4.a }
 }
 country_event = {
 	id = alg_news_non_aligned.5
@@ -5817,9 +5603,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = alg_news_non_aligned.5.a
-	}
+	option = { name = alg_news_non_aligned.5.a }
 }
 country_event = {
 	id = alg_news_non_aligned.6
@@ -5829,9 +5613,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = alg_news_non_aligned.6.a
-	}
+	option = { name = alg_news_non_aligned.6.a }
 }
 # Auto Scandal Triggers
 country_event = {
@@ -6251,9 +6033,7 @@ country_event = {
 	option = {
 		name = ALG_fln.1.b
 		log = "[GetDateText]: [This.GetName]: ALG_fln.1.b executed"
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 		custom_effect_tooltip = ALG_blame_others_tt
 		newline = yes
 		increase_corruption = yes
@@ -6308,9 +6088,7 @@ country_event = {
 	option = {
 		name = ALG_fln.1.e
 		log = "[GetDateText]: [This.GetName]: ALG_fln.1.e executed"
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		custom_effect_tooltip = ALG_anti_corruption_campaign_tt
 		newline = yes
 		set_temp_variable = { treasury_change = -15 }
@@ -6528,9 +6306,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6558,9 +6334,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6588,9 +6362,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6618,9 +6390,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6648,9 +6418,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6678,9 +6446,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6708,9 +6474,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6738,9 +6502,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6768,9 +6530,7 @@ country_event = {
 			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = { id = algeria_power_balance value = -0.05 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6796,19 +6556,13 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_power_balance = {
-					id = algeria_power_balance
-				}
-			}
+			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = {
 				id = algeria_power_balance
 				value = 0.02
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6824,19 +6578,13 @@ country_event = {
 		name = algerian_events.2015.a
 		log = "[GetDateText]: [This.GetName]: algerian_events.2015.a executed"
 		if = {
-			limit = {
-				has_power_balance = {
-					id = algeria_power_balance
-				}
-			}
+			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = {
 				id = algeria_power_balance
 				value = -0.01
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6853,24 +6601,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: algerian_events.2025.a executed"
 		clr_country_flag = ALG_protests_ongoing
 		clear_variable = ALG_protest_exhaustion
-		every_owned_state = {
-			clr_state_flag = ALG_locals_swayed
-		}
+		every_owned_state = { clr_state_flag = ALG_locals_swayed }
 		ALG_update_hirak_gui_dirty_variable = yes
 		if = {
-			limit = {
-				has_power_balance = {
-					id = algeria_power_balance
-				}
-			}
+			limit = { has_power_balance = { id = algeria_power_balance } }
 			add_power_balance_value = {
 				id = algeria_power_balance
 				value = 0.05
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 country_event = {
@@ -6916,9 +6656,7 @@ country_event = {
 		hidden_effect = {
 			news_event = { id = algerian_events.230 days = 7 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 news_event = {
@@ -6931,8 +6669,6 @@ news_event = {
 
 	option = {
 		name = algerian_events.230.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }

--- a/events/Chechnya.txt
+++ b/events/Chechnya.txt
@@ -8,12 +8,11 @@ country_event = {
 	id = chechnya.0
 	title = chechnya.0.t
 	desc = chechnya.0.d
-
-	fire_only_once = yes
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.0.a
 		log = "[GetDateText]: [This.GetName]: chechnya.0.a executed"
 		CHE = {
@@ -33,16 +32,15 @@ country_event = {
 		change_influence_percentage = yes
 		ai_chance = {
 			base = 50
-
 		}
 	}
-	option = {	#Never
+
+	option = { #Never
 		name = chechnya.0.b
 		log = "[GetDateText]: [This.GetName]: chechnya.0.b executed"
 		CHE = { country_event = diplomatic_response.2 }
 		ai_chance = {
 			base = 50
-
 		}
 	}
 }
@@ -51,12 +49,11 @@ country_event = {
 	id = chechnya.1
 	title = chechnya.1.t
 	desc = chechnya.1.d
-
 	picture = GFX_chechnya_rage_kadyrov
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.1.a
 		log = "[GetDateText]: [This.GetName]: chechnya.1.a executed"
 		CHE = {
@@ -73,10 +70,10 @@ country_event = {
 		}
 		ai_chance = {
 			base = 10
-
 		}
 	}
-	option = {	#Never
+
+	option = { #Never
 		name = chechnya.1.b
 		log = "[GetDateText]: [This.GetName]: chechnya.1.b executed"
 		CHE = {
@@ -86,7 +83,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 90
-
 		}
 	}
 }
@@ -95,12 +91,11 @@ country_event = {
 	id = chechnya.2
 	title = chechnya.2.t
 	desc = chechnya.2.d
-
 	picture = GFX_chechnya_rage_kadyrov
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.2.a
 		log = "[GetDateText]: [This.GetName]: chechnya.2.a executed"
 		CHE = {
@@ -117,10 +112,10 @@ country_event = {
 		}
 		ai_chance = {
 			base = 10
-
 		}
 	}
-	option = {	#Never
+
+	option = { #Never
 		name = chechnya.2.b
 		log = "[GetDateText]: [This.GetName]: chechnya.2.b executed"
 		CHE = {
@@ -130,7 +125,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 90
-
 		}
 	}
 }
@@ -139,12 +133,11 @@ country_event = {
 	id = chechnya.3
 	title = chechnya.3.t
 	desc = chechnya.3.d
-
 	picture = GFX_chechnya_rage_kadyrov
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.3.a
 		log = "[GetDateText]: [This.GetName]: chechnya.3.a executed"
 		CHE = {
@@ -161,10 +154,10 @@ country_event = {
 		}
 		ai_chance = {
 			base = 10
-
 		}
 	}
-	option = {	#Never
+
+	option = { #Never
 		name = chechnya.3.b
 		log = "[GetDateText]: [This.GetName]: chechnya.3.b executed"
 		CHE = {
@@ -174,7 +167,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 90
-
 		}
 	}
 }
@@ -184,20 +176,17 @@ country_event = {
 	title = chechnya.4.t
 	desc = chechnya.4.d
 	picture = GFX_chehcnya_karydov_tsar
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.4.a
 		log = "[GetDateText]: [This.GetName]: chechnya.4.a executed"
 		add_stability = 0.02
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
@@ -205,20 +194,17 @@ country_event = {
 	title = chechnya.5.t
 	desc = chechnya.5.d
 	picture = GFX_chechnya_ros_gvardia
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.5.a
 		log = "[GetDateText]: [This.GetName]: chechnya.5.a executed"
 		add_stability = 0.02
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
@@ -226,19 +212,16 @@ country_event = {
 	title = chechnya.6.t
 	desc = chechnya.6.d
 	picture = GFX_chechnya_ahmat_battalion
-
 	is_triggered_only = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.6.a
 		log = "[GetDateText]: [This.GetName]: chechnya.6.a executed"
 		add_stability = 0.01
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
@@ -246,19 +229,16 @@ country_event = {
 	title = chechnya.7.t
 	desc = chechnya.7.d
 	picture = GFX_checnya_gudermes
-
 	is_triggered_only = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.7.a
 		log = "[GetDateText]: [This.GetName]: chechnya.7.a executed"
 		add_stability = 0.01
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
@@ -266,20 +246,17 @@ country_event = {
 	title = chechnya.8.t
 	desc = chechnya.8.d
 	picture = GFX_checnya_ahmat_bronemachine
-
 	is_triggered_only = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.8.a
 		log = "[GetDateText]: [This.GetName]: chechnya.8.a executed"
 		add_stability = 0.01
 		set_technology = { util_vehicle_7 = 1 }
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
@@ -287,10 +264,9 @@ country_event = {
 	title = chechnya.9.t
 	desc = chechnya.9.d
 	picture = GFX_chehcnya_djahd_mobile
-
 	is_triggered_only = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.9.a
 		log = "[GetDateText]: [This.GetName]: chechnya.9.a executed"
 		add_tech_bonus = {
@@ -301,21 +277,18 @@ country_event = {
 		}
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
 	id = chechnya.11
 	title = chechnya.11.t
 	desc = chechnya.11.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.11.a
 		log = "[GetDateText]: [This.GetName]: chechnya.11.a executed"
 		kill_country_leader = yes
@@ -332,22 +305,19 @@ country_event = {
 		}
 		ai_chance = {
 			base = 90
-
 		}
 	}
-
 }
 
 country_event = {
 	id = chechnya.12
 	title = chechnya.12.t
 	desc = chechnya.12.d
-
 	picture = GFX_chechnya_rage_kadyrov
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = chechnya.12.a
 		log = "[GetDateText]: [This.GetName]: chechnya.12.a executed"
 		CHE = {
@@ -364,10 +334,10 @@ country_event = {
 		}
 		ai_chance = {
 			base = 10
-
 		}
 	}
-	option = {	#Never
+
+	option = { #Never
 		name = chechnya.12.b
 		log = "[GetDateText]: [This.GetName]: chechnya.12.b executed"
 		CHE = {
@@ -377,7 +347,6 @@ country_event = {
 		 }
 		ai_chance = {
 			base = 90
-
 		}
 	}
 }
@@ -386,7 +355,6 @@ country_event = {
 	id = chechnya.16
 	title = chechnya.16.t
 	desc = chechnya.16.d
-
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
@@ -425,13 +393,11 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = chechnya.17
 	title = chechnya.17.t
 	desc = chechnya.17.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -502,7 +468,6 @@ country_event = {
 	id = chechnya.18
 	title = chechnya.18.t
 	desc = chechnya.18.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -512,26 +477,20 @@ country_event = {
 		SOV = {
 			add_timed_idea = { idea = CHE_russian_instability days = 1090 }
 			white_peace = CHE
-			hidden_effect = {
-				SUB_separatism_plus_subject = yes
-			}
+			hidden_effect = { SUB_separatism_plus_subject = yes }
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = chechnya.18.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 country_event = {
 	id = chechnya.19
 	title = chechnya.19.t
 	desc = chechnya.19.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -560,7 +519,6 @@ country_event = {
 	id = chechnya.20
 	title = chechnya.20.t
 	desc = chechnya.20.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -579,7 +537,6 @@ country_event = {
 	id = chechnya.21
 	title = chechnya.21.t
 	desc = chechnya.21.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -593,7 +550,6 @@ country_event = {
 	id = chechnya.22
 	title = chechnya.22.t
 	desc = chechnya.22.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -620,7 +576,6 @@ country_event = {
 	id = chechnya.23
 	title = chechnya.23.t
 	desc = chechnya.23.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -656,7 +611,6 @@ country_event = {
 	id = chechnya.24
 	title = chechnya.24.t
 	desc = chechnya.24.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -820,8 +774,9 @@ country_event = {
 	id = chechnya.26
 	title = chechnya.26.t
 	desc = chechnya.26.d
-	is_triggered_only = yes
 	picture = GFX_belarus_silesia
+	is_triggered_only = yes
+
 	option = {
 		name = chechnya.26.a
 		log = "[GetDateText]: [This.GetName]: chechnya.26.a executed"
@@ -833,15 +788,12 @@ country_event = {
 			modify_silesiabund_support = yes
 			}
 		}
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
+
 	option = {
 		name = chechnya.26.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -849,8 +801,9 @@ country_event = {
 	id = chechnya.27
 	title = chechnya.27.t
 	desc = chechnya.27.d
-	is_triggered_only = yes
 	picture = GFX_belarus_silesia
+	is_triggered_only = yes
+
 	option = {
 		name = chechnya.27.a
 		log = "[GetDateText]: [This.GetName]: chechnya.27.a executed"
@@ -866,10 +819,7 @@ country_event = {
 			add_timed_idea = { idea = SIL_defence_republic days = 120 }
 			country_event = chechnya.28
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -877,14 +827,13 @@ country_event = {
 	id = chechnya.28
 	title = chechnya.28.t
 	desc = chechnya.28.d
-	is_triggered_only = yes
 	picture = GFX_belarus_silesia
+	is_triggered_only = yes
+
 	option = {
 		name = chechnya.28.a
 		log = "[GetDateText]: [This.GetName]: chechnya.28.a executed"
-		hidden_effect = {
-			add_manpower = 3500
-		}
+		hidden_effect = { add_manpower = 3500 }
 		division_template = {
 			name = "Silesian Militia"
 			regiments = {
@@ -918,9 +867,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				POL = { has_country_flag = SIL_chechen_help }
-			}
+			limit = { POL = { has_country_flag = SIL_chechen_help } }
 		random_owned_controlled_state = {
 			limit = { ROOT = { has_full_control_of_state = PREV } }
 			prioritize = { 115 }
@@ -937,8 +884,9 @@ country_event = {
 	id = chechnya.29
 	title = chechnya.29.t
 	desc = chechnya.29.d
-	is_triggered_only = yes
 	picture = GFX_che_dinamo_terror
+	is_triggered_only = yes
+
 	option = {
 		name = chechnya.29.a
 		trigger = { original_tag = SOV }
@@ -954,28 +902,19 @@ country_event = {
 	id = chechnya.30
 	title = chechnya.30.t
 	desc = chechnya.30.d
-	is_triggered_only = yes
 	picture = GFX_che_flag
+	is_triggered_only = yes
+
 	option = {
 		name = chechnya.30.a
 		log = "[GetDateText]: [This.GetName]: chechnya.30.a executed"
 		hidden_effect = {
 			if = {
-				limit = {
-					SOV = {
-						has_completed_focus = SOV_second_slujba
-					}
-				}
+				limit = { SOV = { has_completed_focus = SOV_second_slujba } }
 				complete_national_focus = CHE_loyal_govern
 			}
 			else_if = {
-				limit = {
-					SOV = {
-						NOT = {
-							has_completed_focus = SOV_second_slujba
-						}
-					}
-				}
+				limit = { SOV = { NOT = { has_completed_focus = SOV_second_slujba } } }
 				complete_national_focus = CHE_ahmat_after
 			}
 		}
@@ -986,20 +925,19 @@ country_event = {
 	id = chechnya.31
 	title = chechnya.31.t
 	desc = chechnya.31.d
-	is_triggered_only = yes
 	picture = GFX_che_flag
-	option = {
-		name = chechnya.31.a
+	is_triggered_only = yes
 
-	}
+	option = { name = chechnya.31.a }
 }
 
 country_event = {
 	id = chechnya.32
 	title = chechnya.32.t
 	desc = chechnya.32.d
-	is_triggered_only = yes
 	picture = GFX_che_kadyrov_alkhanov
+	is_triggered_only = yes
+
 	option = {
 		name = chechnya.32.a
 		log = "[GetDateText]: [This.GetName]: chechnya.32.a executed"
@@ -1012,6 +950,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = chechnya.32.b
 		log = "[GetDateText]: [This.GetName]: chechnya.32.b executed"
@@ -1029,10 +968,8 @@ country_event = {
 	id = chechnya.33
 	title = chechnya.33.t
 	desc = chechnya.33.d
-	is_triggered_only = yes
 	picture = GFX_che_alkhanov
-	option = {
-		name = chechnya.33.a
+	is_triggered_only = yes
 
-	}
+	option = { name = chechnya.33.a }
 }

--- a/events/Cuba.txt
+++ b/events/Cuba.txt
@@ -38,9 +38,8 @@ country_event = {
 	desc = cuba.9.d
 	picture = GFX_castro_event
 	is_triggered_only = yes
-	option = {
-		name = cuba.9.a
-	 }
+
+	option = { name = cuba.9.a }
 }
 
 country_event = {
@@ -49,17 +48,17 @@ country_event = {
 	desc = cuba.10.d
 	picture = GFX_cuba_constitution
 	is_triggered_only = yes
-	option = {
-		name = cuba.10.a
-	 }
+
+	option = { name = cuba.10.a }
 }
 
 country_event = {
 	id = cuba.11
 	title = cuba.11.t
 	desc = cuba.11.d
-	is_triggered_only = yes
 	picture = GFX_raul_castro
+	is_triggered_only = yes
+
 	option = {
 		name = cuba.11.a
 		log = "[GetDateText]: [This.GetName]: cuba.11.a"
@@ -94,6 +93,7 @@ country_event = {
 	desc = cuba.12.d
 	picture = GFX_castro_democratic
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.12.a
 		log = "[GetDateText]: [This.GetName]: cuba.12.a"
@@ -103,7 +103,6 @@ country_event = {
 			change_ruling_party_effect = yes
 			recalculate_party = yes
 		}
-
 		create_country_leader = {
 			name = "Fidel Castro"
 			picture = "fidel_castro.dds"
@@ -121,21 +120,19 @@ country_event = {
 	desc = cuba.14.d
 	picture = GFX_cuba_guantanamo_question_event
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.14.a
 		log = "[GetDateText]: [This.GetName]: cuba.14.a"
 		CUB = { country_event = { id = cuba.26 days = 1 } }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	 }
+
 	 option = {
 		name = cuba.14.b
 		log = "[GetDateText]: [This.GetName]: cuba.14.b"
 		CUB = { country_event = { id = cuba.27 days = 1 } }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	 }
 }
 country_event = {
@@ -144,6 +141,7 @@ country_event = {
 	desc = cuba.15.d
 	picture = GFX_rohel
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.15.a
 		log = "[GetDateText]: [This.GetName]: cuba.15.a"
@@ -151,6 +149,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = -5 }
 		change_communist_cadres_opinion = yes
 	 }
+
 	 option = {
 		name = cuba.15.b
 		log = "[GetDateText]: [This.GetName]: cuba.15.b"
@@ -165,9 +164,8 @@ country_event = {
 	desc = cuba.16.d
 	picture = GFX_Pope_roma_and_raul
 	is_triggered_only = yes
-	option = {
-		name = cuba.16.a
-	 }
+
+	option = { name = cuba.16.a }
 }
 #alba events
 country_event = {
@@ -176,27 +174,21 @@ country_event = {
 	desc = cuba.17.d
 	picture = GFX_alba_country_event
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.17.a
 		log = "[GetDateText]: [This.GetName]: cuba.17.a"
-		CUB = {
-			add_ideas = CUB_alba_idea
-		}
-		VEN = {
-			add_ideas = CUB_alba_idea
-		}
+		CUB = { add_ideas = CUB_alba_idea }
+		VEN = { add_ideas = CUB_alba_idea }
 		CUB = { country_event = { id = cuba.18 days = 1 } }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	 }
+
 	option = {
 		name = cuba.17.b
 		log = "[GetDateText]: [This.GetName]: cuba.17.b"
 		CUB = { country_event = { id = cuba.19 days = 1 } }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	 }
 }
 #They said YES
@@ -206,6 +198,7 @@ country_event = {
 	desc = cuba.18.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		custom_effect_tooltip = cuba_alba_tt
 		name = cuba.18.a
@@ -223,23 +216,21 @@ country_event = {
 	desc = cuba.19.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
-	option = {
-		name = cuba.19.a
-	 }
+
+	option = { name = cuba.19.a }
 }
 #ALBA formed
 news_event = {
 	id = cuba_news.20
-	picture = GFX_alba_creation
 	title = cuba_news.20.t
 	desc = cuba_news.20.d
-	fire_only_once = yes
-	major = yes
+	picture = GFX_alba_creation
 	is_triggered_only = yes
+	major = yes
+	fire_only_once = yes
+
 	option = {
-		trigger = {
-		NOT = { original_tag = CUB }
-		}
+		trigger = { NOT = { original_tag = CUB } }
 		name = cuba_news.20.a
 	 }
 }
@@ -250,6 +241,7 @@ country_event = {
 	desc = cuba.21.d
 	picture = GFX_alba_country_event
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: cuba.21.a"
 		name = cuba.21.a
@@ -263,6 +255,7 @@ country_event = {
 	desc = cuba.22.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.22.a
 		log = "[GetDateText]: [This.GetName]: cuba.22.a"
@@ -276,9 +269,8 @@ news_event = {
 	desc = cuba_news.24.d
 	picture = GFX_cuba_eacu
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.24.a
-	 }
+
+	option = { name = cuba_news.24.a }
 }
 
 country_event = {
@@ -287,6 +279,7 @@ country_event = {
 	desc = cuba.25.d
 	picture = GFX_event_for_china_cuba
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.25.a
 		log = "[GetDateText]: [This.GetName]: cuba.25.a"
@@ -297,18 +290,12 @@ country_event = {
 				active = yes
 			}
 		}
-
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = cuba.25.b
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -319,6 +306,7 @@ country_event = {
 	desc = cuba.26.d
 	picture = GFX_prison_cuba
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.26.a
 		log = "[GetDateText]: [This.GetName]: cuba.26.a"
@@ -352,13 +340,12 @@ country_event = {
 #world event
 news_event = {
 	id = cuba_news.29
-	picture = GFX_NATO_picture
 	title = cuba_news.29.t
 	desc = cuba_news.29.d
+	picture = GFX_NATO_picture
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.29.a
-	 }
+
+	option = { name = cuba_news.29.a }
 }
 news_event = {
 	id = cuba_news.30
@@ -366,9 +353,8 @@ news_event = {
 	desc = cuba_news.30.d
 	picture = GFX_cuba_return_guantanamo
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.30.a
-	 }
+
+	option = { name = cuba_news.30.a }
 }
 
 country_event = {
@@ -377,9 +363,8 @@ country_event = {
 	desc = cuba.33.d
 	picture = GFX_navalny_prison
 	is_triggered_only = yes
-	option = {
-		name = cuba.33.a
-	 }
+
+	option = { name = cuba.33.a }
 }
 
 country_event = {
@@ -388,9 +373,8 @@ country_event = {
 	desc = cuba.34.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
-	option = {
-		name = cuba.34.a
-	 }
+
+	option = { name = cuba.34.a }
 }
 #NATIONALISTS EVENTS
 news_event = {
@@ -399,9 +383,8 @@ news_event = {
 	desc = cuba_news.35.d
 	picture = GFX_falanga_in_power
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.35.a
-	 }
+
+	option = { name = cuba_news.35.a }
 }
 country_event = {
 	id = cuba.36
@@ -409,11 +392,13 @@ country_event = {
 	desc = cuba.36.d
 	picture = GFX_Military_Reform
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.36.a
 		log = "[GetDateText]: [This.GetName]: cuba.36.a"
 		CUB = { country_event = { id = cuba.37 days = 1 } }
 	 }
+
 	 option = {
 		name = cuba.36.b
 		log = "[GetDateText]: [This.GetName]: cuba.36.b"
@@ -426,6 +411,7 @@ country_event = {
 	desc = cuba.37.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.37.a
 		log = "[GetDateText]: [This.GetName]: cuba.37.a"
@@ -443,6 +429,7 @@ country_event = {
 	desc = cuba.38.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	option = {
 		set_temp_variable = { wargoal_on = DOM }
 		set_temp_variable = { wargoal_type = 2 }
@@ -461,6 +448,7 @@ country_event = {
 	desc = cuba.39.d
 	picture = GFX_hard_choice_cuba
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.39.a
 		#2 party
@@ -471,37 +459,31 @@ country_event = {
 			set_temp_variable = { disable_elections = 0 }
 			change_ruling_party_effect = yes
 		}
-
 		set_temp_variable = { party_index = 2 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = cub_liberal_union_tt
-
 		ai_chance = {
 			base = 1
 		}
 	 }
+
 	 option = {
 		name = cuba.39.b
 		#3 party
 		log = "[GetDateText]: [This.GetName]: cuba.39.b"
-
 		if = {
 			limit = { NOT = { check_variable = { ruling_party = 3 } } }
 			set_temp_variable = { rul_party_temp = 3 }
 			set_temp_variable = { disable_elections = 0 }
 			change_ruling_party_effect = yes
 		}
-
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = cub_democratic_union_tt
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -510,6 +492,7 @@ country_event = {
 			}
 		}
 	 }
+
 	 option = {
 		name = cuba.39.c
 		log = "[GetDateText]: [This.GetName]: cuba.39.c"
@@ -519,17 +502,12 @@ country_event = {
 			set_temp_variable = { disable_elections = 0 }
 			change_ruling_party_effect = yes
 		}
-
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = cub_christian_union_tt
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -555,10 +533,7 @@ country_event = {
 			modify_treasury_effect = yes
 			country_event = { id = cuba.41 days = 1 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -572,10 +547,7 @@ country_event = {
 			country_event = { id = cuba.42 days = 1 }
 		}
 		set_country_flag = puerto_disagree
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	 }
 }
 #YES
@@ -585,9 +557,8 @@ country_event = {
 	desc = cuba.41.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
-	option = {
-		name = cuba.41.a
-	 }
+
+	option = { name = cuba.41.a }
 }
 #NO
 country_event = {
@@ -596,9 +567,8 @@ country_event = {
 	desc = cuba.42.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
-	option = {
-		name = cuba.42.a
-	 }
+
+	option = { name = cuba.42.a }
 }
 #Democratic Finish Blockade
 country_event = {
@@ -607,6 +577,7 @@ country_event = {
 	desc = cuba.43.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.43.a
 		log = "[GetDateText]: [This.GetName]: cuba.43.a"
@@ -619,6 +590,7 @@ country_event = {
 			country_event = { id = cuba.44 days = 1 }
 		}
 	 }
+
 	 option = {
 		name = cuba.43.b
 		log = "[GetDateText]: [This.GetName]: cuba.43.b"
@@ -638,9 +610,8 @@ country_event = {
 	desc = cuba.44.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
-	option = {
-		name = cuba.44.a
-	 }
+
+	option = { name = cuba.44.a }
 }
 #no
 country_event = {
@@ -649,9 +620,8 @@ country_event = {
 	desc = cuba.45.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
-	option = {
-		name = cuba.45.a
-	 }
+
+	option = { name = cuba.45.a }
 }
 country_event = {
 	id = cuba.49
@@ -659,6 +629,7 @@ country_event = {
 	desc = cuba.49.d
 	picture = GFX_important_decision_cuba
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.49.a
 		log = "[GetDateText]: [This.GetName]: cuba.49.a"
@@ -716,6 +687,7 @@ country_event = {
 	desc = CubaConf.50.d
 	picture = GFX_antillean_conf_cuba
 	is_triggered_only = yes
+
 	option = {
 		name = CubaConf.50.a
 		log = "[GetDateText]: [This.GetName]: CubaConf.50.a executed"
@@ -742,6 +714,7 @@ country_event = {
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
 	}
+
 	option = {
 		name = CubaConf.50.b
 		log = "[GetDateText]: [This.GetName]: CubaConf.50.a executed"
@@ -750,7 +723,7 @@ country_event = {
 		set_temp_variable = { tag_index = CUB }
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
-		CUB = {	country_event = { id = CubaConf.51 days = 1 } }
+		CUB = { country_event = { id = CubaConf.51 days = 1 } }
 	}
 }
 
@@ -760,9 +733,8 @@ country_event = {
 	desc = CubaConf.51.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
-	option = {
-		name = CubaConf.51.a
-	}
+
+	option = { name = CubaConf.51.a }
 }
 #Change Path AI
 country_event = {
@@ -771,6 +743,7 @@ country_event = {
 	desc = cuba.52.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.52.a
 		log = "[GetDateText]: [This.GetName]: cuba.52.a"
@@ -821,6 +794,7 @@ country_event = {
 	desc = cuba.53.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.53.a
 		log = "[GetDateText]: [This.GetName]: cuba.53.a"
@@ -838,11 +812,13 @@ country_event = {
 	desc = cuba.54.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.54.a
 		log = "[GetDateText]: [This.GetName]: cuba.54.a"
 		CUB = { country_event = { id = cuba.55 days = 1 } }
 	 }
+
 	 option = {
 		name = cuba.54.a
 		log = "[GetDateText]: [This.GetName]: cuba.54.a"
@@ -858,6 +834,7 @@ country_event = {
 	desc = cuba.55.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.55.a
 		log = "[GetDateText]: [This.GetName]: cuba.55.a"
@@ -878,6 +855,7 @@ country_event = {
 	desc = cuba.56.d
 	picture = GFX_cargo_ship
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.56.a
 		log = "[GetDateText]: [This.GetName]: cuba.56.a"
@@ -885,16 +863,13 @@ country_event = {
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
-		CUB = {
-			one_random_infrastructure = yes
-		}
+		CUB = { one_random_infrastructure = yes }
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = CUB }
 		change_influence_percentage = yes
 	 }
-	 option = {
-		name = cuba.56.b
-	 }
+
+	 option = { name = cuba.56.b }
 }
 country_event = {
 	id = cuba.57
@@ -902,6 +877,7 @@ country_event = {
 	desc = cuba.57.d
 	picture = GFX_cargo_ship
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.57.a
 		log = "[GetDateText]: [This.GetName]: cuba.57.a"
@@ -912,9 +888,8 @@ country_event = {
 		set_temp_variable = { influence_target = CUB }
 		change_influence_percentage = yes
 	 }
-	 option = {
-		name = cuba.57.b
-	 }
+
+	 option = { name = cuba.57.b }
 }
 news_event = {
 	id = cuba_news.59
@@ -922,9 +897,8 @@ news_event = {
 	desc = cuba_news.59.d
 	picture = GFX_Obama_news_cuba
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.59.a
-	 }
+
+	option = { name = cuba_news.59.a }
 }
 country_event = {
 	id = cuba.58
@@ -932,6 +906,7 @@ country_event = {
 	desc = cuba.58.d
 	picture = GFX_computer
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.58.a
 		log = "[GetDateText]: [This.GetName]: cuba.58.a"
@@ -944,9 +919,8 @@ news_event = {
 	desc = cuba_news.60.d
 	picture = GFX_putin_cuba_news
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.60.a
-	 }
+
+	option = { name = cuba_news.60.a }
 }
 news_event = {
 	id = cuba_news.61
@@ -954,9 +928,8 @@ news_event = {
 	desc = cuba_news.61.d
 	picture = GFX_miguel_diaz_canel
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.61.a
-	 }
+
+	option = { name = cuba_news.61.a }
 }
 news_event = {
 	id = cuba_news.62
@@ -964,9 +937,8 @@ news_event = {
 	desc = cuba_news.62.d
 	picture = GFX_cuban_prisons_event
 	is_triggered_only = yes
-	option = {
-		name = cuba_news.62.a
-	 }
+
+	option = { name = cuba_news.62.a }
 }
 country_event = {
 	id = cuba.63
@@ -974,6 +946,7 @@ country_event = {
 	desc = cuba.63.d
 	picture = GFX_USA_generic
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.63.a
 		log = "[GetDateText]: [This.GetName]: cuba.63.a"
@@ -985,6 +958,7 @@ country_event = {
 		give_military_access = USA
 		CUB = { country_event = { id = cuba.64 days = 1 } }
 	 }
+
 	 option = {
 		name = cuba.63.b
 		log = "[GetDateText]: [This.GetName]: cuba.63.b"
@@ -997,9 +971,8 @@ country_event = {
 	desc = cuba.64.d
 	picture = GFX_USA_generic
 	is_triggered_only = yes
-	option = {
-		name = cuba.64.a
-	 }
+
+	option = { name = cuba.64.a }
 }
 country_event = {
 	id = cuba.65
@@ -1007,9 +980,8 @@ country_event = {
 	desc = cuba.65.d
 	picture = GFX_USA_generic
 	is_triggered_only = yes
-	option = {
-		name = cuba.65.a
-	 }
+
+	option = { name = cuba.65.a }
 }
 country_event = {
 	id = cuba.66
@@ -1021,25 +993,17 @@ country_event = {
 	option = {
 		name = cuba.66.a
 		log = "[GetDateText]: [This.GetName]: cuba.66.a executed"
-		USA = {
-			clr_country_flag = blockade_cuba_yes
-		}
-		CUB = {
-			remove_ideas = CUB_idea_blockade1
-		}
-		ai_chance = {
-			base = 100
-		}
+		USA = { clr_country_flag = blockade_cuba_yes }
+		CUB = { remove_ideas = CUB_idea_blockade1 }
+		ai_chance = { base = 100 }
 		CUB = { country_event = { id = cuba.67 days = 1 } }
 	}
+
 	option = {
 		name = cuba.66.a
 		log = "[GetDateText]: [This.GetName]: cuba.66.a executed"
 		CUB = { country_event = { id = cuba.68 days = 1 } }
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1049,10 +1013,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = cuba.67.a
-
-	}
+	option = { name = cuba.67.a }
 }
 country_event = {
 	id = cuba.68
@@ -1061,9 +1022,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = cuba.68.a
-	}
+	option = { name = cuba.68.a }
 }
 
 # Cuba Asks for Protection
@@ -1073,6 +1032,7 @@ country_event = {
 	desc = cuba.72.d
 	picture = GFX_Military_Reform
 	is_triggered_only = yes
+
 	option = {
 		name = cuba.72.a
 		log = "[GetDateText]: [This.GetName]: cuba.72.a"
@@ -1085,7 +1045,6 @@ country_event = {
 			}
 		}
 		CUB = { country_event = { id = cuba.73 days = 1 } }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1116,7 +1075,6 @@ country_event = {
 		name = cuba.72.b
 		log = "[GetDateText]: [This.GetName]: cuba.72.b"
 		CUB = { country_event = { id = cuba.74 days = 1 } }
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -1145,9 +1103,8 @@ country_event = {
 	desc = cuba.73.d
 	picture = GFX_Military_Reform
 	is_triggered_only = yes
-	option = {
-		name = cuba.73.a
-	 }
+
+	option = { name = cuba.73.a }
 }
 country_event = {
 	id = cuba.74
@@ -1155,7 +1112,6 @@ country_event = {
 	desc = cuba.74.d
 	picture = GFX_Military_Reform
 	is_triggered_only = yes
-	option = {
-		name = cuba.74.a
-	 }
+
+	option = { name = cuba.74.a }
 }

--- a/events/Ecuador.txt
+++ b/events/Ecuador.txt
@@ -2,51 +2,36 @@ add_namespace = ecuador
 add_namespace = ecuadornews
 
 news_event = {
-
 	id = ecuadornews.1
 	title = ecuadornews.1.t
 	desc = ecuadornews.1.d
 	picture = GFX_ecu_coup_picture
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = ecuadornews.1.a
-	}
+	option = { name = ecuadornews.1.a }
 }
 
 news_event = {
-
 	id = ecuadornews.2
 	title = ecuadornews.2.t
 	desc = ecuadornews.2.d
 	picture = GFX_ecu_coup_picture
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = ecuadornews.2.a
-	}
+	option = { name = ecuadornews.2.a }
 }
 
 news_event = {
-
 	id = ecuadornews.3
 	title = ecuadornews.3.t
 	desc = ecuadornews.3.d
 	picture = GFX_ecu_coup_picture2
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = ecuadornews.3.a
-	}
+	option = { name = ecuadornews.3.a }
 }
 
 country_event = {
@@ -59,9 +44,7 @@ country_event = {
 	option = {
 		name = ecuador.1.a
 		log = "[GetDateText]: [This.GetName]: ecuador.1.a executed"
-
 		add_stability = 0.05
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -74,12 +57,8 @@ country_event = {
 	option = {
 		name = ecuador.1.b
 		log = "[GetDateText]: [This.GetName]: ecuador.1.b executed"
-
 		add_political_power = 100
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -87,13 +66,12 @@ country_event = {
 	id = ecuador.2
 	title = ecuador.2.t
 	desc = ecuador.2.d
-	is_triggered_only = yes
 	picture = GFX_ecu_protest
+	is_triggered_only = yes
 
 	option = {
 		name = ecuador.2.a
 		log = "[GetDateText]: [This.GetName]: ecuador.2.a executed"
-
 		add_political_power = -50
 		add_stability = -0.05
 	}
@@ -104,12 +82,12 @@ country_event = {
 	title = ecuador.3.t
 	desc = ecuador.3.d
 	is_triggered_only = yes
+
 	immediate = {
 		hidden_effect = {
 			retire_country_leader = yes
 			set_temp_variable = { rul_party_temp = 22 }
 			change_ruling_party_effect = yes
-
 			create_country_leader = {
 				name = "Carlos Mendoza"
 				picture = "Carlos_Mendoza.dds"
@@ -119,7 +97,6 @@ country_event = {
 					military_career
 				}
 			}
-
 			set_temp_variable = { party_index = 22 }
 			set_temp_variable = { party_popularity_increase = 0.10 }
 			set_temp_variable = { temp_outlook_increase = 0.10 }
@@ -130,15 +107,11 @@ country_event = {
 	option = {
 		name = ecuador.3.a
 		log = "[GetDateText]: [This.GetName]: ecuador.3.a executed"
-
 		hidden_effect = {
 			retire_country_leader = yes
-
 			country_event = { id = ecuador.4 hours = 1 }
-
 			news_event = { id = ecuadornews.2 hours = 6 }
 		}
-
 		create_country_leader = {
 			name = "Lucio Gutierrez"
 			picture = "General_Lucio_Gutierrez.dds"
@@ -148,7 +121,6 @@ country_event = {
 				military_career
 			}
 		}
-
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -161,14 +133,10 @@ country_event = {
 	option = {
 		name = ecuador.3.b
 		log = "[GetDateText]: [This.GetName]: ecuador.3.b executed"
-
 		hidden_effect = {
 			news_event = { id = ecuadornews.1 hours = 6 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -182,9 +150,7 @@ country_event = {
 	option = {
 		name = ecuador.4.a
 		log = "[GetDateText]: [This.GetName]: ecuador.4.a executed"
-
 		add_political_power = 20
-
 		hidden_effect = {
 			country_event = { id = ecuador.5 hours = 2 }
 		}
@@ -205,10 +171,8 @@ country_event = {
 			retire_country_leader = yes
 			set_temp_variable = { rul_party_temp = 0 }
 			change_ruling_party_effect = yes
-
 			news_event = { id = ecuadornews.3 hours = 6 }
 		}
-
 		create_country_leader = {
 			name = "Gustavo Noboa"
 			picture = "Gustavo_Noboa.dds"
@@ -218,12 +182,10 @@ country_event = {
 				doctor
 			}
 		}
-
 		set_temp_variable = { party_index = 0 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 3
 			modifier = {
@@ -235,8 +197,6 @@ country_event = {
 
 	option = {
 		name = ecuador.5.b
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }

--- a/events/United States.txt
+++ b/events/United States.txt
@@ -213,7 +213,7 @@ country_event = {
 
 	trigger = {
 		tag = USA
-		has_full_control_of_state = 778	#Illinois
+		has_full_control_of_state = 778 #Illinois
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
@@ -240,10 +240,10 @@ country_event = {
 		OR = {
 			NOT = { has_government = communism }
 			NOT = { has_government = nationalist }
-			NOT = {	check_variable = { ruling_party = 4 } }
-			NOT = {	check_variable = { ruling_party = 19 } }
-			NOT = {	check_variable = { ruling_party = 20 } }
-			NOT = {	check_variable = { ruling_party = 21 } }
+			NOT = { check_variable = { ruling_party = 4 } }
+			NOT = { check_variable = { ruling_party = 19 } }
+			NOT = { check_variable = { ruling_party = 20 } }
+			NOT = { check_variable = { ruling_party = 21 } }
 		}
 		NOT = { has_country_flag = collapsed_nation }
 	}
@@ -453,9 +453,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: usa.6.o1 executed"
 		add_political_power = -50
 		add_stability = -0.05
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -464,9 +462,7 @@ country_event = {
 		add_stability = -0.03
 		set_temp_variable = { treasury_change = -0.5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #Elian Gonzalez Affair
@@ -488,7 +484,7 @@ country_event = {
 		}
 	}
 
-	option = {	#Send the boy back
+	option = { #Send the boy back
 		name = usa.7.o1
 		log = "[GetDateText]: [This.GetName]: usa.7.o1 executed"
 		add_political_power = 50
@@ -525,7 +521,7 @@ country_event = {
 		}
 	}
 
-	option = {	#Keep him here
+	option = { #Keep him here
 		name = usa.7.o2
 		log = "[GetDateText]: [This.GetName]: usa.7.o2 executed"
 		add_political_power = -100
@@ -659,7 +655,7 @@ country_event = {
 
 	trigger = {
 		tag = USA
-		has_full_control_of_state = 800	#Texas
+		has_full_control_of_state = 800 #Texas
 		date > 2000.03.20
 		date < 2000.04.1
 		NOT = { has_country_flag = collapsed_nation }
@@ -741,7 +737,7 @@ country_event = {
 
 	trigger = {
 		tag = USA
-		has_full_control_of_state = 800	#Texas
+		has_full_control_of_state = 800 #Texas
 		date > 2000.3.1
 		date < 2000.4.5
 		NOT = { has_country_flag = collapsed_nation }
@@ -770,9 +766,7 @@ country_event = {
 		USA_congress_small_support = yes
 		set_temp_variable = { treasury_change = -0.5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 0.50
-		}
+		ai_chance = { base = 0.50 }
 	}
 
 	#Mobilize Diaster Relief
@@ -892,9 +886,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 		hidden_effect = { country_event = { id = usa.1000 days = 120 random_hours = 20 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -911,7 +903,7 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
-	option = {	#A new alternative?
+	option = { #A new alternative?
 		name = usa.18.a
 		log = "[GetDateText]: [This.GetName]: usa.18.o1 executed"
 		set_temp_variable = { party_index = 16 }
@@ -957,9 +949,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
 		hidden_effect = { country_event = { id = usa.1000 days = 120 random_hours = 20 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -976,7 +966,7 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
-	option = {	#The establishment is right.
+	option = { #The establishment is right.
 		name = usa.20.o1
 		log = "[GetDateText]: [This.GetName]: usa.20.o1 executed"
 		add_popularity = { ideology = democratic popularity = 0.02 }
@@ -998,7 +988,7 @@ country_event = {
 		}
 	}
 
-	option = {	#The environmentalists are right.
+	option = { #The environmentalists are right.
 		name = usa.20.o2
 		log = "[GetDateText]: [This.GetName]: usa.20.o2 executed"
 		add_popularity = { ideology = neutrality popularity = 0.02 }
@@ -1020,7 +1010,7 @@ country_event = {
 		}
 	}
 
-	option = {	#Perhaps we should listen to the nationalists?
+	option = { #Perhaps we should listen to the nationalists?
 		name = usa.20.o3
 		log = "[GetDateText]: [This.GetName]: usa.20.o3 executed"
 		add_popularity = { ideology = nationalist popularity = 0.02 }
@@ -1053,9 +1043,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
 		hidden_effect = { country_event = { id = usa.1000 days = 120 random_hours = 20 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1073,7 +1061,7 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
-	option = {	#The establishment is right.
+	option = { #The establishment is right.
 		name = usa.22.o1
 		log = "[GetDateText]: [This.GetName]: usa.22.o1 executed"
 		set_temp_variable = { party_index = 2 }
@@ -1099,7 +1087,7 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
-	option = {	#Unfortunate
+	option = { #Unfortunate
 		name = usa.23.o1
 		log = "[GetDateText]: [This.GetName]: usa.23.o1 executed"
 		add_political_power = -50
@@ -1144,9 +1132,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = 7 }
 		change_wall_street_opinion = yes
 		country_event = { id = usa.33 days = 90 random_hours = 20 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	#Not Guilty
@@ -1213,9 +1199,7 @@ country_event = {
 		change_industrial_conglomerates_opinion = yes
 		change_small_medium_business_owners_opinion = yes
 		set_country_flag = USA_allowed_microsoft_monopoly
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1230,7 +1214,7 @@ country_event = {
 
 	trigger = {
 		tag = USA
-		has_full_control_of_state = 806	#Arizona
+		has_full_control_of_state = 806 #Arizona
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
@@ -1241,9 +1225,7 @@ country_event = {
 		add_manpower = -19
 		set_temp_variable = { temp_opinion = -2 }
 		change_the_military_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1278,9 +1260,7 @@ country_event = {
 		modify_treasury_effect = yes
 		set_temp_variable = { temp_opinion = 7 }
 		change_wall_street_opinion = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	#Save the Company!
@@ -1336,9 +1316,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = 8 }
 		change_wall_street_opinion = yes
 		change_defense_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1349,9 +1327,7 @@ country_event = {
 		add_political_power = 100
 		set_temp_variable = { modify_economic_regulation = 4 }
 		USA_modify_economic_regulation = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	#Declare Apple's OS Illegal
@@ -1370,7 +1346,7 @@ country_event = {
 		tag = USA
 		date > 2000.10.01
 		date < 2000.10.31
-		has_full_control_of_state = 782	#Kentucky
+		has_full_control_of_state = 782 #Kentucky
 		NOT = { has_country_flag = collapsed_nation }
 	}
 
@@ -1383,9 +1359,7 @@ country_event = {
 		modify_treasury_effect = yes
 		set_temp_variable = { temp_opinion = -3 }
 		change_fossil_fuel_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1394,9 +1368,7 @@ country_event = {
 		add_stability = -0.01
 		set_temp_variable = { arg_popularity = -0.025 }
 		add_ruling_outlook_popularity = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	#The local authorities are capable
@@ -1442,9 +1414,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: usa.53.o1 executed"
 		add_opinion_modifier = { target = ISR modifier = peace_talks }
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1527,19 +1497,19 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: usa.63.o1 executed"
 		add_political_power = 20
 		#State Names
-		809 = { set_state_name = USA_809_name_comm }		#Washington			#Arvo Kustaa Halberg (Gus Hall)
-		790 = { set_state_name = USA_790_name_comm }		#North Carolina		#Vladimir Lenin
-		791 = { set_state_name = USA_791_name_comm }			#South Carolina		#Karl Marx
-		797 = { set_state_name = USA_797_name_comm }		#Louisiana			#Louis Charles Delescluze
-		773 = { set_state_name = USA_773_name_comm }		#Virginia			#Joseph Stalin
-		774 = { set_state_name = USA_774_name_comm }			#West Virginia		#Mao Zedong
-		792 = { set_state_name = USA_792_name_comm }		#Georgia			#Malcolm X
-		803 = { set_state_name = USA_803_name_comm }		#New Mexico			#Manabendra Nath Roy
-		765 = { set_state_name = USA_765_name_comm }			#New Hampshire		#Albert Inkpin
-		770 = { set_state_name = USA_770_name_comm }		#New Jersey			#Earl Browder
-		772 = { set_state_name = USA_772_name_comm }			#Maryland			#Margot Honecker
-		771 = { set_state_name = USA_771_name_comm }			#Pennsylvania		#Eugene Debs
-		769 = { set_state_name = USA_769_name_comm }			#New York			#Friedrich Engels
+		809 = { set_state_name = USA_809_name_comm } #Washington			#Arvo Kustaa Halberg (Gus Hall)
+		790 = { set_state_name = USA_790_name_comm } #North Carolina		#Vladimir Lenin
+		791 = { set_state_name = USA_791_name_comm } #South Carolina		#Karl Marx
+		797 = { set_state_name = USA_797_name_comm } #Louisiana			#Louis Charles Delescluze
+		773 = { set_state_name = USA_773_name_comm } #Virginia			#Joseph Stalin
+		774 = { set_state_name = USA_774_name_comm } #West Virginia		#Mao Zedong
+		792 = { set_state_name = USA_792_name_comm } #Georgia			#Malcolm X
+		803 = { set_state_name = USA_803_name_comm } #New Mexico			#Manabendra Nath Roy
+		765 = { set_state_name = USA_765_name_comm } #New Hampshire		#Albert Inkpin
+		770 = { set_state_name = USA_770_name_comm } #New Jersey			#Earl Browder
+		772 = { set_state_name = USA_772_name_comm } #Maryland			#Margot Honecker
+		771 = { set_state_name = USA_771_name_comm } #Pennsylvania		#Eugene Debs
+		769 = { set_state_name = USA_769_name_comm } #New York			#Friedrich Engels
 		#Province Names
 		set_province_name = { id = 3957 name = USA_3957_name_comm }
 		set_temp_variable = { temp_opinion = 15 }
@@ -1647,9 +1617,7 @@ news_event = {
 
 	option = {
 		name = USA_FOCUS.1.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -1671,15 +1639,11 @@ news_event = {
 		}
 	}
 
-	option = {
-		name = USA_FOCUS.1.d
-	}
+	option = { name = USA_FOCUS.1.d }
 
 	option = {
 		name = USA_FOCUS.1.e
-		trigger = {
-			tag = POL
-		}
+		trigger = { tag = POL }
 	}
 }
 
@@ -1702,11 +1666,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_FOCUS.2.a executed"
 		hidden_effect = {
 			if = {
-				limit = {
-					NOT = {
-						has_template = "Armored Brigade"
-					}
-				}
+				limit = { NOT = { has_template = "Armored Brigade" } }
 				division_template = {
 					name = "Armored Brigade"
 					regiments = {
@@ -1800,9 +1760,7 @@ news_event = {
 
 	option = {
 		name = USA_FOCUS.3.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -1843,9 +1801,7 @@ news_event = {
 		}
 	}
 
-	option = {
-		name = USA_FOCUS.3.e
-	}
+	option = { name = USA_FOCUS.3.e }
 }
 
 ##US Armoured Brigade in Turkey Activated - Spawns in Ankara
@@ -1870,11 +1826,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_FOCUS.4.a executed"
 		hidden_effect = {
 			if = {
-				limit = {
-					NOT = {
-						has_template = "Armored Brigade"
-					}
-				}
+				limit = { NOT = { has_template = "Armored Brigade" } }
 				division_template = {
 					name = "Armored Brigade"
 					regiments = {
@@ -1902,9 +1854,7 @@ country_event = {
 		}
 		custom_effect_tooltip = USA_deploy_ankara_s_brigade_tt
 		news_event = { id = USA_FOCUS.3 days = 1 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2391,9 +2341,7 @@ country_event = {
 			news_event = { id = usa_economic_events_news.3 days = 2 }
 			country_event = { id = usa_economic_events.4 days = 40 random_hours = 30 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2422,9 +2370,7 @@ country_event = {
 			news_event = { id = usa_economic_events_news.3 days = 2 }
 			country_event = { id = usa_economic_events.4 days = 40 random_hours = 30 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	#Allow the Merger
@@ -2462,9 +2408,7 @@ country_event = {
 			news_event = { id = usa_economic_events_news.4 days = 2 }
 			country_event = { id = usa_economic_events.5 days = 40 random_hours = 30 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2478,9 +2422,7 @@ country_event = {
 			news_event = { id = usa_economic_events_news.4 days = 2 }
 			country_event = { id = usa_economic_events.5 days = 40 random_hours = 30 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2494,9 +2436,7 @@ country_event = {
 			news_event = { id = usa_economic_events_news.4 days = 2 }
 			country_event = { id = usa_economic_events.5 days = 40 random_hours = 30 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	#Bailout the Company - shoots off another event about a year later where AiG fails due to liquidity/securities
@@ -2910,9 +2850,7 @@ country_event = {
 			check_variable = { global.month = 10 }
 			check_variable = { global.month = 12 }
 		}
-		any_owned_state = {
-			check_variable = { building_level@arms_factory > 0 }
-		}
+		any_owned_state = { check_variable = { building_level@arms_factory > 0 } }
 	}
 
 	# Oh no
@@ -2922,26 +2860,20 @@ country_event = {
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
 		random_owned_controlled_state = {
-			limit = {
-				check_variable = { building_level@arms_factory > 0 }
-			}
+			limit = { check_variable = { building_level@arms_factory > 0 } }
 			remove_building = {
 				type = arms_factory
 				level = 1
 			}
 		}
 		random_owned_controlled_state = {
-			limit = {
-				check_variable = { building_level@arms_factory > 0 }
-			}
+			limit = { check_variable = { building_level@arms_factory > 0 } }
 			remove_building = {
 				type = arms_factory
 				level = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2979,26 +2911,20 @@ country_event = {
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
 		random_owned_controlled_state = {
-			limit = {
-				check_variable = { building_level@industrial_complex > 0 }
-			}
+			limit = { check_variable = { building_level@industrial_complex > 0 } }
 			remove_building = {
 				type = industrial_complex
 				level = 1
 			}
 		}
 		random_owned_controlled_state = {
-			limit = {
-				check_variable = { building_level@industrial_complex > 0 }
-			}
+			limit = { check_variable = { building_level@industrial_complex > 0 } }
 			remove_building = {
 				type = industrial_complex
 				level = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3038,18 +2964,14 @@ country_event = {
 		set_temp_variable = { temp_opinion = -3 }
 		change_wall_street_opinion = yes
 		every_owned_state = {
-			limit = {
-				check_variable = { building_level@industrial_complex > 0 }
-			}
+			limit = { check_variable = { building_level@industrial_complex > 0 } }
 			random_select_amount = 2
 			remove_building = {
 				type = industrial_complex
 				level = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3082,9 +3004,7 @@ country_event = {
 		add_ruling_outlook_popularity = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_wall_street_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3143,9 +3063,7 @@ country_event = {
 		}
 		set_country_flag = USA_american_recession_over
 		news_event = { id = usa_economic_events_news.6 days = 1 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3311,9 +3229,7 @@ country_event = {
 			clear_variable = american_influence_value
 			clear_variable = american_influence_index
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3445,9 +3361,7 @@ country_event = {
 			clear_variable = american_influence_value
 			clear_variable = american_influence_index
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# The Free Market...
@@ -3493,9 +3407,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3527,9 +3439,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# See if we can throw money at the problem...
@@ -3573,9 +3483,7 @@ news_event = {
 	title = usa_economic_events_news.1.t
 	desc = {
 		text = usa_economic_events_news.1.d3
-		trigger = {
-			USA = { has_country_flag = usa_nothing_one }
-		}
+		trigger = { USA = { has_country_flag = usa_nothing_one } }
 	}
 	picture = GFX_world_lehmanbrothers
 	is_triggered_only = yes
@@ -3589,9 +3497,7 @@ news_event = {
 	#Hecking Wall Street
 	option = {
 		name = usa_economic_events_news.1.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -3609,7 +3515,7 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.1.c
 		trigger = {
-			NOT = {	tag = USA }
+			NOT = { tag = USA }
 			OR = {
 				tag = CHI
 				tag = SOV
@@ -3630,21 +3536,15 @@ news_event = {
 	title = usa_economic_events_news.2.t
 	desc = {
 		text = usa_economic_events_news.2.d1
-		trigger = {
-			USA = { has_country_flag = usa_nationalize_two }
-		}
+		trigger = { USA = { has_country_flag = usa_nationalize_two } }
 	}
 	desc = {
 		text = usa_economic_events_news.2.d2
-		trigger = {
-			USA = { has_country_flag = usa_bailout_two }
-		}
+		trigger = { USA = { has_country_flag = usa_bailout_two } }
 	}
 	desc = {
 		text = usa_economic_events_news.2.d3
-		trigger = {
-			USA = { has_country_flag = usa_nothing_two }
-		}
+		trigger = { USA = { has_country_flag = usa_nothing_two } }
 	}
 	picture = GFX_world_fanniemae
 	is_triggered_only = yes
@@ -3657,9 +3557,7 @@ news_event = {
 
 	option = {
 		name = usa_economic_events_news.2.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -3677,7 +3575,7 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.2.c
 		trigger = {
-			NOT = {	tag = USA }
+			NOT = { tag = USA }
 			OR = {
 				tag = CHI
 				tag = SOV
@@ -3698,21 +3596,15 @@ news_event = {
 	title = usa_economic_events_news.3.t
 	desc = {
 		text = usa_economic_events_news.3.d1
-		trigger = {
-			USA = { has_country_flag = usa_nationalize_three }
-		}
+		trigger = { USA = { has_country_flag = usa_nationalize_three } }
 	}
 	desc = {
 		text = usa_economic_events_news.3.d2
-		trigger = {
-			USA = { has_country_flag = usa_bailout_three }
-		}
+		trigger = { USA = { has_country_flag = usa_bailout_three } }
 	}
 	desc = {
 		text = usa_economic_events_news.3.d3
-		trigger = {
-			USA = { has_country_flag = usa_nothing_three }
-		}
+		trigger = { USA = { has_country_flag = usa_nothing_three } }
 	}
 	picture = GFX_world_bearstearns
 	is_triggered_only = yes
@@ -3725,9 +3617,7 @@ news_event = {
 
 	option = {
 		name = usa_economic_events_news.3.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -3745,7 +3635,7 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.3.c
 		trigger = {
-			NOT = {	tag = USA }
+			NOT = { tag = USA }
 			OR = {
 				tag = CHI
 				tag = SOV
@@ -3766,9 +3656,7 @@ news_event = {
 	title = usa_economic_events_news.4.t
 	desc = {
 		text = usa_economic_events_news.4.d3
-		trigger = {
-			USA = { has_country_flag = usa_nothing_four }
-		}
+		trigger = { USA = { has_country_flag = usa_nothing_four } }
 	}
 	picture = GFX_world_aig
 	is_triggered_only = yes
@@ -3781,9 +3669,7 @@ news_event = {
 
 	option = {
 		name = usa_economic_events_news.4.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -3801,7 +3687,7 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.4.c
 		trigger = {
-			NOT = {	tag = USA }
+			NOT = { tag = USA }
 			OR = {
 				tag = CHI
 				tag = SOV
@@ -3839,13 +3725,10 @@ news_event = {
 			tag = AST #custom aftershock content
 		}
 	}
-
 	#Hecking Wall Street
 	option = {
 		name = usa_economic_events_news.6.a
-		trigger = {
-			tag = USA
-		}
+		trigger = { tag = USA }
 	}
 
 	option = {
@@ -3863,7 +3746,7 @@ news_event = {
 	option = {
 		name = usa_economic_events_news.6.c
 		trigger = {
-			NOT = {	tag = USA }
+			NOT = { tag = USA }
 			OR = {
 				tag = CHI
 				tag = SOV
@@ -4368,9 +4251,7 @@ country_event = {
 	title = donald_trump.21.t
 	desc = {
 		text = donald_trump.21.d2
-		trigger = {
-			has_country_flag = spacex_reaches_mars_first
-		}
+		trigger = { has_country_flag = spacex_reaches_mars_first }
 	}
 	picture = GFX_manned_mission_mars
 	is_triggered_only = yes
@@ -4378,11 +4259,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = spacex_reaches_mars_first
-				}
-			}
+			limit = { NOT = { has_country_flag = spacex_reaches_mars_first } }
 			set_country_flag = nasa_reaches_mars_first
 		}
 	}
@@ -4438,9 +4315,7 @@ country_event = {
 	title = donald_trump.22.t
 	desc = {
 		text = donald_trump.22.d2
-		trigger = {
-			has_country_flag = spacex_reaches_mars_first
-		}
+		trigger = { has_country_flag = spacex_reaches_mars_first }
 	}
 	picture = GFX_astronauts
 	is_triggered_only = yes
@@ -4486,9 +4361,7 @@ country_event = {
 	title = donald_trump.25.t
 	desc = {
 		text = donald_trump.25.d2
-		trigger = {
-			has_country_flag = nasa_reaches_mars_first
-		}
+		trigger = { has_country_flag = nasa_reaches_mars_first }
 	}
 	picture = GFX_spacex_mars
 	is_triggered_only = yes
@@ -4496,11 +4369,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = nasa_reaches_mars_first
-				}
-			}
+			limit = { NOT = { has_country_flag = nasa_reaches_mars_first } }
 			set_country_flag = spacex_reaches_mars_first
 		}
 	}
@@ -8583,9 +8452,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8653,9 +8520,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -8702,9 +8567,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8825,9 +8688,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8893,9 +8754,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -8942,9 +8801,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -9064,9 +8921,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -9185,9 +9040,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -9253,9 +9106,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -9302,9 +9153,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -9367,9 +9216,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -9416,9 +9263,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9481,9 +9326,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -9530,9 +9373,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9595,9 +9436,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -9644,9 +9483,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9709,9 +9546,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -9758,9 +9593,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9823,9 +9656,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -9872,9 +9703,7 @@ country_event = {
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10215,9 +10044,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10247,9 +10074,7 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.07 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10263,9 +10088,7 @@ country_event = {
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10317,9 +10140,7 @@ country_event = {
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10356,9 +10177,7 @@ country_event = {
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10378,9 +10197,7 @@ country_event = {
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10426,9 +10243,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10459,9 +10274,7 @@ country_event = {
 		set_temp_variable = { party_index = 15 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10475,9 +10288,7 @@ country_event = {
 		set_temp_variable = { party_index = 15 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10508,9 +10319,7 @@ country_event = {
 			remove_idea = wall_street
 			add_idea = farmers
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10524,9 +10333,7 @@ country_event = {
 			remove_idea = wall_street
 			add_idea = small_medium_business_owners
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -10559,9 +10366,7 @@ country_event = {
 			remove_idea = defense_industry
 			add_idea = labour_unions
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -10578,9 +10383,7 @@ country_event = {
 			remove_idea = defense_industry
 			add_idea = the_clergy
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10613,9 +10416,7 @@ country_event = {
 			remove_idea = intelligence_community
 			add_idea = industrial_conglomerates
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10632,9 +10433,7 @@ country_event = {
 			remove_idea = intelligence_community
 			add_idea = fossil_fuel_industry
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10660,9 +10459,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		set_temp_variable = { temp_outlook_increase = 0.06 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10678,9 +10475,7 @@ country_event = {
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10706,9 +10501,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.30 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -10721,9 +10514,7 @@ country_event = {
 		set_temp_variable = { party_index = 21 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10733,9 +10524,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.30 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10877,9 +10666,7 @@ country_event = {
 	major = yes
 	fire_only_once = yes
 
-	trigger = {
-		tag = USA
-	}
+	trigger = { tag = USA }
 
 	option = {
 		name = USA_reformed_republic.300.o1
@@ -10909,9 +10696,7 @@ country_event = {
 	major = yes
 	fire_only_once = yes
 
-	trigger = {
-		tag = USA
-	}
+	trigger = { tag = USA }
 
 	option = {
 		name = USA_reformed_republic.301.o1
@@ -11983,11 +11768,7 @@ news_event = {
 
 	option = {
 		name = USA_collapse_event.3000.o2
-		trigger = {
-			NOT = {
-				original_tag = USA
-			}
-		}
+		trigger = { NOT = { original_tag = USA } }
 	}
 }
 
@@ -12487,9 +12268,7 @@ country_event = {
 	option = {
 		name = USA_collapse_event.7.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.7.o2 executed"
-		CAS = {
-			change_tag_from = USA
-		}
+		CAS = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = cascadian_soldier }
 			set_nationality = CAS
@@ -12658,18 +12437,10 @@ country_event = {
 				transfer_state = 794
 				transfer_state = 796
 			}
-			SAM = {
-				transfer_state = 826
-			}
-			MIC = {
-				transfer_state = 818
-			}
-			ENG = {
-				transfer_state = 824
-			}
-			CUB = {
-				transfer_state = 424
-			}
+			SAM = { transfer_state = 826 }
+			MIC = { transfer_state = 818 }
+			ENG = { transfer_state = 824 }
+			CUB = { transfer_state = 424 }
 		}
 	}
 
@@ -12721,9 +12492,7 @@ country_event = {
 	option = {
 		name = USA_collapse_event.9.o2
 		log = "[GetDateText]: [This.GetName]: USA_collapse_event.9.o2 executed"
-		CSA = {
-			change_tag_from = USA
-		}
+		CSA = { change_tag_from = USA }
 		every_unit_leader = {
 			limit = { has_trait = southern_soldier }
 			set_nationality = CSA
@@ -12859,12 +12628,8 @@ country_event = {
 				transfer_state = 811
 				add_state_core = 811
 			}
-			BHR = {
-				transfer_state = 624
-			}
-			KUW = {
-				transfer_state = 488
-			}
+			BHR = { transfer_state = 624 }
+			KUW = { transfer_state = 488 }
 		}
 	}
 
@@ -14108,15 +13873,9 @@ country_event = {
 		custom_effect_tooltip = USA_collapse_description
 		for_each_scope_loop = {
 			array = USA_collapse_releases
-			USA = {
-				release = PREV
-			}
+			USA = { release = PREV }
 		}
-		USA = {
-			every_subject_country = {
-				USA = { end_puppet = PREV }
-			}
-		}
+		USA = { every_subject_country = { USA = { end_puppet = PREV } } }
 		ai_chance = { base = 30 }
 	}
 }
@@ -14377,9 +14136,7 @@ country_event = {
 			idea = CAN_american_refugee_crisis
 			days = 365
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -14401,9 +14158,7 @@ country_event = {
 			idea = MEX_american_refugee_crisis
 			days = 365
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -14473,9 +14228,7 @@ country_event = {
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 7
-		}
+		ai_chance = { base = 7 }
 	}
 
 	option = {
@@ -14487,9 +14240,7 @@ country_event = {
 			remove_idea = USA_migrant_crisis_one
 			add_idea = USA_migrant_crisis_two_a
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -14533,9 +14284,7 @@ country_event = {
 		add_to_variable = { econ_production_efficiency_cap = 0.05 tooltip = production_factory_max_efficiency_factor_tt }
 		add_to_variable = { econ_civ_factory_workforce = -0.03 tooltip = civ_facs_worker_requirement_modifier_tt }
 		add_to_variable = { econ_office_workforce = -0.03 tooltip = offices_worker_requirement_modifier_tt }
-		ai_chance = {
-			base = 7
-		}
+		ai_chance = { base = 7 }
 	}
 
 	option = {
@@ -14551,9 +14300,7 @@ country_event = {
 		add_to_variable = { domestic_communist_drift = 0.01 tooltip = communism_drift_tt }
 		add_to_variable = { domestic_nationalist_drift = 0.01 tooltip = nationalist_drift_tt }
 		add_to_variable = { domestic_democratic_drift = -0.02 tooltip = democratic_drift_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -14593,9 +14340,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.07 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -14616,9 +14361,7 @@ country_event = {
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 7
-		}
+		ai_chance = { base = 7 }
 	}
 }
 
@@ -14655,9 +14398,7 @@ country_event = {
 				add_idea = USA_migrant_crisis_three
 			}
 		}
-		ai_chance = {
-			base = 7
-		}
+		ai_chance = { base = 7 }
 	}
 
 	option = {
@@ -14680,9 +14421,7 @@ country_event = {
 				add_idea = USA_migrant_crisis_three_a
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -14764,7 +14503,7 @@ country_event = {
 }
 
 country_event = {
-	id = USA_crisis_event.1007  ## January 22nd
+	id = USA_crisis_event.1007 ## January 22nd
 	title = USA_crisis_event.1007.t
 	desc = USA_crisis_event.1007.d
 	picture = GFX_politics_negotiations
@@ -16344,7 +16083,7 @@ country_event = {
 
  #### Flash point event Violence Path
 country_event = {
-	id = USA_crisis_event.1107  ##March
+	id = USA_crisis_event.1107 ##March
 	title = USA_crisis_event.1107.t
 	desc = USA_crisis_event.1107.d
 	picture = GFX_news_generic_soldiers
@@ -16385,7 +16124,7 @@ country_event = {
 }
 
 country_event = {
-	id = USA_crisis_event.1108  ##May
+	id = USA_crisis_event.1108 ##May
 	title = USA_crisis_event.1108.t
 	desc = USA_crisis_event.1108.d
 	picture = GFX_politics_protest
@@ -16438,7 +16177,7 @@ country_event = {
 }
 
 country_event = {
-	id = USA_crisis_event.1109  ##July
+	id = USA_crisis_event.1109 ##July
 	title = USA_crisis_event.1109.t
 	desc = USA_crisis_event.1109.d
 	picture = GFX_politics_protest
@@ -16493,7 +16232,7 @@ country_event = {
 }
 
 country_event = {
-	id = USA_crisis_event.1110  ##September
+	id = USA_crisis_event.1110 ##September
 	title = USA_crisis_event.1110.t
 	desc = USA_crisis_event.1110.d
 	picture = GFX_news_generic_soldiers
@@ -18740,9 +18479,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.04 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -18857,9 +18594,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.04 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -18962,9 +18697,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19060,9 +18793,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19160,9 +18891,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19270,9 +18999,7 @@ country_event = {
 				producer = USA
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19367,9 +19094,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19476,9 +19201,7 @@ country_event = {
 				producer = USA
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19571,9 +19294,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19666,9 +19387,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.07 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19773,9 +19492,7 @@ country_event = {
 				producer = USA
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -19855,9 +19572,7 @@ country_event = {
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -20106,9 +19821,7 @@ country_event = {
 				producer = USA
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -20173,9 +19886,7 @@ country_event = {
 			set_temp_variable = { treasury_change = 10 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -20209,9 +19920,7 @@ country_event = {
 		FSA = {
 			add_ideas = { USA_fsa_the_damascus_legion }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -20249,9 +19958,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20346,9 +20053,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20367,9 +20072,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.20000.o1 executed"
 		set_cosmetic_tag = CAN_american_monarchist_subject
 		set_variable = { dynamic_flag_variant = 8 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20399,9 +20102,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20425,9 +20126,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20522,9 +20221,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20543,9 +20240,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.40000.o1 executed"
 		set_cosmetic_tag = MEX_american_monarchist_subject
 		set_variable = { dynamic_flag_variant = 8 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20575,9 +20270,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20601,9 +20294,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20716,9 +20407,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20737,9 +20426,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.60000.o1 executed"
 		set_cosmetic_tag = CUB_american_monarchist_subject
 		set_variable = { dynamic_flag_variant = 8 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20769,9 +20456,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20795,9 +20480,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20908,9 +20591,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20929,9 +20610,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.80000.o1 executed"
 		set_cosmetic_tag = PAN_american_monarchist_subject
 		set_variable = { dynamic_flag_variant = 8 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20961,9 +20640,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -20987,9 +20664,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21108,9 +20783,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21129,9 +20802,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.100000.o1 executed"
 		set_cosmetic_tag = COL_american_monarchist_subject
 		set_variable = { dynamic_flag_variant = 8 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21161,9 +20832,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21187,9 +20856,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21309,9 +20976,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21330,9 +20995,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.120000.o1 executed"
 		set_cosmetic_tag = BRA_american_monarchist_subject
 		set_variable = { dynamic_flag_variant = 8 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21362,9 +21025,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21395,9 +21056,7 @@ country_event = {
 			target = JAM
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21428,9 +21087,7 @@ country_event = {
 			target = NIC
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21468,9 +21125,7 @@ country_event = {
 			target = SUR
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21508,9 +21163,7 @@ country_event = {
 			target = BOL
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21528,9 +21181,7 @@ country_event = {
 		name = USA_monarchist_event.17.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.17.o1 executed"
 		add_ideas = USA_idea_hemispheric_economic_program
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21548,9 +21199,7 @@ country_event = {
 		name = USA_monarchist_event.18.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.18.o1 executed"
 		add_ideas = USA_idea_hemispheric_economic_program
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21568,9 +21217,7 @@ country_event = {
 		name = USA_monarchist_event.19.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.19.o1 executed"
 		add_ideas = USA_idea_hemispheric_economic_program
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21588,9 +21235,7 @@ country_event = {
 		name = USA_monarchist_event.20.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.20.o1 executed"
 		add_ideas = USA_idea_hemispheric_economic_program
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21608,9 +21253,7 @@ country_event = {
 		name = USA_monarchist_event.21.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.21.o1 executed"
 		add_ideas = USA_idea_public_unity_programs
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21628,9 +21271,7 @@ country_event = {
 		name = USA_monarchist_event.22.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.22.o1 executed"
 		add_ideas = USA_idea_public_unity_programs
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21648,9 +21289,7 @@ country_event = {
 		name = USA_monarchist_event.23.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.23.o1 executed"
 		add_ideas = USA_idea_public_unity_programs
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21668,9 +21307,7 @@ country_event = {
 		name = USA_monarchist_event.24.o1
 		log = "[GetDateText]: [This.GetName]: USA_monarchist_event.24.o1 executed"
 		add_ideas = USA_idea_public_unity_programs
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21708,9 +21345,7 @@ country_event = {
 			target = TRI
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21741,9 +21376,7 @@ country_event = {
 			target = ELS
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21767,9 +21400,7 @@ country_event = {
 			target = ECU
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21793,9 +21424,7 @@ country_event = {
 			target = ARG
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21861,9 +21490,7 @@ country_event = {
 			target = GRA
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21894,9 +21521,7 @@ country_event = {
 			target = GUA
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21920,9 +21545,7 @@ country_event = {
 			target = PRU
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21946,9 +21569,7 @@ country_event = {
 			target = CHL
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21969,9 +21590,7 @@ country_event = {
 			remove_idea = USA_idea_hemispheric_economic_program
 			add_idea = USA_idea_the_new_world_economic_exchange
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -21992,9 +21611,7 @@ country_event = {
 			remove_idea = USA_idea_hemispheric_economic_program
 			add_idea = USA_idea_the_new_world_economic_exchange
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -22015,9 +21632,7 @@ country_event = {
 			remove_idea = USA_idea_hemispheric_economic_program
 			add_idea = USA_idea_the_new_world_economic_exchange
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -22038,9 +21653,7 @@ country_event = {
 			remove_idea = USA_idea_hemispheric_economic_program
 			add_idea = USA_idea_the_new_world_economic_exchange
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -22080,9 +21693,7 @@ news_event = {
 
 	option = {
 		name = usa_news.18.o4
-		trigger = {
-			original_tag = SUD
-		}
+		trigger = { original_tag = SUD }
 		effect_tooltip = {
 			USA = {
 				add_opinion_modifier = {
@@ -22126,9 +21737,7 @@ country_event = {
 			add_to_variable = { var = USA_f35_progress value = 10 }
 			clamp_variable = { var = USA_f35_progress min = 0 max = 100 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -22173,9 +21782,7 @@ country_event = {
 			clamp_variable = { var = F35_contribution min = 0 max = 100 }
 		}
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -22197,9 +21804,7 @@ country_event = {
 			add_to_variable = { var = F35_contribution value = 2 }
 			clamp_variable = { var = F35_contribution min = 0 max = 100 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -22221,9 +21826,7 @@ country_event = {
 			add_to_variable = { var = F35_contribution value = 3 }
 			clamp_variable = { var = F35_contribution min = 0 max = 100 }
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 
@@ -22254,9 +21857,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -22278,17 +21879,13 @@ country_event = {
 			}
 		}
 		every_country = {
-			limit = {
-				has_idea = Major_Non_NATO_Ally
-			}
+			limit = { has_idea = Major_Non_NATO_Ally }
 			country_event = {
 				id = usa.83
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -22310,18 +21907,14 @@ country_event = {
 			}
 		}
 		every_country = {
-			limit = {
-				has_idea = Major_Non_NATO_Ally
-			}
+			limit = { has_idea = Major_Non_NATO_Ally }
 			country_event = {
 				id = usa.93
 				days = 2
 			}
 		}
 		custom_effect_tooltip = USA_f35_apply_TT
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -22350,26 +21943,16 @@ country_event = {
 		set_country_flag = USA_accepted_into_f35_program
 		set_country_flag = { flag = USA_f35_recently_joined value = 1 days = 180 }
 		if = {
-			limit = {
-				USA = {
-					has_country_flag = USA_f35_designed
-				}
-			}
+			limit = { USA = { has_country_flag = USA_f35_designed } }
 			set_country_flag = USA_f35_program_member_new
 		}
-		else = {
-			set_country_flag = USA_f35_legacy_members
-		}
-		ai_chance = {
-			base = 10
-		}
+		else = { set_country_flag = USA_f35_legacy_members }
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = usa.83.o2
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -22523,11 +22106,7 @@ country_event = {
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
 		if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 14
-				}
-			}
+			limit = { check_variable = { F35_contribution > 14 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe_3
 				variant_name = "F-35A Lightning II"
@@ -22536,11 +22115,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 9
-				}
-			}
+			limit = { check_variable = { F35_contribution > 9 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe_3
 				variant_name = "F-35A Lightning II"
@@ -22549,11 +22124,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 5
-				}
-			}
+			limit = { check_variable = { F35_contribution > 5 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe_3
 				variant_name = "F-35A Lightning II"
@@ -22562,11 +22133,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 3
-				}
-			}
+			limit = { check_variable = { F35_contribution > 3 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe_3
 				variant_name = "F-35A Lightning II"
@@ -22575,11 +22142,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 0
-				}
-			}
+			limit = { check_variable = { F35_contribution > 0 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe_3
 				variant_name = "F-35A Lightning II"
@@ -22588,11 +22151,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution = 0
-				}
-			}
+			limit = { check_variable = { F35_contribution = 0 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe_3
 				variant_name = "F-35A Lightning II"
@@ -22600,9 +22159,7 @@ country_event = {
 				producer = USA
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -22613,11 +22170,7 @@ country_event = {
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
 		if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 14
-				}
-			}
+			limit = { check_variable = { F35_contribution > 14 } }
 			add_equipment_to_stockpile = {
 				type = cv_small_plane_strike_airframe_3
 				variant_name = "F-35B Lightning II"
@@ -22626,11 +22179,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 9
-				}
-			}
+			limit = { check_variable = { F35_contribution > 9 } }
 			add_equipment_to_stockpile = {
 				type = cv_small_plane_strike_airframe_3
 				variant_name = "F-35B Lightning II"
@@ -22639,11 +22188,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 5
-				}
-			}
+			limit = { check_variable = { F35_contribution > 5 } }
 			add_equipment_to_stockpile = {
 				type = cv_small_plane_strike_airframe_3
 				variant_name = "F-35B Lightning II"
@@ -22652,11 +22197,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 3
-				}
-			}
+			limit = { check_variable = { F35_contribution > 3 } }
 			add_equipment_to_stockpile = {
 				type = cv_small_plane_strike_airframe_3
 				variant_name = "F-35B Lightning II"
@@ -22665,11 +22206,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution > 0
-				}
-			}
+			limit = { check_variable = { F35_contribution > 0 } }
 			add_equipment_to_stockpile = {
 				type = cv_small_plane_strike_airframe_3
 				variant_name = "F-35B Lightning II"
@@ -22678,11 +22215,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				check_variable = {
-					F35_contribution = 0
-				}
-			}
+			limit = { check_variable = { F35_contribution = 0 } }
 			add_equipment_to_stockpile = {
 				type = cv_small_plane_strike_airframe_3
 				variant_name = "F-35B Lightning II"
@@ -22690,9 +22223,7 @@ country_event = {
 				producer = USA
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -22717,9 +22248,7 @@ country_event = {
 			}
 			add_dynamic_modifier = { modifier = USA_f35_supply_chain }
 		}
-		FROM = {
-			country_event = usa.87
-		}
+		FROM = { country_event = usa.87 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -22727,28 +22256,20 @@ country_event = {
 				add = 10
 			}
 			modifier = {
-				FROM = {
-					has_government = democratic
-				}
+				FROM = { has_government = democratic }
 				add = 5
 			}
 			modifier = {
 				add = 5
-				FROM = {
-					has_war = no
-				}
+				FROM = { has_war = no }
 			}
 			modifier = {
 				add = -5
-				check_variable = {
-					f35_production_debuff < -0.20
-				}
+				check_variable = { f35_production_debuff < -0.20 }
 			}
 			modifier = {
 				add = -5
-				check_variable = {
-					f35_production_debuff < -0.40
-				}
+				check_variable = { f35_production_debuff < -0.40 }
 			}
 		}
 	}
@@ -22756,12 +22277,8 @@ country_event = {
 	option = {
 		name = usa.86.o2
 		log = "[GetDateText]: [This.GetName]: usa.86.o2 executed"
-		FROM = {
-			country_event = usa.88
-		}
-		ai_chance = {
-			base = 1
-		}
+		FROM = { country_event = usa.88 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -22821,9 +22338,7 @@ country_event = {
 			}
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -22875,9 +22390,7 @@ country_event = {
 			}
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -22929,9 +22442,7 @@ country_event = {
 			}
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -22983,9 +22494,7 @@ country_event = {
 			}
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -22998,9 +22507,7 @@ country_event = {
 
 	option = {
 		name = usa.88.o1
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23014,9 +22521,7 @@ country_event = {
 	option = {
 		name = usa.89.o1
 		log = "[GetDateText]: [This.GetName]: usa.89.o1 executed"
-		FROM = {
-			country_event = usa.90
-		}
+		FROM = { country_event = usa.90 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -23024,16 +22529,12 @@ country_event = {
 				add = 15
 			}
 			modifier = {
-				FROM = {
-					has_government = democratic
-				}
+				FROM = { has_government = democratic }
 				add = 5
 			}
 			modifier = {
 				add = 5
-				FROM = {
-					has_war = no
-				}
+				FROM = { has_war = no }
 			}
 		}
 	}
@@ -23182,21 +22683,13 @@ country_event = {
 		custom_effect_tooltip = USA_unlock_f35_decision_TT
 		add_to_array = { global.f35_members = THIS.id }
 		if = {
-			limit = {
-				USA = {
-					has_country_flag = USA_f35_designed
-				}
-			}
+			limit = { USA = { has_country_flag = USA_f35_designed } }
 			set_country_flag = USA_f35_program_member_new
 		}
-		else = {
-			set_country_flag = USA_f35_legacy_members
-		}
+		else = { set_country_flag = USA_f35_legacy_members }
 		set_country_flag = USA_accepted_into_f35_program
 		set_country_flag = { flag = USA_f35_recently_joined value = 1 days = 180 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23211,9 +22704,7 @@ country_event = {
 		name = usa.91.o1
 		log = "[GetDateText]: [This.GetName]: usa.91.o1 executed"
 		custom_effect_tooltip = USA_reasons_for_denial_TT
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23236,9 +22727,7 @@ country_event = {
 		clr_country_flag = F35_placed_small_order_B
 		clr_country_flag = F35_placed_large_order_A
 		clr_country_flag = F35_placed_large_order_B
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23251,9 +22740,7 @@ country_event = {
 
 	option = {
 		name = usa.93.o1
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23291,9 +22778,7 @@ country_event = {
 
 	option = {
 		name = usa.95.o1
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23309,24 +22794,14 @@ news_event = {
 
 	option = {
 		name = usa.100.a
-		trigger = {
-			has_government = democratic
-		}
-		ai_chance = {
-			base = 10
-		}
+		trigger = { has_government = democratic }
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = usa.100.b
-		trigger = {
-			NOT = {
-				has_government = democratic
-			}
-		}
-		ai_chance = {
-			base = 10
-		}
+		trigger = { NOT = { has_government = democratic } }
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -23347,9 +22822,7 @@ country_event = {
 		add_manpower = -25
 		newline = yes
 		army_experience = 35
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -25184,9 +24657,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -25199,9 +24670,7 @@ country_event = {
 
 	option = {
 		name = department_of_state.33.a
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -25230,14 +24699,8 @@ country_event = {
 
 	trigger = {
 		country_exists = ESB
-		NOT = {
-			ESB = {
-				is_subject = yes
-			}
-		}
-		ESB = {
-			is_neighbor_of = CHI
-		}
+		NOT = { ESB = { is_subject = yes } }
+		ESB = { is_neighbor_of = CHI }
 	}
 
 	option = {
@@ -25337,9 +24800,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 
 	option = {
@@ -25490,9 +24951,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -25524,9 +24983,7 @@ country_event = {
 			annex_country = { target = UDM transfer_troops = yes }
 			annex_country = { target = CHU transfer_troops = yes }
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -26434,9 +25891,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -28568,12 +28023,8 @@ country_event = {
 	immediate = {
 		hidden_effect = {
 			every_owned_state = {
-				limit = {
-					is_core_of = CSB
-				}
-				THIS = {
-					transfer_state_to = CSB
-				}
+				limit = { is_core_of = CSB }
+				THIS = { transfer_state_to = CSB }
 			}
 			every_owned_state = {
 				limit = {
@@ -28590,73 +28041,39 @@ country_event = {
 						}
 					}
 				}
-				THIS = {
-					transfer_state_to = RUS
-				}
+				THIS = { transfer_state_to = RUS }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = ESB
-				}
-				THIS = {
-					transfer_state_to = ESB
-				}
+				limit = { is_core_of = ESB }
+				THIS = { transfer_state_to = ESB }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = KOM
-				}
-				THIS = {
-					transfer_state_to = KOM
-				}
+				limit = { is_core_of = KOM }
+				THIS = { transfer_state_to = KOM }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = KOM
-				}
-				THIS = {
-					transfer_state_to = KOM
-				}
+				limit = { is_core_of = KOM }
+				THIS = { transfer_state_to = KOM }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = KAE
-				}
-				THIS = {
-					transfer_state_to = KAE
-				}
+				limit = { is_core_of = KAE }
+				THIS = { transfer_state_to = KAE }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = TAT
-				}
-				THIS = {
-					transfer_state_to = TAT
-				}
+				limit = { is_core_of = TAT }
+				THIS = { transfer_state_to = TAT }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = NEE
-				}
-				THIS = {
-					transfer_state_to = NEE
-				}
+				limit = { is_core_of = NEE }
+				THIS = { transfer_state_to = NEE }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = URA
-				}
-				THIS = {
-					transfer_state_to = URA
-				}
+				limit = { is_core_of = URA }
+				THIS = { transfer_state_to = URA }
 			}
 			every_owned_state = {
-				limit = {
-					is_core_of = BSH
-				}
-				THIS = {
-					transfer_state_to = BSH
-				}
+				limit = { is_core_of = BSH }
+				THIS = { transfer_state_to = BSH }
 			}
 		}
 	}
@@ -29621,9 +29038,7 @@ news_event = {
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
-	option = {
-		name = department_of_state.241.a
-	}
+	option = { name = department_of_state.241.a }
 }
 
 # Trump NATO Dilemma
@@ -29651,15 +29066,11 @@ country_event = {
 			array = global.nato_members
 			tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
 			if = {
-				limit = {
-					NOT = { original_tag = USA }
-				}
+				limit = { NOT = { original_tag = USA } }
 				add_opinion_modifier = { target = USA modifier = usa_fp_major_diplomatic_fallout }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -29678,9 +29089,7 @@ country_event = {
 		}
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		custom_effect_tooltip = USA_2_percent_TT
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
@@ -29691,15 +29100,11 @@ country_event = {
 			array = global.nato_members
 			tooltip = TT_ALL_NATO_MEMBER_NATIONS_GAIN
 			if = {
-				limit = {
-					NOT = { original_tag = USA }
-				}
+				limit = { NOT = { original_tag = USA } }
 				add_opinion_modifier = { target = USA modifier = usa_fp_diplomatic_cooperation }
 			}
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	# Threaten to leave unless allies step up their spending
@@ -29714,9 +29119,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = department_of_state.234.a
-	}
+	option = { name = department_of_state.234.a }
 }
 
 country_event = {
@@ -29730,9 +29133,7 @@ country_event = {
 		name = department_of_state.96.a
 		log = "[GetDateText]: [This.GetName]: department_of_state.96.a executed"
 		news_event = department_of_state.98
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -29985,9 +29386,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: department_of_state.97.b executed"
 		USA = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = VEN
 					autonomy_state = autonomy_autonomous_state_colored
@@ -30004,9 +29403,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -30734,9 +30131,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.136.a
-	}
+	option = { name = department_of_state.136.a }
 }
 
 # Haiti Stabilization - HAI Notification
@@ -30812,9 +30207,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.141.a
-	}
+	option = { name = department_of_state.141.a }
 }
 
 # Canada Investment Proposal
@@ -30867,9 +30260,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = department_of_state.143.a
-	}
+	option = { name = department_of_state.143.a }
 }
 
 # West Africa Development Notification
@@ -30903,9 +30294,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.145.a
-	}
+	option = { name = department_of_state.145.a }
 }
 
 # Pacific Islands Compact Notification
@@ -30935,9 +30324,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.147.a
-	}
+	option = { name = department_of_state.147.a }
 }
 
 # AGOA Notification
@@ -30967,9 +30354,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.149.a
-	}
+	option = { name = department_of_state.149.a }
 }
 
 ###########################
@@ -31033,9 +30418,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.151.a
-	}
+	option = { name = department_of_state.151.a }
 }
 
 # Philippine EDCA Proposal
@@ -31099,9 +30482,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.153.a
-	}
+	option = { name = department_of_state.153.a }
 }
 
 # Korean Reunification Talks
@@ -31186,9 +30567,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = department_of_state.155.a
-	}
+	option = { name = department_of_state.155.a }
 }
 
 ###########################
@@ -35915,9 +35294,7 @@ country_event = {
 
 	option = {
 		name = usa_economic_events.416.a
-		trigger = {
-			has_country_flag = USA_intel_outsourced_leading_edge
-		}
+		trigger = { has_country_flag = USA_intel_outsourced_leading_edge }
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.416.a executed"
 		effect_tooltip = { add_timed_idea = { idea = USA_intel_fabless_architecture_house days = 365 } }
 		hidden_effect = { USA_intel_apply_fabless_architecture_house = yes }
@@ -35972,7 +35349,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36062,7 +35438,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36152,7 +35527,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36242,7 +35616,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36332,7 +35705,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36422,7 +35794,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36512,7 +35883,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36618,7 +35988,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36724,7 +36093,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36830,7 +36198,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -36936,7 +36303,6 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-
 		original_tag = USA
 		NOT = { has_country_flag = collapsed_nation }
 		NOT = {
@@ -37806,9 +37172,7 @@ country_event = {
 			uses = 1
 			category = CAT_computing_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_sun_interoperability_compact
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_sun_interoperability_compact }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -37827,9 +37191,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_sun_separate_procurement
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_sun_separate_procurement }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -37866,9 +37228,7 @@ country_event = {
 			uses = 1
 			category = CAT_internet_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_sun_open_source_stack
-		}
+		hidden_effect = { set_country_flag = USA_sun_open_source_stack }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -37887,9 +37247,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_sun_dual_licensing
-		}
+		hidden_effect = { set_country_flag = USA_sun_dual_licensing }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -37926,9 +37284,7 @@ country_event = {
 			uses = 1
 			category = CAT_computing_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_sun_mysql_open_governance
-		}
+		hidden_effect = { set_country_flag = USA_sun_mysql_open_governance }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -37947,9 +37303,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_sun_mysql_commercial_stack
-		}
+		hidden_effect = { set_country_flag = USA_sun_mysql_commercial_stack }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -37982,9 +37336,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.478.a executed"
 		add_political_power = 10
 		USA_oracle_apply_sun_acquired = yes
-		hidden_effect = {
-			set_country_flag = USA_sun_oracle_acquisition
-		}
+		hidden_effect = { set_country_flag = USA_sun_oracle_acquisition }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38005,9 +37357,7 @@ country_event = {
 			uses = 1
 			category = CAT_computing_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_sun_independent_restructuring
-		}
+		hidden_effect = { set_country_flag = USA_sun_independent_restructuring }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38070,12 +37420,8 @@ country_event = {
 			uses = 1
 			category = CAT_internet_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_sun_foundation_stewardship
-		}
-		ai_chance = {
-			base = 55
-		}
+		hidden_effect = { set_country_flag = USA_sun_foundation_stewardship }
+		ai_chance = { base = 55 }
 	}
 
 	option = {
@@ -38088,12 +37434,8 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.005 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_sun_full_integration
-		}
-		ai_chance = {
-			base = 45
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_sun_full_integration }
+		ai_chance = { base = 45 }
 	}
 }
 
@@ -38119,9 +37461,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.480.a executed"
 		add_political_power = -10
 		add_stability = -0.005
-		hidden_effect = {
-			set_country_flag = USA_microsoft_nokia_double_down
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_nokia_double_down }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38139,9 +37479,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_nokia_exit
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_nokia_exit }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38155,9 +37493,7 @@ country_event = {
 		name = usa_economic_events.480.c
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.480.c executed"
 		add_political_power = -5
-		hidden_effect = {
-			set_country_flag = USA_microsoft_nokia_spinoff
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_nokia_spinoff }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -38194,9 +37530,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_linkedin_integrated
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_linkedin_integrated }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -38215,9 +37549,7 @@ country_event = {
 			uses = 1
 			category = CAT_internet_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_linkedin_conditions
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_linkedin_conditions }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38232,9 +37564,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.481.c executed"
 		add_political_power = -10
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_microsoft_linkedin_blocked
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_linkedin_blocked }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38273,9 +37603,7 @@ country_event = {
 			uses = 1
 			category = CAT_computing_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_github_autonomy
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_github_autonomy }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38294,9 +37622,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_github_azure_integration
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_github_azure_integration }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38317,9 +37643,7 @@ country_event = {
 			uses = 1
 			category = CAT_encryption_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_github_blocked
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_github_blocked }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38335,9 +37659,7 @@ country_event = {
 	title = usa_economic_events.483.t
 	desc = {
 		text = usa_economic_events.483.d_oracle
-		trigger = {
-			has_country_flag = USA_sun_oracle_acquisition
-		}
+		trigger = { has_country_flag = USA_sun_oracle_acquisition }
 	}
 	desc = {
 		text = usa_economic_events.483.d_independent
@@ -38389,9 +37711,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_oracle_managed_interconnect
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_oracle_managed_interconnect }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38417,9 +37737,7 @@ country_event = {
 			uses = 1
 			category = CAT_internet_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_vendor_neutral_gateway
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_vendor_neutral_gateway }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38444,9 +37762,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_clouds_separate
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_clouds_separate }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38467,12 +37783,8 @@ country_event = {
 			uses = 1
 			category = CAT_computing_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_java_governance_neutral
-		}
-		ai_chance = {
-			base = 55
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_java_governance_neutral }
+		ai_chance = { base = 55 }
 	}
 
 	option = {
@@ -38486,12 +37798,8 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.005 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_sun_absorbed_into_azure
-		}
-		ai_chance = {
-			base = 45
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_sun_absorbed_into_azure }
+		ai_chance = { base = 45 }
 	}
 }
 
@@ -38522,9 +37830,7 @@ country_event = {
 			uses = 1
 			category = CAT_computing_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_ivas_fielded
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_ivas_fielded }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -38538,9 +37844,7 @@ country_event = {
 		name = usa_economic_events.484.b
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.484.b executed"
 		add_political_power = -5
-		hidden_effect = {
-			set_country_flag = USA_microsoft_ivas_restructured
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_ivas_restructured }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38554,9 +37858,7 @@ country_event = {
 		name = usa_economic_events.484.c
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.484.c executed"
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_microsoft_ivas_challenger
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_ivas_challenger }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -38593,9 +37895,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.005 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_activision_approved
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_activision_approved }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -38614,9 +37914,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_activision_remedies
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_activision_remedies }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38631,9 +37929,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.485.c executed"
 		add_political_power = -10
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_microsoft_activision_blocked
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_activision_blocked }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38672,9 +37968,7 @@ country_event = {
 			uses = 1
 			category = CAT_encryption_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_security_first
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_security_first }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38695,9 +37989,7 @@ country_event = {
 			uses = 1
 			category = CAT_encryption_tech
 		}
-		hidden_effect = {
-			set_country_flag = USA_microsoft_security_balanced
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_security_balanced }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38717,9 +38009,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_microsoft_ship_fast
-		}
+		hidden_effect = { set_country_flag = USA_microsoft_ship_fast }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38757,9 +38047,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_integrated_rd
-		}
+		hidden_effect = { set_country_flag = USA_spacex_integrated_rd }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38778,9 +38066,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_contract_first
-		}
+		hidden_effect = { set_country_flag = USA_spacex_contract_first }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -38795,9 +38081,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.487.c executed"
 		add_political_power = -5
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_off_the_shelf_speed
-		}
+		hidden_effect = { set_country_flag = USA_spacex_off_the_shelf_speed }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -38836,9 +38120,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_cargo_dual_source
-		}
+		hidden_effect = { set_country_flag = USA_spacex_cargo_dual_source }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -38857,9 +38139,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_cargo_single_champion
-		}
+		hidden_effect = { set_country_flag = USA_spacex_cargo_single_champion }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -38874,9 +38154,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.488.c executed"
 		add_political_power = -15
 		add_stability = 0.01
-		hidden_effect = {
-			set_country_flag = USA_spacex_shuttle_extended
-		}
+		hidden_effect = { set_country_flag = USA_spacex_shuttle_extended }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -38914,9 +38192,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_flight_test_iteration
-		}
+		hidden_effect = { set_country_flag = USA_spacex_flight_test_iteration }
 		ai_chance = {
 			base = 65
 			modifier = {
@@ -38931,9 +38207,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.489.b executed"
 		add_political_power = 5
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_oversight_tightened
-		}
+		hidden_effect = { set_country_flag = USA_spacex_oversight_tightened }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -38952,9 +38226,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_prime_consolidation
-		}
+		hidden_effect = { set_country_flag = USA_spacex_prime_consolidation }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -38992,9 +38264,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_civil_qualified
-		}
+		hidden_effect = { set_country_flag = USA_spacex_civil_qualified }
 		ai_chance = {
 			base = 65
 			modifier = {
@@ -39009,9 +38279,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.490.b executed"
 		add_political_power = -5
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_conservative_certification
-		}
+		hidden_effect = { set_country_flag = USA_spacex_conservative_certification }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -39030,9 +38298,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_commercial_only
-		}
+		hidden_effect = { set_country_flag = USA_spacex_commercial_only }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -39075,9 +38341,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_reuse_ramp
-		}
+		hidden_effect = { set_country_flag = USA_spacex_reuse_ramp }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -39092,9 +38356,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.491.b executed"
 		add_political_power = -5
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_cadence_conservative
-		}
+		hidden_effect = { set_country_flag = USA_spacex_cadence_conservative }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -39113,9 +38375,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_expendable_revenue
-		}
+		hidden_effect = { set_country_flag = USA_spacex_expendable_revenue }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -39153,9 +38413,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_heavy_national_missions
-		}
+		hidden_effect = { set_country_flag = USA_spacex_heavy_national_missions }
 		ai_chance = {
 			base = 65
 			modifier = {
@@ -39174,9 +38432,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_heavy_commercial_only
-		}
+		hidden_effect = { set_country_flag = USA_spacex_heavy_commercial_only }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -39191,9 +38447,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.492.c executed"
 		add_political_power = -5
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_heavy_deferred
-		}
+		hidden_effect = { set_country_flag = USA_spacex_heavy_deferred }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -39231,9 +38485,7 @@ country_event = {
 			uses = 1
 			category = CAT_satellite
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_starlink_allied
-		}
+		hidden_effect = { set_country_flag = USA_spacex_starlink_allied }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -39252,9 +38504,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.0025 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_starlink_commercial
-		}
+		hidden_effect = { set_country_flag = USA_spacex_starlink_commercial }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -39269,9 +38519,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.493.c executed"
 		add_political_power = -10
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_starlink_restricted
-		}
+		hidden_effect = { set_country_flag = USA_spacex_starlink_restricted }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -39310,9 +38558,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_crew_certified
-		}
+		hidden_effect = { set_country_flag = USA_spacex_crew_certified }
 		ai_chance = {
 			base = 65
 			modifier = {
@@ -39331,9 +38577,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_crew_dual_provider
-		}
+		hidden_effect = { set_country_flag = USA_spacex_crew_dual_provider }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -39348,9 +38592,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.494.c executed"
 		add_political_power = 10
 		add_stability = -0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_crew_adjunct
-		}
+		hidden_effect = { set_country_flag = USA_spacex_crew_adjunct }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -39388,9 +38630,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_hls_awarded
-		}
+		hidden_effect = { set_country_flag = USA_spacex_hls_awarded }
 		ai_chance = {
 			base = 65
 			modifier = {
@@ -39405,9 +38645,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.495.b executed"
 		add_political_power = -15
 		add_stability = 0.005
-		hidden_effect = {
-			set_country_flag = USA_spacex_hls_split
-		}
+		hidden_effect = { set_country_flag = USA_spacex_hls_split }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -39426,9 +38664,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_hls_government_lander
-		}
+		hidden_effect = { set_country_flag = USA_spacex_hls_government_lander }
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -39467,9 +38703,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_nssl_dual_source
-		}
+		hidden_effect = { set_country_flag = USA_spacex_nssl_dual_source }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -39488,9 +38722,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_nssl_legacy_prime
-		}
+		hidden_effect = { set_country_flag = USA_spacex_nssl_legacy_prime }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -39510,9 +38742,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_productivity = 0.005 tooltip = productivity_growth_modifier_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_nssl_sole_source
-		}
+		hidden_effect = { set_country_flag = USA_spacex_nssl_sole_source }
 		ai_chance = {
 			base = 15
 			modifier = {
@@ -39550,9 +38780,7 @@ country_event = {
 			uses = 1
 			category = CAT_space
 		}
-		hidden_effect = {
-			set_country_flag = USA_spacex_licensing_iterative
-		}
+		hidden_effect = { set_country_flag = USA_spacex_licensing_iterative }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -39567,9 +38795,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.497.b executed"
 		add_political_power = -5
 		add_stability = 0.01
-		hidden_effect = {
-			set_country_flag = USA_spacex_licensing_environmental
-		}
+		hidden_effect = { set_country_flag = USA_spacex_licensing_environmental }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -39588,9 +38814,7 @@ country_event = {
 			MODIFIER = us_economic_policies
 		}
 		add_to_variable = { econ_factory_output = 0.0025 tooltip = industrial_capacity_factory_tt }
-		hidden_effect = {
-			set_country_flag = USA_spacex_licensing_federalized
-		}
+		hidden_effect = { set_country_flag = USA_spacex_licensing_federalized }
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -39617,9 +38841,7 @@ country_event = {
 
 	option = {
 		name = usa_economic_events.498.a
-		trigger = {
-			has_country_flag = USA_spacex_nssl_sole_source
-		}
+		trigger = { has_country_flag = USA_spacex_nssl_sole_source }
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.498.a executed"
 		effect_tooltip = { add_timed_idea = { idea = USA_spacex_commercial_monopoly_risk days = 365 } }
 		hidden_effect = { USA_spacex_apply_commercial_monopoly_risk = yes }
@@ -39864,9 +39086,7 @@ country_event = {
 
 	option = {
 		name = usa_economic_events.503.a
-		trigger = {
-			country_exists = UKR
-		}
+		trigger = { country_exists = UKR }
 		log = "[GetDateText]: [Root.GetName]: usa_economic_events.503.a executed"
 		send_equipment = { type = guided_missile_equipment amount = 150 target = UKR }
 		add_war_support = 0.02


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,609 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.