### PR TITLE
Standardize event files — batch 03/14

### DIFF
--- a/events/Germany.txt
+++ b/events/Germany.txt
@@ -34,11 +34,7 @@ country_event = {
 		name = germany.1.a
 		log = "[GetDateText]: [This.GetName]: germany.1.a executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_rightist_status_by_5
 			add_to_variable = { GER_rightwing_department_status = 5 }
 		}
@@ -53,9 +49,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# No, there's no need for this
@@ -63,22 +57,15 @@ country_event = {
 		name = germany.1.b
 		log = "[GetDateText]: [This.GetName]: germany.1.b executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_decrease_rightist_status_by_3
 			add_to_variable = { GER_rightwing_department_status = -3 }
 		}
 		set_temp_variable = { treasury_change = 25.74 }
 		modify_treasury_effect = yes
 		increase_corruption = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # V-Maenner in Landesvorstand
@@ -102,9 +89,7 @@ country_event = {
 			ideology = democratic
 			popularity = -0.04
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# I think we need another case opened up...
@@ -126,11 +111,8 @@ country_event = {
 				days = 35
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Investigation against V-Maenner
@@ -146,11 +128,8 @@ country_event = {
 		name = germany.3.a
 		log = "[GetDateText]: [This.GetName]: germany.3.a executed"
 		add_stability = -0.03
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # NPD Investigation ending 18.03.03 (FAIL)
@@ -170,11 +149,8 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.03
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 #SUCCESS
 country_event = {
@@ -195,11 +171,8 @@ country_event = {
 			ideology = democratic
 			popularity = 0.05
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany.402
@@ -231,9 +204,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Some cash
@@ -258,9 +229,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Little cash
@@ -283,13 +252,10 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 		set_temp_variable = { treasury_change = -6.52 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 # Düsseldorf-Anschlag
@@ -306,11 +272,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.5.a executed"
 		custom_effect_tooltip = GER_open_investigation
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_rightist_status_by_1
 			add_to_variable = { GER_rightwing_department_status = 1 }
 		}
@@ -325,32 +287,22 @@ country_event = {
 		newline = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				check_variable = { GER_rightwing_department_status < 30 }
 			}
 			custom_effect_tooltip = GER_due_to_low_dept_status
 			newline = yes
 			add_stability = -0.03
 		}
-		else = {
-			add_stability = -0.01
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { add_stability = -0.01 }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.5.b
 		log = "[GetDateText]: [This.GetName]: germany.5.b executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_decrease_rightist_status_by_2
 			add_to_variable = { GER_rightwing_department_status = -2 }
 		}
@@ -358,22 +310,15 @@ country_event = {
 		if = {
 			limit = {
 				check_variable = { GER_rightwing_department_status < 30 }
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 			}
 			custom_effect_tooltip = GER_due_to_low_dept_status
 			newline = yes
 			add_stability = -0.05
 		}
-		else = {
-			add_stability = -0.02
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { add_stability = -0.02 }
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -388,11 +333,7 @@ country_event = {
 		name = germany.501.a
 		log = "[GetDateText]: [This.GetName]: germany.501.a executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_rightist_status_by_1
 			add_to_variable = { GER_rightwing_department_status = 1 }
 		}
@@ -402,7 +343,6 @@ country_event = {
 			popularity = -0.02
 		}
 	}
-
 }
 
 # Düsseldorf-Anschlag Synagoge
@@ -419,11 +359,7 @@ country_event = {
 		name = germany.6.a
 		log = "[GetDateText]: [This.GetName]: germany.6.a executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_islamist_status_by_1
 			add_to_variable = { GER_islamist_department_status = 1 }
 		}
@@ -431,9 +367,7 @@ country_event = {
 		modify_treasury_effect = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -470,9 +404,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	#I want a complete investigation!
@@ -480,11 +412,7 @@ country_event = {
 		name = germany.6.b
 		log = "[GetDateText]: [This.GetName]: germany.6.b executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_islamist_status_by_2
 			add_to_variable = { GER_islamist_department_status = 2 }
 		}
@@ -493,9 +421,7 @@ country_event = {
 		newline = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -532,9 +458,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Our prisons are filling up, let them go
@@ -542,11 +466,7 @@ country_event = {
 		name = germany.6.c
 		log = "[GetDateText]: [This.GetName]: germany.6.c executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_decrease_islamist_status_by_3
 			add_to_variable = { GER_islamist_department_status = -3 }
 		}
@@ -555,9 +475,7 @@ country_event = {
 		newline = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -607,11 +525,8 @@ country_event = {
 			ideology = democratic
 			popularity = -0.02
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany.8
@@ -626,20 +541,14 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.8.a executed"
 		custom_effect_tooltip = germany.8.a_desc
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_islamist_status_by_2
 			add_to_variable = { GER_islamist_department_status = 2 }
 		}
 		newline = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -649,12 +558,8 @@ country_event = {
 			newline = yes
 			add_stability = -0.01
 		}
-		else = {
-			add_stability = -0.01
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { add_stability = -0.01 }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -662,11 +567,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.8.b executed"
 		custom_effect_tooltip = germany.8.b_desc
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_rightist_status_by_2
 			add_to_variable = { GER_rightwing_department_status = 2 }
 		}
@@ -674,32 +575,22 @@ country_event = {
 		if = {
 			limit = {
 				check_variable = { GER_rightwing_department_status < 30 }
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 			}
 			custom_effect_tooltip = GER_due_to_low_dept_status
 			newline = yes
 			add_stability = -0.02
 		}
-		else = {
-			add_stability = -0.02
-		}
+		else = { add_stability = -0.02 }
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_islamist_status_by_2
 			add_to_variable = { GER_islamist_department_status = 2 }
 		}
 		newline = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -709,11 +600,8 @@ country_event = {
 			newline = yes
 			add_stability = 0.01
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Committee Of Inquiry Starts Its Investigation
@@ -752,7 +640,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 
 # Kieps Involvement (Letter Found)
@@ -783,9 +670,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -796,9 +681,7 @@ country_event = {
 			id = germany.13
 			days = 35
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -809,11 +692,8 @@ country_event = {
 			id = germany.12
 			days = 35
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Charges Are Dropped
@@ -840,11 +720,8 @@ country_event = {
 				days = 95
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Heavy Fine For The CDU
@@ -866,11 +743,8 @@ country_event = {
 				days = 25
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # The CDU In Chaos
@@ -882,10 +756,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany.14.a
-	}
-
+	option = { name = germany.14.a }
 }
 
 # Bear Head Project: Investigation Results
@@ -910,9 +781,7 @@ country_event = {
 				days = 10
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	#All of this is just paranoia
@@ -922,11 +791,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Fate Of The Missing Files
@@ -951,9 +817,7 @@ country_event = {
 				days = 11
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -962,11 +826,8 @@ country_event = {
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.022 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Kieps Facilitation Payments
@@ -989,7 +850,6 @@ country_event = {
 		newline = yes
 		decrease_corruption = yes
 	}
-
 }
 
 # Volmer Erlass
@@ -1013,7 +873,6 @@ country_event = {
 			country_event = { id = germany.19 days = 365 }
 		}
 	}
-
 }
 
 # Travel insurance as creditworthiness
@@ -1038,9 +897,7 @@ country_event = {
 		hidden_effect = {
 			country_event = { id = germany.20 days = 365 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1048,11 +905,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.19.b executed"
 		set_temp_variable = { treasury_change = 35.93 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Take Back The Reisebüroverfahren
@@ -1068,9 +922,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.20.a executed"
 		add_stability = -0.01
 		hidden_effect = { country_event = { id = germany.21 days = 730 } }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1079,11 +931,8 @@ country_event = {
 		add_stability = -0.02
 		add_political_power = -50
 		hidden_effect = { country_event = { id = germany.21 days = 730 } }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Take Back The Volmer Decree
@@ -1098,9 +947,7 @@ country_event = {
 		name = germany.21.a
 		log = "[GetDateText]: [This.GetName]: germany.21.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1118,11 +965,8 @@ country_event = {
 			}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # EU Sues Germany Over The Volmer Erlass - Germany Loses
@@ -1138,7 +982,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.22.a executed"
 		add_political_power = -100
 	}
-
 }
 
 # EU Sues Germany Over The Volmer Erlass - Germany Wins
@@ -1154,7 +997,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.23.a executed"
 		add_political_power = 150
 	}
-
 }
 
 # Nobody Likes The Ökosteuer
@@ -1173,7 +1015,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.25.a executed"
 		add_political_power = -10
 	}
-
 }
 
 # Women Can Join The Army
@@ -1195,23 +1036,16 @@ country_event = {
 				add_idea = volunteer_women
 			}
 		}
-		else = {
-			add_political_power = 100
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { add_political_power = 100 }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.26.b
 		log = "[GetDateText]: [This.GetName]: germany.26.b executed"
 		add_stability = 0.03
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 #krenz injailed
 country_event = {
@@ -1230,9 +1064,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		log = "[GetDateText]: [This.GetName]: germany.27.a executed"
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1242,11 +1074,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Mannesmann AG Merges With Vodafone
@@ -1260,20 +1089,15 @@ country_event = {
 
 	option = {
 		name = germany.28.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.28.b
 		log = "[GetDateText]: [This.GetName]: germany.28.b executed"
 		add_political_power = -25
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # German Bahn Cancells Transrapid Route Between Hamburg And Berlin
@@ -1289,9 +1113,7 @@ country_event = {
 
 	option = {
 		name = germany.29.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1305,11 +1127,8 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Train Accident Of Brühl
@@ -1336,11 +1155,8 @@ country_event = {
 			}
 			add_manpower = -9
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Elbhochwasser 13.08.2002
@@ -1378,7 +1194,6 @@ country_event = {
 			add_manpower = -9
 		}
 	}
-
 }
 
 # Elbhochwasser 17.08.2002
@@ -1406,7 +1221,6 @@ country_event = {
 			add_manpower = -9
 		}
 	}
-
 }
 
 # Joschka Fischer Visits Iran #
@@ -1427,7 +1241,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.33.a executed"
 		PER = { remove_opinion_modifier = { target = GER modifier = helped_iraqi_chemical_weapons } }
 	}
-
 }
 
 # Helmut Hofer Comes Free #21.1.2000
@@ -1447,7 +1260,6 @@ country_event = {
 		}
 		PER = { remove_opinion_modifier = { target = PER modifier = helmut_hofer_injailed } }
 	}
-
 }
 
 # Fusion Between Allianz AG And Dresdner Bank
@@ -1464,7 +1276,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.35.a executed"
 		add_political_power = 5
 	}
-
 }
 
 # Berlin Banking Scandal
@@ -1498,20 +1309,15 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = -0.01
 		add_political_power = -25
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.36.b
 		log = "[GetDateText]: [This.GetName]: germany.36.b executed"
 		add_stability = -0.02
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Investigative Committee
@@ -1537,9 +1343,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.37.a executed"
 		add_stability = 0.02
 		add_political_power = -30
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1551,11 +1355,8 @@ country_event = {
 				multiply_temp_variable = { treasury_change = 0.08 }
 				modify_treasury_effect = yes
 		increase_corruption = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Diepgen Overtrown
@@ -1587,9 +1388,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
 		add_political_power = -50
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1604,11 +1403,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
 		add_political_power = 50
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Save the Landesbank
@@ -1650,7 +1446,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 # Who bears the Cost
@@ -1687,7 +1482,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 # German Artifacts Found In Argentina @_@
@@ -1714,7 +1508,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = -0.05
 	}
-
 }
 
 # Revive Greifswald Power Plant (started)
@@ -1750,7 +1543,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 # Revive Greifswald Power Plant (completed)
@@ -1778,7 +1570,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Mo' healthcare centres built
@@ -1804,7 +1595,6 @@ country_event = {
 		}
 		add_to_variable = { GER_health_cost = -0.03 tooltip = health_cost_multiplier_modifier_tt }
 	}
-
 }
 #Krater von Wattenscheid
 country_event = {
@@ -1839,7 +1629,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 # Berliner Rede 2001
 country_event = {
@@ -1856,7 +1645,6 @@ country_event = {
 		add_war_support = -0.02
 		log = "[GetDateText]: [This.GetName]: germany.46.a executed"
 	}
-
 }
 #Expo 2000
 country_event = {
@@ -1867,10 +1655,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany.47.a
-	}
-
+	option = { name = germany.47.a }
 }
 # Rau eröffnet Deutschland.de
 country_event = {
@@ -1887,7 +1672,6 @@ country_event = {
 		add_political_power = 10
 		add_stability = 0.01
 	}
-
 }
 # Cebit 2001 22.3
 country_event = {
@@ -1903,7 +1687,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.49.a"
 		add_political_power = 10
 	}
-
 }
 # Möllemann
 country_event = {
@@ -1916,7 +1699,7 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.51 days = 30  random_days = 30 }
+			country_event = { id = germany.51 days = 30 random_days = 30 }
 		}
 	}
 
@@ -1945,7 +1728,6 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: germany.50.b executed"
 	}
-
 }
 # Möllemann
 country_event = {
@@ -1981,7 +1763,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		log = "[GetDateText]: [This.GetName]: germany.51.b executed"
 	}
-
 }
 # Möllemann
 country_event = {
@@ -1994,7 +1775,7 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.53 days = 30  random_days = 30 }
+			country_event = { id = germany.53 days = 30 random_days = 30 }
 		}
 	}
 
@@ -2018,7 +1799,6 @@ country_event = {
 			}
 		log = "[GetDateText]: [This.GetName]: germany.52.b executed"
 	}
-
 }
 # Möllemann
 country_event = {
@@ -2031,7 +1811,7 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.54 days = 30  random_days = 30 }
+			country_event = { id = germany.54 days = 30 random_days = 30 }
 		}
 	}
 
@@ -2054,7 +1834,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		log = "[GetDateText]: [This.GetName]: germany.53.b executed"
 	}
-
 }
 # Möllemann
 country_event = {
@@ -2067,14 +1846,11 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.55 days = 30  random_days = 30 }
+			country_event = { id = germany.55 days = 30 random_days = 30 }
 		}
 	}
 
-	option = {
-		name = germany.54.a
-	}
-
+	option = { name = germany.54.a }
 }
 # Friedmann
 country_event = {
@@ -2087,7 +1863,7 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.56 days = 30  random_days = 30 }
+			country_event = { id = germany.56 days = 30 random_days = 30 }
 		}
 	}
 
@@ -2120,7 +1896,6 @@ country_event = {
 			}
 		log = "[GetDateText]: [This.GetName]: germany.55.b executed"
 	}
-
 }
 # Friedmann
 country_event = {
@@ -2133,7 +1908,7 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.57 days = 30  random_days = 30 }
+			country_event = { id = germany.57 days = 30 random_days = 30 }
 		}
 	}
 
@@ -2150,7 +1925,6 @@ country_event = {
 		add_stability = -0.02
 		log = "[GetDateText]: [This.GetName]: germany.56.b executed"
 	}
-
 }
 # Friedman
 country_event = {
@@ -2163,7 +1937,7 @@ country_event = {
 
 	immediate = {
 		hidden_effect = {
-			country_event = { id = germany.58 days = 30  random_days = 30 }
+			country_event = { id = germany.58 days = 30 random_days = 30 }
 		}
 	}
 
@@ -2173,7 +1947,6 @@ country_event = {
 		add_stability = 0.01
 		log = "[GetDateText]: [This.GetName]: germany.57.a executed"
 	}
-
 }
 # Friedman Nazi songs
 country_event = {
@@ -2211,7 +1984,6 @@ country_event = {
 			}
 		log = "[GetDateText]: [This.GetName]: germany.58.b executed"
 	}
-
 }
 # north korean refugees
 country_event = {
@@ -2247,7 +2019,6 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: germany.59.b executed"
 	}
-
 }
 
 country_event = {
@@ -2265,7 +2036,6 @@ country_event = {
 		}
 		add_political_power = 25
 	}
-
 }
 country_event = {
 	id = germany.61
@@ -2285,7 +2055,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.61.b executed"
 		add_stability = -0.01
 	}
-
 }
 country_event = {
 	id = germany.62
@@ -2320,7 +2089,6 @@ country_event = {
 				value = -0.05
 			}
 	}
-
 }
 country_event = {
 	id = germany.63
@@ -2354,7 +2122,6 @@ country_event = {
 		set_temp_variable = { modify_europeanism = -0.05 }
 			EU_europeanism_change = yes
 	}
-
 }
 
 country_event = {
@@ -2383,7 +2150,6 @@ country_event = {
 			country_event = { id = germany.65 days = 45 }
 		}
 	}
-
 }
 
 country_event = {
@@ -2406,7 +2172,6 @@ country_event = {
 		add_stability = -0.03
 		add_political_power = -10
 	}
-
 }
 country_event = {
 	id = germany.66
@@ -2429,7 +2194,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.65.b executed"
 		army_experience = 25
 	}
