### PR TITLE
Standardize event files — batch 06/14

### DIFF
--- a/events/International Recognition.txt
+++ b/events/International Recognition.txt
@@ -7,11 +7,9 @@ country_event = {
 	desc = recognition.1.d
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
-	minor_flavor = yes
 
-	option = {
-		name = recognition.1.a
-	}
+	minor_flavor = yes
+	option = { name = recognition.1.a }
 }
 
 ### [FROM.GetName] No Longer Recognizes Our Independence!
@@ -21,24 +19,20 @@ country_event = {
 	desc = recognition.3.d
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
-	minor_flavor = yes
 
-	option = {
-		name = recognition.3.a
-	}
+	minor_flavor = yes
+	option = { name = recognition.3.a }
 }
 
 ### [FROM.GetName] Withdraws Recognition of the Breakaway
 country_event = {
 	id = recognition.4
-
 	title = recognition.4.t
 	desc = recognition.4.d
 	picture = GFX_trade_agreement
-
 	is_triggered_only = yes
-	minor_flavor = yes
 
+	minor_flavor = yes
 	option = {
 		name = recognition.4.a
 		log = "[GetDateText]: [This.GetName]: recognition.4.a executed"
@@ -49,17 +43,13 @@ country_event = {
 #We did it!
 country_event = {
 	id = recognition.71
-
 	title = recognition.71.t
 	desc = recognition.71.d
 	picture = GFX_trade_agreement
-
 	is_triggered_only = yes
-	minor_flavor = yes
 
-	immediate = {
-		news_event = recognition.7
-	}
+	minor_flavor = yes
+	immediate = { news_event = recognition.7 }
 
 	option = {
 		name = recognition.71.a
@@ -85,14 +75,12 @@ country_event = {
 #No, we failed!
 country_event = {
 	id = recognition.72
-
 	title = recognition.72.t
 	desc = recognition.72.d
 	picture = GFX_trade_agreement
-
 	is_triggered_only = yes
-	minor_flavor = yes
 
+	minor_flavor = yes
 	option = {
 		name = recognition.72.a
 		log = "[GetDateText]: [This.GetName]: recognition.72.a executed"
@@ -103,43 +91,33 @@ country_event = {
 ### [FROM.GetName] Joins the United Nations!
 news_event = {
 	id = recognition.7
-
 	title = recognition.7.t
 	desc = recognition.7.d
 	picture = GFX_UN_event_global_1
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = recognition.7.a
-	}
+	option = { name = recognition.7.a }
 }
 
 ### [FROM.GetName] Failed to join the UN!
 news_event = {
 	id = recognition.73
-
 	title = recognition.73.t
 	desc = recognition.73.d
 	picture = GFX_UN_event_global_1
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = recognition.73.a
-	}
+	option = { name = recognition.73.a }
 }
 
 ### [FROM.GetName] is Pressuring Us to Recognize [pressured_to_recognize]
 country_event = {
 	id = recognition.8
-
 	title = recognition.8.t
 	desc = recognition.8.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -297,7 +275,6 @@ country_event = {
 #Scoping Events to prompt UN SC votes for International Recog
 country_event = {
 	id = recognition.10
-
 	is_triggered_only = yes
 	hidden = yes
 
@@ -340,7 +317,6 @@ country_event = {
 		for_each_loop = {
 			array = global.security_council_members
 			value = v
-
 			var:v = {
 				if = {
 					limit = { is_eligible_current_sc_voter = yes }
@@ -368,7 +344,6 @@ country_event = {
 	title = recognition.12.t
 	desc = recognition.12.d
 	picture = GFX_UN_gen_assembly
-
 	is_triggered_only = yes
 
 	#Yes
@@ -379,9 +354,7 @@ country_event = {
 			limit = { has_global_flag = current_ongoing_sc_vote }
 			add_to_array = { global.security_council_vote_yes = THIS }
 		}
-
 		international_systems_update = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -406,6 +379,7 @@ country_event = {
 			}
 		}
 	}
+
 	#No
 	option = {
 		name = recognition.12.b
@@ -413,16 +387,12 @@ country_event = {
 			limit = { has_global_flag = current_ongoing_sc_vote }
 			add_to_array = { global.security_council_vote_no = THIS }
 			if = {
-				limit = {
-					is_in_array = { global.p5_sc_members = THIS }
-				}
+				limit = { is_in_array = { global.p5_sc_members = THIS } }
 				set_global_flag = security_council_veto
 			}
 		}
 		log = "[GetDateText]: [THIS.GetName] has voted no"
-
 		international_systems_update = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -447,6 +417,7 @@ country_event = {
 			}
 		}
 	}
+
 	#Abstain
 	option = {
 		name = recognition.12.c
@@ -455,7 +426,6 @@ country_event = {
 			add_to_array = { global.security_council_vote_abstain = THIS }
 		}
 		log = "[GetDateText]: [THIS.GetName] has abstained from voting"
-
 		international_systems_update = yes
 		ai_chance = {
 			base = 1
@@ -470,7 +440,6 @@ country_event = {
 #Scoping Events to prompt UN GA votes for International Recog
 country_event = {
 	id = recognition.13
-
 	is_triggered_only = yes
 	hidden = yes
 
@@ -503,10 +472,7 @@ country_event = {
 	hidden = yes
 
 	immediate = {
-		var:recog_requester = {
-			country_event = recognition.25
-		}
-
+		var:recog_requester = { country_event = recognition.25 }
 		clear_variable = recog_requester
 	}
 }
@@ -516,11 +482,7 @@ country_event = {
 	is_triggered_only = yes
 	hidden = yes
 
-	immediate = {
-		FROM = {
-			country_event = recognition.16
-		}
-	}
+	immediate = { FROM = { country_event = recognition.16 } }
 }
 
 country_event = {
@@ -528,44 +490,31 @@ country_event = {
 	is_triggered_only = yes
 	hidden = yes
 
-	immediate = {
-		var:prev_owner = {
-			country_event = recognition.31
-		}
-	}
+	immediate = { var:prev_owner = { country_event = recognition.31 } }
 }
 
 country_event = {
 	id = recognition.31
 	title = recognition.31.t
 	desc = recognition.31.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	#Don't recognize option
 	option = {
 		name = recognition.31.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	#Recognize option
 	option = {
 		name = recognition.31.b
 		log = "[GetDateText]: [This.GetName]: recognition.31.b"
-
 		if = {
 			limit = { NOT = { is_in_array = { recognised_countries = FROM } } }
 			add_to_array = { recognised_countries = FROM }
 		}
-
-		FROM = {
-			country_event = recognition.16
-		}
-
+		FROM = { country_event = recognition.16 }
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -592,29 +541,24 @@ country_event = {
 	id = recognition.16
 	title = recognition.16.t
 	desc = recognition.16.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	#Don't recognize option
 	option = {
 		name = recognition.16.a
-
 		ai_chance = {
 			base = 1
-
 			# Negative opinion of requester
 			modifier = {
 				add = 3
 				has_opinion = { target = FROM value < -25 }
 			}
-
 			# Strong dislike of requester
 			modifier = {
 				add = 5
 				has_opinion = { target = FROM value < -50 }
 			}
-
 			# Good relations with the original owner
 			modifier = {
 				add = 4
@@ -624,7 +568,6 @@ country_event = {
 					ROOT = { has_opinion = { target = PREV value > 25 } }
 				}
 			}
-
 			# Same faction as original owner — strong refusal
 			modifier = {
 				add = 8
@@ -633,7 +576,6 @@ country_event = {
 					is_in_faction_with = ROOT
 				}
 			}
-
 			# Ideologically aligned with original owner
 			modifier = {
 				add = 3
@@ -642,7 +584,6 @@ country_event = {
 					has_government = ROOT
 				}
 			}
-
 			# Opposing ideology to requester
 			modifier = {
 				add = 2
@@ -654,15 +595,12 @@ country_event = {
 	#Recognize option
 	option = {
 		name = recognition.16.b
-
 		log = "[GetDateText]: [This.GetName]: recognition.16.b executed"
-
 		add_political_power = -25
 		if = {
 			limit = { NOT = { is_in_array = { recognised_countries = FROM } } }
 			add_to_array = { recognised_countries = FROM }
 		}
-
 		custom_effect_tooltip = TT_ALL_UN_MEMBERS
 		every_collection_element = {
 			input = { input = collection:un_general_assembly_members_collection }
@@ -686,7 +624,6 @@ country_event = {
 				}
 			}
 		}
-
 		random_country = {
 			limit = {
 				has_country_flag = original_owner_@FROM
@@ -698,7 +635,6 @@ country_event = {
 			}
 			country_event = recognition.1
 		}
-
 		FROM = {
 			add_opinion_modifier = {
 				target = ROOT
@@ -707,40 +643,33 @@ country_event = {
 			recognition_grant_increment = yes
 		}
 		international_systems_update = yes
-
 		ai_chance = {
 			base = 0
-
 			# Warm relations
 			modifier = {
 				add = 1
 				has_opinion = { target = FROM value > 25 }
 			}
-
 			# Good relations
 			modifier = {
 				add = 2
 				has_opinion = { target = FROM value > 50 }
 			}
-
 			# Strong relations
 			modifier = {
 				add = 5
 				has_opinion = { target = FROM value > 75 }
 			}
-
 			# Same faction — strong push
 			modifier = {
 				add = 8
 				is_in_faction_with = FROM
 			}
-
 			# Same ideology group
 			modifier = {
 				add = 3
 				has_government = FROM
 			}
-
 			# Rival of the original owner — opportunistic recognition
 			modifier = {
 				add = 4
@@ -749,7 +678,6 @@ country_event = {
 					ROOT = { has_opinion = { target = PREV value < -25 } }
 				}
 			}
-
 			# Already recognized by many — bandwagon effect
 			modifier = {
 				add = 2
@@ -763,6 +691,7 @@ country_event = {
 	id = recognition.17
 	is_triggered_only = yes
 	hidden = yes
+
 	immediate = {
 		every_collection_element = {
 			input = { input = collection:un_general_assembly_members_collection }
@@ -783,15 +712,12 @@ country_event = {
 	title = recognition.18.t
 	desc = recognition.18.d
 	picture = GFX_EventCountry_Template
-
 	is_triggered_only = yes
 
 	option = {
 		name = recognition.18.a
-
 		ai_chance = {
 			base = 0
-
 			modifier = {
 				add = 100
 				has_country_flag = original_owner_@FROM
@@ -807,7 +733,6 @@ country_event = {
 		name = recognition.18.b
 		log = "[GetDateText]: [This.GetName]: recognition.18.b"
 		add_to_array = { recognised_countries = FROM }
-
 		random_country = {
 			limit = {
 				has_country_flag = original_owner_@FROM
@@ -816,16 +741,13 @@ country_event = {
 			add_opinion_modifier = { target = ROOT modifier = recognises_them }
 			country_event = recognition.1
 		}
-
 		FROM = {
 			every_allied_country = {
 				add_opinion_modifier = { target = ROOT modifier = supporting_recognized_ally }
 			}
-
 			add_opinion_modifier = { target = ROOT modifier = recognises_us }
 			recognition_grant_increment = yes
 		}
-
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -859,46 +781,34 @@ country_event = {
 ### [FROM.GetName] gets SC recomendation
 news_event = {
 	id = recognition.121
-
 	title = recognition.121.t
 	desc = recognition.121.d
 	picture = GFX_UN_event_global_2
-
 	is_triggered_only = yes
 
-	option = {
-		name = recognition.121.a
-	}
+	option = { name = recognition.121.a }
 }
 
 #Fails to pass the SC
 news_event = {
 	id = recognition.122
-
 	title = recognition.122.t
 	desc = recognition.122.d
 	picture = GFX_UN_event_global_2
-
 	is_triggered_only = yes
 
-	option = {
-		name = recognition.122.a
-	}
+	option = { name = recognition.122.a }
 }
 
 # Fired once when recognition first reaches the UN-ascension threshold (40% of GA)
 country_event = {
 	id = recognition.45
-
 	title = recognition.45.t
 	desc = recognition.45.d
 	picture = GFX_UN_event_global_1
-
 	is_triggered_only = yes
 
-	option = {
-		name = recognition.45.a
-	}
+	option = { name = recognition.45.a }
 }
 
 country_event = {
@@ -917,7 +827,6 @@ country_event = {
 		}
 		for_each_scope_loop = {
 			array = global.UN_general_assembly
-
 			if = {
 				limit = { NOT = { has_auto_ga_vote = yes } }
 				country_event = recognition.15
@@ -939,7 +848,6 @@ country_event = {
 	title = recognition.15.t
 	desc = recognition.15.d
 	picture = GFX_UN_gen_assembly
-
 	is_triggered_only = yes
 
 	#Yes
@@ -950,9 +858,7 @@ country_event = {
 			limit = { has_global_flag = current_ongoing_ga_vote }
 			add_to_array = { global.general_assembly_vote_yes = THIS }
 		}
-
 		international_systems_update = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -977,6 +883,7 @@ country_event = {
 			}
 		}
 	}
+
 	#No
 	option = {
 		name = recognition.15.b
@@ -985,9 +892,7 @@ country_event = {
 			add_to_array = { global.general_assembly_vote_no = THIS }
 		}
 		log = "[GetDateText]: [THIS.GetName] has voted no"
-
 		international_systems_update = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1012,6 +917,7 @@ country_event = {
 			}
 		}
 	}
+
 	#Abstain
 	option = {
 		name = recognition.15.c
@@ -1020,11 +926,9 @@ country_event = {
 			add_to_array = { global.general_assembly_vote_abstain = THIS }
 		}
 		log = "[GetDateText]: [THIS.GetName] has abstained from voting"
-
 		international_systems_update = yes
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				factor = 0
 				is_in_array = { recognised_countries = FROM.FROM }

--- a/events/Nigeria.txt
+++ b/events/Nigeria.txt
@@ -59,14 +59,12 @@ country_event = {
 			change_relative_party_popularity = yes
 			custom_effect_tooltip = NIG_religious_conversion_christian_TT
 			add_stability = -0.00725
-
 		}
 		if = {
 			limit = {
 				has_country_flag = NIG_religious_conversion_borno
 			}
 			340 = { set_state_flag = NIG_christian_state }
-
 			###BASE OF BOKO HARAM CAN TRIGGER THE CIVIL WAR EARLIER
 			add_stability = -0.06
 			set_temp_variable = { party_index = 14 }
@@ -126,6 +124,7 @@ country_event = {
 		}
 		NIG_clear_conversion_country_flags = yes
 	}
+
 	option = { #Islamic State
 		name = nigeria_md.1.b
 		trigger = { has_completed_focus = NIG_convert_the_christians }
@@ -242,9 +241,7 @@ country_event = {
 	}
 	desc = {
 		text = nigeria_md.2.d2
-		trigger = {
-			has_completed_focus = NIG_convert_the_christians
-		}
+		trigger = { has_completed_focus = NIG_convert_the_christians }
 	}
 	picture = GFX_politics_demands
 	is_triggered_only = yes
@@ -279,7 +276,6 @@ country_event = {
 			change_relative_party_popularity = yes
 			custom_effect_tooltip = NIG_religious_conversion_christian_TT
 			add_stability = -0.014
-
 		}
 		if = { limit = { has_country_flag = NIG_religious_conversion_borno }
 			340 = { set_state_flag = NIG_christian_state }
@@ -330,8 +326,8 @@ country_event = {
 			add_stability = -0.0125
 		}
 		NIG_clear_conversion_country_flags = yes
-
 	}
+
 	option = {
 		name = nigeria_md.2.b
 		trigger = { has_completed_focus = NIG_convert_the_christians }
@@ -448,12 +444,9 @@ country_event = {
 	}
 	desc = {
 		text = nigeria_md.3.d2
-		trigger = {
-			has_completed_focus = NIG_convert_the_christians
-		}
+		trigger = { has_completed_focus = NIG_convert_the_christians }
 	}
 	picture = GFX_terrorist_attack
-
 	is_triggered_only = yes
 
 	option = {
@@ -495,7 +488,6 @@ country_event = {
 			change_relative_party_popularity = yes
 			custom_effect_tooltip = NIG_religious_conversion_christian_TT
 			add_stability = -0.029
-
 		}
 		if = {
 			limit = {
@@ -559,8 +551,8 @@ country_event = {
 			add_stability = -0.023
 		}
 		NIG_clear_conversion_country_flags = yes
-
 	}
+
 	option = {
 		name = nigeria_md.3.b
 		trigger = { has_completed_focus = NIG_convert_the_christians }
@@ -713,7 +705,6 @@ country_event = {
 					NIG = { set_capital = { state = PREV } }
 				}
 			}
-
 			if = { limit = { has_government = neutrality }
 				start_civil_war = {
 					ruling_party = neutrality
@@ -792,7 +783,6 @@ country_event = {
 				}
 				division_template = {
 					name = "Al Milishia al-islamiyya"
-
 					regiments = {
 						Militia_Bat = { x = 0 y = 0 }
 						Militia_Bat = { x = 0 y = 1 }
@@ -820,7 +810,6 @@ country_event = {
 						owner = PREV
 					}
 				}
-
 			}
 		}
 		else_if = {
@@ -830,7 +819,6 @@ country_event = {
 				delete_unit_template_and_units = { division_template = "Christian Militias" }
 				delete_unit_template_and_units = { division_template = "Islamic Militias" }
 			}
-
 			for_each_scope_loop = {
 				array = owned_states
 				if = { limit = { NOT = { has_state_flag = NIG_islamic_state } }
@@ -915,7 +903,6 @@ country_event = {
 				}
 				division_template = {
 					name = "Christian Militias"
-
 					regiments = {
 						Militia_Bat = { x = 0 y = 0 }
 						Militia_Bat = { x = 0 y = 1 }
@@ -943,7 +930,6 @@ country_event = {
 						owner = PREV
 					}
 				}
-
 			}
 		}
 	}
@@ -956,7 +942,6 @@ country_event = {
 	title = nigeria_md.5.t
 	desc = nigeria_md.5.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -982,9 +967,9 @@ country_event = {
 	title = nigeria_md.6.t
 	desc = nigeria_md.6.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	option = {
 		name = nigeria_md.6.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.6.a executed"
@@ -1017,26 +1002,20 @@ country_event = {
 			set_temp_variable = { percent_change = 2 }
 			set_temp_variable = { tag_index = PREV.id }
 			change_influence_percentage = yes
-
 			random_owned_controlled_state = {
-				limit = {
-					infrastructure < 5
-				}
-
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
 					instant_build = yes
 				}
 			}
-
 			country_event = { id = diplomatic_response.1 days = 1 }
 		}
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
 		set_temp_variable = { int_investment_change = 6 }
 		modify_international_investment_effect = yes
-
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -1066,7 +1045,6 @@ country_event = {
 		}
 		add_opinion_modifier = { target = NIG modifier = denied_us }
 		reverse_add_opinion_modifier = { target = NIG modifier = denied_us }
-
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -1095,7 +1073,6 @@ country_event = {
 	title = nigeria_md.8.t
 	desc = nigeria_md.8.d
 	picture = GFX_african_union
-
 	is_triggered_only = yes
 
 	option = { #Yeah, Sure
@@ -1186,7 +1163,6 @@ country_event = {
 			add_to_faction = ROOT
 			country_event = diplomatic_response.1
 		}
-
 		ai_chance = {
 			base = 75
 		}
@@ -1195,7 +1171,6 @@ country_event = {
 	option = { ##We are the True Jihadists!
 		name = nigeria_md.9.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.9.b executed"
-
 		NIG = { country_event = diplomatic_response.2 }
 		ai_chance = {
 			base = 25
@@ -1210,21 +1185,16 @@ country_event = {
 	desc = nigeria_md.11.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# A Satisifying Conclusion...
 	option = {
 		name = nigeria_md.11.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.11.a executed"
-
 		add_stability = 0.10
 		add_political_power = 100
-
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -1237,6 +1207,7 @@ country_event = {
 	desc = nigeria_md.100.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		NOT = { has_completed_focus = NIG_end_sharia_law }
@@ -1247,9 +1218,7 @@ country_event = {
 	option = {
 		name = nigeria_md.100.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.100.a executed"
-
 		add_stability = 0.02
-
 		ai_chance = {
 			base = 75
 			modifier = {
@@ -1263,12 +1232,9 @@ country_event = {
 	option = {
 		name = nigeria_md.100.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.100.b executed"
-
 		custom_effect_tooltip = NIG_sharia_law_warning_tt
 		set_country_flag = NIG_sharia_law_warning_flag
-
 		add_political_power = 150
-
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -1291,6 +1257,7 @@ country_event = {
 	desc = nigeria_md.101.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		NOT = { has_completed_focus = NIG_end_sharia_law }
@@ -1303,10 +1270,7 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: nigeria_md.101.a executed"
 		add_stability = 0.01
 		add_political_power = -50
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	# Ignore the Situation
@@ -1314,10 +1278,7 @@ country_event = {
 		name = nigeria_md.101.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.101.b executed"
 		add_stability = -0.02
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -1328,6 +1289,7 @@ country_event = {
 	desc = nigeria_md.102.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		NOT = { has_completed_focus = NIG_continue_sharia_law }
@@ -1340,7 +1302,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: nigeria_md.102.a executed"
 		add_stability = 0.02
 		add_political_power = -50
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -1355,7 +1316,6 @@ country_event = {
 		name = nigeria_md.102.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.102.b executed"
 		add_stability = -0.02
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -1373,6 +1333,7 @@ country_event = {
 	desc = nigeria_md.103.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		NOT = { owns_state = 322 }
@@ -1384,12 +1345,9 @@ country_event = {
 		name = nigeria_md.103.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.103.a executed"
 		add_political_power = 150
-
 		add_opinion_modifier = { target = CAM modifier = NIG_accepted_the_icj_ruling }
 		reverse_add_opinion_modifier = { target = CAM modifier = NIG_accepted_the_icj_ruling }
-
 		remove_ideas = NIG_bakassi_occupation_idea
-
 		ai_chance = {
 			base = 75
 			modifier = {
@@ -1404,36 +1362,25 @@ country_event = {
 	option = {
 		name = nigeria_md.103.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.103.b executed"
-
 		add_named_threat = {
 			threat = 3
 			name = NIG_the_bakassi_peninsula
 		}
-
 		custom_effect_tooltip = NIG_the_bakassi_peninsula_tt
-
 		add_opinion_modifier = { target = CAM modifier = NIG_rejected_the_icj_ruling }
 		reverse_add_opinion_modifier = { target = CAM modifier = NIG_rejected_the_icj_ruling }
-
 		set_temp_variable = { percent_change = -0.75 }
 		set_temp_variable = { tag_index = NIG.id }
 		every_other_country = {
-			limit = {
-				has_country_flag = african_nation_flag
-			}
+			limit = { has_country_flag = african_nation_flag }
 			change_influence_percentage = yes
-
 			add_opinion_modifier = { target = NIG modifier = NIG_rejected_the_icj_ruling_2 }
 			reverse_add_opinion_modifier = { target = NIG modifier = NIG_rejected_the_icj_ruling_2 }
 		}
-
 		CAM = {
 			country_event = { id = nigeria_ambazonia.1 days = 5 }
 		}
-
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -1444,19 +1391,16 @@ country_event = {
 	desc = nigeria_md.104.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Pay for the Damages
 	option = {
 		name = nigeria_md.104.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.104.a executed"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 		add_stability = 0.025
 	}
 
@@ -1464,7 +1408,6 @@ country_event = {
 	option = {
 		name = nigeria_md.104.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.104.b executed"
-
 		add_stability = 0.01
 	}
 }
@@ -1476,21 +1419,17 @@ country_event = {
 	desc = nigeria_md.105.d
 	picture = GFX_1st_africa_academy
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# A Wonderful Distraction
 	option = {
 		name = nigeria_md.105.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.105.a executed"
-
 		set_temp_variable = { percent_change = 0.75 }
 		set_temp_variable = { tag_index = NIG.id }
 		every_other_country = {
-			limit = {
-				has_country_flag = african_nation_flag
-			}
+			limit = { has_country_flag = african_nation_flag }
 			change_influence_percentage = yes
 		}
 	}
@@ -1503,6 +1442,7 @@ country_event = {
 	desc = nigeria_md.106.d
 	picture = GFX_lagos_armory_explosion
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		has_full_control_of_state = 334
@@ -1512,13 +1452,10 @@ country_event = {
 	option = {
 		name = nigeria_md.106.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.106.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
-
 		add_political_power = -50
-
 		334 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1553,6 +1490,7 @@ country_event = {
 	desc = nigeria_md.107.d
 	picture = GFX_port_harcourt_attack
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		has_full_control_of_state = 332
@@ -1562,7 +1500,6 @@ country_event = {
 	option = {
 		name = nigeria_md.107.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.107.a executed"
-
 		add_political_power = -50
 	}
 
@@ -1570,7 +1507,6 @@ country_event = {
 	option = {
 		name = nigeria_md.107.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.107.b executed"
-
 		add_stability = -0.02
 	}
 }
@@ -1582,6 +1518,7 @@ country_event = {
 	desc = nigeria_md.108.d
 	picture = GFX_lagos_pipeline
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		has_full_control_of_state = 334
@@ -1591,9 +1528,7 @@ country_event = {
 	option = {
 		name = nigeria_md.108.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.108.a executed"
-
 		add_political_power = -50
-
 		334 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1609,9 +1544,7 @@ country_event = {
 	option = {
 		name = nigeria_md.108.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.108.b executed"
-
 		add_stability = -0.02
-
 		334 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1631,19 +1564,16 @@ country_event = {
 	desc = nigeria_md.109.d
 	picture = GFX_zamfara_dam
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Investigate the Collapse
 	option = {
 		name = nigeria_md.109.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.109.a executed"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
@@ -1653,7 +1583,6 @@ country_event = {
 	option = {
 		name = nigeria_md.109.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.109.b executed"
-
 		add_political_power = 50
 	}
 }
@@ -1665,6 +1594,7 @@ country_event = {
 	desc = nigeria_md.110.d
 	picture = GFX_violence_leading_up_2007
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		has_elections = yes
@@ -1674,7 +1604,6 @@ country_event = {
 	option = {
 		name = nigeria_md.110.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.110.a executed"
-
 		increase_policing_budget = yes
 	}
 
@@ -1682,11 +1611,9 @@ country_event = {
 	option = {
 		name = nigeria_md.110.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.110.b executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
-
 		add_stability = -0.03
 	}
 }
@@ -1698,15 +1625,13 @@ country_event = {
 	desc = nigeria_md.111.d
 	picture = GFX_oil_spill_kaduna
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Deploy federal forces to the area
 	option = {
 		name = nigeria_md.111.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.111.a executed"
-
 		add_stability = 0.02
 	}
 
@@ -1714,7 +1639,6 @@ country_event = {
 	option = {
 		name = nigeria_md.111.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.111.b executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
@@ -1728,19 +1652,16 @@ country_event = {
 	desc = nigeria_md.112.d
 	picture = GFX_ijegun_explosion
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Investigate the Explosion
 	option = {
 		name = nigeria_md.112.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.112.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
 		add_political_power = -75
 		334 = {
 			if = {
@@ -1757,9 +1678,7 @@ country_event = {
 	option = {
 		name = nigeria_md.112.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.112.b executed"
-
 		add_political_power = 50
-
 		334 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1779,6 +1698,7 @@ country_event = {
 	desc = nigeria_md.113.d
 	picture = GFX_islamist_attack_bauchi
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = NIG
 		NOT = { has_completed_focus = NIG_end_sharia_law }
@@ -1789,11 +1709,9 @@ country_event = {
 	option = {
 		name = nigeria_md.113.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.113.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
 		add_political_power = -75
 	}
 
@@ -1801,7 +1719,6 @@ country_event = {
 	option = {
 		name = nigeria_md.113.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.113.b executed"
-
 		add_political_power = 50
 	}
 }
@@ -1813,16 +1730,14 @@ country_event = {
 	desc = nigeria_md.114.d
 	picture = GFX_afe_babola_university
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# A Wonderful Opportunity
 	option = {
 		name = nigeria_md.114.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.114.a executed"
 		add_political_power = 150
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
@@ -1836,15 +1751,13 @@ country_event = {
 	desc = nigeria_md.115.d
 	picture = GFX_court
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Nature has to run its course
 	option = {
 		name = nigeria_md.115.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.115.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		change_relative_party_popularity = yes
@@ -1854,11 +1767,9 @@ country_event = {
 	option = {
 		name = nigeria_md.115.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.115.b executed"
-
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		add_political_power = -50
 	}
 
@@ -1866,11 +1777,9 @@ country_event = {
 	option = {
 		name = nigeria_md.115.c
 		log = "[GetDateText]: [This.GetName]: nigeria_md.115.c executed"
-
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
@@ -1884,19 +1793,16 @@ country_event = {
 	desc = nigeria_md.116.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# A truly tragic day
 	option = {
 		name = nigeria_md.116.a
 		log = "[GetDateText]: [This.GetName]: nigeria_md.116.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		change_relative_party_popularity = yes
-
 		add_stability = -0.03
 	}
 }
@@ -1908,9 +1814,8 @@ country_event = {
 	desc = nigeria_md.117.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Provide additional funding to the local authorities
 	option = {
@@ -1919,7 +1824,6 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 		add_stability = 0.02
 	}
 
@@ -1927,7 +1831,6 @@ country_event = {
 	option = {
 		name = nigeria_md.117.b
 		log = "[GetDateText]: [This.GetName]: nigeria_md.117.b executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
@@ -1942,16 +1845,14 @@ country_event = {
 	desc = nigeria_ambazonia.1.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = CAM
-	}
+
+	trigger = { original_tag = CAM }
 
 	# Bakassi is Rightfully Ours. Demand the Nigerians Leave
 	# Leads to: Ambazonia: The Request
 	option = {
 		name = nigeria_ambazonia.1.a
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.1.a executed"
-
 		custom_effect_tooltip = NIG_ambazonia.1.a_tt
 		NIG = {
 			country_event = { id = nigeria_ambazonia.4 days = 5 }
@@ -1963,9 +1864,7 @@ country_event = {
 	option = {
 		name = nigeria_ambazonia.1.b
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.1.b executed"
-
 		custom_effect_tooltip = NIG_ambazonia.1.b_tt
-
 		NIG = {
 			country_event = { id = nigeria_ambazonia.2 days = 5 }
 		}
@@ -1976,13 +1875,10 @@ country_event = {
 	option = {
 		name = nigeria_ambazonia.1.c
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.1.c executed"
-
 		add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia }
 		reverse_add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia }
-
 		NIG = {
 			transfer_state = 322 # Given them Ambazonia
-
 			every_other_country = {
 				limit = {
 					has_country_flag = african_nation_flag
@@ -1990,7 +1886,6 @@ country_event = {
 				add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia_2 }
 				reverse_add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia_2 }
 			}
-
 			# Nigeria annexes Ambazonia on map
 			country_event = { id = nigeria_ambazonia.3 days = 5 }
 		}
@@ -2004,16 +1899,14 @@ country_event = {
 	desc = nigeria_ambazonia.2.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Fight Back!
 	# Leads to: Ambazonia: Nigeria Defends Bakassi
 	option = {
 		name = nigeria_ambazonia.2.a
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.4.a executed"
-
 		NIG = {
 			country_event = { id = nigeria_ambazonia.5 days = 5 }
 		}
@@ -2024,7 +1917,6 @@ country_event = {
 	option = {
 		name = nigeria_ambazonia.2.b
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.2.b executed"
-
 		NIG = {
 			country_event = { id = nigeria_ambazonia.6 days = 5 }
 		}
@@ -2039,32 +1931,25 @@ country_event = {
 	desc = nigeria_ambazonia.3.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Bakassi is Rightfully Ours!
 	option = {
 		name = nigeria_ambazonia.3.a
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.3.a executed"
-
 		effect_tooltip = {
 			transfer_state = 322
-
 			add_opinion_modifier = { target = CAM modifier = NIG_occupying_ambazonia }
 			reverse_add_opinion_modifier = { target = CAM modifier = NIG_occupying_ambazonia }
-
 			NIG = {
 				every_other_country = {
-					limit = {
-						has_country_flag = african_nation_flag
-					}
+					limit = { has_country_flag = african_nation_flag }
 					add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia_2 }
 					reverse_add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia_2 }
 				}
 			}
 		}
-
 		news_event = { id = nigeria_ambazonia.7 days = 5 }
 	}
 }
@@ -2076,20 +1961,17 @@ country_event = {
 	desc = nigeria_ambazonia.4.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = NIG
-	}
+
+	trigger = { original_tag = NIG }
 
 	# Accept Cameroon's Request
 	# Leads to: Ambazonia: Nigeria Defends Bakassi
 	option = {
 		name = nigeria_ambazonia.4.a
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.4.a executed"
-
 		CAM = {
 			country_event = { id = nigeria_ambazonia.5 days = 5 }
 		}
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2107,11 +1989,9 @@ country_event = {
 	option = {
 		name = nigeria_ambazonia.4.b
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.4.b executed"
-
 		CAM = {
 			country_event = { id = nigeria_ambazonia.6 days = 5 }
 		}
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2132,36 +2012,26 @@ country_event = {
 	desc = nigeria_ambazonia.5.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = CAM
-	}
+
+	trigger = { original_tag = CAM }
 
 	# Concede Bakassi
 	# Leads to: Ambazonia: Cameroon Concedes Bakassi
 	option = {
 		name = nigeria_ambazonia.5.a
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.5.a executed"
-
 		NIG = {
 			transfer_state = 322
-
 			every_other_country = {
-				limit = {
-					has_country_flag = african_nation_flag
-				}
+				limit = { has_country_flag = african_nation_flag }
 				add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia_2 }
 				reverse_add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia_2 }
 			}
 		}
-
 		add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia }
 		reverse_add_opinion_modifier = { target = NIG modifier = NIG_occupying_ambazonia }
-
 		news_event = { id = nigeria_ambazonia.7 days = 5 }
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	# Escalate the Conflict
@@ -2169,7 +2039,6 @@ country_event = {
 	option = {
 		name = nigeria_ambazonia.5.b
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.5.b executed"
-
 		CAM = {
 			declare_war_on = {
 				target = NIG
@@ -2180,9 +2049,7 @@ country_event = {
 			# Set provinicial controller for Bakassi
 			set_province_controller = 10831
 		}
-
 		news_event = { id = nigeria_ambazonia.8 days = 5 }
-
 		ai_chance = {
 			base = 50
 		}
@@ -2196,16 +2063,14 @@ country_event = {
 	desc = nigeria_ambazonia.6.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = CAM
-	}
+
+	trigger = { original_tag = CAM }
 
 	# Bakassi is Rightfully Ours!
 	# Leads to: Ambazonia: Nigeria Withdraws from Ambazonia
 	option = {
 		name = nigeria_ambazonia.6.a
 		log = "[GetDateText]: [This.GetName]: nigeria_ambazonia.6.a executed"
-
 		news_event = { id = nigeria_ambazonia.9 days = 5 }
 	}
 }
@@ -2219,10 +2084,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = nigeria_ambazonia.7.a
-
-	}
+	option = { name = nigeria_ambazonia.7.a }
 }
 
 # The Second Ambazonian War
@@ -2234,10 +2096,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = nigeria_ambazonia.8.a
-
-	}
+	option = { name = nigeria_ambazonia.8.a }
 }
 
 # Nigeria Withdraws from Ambazonia
@@ -2249,7 +2108,5 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = nigeria_ambazonia.9.a
-	}
+	option = { name = nigeria_ambazonia.9.a }
 }

--- a/events/Russia.txt
+++ b/events/Russia.txt
@@ -33,7 +33,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	#Accept
+	option = { #Accept
 		name = russia.0.o1
 		log = "[GetDateText]: [This.GetName]: russia.0.o1 executed"
 		if = { limit = { is_in_faction = yes }
@@ -57,7 +57,7 @@ country_event = {
 		}
 	}
 
-	option = {	#Never
+	option = { #Never
 		name = russia.0.o2
 		log = "[GetDateText]: [This.GetName]: russia.0.o2 executed"
 		SOV = { country_event = diplomatic_response.2 }
@@ -95,7 +95,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	#Horrible!
+	option = { #Horrible!
 		name = russia.1.o1
 		log = "[GetDateText]: [This.GetName]: russia.1.o1 executed"
 		navy_experience = 2
@@ -120,7 +120,7 @@ country_event = {
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
 
-	option = {	#We will turn our back on Russia
+	option = { #We will turn our back on Russia
 		name = russia.5.o1
 		log = "[GetDateText]: [This.GetName]: russia.5.o1 executed"
 		ai_chance = {
@@ -141,7 +141,7 @@ country_event = {
 		SOV = { remove_from_faction = ROOT }
 	}
 
-	option = {	#Loyalty must stay in place
+	option = { #Loyalty must stay in place
 		name = russia.5.o2
 		log = "[GetDateText]: [This.GetName]: russia.5.o2 executed"
 		ai_chance = {
@@ -184,9 +184,7 @@ country_event = {
 			transfer_state = 669
 			669 = { add_core_of = SOV }
 		}
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	option = { #We will stand and fight!
@@ -223,7 +221,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	#Excellent
+	option = { #Excellent
 		name = russia.8.o1
 		log = "[GetDateText]: [This.GetName]: russia.8.o1 executed"
 		effect_tooltip = {
@@ -261,7 +259,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {	#They know very well what the consequence is.
+	option = { #They know very well what the consequence is.
 		name = russia.9.o1
 		log = "[GetDateText]: [This.GetName]: russia.9.o1 executed"
 		declare_war_on = {
@@ -285,9 +283,7 @@ country_event = {
 	is_triggered_only = yes
 
 	##Scotch has banned
-	option = {
-		name = russia.15.o1
-	}
+	option = { name = russia.15.o1 }
 }
 ##Play DPR,LPR or HPR
 country_event = {
@@ -301,33 +297,25 @@ country_event = {
 	option = {
 		name = russia.16.o1
 		log = "[GetDateText]: [This.GetName]: russia.16.o1 executed"
-		DPR = {
-			change_tag_from = SOV
-		}
+		DPR = { change_tag_from = SOV }
 		trigger = { country_exists = DPR }
 	}
 
 	option = {
 		name = russia.16.o2
 		log = "[GetDateText]: [This.GetName]: russia.16.o2 executed"
-		LPR = {
-			change_tag_from = SOV
-		}
+		LPR = { change_tag_from = SOV }
 		trigger = { country_exists = LPR }
 	}
 
 	option = {
 		name = russia.16.o4
 		log = "[GetDateText]: [This.GetName]: russia.16.o4 executed"
-		HPR = {
-			change_tag_from = SOV
-		}
+		HPR = { change_tag_from = SOV }
 		trigger = { country_exists = HPR }
 	}
 
-	option = {
-		name = russia.16.o5
-	}
+	option = { name = russia.16.o5 }
 
 	##Play LPR
 	##Play HPR
@@ -376,9 +364,7 @@ country_event = {
 			modify_subjectnalogs_support = yes
 			SUB_separatism_plus_subject = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -410,9 +396,7 @@ country_event = {
 			modify_subjectnalogs_support = yes
 			SUB_separatism_plus_subject = yes
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -490,9 +474,7 @@ country_event = {
 		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -505,9 +487,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.39 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 ### Ukrainian Coup
@@ -520,9 +500,7 @@ country_event = {
 
 	option = {
 		name = russia.33.o1
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -542,9 +520,7 @@ country_event = {
 				id = russia_news.9
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -563,9 +539,7 @@ country_event = {
 				id = russia_news.10
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -576,9 +550,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = russia.38.o1
-	}
+	option = { name = russia.38.o1 }
 }
 country_event = {
 	id = russia.39
@@ -587,9 +559,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = russia.39.o1
-	}
+	option = { name = russia.39.o1 }
 }
 #TOS Export
 country_event = {
@@ -602,9 +572,7 @@ country_event = {
 	option = {
 		name = russia.41.o1
 		log = "[GetDateText]: [This.GetName]: russia.41.o1 executed"
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
 		add_equipment_to_stockpile = {
@@ -618,9 +586,7 @@ country_event = {
 	option = {
 		name = russia.41.o2
 		log = "[GetDateText]: [This.GetName]: russia.41.o2 executed"
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		SOV = { country_event = russia.45 }
 	}
 }
@@ -645,9 +611,7 @@ country_event = {
 	picture = GFX_tosochka
 	is_triggered_only = yes
 
-	option = {
-		name = russia.45.a
-	}
+	option = { name = russia.45.a }
 }
 #Tanks Export
 country_event = {
@@ -661,9 +625,7 @@ country_event = {
 	option = {
 		name = russia.46.o1
 		log = "[GetDateText]: [This.GetName]: russia.46.o1 executed"
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		set_temp_variable = { treasury_change = -20 }
 		modify_treasury_effect = yes
 		if = {
@@ -687,9 +649,7 @@ country_event = {
 	option = {
 		name = russia.46.o2
 		log = "[GetDateText]: [This.GetName]: russia.46.o2 executed"
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		SOV = { country_event = russia.48 }
 	}
 }
@@ -714,9 +674,7 @@ country_event = {
 	picture = GFX_t90
 	is_triggered_only = yes
 
-	option = {
-		name = russia.48.a
-	}
+	option = { name = russia.48.a }
 }
 #Aze vs Armenia choose
 country_event = {
@@ -772,9 +730,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: russia.51.a executed"
 		SOV = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = ROOT
 					autonomy_state = autonomy_puppet_state_colored
@@ -811,11 +767,7 @@ country_event = {
 				add = 30
 			}
 		}
-		hidden_effect = {
-		SOV = {
-			add_ideas = SOV_i_blin_idea
-		}
-	}
+		hidden_effect = { SOV = { add_ideas = SOV_i_blin_idea } }
 		random_owned_controlled_state = {
 			add_resource = {
 				type = oil
@@ -838,9 +790,7 @@ country_event = {
 				add = -30
 			}
 		}
-		SOV = {
-			country_event = russia.53
-		}
+		SOV = { country_event = russia.53 }
 	}
 }
 country_event = {
@@ -850,9 +800,7 @@ country_event = {
 	picture = GFX_olsen
 	is_triggered_only = yes
 
-	option = {
-		name = russia.53.a
-	}
+	option = { name = russia.53.a }
 }
 
 ##VKS Founded
@@ -873,9 +821,7 @@ country_event = {
 		add_to_variable = { SOV_air_air_mission_xp_gain_factor = 0.10 tooltip = air_mission_xp_gain_factor_tt }
 		add_to_variable = { SOV_air_air_accidents_factor = -0.02 tooltip = air_accidents_factor_tt }
 		add_to_variable = { SOV_air_airforce_personnel_cost_multiplier_modifier = -0.10 tooltip = airforce_personnel_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 ##Borya the Tsar
@@ -1098,9 +1044,7 @@ country_event = {
 		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1113,9 +1057,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.79 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -1125,9 +1067,7 @@ country_event = {
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
 
-	option = {
-		name = russia.78.o1
-	}
+	option = { name = russia.78.o1 }
 }
 country_event = {
 	id = russia.79
@@ -1136,9 +1076,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = russia.79.o1
-	}
+	option = { name = russia.79.o1 }
 }
 
 country_event = {
@@ -1164,9 +1102,7 @@ country_event = {
 		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1179,9 +1115,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.82 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -1191,9 +1125,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = russia.81.o1
-	}
+	option = { name = russia.81.o1 }
 }
 country_event = {
 	id = russia.82
@@ -1202,9 +1134,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = russia.82.o1
-	}
+	option = { name = russia.82.o1 }
 }
 
 country_event = {
@@ -1217,9 +1147,7 @@ country_event = {
 	option = {
 		name = russia.83.o1
 		log = "[GetDateText]: [This.GetName]: russia.83.o1 executed"
-		GEO = {
-			puppet = ROOT
-		}
+		GEO = { puppet = ROOT }
 		add_political_power = 150
 		add_opinion_modifier = { target = SOV modifier = betrayed_our_cause }
 		reverse_add_opinion_modifier = { target = SOV modifier = betrayed_our_cause }
@@ -1227,9 +1155,7 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = GEO }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1243,9 +1169,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -1322,9 +1246,7 @@ country_event = {
 		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1337,9 +1259,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.88 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -1349,9 +1269,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = russia.87.o1
-	}
+	option = { name = russia.87.o1 }
 }
 country_event = {
 	id = russia.88
@@ -1360,9 +1278,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = russia.88.o1
-	}
+	option = { name = russia.88.o1 }
 }
 ################
 country_event = {
@@ -1430,9 +1346,7 @@ country_event = {
 		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1445,9 +1359,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.90 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -1457,9 +1369,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = russia.90.o1
-	}
+	option = { name = russia.90.o1 }
 }
 country_event = {
 	id = russia.92
@@ -1502,9 +1412,7 @@ country_event = {
 		set_temp_variable = { tag_index = ROOT }
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1517,9 +1425,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.94 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -1529,9 +1435,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = russia.93.o1
-	}
+	option = { name = russia.93.o1 }
 }
 country_event = {
 	id = russia.94
@@ -1540,9 +1444,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = russia.94.o1
-	}
+	option = { name = russia.94.o1 }
 }
 country_event = {
 	id = russia.95
@@ -1566,9 +1468,7 @@ country_event = {
 					active = yes
 				}
 			}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1581,9 +1481,7 @@ country_event = {
 		SOV = {
 			country_event = { id = russia.97 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -1593,9 +1491,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = russia.96.o1
-	}
+	option = { name = russia.96.o1 }
 }
 country_event = {
 	id = russia.97
@@ -1604,9 +1500,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = russia.97.o1
-	}
+	option = { name = russia.97.o1 }
 }
 country_event = {
 	id = russia.98
@@ -1759,18 +1653,14 @@ country_event = {
 		add_popularity = { ideology = democratic popularity = 0.05 }
 		recalculate_party = yes
 		add_stability = 0.05
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
 		name = russia.104.o2
 		log = "[GetDateText]: [This.GetName]: russia.104.o2 executed"
 		country_event = { id = russia.105 days = 10 }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -1901,9 +1791,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -1927,9 +1815,7 @@ country_event = {
 	is_triggered_only = yes
 
 	# Unfourtnate...
-	option = {
-		name = russia.120.a
-	}
+	option = { name = russia.120.a }
 }
 
 #Livonia Governorate
@@ -1951,9 +1837,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				ROOT = {
-					is_subject_of = SOV
-				}
+				ROOT = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -2016,9 +1900,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = russia_governorate.2.o1
-	}
+	option = { name = russia_governorate.2.o1 }
 }
 #Livonia Governorate Disagree
 country_event = {
@@ -2037,11 +1919,7 @@ country_event = {
 		}
 		if = {
 			limit = { LIT = { NOT = { is_subject_of = SOV } } }
-			LIT = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			LIT = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = LIT }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2073,9 +1951,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				ROOT = {
-					is_subject_of = SOV
-				}
+				ROOT = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -2138,9 +2014,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = russia_governorate.5.o1
-	}
+	option = { name = russia_governorate.5.o1 }
 }
 #Courland Governorate Disagree
 country_event = {
@@ -2159,11 +2033,7 @@ country_event = {
 		}
 		if = {
 			limit = { LAT = { NOT = { is_subject_of = SOV } } }
-			LAT = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			LAT = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = LAT }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2195,9 +2065,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				ROOT = {
-					is_subject_of = SOV
-				}
+				ROOT = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -2260,9 +2128,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = russia_governorate.8.o1
-	}
+	option = { name = russia_governorate.8.o1 }
 }
 #Estland Governorate Disagree
 country_event = {
@@ -2281,11 +2147,7 @@ country_event = {
 		}
 		if = {
 			limit = { EST = { NOT = { is_subject_of = SOV } } }
-			EST = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			EST = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = EST }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2317,9 +2179,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				GEO = {
-					is_subject_of = SOV
-				}
+				GEO = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -2381,9 +2241,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = russia_governorate.11.o1
-	}
+	option = { name = russia_governorate.11.o1 }
 }
 #Tiflis Governorate Disagree
 country_event = {
@@ -2402,11 +2260,7 @@ country_event = {
 		}
 		if = {
 			limit = { GEO = { NOT = { is_subject_of = SOV } } }
-			GEO = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			GEO = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = GEO }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2438,9 +2292,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				MLV = {
-					is_subject_of = SOV
-				}
+				MLV = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -2501,9 +2353,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = russia_governorate.14.o1
-	}
+	option = { name = russia_governorate.14.o1 }
 }
 #Bessarabia Governorate Disagree
 country_event = {
@@ -2522,11 +2372,7 @@ country_event = {
 		}
 		if = {
 			limit = { MLV = { NOT = { is_subject_of = SOV } } }
-			MLV = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			MLV = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = MLV }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2558,15 +2404,11 @@ country_event = {
 				add = 90
 			}
 			modifier = {
-				BLR = {
-					is_subject_of = SOV
-				}
+				BLR = { is_subject_of = SOV }
 				add = 90
 			}
 		}
-		SOV = {
-			country_event = russia_governorate.17
-		}
+		SOV = { country_event = russia_governorate.17 }
 		BLR = {
 			set_country_flag = SOV_subject_governorate
 			set_cosmetic_tag = GOV_BLR
@@ -2626,11 +2468,7 @@ country_event = {
 	option = {
 		name = russia_governorate.16.o3
 		log = "[GetDateText]: [This.GetName]: russia_governorate.16.o3 executed"
-		trigger = {
-			NOT = {
-				has_autonomy_state = autonomy_union_state
-			}
-		}
+		trigger = { NOT = { has_autonomy_state = autonomy_union_state } }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -2690,11 +2528,7 @@ country_event = {
 		}
 		if = {
 			limit = { BLR = { NOT = { is_subject_of = SOV } } }
-			BLR = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			BLR = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = BLR }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2720,41 +2554,27 @@ country_event = {
 	option = {
 		name = russia_governorate.19.o1
 		log = "[GetDateText]: [This.GetName]: russia_governorate.19.o1 executed"
-		ai_chance = {
-			base = 50
-		}
-		BLR = {
-			set_country_flag = BLR_unionstate_agree
-		}
+		ai_chance = { base = 50 }
+		BLR = { set_country_flag = BLR_unionstate_agree }
 		hidden_effect = {
 			if = {
-				limit = {
-					has_idea = BLR_cheln_trade
-				}
+				limit = { has_idea = BLR_cheln_trade }
 				remove_ideas = BLR_cheln_trade
 			}
 			if = {
-				limit = {
-					has_idea = BLR_unstable_national_currency
-				}
+				limit = { has_idea = BLR_unstable_national_currency }
 				remove_ideas = BLR_unstable_national_currency
 			}
 			if = {
-				limit = {
-					has_idea = BLR_unstable_national_currency2
-				}
+				limit = { has_idea = BLR_unstable_national_currency2 }
 				remove_ideas = BLR_unstable_national_currency2
 				}
 			if = {
-				limit = {
-					has_idea = BLR_unstable_national_currency3
-				}
+				limit = { has_idea = BLR_unstable_national_currency3 }
 				remove_ideas = BLR_unstable_national_currency3
 			}
 			if = {
-				limit = {
-					has_idea = BLR_unstable_national_currency4
-				}
+				limit = { has_idea = BLR_unstable_national_currency4 }
 				remove_ideas = BLR_unstable_national_currency4
 			}
 			BLR = {
@@ -2780,16 +2600,10 @@ country_event = {
 	option = {
 		name = russia_governorate.19.o2
 		log = "[GetDateText]: [This.GetName]: russia_governorate.19.o2 executed"
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 		if = {
 			limit = { BLR = { NOT = { is_subject_of = SOV } } }
-			BLR = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			BLR = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = BLR }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2822,28 +2636,20 @@ country_event = {
 				add = -50
 			}
 			modifier = {
-				ARM = {
-					is_subject_of = SOV
-				}
+				ARM = { is_subject_of = SOV }
 				add = 50
 			}
 			modifier = {
 				ARM = {
 					is_subject = yes
-					NOT = {
-						is_subject_of = SOV
-					}
+					NOT = { is_subject_of = SOV }
 				}
 				add = -90
 			}
 		}
-		SOV = {
-			country_event = russia_governorate.21
-		}
+		SOV = { country_event = russia_governorate.21 }
 		if = {
-			limit = {
-				NKR = { is_subject_of = ARM }
-			}
+			limit = { NKR = { is_subject_of = ARM } }
 			ARM = { country_event = russia_governorate.24 }
 		}
 		ARM = {
@@ -2876,11 +2682,7 @@ country_event = {
 	option = {
 		name = russia_governorate.20.o3
 		log = "[GetDateText]: [This.GetName]: russia_governorate.20.o3 executed"
-		trigger = {
-			NOT = {
-				has_autonomy_state = autonomy_union_state
-			}
-		}
+		trigger = { NOT = { has_autonomy_state = autonomy_union_state } }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2894,9 +2696,7 @@ country_event = {
 			modifier = {
 				ARM = {
 					is_subject = yes
-					NOT = {
-						is_subject_of = SOV
-					}
+					NOT = { is_subject_of = SOV }
 				}
 				add = -90
 			}
@@ -2945,11 +2745,7 @@ country_event = {
 		}
 		if = {
 			limit = { ARM = { NOT = { is_subject_of = SOV } } }
-			ARM = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			ARM = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = ARM }
 				set_temp_variable = { wargoal_type = 2 }
@@ -2975,13 +2771,9 @@ country_event = {
 	option = {
 		name = russia_governorate.23.o1
 		log = "[GetDateText]: [This.GetName]: russia_governorate.23.o1 executed"
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 		if = {
-			limit = {
-				NKR = { is_subject_of = ARM }
-			}
+			limit = { NKR = { is_subject_of = ARM } }
 			ARM = { country_event = russia_governorate.24 }
 		}
 		ARM = { set_country_flag = USR_armenia_create_union_state }
@@ -3009,16 +2801,10 @@ country_event = {
 	option = {
 		name = russia_governorate.23.o2
 		log = "[GetDateText]: [This.GetName]: russia_governorate.23.o2 executed"
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		if = {
 			limit = { ARM = { NOT = { is_subject_of = SOV } } }
-			ARM = {
-				every_controlled_state = {
-					add_core_of = SOV
-				}
-			}
+			ARM = { every_controlled_state = { add_core_of = SOV } }
 			SOV = {
 				set_temp_variable = { wargoal_on = ARM }
 				set_temp_variable = { wargoal_type = 2 }
@@ -3063,9 +2849,7 @@ country_event = {
 			end_wars = no
 			end_civil_wars = no
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -3079,9 +2863,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = russia_news.10000.a
-	}
+	option = { name = russia_news.10000.a }
 }
 
 #The Rise of a New Union
@@ -3117,9 +2899,7 @@ news_event = {
 
 	option = {
 		name = russia_news.5.o4
-		trigger = {
-			has_war_with = SOV
-		}
+		trigger = { has_war_with = SOV }
 	}
 }
 
@@ -3157,9 +2937,7 @@ news_event = {
 
 	option = {
 		name = russia_news.6.o4
-		trigger = {
-			has_war_with = SOV
-		}
+		trigger = { has_war_with = SOV }
 	}
 }
 
@@ -3197,9 +2975,7 @@ news_event = {
 
 	option = {
 		name = russia_news.7.o4
-		trigger = {
-			has_war_with = SOV
-		}
+		trigger = { has_war_with = SOV }
 	}
 }
 
@@ -3215,9 +2991,7 @@ news_event = {
 
 	option = {
 		name = russia_news.8.o1
-		trigger = {
-			NOT = { original_tag = SOV }
-		}
+		trigger = { NOT = { original_tag = SOV } }
 	}
 
 	option = {
@@ -3265,9 +3039,7 @@ news_event = {
 
 	option = {
 		name = russia_news.10.o1
-		trigger = {
-			NOT = { original_tag = SOV }
-		}
+		trigger = { NOT = { original_tag = SOV } }
 	}
 
 	option = {
@@ -3308,9 +3080,7 @@ news_event = {
 
 	option = {
 		name = russia_news.11.o3
-		trigger = {
-			has_idea = NATO_member
-		}
+		trigger = { has_idea = NATO_member }
 	}
 
 	option = {
@@ -3356,9 +3126,7 @@ news_event = {
 
 	option = {
 		name = russia_news.13.o3
-		trigger = {
-			has_idea = NATO_member
-		}
+		trigger = { has_idea = NATO_member }
 	}
 
 	option = {
@@ -3414,9 +3182,7 @@ news_event = {
 
 	option = {
 		name = russia_news.50.o4
-		trigger = {
-			has_war_with = SOV
-		}
+		trigger = { has_war_with = SOV }
 	}
 }
 
@@ -3438,9 +3204,7 @@ news_event = {
 
 	option = {
 		name = russia_news.51.o2
-		trigger = {
-			NOT = { original_tag = SOV }
-		}
+		trigger = { NOT = { original_tag = SOV } }
 	}
 }
 
@@ -3627,9 +3391,7 @@ country_event = {
 
 	trigger = { tag = SOV }
 
-	option = {
-		name = rusboloto.3.a
-	}
+	option = { name = rusboloto.3.a }
 }
 
 country_event = {
@@ -3641,9 +3403,7 @@ country_event = {
 
 	trigger = { tag = SOV }
 
-	option = {
-		name = sov_other.2.a
-	}
+	option = { name = sov_other.2.a }
 }
 
 country_event = {
@@ -3655,9 +3415,7 @@ country_event = {
 
 	trigger = { tag = SOV }
 
-	option = {
-		name = sov_other.6.a
-	}
+	option = { name = sov_other.6.a }
 }
 
 country_event = {
@@ -3676,20 +3434,14 @@ country_event = {
 
 	option = {
 		name = sov_other.9.a
-		trigger = {
-			tag = UKR
-		}
+		trigger = { tag = UKR }
 		log = "[GetDateText]: [This.GetName]: sov_other.9.a executed"
-		UKR = {
-			add_stability = 0.05
-		}
+		UKR = { add_stability = 0.05 }
 	}
 
 	option = {
 		name = sov_other.9.b
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: sov_other.9.b executed"
 		UKR = {
 			add_opinion_modifier = { target = SOV modifier = has_expressed_loyalty }
@@ -3711,13 +3463,9 @@ country_event = {
 
 	option = {
 		name = sov_other.10.a
-		trigger = {
-			tag = UKR
-		}
+		trigger = { tag = UKR }
 		log = "[GetDateText]: [This.GetName]: sov_other.10.a executed"
-		UKR = {
-			decrease_corruption = yes
-		}
+		UKR = { decrease_corruption = yes }
 	}
 }
 country_event = {
@@ -3727,9 +3475,7 @@ country_event = {
 	picture = GFX_russian_us_troops_together_training_two
 	is_triggered_only = yes
 
-	option = {
-		name = sov_other.12.a
-	}
+	option = { name = sov_other.12.a }
 }
 country_event = {
 	id = sov_other.13
@@ -3742,28 +3488,16 @@ country_event = {
 
 	option = {
 		name = sov_other.13.a
-		trigger = {
-			tag = UKR
-		}
+		trigger = { tag = UKR }
 		log = "[GetDateText]: [This.GetName]: sov_other.13.a executed"
-		hidden_effect = {
-			SOV = {
-				country_event = sov_other.14
-			}
-		}
+		hidden_effect = { SOV = { country_event = sov_other.14 } }
 	}
 
 	option = {
 		name = sov_other.13.b
-		trigger = {
-			tag = UKR
-		}
+		trigger = { tag = UKR }
 		log = "[GetDateText]: [This.GetName]: sov_other.13.b executed"
-		hidden_effect = {
-			SOV = {
-				country_event = sov_other.15
-			}
-		}
+		hidden_effect = { SOV = { country_event = sov_other.15 } }
 	}
 }
 country_event = {
@@ -3777,9 +3511,7 @@ country_event = {
 
 	option = {
 		name = sov_other.14.a
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: sov_other.14.a executed"
 		hidden_effect = {
 			if = {
@@ -3833,9 +3565,7 @@ country_event = {
 
 	option = {
 		name = sov_other.15.a
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: sov_other.15.a executed"
 		set_temp_variable = { percent_change = -5 }
 		set_temp_variable = { influence_target = UKR }
@@ -3885,9 +3615,7 @@ country_event = {
 	picture = GFX_nat_befriend_armenia
 	is_triggered_only = yes
 
-	option = {
-		name = sov_other.17.a
-	}
+	option = { name = sov_other.17.a }
 }
 #Artsakh peacekeeping
 country_event = {
@@ -3918,9 +3646,7 @@ country_event = {
 			set_state_owner = 1037
 			set_state_owner = 1036
 		}
-		SOV = {
-			give_guarantee = NKR
-		}
+		SOV = { give_guarantee = NKR }
 	}
 
 	option = {
@@ -3965,9 +3691,7 @@ country_event = {
 			}
 		}
 		log = "[GetDateText]: [This.GetName]: sov_other.20.a executed"
-		SOV = {
-			country_event = sov_other.21
-		}
+		SOV = { country_event = sov_other.21 }
 	}
 
 	option = {
@@ -3980,9 +3704,7 @@ country_event = {
 			}
 		}
 		log = "[GetDateText]: [This.GetName]: sov_other.20.b executed"
-		AZE = {
-			country_event = sov_other.19
-		}
+		AZE = { country_event = sov_other.19 }
 	}
 }
 country_event = {
@@ -4000,9 +3722,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = sov_other.21.a
-	}
+	option = { name = sov_other.21.a }
 }
 #DPK agree or not agree?
 country_event = {
@@ -4024,18 +3744,14 @@ country_event = {
 		modify_treasury_effect = yes
 		BLR = { country_event = sov_other.25 }
 		SOV = { country_event = sov_other.23 }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = sov_other.22.b
 		log = "[GetDateText]: [This.GetName]: sov_other.22.b executed"
 		SOV = { country_event = sov_other.24 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #DPK agree
@@ -4163,9 +3879,7 @@ country_event = {
 	picture = GFX_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = sov_other.33.a
-	}
+	option = { name = sov_other.33.a }
 }
 #They leave Us
 country_event = {
@@ -4175,9 +3889,7 @@ country_event = {
 	picture = GFX_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = sov_other.34.a
-	}
+	option = { name = sov_other.34.a }
 }
 #KOBA
 country_event = {
@@ -4194,9 +3906,7 @@ country_event = {
 		hidden_effect = {
 			country_event = { id = sov_other.36 days = 100 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -4206,9 +3916,7 @@ country_event = {
 			set_country_flag = SOV_did_not_allow_duma_to_speak
 			mark_focus_tree_layout_dirty = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #KOBA
@@ -4339,9 +4047,7 @@ country_event = {
 			idea = SOV_harsh_raskulachivanie_idea
 			days = 180
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4353,9 +4059,7 @@ country_event = {
 			idea = SOV_moderate_raskulachivanie_idea
 			days = 180
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4367,9 +4071,7 @@ country_event = {
 			idea = SOV_moderate_raskulachivanie_idea
 			days = 180
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4389,9 +4091,7 @@ country_event = {
 		add_war_support = 0.03
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_revived_politburo_modifier }
 		add_to_variable = { SOV_revived_politburo_nationalist_support = 0.03 tooltip = nationalist_drift_tt }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4401,9 +4101,7 @@ country_event = {
 		add_stability = 0.02
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_revived_politburo_modifier }
 		add_to_variable = { SOV_revived_politburo_communism_support = 0.03 tooltip = communism_drift_tt }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4422,9 +4120,7 @@ country_event = {
 		add_political_power = 75
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_revived_politburo_modifier }
 		add_to_variable = { SOV_revived_politburo_democratic_support = 0.03 tooltip = democratic_drift_tt }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4434,9 +4130,7 @@ country_event = {
 		add_stability = 0.02
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_revived_politburo_modifier }
 		add_to_variable = { SOV_revived_politburo_communism_support = 0.03 tooltip = communism_drift_tt }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4455,9 +4149,7 @@ country_event = {
 		add_stability = 0.03
 		add_war_support = 0.02
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_revived_politburo_modifier }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4466,9 +4158,7 @@ country_event = {
 		add_stability = 0.05
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SOV_revived_politburo_modifier }
 		add_to_variable = { SOV_revived_politburo_communism_support = 0.07 tooltip = communism_drift_tt }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4514,9 +4204,7 @@ country_event = {
 			name = SOV_Gorky
 		}
 		hidden_effect = { 660 = { set_state_name = SOV_Gorky } }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4557,9 +4245,7 @@ country_event = {
 			name = SOV_Stalinsk
 		}
 		hidden_effect = { 1066 = { set_state_name = SOV_Stalinsk } }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4589,9 +4275,7 @@ country_event = {
 				id = sov_nationalists_news.2
 			}
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4612,9 +4296,7 @@ country_event = {
 				id = sov_nationalists_news.2
 			}
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4651,9 +4333,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				ROOT = {
-					is_subject_of = SOV
-				}
+				ROOT = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -4710,9 +4390,7 @@ country_event = {
 			country = SOV
 			relation = military_access
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -4721,9 +4399,7 @@ country_event = {
 		SOV = {
 			country_event = { id = sov_nationalists.10 days = 1 }
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -4809,9 +4485,7 @@ country_event = {
 		name = sov_nationalists.12.a
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.12.a"
 		if = {
-			limit = {
-				is_in_faction = yes
-			}
+			limit = { is_in_faction = yes }
 			leave_faction = yes
 		}
 		SOV = {
@@ -4835,9 +4509,7 @@ country_event = {
 			add_opinion_modifier = { target = ROOT modifier = major_breach_of_trust }
 		}
 		if = {
-			limit = {
-				original_tag = ARM
-			}
+			limit = { original_tag = ARM }
 			add_war_support = 0.05
 			AZE = { country_event = sov_other.17 }
 			ARM = {
@@ -4858,9 +4530,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.12.b
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.12.b"
-		SOV = {
-			country_event = sov_nationalists.13
-		}
+		SOV = { country_event = sov_nationalists.13 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -4885,9 +4555,7 @@ country_event = {
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.13.a
-	}
+	option = { name = sov_nationalists.13.a }
 }
 country_event = {
 	id = sov_nationalists.14
@@ -4927,9 +4595,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.15.b
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.15.b"
-		SOV = {
-			country_event = sov_nationalists.17
-		}
+		SOV = { country_event = sov_nationalists.17 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4954,9 +4620,7 @@ country_event = {
 	picture = GFX_union_state
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.17.a
-	}
+	option = { name = sov_nationalists.17.a }
 }
 
 #Jirik Crusade
@@ -5077,9 +4741,7 @@ country_event = {
 
 	trigger = { tag = SOV }
 
-	option = {
-		name = sov_nationalists.20.a
-	}
+	option = { name = sov_nationalists.20.a }
 }
 
 country_event = {
@@ -5150,9 +4812,7 @@ country_event = {
 			name = SOV_Nizhny_Novgorod
 		}
 		hidden_effect = { 660 = { set_state_name = SOV_Nizhny_Novgorod } }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -5213,9 +4873,7 @@ country_event = {
 			name = SOV_Novokuznetsk
 		}
 		hidden_effect = { 1066 = { set_state_name = SOV_Novokuznetsk } }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 ##Annex Transnistria
@@ -5248,9 +4906,7 @@ country_event = {
 				set_temp_variable = { modify_subjectnalogs = 0.5 }
 				modify_subjectnalogs_support = yes
 			}
-			PMR = {
-				PMR_russian_join_script = yes
-			}
+			PMR = { PMR_russian_join_script = yes }
 			SUB_separatism_minus_subject = yes
 			hidden_effect = {
 				news_event = {
@@ -5259,16 +4915,12 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = sov_nationalists.22.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 ##Annex Manchuria
@@ -5345,15 +4997,11 @@ country_event = {
 country_event = {
 	id = sov_nationalists.24
 	title = {
-		trigger = {
-			SOV = { has_country_flag = CHI_accepts_annexation }
-		}
+		trigger = { SOV = { has_country_flag = CHI_accepts_annexation } }
 		text = sov_nationalists.24.t
 	}
 	desc = {
-		trigger = {
-			SOV = { has_country_flag = CHI_accepts_annexation }
-		}
+		trigger = { SOV = { has_country_flag = CHI_accepts_annexation } }
 		text = sov_nationalists.24.d
 	}
 	picture = GFX_SOV_generic
@@ -5376,9 +5024,7 @@ country_event = {
 country_event = {
 	id = sov_nationalists.25
 	title = {
-		trigger = {
-			has_country_flag = CHI_refused_annexation
-		}
+		trigger = { has_country_flag = CHI_refused_annexation }
 		text = sov_nationalists.25.t
 	}
 	desc = sov_nationalists.25.d
@@ -5413,9 +5059,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.27.a
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.27.a executed"
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 		if = {
 			limit = { ROOT = { is_subject_of = SOV } }
 			annex_country = { target = ROOT transfer_troops = yes }
@@ -5438,9 +5082,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.27.b
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.27.b executed"
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 		SOV = {
 			set_temp_variable = { wargoal_on = ROOT }
 			set_temp_variable = { wargoal_type = 2 }
@@ -5463,14 +5105,8 @@ country_event = {
 	option = {
 		name = sov_nationalists.28.a
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.28.a executed"
-		ai_chance = {
-			base = 100
-		}
-		ROOT = {
-			every_owned_state = {
-				add_core_of = SOV
-			}
-		}
+		ai_chance = { base = 100 }
+		ROOT = { every_owned_state = { add_core_of = SOV } }
 		SOV = {
 			country_event = sov_nationalists.51
 			add_to_variable = { treasury = ROOT.treasury }
@@ -5483,9 +5119,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.28.b
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.28.b executed"
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		SOV = {
 			set_temp_variable = { wargoal_on = ROOT }
 			add_threat_from_wargoal_effect = yes
@@ -5504,9 +5138,7 @@ country_event = {
 	picture = GFX_jirik_zyuga
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.29.a
-	}
+	option = { name = sov_nationalists.29.a }
 }
 country_event = {
 	id = sov_nationalists.30
@@ -5714,9 +5346,7 @@ country_event = {
 					OR = {
 						UKR = { owns_state = 669 }
 						UKR = { owns_state = 1112 }
-						CRM = {
-							is_subject_of = SOV
-						}
+						CRM = { is_subject_of = SOV }
 					}
 				}
 				jirik_ukraine_crimea = yes
@@ -5774,9 +5404,7 @@ country_event = {
 		name = sov_nationalists.37.a
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.37.a executed"
 		custom_effect_tooltip = jirik_kazaks_rebellion_tt
-		hidden_effect = {
-			jirik_kazak_kazah = yes
-		}
+		hidden_effect = { jirik_kazak_kazah = yes }
 	}
 }
 
@@ -5900,9 +5528,7 @@ country_event = {
 				factor = 90
 			}
 			modifier = {
-				ROOT = {
-					is_subject_of = SOV
-				}
+				ROOT = { is_subject_of = SOV }
 				factor = 90
 			}
 		}
@@ -6057,18 +5683,14 @@ country_event = {
 			producer = SOV
 		}
 		SOV = { country_event = sov_nationalists.45 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
 		name = sov_nationalists.44.o2
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.44.o2 executed"
 		SOV = { country_event = sov_nationalists.48 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #They Agree Weapon
@@ -6121,9 +5743,7 @@ country_event = {
 	picture = GFX_sov_empire_new_russian_army
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.48.o1
-	}
+	option = { name = sov_nationalists.48.o1 }
 }
 #Russian Empire Give Base
 country_event = {
@@ -6141,32 +5761,24 @@ country_event = {
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
 		if = {
-			limit = {
-				tag = IRQ
-			}
+			limit = { tag = IRQ }
 			add_ideas = SOV_IRQ_base
 			give_military_access = SOV
 		}
 		if = {
-			limit = {
-				tag = LBA
-			}
+			limit = { tag = LBA }
 			add_ideas = SOV_LBA_base
 			give_military_access = SOV
 		}
 		SOV = { country_event = sov_nationalists.47 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
 		name = sov_nationalists.49.o2
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.49.o2 executed"
 		SOV = { country_event = sov_nationalists.48 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6178,9 +5790,7 @@ country_event = {
 	picture = GFX_sov_empire_herb
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.50.o1
-	}
+	option = { name = sov_nationalists.50.o1 }
 }
 
 #Russian Empire Annex Another country
@@ -6191,9 +5801,7 @@ country_event = {
 	picture = GFX_sov_empire_herb
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.51.o1
-	}
+	option = { name = sov_nationalists.51.o1 }
 }
 
 #Russian Empire Start Revoult in Our Country
@@ -6204,9 +5812,7 @@ country_event = {
 	picture = GFX_sov_empire_herb
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nationalists.52.o1
-	}
+	option = { name = sov_nationalists.52.o1 }
 }
 
 #Russian Empire Start Special Operation on Azerbaijan
@@ -6220,9 +5826,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.53.o1
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.53.o1 executed"
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		declare_war_on = {
 			target = AZE
 			type = annex_everything
@@ -6231,9 +5835,7 @@ country_event = {
 
 	option = {
 		name = sov_nationalists.53.o2
-		trigger = {
-			tag = AZE
-		}
+		trigger = { tag = AZE }
 	}
 }
 
@@ -6305,9 +5907,7 @@ country_event = {
 	option = {
 		name = sov_nationalists.57.o1
 		log = "[GetDateText]: [This.GetName]: sov_nationalists.57.o1 executed"
-		SOV = {
-			934 = { add_core_of = SOV }
-		}
+		SOV = { 934 = { add_core_of = SOV } }
 		add_political_power = -100
 		add_popularity = {
 			ideology = nationalist
@@ -6324,9 +5924,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.1.a
-	}
+	option = { name = sov_nationalists_news.1.a }
 }
 
 news_event = {
@@ -6337,9 +5935,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.2.a
-	}
+	option = { name = sov_nationalists_news.2.a }
 }
 news_event = {
 	id = sov_nationalists_news.3
@@ -6349,9 +5945,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.3.a
-	}
+	option = { name = sov_nationalists_news.3.a }
 }
 news_event = {
 	id = sov_nationalists_news.4
@@ -6361,9 +5955,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.4.a
-	}
+	option = { name = sov_nationalists_news.4.a }
 }
 news_event = {
 	id = sov_nationalists_news.5
@@ -6373,9 +5965,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.5.a
-	}
+	option = { name = sov_nationalists_news.5.a }
 }
 news_event = {
 	id = sov_nationalists_news.6
@@ -6385,9 +5975,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.6.a
-	}
+	option = { name = sov_nationalists_news.6.a }
 }
 news_event = {
 	id = sov_nationalists_news.7
@@ -6397,9 +5985,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.7.a
-	}
+	option = { name = sov_nationalists_news.7.a }
 }
 news_event = {
 	id = sov_nationalists_news.8
@@ -6409,9 +5995,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.8.a
-	}
+	option = { name = sov_nationalists_news.8.a }
 }
 news_event = {
 	id = sov_nationalists_news.9
@@ -6421,9 +6005,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.9.a
-	}
+	option = { name = sov_nationalists_news.9.a }
 }
 news_event = {
 	id = sov_nationalists_news.10
@@ -6433,9 +6015,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.10.a
-	}
+	option = { name = sov_nationalists_news.10.a }
 }
 news_event = {
 	id = sov_nationalists_news.11
@@ -6445,9 +6025,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.11.a
-	}
+	option = { name = sov_nationalists_news.11.a }
 }
 news_event = {
 	id = sov_nationalists_news.12
@@ -6457,9 +6035,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.12.a
-	}
+	option = { name = sov_nationalists_news.12.a }
 }
 news_event = {
 	id = sov_nationalists_news.13
@@ -6469,9 +6045,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.13.a
-	}
+	option = { name = sov_nationalists_news.13.a }
 }
 news_event = {
 	id = sov_nationalists_news.14
@@ -6481,9 +6055,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.14.a
-	}
+	option = { name = sov_nationalists_news.14.a }
 }
 news_event = {
 	id = sov_nationalists_news.15
@@ -6493,9 +6065,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.15.a
-	}
+	option = { name = sov_nationalists_news.15.a }
 }
 news_event = {
 	id = sov_nationalists_news.16
@@ -6505,9 +6075,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.16.a
-	}
+	option = { name = sov_nationalists_news.16.a }
 }
 news_event = {
 	id = sov_nationalists_news.17
@@ -6517,9 +6085,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.17.a
-	}
+	option = { name = sov_nationalists_news.17.a }
 }
 news_event = {
 	id = sov_nationalists_news.18
@@ -6529,9 +6095,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.18.a
-	}
+	option = { name = sov_nationalists_news.18.a }
 }
 news_event = {
 	id = sov_nationalists_news.19
@@ -6541,9 +6105,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.19.a
-	}
+	option = { name = sov_nationalists_news.19.a }
 }
 news_event = {
 	id = sov_nationalists_news.20
@@ -6553,9 +6115,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.20.a
-	}
+	option = { name = sov_nationalists_news.20.a }
 }
 news_event = {
 	id = sov_nationalists_news.21
@@ -6565,9 +6125,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.21.a
-	}
+	option = { name = sov_nationalists_news.21.a }
 }
 news_event = {
 	id = sov_nationalists_news.22
@@ -6577,9 +6135,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.22.a
-	}
+	option = { name = sov_nationalists_news.22.a }
 }
 news_event = {
 	id = sov_nationalists_news.23
@@ -6589,9 +6145,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.23.a
-	}
+	option = { name = sov_nationalists_news.23.a }
 }
 news_event = {
 	id = sov_nationalists_news.24
@@ -6601,9 +6155,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.24.a
-	}
+	option = { name = sov_nationalists_news.24.a }
 }
 news_event = {
 	id = sov_nationalists_news.25
@@ -6613,9 +6165,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.25.a
-	}
+	option = { name = sov_nationalists_news.25.a }
 }
 news_event = {
 	id = sov_nationalists_news.26
@@ -6625,9 +6175,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.26.a
-	}
+	option = { name = sov_nationalists_news.26.a }
 }
 news_event = {
 	id = sov_nationalists_news.27
@@ -6637,9 +6185,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.27.a
-	}
+	option = { name = sov_nationalists_news.27.a }
 }
 news_event = {
 	id = sov_nationalists_news.28
@@ -6649,9 +6195,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.28.a
-	}
+	option = { name = sov_nationalists_news.28.a }
 }
 news_event = {
 	id = sov_nationalists_news.29
@@ -6661,9 +6205,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_nationalists_news.29.a
-	}
+	option = { name = sov_nationalists_news.29.a }
 }
 ### Operation in Ukraine Events
 ##Operation Declared
@@ -6755,9 +6297,7 @@ country_event = {
 			}
 			decrease_economic_growth = yes
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 ##Fast Operation Failed
@@ -6779,9 +6319,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		change_relative_party_popularity = yes
 		add_timed_idea = { idea = SOV_slow_advance_idea days = 720 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -6803,9 +6341,7 @@ country_event = {
 		set_temp_variable = { party_index = 6 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -6843,9 +6379,7 @@ country_event = {
 				modifier = major_breach_of_trust
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 ##Sanctions Imposed on Russia!
@@ -6858,9 +6392,7 @@ country_event = {
 
 	option = {
 		name = sov_final_strike.5.a
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 ##Belarus go to war?
@@ -6874,9 +6406,7 @@ country_event = {
 	option = {
 		name = sov_final_strike.6.a
 		log = "[GetDateText]: [This.GetName]: sov_final_strike.6.a"
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 		set_temp_variable = { wargoal_on = UKR }
 		add_threat_from_wargoal_effect = yes
 		create_wargoal = {
@@ -6887,9 +6417,7 @@ country_event = {
 
 	option = {
 		name = sov_final_strike.6.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -6907,9 +6435,7 @@ country_event = {
 		add_ideas = { SOV_ruble_collapse }
 		set_temp_variable = { treasury_change = -50 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 ##Operation Declared in Finland
@@ -6990,9 +6516,7 @@ country_event = {
 			}
 			decrease_economic_growth = yes
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 ##Impose sanctions on Russia
@@ -7029,9 +6553,7 @@ country_event = {
 				modifier = major_breach_of_trust
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7047,9 +6569,7 @@ news_event = {
 
 	option = {
 		name = Sov_warsaw_pact.1.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7062,9 +6582,7 @@ country_event = {
 
 	option = {
 		name = Sov_warsaw_pact.3.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7077,9 +6595,7 @@ news_event = {
 
 	option = {
 		name = Sov_warsaw_pact.4.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7092,9 +6608,7 @@ country_event = {
 
 	option = {
 		name = Sov_warsaw_pact.5.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7108,9 +6622,7 @@ country_event = {
 	option = {
 		name = Sov_warsaw_pact.6.a
 		log = "[GetDateText]: [This.GetName]: Sov_warsaw_pact.6.a"
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 		SOV = { add_to_faction = POL }
 	}
 }
@@ -7125,14 +6637,8 @@ country_event = {
 	option = {
 		name = Sov_warsaw_pact.7.a
 		log = "[GetDateText]: [This.GetName]: Sov_warsaw_pact.7.a"
-		ai_chance = {
-			base = 100
-		}
-		SLO = {
-			every_owned_state = {
-				add_core_of = CZE
-			}
-		}
+		ai_chance = { base = 100 }
+		SLO = { every_owned_state = { add_core_of = CZE } }
 		CZE = {
 			annex_country = { target = SLO transfer_troops = yes }
 			set_cosmetic_tag = CZR_union
@@ -7185,13 +6691,9 @@ country_event = {
 				set_temp_variable = { rul_party_temp = 4 }
 				change_ruling_party_effect = yes
 			}
-			GER = {
-				set_capital = { state = 966 }
-			}
+			GER = { set_capital = { state = 966 } }
 			every_country = {
-				limit = {
-					has_country_flag = GDR_test
-				}
+				limit = { has_country_flag = GDR_test }
 				add_named_threat = {
 					name = birth_of_eastern_germany_world_tension
 					threat = 16
@@ -7210,9 +6712,7 @@ news_event = {
 
 	option = {
 		name = Sov_warsaw_pact.13.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7227,24 +6727,18 @@ country_event = {
 		name = Sov_warsaw_pact.15.a
 		log = "[GetDateText]: [This.GetName]: Sov_warsaw_pact.15.a"
 		leave_faction = yes
-		SOV = {
-			end_puppet = ROOT
-		}
+		SOV = { end_puppet = ROOT }
 		set_country_flag = WP_escaped
 		remove_ideas = faction_warsaw_pact_idea
 		remove_ideas = SOV_warsaw_pact_joint_exercises_idea
 		remove_ideas = SOV_warsaw_pact_exercises_south_idea1
 		remove_ideas = SOV_warsaw_pact_exercises_north_idea
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 
 	option = {
 		name = Sov_warsaw_pact.15.b
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 
@@ -7269,26 +6763,20 @@ country_event = {
 				target = GER
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = Sov_warsaw_pact.17.b
 		log = "[GetDateText]: [This.GetName]: Sov_warsaw_pact.17.b"
 		every_country = {
-			limit = {
-				has_country_flag = GDR_test
-			}
+			limit = { has_country_flag = GDR_test }
 			country_event = sov_warsaw_pact.18
 		}
 		add_political_power = -300
 		add_stability = -0.04
 		add_war_support = -0.07
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -7306,16 +6794,12 @@ country_event = {
 		add_stability = -0.02
 		add_war_support = -0.01
 		leave_faction = yes
-		SOV = {
-			end_puppet = ROOT
-		}
+		SOV = { end_puppet = ROOT }
 		remove_ideas = faction_warsaw_pact_idea
 		remove_ideas = SOV_warsaw_pact_joint_exercises_idea
 		remove_ideas = SOV_warsaw_pact_exercises_south_idea1
 		remove_ideas = SOV_warsaw_pact_exercises_north_idea
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7329,9 +6813,7 @@ news_event = {
 
 	option = {
 		name = Sov_warsaw_pact.19.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -7527,9 +7009,7 @@ country_event = {
 			end_civil_wars = no
 		}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7544,9 +7024,7 @@ country_event = {
 	timeout_days = 1
 	option = {
 		name = sov_sover_state.14.a
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -7561,9 +7039,7 @@ country_event = {
 	timeout_days = 1
 	option = {
 		name = sov_sover_state.15.a
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -7579,9 +7055,7 @@ country_event = {
 		name = sov_medvedev.1.a
 		log = "[GetDateText]: [This.GetName]: sov_medvedev.1.a"
 		add_stability = -0.15
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -7599,20 +7073,14 @@ country_event = {
 			country = SOV
 			relation = non_aggression_pact
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = sov_medvedev.4.b
 		log = "[GetDateText]: [This.GetName]: sov_medvedev.4.b"
-		SOV = {
-			country_event = sov_medvedev.5
-		}
-		ai_chance = {
-			base = 20
-		}
+		SOV = { country_event = sov_medvedev.5 }
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -7634,9 +7102,7 @@ country_event = {
 			ideology = democratic
 			popularity = -0.05
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -7656,9 +7122,7 @@ country_event = {
 			expire = "2050.1.1"
 			ideology = Conservative
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -7677,9 +7141,7 @@ country_event = {
 			expire = "2050.1.1"
 			ideology = Conservative
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -7707,9 +7169,7 @@ country_event = {
 			picture = "Dimitry_Medvedev.dds"
 			ideology = Western_Autocracy
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -7771,9 +7231,7 @@ country_event = {
 			limit = { has_idea = SOV_private_media_nationalisation_idea }
 			remove_ideas = SOV_private_media_nationalisation_idea
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -7790,9 +7248,7 @@ country_event = {
 		add_stability = 0.02
 		set_temp_variable = { treasury_change = 5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -8059,9 +7515,7 @@ country_event = {
 			base = 10
 			modifier = {
 				factor = 0
-				SOV = {
-					has_added_tension_amount > 10
-				}
+				SOV = { has_added_tension_amount > 10 }
 			}
 			modifier = {
 				add = 10
@@ -8078,9 +7532,7 @@ country_event = {
 			base = 10
 			modifier = {
 				factor = 0
-				SOV = {
-					has_added_tension_amount > 10
-				}
+				SOV = { has_added_tension_amount > 10 }
 			}
 			modifier = {
 				add = 10
@@ -8146,9 +7598,7 @@ country_event = {
 		name = sov_dissolution.5.a
 		log = "[GetDateText]: [This.GetName]: sov_dissolution.5.a executed"
 		every_owned_state = {
-			limit = {
-				industrial_complex > 0
-			}
+			limit = { industrial_complex > 0 }
 			random_select_amount = 3
 			remove_building = {
 				type = industrial_complex
@@ -8335,9 +7785,7 @@ country_event = {
 	picture = GFX_astronauts
 	is_triggered_only = yes
 
-	option = {
-		name = russia.300.a
-	}
+	option = { name = russia.300.a }
 }
 
 country_event = {
@@ -8410,9 +7858,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = russia.3022.a
-	}
+	option = { name = russia.3022.a }
 }
 
 country_event = {
@@ -8442,9 +7888,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = russia.3033.a
-	}
+	option = { name = russia.3033.a }
 }
 
 country_event = {
@@ -8475,9 +7919,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = russia.3044.a
-	}
+	option = { name = russia.3044.a }
 }
 country_event = {
 	id = sov_economic.1
@@ -8498,9 +7940,7 @@ country_event = {
 		change_oligarchs_opinion = yes
 		set_temp_variable = { temp_opinion = -10 }
 		change_fossil_fuel_industry_opinion = yes
-		SOV = {
-			set_country_flag = SOV_khodorkovsky_found_guilty
-		}
+		SOV = { set_country_flag = SOV_khodorkovsky_found_guilty }
 		add_to_variable = { SOV_statist_verdicts = 1 }
 		custom_effect_tooltip = SOV_verdict_scorecard_TT
 		ai_chance = {
@@ -8806,9 +8246,7 @@ country_event = {
 				target = SOV
 			}
 		}
-		hidden_effect = {
-			SOV = { add_ideas = SOV_nord_stream_sov_idea }
-		}
+		hidden_effect = { SOV = { add_ideas = SOV_nord_stream_sov_idea } }
 		USA = {
 			add_opinion_modifier = {
 				target = GER
@@ -8820,9 +8258,7 @@ country_event = {
 			}
 		}
 		SOV = { country_event = sov_economic.8 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -8838,9 +8274,7 @@ country_event = {
 			set_country_flag = SOV_nord_stream_refused
 			country_event = sov_economic.9
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 country_event = {
@@ -8863,11 +8297,9 @@ country_event = {
 	desc = sov_economic.9.d
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
-	minor_flavor = yes
 
-	option = {
-		name = sov_economic.9.a
-	}
+	minor_flavor = yes
+	option = { name = sov_economic.9.a }
 }
 country_event = {
 	id = sov_economic.10
@@ -8886,17 +8318,13 @@ country_event = {
 			add_opinion_modifier = { modifier = economic_mission target = TUR }
 			reverse_add_opinion_modifier = { modifier = economic_mission target = TUR }
 		}
-		hidden_effect = {
-			SOV = { add_ideas = SOV_blue_stream_sov_idea }
-		}
+		hidden_effect = { SOV = { add_ideas = SOV_blue_stream_sov_idea } }
 		USA = {
 			add_opinion_modifier = { target = TUR modifier = recent_actions_negative }
 			add_opinion_modifier = { target = SOV modifier = recent_actions_negative }
 		}
 		SOV = { country_event = sov_economic.8 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -8912,9 +8340,7 @@ country_event = {
 			set_country_flag = SOV_blue_stream_refused
 			country_event = sov_economic.9
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 country_event = {
@@ -8942,9 +8368,7 @@ country_event = {
 				target = SOV
 			}
 		}
-		hidden_effect = {
-			SOV = { add_ideas = SOV_turkey_stream_sov_idea }
-		}
+		hidden_effect = { SOV = { add_ideas = SOV_turkey_stream_sov_idea } }
 		USA = {
 			add_opinion_modifier = {
 				target = TUR
@@ -8956,9 +8380,7 @@ country_event = {
 			}
 		}
 		SOV = { country_event = sov_economic.8 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -8974,9 +8396,7 @@ country_event = {
 			set_country_flag = SOV_turkey_stream_refused
 			country_event = sov_economic.9
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 country_event = {
@@ -9004,9 +8424,7 @@ country_event = {
 				target = SOV
 			}
 		}
-		hidden_effect = {
-			SOV = { add_ideas = SOV_nord_stream2_sov_idea }
-		}
+		hidden_effect = { SOV = { add_ideas = SOV_nord_stream2_sov_idea } }
 		USA = {
 			add_opinion_modifier = {
 				target = GER
@@ -9018,9 +8436,7 @@ country_event = {
 			}
 		}
 		SOV = { country_event = sov_economic.8 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -9036,9 +8452,7 @@ country_event = {
 			set_country_flag = SOV_nord_stream2_refused
 			country_event = sov_economic.9
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -9060,18 +8474,14 @@ country_event = {
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
 		SOV = { country_event = sov_economic.14 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
 		name = sov_economic.13.b
 		log = "[GetDateText]: [This.GetName]: sov_economic.13.b executed"
 		SOV = { country_event = sov_economic.15 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9098,9 +8508,7 @@ country_event = {
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
 
-	option = {
-		name = sov_economic.15.a
-	}
+	option = { name = sov_economic.15.a }
 }
 #Trading mission
 country_event = {
@@ -9144,9 +8552,7 @@ country_event = {
 		SOV = {
 			country_event = { id = sov_economic.18 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -9335,54 +8741,42 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: sov_economic.25.a executed"
 		custom_effect_tooltip = SOV_sanctions_capitalization_tt
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_rosneft
-			}
+			limit = { has_completed_focus = SOV_economic_reform_rosneft }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_rosneft = -3 }
 				SOV_modify_capitalisation_rosneft_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_destiny_sber
-			}
+			limit = { has_completed_focus = SOV_economic_destiny_sber }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_sberbank = -1.5 }
 				SOV_modify_capitalisation_sberbank_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_gazprom
-			}
+			limit = { has_completed_focus = SOV_economic_reform_gazprom }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_gazprom = -3 }
 				SOV_modify_capitalisation_gazprom_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_mts
-			}
+			limit = { has_completed_focus = SOV_economic_mts }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_mts = -0.470 }
 				SOV_modify_capitalisation_mts_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_vtb
-			}
+			limit = { has_completed_focus = SOV_economic_vtb }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_vtb = -0.350 }
 				SOV_modify_capitalisation_vtb_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_alrosa
-			}
+			limit = { has_completed_focus = SOV_economic_alrosa }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_alrosa = -0.230 }
 				SOV_modify_capitalisation_alrosa_support = yes
@@ -9403,54 +8797,42 @@ country_event = {
 		name = sov_economic.26.a
 		log = "[GetDateText]: [This.GetName]: sov_economic.26.a executed"
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_rosneft
-			}
+			limit = { has_completed_focus = SOV_economic_reform_rosneft }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_rosneft = -1.5 }
 				SOV_modify_capitalisation_rosneft_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_destiny_sber
-			}
+			limit = { has_completed_focus = SOV_economic_destiny_sber }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_sberbank = -0.750 }
 				SOV_modify_capitalisation_sberbank_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_gazprom
-			}
+			limit = { has_completed_focus = SOV_economic_reform_gazprom }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_gazprom = -1.8 }
 				SOV_modify_capitalisation_gazprom_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_mts
-			}
+			limit = { has_completed_focus = SOV_economic_mts }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_mts = -0.230 }
 				SOV_modify_capitalisation_mts_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_vtb
-			}
+			limit = { has_completed_focus = SOV_economic_vtb }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_vtb = -0.350 }
 				SOV_modify_capitalisation_vtb_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_alrosa
-			}
+			limit = { has_completed_focus = SOV_economic_alrosa }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_alrosa = -0.270 }
 				SOV_modify_capitalisation_alrosa_support = yes
@@ -9600,54 +8982,42 @@ country_event = {
 		name = sov_economic.31.a
 		log = "[GetDateText]: [This.GetName]: sov_economic.31.a executed"
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_rosneft
-			}
+			limit = { has_completed_focus = SOV_economic_reform_rosneft }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_rosneft = -1.1 }
 				SOV_modify_capitalisation_rosneft_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_destiny_sber
-			}
+			limit = { has_completed_focus = SOV_economic_destiny_sber }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_sberbank = -0.450 }
 				SOV_modify_capitalisation_sberbank_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_gazprom
-			}
+			limit = { has_completed_focus = SOV_economic_reform_gazprom }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_gazprom = -1.2 }
 				SOV_modify_capitalisation_gazprom_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_mts
-			}
+			limit = { has_completed_focus = SOV_economic_mts }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_mts = -0.490 }
 				SOV_modify_capitalisation_mts_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_vtb
-			}
+			limit = { has_completed_focus = SOV_economic_vtb }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_vtb = -0.220 }
 				SOV_modify_capitalisation_vtb_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_alrosa
-			}
+			limit = { has_completed_focus = SOV_economic_alrosa }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_alrosa = -0.170 }
 				SOV_modify_capitalisation_alrosa_support = yes
@@ -9668,54 +9038,42 @@ country_event = {
 		name = sov_economic.32.a
 		log = "[GetDateText]: [This.GetName]: sov_economic.32.a executed"
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_rosneft
-			}
+			limit = { has_completed_focus = SOV_economic_reform_rosneft }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_rosneft = 0.980 }
 				SOV_modify_capitalisation_rosneft_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_destiny_sber
-			}
+			limit = { has_completed_focus = SOV_economic_destiny_sber }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_sberbank = 0.350 }
 				SOV_modify_capitalisation_sberbank_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_reform_gazprom
-			}
+			limit = { has_completed_focus = SOV_economic_reform_gazprom }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_gazprom = 1.2 }
 				SOV_modify_capitalisation_gazprom_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_mts
-			}
+			limit = { has_completed_focus = SOV_economic_mts }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_mts = 0.290 }
 				SOV_modify_capitalisation_mts_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_vtb
-			}
+			limit = { has_completed_focus = SOV_economic_vtb }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_vtb = 0.170 }
 				SOV_modify_capitalisation_vtb_support = yes
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SOV_economic_alrosa
-			}
+			limit = { has_completed_focus = SOV_economic_alrosa }
 			SOV = {
 				set_temp_variable = { SOV_modify_capitalisation_alrosa = 0.170 }
 				SOV_modify_capitalisation_alrosa_support = yes
@@ -9736,9 +9094,7 @@ country_event = {
 		name = sov_economic.33.a
 		log = "[GetDateText]: [This.GetName]: sov_economic.33.a executed"
 		custom_effect_tooltip = SOV_run_moex_tt
-		hidden_effect = {
-			clr_country_flag = SOV_stop_moex
-		}
+		hidden_effect = { clr_country_flag = SOV_stop_moex }
 	}
 }
 
@@ -9760,9 +9116,7 @@ country_event = {
 		change_influence_percentage = yes
 		set_temp_variable = { treasury_change = 5.00 }
 		modify_treasury_effect = yes
-		SOV = {
-			country_event = sov_economic.35
-		}
+		SOV = { country_event = sov_economic.35 }
 		ai_chance = { base = 90 }
 	}
 
@@ -9773,9 +9127,7 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = PMR }
 		change_influence_percentage = yes
-		SOV = {
-			country_event = sov_economic.36
-		}
+		SOV = { country_event = sov_economic.36 }
 		ai_chance = { base = 10 }
 	}
 }
@@ -9831,9 +9183,7 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = PMR }
 		change_influence_percentage = yes
-		SOV = {
-			country_event = sov_economic.38
-		}
+		SOV = { country_event = sov_economic.38 }
 		ai_chance = { base = 90 }
 	}
 
@@ -9844,9 +9194,7 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = PMR }
 		change_influence_percentage = yes
-		SOV = {
-			country_event = sov_economic.39
-		}
+		SOV = { country_event = sov_economic.39 }
 		ai_chance = { base = 10 }
 	}
 }
@@ -10059,9 +9407,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		trigger = {
-			has_country_flag = sov_zug_econ
-		}
+		trigger = { has_country_flag = sov_zug_econ }
 		name = sov_liberals.2.o1
 		log = "[GetDateText]: [This.GetName]: sov_liberals.2.o1 executed"
 		add_political_power = -100
@@ -10073,8 +9419,7 @@ country_event = {
 	}
 
 	option = {
-		trigger = { has_country_flag = sov_zir_econ
-		}
+		trigger = { has_country_flag = sov_zir_econ }
 		name = sov_liberals.2.o2
 		log = "[GetDateText]: [This.GetName]: sov_liberals.2.o2 executed"
 		add_political_power = -100
@@ -10456,9 +9801,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.12.a
-	}
+	option = { name = sov_liberals.12.a }
 }
 #CIS - Invite Decline
 country_event = {
@@ -10468,9 +9811,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.13.a
-	}
+	option = { name = sov_liberals.13.a }
 }
 
 #CIS - Unite State
@@ -10563,9 +9904,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.15.a
-	}
+	option = { name = sov_liberals.15.a }
 }
 #CIS - Unite State Decline
 country_event = {
@@ -10575,9 +9914,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.16.a
-	}
+	option = { name = sov_liberals.16.a }
 }
 
 #CIS - Unite Arms Forces
@@ -10593,18 +9930,14 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: sov_liberals.17.a"
 		SOV = { country_event = { id = sov_liberals.18 days = 1 } }
 		SUB_subjects_integrate_army_of_russia = yes
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = sov_liberals.17.b
 		log = "[GetDateText]: [This.GetName]: sov_liberals.17.b"
 		SOV = { country_event = { id = sov_liberals.19 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10616,9 +9949,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.18.a
-	}
+	option = { name = sov_liberals.18.a }
 }
 #CIS - Unite Arms Forces Decline
 country_event = {
@@ -10628,9 +9959,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.19.a
-	}
+	option = { name = sov_liberals.19.a }
 }
 
 #CIS - Leave Bad
@@ -10641,9 +9970,7 @@ country_event = {
 	picture = GFX_ukr_cis
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.21.a
-	}
+	option = { name = sov_liberals.21.a }
 }
 
 #Russia Request Invest in Kaliningrad
@@ -10689,9 +10016,7 @@ country_event = {
 		SOV = {
 			country_event = { id = sov_liberals.24 days = 1 }
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -10721,9 +10046,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = sov_liberals.24.a
-	}
+	option = { name = sov_liberals.24.a }
 }
 
 #Russia Request Invest in Kaliningrad - Finish
@@ -10740,17 +10063,11 @@ country_event = {
 		set_temp_variable = { SOV_modify_economic = 1 }
 		SOV_modify_economic_support = yes
 		if = {
-			limit = {
-				check_variable = { kaliningrad_invest < 2 }
-			}
-			642 = {
-				add_extra_state_shared_building_slots = 1
-			}
+			limit = { check_variable = { kaliningrad_invest < 2 } }
+			642 = { add_extra_state_shared_building_slots = 1 }
 		}
 		else_if = {
-			limit = {
-				check_variable = { kaliningrad_invest > 2 }
-			}
+			limit = { check_variable = { kaliningrad_invest > 2 } }
 			642 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -10806,9 +10123,7 @@ country_event = {
 		set_temp_variable = { SOV_modify_economic = 1 }
 		SOV_modify_economic_support = yes
 		if = {
-			limit = {
-				owns_state = 691
-			}
+			limit = { owns_state = 691 }
 			691 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -10821,9 +10136,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				owns_state = 1069
-			}
+			limit = { owns_state = 1069 }
 			1069 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -10836,9 +10149,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				owns_state = 1136
-			}
+			limit = { owns_state = 1136 }
 			1136 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -10851,9 +10162,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				owns_state = 1137
-			}
+			limit = { owns_state = 1137 }
 			1137 = {
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -10885,9 +10194,7 @@ country_event = {
 			target = GEO
 			type = annex_everything
 		}
-		hidden_effect = {
-			set_country_flag = georgia_broken_relations
-		}
+		hidden_effect = { set_country_flag = georgia_broken_relations }
 		ai_chance = { base = 70 }
 	}
 
@@ -10919,9 +10226,7 @@ country_event = {
 		add_political_power = -100
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -10970,9 +10275,7 @@ country_event = {
 
 	trigger = { tag = SOV }
 
-	option = {
-		name = sov_liberals.30.a
-	}
+	option = { name = sov_liberals.30.a }
 }
 
 country_event = {
@@ -11016,9 +10319,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = sov_liberals_news.1.a
-	}
+	option = { name = sov_liberals_news.1.a }
 }
 
 country_event = {
@@ -11031,14 +10332,8 @@ country_event = {
 	option = {
 		name = sov_nazbol.1.a
 		log = "[GetDateText]: [This.GetName]: sov_nazbol.1.a executed"
-		ai_chance = {
-			base = 100
-		}
-		ROOT = {
-			every_owned_state = {
-				add_core_of = SOV
-			}
-		}
+		ai_chance = { base = 100 }
+		ROOT = { every_owned_state = { add_core_of = SOV } }
 		SOV = {
 			country_event = sov_nazbol.2
 			add_to_variable = { treasury = ROOT.treasury }
@@ -11051,9 +10346,7 @@ country_event = {
 	option = {
 		name = sov_nazbol.1.b
 		log = "[GetDateText]: [This.GetName]: sov_nazbol.1.b executed"
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		SOV = {
 			set_temp_variable = { wargoal_on = ROOT }
 			add_threat_from_wargoal_effect = yes
@@ -11073,9 +10366,7 @@ country_event = {
 	picture = GFX_sov_nazbolls
 	is_triggered_only = yes
 
-	option = {
-		name = sov_nazbol.2.a
-	}
+	option = { name = sov_nazbol.2.a }
 }
 
 country_event = {
@@ -11098,9 +10389,7 @@ country_event = {
 		if = {
 			limit = {
 				tag = UKR
-				UKR = {
-					owns_state = 669
-				}
+				UKR = { owns_state = 669 }
 			}
 			transfer_state = 669
 			669 = { add_core_of = SOV }
@@ -11108,9 +10397,7 @@ country_event = {
 		if = {
 			limit = {
 				tag = UKR
-				UKR = {
-					owns_state = 696
-				}
+				UKR = { owns_state = 696 }
 			}
 			transfer_state = 696
 			696 = { add_core_of = SOV }
@@ -11118,9 +10405,7 @@ country_event = {
 		if = {
 			limit = {
 				tag = LAT
-				LAT = {
-					owns_state = 1013
-				}
+				LAT = { owns_state = 1013 }
 			}
 			transfer_state = 1013
 			1013 = { add_core_of = SOV }
@@ -11128,9 +10413,7 @@ country_event = {
 		if = {
 			limit = {
 				tag = KAZ
-				KAZ = {
-					owns_state = 714
-				}
+				KAZ = { owns_state = 714 }
 			}
 			transfer_state = 714
 			714 = { add_core_of = SOV }
@@ -11138,9 +10421,7 @@ country_event = {
 		if = {
 			limit = {
 				tag = KAZ
-				KAZ = {
-					owns_state = 715
-				}
+				KAZ = { owns_state = 715 }
 			}
 			transfer_state = 715
 			715 = { add_core_of = SOV }
@@ -11178,9 +10459,7 @@ country_event = {
 
 	trigger = { tag = SOV }
 
-	option = {
-		name = sov_nazbol.4.a
-	}
+	option = { name = sov_nazbol.4.a }
 }
 
 #GRU start
@@ -11233,18 +10512,14 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = sov_gru.1.b
 		log = "[GetDateText]: [This.GetName]: sov_gru.1.b executed"
 		SOV = { country_event = sov_gru.3 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -11361,11 +10636,7 @@ country_event = {
 			}
 			spawn_light_infantry_wagner = yes
 			if = {
-				limit = {
-					SOV = {
-						has_completed_focus = SOV_wagner_rusich
-					}
-				}
+				limit = { SOV = { has_completed_focus = SOV_wagner_rusich } }
 				division_template = {
 					name = "DSHRG Rusich"
 					is_locked = yes
@@ -11384,18 +10655,14 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = sov_gru.6.b
 		log = "[GetDateText]: [This.GetName]: sov_gru.6.b executed"
 		SOV = { country_event = sov_gru.8 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -11411,9 +10678,7 @@ country_event = {
 		name = sov_gru.7.a
 		log = "[GetDateText]: [This.GetName]: sov_gru.7.a executed"
 		clr_country_flag = SOV_wagner_active
-		hidden_effect = {
-			remove_ideas = SOV_wagner
-		}
+		hidden_effect = { remove_ideas = SOV_wagner }
 	}
 }
 #Wagner Decline
@@ -11486,11 +10751,7 @@ country_event = {
 			}
 			spawn_light_infantry_wagner = yes
 			if = {
-				limit = {
-					SOV = {
-						has_completed_focus = SOV_wagner_rusich
-					}
-				}
+				limit = { SOV = { has_completed_focus = SOV_wagner_rusich } }
 				division_template = {
 					name = "DSHRG Rusich"
 					is_locked = yes
@@ -11510,18 +10771,14 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = sov_gru.10.b
 		log = "[GetDateText]: [This.GetName]: sov_gru.10.b executed"
 		SOV = { country_event = sov_gru.12 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -11537,9 +10794,7 @@ country_event = {
 		name = sov_gru.11.a
 		log = "[GetDateText]: [This.GetName]: sov_gru.11.a executed"
 		clr_country_flag = SOV_wagner_active
-		hidden_effect = {
-			remove_ideas = SOV_wagner_africa
-		}
+		hidden_effect = { remove_ideas = SOV_wagner_africa }
 	}
 }
 #Wagner Decline
@@ -11971,15 +11226,11 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		SOV_computing_sovereignty_outcome_settled = no
-	}
+	trigger = { SOV_computing_sovereignty_outcome_settled = no }
 
 	option = {
 		name = sov_economic.305.a
-		trigger = {
-			has_country_flag = SOV_cs_chinese_foundry_turn
-		}
+		trigger = { has_country_flag = SOV_cs_chinese_foundry_turn }
 		log = "[GetDateText]: [Root.GetName]: sov_economic.305.a executed"
 		effect_tooltip = { add_timed_idea = { idea = SOV_computing_sovereignty_chinese_substitution days = 365 } }
 		hidden_effect = { SOV_computing_sovereignty_apply_chinese_substitution = yes }
@@ -12059,9 +11310,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_to_variable = { SOV_statist_verdicts = 1 }
 		custom_effect_tooltip = SOV_verdict_scorecard_TT
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -12080,12 +11329,9 @@ country_event = {
 		change_fossil_fuel_industry_opinion = yes
 		add_to_variable = { SOV_oligarch_verdicts = 1 }
 		custom_effect_tooltip = SOV_verdict_scorecard_TT
-
 		newline = yes
 		set_temp_variable = { treasury_change = 5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }

--- a/events/San Marino.txt
+++ b/events/San Marino.txt
@@ -9,6 +9,7 @@ country_event = {
 	desc = SMA_countries.1.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = { # yes
 		name = SMA_countries.1.a
 		log = "[GetDateText]: [This.GetName]: SMA_countries.1.a executed"
@@ -34,6 +35,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # no
 		name = SMA_countries.1.b
 		log = "[GetDateText]: [This.GetName]: SMA_countries.1.b executed"
@@ -55,11 +57,10 @@ country_event = {
 	desc = SMA_countries.2.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	option = {
 		name = SMA_countries.2.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -70,12 +71,11 @@ country_event = {
 	desc = SMA_countries.3.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = SMA_countries.3.a
 		log = "[GetDateText]: [This.GetName]: SMA_countries.3.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_ideas = SMA_rights_of_italian_workers_in_san_marino
 		set_temp_variable = { treasury_change = -2.00 }
 		modify_treasury_effect = yes
@@ -89,6 +89,7 @@ country_event = {
 	desc = SMA_countries.4.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	option = { # yes
 		name = SMA_countries.4.a
 		log = "[GetDateText]: [This.GetName]: SMA_countries.4.a executed"
@@ -119,7 +120,6 @@ country_event = {
 				}
 				set_temp_variable = { treasury_change = -1.50 }
 				modify_treasury_effect = yes
-
 				set_temp_variable = { percent_change = -5 }
 				change_domestic_influence_percentage = yes
 			}
@@ -136,7 +136,6 @@ country_event = {
 				one_random_industrial_complex = yes
 				set_temp_variable = { treasury_change = 3.50 }
 				modify_treasury_effect = yes
-
 				set_temp_variable = { percent_change = -0.5 }
 				change_domestic_influence_percentage = yes
 			}
@@ -165,10 +164,8 @@ country_event = {
 						instant_build = yes
 					}
 				}
-
 				set_temp_variable = { treasury_change = -1.00 }
 				modify_treasury_effect = yes
-
 				set_temp_variable = { percent_change = -0.5 }
 				change_domestic_influence_percentage = yes
 			}
@@ -189,7 +186,6 @@ country_event = {
 					one_random_industrial_complex = yes
 					set_temp_variable = { treasury_change = 3.50 }
 					modify_treasury_effect = yes
-
 					set_temp_variable = { percent_change = -0.5 }
 					change_domestic_influence_percentage = yes
 				}
@@ -201,7 +197,6 @@ country_event = {
 				ROOT = {
 					set_temp_variable = { treasury_change = -2.00 }
 					modify_treasury_effect = yes
-
 					set_country_flag = san_marino_investment_one
 				}
 				SMA = {
@@ -219,10 +214,8 @@ country_event = {
 							instant_build = yes
 						}
 					}
-
 					set_temp_variable = { treasury_change = 1.00 }
 					modify_treasury_effect = yes
-
 					set_temp_variable = { percent_change = -0.5 }
 					change_domestic_influence_percentage = yes
 				}
@@ -232,6 +225,7 @@ country_event = {
 			country_event = SMA_countries.6
 		}
 	}
+
 	option = { # no
 		name = SMA_countries.4.b
 		log = "[GetDateText]: [This.GetName]: SMA_countries.4.b executed"
@@ -253,11 +247,10 @@ country_event = {
 	desc = SMA_countries.5.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	option = {
 		name = SMA_countries.5.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -266,11 +259,10 @@ country_event = {
 	desc = SMA_countries.6.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	option = {
 		name = SMA_countries.6.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -279,14 +271,10 @@ news_event = {
 	title = SMA_news.1.t
 	desc = SMA_news.1.desc
 	picture = GFX_christian_event
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SMA_news.1.a
-	}
-
+	option = { name = SMA_news.1.a }
 }
 
 news_event = {
@@ -294,21 +282,17 @@ news_event = {
 	title = SMA_news.2.t
 	desc = SMA_news.2.desc
 	picture = GFX_news_update_gdpc
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SMA_news.2.a
-		trigger = {
-			NOT = { tag = SMA }
-		}
+		trigger = { NOT = { tag = SMA } }
 	}
+
 	option = {
 		name = SMA_news.2.b
-		trigger = {
-			tag = SMA
-		}
+		trigger = { tag = SMA }
 	}
 }
 
@@ -317,6 +301,7 @@ country_event = {
 	title = SMA.1.t
 	desc = SMA.1.d
 	is_triggered_only = yes
+
 	option = {
 		name = SMA.1.a
 		log = "[GetDateText]: [This.GetName]: SMA.1.a executed"
@@ -327,11 +312,7 @@ country_event = {
 				is_historical_focus_on = yes
 			}
 		}
-		HLS = {
-			every_owned_state = {
-				add_core_of = SMA
-			}
-		}
+		HLS = { every_owned_state = { add_core_of = SMA } }
 		SMA = {
 			annex_country = {
 				target = HLS
@@ -353,11 +334,10 @@ country_event = {
 			set_country_flag = SMA_vatican_union
 		}
 	}
+
 	option = {
 		name = SMA.1.b
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -367,27 +347,23 @@ country_event = {
 	desc = SMA.2.d
 	picture = GFX_report_event_Sicily_Farms
 	is_triggered_only = yes
+
 	option = {
 		name = SMA.2.a
 		log = "[GetDateText]: [This.GetName]: SMA.2.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		SMA = {
 			add_stability = 0.1
 			set_temp_variable = { treasury_change = -3.50 }
 			modify_treasury_effect = yes
 		}
 	}
+
 	option = {
 		name = SMA.2.b
 		log = "[GetDateText]: [This.GetName]: SMA.2.b executed"
-		ai_chance = {
-			base = 1
-		}
-		SMA = {
-			add_stability = -0.15
-		}
+		ai_chance = { base = 1 }
+		SMA = { add_stability = -0.15 }
 	}
 }
 
@@ -397,22 +373,20 @@ country_event = {
 	desc = SMA.3.d
 	picture = GFX_united_states_dollar
 	is_triggered_only = yes
+
 	option = {
 		name = SMA.3.a
 		log = "[GetDateText]: [This.GetName]: SMA.3.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		news_event = SMA_news.2
 		set_temp_variable = { treasury_change = 25.00 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = SMA.3.b
 		log = "[GetDateText]: [This.GetName]: SMA.3.b executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_stability = 0.3
 		add_political_power = 100
 	}
@@ -423,8 +397,10 @@ country_event = {
 	title = SMA.6.t
 	desc = SMA.6.d
 	picture = GFX_internal_faction_religion
-	trigger = { has_country_flag = SMA_vatican_union }
 	is_triggered_only = yes
+
+	trigger = { has_country_flag = SMA_vatican_union }
+
 	option = {
 		name = SMA.6.a
 		log = "[GetDateText]: [This.GetName]: SMA.6.a executed"
@@ -472,6 +448,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
 	}
+
 	option = { # No
 		name = SMA.8.b
 		log = "[GetDateText]: [This.GetName]: SMA.8.b executed"

--- a/events/SubjectRussia.txt
+++ b/events/SubjectRussia.txt
@@ -211,9 +211,7 @@ country_event = {
 		change_influence_percentage = yes
 		add_opinion_modifier = { target = FROM modifier = recent_actions_positive }
 		reverse_add_opinion_modifier = { target = FROM modifier = recent_actions_positive }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -225,9 +223,7 @@ country_event = {
 		set_temp_variable = { percent_change = -3 }
 		set_temp_variable = { influence_target = FROM }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Subsidies Gives
@@ -256,9 +252,7 @@ country_event = {
 			set_temp_variable = { modify_subjectinped = -5 }
 			modify_subjectinped_support = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #Subsidies Not Gives
@@ -303,9 +297,7 @@ country_event = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_international_bankers_opinion = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = { #Net
@@ -456,16 +448,12 @@ country_event = {
 		set_temp_variable = { percent_change = 3 }
 		set_temp_variable = { tag_index = TAT }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = subject_rus.22.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Tatneft Neft
@@ -588,18 +576,14 @@ country_event = {
 			limit = { 570 = { is_owned_and_controlled_by = CHI } }
 			570 = { add_state_modifier = { modifier = { state_resources_factor = 0.05 } } }
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = subject_rus.27.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.27.b executed"
 		BSH = { country_event = subject_rus.29 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #BSH invest Hubei China
@@ -616,9 +600,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: subject_rus.28.a executed"
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #BSH invest Hubei China
@@ -632,9 +614,7 @@ country_event = {
 
 	option = {
 		name = subject_rus.29.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #Chechnya Try to annex Ingushetia
@@ -653,9 +633,7 @@ country_event = {
 		set_temp_variable = { percent_change = 10 }
 		set_temp_variable = { influence_target = CHE }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -665,9 +643,7 @@ country_event = {
 		set_temp_variable = { percent_change = -8 }
 		set_temp_variable = { influence_target = CHE }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Chechnya Annex Ingushetia
@@ -775,16 +751,12 @@ country_event = {
 			autonomy_state = autonomy_republic_rf
 		 }
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = subject_rus.41.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -862,9 +834,7 @@ country_event = {
 		change_influence_percentage = yes
 		add_opinion_modifier = { target = FROM modifier = recent_actions_positive }
 		reverse_add_opinion_modifier = { target = FROM modifier = recent_actions_positive }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -876,9 +846,7 @@ country_event = {
 		set_temp_variable = { percent_change = -3 }
 		set_temp_variable = { influence_target = FROM }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Bashkiriya Try to create Volga SSR
@@ -1010,9 +978,7 @@ country_event = {
 		change_influence_percentage = yes
 		add_opinion_modifier = { target = FROM modifier = recent_actions_positive }
 		reverse_add_opinion_modifier = { target = FROM modifier = recent_actions_positive }
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -1024,9 +990,7 @@ country_event = {
 		set_temp_variable = { percent_change = -2 }
 		set_temp_variable = { influence_target = FROM }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Ecology Gives
@@ -1044,9 +1008,7 @@ country_event = {
 		set_temp_variable = { modify_subjectavtoritet = -26 }
 		modify_subjectavtoritet_support = yes
 		KHM_ecology_good_script = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #Ecology Not Gives
@@ -1218,14 +1180,8 @@ country_event = {
 	option = {
 		name = subject_rus.90.a
 		log = "[GetDateText]: [This.GetName]: subject_rus.90.a executed"
-		ai_chance = {
-			base = 10
-		}
-		trigger = {
-			KHM = {
-				SUB_is_rf_subject = yes
-			}
-		}
+		ai_chance = { base = 10 }
+		trigger = { KHM = { SUB_is_rf_subject = yes } }
 		SOV = { add_state_core = 678 }
 		annex_country = { target = KHM transfer_troops = yes }
 		add_political_power = -100
@@ -1234,24 +1190,16 @@ country_event = {
 	option = {
 		name = subject_rus.90.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.90.b executed"
-		ai_chance = {
-			base = 90
-		}
-		trigger = {
-			SOV = { owns_state = 678 }
-		}
-		KHM = {
-			set_country_flag = SOV_subject_okrug
-		}
+		ai_chance = { base = 90 }
+		trigger = { SOV = { owns_state = 678 } }
+		KHM = { set_country_flag = SOV_subject_okrug }
 		set_autonomy = {
 			target = KHM
 			autonomy_state = autonomy_okrug_rf
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			KHM = {
-				add_ideas = SUB_small_taxes
-			}
+			KHM = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
@@ -1272,21 +1220,15 @@ country_event = {
 	option = {
 		name = subject_rus.90.c
 		log = "[GetDateText]: [This.GetName]: subject_rus.90.c executed"
-		ai_chance = {
-			base = 0
-		}
-		trigger = {
-			SOV = { owns_state = 678 }
-		}
+		ai_chance = { base = 0 }
+		trigger = { SOV = { owns_state = 678 } }
 		add_political_power = -100
 		KHM = {
 			transfer_state = 678
 			add_state_core = 678
 		}
 		SOV = { add_state_core = 678 }
-		KHM = {
-			set_country_flag = SOV_subject_okrug
-		}
+		KHM = { set_country_flag = SOV_subject_okrug }
 		set_autonomy = {
 			target = KHM
 			autonomy_state = autonomy_okrug_rf
@@ -1297,18 +1239,14 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			KHM = {
-				add_ideas = SUB_small_taxes
-			}
+			KHM = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		KHM = {
-			change_tag_from = SOV
-		}
+		KHM = { change_tag_from = SOV }
 	}
 }
 #TATARSTAN RELEASE
@@ -1322,14 +1260,8 @@ country_event = {
 	option = {
 		name = subject_rus.91.a
 		log = "[GetDateText]: [This.GetName]: subject_rus.91.a executed"
-		ai_chance = {
-			base = 10
-		}
-		trigger = {
-			TAT = {
-				SUB_is_rf_subject = yes
-			}
-		}
+		ai_chance = { base = 10 }
+		trigger = { TAT = { SUB_is_rf_subject = yes } }
 		SOV = { add_state_core = 661 }
 		annex_country = { target = TAT transfer_troops = yes }
 		add_political_power = -100
@@ -1338,24 +1270,16 @@ country_event = {
 	option = {
 		name = subject_rus.91.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.91.b executed"
-		ai_chance = {
-			base = 90
-		}
-		trigger = {
-			SOV = { owns_state = 661 }
-		}
-		TAT = {
-			set_country_flag = SOV_subject_republic
-		}
+		ai_chance = { base = 90 }
+		trigger = { SOV = { owns_state = 661 } }
+		TAT = { set_country_flag = SOV_subject_republic }
 		set_autonomy = {
 			target = TAT
 			autonomy_state = autonomy_republic_rf
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			TAT = {
-				add_ideas = SUB_small_taxes
-			}
+			TAT = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
@@ -1376,21 +1300,15 @@ country_event = {
 	option = {
 		name = subject_rus.91.c
 		log = "[GetDateText]: [This.GetName]: subject_rus.91.c executed"
-		ai_chance = {
-			base = 0
-		}
-		trigger = {
-			SOV = { owns_state = 661 }
-		}
+		ai_chance = { base = 0 }
+		trigger = { SOV = { owns_state = 661 } }
 		add_political_power = -100
 		TAT = {
 			transfer_state = 661
 			add_state_core = 661
 		}
 		SOV = { add_state_core = 661 }
-		TAT = {
-			set_country_flag = SOV_subject_republic
-		}
+		TAT = { set_country_flag = SOV_subject_republic }
 		set_autonomy = {
 			target = TAT
 			autonomy_state = autonomy_republic_rf
@@ -1401,18 +1319,14 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			TAT = {
-				add_ideas = SUB_small_taxes
-			}
+			TAT = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		TAT = {
-			change_tag_from = SOV
-		}
+		TAT = { change_tag_from = SOV }
 	}
 }
 #BASHORTOSTAN RELEASE
@@ -1426,14 +1340,8 @@ country_event = {
 	option = {
 		name = subject_rus.92.a
 		log = "[GetDateText]: [This.GetName]: subject_rus.92.a executed"
-		ai_chance = {
-			base = 10
-		}
-		trigger = {
-			BSH = {
-				SUB_is_rf_subject = yes
-			}
-		}
+		ai_chance = { base = 10 }
+		trigger = { BSH = { SUB_is_rf_subject = yes } }
 		SOV = { add_state_core = 664 }
 		annex_country = { target = BSH transfer_troops = yes }
 		add_political_power = -100
@@ -1442,15 +1350,9 @@ country_event = {
 	option = {
 		name = subject_rus.92.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.92.b executed"
-		ai_chance = {
-			base = 90
-		}
-		trigger = {
-			SOV = { owns_state = 664 }
-		}
-		BSH = {
-			set_country_flag = SOV_subject_republic
-		}
+		ai_chance = { base = 90 }
+		trigger = { SOV = { owns_state = 664 } }
+		BSH = { set_country_flag = SOV_subject_republic }
 		set_autonomy = {
 			target = BSH
 			autonomy_state = autonomy_republic_rf
@@ -1466,9 +1368,7 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			BSH = {
-				add_ideas = SUB_small_taxes
-			}
+			BSH = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
@@ -1480,21 +1380,15 @@ country_event = {
 	option = {
 		name = subject_rus.92.c
 		log = "[GetDateText]: [This.GetName]: subject_rus.92.c executed"
-		ai_chance = {
-			base = 0
-		}
-		trigger = {
-			SOV = { owns_state = 664 }
-		}
+		ai_chance = { base = 0 }
+		trigger = { SOV = { owns_state = 664 } }
 		add_political_power = -100
 		BSH = {
 			transfer_state = 664
 			add_state_core = 664
 		}
 		SOV = { add_state_core = 664 }
-		BSH = {
-			set_country_flag = SOV_subject_republic
-		}
+		BSH = { set_country_flag = SOV_subject_republic }
 		set_autonomy = {
 			target = BSH
 			autonomy_state = autonomy_republic_rf
@@ -1505,18 +1399,14 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			BSH = {
-				add_ideas = SUB_small_taxes
-			}
+			BSH = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		BSH = {
-			change_tag_from = SOV
-		}
+		BSH = { change_tag_from = SOV }
 	}
 }
 #CRIMEA RELEASE
@@ -1530,14 +1420,8 @@ country_event = {
 	option = {
 		name = subject_rus.93.a
 		log = "[GetDateText]: [This.GetName]: subject_rus.93.a executed"
-		ai_chance = {
-			base = 10
-		}
-		trigger = {
-			CRM = {
-				SUB_is_rf_subject = yes
-			}
-		}
+		ai_chance = { base = 10 }
+		trigger = { CRM = { SUB_is_rf_subject = yes } }
 		annex_country = { target = CRM transfer_troops = yes }
 		add_political_power = -100
 	}
@@ -1545,15 +1429,9 @@ country_event = {
 	option = {
 		name = subject_rus.93.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.93.b executed"
-		ai_chance = {
-			base = 90
-		}
-		trigger = {
-			SOV = { owns_state = 669 }
-		}
-		CRM = {
-			set_country_flag = SOV_subject_republic
-		}
+		ai_chance = { base = 90 }
+		trigger = { SOV = { owns_state = 669 } }
+		CRM = { set_country_flag = SOV_subject_republic }
 		set_autonomy = {
 			target = CRM
 			autonomy_state = autonomy_republic_rf
@@ -1574,9 +1452,7 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			CRM = {
-				add_ideas = SUB_small_taxes
-			}
+			CRM = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
@@ -1588,12 +1464,8 @@ country_event = {
 	option = {
 		name = subject_rus.93.c
 		log = "[GetDateText]: [This.GetName]: subject_rus.93.c executed"
-		ai_chance = {
-			base = 0
-		}
-		trigger = {
-			SOV = { owns_state = 669 }
-		}
+		ai_chance = { base = 0 }
+		trigger = { SOV = { owns_state = 669 } }
 		add_political_power = -100
 		CRM = {
 			transfer_state = 669
@@ -1605,9 +1477,7 @@ country_event = {
 			add_state_core = 669
 			add_state_core = 1112
 		}
-		CRM = {
-			set_country_flag = SOV_subject_republic
-		}
+		CRM = { set_country_flag = SOV_subject_republic }
 		set_autonomy = {
 			target = CRM
 			autonomy_state = autonomy_republic_rf
@@ -1618,18 +1488,14 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			CRM = {
-				add_ideas = SUB_small_taxes
-			}
+			CRM = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		CRM = {
-			change_tag_from = SOV
-		}
+		CRM = { change_tag_from = SOV }
 	}
 }
 #They Agree our demands(Status)
@@ -1646,9 +1512,7 @@ country_event = {
 		SUB_change_status_subject = yes
 		add_political_power = 150
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -1663,9 +1527,7 @@ country_event = {
 			country_event = { id = subject_rus.96 days = 0 }
 		}
 		set_country_flag = SUB_subject_rebellion_flag
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #They Agree our demands(Money)
@@ -1682,9 +1544,7 @@ country_event = {
 		set_temp_variable = { treasury_change = 17.5 }
 		modify_treasury_effect = yes
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -1699,9 +1559,7 @@ country_event = {
 			country_event = { id = subject_rus.96 days = 0 }
 		}
 		set_country_flag = SUB_subject_rebellion_flag
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Subject Ahuel
@@ -1719,18 +1577,14 @@ country_event = {
 			target = FROM
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = subject_rus.96.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.96.b executed"
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1865,9 +1719,7 @@ country_event = {
 		country_event = subject_rus.102
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Caucas Nalogs Up(2)
 country_event = {
@@ -1931,9 +1783,7 @@ country_event = {
 		country_event = subject_rus.101
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Siberia Nalogs Up(1)
 country_event = {
@@ -1997,9 +1847,7 @@ country_event = {
 		country_event = subject_rus.104
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Siberia Nalogs Up(2)
 country_event = {
@@ -2063,9 +1911,7 @@ country_event = {
 		country_event = subject_rus.105
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Siberia Nalogs Up(3)
 country_event = {
@@ -2119,9 +1965,7 @@ country_event = {
 		country_event = subject_rus.103
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Volga Nalogs Up(1)
 country_event = {
@@ -2185,9 +2029,7 @@ country_event = {
 		country_event = subject_rus.107
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Volga Nalogs Up(2)
 country_event = {
@@ -2251,9 +2093,7 @@ country_event = {
 		country_event = subject_rus.106
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Other Nalogs Up(1)
 country_event = {
@@ -2301,9 +2141,7 @@ country_event = {
 		country_event = subject_rus.124
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Moscow New Major
 country_event = {
@@ -2312,6 +2150,7 @@ country_event = {
 	desc = subject_rus.109.d
 	picture = GFX_subject_moscow
 	is_triggered_only = yes
+
 	trigger = {
 		owns_state = 652
 		controls_state = 652
@@ -2447,9 +2286,7 @@ country_event = {
 		country_event = subject_rus.112
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Caucas Nalogs Up(2)
 country_event = {
@@ -2513,9 +2350,7 @@ country_event = {
 		country_event = subject_rus.111
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Siberia Nalogs Up(1)
 country_event = {
@@ -2579,9 +2414,7 @@ country_event = {
 		country_event = subject_rus.113
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Siberia Nalogs Up(2)
 country_event = {
@@ -2645,9 +2478,7 @@ country_event = {
 		country_event = subject_rus.114
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Volga Nalogs Up(1)
 country_event = {
@@ -2711,9 +2542,7 @@ country_event = {
 		country_event = subject_rus.117
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Volga Nalogs Up(2)
 country_event = {
@@ -2777,9 +2606,7 @@ country_event = {
 		country_event = subject_rus.116
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Other Nalogs Fall(1)
 country_event = {
@@ -2827,9 +2654,7 @@ country_event = {
 		country_event = subject_rus.125
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #KUBAN Federalisation
 country_event = {
@@ -2842,14 +2667,8 @@ country_event = {
 	option = {
 		name = subject_rus.119.a
 		log = "[GetDateText]: [This.GetName]: subject_rus.119.a executed"
-		ai_chance = {
-			base = 10
-		}
-		trigger = {
-			KUB = {
-				SUB_is_rf_subject = yes
-			}
-		}
+		ai_chance = { base = 10 }
+		trigger = { KUB = { SUB_is_rf_subject = yes } }
 		SOV = {
 			add_state_core = 668
 			add_state_core = 1140
@@ -2891,18 +2710,14 @@ country_event = {
 			set_temp_variable = { percent_change = 25 }
 			set_temp_variable = { influence_target = KUB }
 			change_influence_percentage = yes
-			KUB = {
-				add_ideas = SUB_small_taxes
-			}
+			KUB = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -2940,18 +2755,14 @@ country_event = {
 			set_temp_variable = { percent_change = 25 }
 			set_temp_variable = { influence_target = KUB }
 			change_influence_percentage = yes
-			KUB = {
-				add_ideas = SUB_small_taxes
-			}
+			KUB = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 1.5 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Ural Federalisation
@@ -2965,14 +2776,8 @@ country_event = {
 	option = {
 		name = subject_rus.120.a
 		log = "[GetDateText]: [This.GetName]: subject_rus.120.a executed"
-		ai_chance = {
-			base = 10
-		}
-		trigger = {
-			URA = {
-				SUB_is_rf_subject = yes
-			}
-		}
+		ai_chance = { base = 10 }
+		trigger = { URA = { SUB_is_rf_subject = yes } }
 		SOV = { add_state_core = 676 }
 		annex_country = { target = URA transfer_troops = yes }
 		add_political_power = -100
@@ -2981,12 +2786,8 @@ country_event = {
 	option = {
 		name = subject_rus.120.b
 		log = "[GetDateText]: [This.GetName]: subject_rus.120.b executed"
-		ai_chance = {
-			base = 90
-		}
-		trigger = {
-			SOV = { owns_state = 676 }
-		}
+		ai_chance = { base = 90 }
+		trigger = { SOV = { owns_state = 676 } }
 		URA = {
 			set_country_flag = SOV_subject_oblast
 			transfer_state = 676
@@ -3013,9 +2814,7 @@ country_event = {
 					set_temp_variable = { temp_outlook_increase = 0.45 }
 					change_relative_party_popularity = yes
 				}
-				hidden_effect = {
-					set_variable = { current_term = 0 }
-				}
+				hidden_effect = { set_variable = { current_term = 0 } }
 				create_country_leader = {
 					name = "Eduard Rossel"
 					picture = "gfx/leaders/SOV/sov_rossel.dds"
@@ -3040,12 +2839,8 @@ country_event = {
 	option = {
 		name = subject_rus.120.c
 		log = "[GetDateText]: [This.GetName]: subject_rus.120.c executed"
-		ai_chance = {
-			base = 0
-		}
-		trigger = {
-			SOV = { owns_state = 676 }
-		}
+		ai_chance = { base = 0 }
+		trigger = { SOV = { owns_state = 676 } }
 		add_political_power = -100
 		URA = {
 			transfer_state = 676
@@ -3072,9 +2867,7 @@ country_event = {
 					set_temp_variable = { temp_outlook_increase = 0.25 }
 					change_relative_party_popularity = yes
 				}
-				hidden_effect = {
-					set_variable = { current_term = 0 }
-				}
+				hidden_effect = { set_variable = { current_term = 0 } }
 				create_country_leader = {
 					name = "Eduard Rossel"
 					picture = "gfx/leaders/SOV/sov_rossel.dds"
@@ -3095,9 +2888,7 @@ country_event = {
 			}
 			SUB_separatism_plus_subject = yes
 		}
-		URA = {
-			change_tag_from = SOV
-		}
+		URA = { change_tag_from = SOV }
 	}
 }
 #Subject Other Nalogs UP(2)
@@ -3156,9 +2947,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject Other Nalogs Fall(2)
 country_event = {
@@ -3216,9 +3005,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = subject_rus.108.f
-	}
+	option = { name = subject_rus.108.f }
 }
 #Subject War Against Jirinovsky
 country_event = {
@@ -3235,9 +3022,7 @@ country_event = {
 			target = SOV
 			type = annex_everything
 		}
-		SOV = {
-			add_stability = -0.03
-		}
+		SOV = { add_stability = -0.03 }
 		hidden_effect = {
 			division_template = {
 				name = "The Rebel Battalion"
@@ -3270,9 +3055,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: subject_rus.127.a executed"
 		MLV = {
 			every_core_state = { add_core_of = PMR }
-			every_unit_leader = {
-				set_nationality = PMR
-			}
+			every_unit_leader = { set_nationality = PMR }
 		}
 		PMR = {
 			annex_country = { target = MLV transfer_troops = yes }
@@ -3285,9 +3068,7 @@ country_event = {
 			modify_subjectavtoritet_support = yes
 			country_event = diplomatic_response.1
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -3298,9 +3079,7 @@ country_event = {
 			modify_subjectavtoritet_support = yes
 			country_event = diplomatic_response.2
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Subject Integrate to Our Economic
@@ -3403,9 +3182,7 @@ country_event = {
 		add_opinion_modifier = { target = URA modifier = recent_actions_positive }
 		reverse_add_opinion_modifier = { target = URA modifier = recent_actions_positive }
 		URA = { country_event = { id = ural_event.2 days = 1 } }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -3414,9 +3191,7 @@ country_event = {
 		URA = { country_event = { id = ural_event.3 days = 1 } }
 		add_opinion_modifier = { target = URA modifier = recent_actions_negative }
 		reverse_add_opinion_modifier = { target = URA modifier = recent_actions_negative }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Foreign Investors Agree
@@ -3450,9 +3225,7 @@ country_event = {
 	is_triggered_only = yes
 
 	timeout_days = 5
-	option = {
-		name = ural_event.3.a
-	}
+	option = { name = ural_event.3.a }
 }
 #Belarus Investors
 country_event = {
@@ -3474,9 +3247,7 @@ country_event = {
 		add_opinion_modifier = { target = URA modifier = recent_actions_positive }
 		reverse_add_opinion_modifier = { target = URA modifier = recent_actions_positive }
 		URA = { country_event = { id = ural_event.5 days = 1 } }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -3485,9 +3256,7 @@ country_event = {
 		URA = { country_event = { id = ural_event.6 days = 1 } }
 		add_opinion_modifier = { target = URA modifier = recent_actions_negative }
 		reverse_add_opinion_modifier = { target = URA modifier = recent_actions_negative }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Belarus Investors Agree
@@ -3519,9 +3288,7 @@ country_event = {
 	is_triggered_only = yes
 
 	timeout_days = 5
-	option = {
-		name = ural_event.6.a
-	}
+	option = { name = ural_event.6.a }
 }
 #Ural Declare Republic
 country_event = {
@@ -3663,9 +3430,7 @@ country_event = {
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -3675,9 +3440,7 @@ country_event = {
 		set_temp_variable = { percent_change = -8 }
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Ural Annex Orenburg
@@ -3753,9 +3516,7 @@ country_event = {
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -3765,9 +3526,7 @@ country_event = {
 		set_temp_variable = { percent_change = -8 }
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Ural Annex Chelyaba
@@ -3818,9 +3577,7 @@ country_event = {
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -3830,9 +3587,7 @@ country_event = {
 		set_temp_variable = { percent_change = -8 }
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Ural Annex Orenburg
@@ -3883,9 +3638,7 @@ country_event = {
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -3895,9 +3648,7 @@ country_event = {
 		set_temp_variable = { percent_change = -8 }
 		set_temp_variable = { influence_target = URA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Ural Annex Perm
@@ -3958,9 +3709,7 @@ country_event = {
 				modifier = recent_actions_positive
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -3977,9 +3726,7 @@ country_event = {
 				modifier = recent_actions_negative
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Ural Yes Bundesver
@@ -4006,9 +3753,7 @@ country_event = {
 	picture = GFX_subject_ural
 	is_triggered_only = yes
 
-	option = {
-		name = ural_event.19.a
-	}
+	option = { name = ural_event.19.a }
 }
 #Ural Trade
 country_event = {
@@ -4038,9 +3783,7 @@ country_event = {
 				modifier = recent_actions_positive
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -4057,9 +3800,7 @@ country_event = {
 				modifier = recent_actions_negative
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Ural Yes Trade
@@ -4116,9 +3857,7 @@ country_event = {
 				modifier = recent_actions_positive
 			}
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -4135,9 +3874,7 @@ country_event = {
 				modifier = recent_actions_negative
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Ural Yes Road
@@ -4190,9 +3927,7 @@ country_event = {
 			}
 		}
 		URA = { clr_country_flag = URA_deal_offer }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -4210,9 +3945,7 @@ country_event = {
 			}
 		}
 		URA = { clr_country_flag = URA_deal_offer }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Ural Yes Trade
@@ -4238,9 +3971,7 @@ country_event = {
 	picture = GFX_subject_ural
 	is_triggered_only = yes
 
-	option = {
-		name = ural_event.26.a
-	}
+	option = { name = ural_event.26.a }
 }
 #Ural Kurgan Referendum
 country_event = {
@@ -4255,9 +3986,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.27.a executed"
 		URA = { country_event = { id = ural_event.28 days = 1 } }
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -4265,9 +3994,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.27.b executed"
 		URA = { country_event = { id = ural_event.29 days = 1 } }
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Ural Kurgan Referendum Yes
@@ -4293,9 +4020,7 @@ country_event = {
 	picture = GFX_subject_ural
 	is_triggered_only = yes
 
-	option = {
-		name = ural_event.29.a
-	}
+	option = { name = ural_event.29.a }
 }
 #Ural Chelyabinsk Referendum
 country_event = {
@@ -4310,9 +4035,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.30.a executed"
 		URA = { country_event = { id = ural_event.31 days = 1 } }
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -4320,9 +4043,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.30.b executed"
 		URA = { country_event = { id = ural_event.29 days = 1 } }
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Ural Chelyabinsk Referendum Yes
@@ -4353,9 +4074,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.32.a executed"
 		URA = { country_event = { id = ural_event.33 days = 1 } }
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -4363,9 +4082,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.32.b executed"
 		URA = { country_event = { id = ural_event.29 days = 1 } }
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Ural Orenburg Referendum Yes
@@ -4396,9 +4113,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.34.a executed"
 		URA = { country_event = { id = ural_event.35 days = 1 } }
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -4406,9 +4121,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.34.b executed"
 		URA = { country_event = { id = ural_event.29 days = 1 } }
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Ural Perm Referendum Yes
@@ -4439,9 +4152,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.36.a executed"
 		URA = { country_event = { id = ural_event.37 days = 1 } }
 		SUB_separatism_minus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -4449,9 +4160,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ural_event.36.b executed"
 		URA = { country_event = { id = ural_event.29 days = 1 } }
 		SUB_separatism_plus_subject = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Ural Yugra Referendum Yes
@@ -4500,17 +4209,11 @@ country_event = {
 		custom_effect_tooltip = URA_kazahrevoult_warning_tt
 		hidden_effect = {
 			if = {
-				limit = {
-					URA = { is_subject_of = SOV }
-				}
+				limit = { URA = { is_subject_of = SOV } }
 				URA = { transfer_state = 718 }
 				718 = { add_core_of = URA }
 				if = {
-					limit = {
-						KAZ = {
-							is_in_faction_with = SOV
-						}
-					}
+					limit = { KAZ = { is_in_faction_with = SOV } }
 					leave_faction = yes
 				}
 				declare_war_on = {
@@ -4533,9 +4236,7 @@ country_event = {
 				}
 			}
 			else_if = {
-				limit = {
-					NOT = { URA = { is_subject_of = SOV } }
-				}
+				limit = { NOT = { URA = { is_subject_of = SOV } } }
 				URA = { transfer_state = 718 }
 				718 = { add_core_of = URA }
 				declare_war_on = {
@@ -4571,18 +4272,14 @@ country_event = {
 		add_ideas = URA_romanov_empire
 		set_temp_variable = { treasury_change = 5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = ural_event.39.b
 		log = "[GetDateText]: [This.GetName]: ural_event.39.b executed"
 		URA = { country_event = { id = ural_event.41 days = 1 } }
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Agree Romanov
@@ -4608,9 +4305,7 @@ country_event = {
 	picture = GFX_subject_yugra
 	is_triggered_only = yes
 
-	option = {
-		name = ural_event.41.a
-	}
+	option = { name = ural_event.41.a }
 }
 #USAID
 country_event = {
@@ -4624,18 +4319,14 @@ country_event = {
 		name = ural_event.42.a
 		log = "[GetDateText]: [This.GetName]: ural_event.42.a executed"
 		URA = { country_event = { id = ural_event.43 days = 1 } }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = ural_event.42.b
 		log = "[GetDateText]: [This.GetName]: ural_event.42.b executed"
 		URA = { country_event = { id = ural_event.44 days = 1 } }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 #Agree USAID
@@ -4662,9 +4353,7 @@ country_event = {
 	picture = GFX_USA_generic
 	is_triggered_only = yes
 
-	option = {
-		name = ural_event.44.a
-	}
+	option = { name = ural_event.44.a }
 }
 #Foreign Investors
 country_event = {
@@ -4688,9 +4377,7 @@ country_event = {
 		add_opinion_modifier = { target = URA modifier = recent_actions_positive }
 		reverse_add_opinion_modifier = { target = URA modifier = recent_actions_positive }
 		URA = { country_event = { id = ural_event.48 days = 1 } }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
@@ -4699,9 +4386,7 @@ country_event = {
 		URA = { country_event = { id = ural_event.48 days = 1 } }
 		add_opinion_modifier = { target = URA modifier = recent_actions_negative }
 		reverse_add_opinion_modifier = { target = URA modifier = recent_actions_negative }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Foreign Investors Agree


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,605 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.