### PR TITLE
Standardize event files — batch 07/14

### DIFF
--- a/events/05_muslim_brotherhood.txt
+++ b/events/05_muslim_brotherhood.txt
@@ -10,21 +10,6 @@ country_event = {
 	desc = brotherhood.6.d
 	picture = GFX_election_day
 	is_triggered_only = yes
-	trigger = {
-		is_in_array = { global.possible_muslim_brotherhood_nation = THIS.id }
-		has_game_rule = { rule = rule_disable_muslim_brotherhood_civil_war option = no }
-		has_elections = no
-		NOT = { has_government = neutrality }
-		NOT = { is_muslim_brotherhood = yes }
-		NOT = { has_country_flag = BROTHER_civil_war_has_started }
-		NOT = { has_country_flag = recently_had_muslim_brotherhood_demanded_election }
-		NOT = { has_country_flag = mb_accommodation }
-		NOT = { has_idea = muslim_brotherhood_crackdown }
-		neutrality > 0.35
-	}
-	immediate = {
-		set_country_flag = { flag = recently_had_muslim_brotherhood_demanded_election value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -45,6 +30,23 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		is_in_array = { global.possible_muslim_brotherhood_nation = THIS.id }
+		has_game_rule = { rule = rule_disable_muslim_brotherhood_civil_war option = no }
+		has_elections = no
+		NOT = { has_government = neutrality }
+		NOT = { is_muslim_brotherhood = yes }
+		NOT = { has_country_flag = BROTHER_civil_war_has_started }
+		NOT = { has_country_flag = recently_had_muslim_brotherhood_demanded_election }
+		NOT = { has_country_flag = mb_accommodation }
+		NOT = { has_idea = muslim_brotherhood_crackdown }
+		neutrality > 0.35
+	}
+
+	immediate = {
+		set_country_flag = { flag = recently_had_muslim_brotherhood_demanded_election value = 1 days = 180 }
+	}
+
 	option = {
 		name = brotherhood.6.a
 		log = "[GetDateText]: [This.GetName]: brotherhood.6.a option executed"
@@ -54,30 +56,21 @@ country_event = {
 			limit = { has_idea = al_jazeera_allowed }
 			swap_ideas = { remove_idea = al_jazeera_allowed add_idea = al_jazeera_banned }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = brotherhood.6.b
 		log = "[GetDateText]: [This.GetName]: brotherhood.6.b option executed"
 		enable_elections_with_no_leader_change = yes
-
 		if = {
-			limit = {
-				has_idea = al_jazeera_banned
-			}
+			limit = { has_idea = al_jazeera_banned }
 			swap_ideas = { remove_idea = al_jazeera_banned add_idea = al_jazeera_allowed }
 		}
 		if = {
-			limit = {
-				has_idea = muslim_brotherhood_crackdown
-			}
+			limit = { has_idea = muslim_brotherhood_crackdown }
 			 remove_ideas = muslim_brotherhood_crackdown
 		}
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -92,15 +85,12 @@ country_event = {
 	option = {
 		name = brotherhood.6.c
 		log = "[GetDateText]: [This.GetName]: brotherhood.6.c option executed"
-		trigger = {
-			neutrality < 0.6
-		}
+		trigger = { neutrality < 0.6 }
 		set_country_flag = { flag = mb_accommodation value = 1 days = 1825 }
 		add_popularity = { ideology = neutrality popularity = -0.05 }
 		recalculate_party = yes
 		add_stability = 0.03
 		add_political_power = -75
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -119,9 +109,6 @@ country_event = {
 	desc = brotherhood.7.d
 	picture = GFX_marketplace
 	is_triggered_only = yes
-	trigger = {
-		can_fire_muslim_brotherhood_crackdown_event = yes
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -142,15 +129,14 @@ country_event = {
 		}
 	}
 
+	trigger = { can_fire_muslim_brotherhood_crackdown_event = yes }
+
 	option = {
 		name = brotherhood.7.a
 		log = "[GetDateText]: [This.GetName]: brotherhood.7.a option executed"
 		add_popularity = { ideology = neutrality popularity = 0.03 }
 		recalculate_party = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -160,19 +146,15 @@ country_event = {
 	desc = brotherhood.8.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-	trigger = {
-		can_fire_muslim_brotherhood_crackdown_event = yes
-	}
+
+	trigger = { can_fire_muslim_brotherhood_crackdown_event = yes }
 
 	option = {
 		name = brotherhood.8.a
 		log = "[GetDateText]: [This.GetName]: brotherhood.8.a option executed"
 		add_popularity = { ideology = neutrality popularity = 0.05 }
 		recalculate_party = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -182,19 +164,15 @@ country_event = {
 	desc = brotherhood.9.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-	trigger = {
-		can_fire_muslim_brotherhood_crackdown_event = yes
-	}
+
+	trigger = { can_fire_muslim_brotherhood_crackdown_event = yes }
 
 	option = {
 		name = brotherhood.9.a
 		log = "[GetDateText]: [This.GetName]: brotherhood.9.a option executed"
 		add_popularity = { ideology = neutrality popularity = -0.1 }
 		recalculate_party = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -204,14 +182,14 @@ country_event = {
 	desc = brotherhood.10.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = {
 		can_fire_muslim_brotherhood_crackdown_event = yes
 		NOT = { has_war = yes }
 		neutrality > 0.5
 	}
-	immediate = {
-		set_country_flag = BROTHER_civil_war_has_started
-	}
+
+	immediate = { set_country_flag = BROTHER_civil_war_has_started }
 
 	option = {
 		name = brotherhood.10.a
@@ -219,10 +197,7 @@ country_event = {
 		start_civil_war = { ideology = neutrality size = 0.5 }
 		add_popularity = { ideology = neutrality popularity = -0.3 }
 		recalculate_party = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Play as the Brotherhood
@@ -258,17 +233,13 @@ country_event = {
 				size = 0.6
 			}
 		}
-
 		hidden_effect = {
 			every_other_country = {
 				limit = { original_tag = PREV }
 				set_country_flag = BROTHER_civil_war_has_started
 			}
 		}
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -280,6 +251,7 @@ country_event = {
 	desc = brotherhood.11.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = {
 		is_in_array = { global.possible_muslim_brotherhood_nation = THIS.id }
 		has_game_rule = { rule = rule_disable_muslim_brotherhood_civil_war option = no }
@@ -298,7 +270,6 @@ country_event = {
 		add_political_power = 50
 		add_opinion_modifier = { target = FROM modifier = MB_crackdown_patron }
 		reverse_add_opinion_modifier = { target = FROM modifier = MB_crackdown_patron }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -314,7 +285,6 @@ country_event = {
 
 	option = {
 		name = brotherhood.11.b
-
 		ai_chance = {
 			base = 1
 			modifier = {

--- a/events/Mali.txt
+++ b/events/Mali.txt
@@ -107,9 +107,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Ignore the Pastoral Communities
@@ -166,9 +164,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -194,9 +190,7 @@ country_event = {
 		add_stability = 0.02
 		add_opinion_modifier = { target = LBA modifier = MAL_attended_the_maouloud_festival }
 		reverse_add_opinion_modifier = { target = LBA modifier = MAL_attended_the_maouloud_festival }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -232,9 +226,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.005 }
 		modify_treasury_effect = yes
 		increase_military_spending = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Bah, There's No Need
@@ -246,9 +238,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		change_relative_party_popularity = yes
 		add_stability = -0.02
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -498,9 +488,7 @@ country_event = {
 	# A New Face in Politics
 	option = {
 		name = mali.10.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -762,9 +750,7 @@ country_event = {
 			amount = 500
 			producer = SOV
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -785,9 +771,7 @@ country_event = {
 	# Just Another Tuareg Party
 	option = {
 		name = mali.16.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -862,9 +846,7 @@ country_event = {
 		name = mali.19.a
 		log = "[GetDateText]: [This.GetName]: mali.19.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -993,9 +975,7 @@ country_event = {
 	# March on Kidal
 	option = {
 		name = mali.22.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# We Fight for Freedom
@@ -1003,9 +983,7 @@ country_event = {
 		name = mali.22.b
 		log = "[GetDateText]: [This.GetName]: mali.22.b executed"
 		TUA = { change_tag_from = MAL }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1098,9 +1076,7 @@ country_event = {
 	# Ansongo Defects
 	option = {
 		name = mali.24.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Play as Ansar Dine
@@ -1111,9 +1087,7 @@ country_event = {
 			limit = { original_tag = MAL }
 			change_tag_from = MAL
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1250,9 +1224,7 @@ country_event = {
 		else = {
 			add_timed_idea = { idea = AFRICA_idea_tuareg_rebellion days = 280 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1279,9 +1251,7 @@ country_event = {
 			add_timed_idea = { idea = AFRICA_idea_tuareg_rebellion days = 230 }
 		}
 		FRA = { country_event = mali.29 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1343,9 +1313,7 @@ country_event = {
 		set_temp_variable = { tag_index = NGR.id }
 		set_temp_variable = { influence_target = FRA.id }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Place the Responsibility on Areva
@@ -1356,9 +1324,7 @@ country_event = {
 		change_labour_unions_opinion = yes
 		add_political_power = 150
 		add_manpower = -4
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1380,9 +1346,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: mali.30.a executed"
 		add_manpower = -68
 		add_timed_idea = { idea = AFRICA_idea_tuareg_rebellion days = 60 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1407,9 +1371,7 @@ country_event = {
 		else = {
 			add_timed_idea = { idea = AFRICA_idea_tuareg_rebellion days = 60 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1441,9 +1403,7 @@ country_event = {
 			amount = -100
 			producer = SOV
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1477,9 +1437,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-		delete_unit_template_and_units = {
-			division_template = "Rebel Groups"
-		}
+		delete_unit_template_and_units = { division_template = "Rebel Groups" }
 		hidden_effect = {
 			if = {
 				limit = {
@@ -1527,9 +1485,7 @@ country_event = {
 				}
 				random_country_with_original_tag = {
 					original_tag_to_check = MAL
-					limit = {
-						NOT = { tag = MAL }
-					}
+					limit = { NOT = { tag = MAL } }
 					FRA = {
 						remove_relation_modifier = {
 							target = PREV
@@ -1539,9 +1495,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1574,9 +1528,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-		delete_unit_template_and_units = {
-			division_template = "Rebel Groups"
-		}
+		delete_unit_template_and_units = { division_template = "Rebel Groups" }
 		hidden_effect = {
 			if = {
 				limit = {
@@ -1624,9 +1576,7 @@ country_event = {
 				}
 				random_country_with_original_tag = {
 					original_tag_to_check = MAL
-					limit = {
-						NOT = { tag = MAL }
-					}
+					limit = { NOT = { tag = MAL } }
 					FRA = {
 						remove_relation_modifier = {
 							target = PREV
@@ -1636,9 +1586,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 

--- a/events/Norway.txt
+++ b/events/Norway.txt
@@ -6,8 +6,8 @@ country_event = {
 	title = norway.1.t
 	desc = norway.1.d
 	picture = GFX_train_collision
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = norway.1.o1
@@ -15,12 +15,8 @@ country_event = {
 		add_political_power = -50
 		set_temp_variable = { arg_popularity = -0.01 }
 		add_ruling_outlook_popularity = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 
 	option = {
 		name = norway.1.o2
@@ -28,10 +24,7 @@ country_event = {
 		add_stability = -0.03
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -42,7 +35,6 @@ country_event = {
 	id = norway.5
 	title = norway.5.t
 	desc = norway.5.d
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
@@ -69,15 +61,12 @@ country_event = {
 		}
 		newline = yes
 		random_owned_state = {
-			limit = {
-				is_coastal = yes
-			}
+			limit = { is_coastal = yes }
 			add_resource = {
 				type = oil
 				amount = 6
 			}
 		}
-
 		newline = yes
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { influence_target = NRY }
@@ -86,20 +75,15 @@ country_event = {
 		set_temp_variable = { treasury_change = -7.42 }
 		modify_treasury_effect = yes
 		NRY = { country_event = norway.6 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# No
 	option = {
 		name = norway.5.b
 		log = "[GetDateText]: [This.GetName]: norway.5.b executed"
-		NRY = {
-			country_event = norway.7
-		}
-		ai_chance = {
-			base = 0
-		}
+		NRY = { country_event = norway.7 }
+		ai_chance = { base = 0 }
 	}
 }
 # X Country Accepts!
@@ -109,12 +93,11 @@ country_event = {
 	desc = norway.6.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.6.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # X Country Rejects
@@ -122,15 +105,13 @@ country_event = {
 	id = norway.7
 	title = norway.7.t
 	desc = norway.7.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.7.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -139,9 +120,9 @@ country_event = {
 	id = norway.8
 	title = norway.8.t
 	desc = norway.8.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Minimal Amount of Aid
 	option = {
 		name = norway.8.a
@@ -158,10 +139,9 @@ country_event = {
 		newline = yes
 		set_temp_variable = { influence_target = SYR }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Reasonable Amount of Aid
 	option = {
 		name = norway.8.b
@@ -178,10 +158,9 @@ country_event = {
 		newline = yes
 		set_temp_variable = { influence_target = SYR }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Considerable Amount of Aid
 	option = {
 		name = norway.8.c
@@ -198,9 +177,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { influence_target = SYR }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -209,9 +186,9 @@ country_event = {
 	id = norway.81
 	title = norway.81.t
 	desc = norway.81.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Sure
 	option = {
 		name = norway.81.a
@@ -230,6 +207,7 @@ country_event = {
 			}
 		}
 	}
+
 	# No
 	option = {
 		name = norway.81.b
@@ -240,9 +218,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Aid request rejected
@@ -250,15 +226,13 @@ country_event = {
 	id = norway.82
 	title = norway.82.t
 	desc = norway.82.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.82.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -272,6 +246,7 @@ country_event = {
 	desc = norway.91.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
+
 	# Germany
 	option = {
 		name = norway.91.a
@@ -283,15 +258,12 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			NRY_GER_tank_purchase = yes
-		}
+		effect_tooltip = { NRY_GER_tank_purchase = yes }
 		newline = yes
 		custom_effect_tooltip = NRY_higher_relations_more_likely_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# USA
 	option = {
 		name = norway.91.b
@@ -303,14 +275,10 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			NRY_USA_ifv_purchase = yes
-		}
+		effect_tooltip = { NRY_USA_ifv_purchase = yes }
 		newline = yes
 		custom_effect_tooltip = NRY_higher_relations_more_likely_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # US / German Government Approves Arms Sales
@@ -332,9 +300,9 @@ country_event = {
 		trigger = { FROM = { original_tag = GER } }
 		text = norway.92.d
 	}
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	option = {
 		name = norway.9.a
 		log = "[GetDateText]: [This.GetName]: norway.9.a executed"
@@ -346,15 +314,12 @@ country_event = {
 			limit = { FROM = { original_tag = GER } }
 			NRY_GER_tank_purchase = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = norway.9.b
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -363,15 +328,13 @@ country_event = {
 	id = norway.93
 	title = norway.93.t
 	desc = norway.93.d
-
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.93.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Norway Wants To Purchase Weapons
@@ -379,32 +342,24 @@ country_event = {
 	id = norway.94
 	title = norway.94.t
 	desc = norway.94.d
-
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.94.a
 		log = "[GetDateText]: [This.GetName]: norway.94.a executed"
 		if = {
 			limit = { original_tag = USA }
-			NRY = {
-				country_event = norway.9
-			}
+			NRY = { country_event = norway.9 }
 			custom_effect_tooltip = TT_IF_WE_ACCEPT
-			effect_tooltip = {
-				NRY_USA_ifv_purchase = yes
-			}
+			effect_tooltip = { NRY_USA_ifv_purchase = yes }
 		}
 		else_if = {
 			limit = { original_tag = GER }
 			custom_effect_tooltip = TT_IF_WE_ACCEPT
-			effect_tooltip = {
-				NRY_GER_tank_purchase = yes
-			}
-			NRY = {
-				country_event = norway.9
-			}
+			effect_tooltip = { NRY_GER_tank_purchase = yes }
+			NRY = { country_event = norway.9 }
 		}
 		ai_chance = {
 			base = 1
@@ -414,16 +369,13 @@ country_event = {
 			}
 		}
 	}
+
 	# No
 	option = {
 		name = norway.94.b
 		log = "[GetDateText]: [This.GetName]: norway.94.b executed"
-		NRY = {
-			country_event = norway.93
-		}
-		ai_chance = {
-			base = 1
-		}
+		NRY = { country_event = norway.93 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -432,9 +384,9 @@ country_event = {
 	id = norway.10
 	title = norway.10.t
 	desc = norway.10.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.10.a
@@ -464,9 +416,7 @@ country_event = {
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Accepts
@@ -474,9 +424,9 @@ country_event = {
 	id = norway.11
 	title = norway.11.t
 	desc = norway.11.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.11.a
@@ -488,9 +438,7 @@ country_event = {
 			country = SOV
 			relation = non_aggression_pact
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Rejects
@@ -498,15 +446,13 @@ country_event = {
 	id = norway.12
 	title = norway.12.t
 	desc = norway.12.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = norway.12.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -517,6 +463,7 @@ country_event = {
 	desc = norway.14.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Legalization
 	option = {
 		name = norway.14.a
@@ -535,10 +482,9 @@ country_event = {
 			ideology = nationalist
 			popularity = -0.10
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# No Legalization
 	option = {
 		name = norway.14.b
@@ -553,9 +499,7 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.10
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -565,23 +509,21 @@ country_event = {
 	desc = norway.16.d
 	picture = GFX_european_migrant_crisis
 	is_triggered_only = yes
+
 	# Anti Immigration
 	option = {
 		name = norway.16.a
 		log = "[GetDateText]: [This.GetName]: norway.16.a executed"
 		add_ideas = NRY_anti_migration
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Pro Immigration
 	option = {
 		name = norway.16.b
 		log = "[GetDateText]: [This.GetName]: norway.16.b executed"
 		add_ideas = NRY_pro_migration
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Focus Events
@@ -592,13 +534,12 @@ country_event = {
 	desc = norway.100.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.100.a
 		log = "[GetDateText]: [This.GetName]: norway.100.a executed"
-		NRY = {
-			set_country_flag = NRY_UK_AGREED
-		}
+		NRY = { set_country_flag = NRY_UK_AGREED }
 		set_temp_variable = { receiver_nation = NRY.id }
 		set_temp_variable = { sender_nation = ENG.id }
 		set_improved_trade_agreement = yes
@@ -639,6 +580,7 @@ country_event = {
 			}
 		}
 	}
+
 	# No
 	option = {
 		name = norway.100.b
@@ -650,9 +592,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -663,12 +603,11 @@ country_event = {
 	desc = norway.101.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.101.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # They Reject
@@ -678,12 +617,11 @@ country_event = {
 	desc = norway.102.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.102.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Norway Wants To Construct Infrastructure for us
@@ -693,6 +631,7 @@ country_event = {
 	desc = norway.103.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.103.a
@@ -700,20 +639,12 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_ACCEPT
 		newline = yes
 		if = {
-			limit = {
-				original_tag = SWE
-			}
-			effect_tooltip = {
-				NRY_veidekke_build_sweden = yes
-			}
+			limit = { original_tag = SWE }
+			effect_tooltip = { NRY_veidekke_build_sweden = yes }
 		}
 		else_if = {
-			limit = {
-				original_tag = FIN
-			}
-			effect_tooltip = {
-				NRY_veidekke_build_finland = yes
-			}
+			limit = { original_tag = FIN }
+			effect_tooltip = { NRY_veidekke_build_finland = yes }
 		}
 		newline = yes
 		NRY = {
@@ -740,9 +671,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # They Accept!
@@ -752,35 +681,26 @@ country_event = {
 	desc = norway.104.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.104.a
 		log = "[GetDateText]: [This.GetName]: norway.104.a executed"
 		if = {
-			limit = {
-				FROM = {
-					original_tag = SWE
-				}
-			}
+			limit = { FROM = { original_tag = SWE } }
 			NRY_veidekke_build_sweden = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -7.00 }
 			modify_treasury_effect = yes
 		}
 		else_if = {
-			limit = {
-				FROM = {
-					original_tag = FIN
-				}
-			}
+			limit = { FROM = { original_tag = FIN } }
 			NRY_veidekke_build_finland = yes
 			newline = yes
 			set_temp_variable = { treasury_change = -7.00 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -791,12 +711,11 @@ country_event = {
 	desc = norway.105.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.105.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Norway is influencing our politics
@@ -806,12 +725,11 @@ country_event = {
 	desc = norway.106.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = norway.106.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1104,9 +1022,7 @@ country_event = {
 	picture = GFX_military_exercise
 	is_triggered_only = yes
 
-	trigger = {
-		NRY_kongsberg_outcome_settled = no
-	}
+	trigger = { NRY_kongsberg_outcome_settled = no }
 
 	option = {
 		name = norway.305.a

--- a/events/Sweden.txt
+++ b/events/Sweden.txt
@@ -22,9 +22,7 @@ country_event = {
 		decrease_social_spending = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -32,11 +30,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden.5.o2 executed"
 		add_political_power = -50
 		add_stability = -0.02
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 #NF: Riksbank Policy
@@ -53,9 +48,7 @@ country_event = {
 		add_stability = 0.01
 		set_temp_variable = { temp_opinion = 5 }
 		change_industrial_conglomerates_opinion = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -65,11 +58,8 @@ country_event = {
 		add_stability = -0.01
 		set_temp_variable = { temp_opinion = -5 }
 		change_industrial_conglomerates_opinion = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 
@@ -91,20 +81,15 @@ news_event = {
 		name = Sweden.19.o1
 		log = "[GetDateText]: [This.GetName]: Sweden.19.o1 executed"
 		if = {
-			limit = {
-				original_tag = SWE
-			}
+			limit = { original_tag = SWE }
 			add_ideas = SWE_stealth_submarines
 			navy_experience = 20
 		}
 		if = {
-			limit = {
-				original_tag = USA
-			}
+			limit = { original_tag = USA }
 			navy_experience = 10
 		}
 	}
-
 }
 
 #2021 gov crisis
@@ -149,7 +134,6 @@ country_event = {
 		ai_chance = { base = 2 }
 		country_event = Sweden.21
 	}
-
 }
 
 #
@@ -160,10 +144,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden.21.o2
-	}
-
+	option = { name = Sweden.21.o2 }
 }
 
 
@@ -183,7 +164,6 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden.22.o1 executed"
 		add_stability = 0.05
 	}
-
 }
 
 #Norrtåg Founded, May 2001
@@ -208,14 +188,9 @@ country_event = {
 					instant_build = yes
 					}
 				}
-				else = {
-					442 = {
-						add_extra_state_shared_building_slots = 2
-					}
-				}
+				else = { 442 = { add_extra_state_shared_building_slots = 2 } }
 			}
 	}
-
 }
 
 #Nobel Prize turn 100, December 2001
@@ -228,10 +203,7 @@ news_event = {
 
 	trigger = { original_tag = SWE }
 
-	option = {
-		name = Sweden.24.o1
-	}
-
+	option = { name = Sweden.24.o1 }
 }
 
 #Rinkeby Murder, February 26 2002
@@ -253,7 +225,6 @@ news_event = {
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #Västermalmsgallerian, August 2002
@@ -269,7 +240,6 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden.26.o1 executed"
 		one_office_construction = yes
 	}
-
 }
 
 #Anna Lindh, September 2003
@@ -292,7 +262,6 @@ country_event = {
 		add_political_power = -50
 		hidden_effect = { SWE = { country_event = Sweden.28 } }
 	}
-
 }
 
 #Anna Lindh murderer found
@@ -312,7 +281,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #### Borgers Events ###
@@ -334,9 +302,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.1.o1
-		trigger = {
-			SWE_can_request_from_USA = yes
-		}
+		trigger = { SWE_can_request_from_USA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.1.o1 executed"
 		USA = { country_event = { id = Sweden_foci.1001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -344,9 +310,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.1.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.1.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.1001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -370,7 +334,6 @@ country_event = {
 	}
 
 	#Deny the Request/We Do not have the funds
-
 }
 country_event = {
 	id = Sweden_foci.1001
@@ -408,7 +371,6 @@ country_event = {
 		SWE = { country_event = { id = Sweden_foci.1002 days = 7 } }
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/USA ACCEPTS OUR REQUEST
 country_event = {
@@ -500,7 +462,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 	}
-
 }
 
 # SOV/USA DENIES OUR REQUEST
@@ -519,10 +480,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.1003.o1
-	}
-
+	option = { name = Sweden_foci.1003.o1 }
 }
 
 #Negotiate tank deals
@@ -537,9 +495,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.2.o1
-		trigger = {
-			SWE_can_request_from_USA = yes
-		}
+		trigger = { SWE_can_request_from_USA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.2.o1 executed"
 		USA = { country_event = { id = Sweden_foci.2001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -547,9 +503,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.2.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.2.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.2001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -557,9 +511,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.2.o3
-		trigger = {
-			SWE_can_request_from_GER = yes
-		}
+		trigger = { SWE_can_request_from_GER = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.2.o3 executed"
 		GER = { country_event = { id = Sweden_foci.2001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -583,7 +535,6 @@ country_event = {
 	}
 
 	#Deny the Request/We Do not have the funds
-
 }
 country_event = {
 	id = Sweden_foci.2001
@@ -625,7 +576,6 @@ country_event = {
 		set_country_flag = i_like_tanks_2
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/USA ACCEPTS OUR REQUEST
 country_event = {
@@ -780,8 +730,8 @@ country_event = {
 					special_type_slot_1 = smoke_launchers_2
 					special_type_slot_2 = wet_ammo_storage
 					special_type_slot_3 = empty
-					special_type_slot_4 = tank_battlestation_3		#Battlestation
-					special_type_slot_6 = spaced_armor_gen2		#ERA/Spaced
+					special_type_slot_4 = tank_battlestation_3 #Battlestation
+					special_type_slot_6 = spaced_armor_gen2 #ERA/Spaced
 				}
 				upgrades = {
 					tank_nsb_armor_upgrade = 7
@@ -830,7 +780,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 	}
-
 }
 
 # SOV/USA DENIES OUR REQUEST
@@ -853,10 +802,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.2003.o1
-	}
-
+	option = { name = Sweden_foci.2003.o1 }
 }
 
 #Negotiate tank deals
@@ -871,9 +817,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.3.o1
-		trigger = {
-			SWE_can_request_from_USA = yes
-		}
+		trigger = { SWE_can_request_from_USA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.3.o1 executed"
 		USA = { country_event = { id = Sweden_foci.3001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -881,9 +825,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.3.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.3.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.3001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -891,9 +833,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.3.o3
-		trigger = {
-			SWE_can_request_from_FRA = yes
-		}
+		trigger = { SWE_can_request_from_FRA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.3.o3 executed"
 		FRA = { country_event = { id = Sweden_foci.3001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -917,7 +857,6 @@ country_event = {
 	}
 
 	#Deny the Request/We Do not have the funds
-
 }
 country_event = {
 	id = Sweden_foci.3001
@@ -959,7 +898,6 @@ country_event = {
 		set_country_flag = i_like_helo_2
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/USA ACCEPTS OUR REQUEST
 country_event = {
@@ -987,9 +925,7 @@ country_event = {
 		if = {
 			limit = {
 				has_dlc = "No Step Back"
-				USA = {
-					has_country_flag = i_like_helo_2
-				}
+				USA = { has_country_flag = i_like_helo_2 }
 			}
 			add_equipment_to_stockpile = {
 				type = heavy_tank_chassis_0
@@ -1009,12 +945,8 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				NOT = {
-					has_dlc = "No Step Back"
-				}
-				USA = {
-					has_country_flag = i_like_helo_2
-				}
+				NOT = { has_dlc = "No Step Back" }
+				USA = { has_country_flag = i_like_helo_2 }
 			}
 			add_equipment_to_stockpile = {
 				type = attack_helicopter_1
@@ -1033,9 +965,7 @@ country_event = {
 		if = {
 			limit = {
 				has_dlc = "No Step Back"
-				SOV = {
-					has_country_flag = i_like_helo_2
-				}
+				SOV = { has_country_flag = i_like_helo_2 }
 			}
 			add_equipment_to_stockpile = {
 				type = heavy_tank_chassis_1
@@ -1049,12 +979,8 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				NOT = {
-					has_dlc = "No Step Back"
-				}
-				SOV = {
-					has_country_flag = i_like_helo_2
-				}
+				NOT = { has_dlc = "No Step Back" }
+				SOV = { has_country_flag = i_like_helo_2 }
 			}
 			add_equipment_to_stockpile = {
 				type = attack_helicopter_2
@@ -1068,9 +994,7 @@ country_event = {
 		if = {
 			limit = {
 				has_dlc = "No Step Back"
-				FRA = {
-					has_country_flag = i_like_helo_2
-				}
+				FRA = { has_country_flag = i_like_helo_2 }
 			}
 			add_equipment_to_stockpile = {
 				type = heavy_tank_chassis_1
@@ -1084,12 +1008,8 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				NOT = {
-					has_dlc = "No Step Back"
-				}
-				FRA = {
-					has_country_flag = i_like_helo_2
-				}
+				NOT = { has_dlc = "No Step Back" }
+				FRA = { has_country_flag = i_like_helo_2 }
 			}
 			add_equipment_to_stockpile = {
 				type = attack_helicopter_3
@@ -1101,7 +1021,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 	}
-
 }
 
 # SOV/USA DENIES OUR REQUEST
@@ -1124,10 +1043,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.3003.o1
-	}
-
+	option = { name = Sweden_foci.3003.o1 }
 }
 
 #Negotiate tank deals
@@ -1142,9 +1058,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.4.o1
-		trigger = {
-			SWE_can_request_from_GER = yes
-		}
+		trigger = { SWE_can_request_from_GER = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.4.o1 executed"
 		GER = { country_event = { id = Sweden_foci.4001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1152,9 +1066,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.4.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.4.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.4001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1162,9 +1074,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.4.o3
-		trigger = {
-			SWE_can_request_from_NRY = yes
-		}
+		trigger = { SWE_can_request_from_NRY = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.4.o3 executed"
 		NRY = { country_event = { id = Sweden_foci.4001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1188,7 +1098,6 @@ country_event = {
 	}
 
 	#Deny the Request/We Do not have the funds
-
 }
 country_event = {
 	id = Sweden_foci.4001
@@ -1230,7 +1139,6 @@ country_event = {
 		set_country_flag = i_like_art_2
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/USA ACCEPTS OUR REQUEST
 country_event = {
@@ -1434,7 +1342,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # SOV/USA DENIES OUR REQUEST
@@ -1457,10 +1364,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.4003.o1
-	}
-
+	option = { name = Sweden_foci.4003.o1 }
 }
 
 #Negotiate tank deals
@@ -1475,9 +1379,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.5.o1
-		trigger = {
-			SWE_can_request_from_USA = yes
-		}
+		trigger = { SWE_can_request_from_USA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.5.o1 executed"
 		USA = { country_event = { id = Sweden_foci.5001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1485,9 +1387,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.5.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.5.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.5001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1495,9 +1395,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.5.o3
-		trigger = {
-			SWE_can_request_from_FRA = yes
-		}
+		trigger = { SWE_can_request_from_FRA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.5.o3 executed"
 		FRA = { country_event = { id = Sweden_foci.5001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1521,7 +1419,6 @@ country_event = {
 	}
 
 	#Deny the Request/We Do not have the funds
-
 }
 country_event = {
 	id = Sweden_foci.5001
@@ -1563,7 +1460,6 @@ country_event = {
 		set_country_flag = i_like_potato_2
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/USA ACCEPTS OUR REQUEST
 country_event = {
@@ -1611,7 +1507,7 @@ country_event = {
 				}
 			}
 			add_equipment_to_stockpile = {
-				type = transport_helicopter_2		#Mi-26
+				type = transport_helicopter_2 #Mi-26
 				amount = 60
 				producer = SOV
 			}
@@ -1626,7 +1522,7 @@ country_event = {
 				}
 			}
 			add_equipment_to_stockpile = {
-				type = transport_helicopter_2		#Mi-26
+				type = transport_helicopter_2 #Mi-26
 				variant_name = "AS532 Cougar"
 				amount = 60
 				producer = FRA
@@ -1636,7 +1532,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 	}
-
 }
 
 # SOV/USA DENIES OUR REQUEST
@@ -1659,10 +1554,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.5003.o1
-	}
-
+	option = { name = Sweden_foci.5003.o1 }
 }
 
 #Negotiate submarine deal
@@ -1677,9 +1569,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.6.o1
-		trigger = {
-			SWE_can_request_from_GER = yes
-		}
+		trigger = { SWE_can_request_from_GER = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.6.o1 executed"
 		GER = { country_event = { id = Sweden_foci.6001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1687,9 +1577,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.6.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.6.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.6001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1697,9 +1585,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.6.o3
-		trigger = {
-			SWE_can_request_from_USA = yes
-		}
+		trigger = { SWE_can_request_from_USA = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.6.o3 executed"
 		USA = { country_event = { id = Sweden_foci.6001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1728,7 +1614,6 @@ country_event = {
 	}
 
 	#concentrate on own project
-
 }
 country_event = {
 	id = Sweden_foci.6001
@@ -1770,7 +1655,6 @@ country_event = {
 		set_country_flag = we_all_live_in_a_jellow_submarine_2
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/USA ACCEPTS OUR REQUEST
 country_event = {
@@ -1800,7 +1684,6 @@ country_event = {
 			SWE = { country_event = { id = Sweden_foci.6004 days = 365 } }
 		}
 	}
-
 }
 
 # SOV/USA DENIES OUR REQUEST
@@ -1823,10 +1706,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.6003.o1
-	}
-
+	option = { name = Sweden_foci.6003.o1 }
 }
 
 # auslieferung
@@ -1834,11 +1714,7 @@ country_event = {
 	id = Sweden_foci.6004
 	title = Sweden_foci.6004.t
 	desc = {
-		trigger = {
-			USA = {
-				has_country_flag = we_all_live_in_a_jellow_submarine
-			}
-		}
+		trigger = { USA = { has_country_flag = we_all_live_in_a_jellow_submarine } }
 		text = Sweden_foci.6004.d3
 	}
 	picture = GFX_submarine
@@ -1849,11 +1725,7 @@ country_event = {
 		name = Sweden_foci.6004.o1
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.6004.o1 executed"
 		if = {
-			limit = {
-				GER = {
-					has_country_flag = we_all_live_in_a_jellow_submarine_2
-				}
-			}
+			limit = { GER = { has_country_flag = we_all_live_in_a_jellow_submarine_2 } }
 			SWE = {
 				create_ship = { type = attack_submarine_hull_3 equipment_variant = "Type 212 Class" creator = GER }
 				create_ship = { type = attack_submarine_hull_3 equipment_variant = "Type 212 Class" creator = GER }
@@ -1864,11 +1736,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				SOV = {
-					has_country_flag = we_all_live_in_a_jellow_submarine_2
-				}
-			}
+			limit = { SOV = { has_country_flag = we_all_live_in_a_jellow_submarine_2 } }
 			SWE = {
 				create_ship = { type = attack_submarine_hull_3 equipment_variant = "Lada Class" creator = SOV }
 				create_ship = { type = attack_submarine_hull_3 equipment_variant = "Lada Class" creator = SOV }
@@ -1879,11 +1747,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				USA = {
-					has_country_flag = we_all_live_in_a_jellow_submarine_2
-				}
-			}
+			limit = { USA = { has_country_flag = we_all_live_in_a_jellow_submarine_2 } }
 			SWE = {
 				create_ship = { type = attack_submarine_hull_3 equipment_variant = "Seawolf Class" creator = USA }
 				create_ship = { type = attack_submarine_hull_3 equipment_variant = "Seawolf Class" creator = USA }
@@ -1894,7 +1758,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 	}
-
 }
 
 #Negotiate corvette deal
@@ -1909,9 +1772,7 @@ country_event = {
 	##Accept Send Request
 	option = {
 		name = Sweden_foci.7.o1
-		trigger = {
-			SWE_can_request_from_GER = yes
-		}
+		trigger = { SWE_can_request_from_GER = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.7.o1 executed"
 		GER = { country_event = { id = Sweden_foci.7001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1919,9 +1780,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.7.o2
-		trigger = {
-			SWE_can_request_from_SOV = yes
-		}
+		trigger = { SWE_can_request_from_SOV = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.7.o2 executed"
 		SOV = { country_event = { id = Sweden_foci.7001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1929,9 +1788,7 @@ country_event = {
 
 	option = {
 		name = Sweden_foci.7.o3
-		trigger = {
-			SWE_can_request_from_FIN = yes
-		}
+		trigger = { SWE_can_request_from_FIN = yes }
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.7.o3 executed"
 		FIN = { country_event = { id = Sweden_foci.7001 days = 1 } }
 		ai_chance = { base = 1 }
@@ -1960,7 +1817,6 @@ country_event = {
 	}
 
 	#concentrate on own project
-
 }
 country_event = {
 	id = Sweden_foci.7001
@@ -2002,7 +1858,6 @@ country_event = {
 		set_country_flag = i_see_no_corvette_2
 		ai_chance = { base = 1 }
 	}
-
 }
 # SOV/FIN ACCEPTS OUR REQUEST
 country_event = {
@@ -2032,7 +1887,6 @@ country_event = {
 			SWE = { country_event = { id = Sweden_foci.7004 days = 375 } }
 		}
 	}
-
 }
 
 # SOV/FIN DENIES OUR REQUEST
@@ -2055,10 +1909,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Sweden_foci.7003.o1
-	}
-
+	option = { name = Sweden_foci.7003.o1 }
 }
 
 # auslieferung
@@ -2066,11 +1917,7 @@ country_event = {
 	id = Sweden_foci.7004
 	title = Sweden_foci.7004.t
 	desc = {
-		trigger = {
-			FIN = {
-				has_country_flag = i_see_no_corvette
-			}
-		}
+		trigger = { FIN = { has_country_flag = i_see_no_corvette } }
 		text = Sweden_foci.7004.d3
 	}
 	picture = GFX_corvette
@@ -2081,11 +1928,7 @@ country_event = {
 		name = Sweden_foci.7004.o1
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.7004.o1 executed"
 		if = {
-			limit = {
-				GER = {
-					has_country_flag = i_see_no_corvette_2
-				}
-			}
+			limit = { GER = { has_country_flag = i_see_no_corvette_2 } }
 			SWE = {
 				create_ship = { type = corvette_hull_3 equipment_variant = "Braunschweig Class" creator = GER }
 				create_ship = { type = corvette_hull_3 equipment_variant = "Braunschweig Class" creator = GER }
@@ -2096,11 +1939,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				SOV = {
-					has_country_flag = i_see_no_corvette_2
-				}
-			}
+			limit = { SOV = { has_country_flag = i_see_no_corvette_2 } }
 			SWE = {
 				create_ship = { type = corvette_hull_2 equipment_variant = "Tarantul Class" creator = SOV }
 				create_ship = { type = corvette_hull_2 equipment_variant = "Tarantul Class" creator = SOV }
@@ -2111,11 +1950,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		if = {
-			limit = {
-				FIN = {
-					has_country_flag = i_see_no_corvette_2
-				}
-			}
+			limit = { FIN = { has_country_flag = i_see_no_corvette_2 } }
 			SWE = {
 				create_ship = { type = corvette_hull_3 equipment_variant = "Hamina Class" creator = FIN }
 				create_ship = { type = corvette_hull_3 equipment_variant = "Hamina Class" creator = FIN }
@@ -2126,7 +1961,6 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 	}
-
 }
 
 #logistik invest
@@ -2166,7 +2000,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 #accept (generic, keyed on SWE_royal_offer_chain: 10=infrastructure, 11=cybershield, 12=economic forum, 13=think tank, 14=NATO exercise)
 country_event = {
@@ -2304,7 +2137,6 @@ country_event = {
 		clr_country_flag = SWE_royal_response_queued
 		ai_chance = { base = 1 }
 	}
-
 }
 #denied (generic, keyed on SWE_royal_offer_chain: 10=infrastructure, 11=cybershield, 12=economic forum, 13=think tank, 14=NATO exercise)
 country_event = {
@@ -2442,7 +2274,6 @@ country_event = {
 		clr_country_flag = SWE_royal_response_queued
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #cybershield_europe
@@ -2482,7 +2313,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #economic forum
@@ -2522,7 +2352,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #thinktanks links
@@ -2562,7 +2391,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #Nato exercise
@@ -2587,9 +2415,7 @@ country_event = {
 		}
 		random_country_division = { add_divisional_commander_xp = 110 }
 		random_army_leader = {
-			limit = {
-				is_field_marshal = no
-			}
+			limit = { is_field_marshal = no }
 			gain_xp = 50
 			add_attack = 1
 			add_planning = 1
@@ -2625,7 +2451,6 @@ country_event = {
 		add_political_power = 150
 		ai_chance = { base = 1 }
 	}
-
 }
 #exercise
 country_event = {
@@ -2642,9 +2467,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.143.a executed"
 		random_country_division = { add_divisional_commander_xp = 110 }
 		random_army_leader = {
-			limit = {
-				is_field_marshal = no
-			}
+			limit = { is_field_marshal = no }
 			gain_xp = 50
 			add_attack = 1
 			add_planning = 1
@@ -2660,7 +2483,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #banking
@@ -2686,9 +2508,7 @@ country_event = {
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = SWE }
 		change_influence_percentage = yes
-		SWE = {
-			country_event = Sweden_foci.31
-		}
+		SWE = { country_event = Sweden_foci.31 }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -2701,16 +2521,11 @@ country_event = {
 	option = {
 		name = Sweden_foci.30.b
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.30.b executed"
-		SWE = {
-			country_event = Sweden_foci.32
-		}
-		ai_chance = {
-			base = 5
-		}
+		SWE = { country_event = Sweden_foci.32 }
+		ai_chance = { base = 5 }
 	}
 
 	# no
-
 }
 
 country_event = {
@@ -2725,11 +2540,8 @@ country_event = {
 		name = Sweden_foci.31.a
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.31.a executed"
 		add_political_power = 5
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 country_event = {
@@ -2744,11 +2556,8 @@ country_event = {
 		name = Sweden_foci.32.a
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.32.a executed"
 		add_political_power = -5
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 #blekinge class #need
@@ -2781,7 +2590,6 @@ country_event = {
 				change_defense_industry_opinion = yes
 		ai_chance = { base = 1 }
 	}
-
 }
 #accept
 country_event = {
@@ -2813,7 +2621,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #restructure AA #need
@@ -2912,7 +2719,6 @@ country_event = {
 
 	#longrange
 	#only mobile
-
 }
 
 #restructure airpport #need
@@ -2978,7 +2784,6 @@ country_event = {
 
 	#build a new in Värmland
 	#improve logistics
-
 }
 
 #saab present its new gripen #need
@@ -3065,7 +2870,6 @@ country_event = {
 	}
 
 	#we can use the knowledge
-
 }
 
 #taurus #need
@@ -3124,7 +2928,6 @@ country_event = {
 	}
 
 	#take knowhow
-
 }
 
 #saab present its new gripen #need
@@ -3158,7 +2961,6 @@ country_event = {
 	}
 
 	#take knowhow
-
 }
 
 #they say no
@@ -3182,7 +2984,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #mio update
@@ -3214,7 +3015,6 @@ country_event = {
 	}
 
 	#a nice man with a handsome suitcase
-
 }
 
 #they say no
@@ -3231,9 +3031,7 @@ country_event = {
 		name = Sweden_foci.47.a
 		log = "[GetDateText]: [This.GetName]: Sweden_foci.47.a executed"
 		if = {
-			limit = {
-				has_dlc = "Arms Against Tyranny"
-			}
+			limit = { has_dlc = "Arms Against Tyranny" }
 			mio:SWE_kockums_manufacturer = {
 				add_mio_size_up_requirement_factor = -0.2
 				add_mio_research_bonus = 0.1
@@ -3248,7 +3046,6 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
-
 }
 
 #they say no
@@ -3267,9 +3064,7 @@ country_event = {
 		increase_corruption = yes
 		GER = {
 			if = {
-				limit = {
-					has_dlc = "Arms Against Tyranny"
-				}
+				limit = { has_dlc = "Arms Against Tyranny" }
 				mio:GER_thyssenkrupp_marine_naval_manufacturer = {
 					add_mio_size_up_requirement_factor = -0.2
 					add_mio_funds_gain_factor = 0.1
@@ -3280,7 +3075,6 @@ country_event = {
 		create_ship = { type = attack_submarine_hull_3 equipment_variant = "Type 212 Class" creator = GER }
 		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -3330,7 +3124,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3340,10 +3133,7 @@ country_event = {
 	picture = GFX_military_exercise
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_foci.51.a
-	}
-
+	option = { name = Sweden_foci.51.a }
 }
 
 country_event = {
@@ -3384,7 +3174,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3394,10 +3183,7 @@ country_event = {
 	picture = GFX_military_exercise
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_foci.53.a
-	}
-
+	option = { name = Sweden_foci.53.a }
 }
 #found nordbanken
 country_event = {
@@ -3440,7 +3226,6 @@ country_event = {
 		SWE = { country_event = Sweden_foci.71 }
 		ai_chance = { base = 1 }
 	}
-
 }
 #mio
 country_event = {
@@ -3470,7 +3255,6 @@ country_event = {
 		SWE = { country_event = Sweden_foci.71 }
 		ai_chance = { base = 3 }
 	}
-
 }
 #techsharing
 country_event = {
@@ -3499,7 +3283,6 @@ country_event = {
 		SWE = { country_event = Sweden_foci.71 }
 		ai_chance = { base = 3 }
 	}
-
 }
 country_event = {
 	id = Sweden_foci.57
@@ -3522,9 +3305,7 @@ country_event = {
 			}
 			country_event = Sweden_foci.70
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -3535,11 +3316,8 @@ country_event = {
 			modify_treasury_effect = yes
 			country_event = Sweden_foci.71
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
-
 }
 
 #yes
@@ -3550,10 +3328,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_foci.70.b
-	}
-
+	option = { name = Sweden_foci.70.b }
 }
 #no
 country_event = {
@@ -3563,10 +3338,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_foci.71.b
-	}
-
+	option = { name = Sweden_foci.71.b }
 }
 
 ### news events ###
@@ -3580,10 +3352,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = Sweden_news.2.o1
-	}
-
+	option = { name = Sweden_news.2.o1 }
 }
 
 # nordic aliance
@@ -3637,7 +3406,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 # Totalforsvaret decision announcements, keyed on SWE_notice_type
@@ -3676,9 +3444,7 @@ news_event = {
 		text = Sweden_news.12.t
 	}
 	title = {
-		trigger = {
-			NOT = { SWE_notice_type_known = yes }
-		}
+		trigger = { NOT = { SWE_notice_type_known = yes } }
 		text = Sweden_news.4.other_t
 	}
 	desc = {
@@ -3714,9 +3480,7 @@ news_event = {
 		text = Sweden_news.12.d
 	}
 	desc = {
-		trigger = {
-			NOT = { SWE_notice_type_known = yes }
-		}
+		trigger = { NOT = { SWE_notice_type_known = yes } }
 		text = Sweden_news.4.other_d
 	}
 	picture = GFX_Military_Reform
@@ -3788,13 +3552,10 @@ news_event = {
 
 	option = {
 		name = Sweden_news.4.other_a
-		trigger = {
-			NOT = { SWE_notice_type_known = yes }
-		}
+		trigger = { NOT = { SWE_notice_type_known = yes } }
 		log = "[GetDateText]: [This.GetName]: Sweden_news.4.other_a executed"
 		clr_country_flag = SWE_notice_pending
 	}
-
 }
 
 # new forces
@@ -3845,7 +3606,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #SWE_balance_of_power_category / SWE_open_weapons_depots decision announcements, keyed on SWE_bop_news_type
@@ -3900,9 +3660,7 @@ news_event = {
 		text = Sweden_news.31.t
 	}
 	title = {
-		trigger = {
-			NOT = { SWE_bop_news_type_known = yes }
-		}
+		trigger = { NOT = { SWE_bop_news_type_known = yes } }
 		text = Sweden_news.20.other_t
 	}
 	desc = {
@@ -3954,9 +3712,7 @@ news_event = {
 		text = Sweden_news.31.d
 	}
 	desc = {
-		trigger = {
-			NOT = { SWE_bop_news_type_known = yes }
-		}
+		trigger = { NOT = { SWE_bop_news_type_known = yes } }
 		text = Sweden_news.20.other_d
 	}
 	picture = GFX_politics_negotiations
@@ -4060,13 +3816,10 @@ news_event = {
 
 	option = {
 		name = Sweden_news.20.other_a
-		trigger = {
-			NOT = { SWE_bop_news_type_known = yes }
-		}
+		trigger = { NOT = { SWE_bop_news_type_known = yes } }
 		log = "[GetDateText]: [This.GetName]: Sweden_news.20.other_a executed"
 		clr_country_flag = SWE_bop_news_pending
 	}
-
 }
 #state visit + friendship
 
@@ -4130,7 +3883,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = Sweden_news.33
@@ -4154,7 +3906,6 @@ country_event = {
 			modifier = declaration_of_friendship
 		}
 	}
-
 }
 country_event = {
 	id = Sweden_news.34
@@ -4181,7 +3932,6 @@ country_event = {
 			modifier = declaration_of_friendship
 		}
 	}
-
 }
 
 
@@ -4195,7 +3945,7 @@ country_event = {
 
 	trigger = { original_tag = SWE }
 
-	option = {	#Increase force
+	option = { #Increase force
 		name = Sweden_Forsvarsbeslutet.1.o1
 		log = "[GetDateText]: [This.GetName]: Sweden_Forsvarsbeslutet.1.o1 executed"
 		### Spendings ###
@@ -4415,7 +4165,7 @@ country_event = {
 		ai_chance = { base = 5 }
 	}
 
-	option = {	#increase intervention
+	option = { #increase intervention
 		name = Sweden_Forsvarsbeslutet.1.o2
 		log = "[GetDateText]: [This.GetName]: Sweden_Forsvarsbeslutet.1.o2 executed"
 		### intervention ###
@@ -4483,7 +4233,7 @@ country_event = {
 		ai_chance = { base = 5 }
 	}
 
-	option = {	#save money
+	option = { #save money
 		name = Sweden_Forsvarsbeslutet.1.o3
 		log = "[GetDateText]: [This.GetName]: Sweden_Forsvarsbeslutet.1.o3 executed"
 		### Spendings ###
@@ -4555,7 +4305,6 @@ country_event = {
 		modify_treasury_effect = yes
 		ai_chance = { base = 5 }
 	}
-
 }
 
 # tank
@@ -4584,9 +4333,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.11 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -4601,15 +4348,10 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 			multiply_temp_variable = { treasury_change = -0.06 }
 			modify_treasury_effect = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
-	option = {
-		name = Sweden_Forsvarsbeslutet.2.c
-	}
-
+	option = { name = Sweden_Forsvarsbeslutet.2.c }
 }
 # gripen
 country_event = {
@@ -4631,9 +4373,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 			multiply_temp_variable = { treasury_change = -0.26 }
 			modify_treasury_effect = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
 	option = {
@@ -4648,18 +4388,13 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 			multiply_temp_variable = { treasury_change = -0.10 }
 			modify_treasury_effect = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
 		name = Sweden_Forsvarsbeslutet.3.c
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 # gripen
 country_event = {
@@ -4693,9 +4428,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 			multiply_temp_variable = { treasury_change = -0.20 }
 			modify_treasury_effect = yes
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = {
@@ -4710,18 +4443,13 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 			multiply_temp_variable = { treasury_change = -0.06 }
 			modify_treasury_effect = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
 	option = {
 		name = Sweden_Forsvarsbeslutet.4.c
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #introduce New army
@@ -4770,7 +4498,6 @@ country_event = {
 			base = 2
 		}
 	}
-
 }
 
 #introduce New army
@@ -4807,7 +4534,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 
 #royals
@@ -4823,13 +4549,7 @@ country_event = {
 	#victoria
 	option = {
 		name = Sweden_royal.1.o1
-		trigger = {
-			SWE = {
-				NOT = {
-					has_country_flag = victoria_mandatory_service
-				}
-			}
-		}
+		trigger = { SWE = { NOT = { has_country_flag = victoria_mandatory_service } } }
 		log = "[GetDateText]: [This.GetName]: Sweden_royal.1.o1 executed"
 		custom_effect_tooltip = Sweden_royal.1.o1_desc
 			set_country_flag = victoria_mandatory_service
@@ -4840,13 +4560,7 @@ country_event = {
 
 	option = {
 		name = Sweden_royal.1.o2
-		trigger = {
-			SWE = {
-				NOT = {
-					has_country_flag = philip_mandatory_service
-				}
-			}
-		}
+		trigger = { SWE = { NOT = { has_country_flag = philip_mandatory_service } } }
 		log = "[GetDateText]: [This.GetName]: Sweden_royal.1.o2 executed"
 		custom_effect_tooltip = Sweden_royal.1.o2_desc
 			set_country_flag = philip_mandatory_service
@@ -4862,7 +4576,6 @@ country_event = {
 	}
 
 	#philip
-
 }
 #training as officer
 country_event = {
@@ -4878,9 +4591,7 @@ country_event = {
 		name = Sweden_royal.2.o1
 		trigger = {
 			SWE = {
-				NOT = {
-					has_country_flag = victoria_officer_training
-				}
+				NOT = { has_country_flag = victoria_officer_training }
 				has_country_flag = victoria_mandatory_service
 			}
 		}
@@ -4897,9 +4608,7 @@ country_event = {
 		name = Sweden_royal.2.o2
 		trigger = {
 			SWE = {
-				NOT = {
-					has_country_flag = philip_officer_training
-				}
+				NOT = { has_country_flag = philip_officer_training }
 				has_country_flag = philip_mandatory_service
 			}
 		}
@@ -4913,7 +4622,6 @@ country_event = {
 	}
 
 	#philip
-
 }
 country_event = {
 	id = Sweden_royal.13
@@ -4947,7 +4655,6 @@ country_event = {
 		SWE = { country_event = Sweden_foci.71 }
 		ai_chance = { base = 1 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.01
@@ -4977,9 +4684,7 @@ country_event = {
 				add = 10
 			}
 		}
-		SWE = {
-			country_event = SWE_eastern.101
-		}
+		SWE = { country_event = SWE_eastern.101 }
 	}
 
 	option = {
@@ -4999,11 +4704,8 @@ country_event = {
 				add = 10
 			}
 		}
-		SWE = {
-			country_event = SWE_eastern.102
-		}
+		SWE = { country_event = SWE_eastern.102 }
 	}
-
 }
 
 country_event = {
@@ -5021,7 +4723,6 @@ country_event = {
 			days = 180
 		}
 	}
-
 }
 
 country_event = {
@@ -5031,10 +4732,7 @@ country_event = {
 	picture = GFX_military_exercise
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.102.a
-	}
-
+	option = { name = Sweden_eastern.102.a }
 }
 
 country_event = {
@@ -5061,9 +4759,7 @@ country_event = {
 		name = Sweden_eastern.02.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.02.b executed"
 		SWE = { country_event = SWE_eastern.04 }
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -5078,7 +4774,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -5113,7 +4808,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -5139,7 +4833,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -5154,7 +4847,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.05.a executed"
 		add_stability = -0.03
 	}
-
 }
 country_event = {
 	id = SWE_eastern.07
@@ -5180,9 +4872,7 @@ country_event = {
 	option = {
 		name = Sweden_eastern.07.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.07.b executed"
-		SWE = {
-			country_event = SWE_eastern.09
-		}
+		SWE = { country_event = SWE_eastern.09 }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -5191,7 +4881,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.08
@@ -5210,7 +4899,6 @@ country_event = {
 		set_temp_variable = { influence_target = SWE }
 		change_influence_percentage = yes
 	}
-
 }
 country_event = {
 	id = SWE_eastern.09
@@ -5219,10 +4907,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.09.a
-	}
-
+	option = { name = Sweden_eastern.09.a }
 }
 country_event = {
 	id = SWE_eastern.10
@@ -5234,9 +4919,7 @@ country_event = {
 	option = {
 		name = Sweden_eastern.10.a
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.10.a executed"
-		SWE = {
-			country_event = SWE_eastern.11
-		}
+		SWE = { country_event = SWE_eastern.11 }
 		add_tech_bonus = {
 			name = Sweden_eastern.10.t
 			bonus = 0.15
@@ -5255,9 +4938,7 @@ country_event = {
 	option = {
 		name = Sweden_eastern.10.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.10.b executed"
-		SWE = {
-			country_event = SWE_eastern.12
-		}
+		SWE = { country_event = SWE_eastern.12 }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -5266,7 +4947,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.11
@@ -5280,9 +4960,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.11.a executed"
 		if = {
 			limit = { has_dlc = "Arms Against Tyranny" }
-			mio:SWE_saab_ab_manufacturer = {
-				add_mio_size = 2
-			}
+			mio:SWE_saab_ab_manufacturer = { add_mio_size = 2 }
 		}
 		else = {
 			one_random_arms_factory = yes
@@ -5306,7 +4984,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.12
@@ -5320,7 +4997,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.12.a executed"
 		add_stability = -0.02
 	}
-
 }
 country_event = {
 	id = SWE_eastern.14
@@ -5365,9 +5041,7 @@ country_event = {
 	option = {
 		name = Sweden_eastern.14.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.14.b executed"
-		SWE = {
-			country_event = SWE_eastern.16
-		}
+		SWE = { country_event = SWE_eastern.16 }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -5376,7 +5050,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.15
@@ -5415,7 +5088,6 @@ country_event = {
 		set_temp_variable = { influence_target = SWE }
 		change_influence_percentage = yes
 	}
-
 }
 country_event = {
 	id = SWE_eastern.16
@@ -5424,10 +5096,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.16.a
-	}
-
+	option = { name = Sweden_eastern.16.a }
 }
 country_event = {
 	id = SWE_eastern.17
@@ -5440,9 +5109,7 @@ country_event = {
 		name = Sweden_eastern.17.a
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.17.a executed"
 		add_ideas = SWE_industry_exchange_nko
-		SWE = {
-			country_event = SWE_eastern.18
-		}
+		SWE = { country_event = SWE_eastern.18 }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -5455,9 +5122,7 @@ country_event = {
 	option = {
 		name = Sweden_eastern.17.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.17.b executed"
-		SWE = {
-			country_event = SWE_eastern.19
-		}
+		SWE = { country_event = SWE_eastern.19 }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -5466,7 +5131,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -5481,7 +5145,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.18.a executed"
 		add_ideas = SWE_industry_exchange_swe
 	}
-
 }
 
 country_event = {
@@ -5496,7 +5159,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.19.a executed"
 		add_stability = -0.02
 	}
-
 }
 country_event = {
 	id = SWE_eastern.20
@@ -5513,7 +5175,6 @@ country_event = {
 		set_temp_variable = { influence_target = SOV }
 		change_influence_percentage = yes
 	}
-
 }
 country_event = {
 	id = SWE_eastern.21
@@ -5541,22 +5202,15 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
 		name = Sweden_eastern.21.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.21.b executed"
-		SWE = {
-			country_event = SWE_eastern.23
-		}
-		ai_chance = {
-			base = 40
-		}
+		SWE = { country_event = SWE_eastern.23 }
+		ai_chance = { base = 40 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.22
@@ -5583,7 +5237,6 @@ country_event = {
 		set_temp_variable = { influence_target = SWE }
 		change_influence_percentage = yes
 	}
-
 }
 country_event = {
 	id = SWE_eastern.23
@@ -5592,10 +5245,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.23.a
-	}
-
+	option = { name = Sweden_eastern.23.a }
 }
 country_event = {
 	id = SWE_eastern.24
@@ -5643,9 +5293,7 @@ country_event = {
 			country_event = SWE_eastern.25
 			effect_tooltip = {
 				random_owned_state = {
-					limit = {
-						is_coastal = yes
-					}
+					limit = { is_coastal = yes }
 					add_resource = {
 						type = oil
 						amount = 6
@@ -5653,22 +5301,15 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
 		name = Sweden_eastern.24.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.24.b executed"
-		SWE = {
-			country_event = SWE_eastern.26
-		}
-		ai_chance = {
-			base = 35
-		}
+		SWE = { country_event = SWE_eastern.26 }
+		ai_chance = { base = 35 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.25
@@ -5681,9 +5322,7 @@ country_event = {
 		name = Sweden_eastern.25.a
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.25.a executed"
 		random_owned_state = {
-			limit = {
-				is_coastal = yes
-			}
+			limit = { is_coastal = yes }
 			add_resource = {
 				type = oil
 				amount = 6
@@ -5696,7 +5335,6 @@ country_event = {
 		set_temp_variable = { influence_target = SWE }
 		change_influence_percentage = yes
 	}
-
 }
 country_event = {
 	id = SWE_eastern.26
@@ -5705,10 +5343,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.26.a
-	}
-
+	option = { name = Sweden_eastern.26.a }
 }
 country_event = {
 	id = SWE_eastern.27
@@ -5727,9 +5362,7 @@ country_event = {
 					amount > 0
 				}
 			}
-			add_dynamic_modifier = {
-				modifier = SAF_swe_metals_investment
-			}
+			add_dynamic_modifier = { modifier = SAF_swe_metals_investment }
 		}
 		SWE = {
 			country_event = SWE_eastern.28
@@ -5741,28 +5374,19 @@ country_event = {
 							amount > 0
 						}
 					}
-					add_dynamic_modifier = {
-						modifier = SWE_southafrica_metals
-					}
+					add_dynamic_modifier = { modifier = SWE_southafrica_metals }
 				}
 			}
 		}
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
 		name = Sweden_eastern.27.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.27.b executed"
-		SWE = {
-			country_event = SWE_eastern.29
-		}
-		ai_chance = {
-			base = 35
-		}
+		SWE = { country_event = SWE_eastern.29 }
+		ai_chance = { base = 35 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.28
@@ -5781,12 +5405,9 @@ country_event = {
 					amount > 0
 				}
 			}
-			add_dynamic_modifier = {
-				modifier = SWE_southafrica_metals
-			}
+			add_dynamic_modifier = { modifier = SWE_southafrica_metals }
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.29
@@ -5795,10 +5416,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.29.a
-	}
-
+	option = { name = Sweden_eastern.29.a }
 }
 country_event = {
 	id = SWE_eastern.30
@@ -5812,22 +5430,15 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.30.a executed"
 		SWE = { country_event = SWE_eastern.31 }
 		add_ideas = SWE_cuba_medical_exchange
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 
 	option = {
 		name = Sweden_eastern.30.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.30.b executed"
-		SWE = {
-			country_event = SWE_eastern.32
-		}
-		ai_chance = {
-			base = 30
-		}
+		SWE = { country_event = SWE_eastern.32 }
+		ai_chance = { base = 30 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.31
@@ -5844,7 +5455,6 @@ country_event = {
 			add_idea = SWE_easter_horizon_idea4
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.32
@@ -5853,10 +5463,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.32.a
-	}
-
+	option = { name = Sweden_eastern.32.a }
 }
 country_event = {
 	id = SWE_eastern.33
@@ -5868,26 +5475,17 @@ country_event = {
 	option = {
 		name = Sweden_eastern.33.a
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.33.a executed"
-		SWE = {
-			country_event = SWE_eastern.34
-		}
+		SWE = { country_event = SWE_eastern.34 }
 		add_ideas = SWE_iran_petrochemical_iran
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
 		name = Sweden_eastern.33.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.33.b executed"
-		SWE = {
-			country_event = SWE_eastern.35
-		}
-		ai_chance = {
-			base = 35
-		}
+		SWE = { country_event = SWE_eastern.35 }
+		ai_chance = { base = 35 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.34
@@ -5901,7 +5499,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.34.a executed"
 		add_ideas = SWE_iran_petrochemical_swe
 	}
-
 }
 country_event = {
 	id = SWE_eastern.35
@@ -5910,10 +5507,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.35.a
-	}
-
+	option = { name = Sweden_eastern.35.a }
 }
 country_event = {
 	id = SWE_eastern.36
@@ -5955,22 +5549,15 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
 		name = Sweden_eastern.36.b
 		log = "[GetDateText]: [This.GetName]: Sweden_eastern.36.b executed"
-		SWE = {
-			country_event = SWE_eastern.38
-		}
-		ai_chance = {
-			base = 40
-		}
+		SWE = { country_event = SWE_eastern.38 }
+		ai_chance = { base = 40 }
 	}
-
 }
 country_event = {
 	id = SWE_eastern.37
@@ -5989,7 +5576,6 @@ country_event = {
 			bonus = 0.30
 		}
 	}
-
 }
 country_event = {
 	id = SWE_eastern.38
@@ -5998,10 +5584,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = Sweden_eastern.38.a
-	}
-
+	option = { name = Sweden_eastern.38.a }
 }
 
 # Ericsson corporate history
@@ -6196,9 +5779,7 @@ country_event = {
 			uses = 1
 			category = CAT_landing_craft
 		}
-		mio:SWE_swede_ship_marine_manufacturer = {
-			add_mio_size = 1
-		}
+		mio:SWE_swede_ship_marine_manufacturer = { add_mio_size = 1 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -6217,9 +5798,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: Sweden.310.b executed"
 		set_temp_variable = { treasury_change = 1.50 }
 		modify_treasury_effect = yes
-		mio:SWE_swede_ship_marine_manufacturer = {
-			add_mio_funds = 800
-		}
+		mio:SWE_swede_ship_marine_manufacturer = { add_mio_funds = 800 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -6244,9 +5823,7 @@ country_event = {
 			limit = { has_country_flag = SWE_trossbat_navy_spec }
 			set_temp_variable = { treasury_change = -1.50 }
 		}
-		else = {
-			set_temp_variable = { treasury_change = -3.00 }
-		}
+		else = { set_temp_variable = { treasury_change = -3.00 } }
 		modify_treasury_effect = yes
 		add_tech_bonus = {
 			name = Sweden.311.t
@@ -6270,9 +5847,7 @@ country_event = {
 	option = {
 		name = Sweden.311.b
 		log = "[GetDateText]: [Root.GetName]: Sweden.311.b executed"
-		mio:SWE_swede_ship_marine_manufacturer = {
-			add_mio_funds = 600
-		}
+		mio:SWE_swede_ship_marine_manufacturer = { add_mio_funds = 600 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -6321,9 +5896,7 @@ country_event = {
 	option = {
 		name = Sweden.312.b
 		log = "[GetDateText]: [Root.GetName]: Sweden.312.b executed"
-		mio:SWE_swede_ship_marine_manufacturer = {
-			add_mio_research_bonus = 0.10
-		}
+		mio:SWE_swede_ship_marine_manufacturer = { add_mio_research_bonus = 0.10 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -6638,9 +6211,7 @@ country_event = {
 	picture = GFX_fighter_jet
 	is_triggered_only = yes
 
-	trigger = {
-		SWE_saab_outcome_settled = no
-	}
+	trigger = { SWE_saab_outcome_settled = no }
 
 	option = {
 		name = Sweden.325.a

--- a/events/Tajikistan.txt
+++ b/events/Tajikistan.txt
@@ -14,9 +14,8 @@ country_event = {
 	desc = tajik_flavor.1.d
 	picture = GFX_TAJ_watermelon
 	is_triggered_only = yes
-	trigger = {
-		TAJ_emomali_family_in_charge = yes
-	}
+
+	trigger = { TAJ_emomali_family_in_charge = yes }
 
 	option = {
 		name = tajik_flavor.1.a
@@ -24,9 +23,7 @@ country_event = {
 		add_stability = -0.01
 		hidden_effect = {
 			if = {
-				limit = {
-					has_country_flag = TAJ_party_name
-				}
+				limit = { has_country_flag = TAJ_party_name }
 				create_country_leader = {
 					name = "Emomali Rahmon"
 					picture = "Emomali_Rahmon.dds"
@@ -57,9 +54,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -68,22 +63,20 @@ news_event = {
 	title = tajik_flavor.2.t
 	desc = tajik_flavor.2.d
 	picture = GFX_TAJ_uto_world
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = tajik_flavor.2.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
 	id = tajik_flavor.3
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
+
 	immediate = {
 		log = "[GetDateText]: [This.GetName]: tajik_flavor.3 executed"
 		UZB = {
@@ -144,12 +137,8 @@ country_event = {
 			ideology = fascism
 			popularity = -0.05
 		}
-		724 = {
-			add_manpower = -50000
-		}
-		ai_chance = {
-			base = 1
-		}
+		724 = { add_manpower = -50000 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -159,12 +148,8 @@ country_event = {
 			ideology = fascism
 			popularity = 0.10
 		}
-		724 = {
-			add_manpower = 100000
-		}
-		ai_chance = {
-			base = 1
-		}
+		724 = { add_manpower = 100000 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -202,24 +187,18 @@ country_event = {
 				set_temp_variable = { faction_goal_refresh_transferred_leader = 1 }
 				leave_faction = yes
 			}
-			else = {
-				dismantle_faction = yes
-			}
+			else = { dismantle_faction = yes }
 		}
 		else_if = {
 			limit = { is_in_faction = yes }
 			leave_faction = yes
 		}
-		TAJ = {
-			add_to_faction = PREV
-		}
+		TAJ = { add_to_faction = PREV }
 		if = {
 			limit = { check_variable = { faction_goal_refresh_transferred_leader = 1 } }
 			hidden_effect = { event_target:faction_goal_transferred_leader = { faction_goal_refresh_all_caches = yes } }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -243,15 +222,12 @@ country_event = {
 	id = tajik_focus.3
 	title = tajik_focus.3.t
 	desc = tajik_focus.3.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
 	option = {
 		name = tajik_focus.3.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -260,7 +236,6 @@ country_event = {
 	id = tajik_focus.4
 	title = tajik_focus.4.t
 	desc = tajik_focus.4.d
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
@@ -275,9 +250,7 @@ country_event = {
 			set_temp_variable = { influence_target = TAJ }
 			change_influence_percentage = yes
 		}
-		TAJ = {
-			country_event = tajik_focus.5
-		}
+		TAJ = { country_event = tajik_focus.5 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -290,12 +263,8 @@ country_event = {
 	option = {
 		name = tajik_focus.4.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.4.b executed"
-		TAJ = {
-			country_event = tajik_focus.6
-		}
-		ai_chance = {
-			base = 1
-		}
+		TAJ = { country_event = tajik_focus.6 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -303,7 +272,6 @@ country_event = {
 	id = tajik_focus.5 # We Get Investment
 	title = tajik_focus.5.t
 	desc = tajik_focus.5.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
@@ -311,9 +279,7 @@ country_event = {
 		name = tajik_focus.5.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.5.a executed"
 		one_random_industrial_complex = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -321,16 +287,12 @@ country_event = {
 	id = tajik_focus.6 # We Get No Investment
 	title = tajik_focus.6.t
 	desc = tajik_focus.6.d
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
 	option = {
 		name = tajik_focus.6.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -338,7 +300,6 @@ country_event = {
 	id = tajik_focus.7 # Tajikistan Requests Medical Assistance
 	title = tajik_focus.7.t
 	desc = tajik_focus.7.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -385,7 +346,6 @@ country_event = {
 	id = tajik_focus.8 # U.S. Sends Medical Doctors
 	title = tajik_focus.8.t
 	desc = tajik_focus.8.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -396,9 +356,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_nuri_gets_live_longer_TT
 		add_to_variable = { var = TAJ_nuri_months value = 36 }
 		clamp_variable = { var = TAJ_nuri_months min = -36 max = 0 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -406,16 +364,12 @@ country_event = {
 	id = tajik_focus.9 # U.S. Refuses to Sends Medical Doctors
 	title = tajik_focus.9.t
 	desc = tajik_focus.9.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
 	option = {
 		name = tajik_focus.9.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -423,13 +377,14 @@ country_event = {
 	id = tajik_focus.10 # Nuri dies
 	title = tajik_focus.10.t
 	desc = tajik_focus.10.d
-
 	is_triggered_only = yes
+
 	trigger = {
 		TAJ = {
 			has_country_leader = { name = "Sayid Abdulloh Nuri" ruling_only = yes }
 		}
 	}
+
 	option = {
 		name = tajik_focus.10.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.10.a executed"
@@ -442,19 +397,13 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = TAJ_nuri_cured
-				}
-			}
+			limit = { NOT = { has_country_flag = TAJ_nuri_cured } }
 			add_stability = -0.05
 			set_temp_variable = { party_popularity_increase = -0.1 }
 			set_temp_variable = { temp_outlook_increase = -0.1 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -463,7 +412,6 @@ country_event = {
 	title = tajik_focus.11.t
 	desc = tajik_focus.11.d
 	picture = GFX_axis_of_resistance_country
-
 	is_triggered_only = yes
 
 	option = { # Accepts
@@ -475,22 +423,20 @@ country_event = {
 				days = 0
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
 	}
+
 	option = { # Declines
 		name = tajik_focus.11.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.11.b executed"
-
 		FROM = {
 			country_event = {
 				id = AFG_contact_iran.5
 				days = 0
 			}
 		}
-
 		ai_chance = {
 			base = 0
 		}
@@ -501,8 +447,8 @@ country_event = { # Tajikistan Invites us to Central Asian Security Association
 	id = tajik_focus.12
 	title = tajik_focus.12.t
 	desc = tajik_focus.12.d
-	is_triggered_only = yes
 	picture = GFX_event_tajikistan_flag
+	is_triggered_only = yes
 
 	option = { # Accepts
 		name = tajik_focus.12.a
@@ -527,6 +473,7 @@ country_event = { # Tajikistan Invites us to Central Asian Security Association
 			}
 		}
 	}
+
 	option = { # Declines
 		name = tajik_focus.12.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.12.b executed"
@@ -546,8 +493,8 @@ country_event = {
 	id = tajik_focus.14
 	title = tajik_focus.14.t
 	desc = tajik_focus.14.d
-	is_triggered_only = yes
 	picture = GFX_event_tajikistan_flag
+	is_triggered_only = yes
 
 	option = { # Accepts
 		name = tajik_focus.14.a
@@ -571,7 +518,6 @@ country_event = {
 
 	option = { # Accepts
 		name = tajik_focus.15.a
-
 		ai_chance = {
 			base = 1
 		}
@@ -614,6 +560,7 @@ country_event = { #Tajikistan Wants to Strengthen Ties
 			}
 		}
 	}
+
 	option = { # Rejects
 		name = tajik_focus.16.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.16.b executed"
@@ -641,18 +588,16 @@ country_event = { #America Offers Support
 		log = "[GetDateText]: [This.GetName]: tajik_focus.17.a executed"
 		one_random_industrial_complex = yes
 		one_random_arms_factory = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = tajik_focus.17.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.17.b executed"
 		one_office_construction = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = tajik_focus.17.c
 		log = "[GetDateText]: [This.GetName]: tajik_focus.17.c executed"
@@ -662,9 +607,7 @@ country_event = { #America Offers Support
 		change_relative_party_popularity = yes
 		newline = yes
 		add_political_power = 300
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -677,10 +620,7 @@ country_event = { #America Does Not Offer Support
 
 	option = {
 		name = tajik_focus.18.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -688,8 +628,8 @@ country_event = { # A Change in Course?
 	id = tajik_focus.19
 	title = tajik_focus.19.t
 	desc = tajik_focus.19.d
-	is_triggered_only = yes
 	picture = GFX_event_tajikistan_flag
+	is_triggered_only = yes
 
 	option = {
 		name = tajik_focus.19.a
@@ -704,9 +644,7 @@ country_event = { # A Change in Course?
 			change_relative_party_popularity = yes
 		}
 		if = {
-			limit = {
-				has_country_flag = TAJ_shodi
-			}
+			limit = { has_country_flag = TAJ_shodi }
 			create_country_leader = {
 				name = "Shodi Shabdolov "
 				picture = "shodi_shabdolov.dds"
@@ -719,9 +657,7 @@ country_event = { # A Change in Course?
 			}
 		}
 		if = {
-			limit = {
-				has_country_flag = TAJ_abdulloyev
-			}
+			limit = { has_country_flag = TAJ_abdulloyev }
 			create_country_leader = {
 				name = "Miroj Abdulloyev"
 				picture = "miroj_abdulloyev.dds"
@@ -735,9 +671,7 @@ country_event = { # A Change in Course?
 			}
 		}
 		if = {
-			limit = {
-				has_country_flag = TAJ_talbakov
-			}
+			limit = { has_country_flag = TAJ_talbakov }
 			create_country_leader = {
 				name = "Ismoil Talbakov"
 				picture = "ismoil_talbakov.dds"
@@ -759,9 +693,7 @@ country_event = { # A Change in Course?
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -777,9 +709,7 @@ country_event = { # A Change in Course?
 		newline = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_oligarchs_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -861,11 +791,7 @@ country_event = { # Tajikistan Wants a Non-Aggro Pact
 			relation = non_aggression_pact
 		}
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = TAL
-				}
-			}
+			limit = { ROOT = { original_tag = TAL } }
 			TAJ = {
 				custom_effect_tooltip = TAJ_decrease_bda_unrest_5_TT
 				add_to_variable = { var = TAJ_badakhshan_unrest_var value = -5 }
@@ -873,9 +799,7 @@ country_event = { # Tajikistan Wants a Non-Aggro Pact
 				add_stability = 0.05
 			}
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 
@@ -910,13 +834,12 @@ country_event = { # The Secretary
 			base = 1
 		}
 	}
+
 	option = {
 		name = tajik_focus.24.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.24.b executed"
 		if = {
-			limit = {
-				has_country_flag = TAJ_changed_in_course
-			}
+			limit = { has_country_flag = TAJ_changed_in_course }
 			create_country_leader = {
 				name = "Miroj Abdulloyev"
 				picture = "miroj_abdulloyev.dds"
@@ -943,17 +866,14 @@ country_event = { # The Secretary
 			}
 		}
 		set_country_flag = TAJ_abdulloyev
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = tajik_focus.24.c
 		log = "[GetDateText]: [This.GetName]: tajik_focus.24.c executed"
 		if = {
-			limit = {
-				has_country_flag = TAJ_changed_in_course
-			}
+			limit = { has_country_flag = TAJ_changed_in_course }
 			create_country_leader = {
 				name = "Ismoil Talbakov"
 				picture = "ismoil_talbakov.dds"
@@ -978,9 +898,7 @@ country_event = { # The Secretary
 			}
 		}
 		set_country_flag = TAJ_talbakov
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1000,6 +918,7 @@ country_event = { # Selection of the UTO Committee
 			base = 1
 		}
 	}
+
 	option = { # Democratic Party will lead it forward
 		name = tajik_focus.25.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.25.b executed"
@@ -1009,6 +928,7 @@ country_event = { # Selection of the UTO Committee
 			base = 1
 		}
 	}
+
 	option = { # Communist Party will lead it forward
 		name = tajik_focus.25.c
 		log = "[GetDateText]: [This.GetName]: tajik_focus.25.c executed"
@@ -1061,6 +981,7 @@ country_event = { # Assault on the Palace
 			base = 1
 		}
 	}
+
 	option = { # Launch an armored assualt
 		name = tajik_focus.26.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.25.b executed"
@@ -1086,6 +1007,7 @@ country_event = { # Assault on the Palace
 			base = 1
 		}
 	}
+
 	option = { # Send in experienced troops
 		name = tajik_focus.26.c
 		log = "[GetDateText]: [This.GetName]: tajik_focus.25.c executed"
@@ -1122,10 +1044,7 @@ country_event = { # Rahmon Flees
 
 	option = {
 		name = tajik_focus.27.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1151,9 +1070,7 @@ country_event = { # Rahmon Killed
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1168,26 +1085,18 @@ country_event = { # UTO Demands
 		name = tajik_focus.280.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.280.a executed"
 		if = {
-			limit = {
-				emerging_communist_state_are_in_power = no
-			}
+			limit = { emerging_communist_state_are_in_power = no }
 			activate_mission = TAJ_communist_demand
 		}
 		if = {
-			limit = {
-				nationalist_right_wing_populists_are_in_power = no
-			}
+			limit = { nationalist_right_wing_populists_are_in_power = no }
 			activate_mission = TAJ_nationalist_demand
 		}
 		if = {
-			limit = {
-				neutrality_muslim_brotherhood_in_power_or_coalition = no
-			}
+			limit = { neutrality_muslim_brotherhood_in_power_or_coalition = no }
 			activate_mission = TAJ_islamist_demand
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1198,11 +1107,7 @@ country_event = { # Re-Join CSTO?
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
-	trigger = {
-		NOT = {
-			has_war_with = SOV
-		}
-	}
+	trigger = { NOT = { has_war_with = SOV } }
 
 	option = {
 		name = tajik_focus.281.a
@@ -1213,17 +1118,14 @@ country_event = { # Re-Join CSTO?
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = tajik_focus.281.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.281.b executed"
 		add_political_power = 10
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1241,9 +1143,7 @@ country_event = {
 			ideology = fascism
 			popularity = -0.15
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1259,9 +1159,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: tajik_focus.283.a executed"
 		add_war_support = 0.03
 		custom_effect_tooltip = TAJ_pamir_war_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1359,20 +1257,16 @@ country_event = { # Tajik Revolution
 						communism = 80
 						fascism = 20
 					}
-
 					set_politics = {
 						ruling_party = communism
 						last_election = "1997.6.8"
 						election_frequency = 48
 						elections_allowed = no
 					}
-
 					start_politics_input = yes
-
 					### Party Popularities
 					set_variable = { party_pop_array^6 = 0.80 } #Conservative
 					set_variable = { party_pop_array^10 = 0.20 } #Kingdom
-
 					# Leader Rahmon
 					if = {
 						limit = {
@@ -1399,7 +1293,6 @@ country_event = { # Tajik Revolution
 							}
 						}
 					}
-
 					init_influence = yes
 					set_variable = { domestic_influence_amount = 87 }
 					add_to_array = { influence_array = SOV.id }
@@ -1417,12 +1310,10 @@ country_event = { # Tajik Revolution
 					add_to_array = { influence_array = TUR.id }
 					add_to_array = { influence_array_val = 15 }
 					sort_influence = yes
-
 					### Ruling Party
 					set_variable = { ruling_party = 6 }
 					startup_politics = yes
 					load_focus_tree = { tree = tajikistan_focus keep_completed = yes }
-
 					# Economic initialization
 					set_temp_variable = { nation_to_copy_from = PREV.id }
 					setup_employment_variables = yes
@@ -1516,20 +1407,16 @@ country_event = { # Tajik Revolution
 						communism = 80
 						fascism = 20
 					}
-
 					set_politics = {
 						ruling_party = communism
 						last_election = "1997.6.8"
 						election_frequency = 48
 						elections_allowed = no
 					}
-
 					start_politics_input = yes
-
 					### Party Popularities
 					set_variable = { party_pop_array^6 = 0.80 } #Conservative
 					set_variable = { party_pop_array^10 = 0.20 } #Kingdom
-
 					# Leader Rahmon
 					if = {
 						limit = {
@@ -1556,7 +1443,6 @@ country_event = { # Tajik Revolution
 							}
 						}
 					}
-
 					init_influence = yes
 					set_variable = { domestic_influence_amount = 87 }
 					add_to_array = { influence_array = SOV.id }
@@ -1574,12 +1460,10 @@ country_event = { # Tajik Revolution
 					add_to_array = { influence_array = TUR.id }
 					add_to_array = { influence_array_val = 15 }
 					sort_influence = yes
-
 					### Ruling Party
 					set_variable = { ruling_party = 6 }
 					startup_politics = yes
 					load_focus_tree = { tree = tajikistan_focus keep_completed = yes }
-
 					# Economic initialization
 					set_temp_variable = { nation_to_copy_from = PREV.id }
 					setup_employment_variables = yes
@@ -1617,7 +1501,6 @@ country_event = { # Tajik Revolution
 							Arty_Battery = { x = 0 y = 3 }
 						}
 					}
-
 					722 = {
 						create_unit = {
 							division = "name = \"1. Batalyoni UTO\" division_template = \"Batalyoni UTO\""
@@ -1625,7 +1508,6 @@ country_event = { # Tajik Revolution
 							owner = TAJ
 						}
 					}
-
 					723 = {
 						create_unit = {
 							division = "name = \"2. Batalyoni UTO\" division_template = \"Batalyoni UTO\""
@@ -1709,8 +1591,9 @@ country_event = {
 	id = tajik_focus.30
 	title = tajik_focus.30.t
 	desc = tajik_focus.30.d
-	is_triggered_only = yes
 	picture = GFX_TAJ_dushanbe
+	is_triggered_only = yes
+
 	option = {
 		name = tajik_focus.30.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.30.a executed"
@@ -1756,9 +1639,7 @@ country_event = {
 			idea = TAJ_wealth_of_hoji_akbar
 			days = 1200
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1778,9 +1659,7 @@ country_event = {
 			idea = TAJ_wealth_of_bobojon
 			days = 1200
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1792,18 +1671,14 @@ country_event = {
 			idea = TAJ_wealth_of_ghaffor
 			days = 1200
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = tajik_focus.31.d1
 		log = "[GetDateText]: [This.GetName]: tajik_focus.31.d1 executed"
 		add_political_power = 25
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1819,9 +1694,7 @@ country_event = { # His Excellency (Focus tree event lore background) Completed
 		log = "[GetDateText]: [This.GetName]: tajik_focus.32.a executed"
 		add_stability = 0.05
 		add_political_power = 100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1841,6 +1714,7 @@ country_event = { # Peace of mind and what brings it
 			base = 0
 		}
 	}
+
 	option = { #Presidential Palace
 		name = tajik_focus.33.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.33.b executed"
@@ -1898,9 +1772,7 @@ country_event = { # Asking Taliban for U.S. Weapons & Intel
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1925,9 +1797,7 @@ country_event = { # Taliban Smuggles American Vehicles
 			set_temp_variable = { treasury_change = 15.00 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1940,10 +1810,7 @@ country_event = { # Taliban Ignores Us
 
 	option = {
 		name = tajik_focus.37.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1963,9 +1830,7 @@ country_event = { # Tajikistan Secedes Sarikol Range (CHI)
 			target = TAJ
 			modifier = recent_actions_very_positive
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1979,9 +1844,7 @@ country_event = { # Tajikistan Asks For Weapons Sales
 	option = {
 		name = tajik_focus.39.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.39.a executed"
-		TAJ = {
-			country_event = tajik_focus.40
-		}
+		TAJ = { country_event = tajik_focus.40 }
 		set_temp_variable = { percent_change = 3.00 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = TAJ }
@@ -2001,12 +1864,8 @@ country_event = { # Tajikistan Asks For Weapons Sales
 	option = {
 		name = tajik_focus.39.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.39.b executed"
-		TAJ = {
-			country_event = tajik_focus.41
-		}
-		ai_chance = {
-			base = 1
-		}
+		TAJ = { country_event = tajik_focus.41 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2105,9 +1964,7 @@ country_event = { # China Denies
 			target = CHI
 			modifier = recent_actions_negative
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2120,10 +1977,7 @@ country_event = { # Investments Flood In!
 
 	option = {
 		name = tajik_focus.42.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2133,6 +1987,7 @@ country_event = { # The Lease on the 201st Military Base
 	desc = tajik_focus.43.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	# Let's see what Russia offers
 	option = {
 		name = tajik_focus.43.a
@@ -2143,19 +1998,16 @@ country_event = { # The Lease on the 201st Military Base
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# They aren't worth our time
 	option = {
 		name = tajik_focus.43.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.43.b executed"
 		set_temp_variable = { percent_change = 5 }
 		change_domestic_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2165,6 +2017,7 @@ country_event = { # Tajikistan Requests Concessions
 	desc = tajik_focus.44.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.44.a
@@ -2192,16 +2045,13 @@ country_event = { # Tajikistan Requests Concessions
 			base = 10 # Wants to keep the base
 		}
 	}
+
 	# We're good
 	option = {
 		name = tajik_focus.44.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.44.b executed"
-		TAJ = {
-			country_event = tajik_focus.46
-		}
-		ai_chance = {
-			base = 1
-		}
+		TAJ = { country_event = tajik_focus.46 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2211,6 +2061,7 @@ country_event = { # Russia Offers Concessions
 	desc = tajik_focus.45.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.45.a
@@ -2225,9 +2076,7 @@ country_event = { # Russia Offers Concessions
 		set_temp_variable = { treasury_change = 50.00 }
 		modify_treasury_effect = yes
 		set_country_flag = TAJ_promised_russia
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2237,13 +2086,11 @@ country_event = { # Russia Offers No Concessions
 	desc = tajik_focus.46.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.46.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2253,6 +2100,7 @@ country_event = { # Tajikistan Double Crosses Us!
 	desc = tajik_focus.47.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.47.a
@@ -2261,9 +2109,7 @@ country_event = { # Tajikistan Double Crosses Us!
 			target = TAJ
 			modifier = betrayed_our_cause
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2273,6 +2119,7 @@ country_event = { # Tajikistan Cancels the 201st Base Lease
 	desc = tajik_focus.48.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.48.a
@@ -2281,9 +2128,7 @@ country_event = { # Tajikistan Cancels the 201st Base Lease
 			target = TAJ
 			modifier = diplomatic_disloyalty
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2293,49 +2138,34 @@ country_event = {
 	desc = tajik_focus.49.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.49.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.49.a executed"
-		SOV = {
-			country_event = tajik_focus.50
-		}
-		ai_chance = {
-			base = 1
-		}
+		SOV = { country_event = tajik_focus.50 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = tajik_focus.49.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.49.b executed"
-		USA = {
-			country_event = tajik_focus.50
-		}
-		ai_chance = {
-			base = 1
-		}
+		USA = { country_event = tajik_focus.50 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = tajik_focus.49.c
 		log = "[GetDateText]: [This.GetName]: tajik_focus.49.c executed"
-		CHI = {
-			country_event = tajik_focus.50
-		}
-		ai_chance = {
-			base = 1
-		}
+		CHI = { country_event = tajik_focus.50 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = tajik_focus.49.d1
 		log = "[GetDateText]: [This.GetName]: tajik_focus.49.d1 executed"
-		RAJ = {
-			country_event = tajik_focus.50
-		}
-		ai_chance = {
-			base = 1
-		}
+		RAJ = { country_event = tajik_focus.50 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2345,6 +2175,7 @@ country_event = {
 	desc = tajik_focus.50.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.50.a
@@ -2445,10 +2276,7 @@ country_event = {
 
 	option = {
 		name = tajik_focus.50.b
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2458,17 +2286,14 @@ country_event = {
 	desc = tajik_focus.51.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.51.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.51.a executed"
 		effect_tooltip = {
 			if = {
-				limit = {
-					FROM = {
-						original_tag = SOV
-					}
-				}
+				limit = { FROM = { original_tag = SOV } }
 				TAJ = {
 					swap_ideas = {
 						remove_idea = TAJ_201st_base
@@ -2477,11 +2302,7 @@ country_event = {
 				}
 			}
 			if = {
-				limit = {
-					FROM = {
-						original_tag = USA
-					}
-				}
+				limit = { FROM = { original_tag = USA } }
 				TAJ = {
 					swap_ideas = {
 						remove_idea = TAJ_201st_base
@@ -2490,11 +2311,7 @@ country_event = {
 				}
 			}
 			if = {
-				limit = {
-					FROM = {
-						original_tag = CHI
-					}
-				}
+				limit = { FROM = { original_tag = CHI } }
 				TAJ = {
 					swap_ideas = {
 						remove_idea = TAJ_201st_base
@@ -2503,11 +2320,7 @@ country_event = {
 				}
 			}
 			if = {
-				limit = {
-					FROM = {
-						original_tag = RAJ
-					}
-				}
+				limit = { FROM = { original_tag = RAJ } }
 				TAJ = {
 					swap_ideas = {
 						remove_idea = TAJ_201st_base
@@ -2516,9 +2329,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -2528,6 +2339,7 @@ country_event = {
 	desc = tajik_focus.52.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	# Okay
 	option = {
 		name = tajik_focus.52.a
@@ -2536,14 +2348,8 @@ country_event = {
 			target = TAJ
 			modifier = betrayed_our_cause
 		}
-		effect_tooltip = {
-			TAJ = {
-				remove_ideas = TAJ_201st_base
-			}
-		}
-		ai_chance = {
-			base = 20
-		}
+		effect_tooltip = { TAJ = { remove_ideas = TAJ_201st_base } }
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -2553,15 +2359,15 @@ country_event = {
 	desc = tajik_focus.53.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	# I want it now!
 	option = {
 		name = tajik_focus.53.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.53.a executed"
 		three_random_industrial_complex = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	# Let's take it slow
 	option = {
 		name = tajik_focus.53.b
@@ -2574,9 +2380,7 @@ country_event = {
 		}
 		add_to_variable = { var = TAJ_yearly_var_civ value = 12 }
 		clamp_variable = { var = TAJ_yearly_var_civ min = 0 max = 12 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -2586,6 +2390,7 @@ country_event = {
 	desc = tajik_focus.54.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Good idea
 	option = {
 		name = tajik_focus.54.a
@@ -2595,53 +2400,32 @@ country_event = {
 				NOT = {
 					OR = {
 						has_war_with = UZB
-						UZB = {
-							is_in_faction = yes
-						}
+						UZB = { is_in_faction = yes }
 					}
 				}
-				UZB = {
-					NOT = {
-						is_subject = yes
-					}
-				}
+				UZB = { NOT = { is_subject = yes } }
 			}
-			UZB = {
-				country_event = tajik_focus.55
-			}
+			UZB = { country_event = tajik_focus.55 }
 		}
-
 		if = {
 			limit = {
 				NOT = {
 					OR = {
 						has_war_with = TRK
-						TRK = {
-							is_in_faction = yes
-						}
+						TRK = { is_in_faction = yes }
 					}
 				}
-				TRK = {
-					NOT = {
-						is_subject = yes
-					}
-				}
+				TRK = { NOT = { is_subject = yes } }
 			}
-			TRK = {
-				country_event = tajik_focus.55
-			}
+			TRK = { country_event = tajik_focus.55 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	# No
 	option = {
 		name = tajik_focus.54.b
-
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2652,15 +2436,15 @@ country_event = {
 	desc = tajik_focus.55.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Good idea
 	option = {
 		name = tajik_focus.55.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.55.a executed"
 		FROM = { country_event = { id = md4.17 days = 1 } }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	# No
 	option = {
 		name = tajik_focus.55.b
@@ -2714,9 +2498,7 @@ country_event = {
 		}
 		set_temp_variable = { party_index = 19 }
 		unban_party_scripted_call = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -2728,18 +2510,14 @@ country_event = {
 		add_political_power = 250
 		set_temp_variable = { party_index = 19 }
 		unban_party_scripted_call = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = tajik_focus.56.c
 		log = "[GetDateText]: [This.GetName]: tajik_focus.56.c executed"
 		add_political_power = 500
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2755,9 +2533,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: tajik_focus.57.a executed"
 		custom_effect_tooltip = TAJ_police_spend_TT
 		if = {
-			limit = {
-				has_idea = police_01
-			}
+			limit = { has_idea = police_01 }
 			random_list = {
 				30 = {
 					country_event = {
@@ -2774,9 +2550,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_idea = police_02
-			}
+			limit = { has_idea = police_02 }
 			random_list = {
 				40 = {
 					country_event = {
@@ -2793,9 +2567,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_idea = police_03
-			}
+			limit = { has_idea = police_03 }
 			random_list = {
 				50 = {
 					country_event = {
@@ -2812,9 +2584,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_idea = police_04
-			}
+			limit = { has_idea = police_04 }
 			random_list = {
 				60 = {
 					country_event = {
@@ -2831,9 +2601,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_idea = police_05
-			}
+			limit = { has_idea = police_05 }
 			random_list = {
 				80 = {
 					country_event = {
@@ -2849,9 +2617,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -2878,16 +2644,10 @@ country_event = {
 			upgrade_intelligence_agency = upgrade_interrogation_techniques
 		}
 		if = {
-			limit = {
-				NOT = {
-					has_dlc = "La Resistance"
-				}
-			}
+			limit = { NOT = { has_dlc = "La Resistance" } }
 			increase_policing_budget = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2904,19 +2664,13 @@ country_event = {
 		custom_effect_tooltip = TAJ_umarali_dead_TT
 		newline = yes
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = TAJ_radicalism_ended
-				}
-			}
+			limit = { NOT = { has_country_flag = TAJ_radicalism_ended } }
 			custom_effect_tooltip = TAJ_decrease_irp_influence_10_TT
 			add_to_variable = { var = TAJ_radical_influence value = -10 }
 			clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
 		}
 		if = {
-			limit = {
-				has_country_flag = TAJ_radicalism_ended
-			}
+			limit = { has_country_flag = TAJ_radicalism_ended }
 			add_popularity = {
 				ideology = fascism
 				popularity = -0.05
@@ -2924,9 +2678,7 @@ country_event = {
 		}
 		newline = yes
 		add_political_power = 50
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -2946,19 +2698,13 @@ country_event = {
 		change_relative_party_popularity = yes
 		newline = yes
 		if = {
-			limit = {
-				NOT = {
-					has_country_flag = TAJ_radicalism_ended
-				}
-			}
+			limit = { NOT = { has_country_flag = TAJ_radicalism_ended } }
 			custom_effect_tooltip = TAJ_increase_irp_influence_10_TT
 			add_to_variable = { var = TAJ_radical_influence value = 10 }
 			clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
 		}
 		if = {
-			limit = {
-				has_country_flag = TAJ_radicalism_ended
-			}
+			limit = { has_country_flag = TAJ_radicalism_ended }
 			add_popularity = {
 				ideology = fascism
 				popularity = 0.05
@@ -2966,9 +2712,7 @@ country_event = {
 		}
 		newline = yes
 		add_political_power = -50
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -2988,13 +2732,9 @@ country_event = {
 				province = 1459
 				value = 10
 			}
-			set_capital = {
-				state = 725
-			}
+			set_capital = { state = 725 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -3006,13 +2746,9 @@ country_event = {
 				province = 1623
 				value = 15
 			}
-			set_capital = {
-				state = 726
-			}
+			set_capital = { state = 726 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -3024,13 +2760,9 @@ country_event = {
 				province = 10308
 				value = 15
 			}
-			set_capital = {
-				state = 716
-			}
+			set_capital = { state = 716 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -3040,9 +2772,7 @@ country_event = {
 			province = 1384
 			value = 15
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -3052,10 +2782,12 @@ country_event = {
 	desc = tajik_focus.61.d
 	picture = GFX_election_day
 	is_triggered_only = yes
+
 	trigger = {
 		emerging_conservative_in_power_or_coalition = yes
 		has_elections = no
 	}
+
 	option = {
 		name = tajik_focus.61.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.61.a executed"
@@ -3072,21 +2804,16 @@ country_event = {
 			}
 			clr_country_flag = do_not_retire
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	option = {
 		name = tajik_focus.61.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.61.a executed"
 		custom_effect_tooltip = TAJ_elections_allowable_TT
 		clr_country_flag = TAJ_dictatorship_flag
-		hidden_effect = {
-			enable_elections_with_no_leader_change = yes
-		}
-		ai_chance = {
-			base = 20
-		}
+		hidden_effect = { enable_elections_with_no_leader_change = yes }
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -3096,6 +2823,7 @@ country_event = {
 	desc = tajik_focus.62.d
 	picture = GFX_corvette
 	is_triggered_only = yes
+
 	# Ask the Americans
 	option = {
 		name = tajik_focus.62.a
@@ -3107,10 +2835,9 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = TAJ_willingness_to_accept3_TT
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
+
 	# Ask the Russians
 	option = {
 		name = tajik_focus.62.b
@@ -3122,9 +2849,7 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = TAJ_willingness_to_accept3_TT
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -3135,6 +2860,7 @@ country_event = {
 	desc = tajik_focus.63.d
 	picture = GFX_corvette
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.63.a
@@ -3161,7 +2887,6 @@ country_event = {
 				producer = SOV
 			}
 		}
-
 		if = {
 			limit = {
 				original_tag = SOV
@@ -3175,7 +2900,6 @@ country_event = {
 			}
 		}
 		# USA
-
 		if = {
 			limit = {
 				original_tag = USA
@@ -3189,7 +2913,6 @@ country_event = {
 				producer = USA
 			}
 		}
-
 		if = {
 			limit = {
 				original_tag = USA
@@ -3202,7 +2925,6 @@ country_event = {
 				variant_name = "AH-1S Cobra"
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -3211,6 +2933,7 @@ country_event = {
 			}
 		}
 	}
+
 	# No
 	option = {
 		name = tajik_focus.63.b
@@ -3221,9 +2944,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # FROM Accepts
@@ -3233,6 +2954,7 @@ country_event = {
 	desc = tajik_focus.64.d
 	picture = GFX_corvette
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.64.a
@@ -3318,6 +3040,7 @@ country_event = {
 	desc = tajik_focus.65.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.65.a
@@ -3326,9 +3049,7 @@ country_event = {
 			target = FROM
 			modifier = recent_actions_negative
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3339,6 +3060,7 @@ country_event = {
 	desc = tajik_focus.66.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.66.a
@@ -3349,11 +3071,7 @@ country_event = {
 		change_influence_percentage = yes
 		set_temp_variable = { treasury_change = -15.00 }
 		modify_treasury_effect = yes
-		effect_tooltip = {
-			TAJ = {
-				two_random_arms_factory = yes
-			}
-		}
+		effect_tooltip = { TAJ = { two_random_arms_factory = yes } }
 		TAJ = {
 			country_event = {
 				id = tajik_focus.67
@@ -3368,16 +3086,13 @@ country_event = {
 			}
 		}
 	}
+
 	# No
 	option = {
 		name = tajik_focus.66.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.66.b executed"
-		TAJ = {
-			country_event = tajik_focus.65
-		}
-		ai_chance = {
-			base = 1
-		}
+		TAJ = { country_event = tajik_focus.65 }
+		ai_chance = { base = 1 }
 	}
 }
 # Turkish Factories Built
@@ -3387,14 +3102,13 @@ country_event = {
 	desc = tajik_focus.67.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.67.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.67.a executed"
 		two_random_arms_factory = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3404,6 +3118,7 @@ country_event = {
 	desc = tajik_focus.68.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.68.a
@@ -3434,16 +3149,13 @@ country_event = {
 			}
 		}
 	}
+
 	# No
 	option = {
 		name = tajik_focus.68.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.68.b executed"
-		TAJ = {
-			country_event = tajik_focus.65
-		}
-		ai_chance = {
-			base = 1
-		}
+		TAJ = { country_event = tajik_focus.65 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3453,15 +3165,14 @@ country_event = {
 	desc = tajik_focus.69.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.69.a
 		log = "[GetDateText]: [This.GetName]: tajik_focus.69.a executed"
 		one_random_arms_factory = yes
 		add_ideas = TAJ_iranian_drones
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3471,6 +3182,7 @@ country_event = {
 	desc = tajik_focus.70.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.70.a
@@ -3482,24 +3194,16 @@ country_event = {
 			}
 			add_political_power = 100
 		}
-		else = {
-			decrease_corruption = yes
-		}
-		ai_chance = {
-			base = 1
-		}
+		else = { decrease_corruption = yes }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = tajik_focus.70.b
 		log = "[GetDateText]: [This.GetName]: tajik_focus.70.b executed"
-		every_owned_state = {
-			add_to_variable = { productivity_state_var = 50 }
-		}
+		every_owned_state = { add_to_variable = { productivity_state_var = 50 } }
 		custom_effect_tooltip = TAJ_add_50_prod_every_state_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3507,15 +3211,13 @@ country_event = {
 	id = tajik_focus.71
 	title = tajik_focus.71.t
 	desc = tajik_focus.71.d
-	is_triggered_only = yes
 	picture = GFX_TAJ_dushanbe
+	is_triggered_only = yes
+
 	# Ok
 	option = {
 		name = tajik_focus.71.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3525,7 +3227,6 @@ country_event = {
 	id = tajik_radicalism.1 # IRP Demands Our Resignation
 	title = tajik_radicalism.1.t
 	desc = tajik_radicalism.1.d
-
 	is_triggered_only = yes
 
 	trigger = {
@@ -3553,9 +3254,7 @@ country_event = {
 			change_ruling_party_effect = yes
 		}
 		if = {
-			limit = {
-				date < 2006.8.9
-			}
+			limit = { date < 2006.8.9 }
 			create_country_leader = {
 				name = "Sayid Abdulloh Nuri"
 				picture = "sayid_abdulloh_nuri.dds"
@@ -3576,9 +3275,7 @@ country_event = {
 			}
 		}
 		set_country_flag = TAJ_radicalism_ended
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3598,20 +3295,16 @@ country_event = {
 					neutrality = 80
 					fascism = 20
 				}
-
 				set_politics = {
 					ruling_party = neutrality
 					last_election = "1997.6.8"
 					election_frequency = 48
 					elections_allowed = no
 				}
-
 				start_politics_input = yes
-
 				### Party Popularities
 				set_variable = { party_pop_array^10 = 0.20 } #Kingdom
 				set_variable = { party_pop_array^12 = 0.80 } #Neutral_Muslim_Brotherhood
-
 				# Leader (Before/After Nuri's death)
 				if = {
 					limit = {
@@ -3636,7 +3329,6 @@ country_event = {
 						}
 					}
 				}
-
 				### Ruling Party
 				set_variable = { ruling_party = 12 }
 				startup_politics = yes
@@ -3675,7 +3367,6 @@ country_event = {
 	id = tajik_radicalism.2 # Underground Madrassas
 	title = tajik_radicalism.2.t
 	desc = tajik_radicalism.2.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -3712,9 +3403,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_2_TT
 		add_to_variable = { var = TAJ_radical_influence value = 2 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3722,7 +3411,6 @@ country_event = {
 	id = tajik_radicalism.3 # Religious Sermon Turns Political
 	title = tajik_radicalism.3.t
 	desc = tajik_radicalism.3.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -3753,9 +3441,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_2_TT
 		add_to_variable = { var = TAJ_radical_influence value = 2 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3763,7 +3449,6 @@ country_event = {
 	id = tajik_radicalism.4 # Mosque Charities Expand
 	title = tajik_radicalism.4.t
 	desc = tajik_radicalism.4.d
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
@@ -3796,9 +3481,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_2_TT
 		add_to_variable = { var = TAJ_radical_influence value = 2 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3806,7 +3489,6 @@ country_event = {
 	id = tajik_radicalism.5 # Secret Religious Circles Form
 	title = tajik_radicalism.5.t
 	desc = tajik_radicalism.5.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -3836,9 +3518,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_2_TT
 		add_to_variable = { var = TAJ_radical_influence value = 2 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3848,7 +3528,6 @@ country_event = {
 	id = tajik_radicalism.6 # Confrontations Near Mosques
 	title = tajik_radicalism.6.t
 	desc = tajik_radicalism.6.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -3878,9 +3557,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_4_TT
 		add_to_variable = { var = TAJ_radical_influence value = 4 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3888,7 +3565,6 @@ country_event = {
 	id = tajik_radicalism.7 # Rise in Attacks Against Police Checkpoints
 	title = tajik_radicalism.7.t
 	desc = tajik_radicalism.7.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -3921,9 +3597,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_4_TT
 		add_to_variable = { var = TAJ_radical_influence value = 4 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3931,7 +3605,6 @@ country_event = {
 	id = tajik_radicalism.8 # Locals Resist Government Patrols
 	title = tajik_radicalism.8.t
 	desc = tajik_radicalism.8.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -3962,9 +3635,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_4_TT
 		add_to_variable = { var = TAJ_radical_influence value = 4 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3972,7 +3643,6 @@ country_event = {
 	id = tajik_radicalism.9 # Increase of Radicalized Tajiks Returning from Abroad
 	title = tajik_radicalism.9.t
 	desc = tajik_radicalism.9.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -4007,9 +3677,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_4_TT
 		add_to_variable = { var = TAJ_radical_influence value = 4 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # High tier
@@ -4018,7 +3686,6 @@ country_event = {
 	id = tajik_radicalism.10 # Government convoy ambushed
 	title = tajik_radicalism.10.t
 	desc = tajik_radicalism.10.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -4054,9 +3721,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_6_TT
 		add_to_variable = { var = TAJ_radical_influence value = 6 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4064,7 +3729,6 @@ country_event = {
 	id = tajik_radicalism.11 # Military Base Attacked
 	title = tajik_radicalism.11.t
 	desc = tajik_radicalism.11.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -4094,9 +3758,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_6_TT
 		add_to_variable = { var = TAJ_radical_influence value = 6 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4104,7 +3766,6 @@ country_event = {
 	id = tajik_radicalism.12 # Terror Attack in Russia!
 	title = tajik_radicalism.12.t
 	desc = tajik_radicalism.12.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -4144,9 +3805,7 @@ country_event = {
 			}
 			country_event = tajik_radicalism.121
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4154,7 +3813,6 @@ country_event = {
 	id = tajik_radicalism.120 # Terror Attack in Russia! (TAJ pays us!)
 	title = tajik_radicalism.120.t
 	desc = tajik_radicalism.120.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -4189,7 +3847,6 @@ country_event = {
 	id = tajik_radicalism.121 # Terror Attack in Russia! (TAJ Does not pay us!)
 	title = tajik_radicalism.121.t
 	desc = tajik_radicalism.121.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -4222,13 +3879,11 @@ country_event = {
 	id = tajik_radicalism.14 # Terror Attack in Large Commercial District
 	title = tajik_radicalism.14.t
 	desc = tajik_radicalism.14.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	trigger = {
-		NOT = {
-			has_idea = TAJ_disrupted_commerce
-		}
+		NOT = { has_idea = TAJ_disrupted_commerce }
 		NOT = {
 			OR = {
 				neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -4237,6 +3892,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Crackdown on them!
 		name = tajik_radicalism.14.a
 		log = "[GetDateText]: [This.GetName]: tajik_radicalism.14.a executed"
@@ -4255,9 +3911,7 @@ country_event = {
 		custom_effect_tooltip = TAJ_increase_irp_influence_10_TT
 		add_to_variable = { var = TAJ_radical_influence value = 10 }
 		clamp_variable = { var = TAJ_radical_influence min = 0 max = 100 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # ISI-K Begins to Appear
@@ -4265,7 +3919,6 @@ country_event = {
 	id = tajik_radicalism.15
 	title = tajik_radicalism.15.t
 	desc = tajik_radicalism.15.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -4294,8 +3947,8 @@ country_event = {
 	id = tajik_radicalism.16 # IS-KP Start Large Scale Attacks
 	title = tajik_radicalism.16.t
 	desc = tajik_radicalism.16.d
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		NOT = {
@@ -4323,20 +3976,16 @@ country_event = {
 					neutrality = 20
 					fascism = 80
 				}
-
 				set_politics = {
 					ruling_party = fascism
 					last_election = "1997.6.8"
 					election_frequency = 48
 					elections_allowed = no
 				}
-
 				start_politics_input = yes
-
 				### Party Popularities
 				set_variable = { party_pop_array^10 = 0.80 } #Kingdom
 				set_variable = { party_pop_array^12 = 0.20 } #Neutral_Muslim_Brotherhood
-
 				# Leader
 				create_country_leader = {
 					name = "Hafiz Saeed Khan"
@@ -4346,7 +3995,6 @@ country_event = {
 						salafist_Kingdom
 					}
 				}
-
 				### Ruling Party
 				set_variable = { ruling_party = 10 }
 				startup_politics = yes
@@ -4418,7 +4066,6 @@ country_event = {
 					salafist_Kingdom
 				}
 			}
-
 			create_dynamic_country = {
 				original_tag = TAJ
 				set_cosmetic_tag = TAJ
@@ -4429,19 +4076,15 @@ country_event = {
 				set_popularities = {
 					nationalist = 100
 				}
-
 				set_politics = {
 					ruling_party = nationalist
 					last_election = "1997.6.8"
 					election_frequency = 48
 					elections_allowed = no
 				}
-
 				start_politics_input = yes
-
 				### Party Popularities
 				set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-
 				# Leader
 				create_country_leader = {
 					name = "Sherali Mirzo"
@@ -4452,13 +4095,11 @@ country_event = {
 						military_career
 					}
 				}
-
 				### Ruling Party
 				set_variable = { ruling_party = 22 }
 				startup_politics = yes
 				load_focus_tree = { tree = tajikistan_focus keep_completed = yes }
 			}
-
 			724 = {
 				transfer_state_to = IRP
 			}
@@ -4484,19 +4125,15 @@ country_event = {
 				set_popularities = {
 					nationalist = 100
 				}
-
 				set_politics = {
 					ruling_party = nationalist
 					last_election = "1997.6.8"
 					election_frequency = 48
 					elections_allowed = no
 				}
-
 				start_politics_input = yes
-
 				### Party Popularities
 				set_variable = { party_pop_array^22 = 1 } #Nat_Autocracy
-
 				# Leader
 				create_country_leader = {
 					name = "Sherali Mirzo "
@@ -4507,7 +4144,6 @@ country_event = {
 						military_career
 					}
 				}
-
 				### Ruling Party
 				set_variable = { ruling_party = 22 }
 				startup_politics = yes
@@ -4544,7 +4180,6 @@ country_event = {
 	id = iranic_confederation.1 # FROM invites us to join the Iranic Confederation
 	title = iranic_confederation.1.t
 	desc = iranic_confederation.1.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -4564,7 +4199,6 @@ country_event = {
 		}
 		FROM = {
 			country_event = iranic_confederation.2
-
 			add_to_variable = { var = iranic_states value = 1 }
 			clamp_variable = { var = iranic_states min = 0 max = 100 }
 		}
@@ -4590,7 +4224,6 @@ country_event = {
 	id = iranic_confederation.2 # FROM Accepts!
 	title = iranic_confederation.2.t
 	desc = iranic_confederation.2.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -4607,9 +4240,7 @@ country_event = {
 			relation = military_access
 			active = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4617,15 +4248,12 @@ country_event = {
 	id = iranic_confederation.3 # FROM Rejects!
 	title = iranic_confederation.3.t
 	desc = iranic_confederation.3.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.3.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4633,7 +4261,6 @@ country_event = {
 	id = iranic_confederation.4 # Confederation Leader
 	title = iranic_confederation.4.t
 	desc = iranic_confederation.4.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -4665,6 +4292,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Afghanistan
 		name = iranic_confederation.4.b
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.4.b executed"
@@ -4693,6 +4321,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Tajikistan
 		name = iranic_confederation.4.c
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.4.c executed"
@@ -4721,6 +4350,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Kurdistan
 		name = iranic_confederation.4.e
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.4.e executed"
@@ -4749,6 +4379,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # South Ossetia
 		name = iranic_confederation.4.f
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.4.f executed"
@@ -4783,10 +4414,10 @@ country_event = {
 	id = iranic_confederation.5 # Confederation Leader
 	title = iranic_confederation.5.t
 	desc = iranic_confederation.5.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	option = { # Iran
 		name = iranic_confederation.5.a
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.5.a executed"
@@ -4840,6 +4471,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Afghanistan
 		name = iranic_confederation.5.b
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.5.b executed"
@@ -4893,6 +4525,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Tajikistan
 		name = iranic_confederation.5.c
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.5.c executed"
@@ -4946,6 +4579,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Kurdistan
 		name = iranic_confederation.5.e
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.5.e executed"
@@ -4999,6 +4633,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # South Ossetia
 		name = iranic_confederation.5.f
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.5.f executed"
@@ -5058,7 +4693,6 @@ country_event = {
 	id = iranic_confederation.6
 	title = iranic_confederation.6.t
 	desc = iranic_confederation.6.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -5072,9 +4706,7 @@ country_event = {
 				autonomy_state = autonomy_irn_province
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5082,7 +4714,6 @@ country_event = {
 	id = iranic_confederation.7
 	title = iranic_confederation.7.t
 	desc = iranic_confederation.7.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -5091,9 +4722,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.7.a executed"
 		ROOT = {
 			every_country = {
-				limit = {
-					has_country_flag = iranic_confederation_member
-				}
+				limit = { has_country_flag = iranic_confederation_member }
 				transfer_units_fraction = {
 					target = FROM
 					size = 1.0
@@ -5104,16 +4733,12 @@ country_event = {
 				}
 			}
 			every_state = {
-				limit = {
-					has_state_flag = IRN_iranic_confederation
-				}
+				limit = { has_state_flag = IRN_iranic_confederation }
 				add_core_of = FROM
 				transfer_state_to = FROM
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5121,7 +4746,6 @@ country_event = {
 	id = iranic_confederation.8
 	title = iranic_confederation.8.t
 	desc = iranic_confederation.8.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -5129,12 +4753,8 @@ country_event = {
 		name = iranic_confederation.8.a
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.8.a executed"
 		add_stability = 0.03
-		hidden_effect = {
-			IRN_vote = yes
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { IRN_vote = yes }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5144,55 +4764,36 @@ country_event = {
 	id = iranic_confederation.9
 	title = iranic_confederation.9.t
 	desc = iranic_confederation.9.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.9.a
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.9.a executed"
-		trigger = {
-			976 = {
-				is_owned_and_controlled_by = ROOT
-			}
-		}
-		set_capital = {
-			state = 976
-		}
+		trigger = { 976 = { is_owned_and_controlled_by = ROOT } }
+		set_capital = { state = 976 }
 		add_victory_points = {
 			province = 8074
 			value = 10
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = iranic_confederation.9.b
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.9.b executed"
-		trigger = {
-			409 = {
-				is_owned_and_controlled_by = ROOT
-			}
-		}
-		set_capital = {
-			state = 409
-		}
+		trigger = { 409 = { is_owned_and_controlled_by = ROOT } }
+		set_capital = { state = 409 }
 		add_victory_points = {
 			province = 4893
 			value = 10
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = iranic_confederation.9.c
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5200,25 +4801,16 @@ country_event = {
 	id = iranic_confederation.10
 	title = iranic_confederation.10.t
 	desc = iranic_confederation.10.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.10.a
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.10.a executed"
-		416 = {
-			add_core_of = FROM
-		}
-		417 = {
-			add_core_of = FROM
-		}
-		FROM = {
-			country_event = iranic_confederation.11
-		}
-		ai_chance = {
-			base = 1
-		}
+		416 = { add_core_of = FROM }
+		417 = { add_core_of = FROM }
+		FROM = { country_event = iranic_confederation.11 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5232,12 +4824,8 @@ country_event = {
 			transfer_state_to = FROM
 			add_core_of = FROM
 		}
-		FROM = {
-			country_event = iranic_confederation.12
-		}
-		ai_chance = {
-			base = 0
-		}
+		FROM = { country_event = iranic_confederation.12 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -5245,7 +4833,6 @@ country_event = {
 	id = iranic_confederation.11
 	title = iranic_confederation.11.t
 	desc = iranic_confederation.11.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -5258,9 +4845,7 @@ country_event = {
 			target = PAK
 			type = take_core_state
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5268,15 +4853,12 @@ country_event = {
 	id = iranic_confederation.12
 	title = iranic_confederation.12.t
 	desc = iranic_confederation.12.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.12.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5284,25 +4866,16 @@ country_event = {
 	id = iranic_confederation.15
 	title = iranic_confederation.15.t
 	desc = iranic_confederation.15.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.15.a
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.15.a executed"
-		162 = {
-			add_core_of = FROM
-		}
-		935 = {
-			add_core_of = FROM
-		}
-		FROM = {
-			country_event = iranic_confederation.16
-		}
-		ai_chance = {
-			base = 1
-		}
+		162 = { add_core_of = FROM }
+		935 = { add_core_of = FROM }
+		FROM = { country_event = iranic_confederation.16 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5316,12 +4889,8 @@ country_event = {
 			transfer_state_to = FROM
 			add_core_of = FROM
 		}
-		FROM = {
-			country_event = iranic_confederation.17
-		}
-		ai_chance = {
-			base = 0
-		}
+		FROM = { country_event = iranic_confederation.17 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -5329,7 +4898,6 @@ country_event = {
 	id = iranic_confederation.16
 	title = iranic_confederation.16.t
 	desc = iranic_confederation.16.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -5342,9 +4910,7 @@ country_event = {
 			target = TUR
 			type = take_core_state
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5352,15 +4918,12 @@ country_event = {
 	id = iranic_confederation.17
 	title = iranic_confederation.17.t
 	desc = iranic_confederation.17.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.17.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5368,19 +4931,14 @@ country_event = {
 	id = iranic_confederation.18
 	title = iranic_confederation.18.t
 	desc = iranic_confederation.18.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.18.a
 		log = "[GetDateText]: [This.GetName]: iranic_confederation.18.a executed"
-		FROM = {
-			country_event = iranic_confederation.19
-		}
-		ai_chance = {
-			base = 1
-		}
+		FROM = { country_event = iranic_confederation.19 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5393,9 +4951,7 @@ country_event = {
 			}
 			country_event = iranic_confederation.20
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5403,7 +4959,6 @@ country_event = {
 	id = iranic_confederation.19
 	title = iranic_confederation.19.t
 	desc = iranic_confederation.19.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
@@ -5416,9 +4971,7 @@ country_event = {
 			target = FROM
 			type = puppet_wargoal_focus
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5426,15 +4979,12 @@ country_event = {
 	id = iranic_confederation.20
 	title = iranic_confederation.20.t
 	desc = iranic_confederation.20.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
 	option = {
 		name = iranic_confederation.20.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5443,7 +4993,6 @@ country_event = {
 	id = pamir_conflict.1
 	title = pamir_conflict.1.t
 	desc = pamir_conflict.1.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -5451,40 +5000,20 @@ country_event = {
 		name = pamir_conflict.1.a
 		log = "[GetDateText]: [This.GetName]: pamir_conflict.1.a executed"
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = TAJ
-				}
-			}
+			limit = { ROOT = { original_tag = TAJ } }
 			add_ideas = TAJ_occupying_batken
 			activate_mission = TAJ_batken_occupation
-			1170 = {
-				transfer_state_to = TAJ
-			}
+			1170 = { transfer_state_to = TAJ }
 		}
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = UZB
-				}
-			}
-			1170 = {
-				transfer_state_to = UZB
-			}
+			limit = { ROOT = { original_tag = UZB } }
+			1170 = { transfer_state_to = UZB }
 		}
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = KYR
-				}
-			}
-			1170 = {
-				transfer_state_to = KYR
-			}
+			limit = { ROOT = { original_tag = KYR } }
+			1170 = { transfer_state_to = KYR }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5492,7 +5021,6 @@ country_event = {
 	id = pamir_conflict.2
 	title = pamir_conflict.2.t
 	desc = pamir_conflict.2.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -5500,9 +5028,7 @@ country_event = {
 		name = pamir_conflict.2.a
 		log = "[GetDateText]: [This.GetName]: pamir_conflict.2.a executed"
 		add_stability = -0.02
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5510,16 +5036,12 @@ country_event = {
 	id = pamir_conflict.3
 	title = pamir_conflict.3.t
 	desc = pamir_conflict.3.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = {
 		name = pamir_conflict.3.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5527,16 +5049,12 @@ country_event = {
 	id = pamir_conflict.4
 	title = pamir_conflict.4.t
 	desc = pamir_conflict.4.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = {
 		name = pamir_conflict.4.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5544,7 +5062,6 @@ country_event = {
 	id = pamir_conflict.5
 	title = pamir_conflict.5.t
 	desc = pamir_conflict.5.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -5552,40 +5069,20 @@ country_event = {
 		name = pamir_conflict.5.a
 		log = "[GetDateText]: [This.GetName]: pamir_conflict.5.a executed"
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = TAJ
-				}
-			}
+			limit = { ROOT = { original_tag = TAJ } }
 			add_ideas = TAJ_occupying_pamir
 			activate_mission = TAJ_pamir_occupation
-			721 = {
-				transfer_state_to = TAJ
-			}
+			721 = { transfer_state_to = TAJ }
 		}
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = UZB
-				}
-			}
-			721 = {
-				transfer_state_to = UZB
-			}
+			limit = { ROOT = { original_tag = UZB } }
+			721 = { transfer_state_to = UZB }
 		}
 		if = {
-			limit = {
-				ROOT = {
-					original_tag = KYR
-				}
-			}
-			721 = {
-				transfer_state_to = KYR
-			}
+			limit = { ROOT = { original_tag = KYR } }
+			721 = { transfer_state_to = KYR }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5595,7 +5092,6 @@ country_event = { # Monthly Goods (Variation 1)
 	id = tajik_corruption.1
 	title = tajik_corruption.1.t
 	desc = tajik_corruption.1.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -5722,187 +5218,145 @@ country_event = { # Monthly Goods (Variation 1)
 			base = 1
 		}
 	}
+
 	# Pass it off to the military
 	option = {
 		name = tajik_corruption.1.b
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.b executed"
-		trigger = {
-			has_idea = the_military
-		}
+		trigger = { has_idea = the_military }
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Pass it off to the oligarchs
 	option = {
 		name = tajik_corruption.1.c
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.c executed"
-		trigger = {
-			has_idea = oligarchs
-		}
+		trigger = { has_idea = oligarchs }
 		set_temp_variable = { temp_opinion = 5 }
 		change_oligarchs_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Pass it off to the farmers
 	option = {
 		name = tajik_corruption.1.c1
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.c1 executed"
-		trigger = {
-			has_idea = farmers
-		}
+		trigger = { has_idea = farmers }
 		set_temp_variable = { temp_opinion = 5 }
 		change_farmers_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Small businesses
 	option = {
 		name = tajik_corruption.1.d1
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.d1 executed"
-		trigger = {
-			has_idea = small_medium_business_owners
-		}
+		trigger = { has_idea = small_medium_business_owners }
 		set_temp_variable = { temp_opinion = 5 }
 		change_small_medium_business_owners_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# fossil fuel
 	option = {
 		name = tajik_corruption.1.e
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.e executed"
-		trigger = {
-			has_idea = fossil_fuel_industry
-		}
+		trigger = { has_idea = fossil_fuel_industry }
 		set_temp_variable = { temp_opinion = 5 }
 		change_fossil_fuel_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# labour unions
 	option = {
 		name = tajik_corruption.1.f
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.f executed"
-		trigger = {
-			has_idea = labour_unions
-		}
+		trigger = { has_idea = labour_unions }
 		set_temp_variable = { temp_opinion = 5 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# International Bankers
 	option = {
 		name = tajik_corruption.1.g
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.g executed"
-		trigger = {
-			has_idea = international_bankers
-		}
+		trigger = { has_idea = international_bankers }
 		set_temp_variable = { temp_opinion = 5 }
 		change_international_bankers_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# industrial conglomerates
 	option = {
 		name = tajik_corruption.1.h
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.h executed"
-		trigger = {
-			has_idea = industrial_conglomerates
-		}
+		trigger = { has_idea = industrial_conglomerates }
 		set_temp_variable = { temp_opinion = 5 }
 		change_industrial_conglomerates_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# military industrial
 	option = {
 		name = tajik_corruption.1.i
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.i executed"
-		trigger = {
-			has_idea = defense_industry
-		}
+		trigger = { has_idea = defense_industry }
 		set_temp_variable = { temp_opinion = 5 }
 		change_defense_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Ulema
 	option = {
 		name = tajik_corruption.1.j
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.j executed"
-		trigger = {
-			has_idea = the_ulema
-		}
+		trigger = { has_idea = the_ulema }
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_ulema_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Sepah
 	option = {
 		name = tajik_corruption.1.k
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.k executed"
-		trigger = {
-			has_idea = iranian_quds_force
-		}
+		trigger = { has_idea = iranian_quds_force }
 		set_temp_variable = { temp_opinion = 5 }
 		change_iranian_quds_force_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Land Owners
 	option = {
 		name = tajik_corruption.1.l
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.l executed"
-		trigger = {
-			has_idea = landowners
-		}
+		trigger = { has_idea = landowners }
 		set_temp_variable = { temp_opinion = 5 }
 		change_landowners_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Intel
 	option = {
 		name = tajik_corruption.1.m
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.m executed"
-		trigger = {
-			has_idea = intelligence_community
-		}
+		trigger = { has_idea = intelligence_community }
 		set_temp_variable = { temp_opinion = 5 }
 		change_intelligence_community_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Maritime
 	option = {
 		name = tajik_corruption.1.n
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.1.n executed"
-		trigger = {
-			has_idea = maritime_industry
-		}
+		trigger = { has_idea = maritime_industry }
 		set_temp_variable = { temp_opinion = 5 }
 		change_maritime_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5911,7 +5365,6 @@ country_event = { # Foreign Influence Has Made It's Way In
 	id = tajik_corruption.2
 	title = tajik_corruption.2.t
 	desc = tajik_corruption.2.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -5924,9 +5377,7 @@ country_event = { # Foreign Influence Has Made It's Way In
 			set_temp_variable = { influence_target = TAJ }
 			change_influence_percentage = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5934,14 +5385,13 @@ country_event = { # Islamist Pamphlets Spread
 	id = tajik_corruption.3
 	title = tajik_corruption.3.t
 	desc = tajik_corruption.3.d
-	trigger = {
-		NOT = {
-			has_government = fascism
-		}
-		neutrality_muslim_brotherhood_in_power_or_coalition = no
-	}
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+
+	trigger = {
+		NOT = { has_government = fascism }
+		neutrality_muslim_brotherhood_in_power_or_coalition = no
+	}
 
 	option = {
 		name = tajik_corruption.3.a
@@ -5952,9 +5402,7 @@ country_event = { # Islamist Pamphlets Spread
 		}
 		newline = yes
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5962,7 +5410,6 @@ country_event = { # Anti-Government Pamphlets Spread
 	id = tajik_corruption.4
 	title = tajik_corruption.4.t
 	desc = tajik_corruption.4.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -5972,9 +5419,7 @@ country_event = { # Anti-Government Pamphlets Spread
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5982,7 +5427,6 @@ country_event = { # Drugs From Abroad Plunge Our Soldiers into Addiction
 	id = tajik_corruption.5
 	title = tajik_corruption.5.t
 	desc = tajik_corruption.5.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -5991,9 +5435,7 @@ country_event = { # Drugs From Abroad Plunge Our Soldiers into Addiction
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.5.a executed"
 		army_experience = -20
 		air_experience = -20
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6001,20 +5443,15 @@ country_event = { # Drugs From Abroad Plunge Our People into Addiction
 	id = tajik_corruption.6
 	title = tajik_corruption.6.t
 	desc = tajik_corruption.6.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
 	option = {
 		name = tajik_corruption.6.a
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.6.a executed"
-		random_core_state = {
-			add_to_variable = { productivity_state_var = -10 }
-		}
+		random_core_state = { add_to_variable = { productivity_state_var = -10 } }
 		custom_effect_tooltip = TAJ_lose_10_prod_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6022,7 +5459,6 @@ country_event = { # Terrorist Attack Linked to Black-Market Trade
 	id = tajik_corruption.7
 	title = tajik_corruption.7.t
 	desc = tajik_corruption.7.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6030,9 +5466,7 @@ country_event = { # Terrorist Attack Linked to Black-Market Trade
 		name = tajik_corruption.7.a
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.7.a executed"
 		random_core_state = {
-			limit = {
-				industrial_complex > 0
-			}
+			limit = { industrial_complex > 0 }
 			if = {
 				limit = { infrastructure > 0 }
 				damage_building = {
@@ -6045,9 +5479,7 @@ country_event = { # Terrorist Attack Linked to Black-Market Trade
 				damage = 1.0
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6055,7 +5487,6 @@ country_event = { # Money Smuggled From National Treasury
 	id = tajik_corruption.8
 	title = tajik_corruption.8.t
 	desc = tajik_corruption.8.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6069,9 +5500,7 @@ country_event = { # Money Smuggled From National Treasury
 			}
 		}
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6079,7 +5508,6 @@ country_event = { # Corrupt Officials Gave Away State Secrets
 	id = tajik_corruption.9
 	title = tajik_corruption.9.t
 	desc = tajik_corruption.9.d
-
 	picture = GFX_politics_surveillence
 	is_triggered_only = yes
 
@@ -6089,25 +5517,17 @@ country_event = { # Corrupt Officials Gave Away State Secrets
 		random_list = {
 			25 = {
 				if = {
-					limit = {
-						NOT = {
-							has_idea = corruption_level_10
-						}
-					}
+					limit = { NOT = { has_idea = corruption_level_10 } }
 					increase_corruption = yes
 				}
-				else = {
-					add_political_power = -300
-				}
+				else = { add_political_power = -300 }
 			}
 			75 = {
 				add_political_power = -75
 				add_command_power = -25
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6115,7 +5535,6 @@ country_event = { # Internal Factions Upset With Mismanagement
 	id = tajik_corruption.10
 	title = tajik_corruption.10.t
 	desc = tajik_corruption.10.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6135,9 +5554,7 @@ country_event = { # Internal Factions Upset With Mismanagement
 		change_landowners_opinion = yes
 		change_maritime_industry_opinion = yes
 		change_intelligence_community_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6147,7 +5564,6 @@ country_event = { # Foreign State Secrets Found
 	id = tajik_corruption.11
 	title = tajik_corruption.11.t
 	desc = tajik_corruption.11.d
-
 	picture = GFX_politics_surveillence
 	is_triggered_only = yes
 
@@ -6158,9 +5574,7 @@ country_event = { # Foreign State Secrets Found
 			specialization = all
 			value = 0.10
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6168,7 +5582,6 @@ country_event = { # Missile Smuggled
 	id = tajik_corruption.12
 	title = tajik_corruption.12.t
 	desc = tajik_corruption.12.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6176,9 +5589,7 @@ country_event = { # Missile Smuggled
 		name = tajik_corruption.12.a
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.12.a executed"
 		if = {
-			limit = {
-				has_dlc = "Gotterdammerung"
-			}
+			limit = { has_dlc = "Gotterdammerung" }
 			add_equipment_to_stockpile = {
 				type = ballistic_missile_equipment_1
 				amount = 2
@@ -6192,9 +5603,7 @@ country_event = { # Missile Smuggled
 				producer = SOV
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6202,7 +5611,6 @@ country_event = { # Gold Smuggled
 	id = tajik_corruption.13
 	title = tajik_corruption.13.t
 	desc = tajik_corruption.13.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6214,9 +5622,7 @@ country_event = { # Gold Smuggled
 			amount = 1
 			state = 724
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6224,7 +5630,6 @@ country_event = { # Weapons Equipment Smuggled
 	id = tajik_corruption.14
 	title = tajik_corruption.14.t
 	desc = tajik_corruption.14.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6242,9 +5647,7 @@ country_event = { # Weapons Equipment Smuggled
 			amount = 15
 			producer = SOV
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6252,7 +5655,6 @@ country_event = { # Foreign Blueprints Smuggled
 	id = tajik_corruption.15
 	title = tajik_corruption.15.t
 	desc = tajik_corruption.15.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6341,9 +5743,7 @@ country_event = { # Foreign Blueprints Smuggled
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6351,7 +5751,6 @@ country_event = { # Military Doctrines Smuggled
 	id = tajik_corruption.16
 	title = tajik_corruption.16.t
 	desc = tajik_corruption.16.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -6376,9 +5775,7 @@ country_event = { # Military Doctrines Smuggled
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6386,7 +5783,6 @@ country_event = { # Farming Equipment Smuggled
 	id = tajik_corruption.17
 	title = tajik_corruption.17.t
 	desc = tajik_corruption.17.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -6394,9 +5790,7 @@ country_event = { # Farming Equipment Smuggled
 		name = tajik_corruption.17.a
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.17.a executed"
 		one_random_agriculture_district = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6404,9 +5798,7 @@ country_event = { # Farming Equipment Smuggled
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.17.b executed"
 		set_temp_variable = { treasury_change = 3.70 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6414,7 +5806,6 @@ country_event = { # Military Tactic Handout Smuggled
 	id = tajik_corruption.18
 	title = tajik_corruption.18.t
 	desc = tajik_corruption.18.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6423,23 +5814,13 @@ country_event = { # Military Tactic Handout Smuggled
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.18.a executed"
 		random_army_leader = {
 			random_list = {
-				25 = {
-					add_attack = 1
-				}
-				25 = {
-					add_defense = 1
-				}
-				25 = {
-					add_logistics = 1
-				}
-				25 = {
-					add_planning = 1
-				}
+				25 = { add_attack = 1 }
+				25 = { add_defense = 1 }
+				25 = { add_logistics = 1 }
+				25 = { add_planning = 1 }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6447,7 +5828,6 @@ country_event = { # Dangerous Contraband Stopped
 	id = tajik_corruption.19
 	title = tajik_corruption.19.t
 	desc = tajik_corruption.19.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6455,9 +5835,7 @@ country_event = { # Dangerous Contraband Stopped
 		name = tajik_corruption.19.a
 		log = "[GetDateText]: [This.GetName]: tajik_corruption.19.a executed"
 		add_political_power = 75
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6466,7 +5844,6 @@ country_event = { # Tajikistan Floods Our Markets With Drugs
 	id = tajik_corruption.20
 	title = tajik_corruption.20.t
 	desc = tajik_corruption.20.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6479,9 +5856,7 @@ country_event = { # Tajikistan Floods Our Markets With Drugs
 		set_country_flag = tajik_drugs_flag
 		effect_tooltip = { add_dynamic_modifier = { modifier = TAJ_tajik_drugs } }
 		TAJ_drug_flow_update = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6489,7 +5864,6 @@ country_event = { # Tajikistan Increases Narcotics Flow Into Our Markets
 	id = tajik_corruption.21
 	title = tajik_corruption.21.t
 	desc = tajik_corruption.21.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6505,14 +5879,9 @@ country_event = { # Tajikistan Increases Narcotics Flow Into Our Markets
 		}
 		random = {
 			chance = 30
-
 				add_stability = -0.01
-
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6520,7 +5889,6 @@ country_event = { # Tajikistan Increases Narcotics Flow Into Our Markets
 	id = tajik_corruption.22
 	title = tajik_corruption.22.t
 	desc = tajik_corruption.22.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -6531,9 +5899,7 @@ country_event = { # Tajikistan Increases Narcotics Flow Into Our Markets
 		clr_country_flag = tajik_drugs_flag
 		effect_tooltip = { remove_dynamic_modifier = { modifier = TAJ_tajik_drugs } }
 		TAJ_drug_flow_update = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6541,7 +5907,6 @@ country_event = { # Tajikistan Threatens to Lower Border Security!
 	id = tajik_corruption.23
 	title = tajik_corruption.23.t
 	desc = tajik_corruption.23.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -6630,7 +5995,6 @@ country_event = { # Russia Grants Economic Support
 	id = tajik_corruption.24
 	title = tajik_corruption.24.t
 	desc = tajik_corruption.24.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
@@ -6678,13 +6042,11 @@ country_event = { # Russia Denies Economic Support
 	id = tajik_corruption.25
 	title = tajik_corruption.25.t
 	desc = tajik_corruption.25.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
 	option = { # We'll Remember That
 		name = tajik_corruption.25.a
-
 		ai_chance = {
 			base = 1
 		}
@@ -6695,13 +6057,11 @@ country_event = { # Russia Threatens Us!
 	id = tajik_corruption.26
 	title = tajik_corruption.26.t
 	desc = tajik_corruption.26.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = { # We'll Remember That
 		name = tajik_corruption.26.a
-
 		ai_chance = {
 			base = 1
 		}
@@ -6712,13 +6072,11 @@ country_event = { # Russia Angered
 	id = tajik_corruption.27
 	title = tajik_corruption.27.t
 	desc = tajik_corruption.27.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = { # We'll Remember That
 		name = tajik_corruption.27.a
-
 		ai_chance = {
 			base = 1
 		}
@@ -6729,7 +6087,6 @@ country_event = { # Russian Ultimatum
 	id = tajik_corruption.28
 	title = tajik_corruption.28.t
 	desc = tajik_corruption.28.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -6747,7 +6104,6 @@ country_event = { # Tajikistan Fails to Comply
 	id = tajik_corruption.29
 	title = tajik_corruption.29.t
 	desc = tajik_corruption.29.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
@@ -6791,14 +6147,11 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Just another day on the Job
 		name = tajik_lore.0.a
 		log = "[GetDateText]: [This.GetName]: tajik_lore.0.a executed"
-
 		hidden_effect = {
 			set_country_flag = TAJ_tajik_lore.1
 		}
@@ -6813,13 +6166,10 @@ country_event = { # The Harshest Truth
 	title = tajik_lore.1.t
 	desc = tajik_lore.1.d
 	picture = GFX_TAJ_Army_reform
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Allahumma arhamna
 		name = tajik_lore.1.a
@@ -6834,13 +6184,10 @@ country_event = { # Arsenal Blueprint
 	title = tajik_lore.2.t
 	desc = tajik_lore.2.d
 	picture = GFX_TAJ_Army_reform
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Looks like rabbit season is in play
 		name = tajik_lore.2.a
@@ -6855,13 +6202,10 @@ country_event = { # Optics from the Tavildara valley pt1
 	title = tajik_lore.3.t
 	desc = tajik_lore.3.d
 	picture = GFX_TAJ_Trucks_gunfire
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Always walking on the brink
 		name = tajik_lore.3.a
@@ -6876,13 +6220,10 @@ country_event = { # Optics from the Tavildara valley pt2
 	title = tajik_lore.4.t
 	desc = tajik_lore.4.d
 	picture = GFX_TAJ_IMU_millitia
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Are fruit’s rotted away and they killed it
 		name = tajik_lore.4.a
@@ -6897,13 +6238,10 @@ country_event = { # The cover up
 	title = tajik_lore.5.t
 	desc = tajik_lore.5.d
 	picture = GFX_TAJ_worker_army
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # A day at its finest
 		name = tajik_lore.5.a
@@ -6918,13 +6256,10 @@ country_event = { # A unwanted call
 	title = tajik_lore.6.t
 	desc = tajik_lore.6.d
 	picture = GFX_TAJ_Rahmon_phone_call
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Well Well Well
 		name = tajik_lore.6.a
@@ -6939,13 +6274,10 @@ country_event = { # Hills Ablaze
 	title = tajik_lore.7.t
 	desc = tajik_lore.7.d
 	picture = GFX_TAJ_Rocket_attack
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # Leave no response
 		name = tajik_lore.7.a
@@ -6953,6 +6285,7 @@ country_event = { # Hills Ablaze
 			base = 1
 		}
 	}
+
 	option = { # Rally the troops
 		name = tajik_lore.7.b
 		log = "[GetDateText]: [This.GetName]: tajik_lore.7.b executed"
@@ -6975,13 +6308,10 @@ country_event = { # Plans for a strike into Tajikistan (Uzbek Event)
 	title = tajik_lore.8.t
 	desc = tajik_lore.8.d
 	picture = GFX_TAJ_Rahmon_speach
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		TAJ = { emerging_conservative_in_power_or_coalition = yes }
-	}
+	trigger = { TAJ = { emerging_conservative_in_power_or_coalition = yes } }
 
 	option = { # there is no choice Are hand is forced
 		name = tajik_lore.8.a
@@ -7009,13 +6339,10 @@ country_event = { # Mine the borders (Uzbek Event)
 	title = tajik_lore.9.t
 	desc = tajik_lore.9.d
 	picture = GFX_TAJ_red_sign_snow_ice
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		TAJ = { emerging_conservative_in_power_or_coalition = yes }
-	}
+	trigger = { TAJ = { emerging_conservative_in_power_or_coalition = yes } }
 
 	option = { # There is no choice Are hand is forced
 		name = tajik_lore.9.a
@@ -7046,13 +6373,10 @@ country_event = { # Uzbekistan lays its landmines
 	title = tajik_lore.10.t
 	desc = tajik_lore.10.d
 	picture = GFX_TAJ_red_sign_snow_ice
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # We are out of our grasp
 		name = tajik_lore.10.a
@@ -7067,6 +6391,7 @@ country_event = { # Uzbekistan lays its landmines
 			base = 1
 		}
 	}
+
 	option = { # We will not accept this
 		name = tajik_lore.10.b
 		log = "[GetDateText]: [This.GetName]: tajik_lore.10.b executed"
@@ -7095,13 +6420,10 @@ country_event = { # Crisis Talks with Uzbekistan
 	title = tajik_lore.11.t
 	desc = tajik_lore.11.d
 	picture = GFX_TAJ_Rahmon_phone_call
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	trigger = {
-		emerging_conservative_in_power_or_coalition = yes
-	}
+	trigger = { emerging_conservative_in_power_or_coalition = yes }
 
 	option = { # A nation wide sigh
 		name = tajik_lore.11.a
@@ -7133,6 +6455,7 @@ news_event = { # Uzbekistan Strikes Tajikistan in Targeted IMU Operation (News)
 			base = 1
 		}
 	}
+
 	option = { # A Shadow Looms Over Us
 		name = tajik_lore.12.b
 		trigger = {
@@ -7142,6 +6465,7 @@ news_event = { # Uzbekistan Strikes Tajikistan in Targeted IMU Operation (News)
 			base = 1
 		}
 	}
+
 	option = { # A Decisive Blow
 		name = tajik_lore.12.c
 		trigger = {
@@ -7158,10 +6482,9 @@ news_event = { # Uzbekistan Mines the Tajik Border (News)
 	title = tajik_lore.13.t
 	desc = tajik_lore.13.d
 	picture = GFX_News_TAJ_border_guards
-
 	is_triggered_only = yes
-	fire_only_once = yes
 	major = yes
+	fire_only_once = yes
 
 	option = { # Days of Hazy lay ahead
 		name = tajik_lore.13.a
@@ -7176,10 +6499,9 @@ news_event = { # Uzbek Invasion of Tajikistan (News)
 	title = tajik_lore.14.t
 	desc = tajik_lore.14.d
 	picture = GFX_News_TAJ_Helicopter
-
 	is_triggered_only = yes
-	fire_only_once = yes
 	major = yes
+	fire_only_once = yes
 
 	option = { # A carefully tread that ended in hellfire
 		name = tajik_lore.14.a


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,597 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.