-
 }
 country_event = {
 	id = germany.67
@@ -2446,7 +2210,6 @@ country_event = {
 		set_country_flag = ger_helsing_se_founded
 		unlock_military_industrial_organization_tooltip = mio:GER_helsing_se
 	}
-
 }
 country_event = {
 	id = germany.68
@@ -2454,8 +2217,8 @@ country_event = {
 	desc = germany.68.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
-	minor_flavor = yes
 
+	minor_flavor = yes
 	trigger = { has_dlc = "Arms Against Tyranny" }
 
 	option = {
@@ -2463,7 +2226,6 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: germany.68.a executed"
 		unlock_military_industrial_organization_tooltip = mio:GER_cg_haenel
 	}
-
 }
 #NSU
 
@@ -2500,7 +2262,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -2538,7 +2299,6 @@ country_event = {
 				value = -0.05
 			}
 	}
-
 }
 
 country_event = {
@@ -2572,7 +2332,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.005 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -2603,7 +2362,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany_nsu.4.b executed"
 		add_stability = -0.02
 	}
-
 }
 
 country_event = {
@@ -2632,7 +2390,6 @@ country_event = {
 		add_stability = -0.02
 		add_political_power = -10
 	}
-
 }
 
 country_event = {
@@ -2665,7 +2422,6 @@ country_event = {
 				value = 0.05
 			}
 	}
-
 }
 
 country_event = {
@@ -2691,7 +2447,6 @@ country_event = {
 			country_event = { id = germany_nsu.8 days = 60 random_days = 360 }
 		}
 	}
-
 }
 country_event = {
 	id = germany_nsu.8
@@ -2737,7 +2492,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_nsu.9
@@ -2779,7 +2533,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 # # # # EAST VS WEST DIVIDE # # # #
@@ -2799,11 +2552,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 country_event = {
@@ -2841,11 +2591,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 country_event = {
@@ -2874,11 +2621,8 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 country_event = {
@@ -2897,11 +2641,8 @@ country_event = {
 		army_experience = -20
 		navy_experience = -20
 		air_experience = -20
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 country_event = {
@@ -2919,11 +2660,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 country_event = {
 	id = germany_divide.6
@@ -2941,11 +2679,8 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 country_event = {
 	id = germany_divide.7
@@ -2960,11 +2695,8 @@ country_event = {
 		name = germany_divide.7.a
 		log = "[GetDateText]: [This.GetName]:germany_divide.7.a executed"
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 country_event = {
 	id = germany_divide.8
@@ -2980,11 +2712,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:germany_divide.8.a executed"
 		set_temp_variable = { int_investment_change = -15.00 }
 		modify_international_investment_effect = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 country_event = {
 	id = germany_divide.9
@@ -2999,11 +2728,8 @@ country_event = {
 		name = germany_divide.9.a
 		log = "[GetDateText]: [This.GetName]:germany_divide.9.a executed"
 		add_stability = -0.02
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 country_event = {
@@ -3020,11 +2746,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 # # # # #
 # East Germans heavily influenced by Russian media
@@ -3111,7 +2834,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # East Germans demand job opportunities
 country_event = {
@@ -3144,7 +2866,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # East Germans ridicule our government
 country_event = {
@@ -3179,7 +2900,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # East Germans mass migrate to the West
 country_event = {
@@ -3281,7 +3001,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # East German businesses fail to compete
 country_event = {
@@ -3300,9 +3019,7 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { treasury_change = -29.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -3314,11 +3031,8 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { treasury_change = 19.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 # East Germans demand lower housing prices
 country_event = {
@@ -3353,7 +3067,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # East Germans call for more political representation
 country_event = {
@@ -3369,9 +3082,7 @@ country_event = {
 		name = germany_divide.17.a
 		log = "[GetDateText]: [This.GetName]:germany_divide.17.a executed"
 		add_political_power = -200
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -3380,11 +3091,8 @@ country_event = {
 		custom_effect_tooltip = GER_east_decrease_opinion2
 		add_to_variable = { GER_east_opinion = -2 }
 		add_political_power = 200
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 # Church closes in East Germany
 country_event = {
@@ -3457,7 +3165,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # Social services failing in East Germany
 country_event = {
@@ -3483,11 +3190,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:germany_divide.19.b executed"
 		custom_effect_tooltip = GER_east_decrease_opinion
 		add_to_variable = { GER_east_opinion = -1 }
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 # Public infrastructure falling apart in East Germany
 country_event = {
@@ -3549,9 +3253,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -3559,11 +3261,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:germany_divide.20.b executed"
 		custom_effect_tooltip = GER_east_decrease_opinion
 		add_to_variable = { GER_east_opinion = -1 }
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 country_event = {
@@ -3575,11 +3274,8 @@ country_event = {
 
 	option = {
 		name = germany_divide.69420.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 # Bavarian's demand independence
 country_event = {
@@ -3595,7 +3291,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:bavaria.1.a executed"
 		set_country_flag = GER_bavaria_gone
 		43 = { remove_core_of = GER }
-		964 = {	remove_core_of = GER }
+		964 = { remove_core_of = GER }
 		newline = yes
 		release = BAY
 		BAY = {
@@ -3611,7 +3307,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:bavaria.1.a executed"
 		set_country_flag = GER_bavaria_gone
 		43 = { remove_core_of = GER }
-		964 = {	remove_core_of = GER }
+		964 = { remove_core_of = GER }
 		newline = yes
 		release = BAY
 		BAY = {
@@ -3632,7 +3328,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 country_event = {
@@ -3648,9 +3343,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:bavaria.2.a executed"
 		custom_effect_tooltip = GER_CSU_BAY_TT
 		set_country_flag = GER_BAY_CSU
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	#SPD
@@ -3659,9 +3352,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:bavaria.2.b executed"
 		custom_effect_tooltip = GER_SPD_BAY_TT
 		set_country_flag = GER_BAY_SPD
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	#GRUNE
@@ -3670,11 +3361,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]:bavaria.2.c executed"
 		custom_effect_tooltip = GER_GRUNE_BAY_TT
 		set_country_flag = GER_BAY_GRUNE
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 # GERMAN EMPIRE EVENTS
 country_event = {
@@ -3684,7 +3372,7 @@ country_event = {
 	picture = GFX_jury
 	is_triggered_only = yes
 
-	option = {	#Okay, we might as well
+	option = { #Okay, we might as well
 		name = germany.200.a
 		log = "[GetDateText]: [This.GetName]: germany.200.a executed"
 		GER = {
@@ -3705,7 +3393,7 @@ country_event = {
 		}
 	}
 
-	option = {	#Hell no
+	option = { #Hell no
 		name = germany.200.b
 		log = "[GetDateText]: [This.GetName]: germany.200.b executed"
 		GER = {
@@ -3715,7 +3403,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3725,7 +3412,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	#Okay, we'll remember that..
+	option = { #Okay, we'll remember that..
 		name = germany.201.a
 		log = "[GetDateText]: [This.GetName]: germany.201.a executed"
 		custom_effect_tooltip = GER_pay_us_TT
@@ -3739,7 +3426,6 @@ country_event = {
 				modify_treasury_effect = yes
 		}
 	}
-
 }
 
 country_event = {
@@ -3749,12 +3435,11 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	#Okay, we'll remember that..
+	option = { #Okay, we'll remember that..
 		name = germany.202.a
 		log = "[GetDateText]: [This.GetName]: germany.202.a executed"
 		custom_effect_tooltip = GER_not_pay_us_TT
 	}
-
 }
 #CDU EVENTS
 country_event = {
@@ -3765,7 +3450,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	# There would be no need for this
+	option = { # There would be no need for this
 		name = germany.203.a
 		log = "[GetDateText]: [This.GetName]: germany.203.a executed"
 		45 = { add_manpower = 2000 }
@@ -3782,7 +3467,7 @@ country_event = {
 		}
 	}
 
-	option = {	# And out you go!
+	option = { # And out you go!
 		name = germany.203.b
 		log = "[GetDateText]: [This.GetName]: germany.203.a executed"
 		add_stability = -0.02
@@ -3801,7 +3486,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 # FDP EVENTS
 country_event = {
@@ -3812,7 +3496,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	# Legalize it
+	option = { # Legalize it
 		name = germany.204.a
 		log = "[GetDateText]: [This.GetName]: germany.204.a executed"
 		custom_effect_tooltip = {
@@ -3829,7 +3513,7 @@ country_event = {
 		}
 	}
 
-	option = {	# No! Hard ban on all drugs!
+	option = { # No! Hard ban on all drugs!
 		name = germany.204.b
 		log = "[GetDateText]: [This.GetName]: germany.204.a executed"
 		custom_effect_tooltip = {
@@ -3839,7 +3523,6 @@ country_event = {
 		add_to_variable = { GER_police_cost = 0.01 tooltip = police_cost_multiplier_modifier_tt }
 		add_to_variable = { GER_health_cost = -0.02 tooltip = health_cost_multiplier_modifier_tt }
 	}
-
 }
 # GREEN EVENTS
 country_event = {
@@ -3849,7 +3532,7 @@ country_event = {
 	picture = GFX_bundeswehr2
 	is_triggered_only = yes
 
-	option = {	# Yes
+	option = { # Yes
 		name = germany.205.a
 		log = "[GetDateText]: [This.GetName]: germany.205.a executed"
 		GER = {
@@ -3881,7 +3564,7 @@ country_event = {
 		}
 	}
 
-	option = {	# No
+	option = { # No
 		name = germany.205.b
 		log = "[GetDateText]: [This.GetName]: germany.205.b executed"
 		GER = {
@@ -3894,7 +3577,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany.206
@@ -3903,7 +3585,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# Great
+	option = { # Great
 		name = germany.206.a
 		log = "[GetDateText]: [This.GetName]: germany.206.a executed"
 		ROOT = {
@@ -3914,7 +3596,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3924,7 +3605,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# Damn
+	option = { # Damn
 		name = germany.207.a
 		log = "[GetDateText]: [This.GetName]: germany.207.a executed"
 		GER = {
@@ -3934,7 +3615,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3944,13 +3624,13 @@ country_event = {
 	picture = GFX_lgbt_parade
 	is_triggered_only = yes
 
-	option = {	# We will be the safe haven
+	option = { # We will be the safe haven
 		name = germany.208.a
 		log = "[GetDateText]: [This.GetName]: germany.208.a executed"
 		add_political_power = 100
 	}
 
-	option = {	# Absolutely not
+	option = { # Absolutely not
 		name = germany.208.b
 		log = "[GetDateText]: [This.GetName]: germany.208.b executed"
 		set_temp_variable = { percent_change = 3 }
@@ -3972,7 +3652,6 @@ country_event = {
 		}
 		add_to_variable = { GER_health_cost = -0.05 tooltip = health_cost_multiplier_modifier_tt }
 	}
-
 }
 # AfD Event
 country_event = {
@@ -3982,7 +3661,7 @@ country_event = {
 	picture = GFX_no_balls
 	is_triggered_only = yes
 
-	option = {	# No more circumsions!
+	option = { # No more circumsions!
 		name = germany.209.a
 		log = "[GetDateText]: [This.GetName]: germany.209.a executed"
 		decrease_healthcare_budget = yes
@@ -3995,7 +3674,7 @@ country_event = {
 		add_stability = -0.05
 	}
 
-	option = {	# Why the hell are you asking me this? Get out of my office!
+	option = { # Why the hell are you asking me this? Get out of my office!
 		name = germany.209.b
 		log = "[GetDateText]: [This.GetName]: germany.209.b executed"
 		set_temp_variable = { party_index = 20 }
@@ -4003,7 +3682,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -4013,7 +3691,7 @@ country_event = {
 	picture = GFX_merica_guns
 	is_triggered_only = yes
 
-	option = {	# We'll buy.. New jets
+	option = { # We'll buy.. New jets
 		name = germany.210.a
 		log = "[GetDateText]: [This.GetName]: germany.210.a executed"
 		add_equipment_to_stockpile = {
@@ -4025,7 +3703,7 @@ country_event = {
 		modify_treasury_effect = yes
 	}
 
-	option = {	# We'll buy.. Infantry equipment
+	option = { # We'll buy.. Infantry equipment
 		name = germany.210.b
 		log = "[GetDateText]: [This.GetName]: germany.210.b executed"
 		add_equipment_to_stockpile = {
@@ -4041,7 +3719,6 @@ country_event = {
 		set_temp_variable = { treasury_change = -25.00 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 country_event = {
@@ -4054,12 +3731,8 @@ country_event = {
 	option = {
 		name = germany.211.a
 		log = "[GetDateText]: [This.GetName]: germany.211.a executed"
-		GER = {
-			country_event = germany.2111
-		}
-		hidden_effect = {
-			NATO_leave = yes
-		}
+		GER = { country_event = germany.2111 }
+		hidden_effect = { NATO_leave = yes }
 		set_temp_variable = { percent_change = 15 }
 		change_domestic_influence_percentage = yes
 		ai_chance = {
@@ -4074,14 +3747,9 @@ country_event = {
 	option = {
 		name = germany.211.b
 		log = "[GetDateText]: [This.GetName]: germany.211.b executed"
-		GER = {
-			country_event = germany.2112
-		}
-		ai_chance = {
-			base = 5
-		}
+		GER = { country_event = germany.2112 }
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4094,7 +3762,6 @@ country_event = {
 	option = { #good
 		name = germany.2111.a
 	}
-
 }
 
 country_event = {
@@ -4107,7 +3774,6 @@ country_event = {
 	option = { #damn
 		name = germany.2112.a
 	}
-
 }
 # Germany asks us to fight against Russia
 country_event = {
@@ -4117,7 +3783,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# Count me in
+	option = { # Count me in
 		name = germany.212.a
 		log = "[GetDateText]: [This.GetName]: germany.212.a executed"
 		GER = {
@@ -4131,7 +3797,7 @@ country_event = {
 		}
 	}
 
-	option = {	# Not worth it
+	option = { # Not worth it
 		name = germany.212.b
 		log = "[GetDateText]: [This.GetName]: germany.212.b executed"
 		GER = {
@@ -4144,7 +3810,6 @@ country_event = {
 			base = 0
 		}
 	}
-
 }
 
 country_event = {
@@ -4154,7 +3819,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# Count me in
+	option = { # Count me in
 		name = germany.213.a
 		log = "[GetDateText]: [This.GetName]: germany.213.a executed"
 		UKR = {
@@ -4171,7 +3836,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -4198,11 +3862,8 @@ country_event = {
 			type = annex_everything
 			target = UKR
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4212,7 +3873,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# Count me in
+	option = { # Count me in
 		name = germany.215.a
 		log = "[GetDateText]: [This.GetName]: germany.215.a executed"
 		GER = {
@@ -4226,7 +3887,7 @@ country_event = {
 		}
 	}
 
-	option = {	# Not worth it
+	option = { # Not worth it
 		name = germany.215.b
 		log = "[GetDateText]: [This.GetName]: germany.215.b executed"
 		GER = {
@@ -4239,7 +3900,6 @@ country_event = {
 			base = 0
 		}
 	}
-
 }
 
 country_event = {
@@ -4249,7 +3909,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# Count me in
+	option = { # Count me in
 		name = germany.216.a
 		log = "[GetDateText]: [This.GetName]: germany.216.a executed"
 		MEX = {
@@ -4266,7 +3926,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -4300,11 +3959,8 @@ country_event = {
 			type = annex_everything
 			target = MEX
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Our new empire
 country_event = {
@@ -4319,9 +3975,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.218.a executed"
 		set_cosmetic_tag = GER_german_empire
 		mark_formed_country_formable = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -4329,20 +3983,15 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.218.b executed"
 		set_cosmetic_tag = GER_holy_german_empire
 		mark_formed_country_formable = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.218.d1
 		log = "[GetDateText]: [This.GetName]: germany.218.d executed"
 		add_stability = 0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Alliance with Russia? (DIE LINKE)
 country_event = {
@@ -4357,9 +4006,7 @@ country_event = {
 		name = germany.219.a
 		log = "[GetDateText]: [This.GetName]: germany.219.a executed"
 		SOV = { country_event = { id = CSTO.1 days = 1 } }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# GUARANTEES
@@ -4372,19 +4019,14 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# DON'T DO ANYTHING
 	option = {
 		name = germany.219.c
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4430,11 +4072,8 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4459,11 +4098,8 @@ country_event = {
 				active = yes
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4476,11 +4112,8 @@ country_event = {
 	# They denied!
 	option = {
 		name = germany.222.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4515,14 +4148,9 @@ country_event = {
 	option = {
 		name = germany.223.b
 		log = "[GetDateText]: [This.GetName]: germany.223.b executed"
-		GER = {
-			country_event = germany.225
-		}
-		ai_chance = {
-			base = 5
-		}
+		GER = { country_event = germany.225 }
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4537,11 +4165,8 @@ country_event = {
 		name = germany.224.a
 		log = "[GetDateText]: [This.GetName]: germany.224.a executed"
 		add_stability = 0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4563,11 +4188,8 @@ country_event = {
 			target = FROM
 		}
 		FROM = { every_core_state = { add_core_of = GER } }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # # # NPD Events
 country_event = {
@@ -4596,9 +4218,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -4.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# A good amount
@@ -4619,9 +4239,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -12.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Very little
@@ -4642,11 +4260,8 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -23.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Germany wants to establish a coalition with us
 country_event = {
@@ -4685,11 +4300,8 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # They accepted
 country_event = {
@@ -4709,11 +4321,8 @@ country_event = {
 		change_influence_percentage = yes
 		newline = yes
 		custom_effect_tooltip = GER_they_will_join_the_war
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # They rejected
 country_event = {
@@ -4726,11 +4335,8 @@ country_event = {
 	# Okay
 	option = {
 		name = germany.229.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4745,9 +4351,7 @@ country_event = {
 		name = germany.230.a
 		log = "[GetDateText]: [This.GetName]: germany.230.a executed"
 		GER = { country_event = germany.232 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Okay
@@ -4769,7 +4373,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -4787,20 +4390,17 @@ country_event = {
 		819 = { transfer_state_to = GER }
 		820 = { transfer_state_to = GER }
 		hidden_effect = {
-			818 = {	remove_core_of = USA }
-			821 = {	remove_core_of = USA }
-			819 = {	remove_core_of = USA }
-			820 = {	remove_core_of = USA }
-			818 = {	add_core_of = GER }
-			821 = {	add_core_of = GER }
-			819 = {	add_core_of = GER }
-			820 = {	add_core_of = GER }
+			818 = { remove_core_of = USA }
+			821 = { remove_core_of = USA }
+			819 = { remove_core_of = USA }
+			820 = { remove_core_of = USA }
+			818 = { add_core_of = GER }
+			821 = { add_core_of = GER }
+			819 = { add_core_of = GER }
+			820 = { add_core_of = GER }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4812,27 +4412,20 @@ country_event = {
 
 	option = {
 		name = germany.232.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.232.b
 		log = "[GetDateText]: [This.GetName]: germany.232.b executed"
 		add_political_power = -100
-		USA = {
-			add_stability = -0.05
-		}
-		818 = {	add_claim_by = GER }
-		821 = {	add_claim_by = GER }
-		819 = {	add_claim_by = GER }
-		820 = {	add_claim_by = GER }
-		ai_chance = {
-			base = 5
-		}
+		USA = { add_stability = -0.05 }
+		818 = { add_claim_by = GER }
+		821 = { add_claim_by = GER }
+		819 = { add_claim_by = GER }
+		820 = { add_claim_by = GER }
+		ai_chance = { base = 5 }
 	}
-
 }
 # Bundeswehr inspection reveals major problems
 country_event = {
@@ -4851,11 +4444,8 @@ country_event = {
 		set_country_flag = GER_bundeswehr_in_need_of_reform
 		newline = yes
 		custom_effect_tooltip = GER_bundeswehr_reform_decisions_TT
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4869,11 +4459,8 @@ country_event = {
 	# Okay
 	option = {
 		name = germany.2343.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Impending disorder
 country_event = {
@@ -4890,11 +4477,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.234.a executed"
 		set_country_flag = GER_incoming_disaster
 		custom_effect_tooltip = GER_the_end_of_republic_TT
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -4973,11 +4557,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5066,7 +4647,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -5079,11 +4659,8 @@ country_event = {
 	# Die Republic Ist Tot
 	option = {
 		name = germany.237.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # WARNING
 country_event = {
@@ -5096,11 +4673,8 @@ country_event = {
 
 	option = {
 		name = germany.238.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Germany invites us to their alliance
 country_event = {
@@ -5129,14 +4703,9 @@ country_event = {
 	option = {
 		name = germany.240.b
 		log = "[GetDateText]: [This.GetName]: germany.240.b executed"
-		GER = {
-			country_event = germany.242
-		}
-		ai_chance = {
-			base = 0
-		}
+		GER = { country_event = germany.242 }
+		ai_chance = { base = 0 }
 	}
-
 }
 # X NATION REJECTS
 country_event = {
@@ -5148,11 +4717,8 @@ country_event = {
 
 	option = {
 		name = germany.242.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Information Event
 country_event = {
@@ -5164,11 +4730,8 @@ country_event = {
 
 	option = {
 		name = germany.369.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # WoT events
 country_event = {
@@ -5192,9 +4755,7 @@ country_event = {
 		clamp_variable = { var = GER_soldiers_in_mideast min = 0 max = 8000 }
 		add_to_variable = { var = GER_soldiers_popularity_mideast value = 34 }
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# 1000 Troops
@@ -5211,9 +4772,7 @@ country_event = {
 		clamp_variable = { var = GER_soldiers_in_mideast min = 0 max = 8000 }
 		add_to_variable = { var = GER_soldiers_popularity_mideast value = 34 }
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# 2000 Troops
@@ -5230,9 +4789,7 @@ country_event = {
 		clamp_variable = { var = GER_soldiers_in_mideast min = 0 max = 8000 }
 		add_to_variable = { var = GER_soldiers_popularity_mideast value = 34 }
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# 4000 Troops
@@ -5249,11 +4806,8 @@ country_event = {
 		clamp_variable = { var = GER_soldiers_in_mideast min = 0 max = 8000 }
 		add_to_variable = { var = GER_soldiers_popularity_mideast value = 34 }
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Successful Airstrike
 country_event = {
@@ -5282,11 +4836,8 @@ country_event = {
 			custom_effect_tooltip = GER_increase_islamist_status_by_1
 			add_to_variable = { GER_islamist_department_status = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Unsuccessful Airstrike
 country_event = {
@@ -5341,11 +4892,8 @@ country_event = {
 			custom_effect_tooltip = GER_decrease_islamist_status_by_1
 			add_to_variable = { GER_islamist_department_status = -1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Successful Attack
 country_event = {
@@ -5373,11 +4921,8 @@ country_event = {
 		custom_effect_tooltip = GER_increase_popularity_2_TT
 		add_to_variable = { var = GER_soldiers_popularity_mideast value = 2 }
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Unsuccessful Attack
 country_event = {
@@ -5447,11 +4992,8 @@ country_event = {
 			custom_effect_tooltip = GER_decrease_islamist_status_by_1
 			add_to_variable = { GER_islamist_department_status = -1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # RANDOM EVENTS THAT WILL FIRE RANDOMLY AS SUGGESTED BY THE FIRST WORD OF THIS COMMENT
@@ -5525,9 +5067,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Clap back!
@@ -5538,11 +5078,8 @@ country_event = {
 			type = infantry_weapons_1
 			amount = -500
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5560,9 +5097,7 @@ country_event = {
 		custom_effect_tooltip = GER_decrease_popularity_2_TT
 		add_to_variable = { var = GER_soldiers_popularity_mideast value = -2 }
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Clap back!
@@ -5574,11 +5109,8 @@ country_event = {
 		clamp_variable = { var = GER_soldiers_popularity_mideast min = 0 max = 100 }
 		set_temp_variable = { treasury_change = -18.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # End of Mission WoT
 country_event = {
@@ -5603,11 +5135,8 @@ country_event = {
 			}
 			add_ideas = GER_idea_afghan_bonus_4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5620,9 +5149,7 @@ country_event = {
 	#Infrastructure
 	option = {
 		name = germany.408.a
-		trigger = {
-			check_variable = { treasury > 3.5 }
-		}
+		trigger = { check_variable = { treasury > 3.5 } }
 		log = "[GetDateText]: [This.GetName]: germany.408.a executed"
 		set_temp_variable = { treasury_change = -3.50 }
 		modify_treasury_effect = yes
@@ -5630,19 +5157,13 @@ country_event = {
 		set_temp_variable = { tag_index = GER }
 		set_temp_variable = { influence_target = UKR }
 		change_influence_percentage = yes
-		UKR = {
-			one_random_infrastructure = yes
-		}
-		ai_chance = {
-			base = 5
-		}
+		UKR = { one_random_infrastructure = yes }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.408.b
-		trigger = {
-			check_variable = { treasury > 7.5 }
-		}
+		trigger = { check_variable = { treasury > 7.5 } }
 		log = "[GetDateText]: [This.GetName]: germany.408.b executed"
 		set_temp_variable = { treasury_change = -7.50 }
 		modify_treasury_effect = yes
@@ -5650,23 +5171,16 @@ country_event = {
 		set_temp_variable = { tag_index = GER }
 		set_temp_variable = { influence_target = UKR }
 		change_influence_percentage = yes
-		UKR = {
-			two_random_industrial_complex = yes
-		}
-		ai_chance = {
-			base = 5
-		}
+		UKR = { two_random_industrial_complex = yes }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany.408.c
 		log = "[GetDateText]: [This.GetName]: germany.408.c executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -5690,9 +5204,7 @@ country_event = {
 		set_temp_variable = { tag_index = GER }
 		set_temp_variable = { influence_target = BLR }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Release secret information on Lukashenko's regime!
@@ -5708,11 +5220,8 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5725,9 +5234,7 @@ country_event = {
 	option = {
 		name = germany.410.a
 		log = "[GetDateText]: [This.GetName]: germany.410.a executed"
-		GER = {
-			country_event = germany.411
-		}
+		GER = { country_event = germany.411 }
 		diplomatic_relation = {
 			country = GER
 			relation = military_access
@@ -5745,14 +5252,9 @@ country_event = {
 	option = {
 		name = germany.410.b
 		log = "[GetDateText]: [This.GetName]: germany.410.b executed"
-		GER = {
-			country_event = germany.412
-		}
-		ai_chance = {
-			base = 5
-		}
+		GER = { country_event = germany.412 }
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5764,11 +5266,8 @@ country_event = {
 
 	option = {
 		name = germany.411.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5780,11 +5279,8 @@ country_event = {
 
 	option = {
 		name = germany.412.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -5812,11 +5308,8 @@ country_event = {
 			decrease_economic_growth = yes
 			decrease_economic_growth = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # BfV shuts down right wing organization
 country_event = {
@@ -5834,9 +5327,7 @@ country_event = {
 		add_political_power = -25
 		custom_effect_tooltip = GER_increase_rightist_status_by_1
 		add_to_variable = { GER_rightwing_department_status = 1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# It's probably better that we don't do that..
@@ -5846,11 +5337,8 @@ country_event = {
 		add_political_power = 25
 		custom_effect_tooltip = GER_decrease_rightist_status_by_1
 		add_to_variable = { GER_rightwing_department_status = -1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # BfV shuts down left wing organization
 country_event = {
@@ -5868,9 +5356,7 @@ country_event = {
 		add_political_power = -25
 		custom_effect_tooltip = GER_increase_leftist_status_by_1
 		add_to_variable = { GER_leftwing_department_status = 1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# It's probably better that we don't do that..
@@ -5880,11 +5366,8 @@ country_event = {
 		add_political_power = 25
 		custom_effect_tooltip = GER_decrease_leftist_status_by_1
 		add_to_variable = { GER_leftwing_department_status = -1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # BfV shuts down islamist organization
@@ -5903,9 +5386,7 @@ country_event = {
 		add_political_power = -25
 		custom_effect_tooltip = GER_increase_islamist_status_by_1
 		add_to_variable = { GER_islamist_department_status = 1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# It's probably better that we don't do that..
@@ -5915,11 +5396,8 @@ country_event = {
 		add_political_power = 25
 		custom_effect_tooltip = GER_decrease_islamist_status_by_1
 		add_to_variable = { GER_islamist_department_status = -1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # BfV requests a larger budget
 country_event = {
@@ -5951,9 +5429,7 @@ country_event = {
 		add_to_variable = { GER_leftwing_department_status = 1 }
 		custom_effect_tooltip = GER_increase_rightist_status_by_1
 		add_to_variable = { GER_rightwing_department_status = 1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# No
@@ -5966,11 +5442,8 @@ country_event = {
 		add_to_variable = { GER_leftwing_department_status = -1 }
 		custom_effect_tooltip = GER_decrease_rightist_status_by_1
 		add_to_variable = { GER_rightwing_department_status = -1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 4th Reich Formed
 country_event = {
@@ -5987,11 +5460,8 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.20
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # War Debt Paid
 country_event = {
@@ -6009,9 +5479,7 @@ country_event = {
 		modify_treasury_effect = yes
 		newline = yes
 		remove_ideas = GER_idea_war_reparations
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6049,9 +5517,7 @@ country_event = {
 				modifier = GER_slight_positive_opinion
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6088,11 +5554,8 @@ country_event = {
 				modifier = GER_great_negative_opinion
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 ### YEARLY EVENTS STARTING 2002
@@ -6113,17 +5576,11 @@ country_event = {
 		block_police_decrease = yes
 		newline = yes
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_rightist_status_by_1
 			add_to_variable = { GER_rightwing_department_status = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Yeah, no
@@ -6132,11 +5589,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany_yearly.1.b executed"
 		decrease_policing_budget = yes
 		block_police_increase = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Erfurt massacre
 country_event = {
@@ -6154,9 +5608,7 @@ country_event = {
 		add_stability = -0.01
 		set_temp_variable = { treasury_change = -12.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# A sad day for the nation...
@@ -6164,11 +5616,8 @@ country_event = {
 		name = germany_yearly.2.b
 		log = "[GetDateText]: [This.GetName]: germany_yearly.2.b executed"
 		add_stability = -0.03
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2003
 # 2004
@@ -6185,20 +5634,14 @@ country_event = {
 		name = germany_yearly.3.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.3.a executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_rightist_status_by_1
 			add_to_variable = { GER_rightwing_department_status = 1 }
 		}
 		if = {
 			limit = {
 				check_variable = { GER_rightwing_department_status < 30 }
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 			}
 			custom_effect_tooltip = GER_due_to_low_dept_status
 			newline = yes
@@ -6209,9 +5652,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -15.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Not much we can do
@@ -6219,33 +5660,22 @@ country_event = {
 		name = germany_yearly.3.b
 		log = "[GetDateText]: [This.GetName]: germany_yearly.3.b executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_decrease_rightist_status_by_1
 			add_to_variable = { GER_rightwing_department_status = -1 }
 		}
 		if = {
 			limit = {
 				check_variable = { GER_rightwing_department_status < 30 }
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 			}
 			custom_effect_tooltip = GER_due_to_low_dept_status
 			newline = yes
 			add_stability = -0.04
 		}
-		else = {
-			add_stability = -0.01
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { add_stability = -0.01 }
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2005
 # Ennepetal hostage taking
@@ -6265,9 +5695,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.025 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Accept the terms, let his family in. But let him go
@@ -6277,9 +5705,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# No time for negotations! Send in the Spezialeinsatzkommando
@@ -6291,11 +5717,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.035 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2006
 # German train bombing attempts
@@ -6311,19 +5734,13 @@ country_event = {
 		name = germany_yearly.5.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.5.a executed"
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_increase_islamist_status_by_1
 			add_to_variable = { GER_islamist_department_status = 1 }
 		}
 		set_temp_variable = { treasury_change = -15.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6339,11 +5756,8 @@ country_event = {
 			}
 		}
 		add_stability = -0.02
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -6359,23 +5773,16 @@ country_event = {
 	option = {
 		name = germany_yearly.6.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.6.a executed"
-		random_army_leader = {
-			retire = yes
-		}
-		ai_chance = {
-			base = 5
-		}
+		random_army_leader = { retire = yes }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany_yearly.6.b
 		log = "[GetDateText]: [This.GetName]: germany_yearly.6.b executed"
 		add_stability = -0.06
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2007
 #Hurrican Kyrill
@@ -6438,9 +5845,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6464,11 +5869,8 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -33.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -6491,9 +5893,7 @@ country_event = {
 			MODIFIER = GER_generic_spending_laws
 		}
 		add_to_variable = { GER_welfare_cost = -0.02 tooltip = social_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# No, keep it as is!
@@ -6508,11 +5908,8 @@ country_event = {
 			MODIFIER = GER_generic_spending_laws
 		}
 		add_to_variable = { GER_welfare_cost = 0.01 tooltip = social_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2008
 #NOKIA Closure
@@ -6536,9 +5933,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Give them some funding to stay open
@@ -6548,11 +5943,8 @@ country_event = {
 		add_stability = 0.01
 		set_temp_variable = { treasury_change = -15.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Telecommunications retentions law
 country_event = {
@@ -6571,9 +5963,7 @@ country_event = {
 			idea = GER_idea_retention_law_comm
 			days = 600
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Give them some funding to stay open
@@ -6582,11 +5972,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany_yearly.10.b executed"
 		set_temp_variable = { treasury_change = 27.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2009
 #Wolfgang Schneiderhan
@@ -6607,9 +5994,7 @@ country_event = {
 		add_political_power = -150
 		army_experience = -20
 		add_war_support = -0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Goodbye
@@ -6617,11 +6002,8 @@ country_event = {
 		name = germany_yearly.11.b
 		log = "[GetDateText]: [This.GetName]: germany_yearly.11.b executed"
 		retire_character = GER_wolfgang_schneiderhan
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 #2010
 country_event = {
@@ -6642,9 +6024,7 @@ country_event = {
 			uses = 1
 			category = CAT_internet_tech
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Warn them of the dangers
@@ -6656,9 +6036,7 @@ country_event = {
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = GER }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Ban the browser entirely
@@ -6670,11 +6048,8 @@ country_event = {
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = GER }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Love parade disaster
 country_event = {
@@ -6690,9 +6065,7 @@ country_event = {
 		name = germany_yearly.14.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.14.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Get medical experts on stand-by next time!
@@ -6705,11 +6078,8 @@ country_event = {
 		}
 		add_to_variable = { GER_health_cost = 0.01 tooltip = health_cost_multiplier_modifier_tt }
 		add_stability = 0.04
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2011
 # Frankfurt Airport Shooting
@@ -6727,9 +6097,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany_yearly.15.a executed"
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -6766,9 +6134,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Pump up security!
@@ -6780,11 +6146,8 @@ country_event = {
 			MODIFIER = GER_generic_spending_laws
 		}
 		add_to_variable = { GER_police_cost = 0.01 tooltip = police_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2012 events
 #Fire at workshop for disabled people kills 14
@@ -6808,9 +6171,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Investigate
@@ -6822,11 +6183,8 @@ country_event = {
 			MODIFIER = GER_generic_spending_laws
 		}
 		add_to_variable = { GER_welfare_cost = 0.01 tooltip = social_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -6842,9 +6200,7 @@ country_event = {
 		name = germany_yearly.17.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.17.a executed"
 		add_stability = 0.02
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Investigate
@@ -6862,11 +6218,8 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -36.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 #2013 Events
 # European Floods
@@ -6997,9 +6350,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -7007,11 +6358,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany_yearly.18.b executed"
 		set_temp_variable = { treasury_change = -36.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Massive surge in immigration
 country_event = {
@@ -7026,49 +6374,28 @@ country_event = {
 	option = {
 		name = germany_yearly.19.a
 		log = "[GetDateText]: [This.GetName]: germany_yearly.19.a executed"
-		43 = {
-			add_manpower = 52200
-		}
-		45 = {
-			add_manpower = 52200
-		}
-		539 = {
-			add_manpower = 52200
-		}
-		38 = {
-			add_manpower = 52200
-		}
-		966 = {
-			add_manpower = 52200
-		}
-		40 = {
-			add_manpower = 52200
-		}
-		39 = {
-			add_manpower = 52200
-		}
-		37 = {
-			add_manpower = 52200
-		}
+		43 = { add_manpower = 52200 }
+		45 = { add_manpower = 52200 }
+		539 = { add_manpower = 52200 }
+		38 = { add_manpower = 52200 }
+		966 = { add_manpower = 52200 }
+		40 = { add_manpower = 52200 }
+		39 = { add_manpower = 52200 }
+		37 = { add_manpower = 52200 }
 		newline = yes
 		add_stability = -0.03
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = germany_yearly.19.b
 		log = "[GetDateText]: [This.GetName]: germany_yearly.19.b executed"
 		add_stability = 0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # 2014
 # Shariah police incident
@@ -7088,9 +6415,7 @@ country_event = {
 		modify_treasury_effect = yes
 		if = {
 			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
+				NOT = { has_country_flag = GER_BFV_GONE }
 				OR = {
 					check_variable = { GER_islamist_department_status < 30 }
 					check_variable = { GER_islamist_spending_level = 1 }
@@ -7098,12 +6423,8 @@ country_event = {
 			}
 			add_stability = -0.01
 		}
-		else = {
-			add_political_power = -100
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { add_political_power = -100 }
+		ai_chance = { base = 5 }
 	}
 
 	# Cool
@@ -7115,19 +6436,12 @@ country_event = {
 			popularity = 0.05
 		}
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = GER_BFV_GONE
-				}
-			}
+			limit = { NOT = { has_country_flag = GER_BFV_GONE } }
 			custom_effect_tooltip = GER_decrease_islamist_status_by_1
 			add_to_variable = { GER_islamist_department_status = -1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 # Minimum wage increase
 country_event = {
@@ -7152,9 +6466,7 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { temp_opinion = 3 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -7171,11 +6483,8 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { temp_opinion = -3 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 # Routes the MEKO export offer so FROM resolves to the buyer
@@ -7188,7 +6497,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.511 executed"
 		GER = { country_event = { id = germany.513 hours = 6 } }
 	}
-
 }
 
 # Routes the submarine export offer so FROM resolves to the buyer
@@ -7201,7 +6509,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.512 executed"
 		GER = { country_event = { id = germany.514 hours = 6 } }
 	}
-
 }
 
 # MEKO
@@ -7274,7 +6581,6 @@ country_event = {
 		set_temp_variable = { treasury_change = 12.0 }
 		modify_treasury_effect = yes
 	}
-
 }
 # HDW
 country_event = {
@@ -7346,7 +6652,6 @@ country_event = {
 		set_temp_variable = { treasury_change = 12.0 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 #to much troops
@@ -7423,7 +6728,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -7455,7 +6759,6 @@ country_event = {
 			country_lock_all_division_template = yes
 		}
 	}
-
 }
 
 country_event = {
@@ -7466,10 +6769,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany.562.a
-	}
-
+	option = { name = germany.562.a }
 }
 
 #harsh reaction
@@ -7520,7 +6820,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Diplomatic reaction
@@ -7571,7 +6870,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #accepted
@@ -7629,7 +6927,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -7645,17 +6942,13 @@ country_event = {
 		name = germany.580.a
 		log = "[GetDateText]: [This.GetName]: germany.580.a executed"
 		country_event = { id = germany.581 days = 2 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# NO
 	option = {
 		name = germany.580.b
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Negotiate Licenses
@@ -7663,9 +6956,7 @@ country_event = {
 		name = germany.580.c
 		log = "[GetDateText]: [This.GetName]: germany.580.c executed"
 		country_event = { id = germany.583 days = 2 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Retire the fleet
@@ -7673,11 +6964,8 @@ country_event = {
 		name = germany.580.e
 		log = "[GetDateText]: [This.GetName]: germany.580.e executed"
 		country_event = { id = germany.582 days = 2 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -7693,9 +6981,7 @@ country_event = {
 		name = germany.581.a
 		log = "[GetDateText]: [This.GetName]: germany.581.a executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = SOV.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.22 }
@@ -7720,11 +7006,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = SOV.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.22 }
@@ -7746,9 +7028,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Buy from Eastern Europe
@@ -7756,9 +7036,7 @@ country_event = {
 		name = germany.581.b
 		log = "[GetDateText]: [This.GetName]: germany.581.b executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = POL.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.22 }
@@ -7805,11 +7083,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.22 }
@@ -7851,9 +7125,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Buy from Ukrain
@@ -7861,9 +7133,7 @@ country_event = {
 		name = germany.581.c
 		log = "[GetDateText]: [This.GetName]: germany.581.c executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = UKR.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.22 }
@@ -7888,11 +7158,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = UKR.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.22 }
@@ -7914,11 +7180,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -7934,9 +7197,7 @@ country_event = {
 		name = germany.582.a
 		log = "[GetDateText]: [This.GetName]: germany.582.a executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = POL.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = 0.22 }
@@ -7961,11 +7222,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = POL.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = 0.22 }
@@ -7987,9 +7244,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# destroy Old stuff
@@ -7997,9 +7252,7 @@ country_event = {
 		name = germany.582.b
 		log = "[GetDateText]: [This.GetName]: germany.582.b executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = POL.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = 0.05 }
@@ -8013,11 +7266,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = POL.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = 0.05 }
@@ -8029,9 +7278,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# sell to Market
@@ -8039,9 +7286,7 @@ country_event = {
 		name = germany.582.c
 		log = "[GetDateText]: [This.GetName]: germany.582.c executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = 0.22 }
@@ -8088,11 +7333,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = 0.22 }
@@ -8134,11 +7375,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -8202,9 +7440,7 @@ country_event = {
 		name = germany.583.b
 		log = "[GetDateText]: [This.GetName]: germany.583.b executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.14 }
@@ -8228,11 +7464,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.14 }
@@ -8252,9 +7484,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Develope a version with east Europeans
@@ -8262,9 +7492,7 @@ country_event = {
 		name = germany.583.c
 		log = "[GetDateText]: [This.GetName]: germany.583.c executed"
 		if = {
-			limit = {
-				has_dlc = "By Blood Alone"
-			}
+			limit = { has_dlc = "By Blood Alone" }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.11 }
@@ -8309,11 +7537,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = {
-					has_dlc = "By Blood Alone"
-				}
-			}
+			limit = { NOT = { has_dlc = "By Blood Alone" } }
 			GER = {
 				set_temp_variable = { treasury_change = GER.gdp_per_capita }
 				multiply_temp_variable = { treasury_change = -0.14 }
@@ -8351,11 +7575,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany.585
@@ -8364,12 +7585,11 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	# no Need for big army
+	option = { # no Need for big army
 		name = germany.585.a
 		log = "[GetDateText]: [This.GetName]: germany.585.a executed"
 		country_lock_all_division_template = no
 	}
-
 }
 country_event = {
 	id = germany.586
@@ -8412,12 +7632,11 @@ country_event = {
 		add_ideas = GER_Idea_Weizsackerkommission
 	}
 
-	option = {	#no
+	option = { #no
 		name = germany.586.b
 		log = "[GetDateText]: [This.GetName]: germany.586.b executed"
 		add_political_power = 10
 	}
-
 }
 country_event = {
 	id = germany.587
@@ -8426,7 +7645,7 @@ country_event = {
 	picture = GFX_german_parliament
 	is_triggered_only = yes
 
-	option = {	#start
+	option = { #start
 		name = germany.587.a
 		log = "[GetDateText]: [This.GetName]: germany.587.a executed"
 		remove_ideas = GER_Idea_Weizsackerkommission
@@ -8443,14 +7662,13 @@ country_event = {
 		}
 	}
 
-	option = {	#no
+	option = { #no
 		name = germany.587.b
 		log = "[GetDateText]: [This.GetName]: germany.587.b executed"
 		add_political_power = 10
 		add_command_power = 10
 		country_lock_all_division_template = no
 	}
-
 }
 country_event = {
 	id = germany.588
@@ -8460,7 +7678,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	# reduce the army and save money
+	option = { # reduce the army and save money
 		name = germany.588.a
 		log = "[GetDateText]: [This.GetName]: germany.588.a executed"
 		custom_effect_tooltip = {
@@ -8478,7 +7696,7 @@ country_event = {
 		}
 	}
 
-	option = {	# specialize without shrinking
+	option = { # specialize without shrinking
 		name = germany.588.b
 		log = "[GetDateText]: [This.GetName]: germany.588.b executed"
 		custom_effect_tooltip = {
@@ -8496,7 +7714,7 @@ country_event = {
 		}
 	}
 
-	option = {	# expand our capabilities
+	option = { # expand our capabilities
 		name = germany.588.c
 		log = "[GetDateText]: [This.GetName]: germany.588.c executed"
 		custom_effect_tooltip = {
@@ -8517,7 +7735,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany.589
@@ -8527,7 +7744,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	# permanent transformation
+	option = { # permanent transformation
 		name = germany.589.a
 		log = "[GetDateText]: [This.GetName]: germany.589.a executed"
 		custom_effect_tooltip = {
@@ -8538,7 +7755,6 @@ country_event = {
 		add_to_variable = { GER_mobilization_speed = 0.05 tooltip = mobilization_speed_tt }
 		army_experience = 15
 	}
-
 }
 country_event = {
 	id = germany.590
@@ -8547,7 +7763,7 @@ country_event = {
 	picture = GFX_Patriot_GER
 	is_triggered_only = yes
 
-	option = {	# mobilize units
+	option = { # mobilize units
 	name = germany.590.a
 	log = "[GetDateText]: [This.GetName]: germany.590.a executed"
 	set_temp_variable = { treasury_change = GER.gdp_per_capita }
@@ -8576,7 +7792,7 @@ country_event = {
 		}
 	}
 
-	option = {	# spread units
+	option = { # spread units
 		name = germany.590.b
 		log = "[GetDateText]: [This.GetName]: germany.590.b executed"
 		set_temp_variable = { treasury_change = GER.gdp_per_capita }
@@ -8614,10 +7830,9 @@ country_event = {
 		}
 	}
 
-	option = {	# we cant effort
+	option = { # we cant effort
 		name = germany.590.c
 	}
-
 }
 
 #### some love ####
@@ -8631,9 +7846,7 @@ country_event = {
 
 	trigger = {
 		OR = {
-			NOT = {
-			has_government = nationalist
-		}
+			NOT = { has_government = nationalist }
 		has_idea = NATO_member
 		}
 	}
@@ -8646,9 +7859,7 @@ country_event = {
 			target = USA
 			modifier = note_of_protest
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8656,11 +7867,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.1.b executed"
 		add_stability = 0.01
 		add_war_support = -0.02
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.2
@@ -8672,9 +7880,7 @@ country_event = {
 
 	trigger = {
 		OR = {
-			NOT = {
-			has_government = nationalist
-		}
+			NOT = { has_government = nationalist }
 		has_idea = NATO_member
 		}
 	}
@@ -8683,20 +7889,15 @@ country_event = {
 		name = Germany_Mech.2.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.2.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = Germany_Mech.2.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.2.b executed"
 		add_war_support = -0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.3
@@ -8710,20 +7911,15 @@ country_event = {
 		name = Germany_Mech.3.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.3.a executed"
 		add_war_support = -0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = Germany_Mech.3.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.3.b executed"
 		add_political_power = -10
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.4
@@ -8738,9 +7934,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.4.a executed"
 		add_war_support = 0.02
 		add_political_power = -15
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8748,11 +7942,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.4.b executed"
 		add_stability = -0.01
 		add_political_power = 15
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.5
@@ -8764,9 +7955,7 @@ country_event = {
 
 	trigger = {
 		OR = {
-			NOT = {
-			has_government = nationalist
-		}
+			NOT = { has_government = nationalist }
 		has_idea = NATO_member
 		}
 	}
@@ -8779,20 +7968,15 @@ country_event = {
 			target = ENG
 			modifier = note_of_protest
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = Germany_Mech.5.b
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.5.b executed"
 		add_political_power = 5
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.6
@@ -8809,9 +7993,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.020 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8821,11 +8003,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.7
@@ -8842,9 +8021,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.020 }
 		set_temp_variable = { temp_outlook_increase = -0.015 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8856,11 +8033,8 @@ country_event = {
 		set_temp_variable = { treasury_change = GER.gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.008 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.8
@@ -8873,12 +8047,8 @@ country_event = {
 	option = {
 		name = Germany_Mech.8.a
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.8.a executed"
-		GER = {
-			one_random_infrastructure = yes
-		}
-		ai_chance = {
-			base = 5
-		}
+		GER = { one_random_infrastructure = yes }
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8887,11 +8057,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -8924,9 +8091,7 @@ country_event = {
 				target = ENG
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8944,11 +8109,8 @@ country_event = {
 				target = ENG
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -8976,9 +8138,7 @@ country_event = {
 				target = USA
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -8996,11 +8156,8 @@ country_event = {
 				target = USA
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -9027,7 +8184,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: germany.589.a executed"
 		add_political_power = 75
 	}
-
 }
 
 # Drews
@@ -9077,7 +8233,6 @@ country_event = {
 		add_command_power = 25
 		add_political_power = 50
 	}
-
 }
 
 #hohmann
@@ -9133,7 +8288,6 @@ country_event = {
 			days = 4
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.24
@@ -9159,7 +8313,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = 0.07
 	}
-
 }
 country_event = {
 	id = Germany_Mech.25
@@ -9193,7 +8346,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = 0.07
 	}
-
 }
 country_event = {
 	id = Germany_Mech.26
@@ -9219,7 +8371,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_political_power = 20
 	}
-
 }
 country_event = {
 	id = Germany_Mech.27
@@ -9256,7 +8407,6 @@ country_event = {
 			popularity = 0.03
 		}
 	}
-
 }
 
 country_event = {
@@ -9297,7 +8447,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Ruwe-Dieter affair
@@ -9347,7 +8496,6 @@ country_event = {
 			popularity = 0.03
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.30
@@ -9400,7 +8548,6 @@ country_event = {
 			popularity = 0.02
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.31
@@ -9446,7 +8593,6 @@ country_event = {
 			popularity = 0.03
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.32
@@ -9495,7 +8641,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -9570,7 +8715,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.41
@@ -9632,7 +8776,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.42
@@ -9690,7 +8833,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.43
@@ -9795,7 +8937,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.44
@@ -9821,7 +8962,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
 	}
-
 }
 country_event = {
 	id = Germany_Mech.45
@@ -9846,7 +8986,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.45.a executed"
 		add_stability = 0.02
 	}
-
 }
 country_event = {
 	id = Germany_Mech.46
@@ -9881,7 +9020,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.47
@@ -9907,7 +9045,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.47.a executed"
 		add_stability = 0.03
 	}
-
 }
 country_event = {
 	id = Germany_Mech.48
@@ -9932,7 +9069,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Germany_Mech.48.a executed"
 		add_stability = -0.03
 	}
-
 }
 ###end###
 
@@ -9969,7 +9105,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10004,7 +9139,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10039,7 +9173,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10074,7 +9207,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10109,7 +9241,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10144,7 +9275,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10179,7 +9309,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10214,7 +9343,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10249,7 +9377,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10284,7 +9411,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10319,7 +9445,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10354,7 +9479,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10389,7 +9513,6 @@ country_event = {
 			value = 0.05
 		}
 	}
-
 }
 
 country_event = {
@@ -10433,7 +9556,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -10477,7 +9599,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -10500,18 +9621,14 @@ country_event = {
 		add_stability = -0.03
 		GER = {
 			random_owned_state = {
-				limit = {
-					industrial_complex > 3
-				}
+				limit = { industrial_complex > 3 }
 				remove_building = {
 					type = industrial_complex
 					level = 1
 				}
 			}
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	# Option B: Offer subsidies to retain the companies
@@ -10530,9 +9647,7 @@ country_event = {
 		}
 		add_stability = 0.02
 		add_political_power = -50
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	# Option C: Nationalize the company (enteignet die Firma)
@@ -10564,7 +9679,6 @@ country_event = {
 			base = 20
 		}
 	}
-
 }
 country_event = {
 	id = Germany_Mech.71
@@ -10590,9 +9704,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
@@ -10617,9 +9729,7 @@ country_event = {
 		set_temp_variable = { treasury_change = GER.gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
@@ -10631,11 +9741,8 @@ country_event = {
 		change_labour_unions_opinion = yes
 		add_stability = -0.05
 		add_political_power = 25
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
-
 }
 country_event = {
 	id = Germany_Mech.72
@@ -10661,9 +9768,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
@@ -10686,9 +9791,7 @@ country_event = {
 		set_temp_variable = { treasury_change = GER.gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
@@ -10705,7 +9808,6 @@ country_event = {
 			base = 10
 		}
 	}
-
 }
 
 #Manichl
@@ -10749,7 +9851,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 #Coldwar
@@ -10806,7 +9907,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.1.b executed"
 		custom_effect_tooltip = GER_Coldwar_2
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.2
@@ -10936,7 +10036,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.3
@@ -11171,7 +10270,6 @@ country_event = {
 			random_country_division = { add_divisional_commander_xp = 110 }
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.4
@@ -11292,7 +10390,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.5
@@ -11402,7 +10499,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.6
@@ -11500,7 +10596,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.7
@@ -11560,7 +10655,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.8
@@ -11588,7 +10682,6 @@ country_event = {
 			add_trait = { trait = disgruntled }
 		}
 	}
-
 }
 
 country_event = {
@@ -11712,7 +10805,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -11750,7 +10842,6 @@ country_event = {
 		set_temp_variable = { treasury_change = 2.14 }
 		modify_treasury_effect = yes
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.11
@@ -11786,7 +10877,6 @@ country_event = {
 		set_temp_variable = { treasury_change = 2.14 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 #Weizsäcker
@@ -11799,7 +10889,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Introduce Fennek JFST
+	option = { # Introduce Fennek JFST
 		name = GER_Cold_War.20.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.20.a executed"
 		custom_effect_tooltip = GER_Fennek_TT
@@ -11833,7 +10923,7 @@ country_event = {
 		modify_treasury_effect = yes
 	}
 
-	option = {	# Update Template design_team = mio:GER_rheinmetall_tank_manufacturer
+	option = { # Update Template design_team = mio:GER_rheinmetall_tank_manufacturer
 		name = GER_Cold_War.20.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.20.b executed"
 		custom_effect_tooltip = GER_Luchs_TT
@@ -11862,7 +10952,7 @@ country_event = {
 		}
 	}
 
-	option = {	# Keep MBT in Structure
+	option = { # Keep MBT in Structure
 		name = GER_Cold_War.20.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.20.c executed"
 		custom_effect_tooltip = GER_Armored_Rec_TT
@@ -11891,7 +10981,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.22
@@ -11902,7 +10991,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Order first tranche and Taurus
+	option = { # Order first tranche and Taurus
 		name = GER_Cold_War.22.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.22.a executed"
 		custom_effect_tooltip = GER_Taurus_TT
@@ -11920,7 +11009,7 @@ country_event = {
 		}
 	}
 
-	option = {	# order first tranch
+	option = { # order first tranch
 		name = GER_Cold_War.22.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.22.b executed"
 		custom_effect_tooltip = GER_Eurofighter_TT
@@ -11933,12 +11022,11 @@ country_event = {
 		}
 	}
 
-	option = {	# to expensive
+	option = { # to expensive
 		name = GER_Cold_War.22.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.22.c executed"
 		custom_effect_tooltip = GER_NO_Eurofighter_TT
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.1
@@ -11967,7 +11055,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.2
@@ -12035,7 +11122,6 @@ country_event = {
 			add_mio_size_up_requirement_factor = -0.1
 		}
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.3
@@ -12062,7 +11148,6 @@ country_event = {
 		ITA = { add_opinion_modifier = { modifier = GER_Rejected_mutual_project target = ROOT } }
 		SPR = { add_opinion_modifier = { modifier = GER_Rejected_mutual_project target = ROOT } }
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.4
@@ -12074,9 +11159,7 @@ country_event = {
 	option = {
 		name = GER_Eurofighter.4.a
 		log = "[GetDateText]: [This.GetName]: GER_Eurofighter.4.a executed"
-		mio:GER_Eurofighter_aircraft_manufacturer = {
-			add_mio_funds = 300
-		}
+		mio:GER_Eurofighter_aircraft_manufacturer = { add_mio_funds = 300 }
 	}
 
 	option = {
@@ -12088,7 +11171,6 @@ country_event = {
 		ITA = { add_opinion_modifier = { modifier = GER_Rejected_mutual_project target = ROOT } }
 		SPR = { add_opinion_modifier = { modifier = GER_Rejected_mutual_project target = ROOT } }
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.5
@@ -12100,11 +11182,8 @@ country_event = {
 	option = {
 		name = GER_Eurofighter.5.a
 		log = "[GetDateText]: [This.GetName]: GER_Eurofighter.5.a executed"
-		mio:GER_Eurofighter_aircraft_manufacturer = {
-			add_mio_funds = 300
-		}
+		mio:GER_Eurofighter_aircraft_manufacturer = { add_mio_funds = 300 }
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.6
@@ -12116,11 +11195,8 @@ country_event = {
 	option = {
 		name = GER_Eurofighter.6.a
 		log = "[GetDateText]: [This.GetName]: GER_Eurofighter.6.a executed"
-		mio:GER_Eurofighter_aircraft_manufacturer = {
-			add_mio_funds = 300
-		}
+		mio:GER_Eurofighter_aircraft_manufacturer = { add_mio_funds = 300 }
 	}
-
 }
 country_event = {
 	id = GER_Eurofighter.7
@@ -12137,7 +11213,6 @@ country_event = {
 			add_mio_research_bonus = 0.07
 		}
 	}
-
 }
 #panavia
 country_event = {
@@ -12161,7 +11236,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_panavia.1.b executed"
 		air_experience = 20
 	}
-
 }
 country_event = {
 	id = GER_panavia.2
@@ -12173,9 +11247,7 @@ country_event = {
 	option = {
 		name = GER_panavia.2.a
 		log = "[GetDateText]: [This.GetName]: GER_panavia.2.a executed"
-		mio:GER_panavia_aircraft_manufacturer = {
-			add_mio_funds = 300
-		}
+		mio:GER_panavia_aircraft_manufacturer = { add_mio_funds = 300 }
 		if = {
 			limit = { has_dlc = "By Blood Alone" }
 			add_tech_bonus = {
@@ -12203,7 +11275,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_panavia.2.b executed"
 		air_experience = 20
 	}
-
 }
 country_event = {
 	id = GER_panavia.3
@@ -12215,9 +11286,7 @@ country_event = {
 	option = {
 		name = GER_panavia.3.a
 		log = "[GetDateText]: [This.GetName]: GER_panavia.3.a executed"
-		mio:GER_panavia_aircraft_manufacturer = {
-			add_mio_funds = 300
-		}
+		mio:GER_panavia_aircraft_manufacturer = { add_mio_funds = 300 }
 		if = {
 			limit = { has_dlc = "By Blood Alone" }
 			add_tech_bonus = {
@@ -12246,7 +11315,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_panavia.3.b executed"
 		air_experience = 20
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.23
@@ -12257,7 +11325,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Order CH-53 G and invest in Tiger
+	option = { # Order CH-53 G and invest in Tiger
 		name = GER_Cold_War.23.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.23.a executed"
 		custom_effect_tooltip = GER_Tiger_TT
@@ -12299,7 +11367,7 @@ country_event = {
 		}
 	}
 
-	option = {	# order CH-53 G and Apache
+	option = { # order CH-53 G and Apache
 		name = GER_Cold_War.23.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.23.b executed"
 		custom_effect_tooltip = GER_Apache_TT
@@ -12329,12 +11397,11 @@ country_event = {
 		}
 	}
 
-	option = {	# to expensive
+	option = { # to expensive
 		name = GER_Cold_War.23.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.23.c executed"
 		custom_effect_tooltip = GER_NO_Tiger_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.24
@@ -12345,7 +11412,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Update Leopard and Marder
+	option = { # Update Leopard and Marder
 		name = GER_Cold_War.24.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.24.a executed"
 		custom_effect_tooltip = GER_2A6_TT
@@ -12396,7 +11463,7 @@ country_event = {
 		}
 	}
 
-	option = {	# 2A5 is enough
+	option = { # 2A5 is enough
 		name = GER_Cold_War.24.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.24.b executed"
 		custom_effect_tooltip = GER_2A5_TT
@@ -12417,12 +11484,11 @@ country_event = {
 		}
 	}
 
-	option = {	# to expensive
+	option = { # to expensive
 		name = GER_Cold_War.24.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.24.c executed"
 		custom_effect_tooltip = GER_NO_2A6_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.25
@@ -12433,7 +11499,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# integrate Artillerie into a SIngle Unit
+	option = { # integrate Artillerie into a SIngle Unit
 		name = GER_Cold_War.25.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.25.a executed"
 		custom_effect_tooltip = GER_Heerestruppe_TT
@@ -12468,12 +11534,11 @@ country_event = {
 		}
 	}
 
-	option = {	# we are Good
+	option = { # we are Good
 		name = GER_Cold_War.25.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.25.b executed"
 		custom_effect_tooltip = GER_keep_structure_TT
 	}
-
 }
 
 #Cooperation with NL
@@ -12488,7 +11553,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Strenghen ties
+	option = { # Strenghen ties
 		name = GER_Cold_War.30.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.30.a executed"
 		GER = {
@@ -12521,13 +11586,12 @@ country_event = {
 		}
 	}
 
-	option = {	# Maintain Status Quo
+	option = { # Maintain Status Quo
 		name = GER_Cold_War.30.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.30.b executed"
 		#end chain
 		custom_effect_tooltip = GER_Status_Quo_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.31
@@ -12538,7 +11602,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Proceed with Synchronization
+	option = { # Proceed with Synchronization
 		name = GER_Cold_War.31.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.31.a executed"
 		set_temp_variable = { percent_change = 2.5 }
@@ -12613,13 +11677,12 @@ country_event = {
 		}
 	}
 
-	option = {	# Postpone the plan
+	option = { # Postpone the plan
 		name = GER_Cold_War.31.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.31.b executed"
 		#end
 		custom_effect_tooltip = GER_Postpone_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.32
@@ -12630,7 +11693,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Standardize equipment
+	option = { # Standardize equipment
 		name = GER_Cold_War.32.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.32.a executed"
 		HOL = {
@@ -12694,7 +11757,7 @@ country_event = {
 		}
 	}
 
-	option = {	# Partial Synchronization
+	option = { # Partial Synchronization
 		name = GER_Cold_War.32.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.32.b executed"
 		HOL = {
@@ -12734,12 +11797,11 @@ country_event = {
 			}
 		}
 
-	option = {	# Maintain Seperate Systems
+	option = { # Maintain Seperate Systems
 		name = GER_Cold_War.32.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.32.c executed"
 		custom_effect_tooltip = GER_Standardization_II_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.33
@@ -12750,7 +11812,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Light Forces
+	option = { # Light Forces
 		name = GER_Cold_War.33.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.33.a executed"
 		HOL = {
@@ -12796,7 +11858,7 @@ country_event = {
 		custom_effect_tooltip = GER_Complimentary_TT
 	}
 
-	option = {	# Medium Forces
+	option = { # Medium Forces
 		name = GER_Cold_War.33.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.33.b executed"
 		HOL = {
@@ -12844,7 +11906,7 @@ country_event = {
 		custom_effect_tooltip = GER_Complimentary_I_TT
 	}
 
-	option = {	# Heavy Forces
+	option = { # Heavy Forces
 		name = GER_Cold_War.33.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.33.c executed"
 		HOL = {
@@ -12891,7 +11953,6 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = GER_Complimentary_II_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.34
@@ -12902,7 +11963,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# Stationate Patriots in NL
+	option = { # Stationate Patriots in NL
 		name = GER_Cold_War.34.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.34.a executed"
 		1169 = {
@@ -12930,7 +11991,7 @@ country_event = {
 		custom_effect_tooltip = GER_Air_defence_TT
 	}
 
-	option = {	# send Equipment
+	option = { # send Equipment
 		name = GER_Cold_War.34.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.34.b executed"
 		HOL = {
@@ -12956,12 +12017,11 @@ country_event = {
 		custom_effect_tooltip = GER_Air_defence_I_TT
 	}
 
-	option = {	# Maintain Sovereign Airdefense
+	option = { # Maintain Sovereign Airdefense
 		name = GER_Cold_War.34.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.34.c executed"
 		custom_effect_tooltip = GER_Air_defence_II_TT
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.35
@@ -12972,7 +12032,7 @@ country_event = {
 
 	trigger = { original_tag = GER }
 
-	option = {	# integrate Army
+	option = { # integrate Army
 		name = GER_Cold_War.35.a
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.35.a executed"
 		GER = {
@@ -12996,7 +12056,7 @@ country_event = {
 		custom_effect_tooltip = GER_Integration_NL_TT
 	}
 
-	option = {	# Integrate in case of a war
+	option = { # Integrate in case of a war
 		name = GER_Cold_War.35.b
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.35.b executed"
 		GER = {
@@ -13010,12 +12070,11 @@ country_event = {
 		custom_effect_tooltip = GER_Integration_NL_I_TT
 	}
 
-	option = {	# Maintain Sovereignty
+	option = { # Maintain Sovereignty
 		name = GER_Cold_War.35.c
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.35.c executed"
 		custom_effect_tooltip = GER_Integration_NL_II_TT
 	}
-
 }
 
 country_event = {
@@ -13120,7 +12179,6 @@ country_event = {
 		name = GER_Cold_War.40.b
 		#to expensive
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.41
@@ -13224,7 +12282,6 @@ country_event = {
 		name = GER_Cold_War.41.b
 		#to expensive
 	}
-
 }
 
 country_event = {
@@ -13317,7 +12374,6 @@ country_event = {
 		name = GER_Cold_War.42.b
 		#to expensive
 	}
-
 }
 country_event = {
 	id = GER_Cold_War.43
@@ -13337,9 +12393,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.43.a executed"
 		custom_effect_tooltip = GER_Cold_War.43.a_desc
 		country_event = GER_Cold_War.40
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13347,9 +12401,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.43.b executed"
 		custom_effect_tooltip = GER_Cold_War.43.b_desc
 		country_event = GER_Cold_War.41
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13357,11 +12409,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: GER_Cold_War.43.c executed"
 		custom_effect_tooltip = GER_Cold_War.43.c_desc
 		country_event = GER_Cold_War.42
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 #migration
@@ -13381,7 +12430,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = Germany_mig.2 #süssmuth kommission reports
@@ -13405,7 +12453,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = Germany_mig.3 #süssmuth kommission debate
@@ -13479,7 +12526,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = Germany_mig.4 #greencard initiative
@@ -13527,7 +12573,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 #foci
@@ -13563,7 +12608,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.2 #Possible expanisions
@@ -13671,7 +12715,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.3 #Airforce
@@ -13709,7 +12752,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.4 #Transport
@@ -13731,9 +12773,7 @@ country_event = {
 			variant_name = "C-130J Super Hercules"
 			producer = USA
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13749,9 +12789,7 @@ country_event = {
 			variant_name = "C-17 Globemaster III"
 			producer = USA
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13767,11 +12805,8 @@ country_event = {
 			uses = 1
 			category = CAT_trans_plane
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.5 #AWACS
@@ -13794,9 +12829,7 @@ country_event = {
 			producer = USA
 		}
 		SWE = { add_opinion_modifier = { target = GER modifier = GER_prefered_the_other_negative_opinion } }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13813,11 +12846,8 @@ country_event = {
 			producer = SWE
 		}
 		USA = { add_opinion_modifier = { target = GER modifier = GER_prefered_the_other_negative_opinion } }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.6 #Airforce
@@ -13863,7 +12893,6 @@ country_event = {
 			base = 6
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.7 #Electronics
@@ -13880,9 +12909,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.10 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_Bosch
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13893,9 +12920,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.11 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_Atlas
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13906,11 +12931,8 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.12 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_Rohde_schwarz
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.8 #Engine
@@ -13927,9 +12949,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.10 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_MAN
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13940,9 +12960,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.11 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_RENK
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13953,11 +12971,8 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.12 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_MTU
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.9 #optics
@@ -13974,9 +12989,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.10 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_Carl_Zeiss
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -13987,9 +13000,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.11 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_EMT_Penzberg
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -14000,11 +13011,8 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.12 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_Hensold
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.10 #C4ISR
@@ -14020,9 +13028,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.10 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_Siemens_AG
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -14032,9 +13038,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.11 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_EADS
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -14044,11 +13048,8 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.12 }
 		modify_treasury_effect = yes
 		add_ideas = GER_idea_DASA
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.11 #NEW APC
@@ -14084,7 +13085,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.110 #Fuchs 2
@@ -14118,7 +13118,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.111 #Fuchs 2
@@ -14173,7 +13172,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.112 #Fuchs 2
@@ -14228,7 +13226,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.113 #Looking for partners
@@ -14311,7 +13308,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1131 #set requirements
@@ -14351,7 +13347,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1132 #Prototype Testing
@@ -14391,7 +13386,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1133 #Results
@@ -14465,7 +13459,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1134 #set requirements
@@ -14505,7 +13498,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1135 #Prototype Testing
@@ -14545,7 +13537,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1136 #Results
@@ -14610,7 +13601,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1137 #set requirements
@@ -14648,7 +13638,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1138 #Prototype Testing
@@ -14686,7 +13675,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1139 #Results
@@ -14748,7 +13736,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -14783,7 +13770,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.120 #Marder2 #Puma
@@ -14817,7 +13803,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.121 #Marder 2
@@ -14872,7 +13857,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.122 #Puma programm
@@ -14908,7 +13892,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -14945,7 +13928,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.125 #Results
@@ -15003,7 +13985,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.124 #Looking for partners
@@ -15092,7 +14073,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1241 #set requirements
@@ -15130,7 +14110,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1242 #Prototype Testing
@@ -15168,7 +14147,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1243 #Results
@@ -15238,7 +14216,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1244 #set requirements
@@ -15276,7 +14253,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1245 #Prototype Testing
@@ -15314,7 +14290,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1246 #Results
@@ -15382,7 +14357,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1247 #set requirements
@@ -15420,7 +14394,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1248 #Prototype Testing
@@ -15458,7 +14431,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1249 #Results
@@ -15526,7 +14498,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.13 #Tank
@@ -15557,7 +14528,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.130 #KF51
@@ -15588,7 +14558,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.131 #Marder 2
@@ -15621,8 +14590,8 @@ country_event = {
 					special_type_slot_1 = smoke_launchers_2
 					special_type_slot_2 = wet_ammo_storage
 					special_type_slot_3 = empty
-					special_type_slot_4 = tank_battlestation_3		#Battlestation
-					special_type_slot_6 = spaced_armor_gen2		#ERA/Spaced
+					special_type_slot_4 = tank_battlestation_3 #Battlestation
+					special_type_slot_6 = spaced_armor_gen2 #ERA/Spaced
 				}
 				upgrades = {
 					tank_nsb_armor_upgrade = 4
@@ -15643,7 +14612,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.132 #KF51
@@ -15679,7 +14647,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.133 #prototype testing
@@ -15715,7 +14682,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.135 #Results
@@ -15747,8 +14713,8 @@ country_event = {
 				special_type_slot_1 = afv_mine_protection
 				special_type_slot_2 = wet_ammo_storage
 				special_type_slot_3 = hardkill_system_gen1
-				special_type_slot_4 = tank_battlestation_4		#Battlestation
-				special_type_slot_6 = spaced_armor_gen3		#ERA/Spaced
+				special_type_slot_4 = tank_battlestation_4 #Battlestation
+				special_type_slot_6 = spaced_armor_gen3 #ERA/Spaced
 			}
 			upgrades = {
 				tank_nsb_armor_upgrade = 4
@@ -15768,7 +14734,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.134 #Looking for partners
@@ -15839,7 +14804,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1341 #set requirements
@@ -15877,7 +14841,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1342 #Prototype Testing
@@ -15915,7 +14878,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1343 #Results
@@ -15948,8 +14910,8 @@ country_event = {
 				special_type_slot_1 = afv_mine_protection
 				special_type_slot_2 = wet_ammo_storage
 				special_type_slot_3 = hardkill_system_gen1
-				special_type_slot_4 = tank_battlestation_4		#Battlestation
-				special_type_slot_6 = spaced_armor_gen3		#ERA/Spaced
+				special_type_slot_4 = tank_battlestation_4 #Battlestation
+				special_type_slot_6 = spaced_armor_gen3 #ERA/Spaced
 			}
 			upgrades = {
 				tank_nsb_armor_upgrade = 4
@@ -15985,7 +14947,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1344 #set requirements
@@ -16023,7 +14984,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1345 #Prototype Testing
@@ -16061,7 +15021,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1346 #Results
@@ -16093,8 +15052,8 @@ country_event = {
 				reload_type_slot = manual_loading
 				special_type_slot_2 = wet_ammo_storage
 				special_type_slot_3 = hardkill_system_gen1
-				special_type_slot_4 = tank_battlestation_4		#Battlestation
-				special_type_slot_6 = spaced_armor_gen3		#ERA/Spaced
+				special_type_slot_4 = tank_battlestation_4 #Battlestation
+				special_type_slot_6 = spaced_armor_gen3 #ERA/Spaced
 			}
 			upgrades = {
 				tank_nsb_armor_upgrade = 7
@@ -16130,7 +15089,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1347 #set requirements
@@ -16169,7 +15127,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1348 #Prototype Testing
@@ -16207,7 +15164,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.1349 #Results
@@ -16239,8 +15195,8 @@ country_event = {
 				reload_type_slot = automatic_loading
 				special_type_slot_2 = wet_ammo_storage
 				special_type_slot_3 = hardkill_system_gen1
-				special_type_slot_4 = tank_battlestation_4		#Battlestation
-				special_type_slot_6 = spaced_armor_gen3		#ERA/Spaced
+				special_type_slot_4 = tank_battlestation_4 #Battlestation
+				special_type_slot_6 = spaced_armor_gen3 #ERA/Spaced
 			}
 			upgrades = {
 				tank_nsb_armor_upgrade = 4
@@ -16276,7 +15232,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.140
@@ -16316,9 +15271,7 @@ country_event = {
 			add_mio_funds = 1000
 			add_mio_research_bonus = 0.1
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -16335,11 +15288,8 @@ country_event = {
 			add_mio_research_bonus = 0.05
 			add_mio_task_capacity = 1
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 country_event = {
 	id = germany_foci.150
@@ -16491,7 +15441,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.151
@@ -16558,7 +15507,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.152
@@ -16647,7 +15595,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = germany_foci.154
@@ -16914,7 +15861,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 #News
@@ -16933,7 +15879,6 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: GER_news.01.a executed"
 		add_war_support = 0.1
 	}
-
 }
 #concord crash 25.6.2000
 news_event = {
@@ -16946,7 +15891,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.03.a }
-
 }
 #taliban destroy buddah in bamiyan 12.3.2001
 news_event = {
@@ -16959,7 +15903,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.04.a }
-
 }
 #Berlinale 2002 good bye lenin
 news_event = {
@@ -16971,7 +15914,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.05.a }
-
 }
 #pisa schock 2002
 news_event = {
@@ -16983,7 +15925,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.06.a }
-
 }
 #loveparde 2000
 news_event = {
@@ -16996,7 +15937,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.07.a }
-
 }
 #open glaskuppel bundestag2001
 news_event = {
@@ -17008,7 +15948,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.08.a }
-
 }
 #2002 kirch insolvent
 news_event = {
@@ -17020,7 +15959,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.09.a }
-
 }
 #transrapid unfall 22.9.2006
 news_event = {
@@ -17032,7 +15970,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.10.a }
-
 }
 #kölnerstadtarchiv 3.3.2009
 news_event = {
@@ -17045,7 +15982,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.11.a }
-
 }
 #VW aufsichtsratsaffaire 2009
 news_event = {
@@ -17057,7 +15993,6 @@ news_event = {
 	fire_only_once = yes
 
 	option = { name = GER_news.12.a }
-
 }
 #2003 Kidnap in algeria
 news_event = {
@@ -17081,7 +16016,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_news.14
@@ -17162,7 +16096,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 news_event = {
 	id = GER_news.15
@@ -17182,7 +16115,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = GER_news.16
@@ -17239,7 +16171,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 news_event = {
 	id = GER_news.17
@@ -17264,7 +16195,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 news_event = {
 	id = GER_news.18
@@ -17300,7 +16230,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 news_event = {
 	id = GER_news.19
@@ -17322,7 +16251,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 news_event = {
 	id = GER_news.20
@@ -17344,7 +16272,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 news_event = {
 	id = GER_news.21
@@ -17365,7 +16292,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 news_event = {
@@ -17383,7 +16309,6 @@ news_event = {
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
 	}
-
 }
 news_event = {
 	id = GER_news.23
@@ -17400,7 +16325,6 @@ news_event = {
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 news_event = {
 	id = GER_news.24
@@ -17417,7 +16341,6 @@ news_event = {
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #the events
@@ -17453,7 +16376,6 @@ country_event = {
 			country_event = { id = GER_Cold_War.43 days = 45 random_days = 60 } # military competition
 		}
 	}
-
 }
 # 2001
 country_event = {
@@ -17481,7 +16403,6 @@ country_event = {
 			country_event = { id = germany.25 days = 100 random_days = 120 } # Ökosteuer
 		}
 	}
-
 }
 
 # 2002
@@ -17510,7 +16431,6 @@ country_event = {
 			country_event = { id = Germany_Mech.91 days = 20 random_days = 40 } # public sector wage round
 		}
 	}
-
 }
 
 # 2003
@@ -17533,7 +16453,6 @@ country_event = {
 			country_event = { id = Germany_Mech.1 random_days = 360 }
 		}
 	}
-
 }
 
 # 2004
@@ -17556,7 +16475,6 @@ country_event = {
 			country_event = { id = Germany_Mech.93 days = 250 random_days = 30 } # steel wage round
 		}
 	}
-
 }
 
 # 2005
@@ -17578,7 +16496,6 @@ country_event = {
 			country_event = { id = GER_Corruption.02 days = 90 random_days = 90 } # KMW scandal
 		}
 	}
-
 }
 
 # Review the Year 2005
@@ -17599,7 +16516,6 @@ country_event = {
 			country_event = { id = Germany_Mech.92 days = 70 random_days = 90 } # healthcare wage round
 		}
 	}
-
 }
 
 # Review the Year 2006
@@ -17618,7 +16534,6 @@ country_event = {
 		country_event = { id = Germany_Mech.6 random_days = 360 }
 		}
 	}
-
 }
 
 # Review the Year 2007
@@ -17639,7 +16554,6 @@ country_event = {
 			country_event = { id = germany.64 days = 34 } # Ludwigshafen fire
 		}
 	}
-
 }
 
 # Review the Year 2008
@@ -17659,7 +16573,6 @@ country_event = {
 			country_event = { id = Germany_Mech.94 days = 120 random_days = 60 } # shipyard strike
 		}
 	}
-
 }
 
 # Review the Year 2009
@@ -17678,7 +16591,6 @@ country_event = {
 			country_event = { id = GER_Corruption.01 days = 60 random_days = 60 } # ThyssenKrupp Marine scandal
 		}
 	}
-
 }
 
 # Review the Year 2010
@@ -17698,7 +16610,6 @@ country_event = {
 			country_event = { id = GER_Corruption.04 days = 100 random_days = 90 } # Heckler & Koch scandal
 		}
 	}
-
 }
 
 # Review the Year 2011
@@ -17718,7 +16629,6 @@ country_event = {
 			country_event = { id = GER_Corruption.03 days = 120 random_days = 90 } # Rheinmetall scandal
 		}
 	}
-
 }
 
 # Review the Year 2012
@@ -17730,10 +16640,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany_yearly.42.a
-	}
-
+	option = { name = germany_yearly.42.a }
 }
 
 # Review the Year 2013
@@ -17752,7 +16659,6 @@ country_event = {
 			country_event = { id = GER_Corruption.05 days = 150 random_days = 90 } # Airbus Defence scandal
 		}
 	}
-
 }
 
 country_event = {
@@ -17770,7 +16676,6 @@ country_event = {
 			country_event = { id = germany.61 days = 1 random_days = 360 }
 		}
 	}
-
 }
 
 country_event = {
@@ -17781,10 +16686,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany_yearly.45.a
-	}
-
+	option = { name = germany_yearly.45.a }
 }
 
 country_event = {
@@ -17803,7 +16705,6 @@ country_event = {
 			country_event = { id = germany.41 days = 170 } # Buenos Aires trove
 		}
 	}
-
 }
 
 country_event = {
@@ -17814,10 +16715,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany_yearly.47.a
-	}
-
+	option = { name = germany_yearly.47.a }
 }
 
 country_event = {
@@ -17828,10 +16726,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany_yearly.48.a
-	}
-
+	option = { name = germany_yearly.48.a }
 }
 
 # Review the Year 2019
@@ -17843,10 +16738,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = germany_yearly.49.a
-	}
-
+	option = { name = germany_yearly.49.a }
 }
 
 #Creation of AfD
@@ -17868,7 +16760,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		change_relative_party_popularity = yes
 	}
-
 }
 # BSE
 country_event = {
@@ -17898,7 +16789,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # React the Crisis
 country_event = {
@@ -17968,7 +16858,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 #Handle the Crisi
 country_event = {
@@ -18019,7 +16908,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 #aftermath
 country_event = {
@@ -18083,7 +16971,6 @@ country_event = {
 			base = 4
 		}
 	}
-
 }
 # Vogel Grippe
 country_event = {
@@ -18138,7 +17025,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # Schweine Grippe
 country_event = {
@@ -18193,7 +17079,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # Negotiate Subventions
 country_event = {
@@ -18259,7 +17144,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # Negotiate Subventions
 country_event = {
@@ -18325,7 +17209,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 #corruption
@@ -18385,7 +17268,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = 0.24 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 #Krauss-Maffei Wegmann
@@ -18444,7 +17326,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = 0.24 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 #Rheinmetall
@@ -18503,7 +17384,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = 0.24 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 #Heckler & Koch
@@ -18562,7 +17442,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = 0.24 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 #Airbus Defence
@@ -18621,7 +17500,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = 0.24 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 # Schweine Grippe
@@ -18698,7 +17576,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 # Restricted Substances
@@ -18775,7 +17652,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 # H5N8
@@ -18852,7 +17728,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 # MKS
@@ -18929,7 +17804,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 # found Ver.di
 country_event = {
@@ -18951,11 +17825,8 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { temp_opinion = 3 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 #Öffentlicher dienst
 country_event = {
@@ -19030,7 +17901,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 country_event = {
@@ -19105,7 +17975,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 country_event = {
@@ -19180,7 +18049,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 
 country_event = {
@@ -19255,7 +18123,6 @@ country_event = {
 			base = 3
 		}
 	}
-
 }
 ##Greens
 #country_event = { #Deutschland Verrecke
@@ -20383,7 +19250,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 country_event = {
 	id = GER_Diplomacy_answer.2
@@ -20398,7 +19264,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 country_event = {
@@ -20452,7 +19317,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = GER_Diplomacy.2
@@ -20503,11 +19367,8 @@ country_event = {
 			}
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 country_event = {
 	id = GER_Diplomacy.3
@@ -20642,7 +19503,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = GER_Diplomacy.4
@@ -20700,7 +19560,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = GER_Diplomacy.5
@@ -20742,9 +19601,7 @@ country_event = {
 			modify_debt_effect = yes
 			country_event = { id = GER_Diplomacy_answer.1 days = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -20754,11 +19611,8 @@ country_event = {
 		GER = {
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -20786,9 +19640,7 @@ country_event = {
 			modify_debt_effect = yes
 			country_event = { id = GER_Diplomacy_answer.1 days = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -20798,11 +19650,8 @@ country_event = {
 		GER = {
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -20863,11 +19712,8 @@ country_event = {
 		GER = {
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -20901,9 +19747,7 @@ country_event = {
 			modify_debt_effect = yes
 			country_event = { id = GER_Diplomacy_answer.1 days = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -20913,11 +19757,8 @@ country_event = {
 		GER = {
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -20964,9 +19805,7 @@ country_event = {
 			modify_debt_effect = yes
 			country_event = { id = GER_Diplomacy_answer.1 days = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -20976,11 +19815,8 @@ country_event = {
 		GER = {
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -21022,9 +19858,7 @@ country_event = {
 			modify_debt_effect = yes
 			country_event = { id = GER_Diplomacy_answer.1 days = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = { #no
@@ -21038,7 +19872,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 
 country_event = {
@@ -21081,9 +19914,7 @@ country_event = {
 			country_event = { id = GER_Diplomacy_answer.1 days = 1 }
 		}
 		if = {
-			limit = {
-				original_tag = CHL
-			}
+			limit = { original_tag = CHL }
 			GER = {
 				38 = {
 					add_resource = {
@@ -21094,9 +19925,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				original_tag = CAN
-			}
+			limit = { original_tag = CAN }
 			GER = {
 				38 = {
 					add_resource = {
@@ -21107,9 +19936,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				original_tag = SAF
-			}
+			limit = { original_tag = SAF }
 			GER = {
 				38 = {
 					add_resource = {
@@ -21120,9 +19947,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				original_tag = NRY
-			}
+			limit = { original_tag = NRY }
 			GER = {
 				38 = {
 					add_resource = {
@@ -21132,9 +19957,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -21144,11 +19967,8 @@ country_event = {
 		GER = {
 			country_event = { id = GER_Diplomacy_answer.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #country_event = { #Soldier arrested
@@ -21825,9 +20645,7 @@ country_event = {
 	picture = GFX_hospital
 	is_triggered_only = yes
 
-	trigger = {
-		GER_siemens_outcome_settled = no
-	}
+	trigger = { GER_siemens_outcome_settled = no }
 
 	option = {
 		name = germany_yearly.305.a

--- a/events/Indian.txt
+++ b/events/Indian.txt
@@ -213,12 +213,8 @@ country_event = {
 		name = indian_event.6.a
 		log = "[GetDateText]: [This.GetName]: indian_event.6.a executed"
 		ai_chance = { base = 1 }
-		RAJ = {
-			country_event = indian_event.667
-		}
-		PAK = {
-			remove_ideas = Major_Non_NATO_Ally
-		}
+		RAJ = { country_event = indian_event.667 }
+		PAK = { remove_ideas = Major_Non_NATO_Ally }
 		add_opinion_modifier = {
 			target = PAK
 			modifier = drama
@@ -233,9 +229,7 @@ country_event = {
 		name = indian_event.6.b
 		log = "[GetDateText]: [This.GetName]: indian_event.6.b executed"
 		ai_chance = { base = 0 }
-		RAJ = {
-			country_event = indian_event.668
-		}
+		RAJ = { country_event = indian_event.668 }
 		add_opinion_modifier = {
 			target = RAJ
 			modifier = drama
@@ -264,9 +258,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.667.a executed"
 		ai_chance = { base = 1 }
 		effect_tooltip = {
-			PAK = {
-				remove_ideas = Major_Non_NATO_Ally
-			}
+			PAK = { remove_ideas = Major_Non_NATO_Ally }
 			USA = {
 				add_opinion_modifier = {
 					target = PAK
@@ -478,9 +470,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = RAJ_eastas.3.o1
-	}
+	option = { name = RAJ_eastas.3.o1 }
 }
 
 country_event = {
@@ -515,9 +505,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = RAJ_eastas.4.o1
-	}
+	option = { name = RAJ_eastas.4.o1 }
 }
 
 news_event = {
@@ -528,9 +516,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = RAJ_eastas.5.o1
-	}
+	option = { name = RAJ_eastas.5.o1 }
 }
 
 country_event = {
@@ -695,9 +681,7 @@ country_event = {
 	picture = GFX_paris_convention
 	is_triggered_only = yes
 
-	option = {
-		name = indian_event.19.a
-	}
+	option = { name = indian_event.19.a }
 }
 
 country_event = {
@@ -707,9 +691,7 @@ country_event = {
 	picture = GFX_paris_convention
 	is_triggered_only = yes
 
-	option = {
-		name = indian_event.20.a
-	}
+	option = { name = indian_event.20.a }
 }
 
 country_event = {
@@ -861,24 +843,18 @@ country_event = {
 		set_temp_variable = { percent_change = 2 }
 		set_temp_variable = { influence_target = RAJ }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = indian_event.27.o2
 		log = "[GetDateText]: [This.GetName]: indian_event.27.o2 executed"
-		RAJ = {
-			country_event = indian_event.60
-		}
+		RAJ = { country_event = indian_event.60 }
 		add_opinion_modifier = {
 			target = RAJ
 			modifier = medium_decrease
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -936,9 +912,7 @@ country_event = {
 			add_state_core = 490
 			add_state_core = 492
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -953,9 +927,7 @@ country_event = {
 				target = BAN
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -967,9 +939,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = indian_event.31.a
-	}
+	option = { name = indian_event.31.a }
 }
 
 country_event = {
@@ -1000,16 +970,12 @@ country_event = {
 				reverse_add_opinion_modifier = { target = VIE modifier = declaration_of_friendship }
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
 		name = indian_event.32.b
-		ai_chance = {
-			base = 19
-		}
+		ai_chance = { base = 19 }
 	}
 }
 
@@ -1024,9 +990,7 @@ country_event = {
 	option = {
 		name = indian_event.33.a
 		log = "[GetDateText]: [This.GetName]: indian_event.33.a executed"
-		ROOT = {
-			every_owned_state = { add_core_of = RAJ }
-		}
+		ROOT = { every_owned_state = { add_core_of = RAJ } }
 		RAJ = {
 			annex_country = { target = ROOT transfer_troops = yes }
 		}
@@ -1053,9 +1017,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -1079,9 +1041,7 @@ country_event = {
 				target = TIB
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -1097,9 +1057,7 @@ country_event = {
 		}
 		add_political_power = -200
 		add_stability = -0.4
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #
@@ -1251,9 +1209,7 @@ country_event = {
 				target = ETK
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -1269,9 +1225,7 @@ country_event = {
 		}
 		add_political_power = -200
 		add_stability = -0.4
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -1286,15 +1240,11 @@ country_event = {
 	option = {
 		name = indian_event.36.a
 		log = "[GetDateText]: [This.GetName]: indian_event.36.a executed"
-		ROOT = {
-			every_owned_state = { add_core_of = RAJ }
-		}
+		ROOT = { every_owned_state = { add_core_of = RAJ } }
 		RAJ = {
 			annex_country = { target = ROOT transfer_troops = yes }
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -1311,9 +1261,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -1333,22 +1281,16 @@ country_event = {
 		name = indian_event.37.a
 		log = "[GetDateText]: [This.GetName]: indian_event.37.a executed"
 		RAJ = { add_to_faction = ROOT }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
 		name = indian_event.37.b
 		log = "[GetDateText]: [This.GetName]: indian_event.37.b executed"
-		RAJ = {
-			country_event = indian_event.38
-		}
+		RAJ = { country_event = indian_event.38 }
 		add_political_power = -200
 		add_stability = -0.4
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -1365,9 +1307,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.38.a executed"
 		add_opinion_modifier = { target = FROM modifier = major_breach_of_trust }
 		reverse_add_opinion_modifier = { target = FROM modifier = major_breach_of_trust }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -1386,9 +1326,7 @@ country_event = {
 				transfer_state = 411
 				transfer_state = 410
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -1396,12 +1334,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.39.b executed"
 		add_political_power = -200
 		add_stability = -0.4
-		RAJ = {
-			country_event = indian_event.40
-		}
-		ai_chance = {
-			base = 10
-		}
+		RAJ = { country_event = indian_event.40 }
+		ai_chance = { base = 10 }
 	}
 }
 country_event = {
@@ -1426,9 +1360,7 @@ country_event = {
 				target = TAL
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -1456,9 +1388,7 @@ country_event = {
 			mission = RAJ_MAO_rebellion_armed
 			days = 10
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 
@@ -1486,9 +1416,7 @@ country_event = {
 			mission = RAJ_MAO_rebellion_armed
 			days = 5
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 
@@ -1516,9 +1444,7 @@ country_event = {
 			mission = RAJ_MAO_rebellion_armed
 			days = -30
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 
@@ -1595,9 +1521,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = raj_exports.1.e
-	}
+	option = { name = raj_exports.1.e }
 }
 
 country_event = {
@@ -1615,9 +1539,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = -0.05
 		add_manpower = -5
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 
@@ -2247,9 +2169,7 @@ country_event = {
 		name = indian_event.53.b
 		log = "[GetDateText]: [This.GetName]: indian_event.53.b executed"
 		set_country_flag = TRK_Not_accepted
-		RAJ = {
-			country_event = indian_event.58
-		}
+		RAJ = { country_event = indian_event.58 }
 	}
 }
 country_event = {
@@ -2286,9 +2206,7 @@ country_event = {
 		FROM = {
 			country_event = { id = md4.17 hours = 3 }
 		}
-		hidden_effect = {
-			remove_ideas = RAJ_BRICS
-		}
+		hidden_effect = { remove_ideas = RAJ_BRICS }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2376,9 +2294,7 @@ country_event = {
 
 	option = {
 		name = indian_event.59.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2391,9 +2307,7 @@ country_event = {
 
 	option = {
 		name = indian_event.60.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3131,9 +3045,7 @@ country_event = {
 
 	option = {
 		name = RAJ_regional.14.c
-		trigger = {
-			NOT = { has_country_flag = RAJ_nepal_blockade_maintained }
-		}
+		trigger = { NOT = { has_country_flag = RAJ_nepal_blockade_maintained } }
 		log = "[GetDateText]: [This.GetName]: RAJ_regional.14.c executed"
 		add_stability = 0.01
 		add_opinion_modifier = { target = NEP modifier = improve_trade }
@@ -3555,9 +3467,7 @@ country_event = {
 		}
 		log = "[GetDateText]: [This.GetName]: RAJ_rebellion.1.a executed"
 		RAJ_set_rebellion_fired_flag = yes
-		hidden_effect = {
-			RAJ_spawn_religious_rebel = yes
-		}
+		hidden_effect = { RAJ_spawn_religious_rebel = yes }
 		add_stability = -0.10
 		add_war_support = -0.05
 	}

--- a/events/Kuban.txt
+++ b/events/Kuban.txt
@@ -57,17 +57,15 @@ country_event = { ##Kuban asking for Belarussian investments
 		set_temp_variable = { percent_change = 1.5 }
 		set_temp_variable = { influence_target = KUB }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = -7 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = kuban.1.b
 		log = "[GetDateText]: [This.GetName]: kuban.1.b executed"
 		KUB = { country_event = { id = kuban.5 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -76,11 +74,10 @@ country_event = {
 	desc = kuban.4.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.4.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -89,11 +86,10 @@ country_event = {
 	desc = kuban.5.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.5.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -122,10 +118,8 @@ country_event = { ##Kuban asking for chinese/german investments
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = KUB }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -158,13 +152,12 @@ country_event = { ##Kuban asking for chinese/german investments
 			}
 		}
 	}
+
 	option = {
 		name = kuban_invest.1.b
 		log = "[GetDateText]: [This.GetName]: kuban_invest.1.b executed"
 		KUB = { country_event = { id = kuban_invest.3 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -173,11 +166,10 @@ country_event = {
 	desc = kuban_invest.2.d
 	picture = GFX_chinese_yuan
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.2.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -186,11 +178,10 @@ country_event = {
 	desc = kuban_invest.3.d
 	picture = GFX_chinese_yuan
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.3.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #USA Investments
@@ -257,17 +248,15 @@ country_event = {
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = KUB }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = kuban_invest.4.b
 		log = "[GetDateText]: [This.GetName]: kuban_invest.4.b executed"
 		KUB = { country_event = { id = kuban_invest.6 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -276,11 +265,10 @@ country_event = {
 	desc = kuban_invest.5.d
 	picture = GFX_united_states_dollar
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.5.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -289,11 +277,10 @@ country_event = {
 	desc = kuban_invest.6.d
 	picture = GFX_united_states_dollar
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.6.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #Russian Investments
@@ -364,17 +351,15 @@ country_event = {
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = KUB }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = kuban_invest.7.b
 		log = "[GetDateText]: [This.GetName]: kuban_invest.7.b executed"
 		KUB = { country_event = { id = kuban_invest.9 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -383,11 +368,10 @@ country_event = {
 	desc = kuban_invest.8.d
 	picture = GFX_russian_rubles
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.8.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -396,11 +380,10 @@ country_event = {
 	desc = kuban_invest.9.d
 	picture = GFX_russian_rubles
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.9.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #Krasnodar Metro Case
@@ -411,6 +394,7 @@ country_event = {
 	picture = GFX_krasnodar_metro
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	option = {
 		name = kuban_invest.10.a #build metro
 		log = "[GetDateText]: [This.GetName]: kuban_invest.10.a executed"
@@ -424,6 +408,7 @@ country_event = {
 			base = 5
 		}
 	}
+
 	option = {
 		name = kuban_invest.10.b #Steal money
 		log = "[GetDateText]: [This.GetName]: kuban_invest.10.b executed"
@@ -454,6 +439,7 @@ country_event = {
 	desc = kuban_invest.11.d
 	picture = GFX_krasnodar_metro
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.11.a
 		log = "[GetDateText]: [This.GetName]: kuban_invest.11.a executed"
@@ -462,9 +448,7 @@ country_event = {
 			modifier = large_decrease
 		}
 		add_political_power = -100
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -473,14 +457,13 @@ country_event = {
 	desc = kuban_invest.12.d
 	picture = GFX_galitsky_event
 	is_triggered_only = yes
+
 	option = {
 		name = kuban_invest.12.a
 		log = "[GetDateText]: [This.GetName]: kuban_invest.12.a executed"
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -488,6 +471,7 @@ country_event = {
 	title = kuban.14.t
 	desc = kuban.14.d
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.14.a
 		log = "[GetDateText]: [This.GetName]: kuban.14.a executed"
@@ -503,9 +487,7 @@ country_event = {
 				technocrat
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -514,6 +496,7 @@ country_event = {
 	desc = kuban.15.d
 	picture = GFX_adygea_question
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.15.a
 		log = "[GetDateText]: [This.GetName]: kuban.15.a executed"
@@ -563,15 +546,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.15.b
 		log = "[GetDateText]: [This.GetName]: kuban.15.b executed"
 		KUB = { country_event = { id = kuban.17 days = 1 } }
 		set_temp_variable = { modify_subjectinped = 20 }
 		modify_subjectinped_support = yes
-		ai_chance = {
-			base = 0.10
-		}
+		ai_chance = { base = 0.10 }
 	}
 }
 country_event = {
@@ -580,11 +562,10 @@ country_event = {
 	desc = kuban.16.d
 	picture = GFX_adygea_question
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.16.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -593,11 +574,10 @@ country_event = {
 	desc = kuban.17.d
 	picture = GFX_adygea_question
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.17.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #BLACK SEA MECHANIC
@@ -607,6 +587,7 @@ country_event = {
 	desc = kuban.18.d
 	picture = GFX_adygea_question
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.18.a
 		log = "[GetDateText]: [This.GetName]: kuban.18.a executed"
@@ -650,13 +631,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.18.b
 		log = "[GetDateText]: [This.GetName]: kuban.18.b executed"
 		KUB = { country_event = { id = kuban.20 days = 1 } }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -665,6 +645,7 @@ country_event = {
 	desc = kuban.30.d
 	picture = GFX_adygea_question
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.30.a
 		log = "[GetDateText]: [This.GetName]: kuban.30.a executed"
@@ -708,13 +689,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.30.b
 		log = "[GetDateText]: [This.GetName]: kuban.30.b executed"
 		KUB = { country_event = { id = kuban.20 days = 1 } }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -723,6 +703,7 @@ country_event = {
 	desc = kuban.21.d
 	picture = GFX_terskaya_sr_event
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.21.a
 		log = "[GetDateText]: [This.GetName]: kuban.21.a executed"
@@ -772,13 +753,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.21.b
 		log = "[GetDateText]: [This.GetName]: kuban.21.b executed"
 		KUB = { country_event = { id = kuban.20 days = 1 } }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -787,6 +767,7 @@ country_event = {
 	desc = kuban.22.d
 	picture = GFX_free_chechnya
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.22.a
 		log = "[GetDateText]: [This.GetName]: kuban.22.a executed"
@@ -830,13 +811,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.22.b
 		log = "[GetDateText]: [This.GetName]: kuban.22.b executed"
 		KUB = { country_event = { id = kuban.20 days = 1 } }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -845,6 +825,7 @@ country_event = {
 	desc = kuban.24.d
 	picture = GFX_stavropol_sr_event
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.24.a
 		log = "[GetDateText]: [This.GetName]: kuban.24.a executed"
@@ -888,13 +869,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.24.b
 		log = "[GetDateText]: [This.GetName]: kuban.24.b executed"
 		KUB = { country_event = { id = kuban.20 days = 1 } }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -903,6 +883,7 @@ country_event = {
 	desc = kuban.23.d
 	picture = GFX_rostov_on_don_event
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.23.a
 		log = "[GetDateText]: [This.GetName]: kuban.23.a executed"
@@ -946,13 +927,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.23.b
 		log = "[GetDateText]: [This.GetName]: kuban.23.b executed"
 		KUB = { country_event = { id = kuban.20 days = 1 } }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -961,11 +941,10 @@ country_event = {
 	desc = kuban.19.d
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.19.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -974,11 +953,10 @@ country_event = {
 	desc = kuban.20.d
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.20.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1043,17 +1021,15 @@ country_event = {
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = KUB }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = kuban.27.b
 		log = "[GetDateText]: [This.GetName]: kuban.27.b executed"
 		KUB = { country_event = { id = kuban.29 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1062,14 +1038,13 @@ country_event = {
 	desc = kuban.28.d
 	picture = GFX_annex_crimea
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.28.a
 		log = "[GetDateText]: [This.GetName]: kuban.28.a executed"
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1078,11 +1053,10 @@ country_event = {
 	desc = kuban.29.d
 	picture = GFX_annex_crimea
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.29.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = { ##Kuban asking for Belarussian investments
@@ -1146,13 +1120,12 @@ country_event = { ##Kuban asking for Belarussian investments
 		set_temp_variable = { treasury_change = -7 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = kuban.33.b
 		log = "[GetDateText]: [This.GetName]: kuban.33.b executed"
 		KUB = { country_event = { id = kuban.32 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1161,11 +1134,10 @@ country_event = {
 	desc = kuban.31.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.31.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1174,11 +1146,10 @@ country_event = {
 	desc = kuban.32.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.32.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1243,17 +1214,15 @@ country_event = {
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = KUB }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = kuban.34.b
 		log = "[GetDateText]: [This.GetName]: kuban.34.b executed"
 		KUB = { country_event = { id = kuban.36 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1262,14 +1231,13 @@ country_event = {
 	desc = kuban.35.d
 	picture = GFX_USA_generic
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.35.a
 		log = "[GetDateText]: [This.GetName]: kuban.35.a executed"
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1278,11 +1246,10 @@ country_event = {
 	desc = kuban.36.d
 	picture = GFX_USA_generic
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.36.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1334,13 +1301,12 @@ country_event = {
 		}
 		KUB = { country_event = { id = kuban.38 days = 1 } }
 	}
+
 	option = {
 		name = kuban.37.b
 		log = "[GetDateText]: [This.GetName]: kuban.37.b executed"
 		KUB = { country_event = { id = kuban.39 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1349,6 +1315,7 @@ country_event = {
 	desc = kuban.38.d
 	picture = GFX_subject_kuban
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.38.a
 		log = "[GetDateText]: [This.GetName]: kuban.38.a executed"
@@ -1358,9 +1325,7 @@ country_event = {
 			set_cosmetic_tag = KUB_kuban_ukr
 			clr_country_flag = dynamic_flag
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1369,11 +1334,10 @@ country_event = {
 	desc = kuban.39.d
 	picture = GFX_subject_kuban
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.39.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1390,7 +1354,6 @@ country_event = {
 			give_military_access = UKR
 			country_event = { id = kuban.41 days = 1 }
 		}
-
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -1423,13 +1386,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.40.b
 		log = "[GetDateText]: [This.GetName]: kuban.40.b executed"
 		KUB = { country_event = { id = kuban.39 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1438,20 +1400,20 @@ country_event = {
 	desc = kuban.41.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = kuban.41.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
 	id = kuban.42
 	title = kuban.42.t
 	desc = kuban.42.d
-	#NEED PICTURE
 	picture = GFX_treaty
 	is_triggered_only = yes
+
+	#NEED PICTURE
 	option = {
 		name = kuban.42.a
 		log = "[GetDateText]: [This.GetName]: kuban.42.a executed"
@@ -1469,10 +1431,9 @@ country_event = {
 				id = kuban_news.1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = kuban.42.b
 		log = "[GetDateText]: [This.GetName]: kuban.42.b executed"
@@ -1489,15 +1450,12 @@ country_event = {
 				set_temp_variable = { treasury_change = 5 }
 				modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
+
 	option = {
 		name = kuban.42.c
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Referndum of South Russia
@@ -1544,13 +1502,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.43.b
 		log = "[GetDateText]: [This.GetName]: kuban.43.b executed"
 		KUB = { country_event = { id = kuban.47 days = 1 } }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 #Donbass Referendum
@@ -1593,13 +1550,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = kuban.44.b
 		log = "[GetDateText]: [This.GetName]: kuban.44.b executed"
 		KUB = { country_event = { id = kuban.47 days = 1 } }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 #Yes to south russia
@@ -1610,22 +1566,18 @@ country_event = {
 	picture = GFX_election_day
 	is_triggered_only = yes
 
-	option = {
-		name = kuban.45.a
-	}
+	option = { name = kuban.45.a }
 }
 #Yes to donbass
 country_event = {
 	id = kuban.46
 	title = kuban.46.t
 	desc = kuban.46.d
-	#NEED PICTURE
 	picture = GFX_election_day
 	is_triggered_only = yes
 
-	option = {
-		name = kuban.46.a
-	}
+	#NEED PICTURE
+	option = { name = kuban.46.a }
 }
 #our referndums denied
 country_event = {
@@ -1635,50 +1587,40 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = kuban.47.a
-	}
+	option = { name = kuban.47.a }
 }
 country_event = {
 	id = kuban.48
 	title = kuban.48.t
 	desc = kuban.48.d
+	picture = GFX_NATO_picture
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_NATO_picture
 
 	option = {
 		name = kuban.48.a
 		log = "[GetDateText]: [This.GetName]: kuban.48.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		KUB = { country_event = { id = kuban.49 days = 1 } }
 	}
 
 	option = {
 		name = kuban.48.b
-		ai_chance = {
-			base = 45
-		}
+		ai_chance = { base = 45 }
 	}
-
 }
 country_event = {
 	id = kuban.49
 	title = kuban.49.t
 	desc = kuban.49.d
+	picture = GFX_NATO_picture
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_NATO_picture
 
 	option = {
 		name = kuban.49.a
 		log = "[GetDateText]: [This.GetName]: kuban.49.a executed"
-
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		if = {
 			limit = { has_idea = CSTO_member }
 			CSTO_leave = yes
@@ -1695,13 +1637,10 @@ news_event = {
 	id = kuban_news.1
 	title = kuban_news.1.t
 	desc = kuban_news.1.d
-	#NEED PICTURE
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = kuban_news.1.o1
-	}
+	#NEED PICTURE
+	option = { name = kuban_news.1.o1 }
 }

--- a/events/SalehEvents.txt
+++ b/events/SalehEvents.txt
@@ -7,6 +7,7 @@ country_event = {
 	desc = Saleh.1.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SAU
 		HOU = {
@@ -24,16 +25,13 @@ country_event = {
 		name = Saleh.1.a
 		log = "[GetDateText]: [This.GetName]: Saleh.1.a executed"
 		set_country_flag = SAU_houthi_power_struggle
-
 		ai_chance = {
 			base = 5
 			modifier = {
 				factor = 0
 				SAU = {
 					has_war = yes
-					NOT = {
-						has_government = fascism
-					}
+					NOT = { has_government = fascism }
 				}
 			}
 		}
@@ -44,14 +42,12 @@ country_event = {
 		name = Saleh.1.b
 		log = "[GetDateText]: [This.GetName]: Saleh.1.b executed"
 		set_country_flag = SAU_houthi_power_struggle
-
 		hidden_effect = {
 			HOU = {
 				country_event = { days = 5 id = Saleh.2 }
 			}
 		}
 		custom_effect_tooltip = HOU_Saleh.2
-
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -70,7 +66,6 @@ country_event = {
 	id = Saleh.2
 	title = Saleh.2.t
 	desc = Saleh.2.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -88,7 +83,6 @@ country_event = {
 				}
 			}
 		}
-
 		hidden_effect = {
 			SAU = {
 				country_event = { days = 5 id = Saleh.8 }
@@ -103,7 +97,6 @@ country_event = {
 		ai_chance = {
 			base = 40
 		}
-
 		hidden_effect = {
 			SAU = {
 				country_event = { days = 5 id = Saleh.3 }
@@ -117,7 +110,6 @@ country_event = {
 	id = Saleh.3
 	title = Saleh.3.t
 	desc = Saleh.3.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -150,7 +142,6 @@ country_event = {
 	id = Saleh.5
 	title = Saleh.5.t
 	desc = Saleh.5.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -168,7 +159,6 @@ country_event = {
 			}
 		}
 	}
-
 	hidden_effect = {
 		HOU = { country_event = { days = 5 id = Saleh.6 } }
 		}
@@ -187,7 +177,6 @@ country_event = {
 	id = Saleh.6
 	title = Saleh.6.t
 	desc = Saleh.6.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -205,13 +194,10 @@ country_event = {
 				}
 			}
 		}
-
 		hidden_effect = {
 			HOU = {
 				kill_country_leader = yes
-
 				news_event = { hours = 16 id = Saleh.12 }
-
 				set_politics = {
 					ruling_party = communism
 					elections_allowed = no
@@ -229,7 +215,6 @@ country_event = {
 		hidden_effect = {
 			HOU = {
 				retire_country_leader = yes
-
 				set_politics = {
 					ruling_party = communism
 					elections_allowed = no
@@ -246,6 +231,7 @@ country_event = {
 	desc = Saleh.7.d
 	picture = GFX_HOU_SPC
 	is_triggered_only = yes
+
 	trigger = {
 		tag = HOU
 		NOT = { has_country_flag = HOU_revolutionary_committee_event }
@@ -253,7 +239,6 @@ country_event = {
 			has_global_flag = GLOBAL_yemeni_civil_war_over
 			has_country_flag = saleh_ally
 		}
-
 		NOT = {
 			OR = {
 				country_exists = YEM
@@ -263,9 +248,7 @@ country_event = {
 		}
 	}
 
-	immediate = {
-		set_country_flag = HOU_revolutionary_committee_event
-	}
+	immediate = { set_country_flag = HOU_revolutionary_committee_event }
 
 	option = { #Refuse SPC
 		name = Saleh.7.a
@@ -276,16 +259,13 @@ country_event = {
 		hidden_effect = {
 			HOU = {
 				retire_country_leader = yes
-
 				clr_global_flag = GLOBAL_yemeni_civil_war_over
-
 				set_politics = {
 					ruling_party = communism
 					elections_allowed = no
 				}
 			}
 		}
-
 		YEM = {
 			create_country_leader = {
 				name = "Ali Abdullah Saleh"
@@ -296,45 +276,36 @@ country_event = {
 					#
 				}
 			}
-
 			add_opinion_modifier = { target = HOU modifier = hostile_status }
-
 			set_politics = {
 				ruling_party = nationalist
 				elections_allowed = no
 			}
-
 			remove_ideas = {
 				youth_radicalization
 			}
-
 			hidden_effect = {
 				set_political_party = {
 					ideology = nationalist
 					popularity = 80
 				}
-
 				set_political_party = {
 					ideology = fascism
 					popularity = 2
 				}
-
 				set_political_party = {
 					ideology = communism
 					popularity = 14
 				}
-
 				set_political_party = {
 					ideology = democratic
 					popularity = 0
 				}
-
 				set_political_party = {
 					ideology = neutrality
 					popularity = 4
 				}
 			}
-
 			hidden_effect = {
 				add_state_core = 197
 				add_state_core = 195
@@ -348,44 +319,38 @@ country_event = {
 			}
 			set_state_controller = 198
 			set_state_controller = 197
-
 			declare_war_on = {
 				target = HOU
 				type = civil_war
 			}
-
 			hidden_effect = {
 				load_oob = "YEM_Saleh"
 				set_equipment_fraction = 0.5
 			}
 		}
 	}
+
 	option = { #Accept SPC
 		name = Saleh.7.b
 		log = "[GetDateText]: [This.GetName]: Saleh.7.b executed"
 		ai_chance = {
 			base = 40
 		}
-
 		hidden_effect = {
 			set_political_party = {
 				ideology = nationalist
 				popularity = 50
 			}
-
 			set_political_party = {
 				ideology = communism
 				popularity = 50
 			}
-
 			set_political_party = {
 				ideology = communism
 				popularity = 0
 			}
 		}
-
 		add_opinion_modifier = { target = SAU modifier = hostile_status }
-
 		set_politics = {
 			ruling_party = nationalist
 			elections_allowed = no
@@ -398,7 +363,6 @@ country_event = {
 	id = Saleh.8
 	title = Saleh.8.t
 	desc = Saleh.8.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -430,7 +394,6 @@ country_event = {
 	id = Saleh.9
 	title = Saleh.9.t
 	desc = Saleh.9.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -448,7 +411,6 @@ country_event = {
 				}
 			}
 		}
-
 		hidden_effect = {
 			custom_effect_tooltip = HOU_Saleh.6
 			SAU = { country_event = { days = 5 id = Saleh.10 } }
@@ -483,7 +445,6 @@ country_event = {
 	id = Saleh.10
 	title = Saleh.10.t
 	desc = Saleh.10.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -515,7 +476,6 @@ country_event = {
 	id = Saleh.11
 	title = Saleh.11.t
 	desc = Saleh.11.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -536,7 +496,6 @@ news_event = {
 	title = Saleh.12.t
 	desc = Saleh.12.d
 	picture = GFX_news_saleh_killed
-
 	is_triggered_only = yes
 	major = yes
 
@@ -550,9 +509,7 @@ news_event = {
 
 	option = {
 		name = Saleh.12.a
-		trigger = {
-			tag = HOU
-		}
+		trigger = { tag = HOU }
 	}
 
 	option = {
@@ -599,7 +556,6 @@ country_event = {
 	title = Saleh.13.t
 	desc = Saleh.13.d
 	picture = GFX_HOU_saleh_speech
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -638,14 +594,11 @@ country_event = {
 	id = Saleh.14
 	title = Saleh.14.t
 	desc = Saleh.14.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	immediate = {
-		SAU = { country_event = Saleh.15 }
-	}
+	immediate = { SAU = { country_event = Saleh.15 } }
 
 	option = {
 	name = Saleh.14.a
@@ -685,9 +638,7 @@ country_event = {
 	option = {
 	name = Saleh.14.c
 	log = "[GetDateText]: [This.GetName]: Saleh.14.c executed"
-	trigger = {
-		tag = UAE
-	}
+	trigger = { tag = UAE }
 		add_opinion_modifier = { target = HOU modifier = Hosted_UAE_summit }
 		add_opinion_modifier = { target = SAU modifier = Hosted_UAE_summit }
 		add_opinion_modifier = { target = YEM modifier = Hosted_UAE_summit }
@@ -699,7 +650,6 @@ country_event = {
 	id = Saleh.15
 	title = Saleh.15.t
 	desc = Saleh.15.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -725,7 +675,6 @@ country_event = {
 	id = Saleh.16
 	title = Saleh.16.t
 	desc = Saleh.16.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 	fire_only_once = yes
@@ -744,7 +693,6 @@ country_event = {
 	id = Saleh.17
 	title = Saleh.17.t
 	desc = Saleh.17.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 	fire_only_once = yes

--- a/events/Uzbekistan.txt
+++ b/events/Uzbekistan.txt
@@ -13,26 +13,20 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: uzbekistan_event.1.a executed"
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	#Back the Uzbeks
 	option = {
 		name = UZB_karakalpakstan.1.b
 		log = "[GetDateText]: [This.GetName]: uzbekistan_event.1.a executed"
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_uzbeks_opinion_effect = yes
-
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 country_event = {
@@ -48,26 +42,22 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.2.a executed"
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	#Back the Uzbeks
 	option = {
 		name = UZB_karakalpakstan.2.b
 		log = "[GetDateText]: [This.GetName]: indian_event.2.b executed"
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
+
 	#Find a resolution for both parties
 }
 #
@@ -84,25 +74,20 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.3.a executed"
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	#Back the Uzbeks
 	option = {
 		name = UZB_karakalpakstan.3.b
 		log = "[GetDateText]: [This.GetName]: indian_event.3.b executed"
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #
@@ -119,24 +104,19 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: indian_event.4.a executed"
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	#Back the Uzbeks
 	option = {
 		name = UZB_karakalpakstan.4.b
 		log = "[GetDateText]: [This.GetName]: indian_event.4.b executed"
 		set_temp_variable = { temp_change = -1 }
 		UZB_modify_karakalpakstan_opinion_effect = yes
-
 		set_temp_variable = { temp_change = 2 }
 		UZB_modify_uzbeks_opinion_effect = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }

--- a/events/Vitebsk.txt
+++ b/events/Vitebsk.txt
@@ -7,17 +7,13 @@ country_event = {
 	id = vitebsk_rus.2
 	title = vitebsk_rus.2.t
 	desc = vitebsk_rus.2.d
-
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
 	option = {
 		name = vitebsk_rus.2.a
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.2.a executed"
-		ai_chance = {
-			base = 70
-		}
-
+		ai_chance = { base = 70 }
 		hidden_effect = {
 		add_equipment_to_stockpile = {
 			type = infantry_weapons_3
@@ -72,9 +68,7 @@ country_event = {
 	option = {
 		name = vitebsk_rus.2.b
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.2.b executed"
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 		set_temp_variable = { percent_change = -7.12 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = VTB }
@@ -96,16 +90,13 @@ country_event = {
 	id = vitebsk_rus.3
 	title = vitebsk_rus.3.t
 	desc = vitebsk_rus.3.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
 	option = {
 		name = vitebsk_rus.3.a
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.3.a executed"
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 		set_temp_variable = { percent_change = 5.12 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = VTB }
@@ -117,12 +108,11 @@ country_event = {
 		modify_treasury_effect = yes
 		}
 	}
+
 	option = {
 		name = vitebsk_rus.3.b
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.3.b executed"
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 		set_temp_variable = { percent_change = -5.12 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = VTB }
@@ -144,16 +134,13 @@ country_event = {
 	id = vitebsk_rus.4
 	title = vitebsk_rus.4.t
 	desc = vitebsk_rus.4.d
-
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
 	option = {
 		name = vitebsk_rus.4.a
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.4.a executed"
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 		hidden_effect = {
 			add_equipment_to_stockpile = {
 				type = infantry_weapons_3
@@ -207,9 +194,7 @@ country_event = {
 	option = {
 		name = vitebsk_rus.4.b
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.4.b executed"
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 		set_temp_variable = { percent_change = -4.12 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = VTB }
@@ -233,16 +218,13 @@ country_event = {
 	id = vitebsk_rus.6
 	title = vitebsk_rus.6.t
 	desc = vitebsk_rus.6.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	option = {
 		name = vitebsk_rus.6.a
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.6.a executed"
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		VTB = {
 			set_country_flag = SUB_russ_polit
 			update_party_name = yes
@@ -269,9 +251,7 @@ country_event = {
 	option = {
 		name = vitebsk_rus.6.b
 		log = "[GetDateText]: [This.GetName]: vitebsk_rus.6.b executed"
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		set_temp_variable = { percent_change = -7.12 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = VTB }
@@ -286,6 +266,5 @@ country_event = {
 				modifier = diplomatic_distance
 			}
 		}
-
 	}
- }
+}


### PR DESCRIPTION
Split from #3800.

Standardizes 6 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 6 files, 2,700 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.