### PR TITLE
Standardize event files — batch 05/14

### DIFF
--- a/events/05_north_korea_events.txt
+++ b/events/05_north_korea_events.txt
@@ -10,11 +10,9 @@ add_namespace = NKO_export
 ###North Korea###
 country_event = {
 	id = korea_north.1
-
 	title = korea_north.1.t
 	desc = korea_north.1.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -56,18 +54,14 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = korea_north.2.a
-	}
+	option = { name = korea_north.2.a }
 }
 
 country_event = {
 	id = korea_north.3 #North Korea 2009 Revaluation
 	title = korea_north.3.t
 	desc = korea_north.3.d
-
 	picture = GFX_united_states_dollar
-
 	is_triggered_only = yes
 
 	option = {
@@ -96,9 +90,7 @@ country_event = {
 	id = korea_north.4
 	title = korea_north.4.t
 	desc = korea_north.4.d
-
 	picture = GFX_stock_market
-
 	is_triggered_only = yes
 
 	option = {
@@ -113,9 +105,7 @@ country_event = {
 	id = korea_north.5
 	title = korea_north.5.t
 	desc = korea_north.5.d
-
 	picture = GFX_politics_eye
-
 	is_triggered_only = yes
 
 	# Maintain Status Quo
@@ -156,9 +146,7 @@ country_event = {
 	id = korea_north.6
 	title = korea_north.6.t
 	desc = korea_north.6.d
-
 	picture = GFX_stock_market
-
 	is_triggered_only = yes
 
 	option = {
@@ -173,9 +161,7 @@ country_event = {
 	id = kim_jong_il_death.1
 	title = kim_jong_il_death.1.t
 	desc = kim_jong_il_death.1.d
-
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	# Kim Jong-un
@@ -219,16 +205,13 @@ news_event = {
 	id = kim_jong_il_death.2
 	title = kim_jong_il_death.2.t
 	desc = kim_jong_il_death.2.d
-
 	picture = GFX_kim_jong_il_funeral
 	is_triggered_only = yes
 
 	option = {
 		name = kim_jong_il_death.2.a
 		if = {
-			limit = {
-				tag = NKO
-			}
+			limit = { tag = NKO }
 			set_country_flag = NKO_kim_jong_il_death_tt
 			kill_country_leader = yes
 			create_country_leader = {
@@ -254,7 +237,6 @@ country_event = {
 	id = kim_jong_il_death.3
 	title = kim_jong_il_death.3.t
 	desc = kim_jong_il_death.3.d
-
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
@@ -284,7 +266,6 @@ news_event = {
 	id = kim_jong_il_death.4
 	title = kim_jong_il_death.4.t
 	desc = kim_jong_il_death.4.d
-
 	picture = GFX_nam_elected
 	is_triggered_only = yes
 
@@ -299,6 +280,7 @@ news_event = {
 		}
 		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = kim_jong_il_death.4.b
 		trigger = {
@@ -316,7 +298,6 @@ news_event = {
 	id = kim_jong_il_death.5 #Kim Jong-un takes the power!
 	title = kim_jong_il_death.5.t
 	desc = kim_jong_il_death.5.d
-
 	picture = GFX_north_korean_officials
 	is_triggered_only = yes
 
@@ -331,6 +312,7 @@ news_event = {
 		}
 		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = kim_jong_il_death.5.b
 		trigger = {
@@ -348,7 +330,6 @@ news_event = {
 	id = kim_jong_il_death.6 #The Military take the power!
 	title = kim_jong_il_death.6.t
 	desc = kim_jong_il_death.6.d
-
 	picture = GFX_anti_kim_coup
 	is_triggered_only = yes
 
@@ -364,6 +345,7 @@ news_event = {
 		}
 		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = kim_jong_il_death.6.b
 		trigger = {
@@ -376,6 +358,7 @@ news_event = {
 			}
 		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = kim_jong_il_death.6.c
 		trigger = {
@@ -395,9 +378,9 @@ country_event = {
 	id = kim_jong_il_death.7 #Zhou Yongkang eavesdropped on Jang Song-thaek's visit to China to meet with Hu Jintao
 	title = kim_jong_il_death.7.t
 	desc = kim_jong_il_death.7.d
-
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	trigger = { original_tag = CHI }
 
 	option = {
@@ -411,6 +394,7 @@ country_event = {
 		}
 		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = kim_jong_il_death.7.b
 		log = "[GetDateText]: [This.GetName]: kim_jong_il_death.7.b executed" #Doing nothing. What does Kim Jong-un have to do with me?
@@ -432,22 +416,15 @@ country_event = {
 		name = korea_russia.1.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.1.a executed"
 		add_ideas = SOV_NKO_base
-		SOV = {
-			country_event = korea_russia.2
-		}
-		ai_chance = {
-			base = 100
-		}
+		SOV = { country_event = korea_russia.2 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.1.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.1.b executed"
-		SOV = {
-			country_event = korea_russia.3
-		}
-		ai_chance = {
-			base = 0
-		}
+		SOV = { country_event = korea_russia.3 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -461,7 +438,6 @@ country_event = {
 
 	option = {
 		name = korea_russia.2.a
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -476,7 +452,6 @@ country_event = {
 
 	option = {
 		name = korea_russia.3.a
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -492,22 +467,15 @@ country_event = {
 	option = {
 		name = korea_russia.4.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.4.a executed"
-		NKO = {
-			country_event = korea_russia.5
-		}
-		ai_chance = {
-			base = 100
-		}
+		NKO = { country_event = korea_russia.5 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.4.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.4.b executed"
-		NKO = {
-			country_event = korea_russia.3
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_russia.3 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -523,9 +491,7 @@ country_event = {
 		name = korea_russia.5.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.5.a executed"
 		set_country_flag = SOV_agree_nuclear
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -545,7 +511,6 @@ country_event = {
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
 		add_ideas = NKO_korean_ratnik_conversion
-
 	}
 }
 
@@ -561,22 +526,15 @@ country_event = {
 		name = korea_russia.7.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.7.a executed"
 		set_country_flag = SOV_gazprom_mechanic_korean_stream_agree
-		NKO = {
-			country_event = korea_russia.2
-		}
-		ai_chance = {
-			base = 100
-		}
+		NKO = { country_event = korea_russia.2 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.7.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.7.b executed"
-		NKO = {
-			country_event = korea_russia.3
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_russia.3 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -599,9 +557,7 @@ country_event = {
 				relation = guarantee
 			}
 		}
-		NKO = {
-			country_event = korea_russia.9
-		}
+		NKO = { country_event = korea_russia.9 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -614,12 +570,11 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = korea_russia.8.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.8.b executed"
-		NKO = {
-			country_event = korea_russia.10
-		}
+		NKO = { country_event = korea_russia.10 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -695,22 +650,15 @@ country_event = {
 				relation = guarantee
 			}
 		}
-		SOV = {
-			country_event = korea_russia.12
-		}
-		ai_chance = {
-			base = 100
-		}
+		SOV = { country_event = korea_russia.12 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.11.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.11.b executed"
-		SOV = {
-			country_event = korea_russia.13
-		}
-		ai_chance = {
-			base = 0
-		}
+		SOV = { country_event = korea_russia.13 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -748,9 +696,7 @@ country_event = {
 	picture = GFX_NKO_russian_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = korea_russia.13.a
-	}
+	option = { name = korea_russia.13.a }
 }
 
 #Korea Ask About Cruiser
@@ -770,29 +716,20 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		NKO = {
-			country_event = korea_russia.15
-		}
+		NKO = { country_event = korea_russia.15 }
 		if = {
-			limit = {
-				has_idea = NKO_korean_russian_friendship
-			}
+			limit = { has_idea = NKO_korean_russian_friendship }
 			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.14.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.14.b executed"
-		NKO = {
-			country_event = korea_russia.3
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_russia.3 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -808,9 +745,7 @@ country_event = {
 		name = korea_russia.15.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.15.a executed"
 		if = {
-			limit = {
-				has_tech = cruiser_hull_1
-			}
+			limit = { has_tech = cruiser_hull_1 }
 			set_technology = { cruiser_hull_2 = 1 }
 			set_temp_variable = { percent_change = 8 }
 			set_temp_variable = { tag_index = SOV }
@@ -820,9 +755,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		else_if = {
-			limit = {
-				NOT = { has_tech = cruiser_hull_1 }
-			}
+			limit = { NOT = { has_tech = cruiser_hull_1 } }
 			set_technology = { cruiser_hull_1 = 1 }
 			set_temp_variable = { percent_change = 11 }
 			set_temp_variable = { tag_index = SOV }
@@ -880,9 +813,7 @@ country_event = {
 		set_temp_variable = { receiver_nation = ROOT.id }
 		set_temp_variable = { sender_nation = NKO.id }
 		set_improved_trade_agreement = yes
-		NKO = {
-			country_event = korea_russia.17
-		}
+		NKO = { country_event = korea_russia.17 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -895,6 +826,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = korea_russia.16.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.16.b executed"
@@ -904,9 +836,7 @@ country_event = {
 				modifier = recent_actions_negative
 			}
 		}
-		NKO = {
-			country_event = korea_russia.18
-		}
+		NKO = { country_event = korea_russia.18 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -982,22 +912,15 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		NKO = {
-			country_event = korea_russia.20
-		}
-		ai_chance = {
-			base = 100
-		}
+		NKO = { country_event = korea_russia.20 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.19.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.19.b executed"
-		NKO = {
-			country_event = korea_russia.3
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_russia.3 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1013,9 +936,7 @@ country_event = {
 		name = korea_russia.20.a
 		log = "[GetDateText]: [This.GetName]: korea_russia.20.a executed"
 		if = {
-			limit = {
-				has_tech = gen_3_light
-			}
+			limit = { has_tech = gen_3_light }
 			set_technology = { gen_3_medium = 1 }
 			set_temp_variable = { percent_change = 8 }
 			set_temp_variable = { tag_index = SOV }
@@ -1025,9 +946,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		else_if = {
-			limit = {
-				NOT = { has_tech = gen_3_light }
-			}
+			limit = { NOT = { has_tech = gen_3_light } }
 			set_technology = { gen_3_light = 1 }
 			set_temp_variable = { percent_change = 11 }
 			set_temp_variable = { tag_index = SOV }
@@ -1047,10 +966,7 @@ country_event = {
 	picture = GFX_NKO_russian_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = korea_russia.21.a
-
-	}
+	option = { name = korea_russia.21.a }
 }
 
 #Exercises with Russia
@@ -1068,22 +984,15 @@ country_event = {
 			idea = NKO_joint_exercises_nko_idea
 			days = 29
 		}
-		NKO = {
-			country_event = korea_russia.23
-		}
-		ai_chance = {
-			base = 100
-		}
+		NKO = { country_event = korea_russia.23 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_russia.22.b
 		log = "[GetDateText]: [This.GetName]: korea_russia.22.b executed"
-		NKO = {
-			country_event = korea_russia.24
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_russia.24 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1129,10 +1038,8 @@ news_event = {
 	title = korea_russia_news.1.t
 	desc = korea_russia_news.1.d
 	picture = GFX_north_korea_russia
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = korea_russia_news.1.a
@@ -1174,22 +1081,15 @@ country_event = {
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		NKO = {
-			country_event = korea_china.2
-		}
-		ai_chance = {
-			base = 100
-		}
+		NKO = { country_event = korea_china.2 }
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.1.b
 		log = "[GetDateText]: [This.GetName]: korea_china.1.b executed"
-		NKO = {
-			country_event = korea_china.3
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.3 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1205,9 +1105,7 @@ country_event = {
 		name = korea_china.2.a
 		log = "[GetDateText]: [This.GetName]: korea_china.2.a executed"
 		if = {
-			limit = {
-				has_tech = gen_3_light
-			}
+			limit = { has_tech = gen_3_light }
 			set_technology = { gen_3_medium = 1 }
 			set_temp_variable = { percent_change = 8 }
 			set_temp_variable = { tag_index = CHI }
@@ -1217,9 +1115,7 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		else_if = {
-			limit = {
-				NOT = { has_tech = gen_3_light }
-			}
+			limit = { NOT = { has_tech = gen_3_light } }
 			set_technology = { gen_3_light = 1 }
 			set_temp_variable = { percent_change = 11 }
 			set_temp_variable = { tag_index = CHI }
@@ -1239,9 +1135,7 @@ country_event = {
 	picture = GFX_NKO_russian_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = korea_china.3.a
-	}
+	option = { name = korea_china.3.a }
 }
 
 # Korea Ask Military Support
@@ -1255,9 +1149,7 @@ country_event = {
 	option = {
 		name = korea_china.4.a
 		log = "[GetDateText]: [This.GetName]: korea_china.4.a executed"
-		NKO = {
-			country_event = korea_china.5
-		}
+		NKO = { country_event = korea_china.5 }
 		if = {
 			limit = { NOT = { NKO = { is_guaranteed_by = CHI } } }
 			give_guarantee = NKO
@@ -1270,20 +1162,14 @@ country_event = {
 				active = yes
 			}
 		}
-
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.4.b
 		log = "[GetDateText]: [This.GetName]: korea_china.4.b executed"
-		NKO = {
-			country_event = korea_china.6
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.6 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1314,10 +1200,7 @@ country_event = {
 	picture = GFX_NKO_russian_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = korea_china.6.a
-
-	}
+	option = { name = korea_china.6.a }
 }
 
 #Korea Ask Invest Resourse
@@ -1331,28 +1214,21 @@ country_event = {
 	option = {
 		name = korea_china.7.a
 		log = "[GetDateText]: [This.GetName]: korea_china.7.a executed"
-		NKO = {
-			country_event = korea_china.8
-		}
+		NKO = { country_event = korea_china.8 }
 		set_temp_variable = { treasury_change = -5.6 }
 		modify_treasury_effect = yes
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.7.b
 		log = "[GetDateText]: [This.GetName]: korea_china.7.b executed"
-		NKO = {
-			country_event = korea_china.6
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.6 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1401,28 +1277,21 @@ country_event = {
 	option = {
 		name = korea_china.9.a
 		log = "[GetDateText]: [This.GetName]: korea_china.9.a executed"
-		NKO = {
-			country_event = korea_china.10
-		}
+		NKO = { country_event = korea_china.10 }
 		set_temp_variable = { treasury_change = -17 }
 		modify_treasury_effect = yes
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.9.b
 		log = "[GetDateText]: [This.GetName]: korea_china.9.b executed"
-		NKO = {
-			country_event = korea_china.6
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.6 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1463,27 +1332,20 @@ country_event = {
 	option = {
 		name = korea_china.11.a
 		log = "[GetDateText]: [This.GetName]: korea_china.11.a executed"
-		NKO = {
-			country_event = korea_china.12
-		}
+		NKO = { country_event = korea_china.12 }
 		set_temp_variable = { percent_change = 6 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
 		add_political_power = -75
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.11.b
 		log = "[GetDateText]: [This.GetName]: korea_china.11.b executed"
-		NKO = {
-			country_event = korea_china.6
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.6 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1518,28 +1380,21 @@ country_event = {
 	option = {
 		name = korea_china.13.a
 		log = "[GetDateText]: [This.GetName]: korea_china.13.a executed"
-		NKO = {
-			country_event = korea_china.14
-		}
+		NKO = { country_event = korea_china.14 }
 		set_temp_variable = { treasury_change = -3 }
 		modify_treasury_effect = yes
 		set_temp_variable = { percent_change = 2 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.13.b
 		log = "[GetDateText]: [This.GetName]: korea_china.13.b executed"
-		NKO = {
-			country_event = korea_china.6
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.6 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1574,26 +1429,19 @@ country_event = {
 	option = {
 		name = korea_china.15.a
 		log = "[GetDateText]: [This.GetName]: korea_china.15.a executed"
-		NKO = {
-			country_event = korea_china.16
-		}
+		NKO = { country_event = korea_china.16 }
 		set_temp_variable = { percent_change = 6 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = NKO }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = korea_china.15.b
 		log = "[GetDateText]: [This.GetName]: korea_china.15.b executed"
-		NKO = {
-			country_event = korea_china.6
-		}
-		ai_chance = {
-			base = 0
-		}
+		NKO = { country_event = korea_china.6 }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1632,7 +1480,6 @@ country_event = {
 	id = NKO_spa.0
 	title = NKO_spa.0.t
 	desc = NKO_spa.0.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -1642,15 +1489,12 @@ country_event = {
 		NOT = { has_civil_war = yes }
 	}
 
-	option = {
-		name = NKO_spa.0.a
-	}
+	option = { name = NKO_spa.0.a }
 }
 
 # NKO_spa.6 — Civil-war / collapse cleanup.
 country_event = {
 	id = NKO_spa.6
-
 	is_triggered_only = yes
 	hidden = yes
 
@@ -1664,9 +1508,9 @@ country_event = {
 	id = NKO_spa.20
 	title = NKO_spa.20.t
 	desc = NKO_spa.20.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1684,9 +1528,9 @@ country_event = {
 	id = NKO_spa.21
 	title = NKO_spa.21.t
 	desc = NKO_spa.21.d
-
 	picture = GFX_computer
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1712,9 +1556,9 @@ country_event = {
 	id = NKO_spa.22
 	title = NKO_spa.22.t
 	desc = NKO_spa.22.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1730,9 +1574,9 @@ country_event = {
 	id = NKO_spa.23
 	title = NKO_spa.23.t
 	desc = NKO_spa.23.d
-
 	picture = GFX_mining
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1757,9 +1601,9 @@ country_event = {
 	id = NKO_spa.24
 	title = NKO_spa.24.t
 	desc = NKO_spa.24.d
-
 	picture = GFX_raid_international_sanctions
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1778,9 +1622,9 @@ country_event = {
 	id = NKO_spa.25
 	title = NKO_spa.25.t
 	desc = NKO_spa.25.d
-
 	picture = GFX_generic_grain_silo
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1795,9 +1639,9 @@ country_event = {
 	id = NKO_spa.26
 	title = NKO_spa.26.t
 	desc = NKO_spa.26.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -1813,9 +1657,9 @@ country_event = {
 	id = NKO_spa.27
 	title = NKO_spa.27.t
 	desc = NKO_spa.27.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	immediate = {
@@ -1858,6 +1702,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = NKO_spa.27.factory_cash
 		trigger = { has_country_flag = NKO_spa_27_rolled_factory }
@@ -1899,6 +1744,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = NKO_spa.27.offices_cash
 		trigger = { has_country_flag = NKO_spa_27_rolled_offices }
@@ -1931,6 +1777,7 @@ country_event = {
 		hidden_effect = { clr_country_flag = NKO_spa_27_rolled_refinery }
 		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = NKO_spa.27.refinery_cash
 		trigger = { has_country_flag = NKO_spa_27_rolled_refinery }
@@ -1963,6 +1810,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = NKO_spa.27.agri_cash
 		trigger = { has_country_flag = NKO_spa_27_rolled_agri }
@@ -1984,9 +1832,9 @@ country_event = {
 	id = NKO_spa.30
 	title = NKO_spa.30.t
 	desc = NKO_spa.30.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2004,9 +1852,9 @@ country_event = {
 	id = NKO_spa.31
 	title = NKO_spa.31.t
 	desc = NKO_spa.31.d
-
 	picture = GFX_steel_mill
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2029,9 +1877,9 @@ country_event = {
 	id = NKO_spa.32
 	title = NKO_spa.32.t
 	desc = NKO_spa.32.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2053,9 +1901,9 @@ country_event = {
 	id = NKO_spa.33
 	title = NKO_spa.33.t
 	desc = NKO_spa.33.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2071,9 +1919,9 @@ country_event = {
 	id = NKO_spa.34
 	title = NKO_spa.34.t
 	desc = NKO_spa.34.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2096,9 +1944,9 @@ country_event = {
 	id = NKO_spa.35
 	title = NKO_spa.35.t
 	desc = NKO_spa.35.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2114,9 +1962,9 @@ country_event = {
 	id = NKO_spa.36
 	title = NKO_spa.36.t
 	desc = NKO_spa.36.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2135,9 +1983,9 @@ country_event = {
 	id = NKO_spa.37
 	title = NKO_spa.37.t
 	desc = NKO_spa.37.d
-
 	picture = GFX_Military_Reform
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2156,9 +2004,9 @@ country_event = {
 	id = NKO_spa.38
 	title = NKO_spa.38.t
 	desc = NKO_spa.38.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2176,9 +2024,9 @@ country_event = {
 	id = NKO_spa.39
 	title = NKO_spa.39.t
 	desc = NKO_spa.39.d
-
 	picture = GFX_mining
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2201,9 +2049,9 @@ country_event = {
 	id = NKO_spa.40
 	title = NKO_spa.40.t
 	desc = NKO_spa.40.d
-
 	picture = GFX_mining
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2226,9 +2074,9 @@ country_event = {
 	id = NKO_spa.41
 	title = NKO_spa.41.t
 	desc = NKO_spa.41.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2250,9 +2098,9 @@ country_event = {
 	id = NKO_spa.42
 	title = NKO_spa.42.t
 	desc = NKO_spa.42.d
-
 	picture = GFX_computer
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2275,9 +2123,9 @@ country_event = {
 	id = NKO_spa.43
 	title = NKO_spa.43.t
 	desc = NKO_spa.43.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2300,9 +2148,9 @@ country_event = {
 	id = NKO_spa.44
 	title = NKO_spa.44.t
 	desc = NKO_spa.44.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2329,9 +2177,9 @@ country_event = {
 	id = NKO_spa.45
 	title = NKO_spa.45.t
 	desc = NKO_spa.45.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2347,9 +2195,9 @@ country_event = {
 	id = NKO_spa.46
 	title = NKO_spa.46.t
 	desc = NKO_spa.46.d
-
 	picture = GFX_generic_grain_silo
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2365,9 +2213,9 @@ country_event = {
 	id = NKO_spa.47
 	title = NKO_spa.47.t
 	desc = NKO_spa.47.d
-
 	picture = GFX_generic_grain_silo
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2391,9 +2239,9 @@ country_event = {
 	id = NKO_spa.48
 	title = NKO_spa.48.t
 	desc = NKO_spa.48.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2410,9 +2258,9 @@ country_event = {
 	id = NKO_spa.49
 	title = NKO_spa.49.t
 	desc = NKO_spa.49.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2429,9 +2277,9 @@ country_event = {
 	id = NKO_spa.50
 	title = NKO_spa.50.t
 	desc = NKO_spa.50.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2447,9 +2295,9 @@ country_event = {
 	id = NKO_spa.51
 	title = NKO_spa.51.t
 	desc = NKO_spa.51.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2465,6 +2313,7 @@ country_event = {
 			modifier = { add = 40 check_variable = { the_military_opinion < 60 } }
 		}
 	}
+
 	option = {
 		name = NKO_spa.51.cadres
 		trigger = { has_idea = communist_cadres }
@@ -2478,6 +2327,7 @@ country_event = {
 			modifier = { add = 40 check_variable = { communist_cadres_opinion < 60 } }
 		}
 	}
+
 	option = {
 		name = NKO_spa.51.donju
 		trigger = { has_idea = the_donju }
@@ -2491,6 +2341,7 @@ country_event = {
 			modifier = { add = 40 check_variable = { the_donju_opinion < 60 } }
 		}
 	}
+
 	option = {
 		name = NKO_spa.51.farmers
 		trigger = { has_idea = farmers }
@@ -2504,6 +2355,7 @@ country_event = {
 			modifier = { add = 40 check_variable = { farmers_opinion < 60 } }
 		}
 	}
+
 	option = {
 		name = NKO_spa.51.labour
 		trigger = { has_idea = labour_unions }
@@ -2517,6 +2369,7 @@ country_event = {
 			modifier = { add = 40 check_variable = { labour_unions_opinion < 60 } }
 		}
 	}
+
 	option = {
 		name = NKO_spa.51.none
 		trigger = {
@@ -2537,9 +2390,9 @@ country_event = {
 	id = NKO_spa.52
 	title = NKO_spa.52.t
 	desc = NKO_spa.52.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2561,9 +2414,9 @@ country_event = {
 	id = NKO_spa.53
 	title = NKO_spa.53.t
 	desc = NKO_spa.53.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { NKO_spa_mechanic_enabled = yes }
 
 	option = {
@@ -2581,7 +2434,6 @@ country_event = {
 	title = nko_naval_buildup.1.t
 	desc = nko_naval_buildup.1.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2596,8 +2448,8 @@ country_event = {
 # --- Submarine track router ---------------------------------
 country_event = {
 	id = nko_naval_buildup.10
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -2653,7 +2505,6 @@ country_event = {
 	title = nko_naval_buildup.11.t
 	desc = nko_naval_buildup.11.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2671,7 +2522,6 @@ country_event = {
 	title = nko_naval_buildup.12.t
 	desc = nko_naval_buildup.12.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2705,7 +2555,6 @@ country_event = {
 	title = nko_naval_buildup.13.t
 	desc = nko_naval_buildup.13.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2726,7 +2575,6 @@ country_event = {
 	title = nko_naval_buildup.14.t
 	desc = nko_naval_buildup.14.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2767,8 +2615,8 @@ country_event = {
 # --- Missile boat track router ------------------------------
 country_event = {
 	id = nko_naval_buildup.20
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -2824,7 +2672,6 @@ country_event = {
 	title = nko_naval_buildup.21.t
 	desc = nko_naval_buildup.21.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2842,7 +2689,6 @@ country_event = {
 	title = nko_naval_buildup.22.t
 	desc = nko_naval_buildup.22.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2861,7 +2707,6 @@ country_event = {
 	title = nko_naval_buildup.23.t
 	desc = nko_naval_buildup.23.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2897,7 +2742,6 @@ country_event = {
 	title = nko_naval_buildup.24.t
 	desc = nko_naval_buildup.24.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -2934,8 +2778,8 @@ country_event = {
 # --- Coastal defense track router ---------------------------
 country_event = {
 	id = nko_naval_buildup.30
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -2991,7 +2835,6 @@ country_event = {
 	title = nko_naval_buildup.31.t
 	desc = nko_naval_buildup.31.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3016,7 +2859,6 @@ country_event = {
 	title = nko_naval_buildup.32.t
 	desc = nko_naval_buildup.32.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3034,7 +2876,6 @@ country_event = {
 	title = nko_naval_buildup.33.t
 	desc = nko_naval_buildup.33.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3059,7 +2900,6 @@ country_event = {
 	title = nko_naval_buildup.34.t
 	desc = nko_naval_buildup.34.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3083,8 +2923,8 @@ country_event = {
 # --- Naval special operations track router ------------------
 country_event = {
 	id = nko_naval_buildup.40
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -3140,7 +2980,6 @@ country_event = {
 	title = nko_naval_buildup.41.t
 	desc = nko_naval_buildup.41.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3158,7 +2997,6 @@ country_event = {
 	title = nko_naval_buildup.42.t
 	desc = nko_naval_buildup.42.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3181,7 +3019,6 @@ country_event = {
 	title = nko_naval_buildup.43.t
 	desc = nko_naval_buildup.43.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3201,7 +3038,6 @@ country_event = {
 	title = nko_naval_buildup.44.t
 	desc = nko_naval_buildup.44.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3227,8 +3063,8 @@ country_event = {
 
 country_event = {
 	id = nko_naval_buildup.50
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -3267,7 +3103,6 @@ country_event = {
 	title = nko_naval_buildup.51.t
 	desc = nko_naval_buildup.51.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3279,12 +3114,14 @@ country_event = {
 		add_political_power = 100
 		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = nko_naval_buildup.51.b
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.51.b executed"
 		add_to_variable = { var = NKO_naval_points value = 1 }
 		ai_chance = { base = 20 }
 	}
+
 	option = {
 		name = nko_naval_buildup.51.c
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.51.c executed"
@@ -3299,7 +3136,6 @@ country_event = {
 	title = nko_naval_buildup.52.t
 	desc = nko_naval_buildup.52.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3312,12 +3148,14 @@ country_event = {
 			modifier = { factor = 0 has_stability < 0.40 }
 		}
 	}
+
 	option = {
 		name = nko_naval_buildup.52.b
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.52.b executed"
 		add_to_variable = { var = NKO_naval_points value = 1 }
 		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = nko_naval_buildup.52.c
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.52.c executed"
@@ -3335,7 +3173,6 @@ country_event = {
 	title = nko_naval_buildup.53.t
 	desc = nko_naval_buildup.53.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3373,12 +3210,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = nko_naval_buildup.53.b
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.53.b executed"
 		add_to_variable = { var = NKO_naval_points value = 1 }
 		ai_chance = { base = 20 }
 	}
+
 	option = {
 		name = nko_naval_buildup.53.c
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.53.c executed"
@@ -3396,7 +3235,6 @@ country_event = {
 	title = nko_naval_buildup.54.t
 	desc = nko_naval_buildup.54.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3410,6 +3248,7 @@ country_event = {
 			modifier = { factor = 0 has_political_power < 10 }
 		}
 	}
+
 	option = {
 		name = nko_naval_buildup.54.b
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.54.b executed"
@@ -3424,7 +3263,6 @@ country_event = {
 	title = nko_naval_buildup.56.t
 	desc = nko_naval_buildup.56.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -3434,12 +3272,14 @@ country_event = {
 		add_war_support = 0.02
 		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = nko_naval_buildup.56.b
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.56.b executed"
 		add_to_variable = { var = NKO_naval_points value = 1 }
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = nko_naval_buildup.56.c
 		log = "[GetDateText]: [This.GetName]: nko_naval_buildup.56.c executed"
@@ -3460,7 +3300,6 @@ country_event = {
 	title = nko_naval_buildup.60.t
 	desc = nko_naval_buildup.60.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3489,7 +3328,6 @@ country_event = {
 	title = nko_naval_buildup.61.t
 	desc = nko_naval_buildup.61.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3519,7 +3357,6 @@ country_event = {
 	title = nko_naval_buildup.62.t
 	desc = nko_naval_buildup.62.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3571,7 +3408,6 @@ country_event = {
 	title = nko_naval_buildup.63.t
 	desc = nko_naval_buildup.63.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3593,7 +3429,6 @@ country_event = {
 	title = nko_naval_buildup.70.t
 	desc = nko_naval_buildup.70.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3611,7 +3446,6 @@ country_event = {
 	title = nko_naval_buildup.71.t
 	desc = nko_naval_buildup.71.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3628,7 +3462,6 @@ country_event = {
 	title = nko_naval_buildup.72.t
 	desc = nko_naval_buildup.72.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3647,7 +3480,6 @@ country_event = {
 	title = nko_naval_buildup.73.t
 	desc = nko_naval_buildup.73.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 	fire_only_once = yes
 
@@ -3666,9 +3498,8 @@ news_event = {
 	title = nko_naval_buildup.99.t
 	desc = nko_naval_buildup.99.d
 	picture = GFX_submarine
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = nko_naval_buildup.99.a
@@ -3691,7 +3522,6 @@ country_event = {
 	title = NKO_export.1.t
 	desc = NKO_export.1.d
 	picture = GFX_north_korea_russia
-
 	is_triggered_only = yes
 
 	option = {
@@ -3721,7 +3551,6 @@ country_event = {
 	title = NKO_export.10.t
 	desc = NKO_export.10.d
 	picture = GFX_decision_nko_armor_button
-
 	is_triggered_only = yes
 
 	option = {
@@ -3739,7 +3568,7 @@ country_event = {
 		FROM = { country_event = { id = NKO_export.11 days = 1 } }
 		ai_chance = {
 			base = 30
-			modifier = { factor = 3  surrender_progress > 0.5 }
+			modifier = { factor = 3 surrender_progress > 0.5 }
 		}
 	}
 
@@ -3752,7 +3581,7 @@ country_event = {
 		FROM = { country_event = { id = NKO_export.11 days = 1 } }
 		ai_chance = {
 			base = 30
-			modifier = { factor = 3  surrender_progress > 0.5 }
+			modifier = { factor = 3 surrender_progress > 0.5 }
 		}
 	}
 
@@ -3770,7 +3599,7 @@ country_event = {
 		FROM = { country_event = { id = NKO_export.11 days = 1 } }
 		ai_chance = {
 			base = 60
-			modifier = { factor = 3  surrender_progress > 0.5 }
+			modifier = { factor = 3 surrender_progress > 0.5 }
 		}
 	}
 
@@ -3783,7 +3612,7 @@ country_event = {
 		FROM = { country_event = { id = NKO_export.11 days = 1 } }
 		ai_chance = {
 			base = 50
-			modifier = { factor = 3  surrender_progress > 0.5 }
+			modifier = { factor = 3 surrender_progress > 0.5 }
 		}
 	}
 
@@ -3793,7 +3622,7 @@ country_event = {
 		FROM = { country_event = { id = NKO_export.12 days = 1 } }
 		ai_chance = {
 			base = 20
-			modifier = { factor = 0  surrender_progress > 0.5 }
+			modifier = { factor = 0 surrender_progress > 0.5 }
 		}
 	}
 }
@@ -3806,7 +3635,6 @@ country_event = {
 	title = NKO_export.11.t
 	desc = NKO_export.11.d
 	picture = GFX_decision_nko_armor_button
-
 	is_triggered_only = yes
 
 	immediate = {
@@ -3815,9 +3643,7 @@ country_event = {
 		NKO_export_do_munitions = yes
 	}
 
-	option = {
-		name = NKO_export.11.a
-	}
+	option = { name = NKO_export.11.a }
 }
 
 # The client declined our arms package. FROM = the declining client.
@@ -3826,12 +3652,9 @@ country_event = {
 	title = NKO_export.12.t
 	desc = NKO_export.12.d
 	picture = GFX_decision_nko_armor_button
-
 	is_triggered_only = yes
 
-	option = {
-		name = NKO_export.12.a
-	}
+	option = { name = NKO_export.12.a }
 }
 
 # Capstone — ten nations supplied. Fired from the NKO_arms_export_capstone decision.
@@ -3840,12 +3663,9 @@ country_event = {
 	title = NKO_export.99.t
 	desc = NKO_export.99.d
 	picture = GFX_NKO_russian_treaty
-
 	is_triggered_only = yes
 
-	option = {
-		name = NKO_export.99.a
-	}
+	option = { name = NKO_export.99.a }
 }
 
 # North Korea offers to deploy intervention forces. Fired by the Storm Corps
@@ -3856,7 +3676,6 @@ country_event = {
 	title = NKO_export.22.t
 	desc = NKO_export.22.d
 	picture = GFX_decision_sov_nko_soldiers
-
 	is_triggered_only = yes
 
 	option = {
@@ -3869,7 +3688,7 @@ country_event = {
 		}
 		ai_chance = {
 			base = 80
-			modifier = { factor = 2  surrender_progress > 0.5 }
+			modifier = { factor = 2 surrender_progress > 0.5 }
 		}
 	}
 
@@ -3883,8 +3702,8 @@ country_event = {
 # accepting host. Registers the deal and starts the manpower watch.
 country_event = {
 	id = NKO_export.23
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		set_temp_variable = { NKO_arms_client_id = FROM.id }
@@ -3898,8 +3717,8 @@ country_event = {
 # manpower it appeals to its patron (event_target:NKO_storm_corps_patron).
 country_event = {
 	id = NKO_export.21
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -3926,7 +3745,6 @@ country_event = {
 	title = NKO_export.20.t
 	desc = NKO_export.20.d
 	picture = GFX_decision_sov_nko_soldiers
-
 	is_triggered_only = yes
 
 	option = {
@@ -3950,7 +3768,7 @@ country_event = {
 		FROM = { add_opinion_modifier = { target = NKO modifier = declined_faction_request } }
 		ai_chance = {
 			base = 30
-			modifier = { factor = 0  NOT = { has_manpower > 100000 } }
+			modifier = { factor = 0 NOT = { has_manpower > 100000 } }
 		}
 	}
 }
@@ -3960,7 +3778,6 @@ country_event = {
 	title = NKO_export.40.t
 	desc = NKO_export.40.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {

--- a/events/Burma.txt
+++ b/events/Burma.txt
@@ -9,14 +9,10 @@ news_event = {
 	title = Burma_News.1.t
 	desc = Burma_News.1.d
 	picture = GFX_trade_agreement
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = Burma_News.1.a
-	}
+	option = { name = Burma_News.1.a }
 }
 
 # Aung San Suu Kyi released
@@ -25,14 +21,10 @@ news_event = {
 	title = Burma_News.2.t
 	desc = Burma_News.2.d
 	picture = GFX_news_aung_san_suu_kyi_released
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = Burma_News.2.a
-	}
+	option = { name = Burma_News.2.a }
 }
 
 # The NLD comes to power in Myanmar
@@ -41,14 +33,10 @@ news_event = {
 	title = Burma_News.3.t
 	desc = Burma_News.3.d
 	picture = GFX_trade_agreement
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = Burma_News.3.a
-	}
+	option = { name = Burma_News.3.a }
 }
 
 # A quiet struggle for dominance
@@ -57,14 +45,10 @@ news_event = {
 	title = Burma_News.4.t
 	desc = Burma_News.4.d
 	picture = GFX_news_press_conference
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = Burma_News.4.a
-	}
+	option = { name = Burma_News.4.a }
 }
 
 #An End to Peace
@@ -73,14 +57,10 @@ news_event = {
 	title = Burma_News.5.t
 	desc = Burma_News.5.d
 	picture = GFX_news_press_conference
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = Burma_News.5.a
-	}
+	option = { name = Burma_News.5.a }
 }
 
 #The {root.getname}
@@ -89,14 +69,10 @@ news_event = {
 	title = Burma_News.6.t
 	desc = Burma_News.6.d
 	picture = GFX_news_press_conference
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = Burma_News.6.a
-	}
+	option = { name = Burma_News.6.a }
 }
 
 #Myanmar cracks down on protests (triggered by “Crackdown on Protests” focus)
@@ -105,25 +81,17 @@ news_event = {
 	title = Burma_News.7.t
 	desc = Burma_News.7.d
 	picture = GFX_trade_agreement
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = Burma_News.7.a
-		trigger = {
-			NOT = {
-				has_government = communism
-			}
-		}
+		trigger = { NOT = { has_government = communism } }
 	}
 
 	option = {
 		name = Burma_News.7.b
-		trigger = {
-			has_government = communism
-		}
+		trigger = { has_government = communism }
 	}
 }
 
@@ -148,9 +116,7 @@ news_event = {
 		has_completed_focus = BRM_crush_the_rebel_groups
 	}
 
-	option = {
-		name = Burma_News.8.a
-	}
+	option = { name = Burma_News.8.a }
 }
 
 #ASEAN Mutual Defence Treaty signed
@@ -160,20 +126,17 @@ news_event = {
 	desc = Burma_News.9.d
 	picture = GFX_trade_agreement
 	is_triggered_only = yes
-	fire_only_once = yes
 	major = yes
+	fire_only_once = yes
 
 	option = {
 		name = Burma_News.9.a
-		trigger = {
-			NOT = { original_tag = CHI }
-		}
+		trigger = { NOT = { original_tag = CHI } }
 	}
+
 	option = {
 		name = Burma_News.9.b
-		trigger = {
-			original_tag = CHI
-		}
+		trigger = { original_tag = CHI }
 	}
 }
 
@@ -183,11 +146,9 @@ country_event = {
 	id = Burma.1
 	title = Burma.1.t
 	desc = Burma.1.d
-
-	fire_only_once = yes
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Yes, we need to contain China
 	option = {
@@ -200,20 +161,17 @@ country_event = {
 				modifier = military_partnership
 			}
 		}
-
 		BRM = {
 			country_event = {
 				id = Burma.2
 				days = 2
 				random_hours = 2
 			}
-
 			add_opinion_modifier = {
 				target = USA
 				modifier = military_partnership
 			}
 		}
-
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -222,9 +180,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 10
-				CHI = {
-					has_added_tension_amount > 0
-				}
+				CHI = { has_added_tension_amount > 0 }
 			}
 		}
 	}
@@ -240,7 +196,6 @@ country_event = {
 				random_hours = 2
 			}
 		}
-
 		ai_chance = {
 			base = 75
 			modifier = {
@@ -257,15 +212,11 @@ country_event = {
 	title = Burma.2.t
 	desc = Burma.2.d
 	picture = GFX_USA_generic
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	# Rejoice!
-	option = {
-		name = Burma.2.a
-	}
+	option = { name = Burma.2.a }
 }
 
 # The US has chosen to abandon us…
@@ -277,9 +228,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = Burma.3.a
-	}
+	option = { name = Burma.3.a }
 }
 
 # Myanmar proposes an ASEAN Mutual Defence Agreement
@@ -287,15 +236,12 @@ country_event = {
 	id = Burma.4
 	title = Burma.4.t
 	desc = Burma.4.d
-
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
-	option = {	#Vote in favour
+	option = { #Vote in favour
 		name = Burma.4.a
 		log = "[GetDateText]: [This.GetName]: Burma.4.a executed"
-
 		if = {
 			limit = { NOT = { is_in_array = { global.ASEAN_defence_treaty_members = THIS } } }
 			add_to_array = { global.ASEAN_defence_treaty_members = ROOT }
@@ -308,16 +254,14 @@ country_event = {
 			id = Burma_News.9
 			days = 7
 		}
-
-
 		ai_chance = {
 			base = 40
 		}
 	}
+
 	# Vote against
 	option = {
 		name = Burma.4.b
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -336,17 +280,13 @@ country_event = {
 	id = Burma.5
 	title = Burma.5.t
 	desc = Burma.5.d
-
 	picture = GFX_election_rally
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
-	option = {	#Support the farmers
+	option = { #Support the farmers
 		name = Burma.5.a
 		log = "[GetDateText]: [This.GetName]: Burma.5.a executed"
-
 		random_list = {
 			50 = {
 				swap_ideas = {
@@ -354,14 +294,12 @@ country_event = {
 					add_idea = farmers
 				}
 			}
-
 			25 = {
 				swap_ideas = {
 					remove_idea = the_military
 					add_idea = labour_unions
 				}
 			}
-
 			25 = {
 				swap_ideas = {
 					remove_idea = the_military
@@ -369,16 +307,14 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = {
 			base = 100
 		}
 	}
 
-	option = {	#Support the trade unions
+	option = { #Support the trade unions
 		name = Burma.5.b
 		log = "[GetDateText]: [This.GetName]: Burma.5.b executed"
-
 		random_list = {
 			50 = {
 				swap_ideas = {
@@ -386,14 +322,12 @@ country_event = {
 					add_idea = labour_unions
 				}
 			}
-
 			25 = {
 				swap_ideas = {
 					remove_idea = the_military
 					add_idea = farmers
 				}
 			}
-
 			25 = {
 				swap_ideas = {
 					remove_idea = the_military
@@ -401,16 +335,14 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = {
 			base = 100
 		}
 	}
 
-	option = {	#Support small and medium business owners
+	option = { #Support small and medium business owners
 		name = Burma.5.c
 		log = "[GetDateText]: [This.GetName]: Burma.5.c executed"
-
 		random_list = {
 			50 = {
 				swap_ideas = {
@@ -418,14 +350,12 @@ country_event = {
 					add_idea = small_medium_business_owners
 				}
 			}
-
 			25 = {
 				swap_ideas = {
 					remove_idea = the_military
 					add_idea = farmers
 				}
 			}
-
 			25 = {
 				swap_ideas = {
 					remove_idea = the_military
@@ -433,7 +363,6 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = {
 			base = 100
 		}
@@ -444,43 +373,36 @@ country_event = {
 	id = Burma.6
 	title = Burma.6.t
 	desc = Burma.6.d
-
 	picture = GFX_rocket_explosion
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
-	option = {	#We can do nothing
+	option = { #We can do nothing
 		name = Burma.6.a
 		log = "[GetDateText]: [This.GetName]: Burma.6.a executed"
-
 		add_political_power = -100
-
 		ai_chance = {
 			base = 5
 		}
 	}
-	option = {	#Send them arms
+
+	option = { #Send them arms
 		name = Burma.6.b
 		log = "[GetDateText]: [This.GetName]: Burma.6.b executed"
-
 		send_equipment = {
 			equipment = infantry_weapons_type
 			amount = 10000
 			target = WAA
 		}
-
 		ai_chance = {
 			base = 20
 		}
 	}
-	option = {	#Send them troops
+
+	option = { #Send them troops
 		name = Burma.6.c
 		log = "[GetDateText]: [This.GetName]: Burma.6.c executed"
-
 		add_threat = 10
-
 		ai_chance = {
 			base = 10
 		}
@@ -491,16 +413,13 @@ country_event = {
 	id = Burma.7
 	title = Burma.7.t
 	desc = Burma.7.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
-	option = {	#Yes, we need to keep out the West
+	option = { #Yes, we need to keep out the West
 		name = Burma.7.a
 		log = "[GetDateText]: [This.GetName]: Burma.7.a executed"
-
 		BRM = {
 			country_event = {
 				id = Burma.8
@@ -508,14 +427,11 @@ country_event = {
 				random_hours = 3
 			}
 		}
-
 		add_opinion_modifier = { target = CHI modifier = military_partnership }
 		reverse_add_opinion_modifier = { target = CHI modifier = military_partnership }
-
 		CHI = {
 			give_guarantee = BRM
 		}
-
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -530,10 +446,10 @@ country_event = {
 			}
 		}
 	}
-	option = {	#No, Myanmar is not a worthy ally
+
+	option = { #No, Myanmar is not a worthy ally
 		name = Burma.7.b
 		log = "[GetDateText]: [This.GetName]: Burma.7.b executed"
-
 		BRM = {
 			country_event = {
 				id = Burma.9
@@ -541,7 +457,6 @@ country_event = {
 				random_hours = 3
 			}
 		}
-
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -557,14 +472,11 @@ country_event = {
 	title = Burma.8.t
 	desc = Burma.8.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
-	option = {	#China has accepted our request!
+	option = { #China has accepted our request!
 		name = Burma.8.a
-
 		ai_chance = {
 			base = 5
 		}
@@ -576,14 +488,11 @@ country_event = {
 	title = Burma.9.t
 	desc = Burma.9.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
-	option = {	#China has chosen to abandon us…
+	option = { #China has chosen to abandon us…
 		name = Burma.9.a
-
 		ai_chance = {
 			base = 5
 		}
@@ -595,7 +504,6 @@ country_event = {
 	id = Burma.10
 	title = Burma.10.t
 	desc = Burma.10.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -622,9 +530,7 @@ country_event = {
 	id = Burma.11
 	title = Burma.11.t
 	desc = Burma.11.d
-
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -674,7 +580,6 @@ country_event = {
 	title = Burma.12.t
 	desc = Burma.12.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -687,7 +592,6 @@ country_event = {
 	title = Burma.13.t
 	desc = Burma.13.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -704,9 +608,7 @@ country_event = {
 	id = Burma.14
 	title = Burma.14.t
 	desc = Burma.14.d
-
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -753,7 +655,6 @@ country_event = {
 	title = Burma.15.t
 	desc = Burma.15.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -775,7 +676,6 @@ country_event = {
 	title = Burma.16.t
 	desc = Burma.16.d
 	picture = GFX_CHI_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -787,11 +687,8 @@ country_event = {
 #Clashes with the Kachin
 country_event = {
 	id = Insurgency.1
-
 	title = Insurgency.1.t
-
 	desc = Insurgency.1.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -804,11 +701,8 @@ country_event = {
 #Clashes with the Karen
 country_event = {
 	id = Insurgency.2
-
 	title = Insurgency.2.t
-
 	desc = Insurgency.2.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -836,11 +730,8 @@ country_event = {
 # Clashes with the Tatmadaw
 country_event = {
 	id = Insurgency.4
-
 	title = Insurgency.4.t
-
 	desc = Insurgency.4.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -885,11 +776,8 @@ country_event = {
 #The rebels are victorious!
 country_event = {
 	id = Insurgency.6
-
 	title = Insurgency.6.t
-
 	desc = Insurgency.6.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -919,9 +807,7 @@ country_event = {
 	is_triggered_only = yes
 
 	# A Stalemate, for now!
-	option = {
-		name = Insurgency.7.a
-	}
+	option = { name = Insurgency.7.a }
 }
 
 #Hidden ceasefire influence increase events
@@ -929,6 +815,7 @@ country_event = {
 	id = Insurgency.8
 	is_triggered_only = yes
 	hidden = yes
+
 	trigger = {
 		has_idea = Ethnic_Insurgencies
 		has_country_flag = ceasefire
@@ -949,13 +836,9 @@ country_event = {
 #The government has offered us a ceasefire
 country_event = {
 	id = Insurgency.11
-
 	title = Insurgency.11.t
-
 	desc = Insurgency.11.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -1021,13 +904,9 @@ country_event = {
 #The rebels are pushing for outrageously large concessions!
 country_event = {
 	id = Insurgency.12
-
 	title = Insurgency.12.t
-
 	desc = Insurgency.12.d
-
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -1065,13 +944,9 @@ country_event = {
 #The rebels are making reasonable demands
 country_event = {
 	id = Insurgency.13
-
 	title = Insurgency.13.t
-
 	desc = Insurgency.13.d
-
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -1109,13 +984,9 @@ country_event = {
 #The rebels have rejected our offer of talks!
 country_event = {
 	id = Insurgency.14
-
 	title = Insurgency.14.t
-
 	desc = Insurgency.14.d
-
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = {
@@ -1127,13 +998,9 @@ country_event = {
 #The government has accepted our demands
 country_event = {
 	id = Insurgency.15
-
 	title = Insurgency.15.t
-
 	desc = Insurgency.15.d
-
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -1153,24 +1020,19 @@ country_event = {
 #The government has rejected our demands!
 country_event = {
 	id = Insurgency.16
-
 	title = Insurgency.16.t
-
 	desc = Insurgency.16.d
-
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
-	option = {
-		name = Insurgency.16.a
-	}
+	option = { name = Insurgency.16.a }
 }
 
 country_event = {
 	id = Insurgency.17
 	is_triggered_only = yes
 	hidden = yes
+
 	immediate = {
 		log = "[GetDateText]: [This.GetName]: Insurgency.17.a executed"
 		FROM = { clr_country_flag = ceasefire_offer }
@@ -1181,11 +1043,8 @@ country_event = {
 country_event = {
 	id = Insurgency.18
 	title = Insurgency.18.t
-
 	desc = Insurgency.18.d
-
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -1206,18 +1065,14 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				original_tag = WAA
-			}
+			limit = { original_tag = WAA }
 			set_variable = {
 				var = NCA_support
 				value = -1
 			}
 		}
 		else_if = {
-			limit = {
-				original_tag = KAC
-			}
+			limit = { original_tag = KAC }
 			set_variable = {
 				var = NCA_support
 				value = -3
@@ -1231,12 +1086,11 @@ country_event = {
 					target = BRM
 					value < -70
 				}
-				NOT = {
-					has_country_flag = ceasefire
-				}
+				NOT = { has_country_flag = ceasefire }
 			}
 		}
 	}
+
 	option = {
 		name = Insurgency.18.b
 		log = "[GetDateText]: [This.GetName]: Insurgency.18.a executed"
@@ -1252,22 +1106,16 @@ country_event = {
 #The First Round of Negotiations - union/federation
 country_event = {
 	id = Insurgency.19
-
 	title = Insurgency.19.t
-
 	desc = Insurgency.19.d
-
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
 		name = Insurgency.19.a
 		log = "[GetDateText]: [This.GetName]: Insurgency.19.a executed"
 		every_other_country = {
-			limit = {
-				has_country_flag = NCA_participant
-			}
+			limit = { has_country_flag = NCA_participant }
 			subtract_from_variable = {
 				var = NCA_support
 				value = 1
@@ -1278,13 +1126,12 @@ country_event = {
 			days = 7
 		}
 	}
+
 	option = {
 		name = Insurgency.19.b
 		log = "[GetDateText]: [This.GetName]: Insurgency.19.b executed"
 		every_other_country = {
-			limit = {
-				has_country_flag = NCA_participant
-			}
+			limit = { has_country_flag = NCA_participant }
 			add_to_variable = {
 				var = NCA_support
 				value = 1
@@ -1295,6 +1142,7 @@ country_event = {
 			days = 7
 		}
 	}
+
 	option = {
 		name = Insurgency.19.c #compromise
 		log = "[GetDateText]: [This.GetName]: Insurgency.19.c executed"
@@ -1312,11 +1160,8 @@ country_event = {
 country_event = {
 	id = Insurgency.20
 	title = Insurgency.20.t
-
 	desc = Insurgency.20.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -1336,6 +1181,7 @@ country_event = {
 			days = 7
 		}
 	}
+
 	option = {
 		name = Insurgency.20.b #improve representation
 		log = "[GetDateText]: [This.GetName]: Insurgency.20.b executed"
@@ -1353,6 +1199,7 @@ country_event = {
 			days = 7
 		}
 	}
+
 	option = {
 		name = Insurgency.20.c #delay
 		log = "[GetDateText]: [This.GetName]: Insurgency.20.c executed"
@@ -1369,13 +1216,9 @@ country_event = {
 #The Final Round of Negotiations - DDR or SSR
 country_event = {
 	id = Insurgency.21
-
 	title = Insurgency.21.t
-
 	desc = Insurgency.21.d
-
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -1417,6 +1260,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Insurgency.21.b
 		log = "[GetDateText]: [This.GetName]: Insurgency.21.b executed"
@@ -1456,6 +1300,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Insurgency.21.c
 		log = "[GetDateText]: [This.GetName]: Insurgency.21.c executed"
@@ -1499,13 +1344,9 @@ country_event = {
 #acceptable draft
 country_event = {
 	id = Insurgency.22
-
 	title = Insurgency.22.t
-
 	desc = Insurgency.22.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -1514,11 +1355,7 @@ country_event = {
 		clr_country_flag = NCA_participant
 		clear_variable = NCA_support
 		if = {
-			limit = {
-				NOT = {
-					has_idea = Nationwide_Ceasefire_Agreement
-				}
-			}
+			limit = { NOT = { has_idea = Nationwide_Ceasefire_Agreement } }
 			add_ideas = Nationwide_Ceasefire_Agreement
 		}
 		add_opinion_modifier = {
@@ -1541,13 +1378,9 @@ country_event = {
 #unacceptable draft
 country_event = {
 	id = Insurgency.23
-
 	title = Insurgency.23.t
-
 	desc = Insurgency.23.d
-
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = {
@@ -1567,24 +1400,16 @@ country_event = {
 #country signed NCA
 country_event = {
 	id = Insurgency.24
-
 	title = Insurgency.24.t
-
 	desc = Insurgency.24.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
 		name = Insurgency.24.a
 		log = "[GetDateText]: [This.GetName]: Insurgency.24.a executed"
 		if = {
-			limit = {
-				NOT = {
-					has_idea = Nationwide_Ceasefire_Agreement
-				}
-			}
+			limit = { NOT = { has_idea = Nationwide_Ceasefire_Agreement } }
 			add_ideas = Nationwide_Ceasefire_Agreement
 		}
 	}
@@ -1593,30 +1418,20 @@ country_event = {
 #country has not signed NCA
 country_event = {
 	id = Insurgency.25
-
 	title = Insurgency.25.t
-
 	desc = Insurgency.25.d
-
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
-	option = {
-		name = Insurgency.25.a
-	}
+	option = { name = Insurgency.25.a }
 }
 
 #Shan rebels have attacked our financial interests
 country_event = {
 	id = Insurgency.26
-
 	title = Insurgency.26.t
-
 	desc = Insurgency.26.d
-
 	picture = GFX_rocket_explosion
-
 	is_triggered_only = yes
 
 	option = {
@@ -1673,13 +1488,9 @@ country_event = {
 #The United Wa State Army has retaliated!
 country_event = {
 	id = Insurgency.27
-
 	title = Insurgency.27.t
-
 	desc = Insurgency.27.d
-
 	picture = GFX_rocket_explosion
-
 	is_triggered_only = yes
 
 	option = {
@@ -1693,11 +1504,8 @@ country_event = {
 #Clashes with the North Shan
 country_event = {
 	id = Insurgency.28
-
 	title = Insurgency.28.t
-
 	desc = Insurgency.28.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 

--- a/events/Romania.txt
+++ b/events/Romania.txt
@@ -6,39 +6,27 @@ country_event = { #Romanian Elections event
 	id = romania_elections.1
 	title = romania_elections.1.t
 	desc = {
-		trigger = {
-			check_variable = { largest_party = 3 }
-		}
+		trigger = { check_variable = { largest_party = 3 } }
 		text = romania_elections.1.d1
 	}
 	desc = {
-		trigger = {
-			check_variable = { largest_party = 20 }
-		}
+		trigger = { check_variable = { largest_party = 20 } }
 		text = romania_elections.1.d2
 	}
 	desc = {
-		trigger = {
-			check_variable = { largest_party = 1 }
-		}
+		trigger = { check_variable = { largest_party = 1 } }
 		text = romania_elections.1.d3
 	}
 	desc = {
-		trigger = {
-			check_variable = { largest_party = 2 }
-		}
+		trigger = { check_variable = { largest_party = 2 } }
 		text = romania_elections.1.d4
 	}
 	desc = {
-		trigger = {
-			check_variable = { largest_party = 18 }
-		}
+		trigger = { check_variable = { largest_party = 18 } }
 		text = romania_elections.1.d5
 	}
 	desc = {
-		trigger = {
-			check_variable = { largest_party = 14 }
-		}
+		trigger = { check_variable = { largest_party = 14 } }
 		text = romania_elections.1.d6
 	}
 	desc = {
@@ -966,17 +954,11 @@ country_event = { #death of king michael
 	title = romania_politics.20.t
 	desc = {
 		text = romania_politics.20.d.a
-		trigger = {
-			western_autocrats_are_in_power = yes
-		}
+		trigger = { western_autocrats_are_in_power = yes }
 	}
 	desc = {
 		text = romania_politics.20.d.b
-		trigger = {
-			NOT = {
-				has_completed_focus = ROM_michael_returns
-			}
-		}
+		trigger = { NOT = { has_completed_focus = ROM_michael_returns } }
 	}
 	picture = GFX_death_of_king_michael
 	is_triggered_only = yes
@@ -984,9 +966,7 @@ country_event = { #death of king michael
 	option = {
 		name = romania_politics.20.a
 		log = "[GetDateText]: [This.GetName]: romania_politics.20.a executed"
-		trigger = {
-			has_country_flag = nicholas_successor
-		}
+		trigger = { has_country_flag = nicholas_successor }
 		set_temp_variable = { party_index = 0 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -1008,9 +988,7 @@ country_event = { #death of king michael
 	option = {
 		name = romania_politics.20.b
 		log = "[GetDateText]: [This.GetName]: romania_politics.20.b executed"
-		trigger = {
-			has_country_flag = margareta_successor
-		}
+		trigger = { has_country_flag = margareta_successor }
 		set_temp_variable = { party_index = 0 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
@@ -1034,9 +1012,7 @@ country_event = { #death of king michael
 		log = "[GetDateText]: [This.GetName]: romania_politics.20.c executed"
 		trigger = {
 			western_autocrats_are_in_power = yes
-			NOT = {
-				has_completed_focus = ROM_resolve_succession
-			}
+			NOT = { has_completed_focus = ROM_resolve_succession }
 		}
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.25 }
@@ -1053,11 +1029,7 @@ country_event = { #death of king michael
 
 	option = {
 		name = romania_politics.20.d
-		trigger = {
-			NOT = {
-				has_completed_focus = ROM_michael_returns
-			}
-		}
+		trigger = { NOT = { has_completed_focus = ROM_michael_returns } }
 	}
 }
 country_event = { ##protesters demand vadims resignation
@@ -1184,19 +1156,11 @@ country_event = { #military removes vadim,romania disintegrates
 				}
 				change_tag_from = ROM
 			}
-			284 = {
-				add_core_of = WLC
-			}
-			150 = {
-				add_core_of = WLC
-			}
-			152 = {
-				add_core_of = WLC
-			}
+			284 = { add_core_of = WLC }
+			150 = { add_core_of = WLC }
+			152 = { add_core_of = WLC }
 			every_state = {
-				limit = {
-					is_core_of = ROM
-				}
+				limit = { is_core_of = ROM }
 				remove_core_of = ROM
 			}
 		}
@@ -1210,17 +1174,11 @@ country_event = {
 	title = romania_politics.24.t
 	desc = {
 		text = romania_politics.24.d.a
-		trigger = {
-			nationalist_right_wing_populists_are_in_power = yes
-		}
+		trigger = { nationalist_right_wing_populists_are_in_power = yes }
 	}
 	desc = {
 		text = romania_politics.24.d.b
-		trigger = {
-			NOT = {
-				nationalist_right_wing_populists_are_in_power = yes
-			}
-		}
+		trigger = { NOT = { nationalist_right_wing_populists_are_in_power = yes } }
 	}
 	picture = GFX_vadim_death
 	is_triggered_only = yes
@@ -1274,11 +1232,7 @@ country_event = {
 	# Random Cuck
 	option = {
 		name = romania_politics.24.c
-		trigger = {
-			NOT = {
-				nationalist_right_wing_populists_are_in_power = yes
-			}
-		}
+		trigger = { NOT = { nationalist_right_wing_populists_are_in_power = yes } }
 	}
 }
 country_event = { #The Hand Against Corruption
@@ -1402,15 +1356,11 @@ country_event = { #Queen of Spades
 	title = romania_politics.55.t
 	desc = {
 		text = romania_politics.55.d.a
-		trigger = {
-			has_country_flag = duda_divorcelol
-		}
+		trigger = { has_country_flag = duda_divorcelol }
 	}
 	desc = {
 		text = romania_politics.55.d.b
-		trigger = {
-			has_country_flag = duda_remains
-		}
+		trigger = { has_country_flag = duda_remains }
 	}
 	picture = GFX_political_deal
 	is_triggered_only = yes

--- a/events/Spain.txt
+++ b/events/Spain.txt
@@ -13,18 +13,16 @@ country_event = {
 	id = spain.1
 	title = spain.1.t
 	desc = spain.1.d
-	trigger = {
-		original_tag = SPR
-	}
 	picture = GFX_canary_islands_flag
 	is_triggered_only = yes
 	fire_only_once = yes
+
+	trigger = { original_tag = SPR }
 
 	# Stifle the Movement
 	option = {
 		name = spain.1.a
 		log = "[GetDateText]: [This.GetName]: spain.1.a executed"
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = -15 }
 		SPR_modify_cultural_opinion = yes
@@ -36,10 +34,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		hidden_effect = {
-			set_country_flag = SPR_stifled_canarios_movement
-		}
+		hidden_effect = { set_country_flag = SPR_stifled_canarios_movement }
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -53,7 +48,6 @@ country_event = {
 	option = {
 		name = spain.1.b
 		log = "[GetDateText]: [This.GetName]: spain.1.b executed"
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
@@ -61,12 +55,10 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.02 }
 			change_relative_party_popularity = yes
 		}
-
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -81,17 +73,14 @@ country_event = {
 		name = spain.1.c
 		log = "[GetDateText]: [This.GetName]: spain.1.c executed"
 		custom_effect_tooltip = SPR_spain_1_c_tt
-
 		if = { limit = { NOT = { check_variable = { ruling_party = 20 } } }
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			change_relative_party_popularity = yes
 		}
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
 		add_stability = 0.03
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -109,30 +98,24 @@ country_event = {
 	desc = spain.2.d
 	picture = GFX_bilbao
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Keep the Status Quo
 	option = {
 		name = spain.2.a
 		log = "[GetDateText]: [This.GetName]: spain.2.a executed"
-
 		add_political_power = 50
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 2 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Limit Their Freedoms
 	option = {
 		name = spain.2.b
 		log = "[GetDateText]: [This.GetName]: spain.2.b executed"
-
 		add_political_power = -25
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -5 }
@@ -144,18 +127,14 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_bilbao_convention_limit_freedoms
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
 
 	# Crush all Resistance
 	option = {
 		name = spain.2.c
 		log = "[GetDateText]: [This.GetName]: spain.2.b executed"
-
 		add_political_power = -50
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -10 }
@@ -167,7 +146,6 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_bilbao_convention_crush_basque
 		ai_chance = {
 			base = 0.25
@@ -190,30 +168,24 @@ country_event = {
 	desc = spain.3.d
 	picture = GFX_lugo
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Keep the Status Quo
 	option = {
 		name = spain.3.a
 		log = "[GetDateText]: [This.GetName]: spain.3.a executed"
-
 		add_political_power = 50
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = 2 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Limit Their Freedoms
 	option = {
 		name = spain.3.b
 		log = "[GetDateText]: [This.GetName]: spain.3.b executed"
-
 		add_political_power = -25
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = -5 }
@@ -225,18 +197,14 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_lugo_convention_limit_freedoms
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
 
 	# Crush all Resistance
 	option = {
 		name = spain.3.c
 		log = "[GetDateText]: [This.GetName]: spain.3.b executed"
-
 		add_political_power = -50
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = -10 }
@@ -248,11 +216,8 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_lugo_convention_crush_galegos
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
 }
 
@@ -263,30 +228,24 @@ country_event = {
 	desc = spain.4.d
 	picture = GFX_barcelona_photo
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Keep the Status Quo
 	option = {
 		name = spain.4.a
 		log = "[GetDateText]: [This.GetName]: spain.4.a executed"
-
 		add_political_power = 50
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = 2 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Limit Their Freedoms
 	option = {
 		name = spain.4.b
 		log = "[GetDateText]: [This.GetName]: spain.4.b executed"
-
 		add_political_power = -25
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
@@ -298,19 +257,14 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_barcelona_convention_limit_freedoms
-		ai_chance = {
-			base = 0.25
-
-		}
+		ai_chance = { base = 0.25 }
 	}
 
 	# Crush all Resistance
 	option = {
 		name = spain.4.c
 		log = "[GetDateText]: [This.GetName]: spain.4.b executed"
-
 		add_political_power = -50
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -10 }
@@ -322,11 +276,8 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_barcelona_crush_the_catalans
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
 }
 
@@ -337,30 +288,24 @@ country_event = {
 	desc = spain.5.d
 	picture = GFX_sevilla
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Keep the Status Quo
 	option = {
 		name = spain.5.a
 		log = "[GetDateText]: [This.GetName]: spain.5.a executed"
-
 		add_political_power = 50
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = 2 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Limit Their Freedoms
 	option = {
 		name = spain.5.b
 		log = "[GetDateText]: [This.GetName]: spain.5.b executed"
-
 		add_political_power = -25
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = -5 }
@@ -372,18 +317,14 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_seville_convention_limit_freedoms
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
 
 	# Crush all Resistance
 	option = {
 		name = spain.5.c
 		log = "[GetDateText]: [This.GetName]: spain.5.b executed"
-
 		add_political_power = -50
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -10 }
@@ -395,11 +336,8 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = SPR_seville_crush_the_andalusia
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
 }
 
@@ -410,9 +348,8 @@ country_event = {
 	desc = spain.6.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Revoke Citizenship
 	option = {
@@ -476,9 +413,8 @@ country_event = {
 	desc = spain.7.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Revoke Citizenship
 	option = {
@@ -501,6 +437,7 @@ country_event = {
 		unlock_decision_tooltip = SPR_revoke_andalusian_citizenship_decision
 		set_country_flag = SPR_revoke_citizenship_southerner_flag
 	}
+
 	# Softer Approach
 	option = {
 		name = spain.7.b
@@ -520,6 +457,7 @@ country_event = {
 		add_stability = 0.02
 		add_political_power = 75
 	}
+
 	# Reconciliation
 	option = {
 		name = spain.7.c
@@ -544,21 +482,16 @@ country_event = {
 	desc = spain.8.d
 	picture = GFX_basque_flag
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.8.a
 		log = "[GetDateText]: [This.GetName]: spain.8.a executed"
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -571,16 +504,11 @@ country_event = {
 			}
 		}
 		modify_treasury_effect = yes
-
 		add_political_power = -25
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -591,29 +519,23 @@ country_event = {
 	desc = spain.9.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.9.a
 		log = "[GetDateText]: [This.GetName]: spain.9.a executed"
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.9.b
 		log = "[GetDateText]: [This.GetName]: spain.9.b executed"
-
 		random_list = {
 			25 = {
 				# riot
@@ -643,11 +565,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
@@ -655,7 +575,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -663,7 +582,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -671,7 +589,6 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -679,12 +596,9 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -693,7 +607,6 @@ country_event = {
 	option = {
 		name = spain.9.c
 		log = "[GetDateText]: [This.GetName]: spain.9.c executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -723,11 +636,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.15 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -735,7 +646,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -743,7 +653,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.45 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -751,16 +660,13 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.6 }
 			modify_treasury_effect = yes
-
 		}
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.75 }
 			modify_treasury_effect = yes
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -774,18 +680,15 @@ country_event = {
 	desc = spain.10.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.10.a
 		log = "[GetDateText]: [This.GetName]: spain.10.a executed"
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		88 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -809,16 +712,12 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.10.b
 		log = "[GetDateText]: [This.GetName]: spain.10.b executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -848,15 +747,12 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -5 }
 			SPR_modify_cultural_opinion = yes
-
 			88 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -884,11 +780,9 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
-
 			88 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -916,11 +810,9 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
-
 			88 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -948,11 +840,9 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
-
 			88 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -980,12 +870,10 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 1 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -999,9 +887,8 @@ country_event = {
 	desc = spain.11.d
 	picture = GFX_guardia_civil
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.11.a
@@ -1009,9 +896,7 @@ country_event = {
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		add_manpower = -20
-
 		88 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1046,21 +931,16 @@ country_event = {
 	desc = spain.12.d
 	picture = GFX_politics_negotiations
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.12.a
 		log = "[GetDateText]: [This.GetName]: spain.12.a executed"
-
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1074,14 +954,10 @@ country_event = {
 		}
 		modify_treasury_effect = yes
 		add_political_power = -25
-
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1092,9 +968,8 @@ country_event = {
 	desc = spain.13.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.13.a
@@ -1103,10 +978,8 @@ country_event = {
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1115,7 +988,6 @@ country_event = {
 	option = {
 		name = spain.13.b
 		log = "[GetDateText]: [This.GetName]: spain.13.b executed"
-
 		random_list = {
 			25 = {
 				# riot
@@ -1145,11 +1017,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
@@ -1157,7 +1027,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -1165,7 +1034,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -1173,7 +1041,6 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -1181,12 +1048,9 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1195,7 +1059,6 @@ country_event = {
 	option = {
 		name = spain.13.c
 		log = "[GetDateText]: [This.GetName]: spain.13.c executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -1228,7 +1091,6 @@ country_event = {
 			if = { limit = { has_idea = police_01 }
 				set_temp_variable = { treasury_change = -0.15 }
 				modify_treasury_effect = yes
-
 				set_temp_variable = { culture_index = 2 }
 				set_temp_variable = { cultural_opinion = -3 }
 				SPR_modify_cultural_opinion = yes
@@ -1236,7 +1098,6 @@ country_event = {
 			if = { limit = { has_idea = police_02 }
 				set_temp_variable = { treasury_change = -0.3 }
 				modify_treasury_effect = yes
-
 				set_temp_variable = { culture_index = 2 }
 				set_temp_variable = { cultural_opinion = -2 }
 				SPR_modify_cultural_opinion = yes
@@ -1244,7 +1105,6 @@ country_event = {
 			if = { limit = { has_idea = police_03 }
 				set_temp_variable = { treasury_change = -0.45 }
 				modify_treasury_effect = yes
-
 				set_temp_variable = { culture_index = 2 }
 				set_temp_variable = { cultural_opinion = -1 }
 				SPR_modify_cultural_opinion = yes
@@ -1252,16 +1112,13 @@ country_event = {
 			if = { limit = { has_idea = police_04 }
 				set_temp_variable = { treasury_change = -0.6 }
 				modify_treasury_effect = yes
-
 			}
 			if = { limit = { has_idea = police_05 }
 				set_temp_variable = { treasury_change = -0.75 }
 				modify_treasury_effect = yes
 			}
-
 			set_temp_variable = { party_popularity_increase = -0.035 }
 			change_relative_party_popularity = yes
-
 			ai_chance = {
 				base = 1
 			}
@@ -1275,18 +1132,15 @@ country_event = {
 	desc = spain.14.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.14.a
 		log = "[GetDateText]: [This.GetName]: spain.14.a executed"
-
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		944 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1310,16 +1164,12 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.14.b
 		log = "[GetDateText]: [This.GetName]: spain.14.b executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -1349,15 +1199,12 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -5 }
 			SPR_modify_cultural_opinion = yes
-
 			944 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1385,11 +1232,9 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
-
 			944 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1417,11 +1262,9 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
-
 			944 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1449,11 +1292,9 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
-
 			944 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1481,7 +1322,6 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 2 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -1499,20 +1339,16 @@ country_event = {
 	desc = spain.15.d
 	picture = GFX_guardia_civil
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.15.a
 		log = "[GetDateText]: [This.GetName]: spain.15.a executed"
-
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		add_manpower = -20
-
 		944 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1547,27 +1383,21 @@ country_event = {
 	desc = spain.16.d
 	picture = GFX_catalonian_flag
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.16.a
 		log = "[GetDateText]: [This.GetName]: spain.16.a executed"
-
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.16.b
 		log = "[GetDateText]: [This.GetName]: spain.16.b executed"
-
 		set_temp_variable = {
 			treasury_change = {
 				value = gdp_total
@@ -1576,14 +1406,10 @@ country_event = {
 		}
 		modify_treasury_effect = yes
 		add_political_power = -25
-
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1594,9 +1420,8 @@ country_event = {
 	desc = spain.17.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.17.a
@@ -1605,10 +1430,8 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1646,11 +1469,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
@@ -1658,7 +1479,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -1666,7 +1486,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -1674,7 +1493,6 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -1682,12 +1500,9 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1725,11 +1540,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.15 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -1737,7 +1550,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -1745,7 +1557,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.45 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -1753,16 +1564,13 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.6 }
 			modify_treasury_effect = yes
-
 		}
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.75 }
 			modify_treasury_effect = yes
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1776,18 +1584,15 @@ country_event = {
 	desc = spain.18.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.18.a
 		log = "[GetDateText]: [This.GetName]: spain.18.a executed"
-
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		86 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -1811,10 +1616,7 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1849,15 +1651,12 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -5 }
 			SPR_modify_cultural_opinion = yes
-
 			86 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1885,11 +1684,9 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
-
 			86 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1917,11 +1714,9 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
-
 			86 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1949,11 +1744,9 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
-
 			86 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1981,12 +1774,10 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 0 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2000,9 +1791,8 @@ country_event = {
 	desc = spain.19.d
 	picture = GFX_guardia_civil
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.19.a
@@ -2010,9 +1800,7 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		add_manpower = -20
-
 		86 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -2047,27 +1835,21 @@ country_event = {
 	desc = spain.20.d
 	picture = GFX_andalusian_flag
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.20.a
 		log = "[GetDateText]: [This.GetName]: spain.20.a executed"
-
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.20.b
 		log = "[GetDateText]: [This.GetName]: spain.20.b executed"
-
 		set_temp_variable = {
 			treasury_change = {
 				value = gdp_total
@@ -2076,14 +1858,10 @@ country_event = {
 		}
 		modify_treasury_effect = yes
 		add_political_power = -25
-
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2094,9 +1872,8 @@ country_event = {
 	desc = spain.21.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.21.a
@@ -2105,10 +1882,8 @@ country_event = {
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2117,7 +1892,6 @@ country_event = {
 	option = {
 		name = spain.21.b
 		log = "[GetDateText]: [This.GetName]: spain.21.b executed"
-
 		random_list = {
 			25 = {
 				# riot
@@ -2147,11 +1921,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
@@ -2159,7 +1931,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -2167,7 +1938,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -2175,7 +1945,6 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -2183,12 +1952,9 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2197,7 +1963,6 @@ country_event = {
 	option = {
 		name = spain.21.c
 		log = "[GetDateText]: [This.GetName]: spain.21.c executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -2227,11 +1992,9 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.15 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
@@ -2239,7 +2002,6 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
@@ -2247,7 +2009,6 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.45 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
@@ -2255,16 +2016,13 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.6 }
 			modify_treasury_effect = yes
-
 		}
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.75 }
 			modify_treasury_effect = yes
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2278,18 +2036,15 @@ country_event = {
 	desc = spain.22.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.22.a
 		log = "[GetDateText]: [This.GetName]: spain.22.a executed"
-
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		93 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -2313,16 +2068,12 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.22.b
 		log = "[GetDateText]: [This.GetName]: spain.22.b executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -2352,15 +2103,12 @@ country_event = {
 				}
 			}
 		}
-
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -5 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2388,11 +2136,9 @@ country_event = {
 		if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2420,11 +2166,9 @@ country_event = {
 		if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2452,11 +2196,9 @@ country_event = {
 		if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2484,12 +2226,10 @@ country_event = {
 		if = { limit = { has_idea = police_05 }
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { culture_index = 3 }
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2503,20 +2243,16 @@ country_event = {
 	desc = spain.23.d
 	picture = GFX_guardia_civil
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.23.a
 		log = "[GetDateText]: [This.GetName]: spain.23.a executed"
-
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		add_manpower = -20
-
 		93 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -2551,27 +2287,21 @@ country_event = {
 	desc = spain.24.d
 	picture = GFX_canary_islands_flag
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.24.a
 		log = "[GetDateText]: [This.GetName]: spain.24.a executed"
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.24.b
 		log = "[GetDateText]: [This.GetName]: spain.24.b executed"
-
 		set_temp_variable = {
 			treasury_change = {
 				value = gdp_total
@@ -2580,14 +2310,10 @@ country_event = {
 		}
 		modify_treasury_effect = yes
 		add_political_power = -25
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2598,9 +2324,8 @@ country_event = {
 	desc = spain.25.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.25.a
@@ -2609,10 +2334,8 @@ country_event = {
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2621,7 +2344,6 @@ country_event = {
 	option = {
 		name = spain.25.b
 		log = "[GetDateText]: [This.GetName]: spain.25.b executed"
-
 		random_list = {
 			25 = {
 				# riot
@@ -2651,33 +2373,28 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { culture_index = 4 }
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
 		}
 		else_if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.2 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
 		}
 		else_if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
 		}
 		else_if = { limit = { has_idea = police_04 }
 			set_temp_variable = { treasury_change = -0.4 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
 		}
@@ -2685,10 +2402,8 @@ country_event = {
 			set_temp_variable = { treasury_change = -0.5 }
 			modify_treasury_effect = yes
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2697,7 +2412,6 @@ country_event = {
 	option = {
 		name = spain.25.c
 		log = "[GetDateText]: [This.GetName]: spain.25.c executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -2727,26 +2441,22 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { culture_index = 4 }
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.15 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
 		}
 		else_if = { limit = { has_idea = police_02 }
 			set_temp_variable = { treasury_change = -0.3 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
 		}
 		else_if = { limit = { has_idea = police_03 }
 			set_temp_variable = { treasury_change = -0.45 }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
 		}
@@ -2758,10 +2468,8 @@ country_event = {
 			set_temp_variable = { treasury_change = -0.75 }
 			modify_treasury_effect = yes
 		}
-
 		set_temp_variable = { party_popularity_increase = -0.035 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2775,18 +2483,15 @@ country_event = {
 	desc = spain.26.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.26.a
 		log = "[GetDateText]: [This.GetName]: spain.26.a executed"
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		93 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -2810,16 +2515,12 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.26.b
 		log = "[GetDateText]: [This.GetName]: spain.26.b executed"
-
 		random_list = {
 			50 = {
 				# riot
@@ -2849,14 +2550,12 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { culture_index = 4 }
 		if = { limit = { has_idea = police_01 }
 			set_temp_variable = { treasury_change = -0.1 }
 			modify_treasury_effect = yes
 			set_temp_variable = { cultural_opinion = -5 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2886,7 +2585,6 @@ country_event = {
 			modify_treasury_effect = yes
 			set_temp_variable = { cultural_opinion = -4 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2916,7 +2614,6 @@ country_event = {
 			modify_treasury_effect = yes
 			set_temp_variable = { cultural_opinion = -3 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2946,7 +2643,6 @@ country_event = {
 			modify_treasury_effect = yes
 			set_temp_variable = { cultural_opinion = -2 }
 			SPR_modify_cultural_opinion = yes
-
 			93 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -2977,7 +2673,6 @@ country_event = {
 			set_temp_variable = { cultural_opinion = -1 }
 			SPR_modify_cultural_opinion = yes
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2991,20 +2686,16 @@ country_event = {
 	desc = spain.27.d
 	picture = GFX_guardia_civil
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.23.a
 		log = "[GetDateText]: [This.GetName]: spain.23.a executed"
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		add_manpower = -20
-
 		93 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -3038,15 +2729,13 @@ country_event = {
 	desc = spain.50.d
 	picture = GFX_toreador
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Ban bullfighting
 	option = {
 		name = spain.50.a
 		log = "[GetDateText]: [This.GetName]: spain.50.a executed"
-
 		add_political_power = -50
 		add_stability = 0.03
 		set_temp_variable = { culture_index = 0 }
@@ -3055,7 +2744,6 @@ country_event = {
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = 2 }
 		SPR_modify_cultural_opinion = yes
-
 		hidden_effect = {
 			# Banning Early prevents the Catalonian & Mallorca Event Chain
 			country_event = { id = spain.51 days = 45 random_days = 45 }
@@ -3073,7 +2761,6 @@ country_event = {
 	option = {
 		name = spain.50.b
 		log = "[GetDateText]: [This.GetName]: spain.50.b executed"
-
 		add_political_power = -25
 		add_stability = 0.01
 		set_temp_variable = { culture_index = 0 }
@@ -3082,7 +2769,6 @@ country_event = {
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = 1 }
 		SPR_modify_cultural_opinion = yes
-
 		hidden_effect = {
 			# Catalonia event chain will trigger but Mallorca event chain will not
 			country_event = { id = spain.52 days = 45 random_days = 45 }
@@ -3109,9 +2795,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = SPR_allow_bullfighting_tt
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -3129,9 +2813,8 @@ country_event = {
 	desc = spain.51.d
 	picture = GFX_const_court_spain
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Repeal the Ban
 	# Reverts to pre-ban state.
@@ -3147,10 +2830,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Challenge the Court
@@ -3158,13 +2838,9 @@ country_event = {
 	option = {
 		name = spain.51.b
 		log = "[GetDateText]: [This.GetName]: spain.51.b executed"
-
 		activate_mission = SPR_challenge_the_court_ban_bull_mission
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # Spanish Constitutional Court Determines Killing the Bull Partially Unconstitutional
@@ -3174,9 +2850,8 @@ country_event = {
 	desc = spain.52.d
 	picture = GFX_const_court_spain
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Repeal the Killing of the Bull
 	option = {
@@ -3191,21 +2866,15 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Challenge the Court
 	option = {
 		name = spain.52.b
 		log = "[GetDateText]: [This.GetName]: spain.52.b executed"
-
 		activate_mission = SPR_challenge_the_court_killing_bull_mission
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3233,9 +2902,8 @@ country_event = {
 	}
 	picture = GFX_const_court_spain
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# The Ban is Upheld
 	option = {
@@ -3247,11 +2915,9 @@ country_event = {
 			}
 		}
 		log = "[GetDateText]: [This.GetName]: spain.53.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.015 }
 		change_relative_party_popularity = yes
 		add_political_power = 50
-
 		hidden_effect = {
 			clr_country_flag = SPR_banfighting_is_upheld
 			clr_country_flag = SPR_bankilling_is_upheld
@@ -3268,11 +2934,9 @@ country_event = {
 			}
 		}
 		log = "[GetDateText]: [This.GetName]: spain.53.b executed"
-
 		set_temp_variable = { party_popularity_increase = -0.015 }
 		change_relative_party_popularity = yes
 		add_political_power = -50
-
 		hidden_effect = {
 			clr_country_flag = SPR_banfighting_is_unconstitutional
 			clr_country_flag = SPR_bankilling_is_unconstitutional
@@ -3287,9 +2951,8 @@ country_event = {
 	desc = spain.54.d
 	picture = GFX_spain_elections
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Host the Referendum
 	option = {
@@ -3303,7 +2966,6 @@ country_event = {
 		set_temp_variable = { temp_failure_rate = 65 }
 		subtract_from_temp_variable = { temp_failure_rate = popularity }
 		custom_effect_tooltip = SPR_referendum_chance_tt
-
 		country_event = { id = spain.55 days = 30 }
 	}
 }
@@ -3315,9 +2977,8 @@ country_event = {
 	desc = spain.55.d
 	picture = GFX_spain_elections
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Referendum Day!
 	option = {
@@ -3329,12 +2990,10 @@ country_event = {
 		add_to_temp_variable = { temp_success_rate = popularity }
 		set_temp_variable = { temp_failure_rate = 65 }
 		subtract_from_temp_variable = { temp_failure_rate = popularity }
-
 		if = { limit = { has_country_flag = SPR_pro_ban_campaign }
 			add_to_temp_variable = { temp_success_rate = 5 }
 			subtract_from_temp_variable = { temp_failure_rate = 5 }
 		}
-
 		random_list = {
 			temp_success_rate = {
 				set_temp_variable = { culture_index = 0 }
@@ -3343,11 +3002,9 @@ country_event = {
 				set_temp_variable = { party_popularity_increase = 0.02 }
 				change_relative_party_popularity = yes
 				add_political_power = 100
-
 				set_country_flag = SPR_results_passed
 			}
 			temp_failure_rate = {
-
 				set_temp_variable = { culture_index = 0 }
 				set_temp_variable = { cultural_opinion = -3 }
 				SPR_modify_cultural_opinion = yes
@@ -3358,7 +3015,6 @@ country_event = {
 				set_temp_variable = { temp_outlook_increase = 0.02 }
 				change_relative_party_popularity = yes
 				add_political_power = -50
-
 				set_country_flag = SPR_results_failed
 			}
 		}
@@ -3374,21 +3030,16 @@ country_event = {
 	title = spain.56.t
 	desc = {
 		text = spain.56.d
-		trigger = {
-			has_country_flag = SPR_results_passed
-		}
+		trigger = { has_country_flag = SPR_results_passed }
 	}
 	desc = {
 		text = spain.56.d2
-		trigger = {
-			has_country_flag = SPR_results_failed
-		}
+		trigger = { has_country_flag = SPR_results_failed }
 	}
 	picture = GFX_spain_elections
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Another Referendum Completed
 	option = {
@@ -3418,9 +3069,8 @@ country_event = {
 	desc = spain.57.d
 	picture = GFX_spain_throne
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# The Carlists Will Rise
 	option = {
@@ -3460,9 +3110,8 @@ country_event = {
 	desc = spain.58.d
 	picture = GFX_message_signing
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# A New Monarchy
 	option = {
@@ -3474,18 +3123,14 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = SPR_spain_58_a_tt
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = 0 }
 			set_temp_variable = { disable_elections = 1 }
 			change_ruling_party_effect = yes
 		}
-
 		set_country_flag = SPR_constitutional_monarchy_flag
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Return to Absolutism
@@ -3498,18 +3143,14 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = SPR_spain_58_b_tt
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = 23 }
 			set_temp_variable = { disable_elections = 1 }
 			change_ruling_party_effect = yes
 		}
-
 		set_country_flag = SPR_absolutist_monarchy_flag
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3520,9 +3161,8 @@ country_event = {
 	desc = spain.59.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# A New Democratic
 	option = {
@@ -3542,9 +3182,8 @@ country_event = {
 	desc = spain.60.d
 	picture = GFX_iberia_united
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Declare the Union
 	option = {
@@ -3564,13 +3203,10 @@ news_event = {
 	picture = GFX_iberia_united_news
 	is_triggered_only = yes
 	major = yes
-	trigger = {
-		original_tag = SPR
-	}
 
-	option = {
-		name = spain.61.a
-	}
+	trigger = { original_tag = SPR }
+
+	option = { name = spain.61.a }
 }
 
 # Demand The Portuguese Throne
@@ -3592,26 +3228,17 @@ country_event = {
 						target = POR
 						transfer_troops = yes
 					}
-					POR = {
-						every_unit_leader = {
-							set_nationality = SPR
-						}
-					}
+					POR = { every_unit_leader = { set_nationality = SPR } }
 				}
 			}
 			else = {
 				POR = {
-					OVERLORD = {
-						end_puppet = PREV
-					}
-					SPR = {
-						puppet = PREV
-					}
+					OVERLORD = { end_puppet = PREV }
+					SPR = { puppet = PREV }
 				}
 			}
 		}
 		SPR = { country_event = spain.63 }
-
 		ai_chance = {
 			base = 4
 			modifier = {
@@ -3662,17 +3289,13 @@ country_event = {
 	option = {
 		name = spain.62.b
 		log = "[GetDateText]: [This.GetName]: spain.62.b executed"
-		trigger = {
-			SPR = { has_country_flag = SPR_bourbon_monarchist }
-		}
-
+		trigger = { SPR = { has_country_flag = SPR_bourbon_monarchist } }
 		effect_tooltip = {
 			add_opinion_modifier = { target = SPR modifier = SPR_tried_to_annex_us }
 			set_temp_variable = { percent_change = -10 }
 			set_temp_variable = { tag_index = FROM.ID }
 			change_influence_percentage = yes
 		}
-
 		SPR = { country_event = spain.64 }
 		ai_chance = {
 			base = 5
@@ -3698,18 +3321,14 @@ country_event = {
 	# Fuck off Carlists
 	option = {
 		name = spain.62.c
-		trigger = {
-			SPR = { has_country_flag = SPR_carlist_rising }
-		}
+		trigger = { SPR = { has_country_flag = SPR_carlist_rising } }
 		log = "[GetDateText]: [Root.GetName]: event spain.62.c"
-
 		effect_tooltip = {
 			add_opinion_modifier = { target = SPR modifier = SPR_tried_to_annex_us }
 			set_temp_variable = { percent_change = -10 }
 			set_temp_variable = { tag_index = FROM.ID }
 			change_influence_percentage = yes
 		}
-
 		SPR = { country_event = spain.64 }
 		ai_chance = {
 			base = 5
@@ -3740,9 +3359,8 @@ country_event = {
 	desc = spain.63.d
 	picture = GFX_politics_talks
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Direct Rule for Now
 	option = {
@@ -3771,7 +3389,6 @@ country_event = {
 				days = 180
 			}
 		}
-
 		ai_chance = { # AI Forced to Optimal Path
 			base = 0
 		}
@@ -3784,11 +3401,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 		if = { limit = { POR = { is_subject = yes } }
-			POR = {
-				OVERLORD = {
-					end_puppet = PREV
-				}
-			}
+			POR = { OVERLORD = { end_puppet = PREV } }
 		}
 		puppet = POR
 		set_temp_variable = { percent_change = 15 }
@@ -3807,10 +3420,7 @@ country_event = {
 				days = 180
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3821,9 +3431,8 @@ country_event = {
 	desc = spain.64.d
 	picture = GFX_politics_talks
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Invade the Inferior Spanish
 	option = {
@@ -3851,10 +3460,7 @@ country_event = {
 			target = FROM
 			modifier = SPR_tried_to_annex_us
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3865,6 +3471,7 @@ country_event = {
 	desc = spain.65.d
 	picture = GFX_politics_demands
 	is_triggered_only = yes
+
 	trigger = {
 		OR = {
 			original_tag = ADO
@@ -3893,20 +3500,11 @@ country_event = {
 						target = ADO
 						transfer_troops = yes
 					}
-					ADO = {
-						every_unit_leader = {
-							set_nationality = SPR
-						}
-					}
+					ADO = { every_unit_leader = { set_nationality = SPR } }
 				}
 			}
-			else = {
-				SPR = {
-					transfer_state = 945
-				}
-			}
+			else = { SPR = { transfer_state = 945 } }
 		}
-
 		SPR = { country_event = spain.66 }
 		ai_chance = {
 			base = 10
@@ -3933,11 +3531,8 @@ country_event = {
 				}
 			}
 		}
-
 		SPR = { country_event = spain.67 }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 
@@ -3948,9 +3543,8 @@ country_event = {
 	desc = spain.66.d
 	picture = GFX_politics_talks
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Haha Lila Hemd
 	option = {
@@ -3976,17 +3570,9 @@ country_event = {
 				target = ADO
 				transfer_troops = yes
 			}
-			ADO = {
-				every_unit_leader = {
-					set_nationality = SPR
-				}
-			}
+			ADO = { every_unit_leader = { set_nationality = SPR } }
 		}
-		else = {
-			SPR = {
-				transfer_state = 945
-			}
-		}
+		else = { SPR = { transfer_state = 945 } }
 		if = { limit = { has_idea = SPR_a_great_victory_for_spain_idea }
 			modify_timed_idea = {
 				idea = SPR_a_great_victory_for_spain_idea
@@ -4009,9 +3595,8 @@ country_event = {
 	desc = spain.67.d
 	picture = GFX_politics_talks
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Haha Lila Hemd
 	option = {
@@ -4152,9 +3737,8 @@ country_event = {
 	desc = spain.69.d
 	picture = GFX_Gibraltar
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Another Victory for Spain!
 	option = {
@@ -4162,7 +3746,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: spain.69.a executed"
 		add_state_core = 19
 		transfer_state = 19
-
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -4189,9 +3772,8 @@ country_event = {
 	desc = spain.70.d
 	picture = GFX_Gibraltar
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Fuck them!
 	option = {
@@ -4206,10 +3788,7 @@ country_event = {
 			type = take_core_state
 			generator = { 19 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4223,9 +3802,7 @@ news_event = {
 	major = yes
 
 	# A Worrying Development
-	option = {
-		name = spain.71.a
-	}
+	option = { name = spain.71.a }
 }
 
 # The LGBTQA Stance
@@ -4235,25 +3812,20 @@ country_event = {
 	desc = spain.72.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# A New Stance
 	option = {
 		name = spain.72.a
 		log = "[GetDateText]: [This.GetName]: spain.72.a executed"
-
 		if = { limit = { has_idea = SPR_anti_lgbtqa_stance_idea }
 			swap_ideas = {
 				add_idea = SPR_pro_lgbtqa_stance_idea
 				remove_idea = SPR_anti_lgbtqa_stance_idea
 			}
 		}
-		else = {
-			add_ideas = SPR_pro_lgbtqa_stance_idea
-		}
-
+		else = { add_ideas = SPR_pro_lgbtqa_stance_idea }
 		if = { limit = { has_country_flag = SPR_ban_gays_stance_conserv_flag }
 			clr_country_flag = SPR_ban_gays_stance_conserv_flag
 		}
@@ -4261,21 +3833,15 @@ country_event = {
 			clr_country_flag = SPR_status_quo_stance_conserv_flag
 		}
 		set_country_flag = SPR_pro_gay_stance_conserv_flag
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Maintain the Status Quo
 	option = {
 		name = spain.72.b
 		log = "[GetDateText]: [This.GetName]: spain.72.b executed"
-
 		add_political_power = 150
-
 		remove_ideas = SPR_lgbtq_affirmations_idea
-
 		if = { limit = { has_country_flag = SPR_ban_gays_stance_conserv_flag }
 			clr_country_flag = SPR_ban_gays_stance_conserv_flag
 		}
@@ -4283,9 +3849,7 @@ country_event = {
 			clr_country_flag = SPR_pro_gay_stance_conserv_flag
 		}
 		set_country_flag = SPR_status_quo_stance_conserv_flag
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Ban Gays
@@ -4298,12 +3862,8 @@ country_event = {
 				remove_idea = SPR_pro_lgbtqa_stance_idea
 			}
 		}
-		else = {
-			add_ideas = SPR_anti_lgbtqa_stance_idea
-		}
-
+		else = { add_ideas = SPR_anti_lgbtqa_stance_idea }
 		remove_ideas = SPR_lgbtq_affirmations_idea
-
 		if = { limit = { has_country_flag = SPR_pro_gay_stance_conserv_flag }
 			clr_country_flag = SPR_pro_gay_stance_conserv_flag
 		}
@@ -4311,9 +3871,7 @@ country_event = {
 			clr_country_flag = SPR_status_quo_stance_conserv_flag
 		}
 		set_country_flag = SPR_ban_gays_stance_conserv_flag
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -4324,9 +3882,8 @@ country_event = {
 	desc = spain.73.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Full Parental Veto
 	option = {
@@ -4335,11 +3892,8 @@ country_event = {
 		add_ideas = SPR_parental_choice_on_all_topics_idea
 		add_stability = -0.05
 		add_political_power = -100
-
 		set_country_flag = SPR_pin_parental_education_full_flag
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Veto on Sexual Education and Other Controversial Topics
@@ -4349,23 +3903,17 @@ country_event = {
 		add_ideas = SPR_parental_choice_on_controversial_idea
 		add_stability = -0.05
 		add_political_power = -50
-
 		set_country_flag = SPR_pin_parental_education_controversial_flag
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Actually... we shouldn't do this
 	option = {
 		name = spain.73.c
 		log = "[GetDateText]: [Root.GetName]: event spain.73.c"
-
 		add_stability = 0.05
 		add_political_power = 100
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -4376,20 +3924,16 @@ country_event = {
 	desc = spain.74.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# A Harsh Stance
 	option = {
 		name = spain.74.a
 		log = "[GetDateText]: [Root.GetName]: event spain.74.a"
 		add_ideas = SPR_a_harsh_nativism_stance_idea
-
 		set_country_flag = SPR_harsh_nativism_stance_flag
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# A Softer Stance
@@ -4397,13 +3941,9 @@ country_event = {
 		name = spain.74.b
 		log = "[GetDateText]: [Root.GetName]: event spain.74.b"
 		add_ideas = SPR_a_soft_nativism_stance_idea
-
 		set_country_flag = SPR_soft_nativism_stance_flag
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # Return of Falangism
@@ -4413,9 +3953,8 @@ country_event = {
 	desc = spain.75.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Glory to Spain!
 	option = {
@@ -4426,7 +3965,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
 		add_political_power = 100
-
 		news_event = spain.76
 		ai_chance = { base = 1 }
 	}
@@ -4441,9 +3979,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = spain.76.a
-	}
+	option = { name = spain.76.a }
 }
 
 # The New Falangist Woman
@@ -4451,22 +3987,18 @@ country_event = {
 	id = spain.77
 	title = spain.77.t
 	desc = spain.77.d
-	is_triggered_only = yes
 	picture = GFX_politics_speak
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# Women Serve the Homefront
 	option = {
 		name = spain.77.a
 		log = "[GetDateText]: [This.GetName]: spain.77.a executed"
 		add_ideas = SPR_women_belong_on_the_homefront_idea
-
 		set_country_flag = SPR_women_homefront_idea_flag
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Strength is in Choice
@@ -4474,11 +4006,8 @@ country_event = {
 		name = spain.77.b
 		log = "[GetDateText]: [This.GetName]: spain.77.b executed"
 		add_ideas = SPR_women_choose_idea
-
 		set_country_flag = SPR_women_choose_idea_flag
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4487,11 +4016,10 @@ country_event = {
 	id = spain.78
 	title = spain.78.t
 	desc = spain.78.d
-	is_triggered_only = yes
 	picture = GFX_politics_demands
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# The French Execution
 	option = {
@@ -4514,14 +4042,11 @@ country_event = {
 			multiply_temp_variable = { party_popularity_increase = -1 }
 			change_relative_party_popularity = yes
 		}
-
 		set_global_flag = SPR_french_execution_gangnam_flag
 		hidden_effect = {
 			news_event = { id = spain.79 days = 1 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Depose the Monarchs
@@ -4544,14 +4069,11 @@ country_event = {
 			multiply_temp_variable = { party_popularity_increase = -1 }
 			change_relative_party_popularity = yes
 		}
-
 		set_global_flag = SPR_chavy_deposition_of_monarchs_flag
 		hidden_effect = {
 			news_event = { id = spain.79 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4560,39 +4082,28 @@ news_event = {
 	id = spain.79
 	title = {
 		text = spain.79.t1
-		trigger = {
-			has_global_flag = SPR_french_execution_gangnam_flag
-		}
+		trigger = { has_global_flag = SPR_french_execution_gangnam_flag }
 	}
 	title = {
 		text = spain.79.t2
-		trigger = {
-			has_global_flag = SPR_chavy_deposition_of_monarchs_flag
-		}
+		trigger = { has_global_flag = SPR_chavy_deposition_of_monarchs_flag }
 	}
 	desc = {
 		text = spain.79.d1
-		trigger = {
-			has_global_flag = SPR_french_execution_gangnam_flag
-		}
+		trigger = { has_global_flag = SPR_french_execution_gangnam_flag }
 	}
 	desc = {
 		text = spain.79.d2
-		trigger = {
-			has_global_flag = SPR_chavy_deposition_of_monarchs_flag
-		}
+		trigger = { has_global_flag = SPR_chavy_deposition_of_monarchs_flag }
 	}
 	picture = GFX_news_election_rally
 	is_triggered_only = yes
 	major = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# A New Way for Spain
-	option = {
-		name = spain.79.a
-	}
+	option = { name = spain.79.a }
 }
 
 # The Emancipation of the New Woman
@@ -4600,11 +4111,10 @@ country_event = {
 	id = spain.80
 	title = spain.80.t
 	desc = spain.80.d
-	is_triggered_only = yes
 	picture = GFX_politics_demands
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# Yes
 	option = {
@@ -4619,36 +4129,29 @@ country_event = {
 	id = spain.81
 	title = spain.81.t
 	desc = spain.81.d
-	is_triggered_only = yes
 	picture = GFX_politics_demands
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# Citizenship for All
 	option = {
 		name = spain.81.a
 		log = "[GetDateText]: [This.GetName]: spain.81.a executed"
-
 		if = {
 			limit = { has_idea = SPR_idea_open_borders_1 }
-
 			swap_ideas = {
 				remove_idea = SPR_idea_open_borders_1
 				add_idea = SPR_idea_open_borders_2
 			}
 		}
-		else = {
-			add_ideas = SPR_idea_open_borders_1
-		}
-
+		else = { add_ideas = SPR_idea_open_borders_1 }
 	}
 
 	# Visa Status
 	option = {
 		name = spain.81.b
 		log = "[GetDateText]: [This.GetName]: spain.81.b executed"
-
 		add_ideas = SPR_idea_visa_programs
 	}
 
@@ -4658,16 +4161,12 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: spain.82.c executed"
 		if = {
 			limit = { has_idea = SPR_anti_immigration_policies_idea }
-
 			swap_ideas = {
 				remove_idea = SPR_anti_immigration_policies_idea
 				add_idea = SPR_anti_immigration_policies_idea_2
 			}
 		}
-		else = {
-			add_ideas = SPR_anti_immigration_policies_idea
-		}
-
+		else = { add_ideas = SPR_anti_immigration_policies_idea }
 	}
 }
 
@@ -4676,11 +4175,10 @@ country_event = {
 	id = spain.83
 	title = spain.83.t
 	desc = spain.83.d
-	is_triggered_only = yes
 	picture = GFX_politics_autocracy
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# The Night of Broken Vitoria
 	option = {
@@ -4691,7 +4189,6 @@ country_event = {
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -15 }
 		SPR_modify_cultural_opinion = yes
-
 		custom_effect_tooltip = SPR_the_following_may_happen_tt
 		random_list = {
 			30 = {
@@ -4711,7 +4208,6 @@ country_event = {
 				88 = { add_manpower = -2000 }
 			}
 		}
-
 		set_country_flag = SPR_night_of_broken_vitora_flag
 		country_event = spain.84
 	}
@@ -4725,7 +4221,6 @@ country_event = {
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		custom_effect_tooltip = SPR_the_following_may_happen_tt
 		random_list = {
 			40 = {
@@ -4744,7 +4239,6 @@ country_event = {
 				88 = { add_manpower = -2000 }
 			}
 		}
-
 		set_country_flag = SPR_round_up_the_conspirators_flag
 		country_event = spain.84
 	}
@@ -4782,11 +4276,10 @@ country_event = {
 			has_country_flag = SPR_choice_1
 		}
 	}
-	is_triggered_only = yes
 	picture = GFX_politics_autocracy
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# The Night of Broken Vitoria
 	option = {
@@ -4843,30 +4336,26 @@ country_event = {
 	id = spain.85
 	title = spain.85.t
 	desc = spain.85.d
+	picture = GFX_prestige_tanker
+	is_triggered_only = yes
+
 	trigger = {
 		tag = SPR
 		date > 2002.1.1
 	}
-	picture = GFX_prestige_tanker
-	is_triggered_only = yes
 
 	# Haha Pink Shirt - Oil
 	option = {
 		name = spain.85.a
 		log = "[GetDateText]: [This.GetName]: spain.85.b executed"
-
 		set_temp_variable = { treasury_change = -2.5 }
 		modify_treasury_effect = yes
-
 		add_manpower = -3000
-
 		set_temp_variable = { culture_index = 2 }
 		set_temp_variable = { cultural_opinion = -3 }
 		SPR_modify_cultural_opinion = yes
-
 		set_temp_variable = { party_popularity_increase = -0.07 }
 		change_relative_party_popularity = yes
-
 		# Penalty in the Coastline
 		944 = { add_dynamic_modifier = { modifier = SPR_oil_spill days = 1460 } }
 		89 = { add_dynamic_modifier = { modifier = SPR_oil_spill days = 1460 } }
@@ -4874,7 +4363,6 @@ country_event = {
 		1055 = { add_dynamic_modifier = { modifier = SPR_oil_spill days = 1460 } }
 		60 = { add_dynamic_modifier = { modifier = SPR_oil_spill days = 1460 } }
 		958 = { add_dynamic_modifier = { modifier = SPR_oil_spill days = 1460 } }
-
 		set_country_flag = SPR_prestige_oil_spill
 		if = { limit = { has_completed_focus = SPR_el_oro_negro }
 			add_stability = -0.05
@@ -4887,11 +4375,10 @@ country_event = {
 	id = spain.86
 	title = spain.86.t
 	desc = spain.86.d
-	is_triggered_only = yes
 	picture = GFX_politics_autocracy
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# The Night of Broken Barcelona
 	option = {
@@ -4902,7 +4389,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -15 }
 		SPR_modify_cultural_opinion = yes
-
 		custom_effect_tooltip = SPR_the_following_may_happen_tt
 		random_list = {
 			30 = {
@@ -4922,7 +4408,6 @@ country_event = {
 				86 = { add_manpower = -2000 }
 			}
 		}
-
 		set_country_flag = SPR_blueshirts_barcelona_flag
 		country_event = spain.87
 	}
@@ -4936,7 +4421,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
-
 		custom_effect_tooltip = SPR_the_following_may_happen_tt
 		random_list = {
 			40 = {
@@ -4955,7 +4439,6 @@ country_event = {
 				86 = { add_manpower = -2000 }
 			}
 		}
-
 		set_country_flag = SPR_round_up_the_conspirators_barcelona_flag
 		country_event = spain.87
 	}
@@ -4993,11 +4476,10 @@ country_event = {
 			has_country_flag = SPR_bar_choice_1
 		}
 	}
-	is_triggered_only = yes
 	picture = GFX_politics_autocracy
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# The Night of Broken Barcelona
 	option = {
@@ -5054,11 +4536,10 @@ country_event = {
 	id = spain.201
 	title = spain.201.t
 	desc = spain.201.d
-	is_triggered_only = yes
 	picture = GFX_2005_migrant_crisis
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	#Refuse Immigrants
 	option = {
@@ -5070,21 +4551,16 @@ country_event = {
 				NOT = { has_idea = SPR_idea_open_borders_2 }
 			}
 		}
-
 		set_temp_variable = { modify_europeanism = 0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		if = { limit = { has_idea = SPR_anti_immigration_policies_idea }
 			swap_ideas = {
 				remove_idea = SPR_anti_immigration_policies_idea
 				add_idea = SPR_anti_immigration_policies_idea_2
 			}
 		}
-		else = {
-			add_ideas = SPR_anti_immigration_policies_idea
-		}
-
+		else = { add_ideas = SPR_anti_immigration_policies_idea }
 		set_country_flag = SPR_refused_immigrants
 		set_country_flag = SPR_mirgrant_crisis_start
 	}
@@ -5101,11 +4577,9 @@ country_event = {
 				NOT = { has_idea = SPR_anti_immigration_policies_idea_2 }
 			}
 		}
-
 		set_temp_variable = { modify_europeanism = -0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		if = { limit = { has_idea = SPR_idea_open_borders_1 }
 			swap_ideas = {
 				remove_idea = SPR_idea_open_borders_1
@@ -5115,7 +4589,6 @@ country_event = {
 		else = {
 			add_ideas = SPR_idea_open_borders_1
 		}
-
 		set_country_flag = SPR_mirgrant_crisis_start
 	}
 
@@ -5129,15 +4602,11 @@ country_event = {
 				NOT = { has_idea = SPR_anti_immigration_policies_idea_2 }
 			}
 		}
-
 		set_temp_variable = { modify_europeanism = -0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		set_country_flag = SPR_increased_immigration
-
 		add_ideas = SPR_idea_increased_immigration
-
 		set_country_flag = SPR_mirgrant_crisis_start
 	}
 }
@@ -5147,29 +4616,23 @@ country_event = {
 	id = spain.202
 	title = spain.202.t
 	desc = spain.202.d
-	is_triggered_only = yes
 	picture = GFX_ceuta_border_thingy
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# Nonlethal Response
 	option = {
 		name = spain.202.a
 		log = "[GetDateText]: [This.GetName]: spain.202.a executed"
 		add_stability = -0.02
-
 		every_other_country = {
-			limit = {
-				has_government = democratic
-			}
-
+			limit = { has_government = democratic }
 			add_opinion_modifier = {
 				target = SPR
 				modifier = small_decrease
 			}
 		}
-
 		set_country_flag = SPR_ceuta_assault
 	}
 
@@ -5186,22 +4649,18 @@ country_event = {
 				NOT = { has_idea = SPR_idea_visa_programs }
 			}
 		}
-
 		set_temp_variable = { modify_europeanism = -0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		every_other_country = {
 			limit = {
 				has_government = democratic
 			}
-
 			add_opinion_modifier = {
 				target = SPR
 				modifier = large_decrease
 			}
 		}
-
 		set_country_flag = SPR_ceuta_assault
 		set_country_flag = SPR_border_massacre
 	}
@@ -5218,14 +4677,11 @@ country_event = {
 				NOT = { has_idea = SPR_anti_immigration_policies_idea_2 }
 			}
 		}
-
 		set_temp_variable = { modify_europeanism = 0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		if = {
 			limit = { has_idea = SPR_idea_open_borders_1 }
-
 			swap_ideas = {
 				remove_idea = SPR_idea_open_borders_1
 				add_idea = SPR_idea_open_borders_2
@@ -5234,7 +4690,6 @@ country_event = {
 		else = {
 			add_ideas = SPR_idea_open_borders_1
 		}
-
 		set_country_flag = SPR_ceuta_assault
 	}
 }
@@ -5244,29 +4699,23 @@ country_event = {
 	id = spain.203
 	title = spain.203.t
 	desc = spain.203.d
-	is_triggered_only = yes
 	picture = GFX_melila_border_thingy
-	trigger = {
-		original_tag = SPR
-	}
+	is_triggered_only = yes
+
+	trigger = { original_tag = SPR }
 
 	# Nonlethal Response
 	option = {
 		name = spain.203.a
 		log = "[GetDateText]: [This.GetName]: spain.203.c executed"
 		add_stability = -0.02
-
 		every_other_country = {
-			limit = {
-				has_government = democratic
-			}
-
+			limit = { has_government = democratic }
 			add_opinion_modifier = {
 				target = SPR
 				modifier = small_decrease
 			}
 		}
-
 		set_country_flag = SPR_mellila_assault
 	}
 
@@ -5281,22 +4730,16 @@ country_event = {
 			}
 		}
 		log = "[GetDateText]: [This.GetName]: spain.203.c executed"
-
 		set_temp_variable = { modify_europeanism = -0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		every_other_country = {
-			limit = {
-				has_government = democratic
-			}
-
+			limit = { has_government = democratic }
 			add_opinion_modifier = {
 				target = SPR
 				modifier = large_decrease
 			}
 		}
-
 		set_country_flag = SPR_border_massacre
 		set_country_flag = SPR_mellila_assault
 	}
@@ -5314,18 +4757,13 @@ country_event = {
 		set_temp_variable = { modify_europeanism = 0.05 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-
 		if = { limit = { has_idea = SPR_idea_open_borders_1 }
-
 			swap_ideas = {
 				remove_idea = SPR_idea_open_borders_1
 				add_idea = SPR_idea_open_borders_2
 			}
 		}
-		else = {
-			add_ideas = SPR_idea_open_borders_1
-		}
-
+		else = { add_ideas = SPR_idea_open_borders_1 }
 		set_country_flag = SPR_mellila_assault
 	}
 }
@@ -5373,15 +4811,11 @@ country_event = {
 	title = spain.205.t
 	desc = {
 		text = spain.205.d1
-		trigger = {
-			NOT = { has_country_flag = SPR_carlists_chosen }
-		}
+		trigger = { NOT = { has_country_flag = SPR_carlists_chosen } }
 	}
 	desc = {
 		text = spain.205.d2
-		trigger = {
-			has_country_flag = SPR_carlists_chosen
-		}
+		trigger = { has_country_flag = SPR_carlists_chosen }
 	}
 	picture = GFX_death_of_Carlos_hugo
 	is_triggered_only = yes
@@ -5422,12 +4856,10 @@ country_event = {
 	desc = spain.206.d
 	picture = GFX_albert_riviera
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
-	immediate = {
-		set_country_flag = SPR_cidudanos_forms
-	}
+
+	trigger = { original_tag = SPR }
+
+	immediate = { set_country_flag = SPR_cidudanos_forms }
 
 	option = {
 		name = spain.206.a
@@ -5446,9 +4878,9 @@ country_event = {
 	desc = spain.207.d
 	picture = GFX_santiago_pascal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
+
 	immediate = {
 		clr_country_flag = SPR_espana_2000_forms
 		set_country_flag = SPR_vox_forms
@@ -5471,12 +4903,10 @@ country_event = {
 	desc = spain.208.d
 	picture = GFX_espana_2000
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
-	immediate = {
-		set_country_flag = SPR_espana_2000_forms
-	}
+
+	trigger = { original_tag = SPR }
+
+	immediate = { set_country_flag = SPR_espana_2000_forms }
 
 	option = {
 		name = spain.208.a
@@ -5495,12 +4925,10 @@ country_event = {
 	desc = spain.209.d
 	picture = GFX_aes
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
-	immediate = {
-		set_country_flag = SPR_alternativa_espana_forms
-	}
+
+	trigger = { original_tag = SPR }
+
+	immediate = { set_country_flag = SPR_alternativa_espana_forms }
 
 	option = {
 		name = spain.209.a
@@ -5519,12 +4947,10 @@ country_event = {
 	desc = spain.210.d
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
-	immediate = {
-		set_country_flag = SPR_unidos_podemos_forms
-	}
+
+	trigger = { original_tag = SPR }
+
+	immediate = { set_country_flag = SPR_unidos_podemos_forms }
 
 	option = {
 		name = spain.210.a
@@ -5543,9 +4969,9 @@ country_event = {
 	desc = spain.211.d
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
+
 	immediate = {
 		clr_country_flag = SPR_unidos_podemos_forms
 		set_country_flag = SPR_unidas_podemos_forms
@@ -5554,7 +4980,6 @@ country_event = {
 	option = {
 		name = spain.211.a
 		log = "[GetDateText]: [This.GetName]: spain.211.a executed"
-
 		add_political_power = 50
 	}
 }
@@ -5566,14 +4991,12 @@ country_event = {
 	desc = spain.212.d
 	picture = GFX_bilbao
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.212.a
 		log = "[GetDateText]: [This.GetName]: spain.212.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
 		set_temp_variable = { culture_index = 1 }
@@ -5589,14 +5012,12 @@ country_event = {
 	desc = spain.213.d
 	picture = GFX_lugo
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.213.a
 		log = "[GetDateText]: [This.GetName]: spain.212.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		change_relative_party_popularity = yes
 		set_temp_variable = { culture_index = 2 }
@@ -5612,16 +5033,13 @@ country_event = {
 	desc = spain.214.d
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.214.a
 		log = "[GetDateText]: [This.GetName]: spain.214.b executed"
-
 		add_manpower = -99
-
 		91 = {
 			if = {
 				limit = { offices > 0 }
@@ -5641,21 +5059,17 @@ country_event = {
 	desc = spain.215.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.215.a
 		log = "[GetDateText]: [This.GetName]: spain.215.b executed"
-
 		add_political_power = -25
-
 		swap_ideas = {
 			remove_idea = SPR_idea_the_eta_1
 			add_idea = SPR_idea_the_eta_2
 		}
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
@@ -5669,14 +5083,12 @@ country_event = {
 	desc = spain.216.d
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.216.a
 		log = "[GetDateText]: [This.GetName]: spain.216.a executed"
-
 		88 = {
 			if = {
 				limit = { rail_way > 0 }
@@ -5714,16 +5126,13 @@ country_event = {
 	desc = spain.217.d
 	picture = GFX_2006_madrid_airport_bombing
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.217.a
 		log = "[GetDateText]: [This.GetName]: spain.217.b executed"
-
 		add_manpower = -54
-
 		91 = {
 			if = {
 				limit = { air_base > 0 }
@@ -5743,21 +5152,17 @@ country_event = {
 	desc = spain.218.d
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.218.a
 		log = "[GetDateText]: [This.GetName]: spain.218.b executed"
-
 		add_political_power = -25
-
 		swap_ideas = {
 			remove_idea = SPR_idea_the_eta_2
 			add_idea = SPR_idea_the_eta_3
 		}
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
@@ -5771,21 +5176,17 @@ country_event = {
 	desc = spain.219.d
 	picture = GFX_ETA_leader_arrest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.219.a
 		log = "[GetDateText]: [This.GetName]: spain.219.b executed"
-
 		add_political_power = -25
-
 		swap_ideas = {
 			remove_idea = SPR_idea_the_eta_3
 			add_idea = SPR_idea_the_eta_4
 		}
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
@@ -5799,16 +5200,13 @@ country_event = {
 	desc = spain.220.d
 	picture = GFX_guardia_civil_bombing
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.220.a
 		log = "[GetDateText]: [This.GetName]: spain.220.b executed"
-
 		add_manpower = -67
-
 		90 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -5818,7 +5216,6 @@ country_event = {
 				}
 			}
 		}
-
 		94 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -5838,18 +5235,14 @@ country_event = {
 	desc = spain.221.d
 	picture = GFX_eta_ceasefire
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.221.a
 		log = "[GetDateText]: [This.GetName]: spain.221.b executed"
-
 		add_political_power = -25
-
 		remove_ideas = SPR_idea_the_eta_4
-
 		set_temp_variable = { culture_index = 1 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
@@ -5863,16 +5256,13 @@ country_event = {
 	desc = spain.222.d
 	picture = GFX_murcia_attack
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.222.a
 		log = "[GetDateText]: [This.GetName]: spain.222.b executed"
-
 		add_manpower = -5
-
 		90 = {
 			if = {
 				limit = { infrastructure > 0 }
@@ -5928,16 +5318,13 @@ country_event = {
 	desc = spain.223.d
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.223.a
 		log = "[GetDateText]: [This.GetName]: spain.223.b executed"
-
 		add_manpower = -42
-
 		91 = {
 			if = {
 				limit = { offices > 0 }
@@ -5956,13 +5343,14 @@ country_event = {
 	title = spain.230.t
 	desc = spain.230.d
 	picture = GFX_2006_catalan_refer
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.230.a
@@ -5971,10 +5359,7 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = 1 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5991,12 +5376,8 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -3 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # 2010 - Early - Spanish Constitutional Court Nullifies the State of Autonomy
@@ -6005,13 +5386,14 @@ country_event = {
 	title = spain.231.t
 	desc = spain.231.d
 	picture = GFX_const_court_spain
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.231.a
@@ -6020,7 +5402,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = -15 }
 		SPR_modify_cultural_opinion = yes
 		add_stability = -0.05
-
 		hidden_effect = { country_event = { id = spain.232 days = 40 random_hours = 48 } }
 	}
 }
@@ -6031,13 +5412,14 @@ country_event = {
 	title = spain.232.t
 	desc = spain.232.d
 	picture = GFX_2010_catalan_prot
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.232.a
@@ -6071,7 +5453,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = 6 }
 		SPR_modify_cultural_opinion = yes
 	}
-
 }
 
 # 2012 - Catalonia Demands Independence
@@ -6080,20 +5461,20 @@ country_event = {
 	title = spain.233.t
 	desc = spain.233.d
 	picture = GFX_2012_catalan_prot
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	# Let Catalonia Go Free
 	option = {
 		name = spain.233.a
 		log = "[GetDateText]: [This.GetName]: spain.233.a executed"
 		custom_effect_tooltip = SPR_catalonia_is_free_tt
-
 		CAT = {
 			transfer_state = 86
 			inherit_technology = FROM
@@ -6102,10 +5483,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		add_stability = 0.05
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Tighten the Grip
@@ -6127,13 +5505,14 @@ country_event = {
 	title = spain.234.t
 	desc = spain.234.d
 	picture = GFX_2012_catalan_prot
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.234.a
@@ -6167,7 +5546,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = 6 }
 		SPR_modify_cultural_opinion = yes
 	}
-
 }
 
 # 2014 - Catalan Way
@@ -6176,13 +5554,14 @@ country_event = {
 	title = spain.235.t
 	desc = spain.235.d
 	picture = GFX_2014_catalan_prot
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.235.a
@@ -6216,7 +5595,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = 6 }
 		SPR_modify_cultural_opinion = yes
 	}
-
 }
 
 # 2014 - Self-Determination Referendum
@@ -6225,13 +5603,14 @@ country_event = {
 	title = spain.236.t
 	desc = spain.236.d
 	picture = GFX_2014_catalan_refer
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	# Referendum
 	option = {
@@ -6273,13 +5652,14 @@ country_event = {
 	title = spain.237.t
 	desc = spain.237.d
 	picture = GFX_2016_catalan_prot
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.237.a
@@ -6313,7 +5693,6 @@ country_event = {
 		set_temp_variable = { cultural_opinion = 6 }
 		SPR_modify_cultural_opinion = yes
 	}
-
 }
 
 # 2017 - Catalonian Decalaration of Independence
@@ -6322,20 +5701,20 @@ country_event = {
 	title = spain.238.t
 	desc = spain.238.d
 	picture = GFX_2017_catalan_refer
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 86
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	# Let Catalonia Go Free
 	option = {
 		name = spain.238.a
 		log = "[GetDateText]: [This.GetName]: spain.238.a executed"
 		custom_effect_tooltip = SPR_catalonia_is_free_tt
-
 		CAT = {
 			transfer_state = 86
 			inherit_technology = SPR
@@ -6344,10 +5723,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		add_stability = 0.05
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Tighten the Grip
@@ -6360,7 +5736,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -10 }
 		SPR_modify_cultural_opinion = yes
-
 		hidden_effect = {
 			country_event = { id = spain.239 days = 4 }
 		}
@@ -6373,13 +5748,14 @@ country_event = {
 	title = spain.239.t
 	desc = spain.239.d
 	picture = GFX_catalan_leader_byebye
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	# Bastard
 	option = {
@@ -6399,13 +5775,14 @@ country_event = {
 	title = spain.240.t
 	desc = spain.240.d
 	picture = GFX_catalan_leaders_trial
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.240.a
@@ -6414,7 +5791,6 @@ country_event = {
 		set_temp_variable = { culture_index = 0 }
 		set_temp_variable = { cultural_opinion = -4 }
 		SPR_modify_cultural_opinion = yes
-
 		hidden_effect = {
 			country_event = { id = spain.241 days = 7 random_days = 14 }
 		}
@@ -6427,13 +5803,14 @@ country_event = {
 	title = spain.241.t
 	desc = spain.241.d
 	picture = GFX_2019_2020_catalan_protests
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
 		NOT = { CAT = { is_subject_of = SPR } }
 		NOT = { has_country_flag = CAT_revolted_against_spain }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.241.a
@@ -6475,6 +5852,8 @@ country_event = {
 	title = spain.242.t
 	desc = spain.242.d
 	picture = GFX_2021_catalan_pardon_monamieletmesuckyour
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 96
@@ -6483,7 +5862,6 @@ country_event = {
 		nationalist_fascists_are_in_power_or_coalition = no
 		nationalist_right_wing_populists_are_in_power_or_coalition = no
 	}
-	is_triggered_only = yes
 
 	# Pardon them
 	option = {
@@ -6501,17 +5879,17 @@ country_event = {
 	title = spain.243.t
 	desc = spain.243.d
 	picture = GFX_const_court_spain
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 95
 	}
-	is_triggered_only = yes
 
 	# Ignore the Courts
 	option = {
 		name = spain.243.a
 		log = "[GetDateText]: [This.GetName]: spain.243.a executed"
-
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = -5 }
 		SPR_modify_cultural_opinion = yes
@@ -6523,17 +5901,13 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Pay Damages to Cubillo
 	option = {
 		name = spain.243.b
 		log = "[GetDateText]: [This.GetName]: spain.243.b executed"
-
 		set_temp_variable = {
 			treasury_change = {
 				value = gdp_total
@@ -6544,12 +5918,8 @@ country_event = {
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # 2012 - Death of Antonio Cubillo
@@ -6558,11 +5928,12 @@ country_event = {
 	title = spain.244.t
 	desc = spain.244.d
 	picture = GFX_death_Antonio_Cubillo
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 95
 	}
-	is_triggered_only = yes
 
 	# Host a State Sponosored Funeral
 	option = {
@@ -6578,21 +5949,14 @@ country_event = {
 		set_temp_variable = { culture_index = 4 }
 		set_temp_variable = { cultural_opinion = 5 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# A Sad Day for the Canary Islands
 	option = {
 		name = spain.244.b
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # 2005 - Metropol Parasol Project
@@ -6602,14 +5966,12 @@ country_event = {
 	desc = spain.245.d
 	picture = GFX_euro_papermoney
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.245.a
 		log = "[GetDateText]: [This.GetName]: spain.245.a executed"
-
 		set_temp_variable = {
 			treasury_change = {
 				value = gdp_total
@@ -6620,26 +5982,19 @@ country_event = {
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = 6 }
 		SPR_modify_cultural_opinion = yes
-
 		set_country_flag = SPR_metropol_parasol_project_money
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = spain.245.b
 		log = "[GetDateText]: [This.GetName]: spain.245.b executed"
-
 		add_political_power = -150
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
 		set_country_flag = SPR_metropol_parasol_project_political
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Do Not Condone this Project
@@ -6647,17 +6002,13 @@ country_event = {
 	option = {
 		name = spain.245.c
 		log = "[GetDateText]: [This.GetName]: spain.245.c executed"
-
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = -3 }
 		SPR_modify_cultural_opinion = yes
 		custom_effect_tooltip = SPR_ignores_the_metropol_parasol_project_tt
 		set_country_flag = SPR_metropol_parasol_project_ignored
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # 2008 - Funding Request for Metropol Parasol Project
@@ -6666,17 +6017,17 @@ country_event = {
 	title = spain.246.t
 	desc = spain.246.d
 	picture = GFX_metropol_parasol_construction
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { has_country_flag = SPR_metropol_parasol_project_ignored }
 	}
-	is_triggered_only = yes
 
 	# Give them the Money
 	option = {
 		name = spain.246.a
 		log = "[GetDateText]: [This.GetName]: spain.245.a executed"
-
 		set_temp_variable = {
 			treasury_change = {
 				value = gdp_total
@@ -6687,27 +6038,19 @@ country_event = {
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = 3 }
 		SPR_modify_cultural_opinion = yes
-
 		modify_country_flag = { flag = SPR_metropol_parasol_project_money value = 2 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# We Are Strapped for Cash
 	option = {
 		name = spain.246.b
 		log = "[GetDateText]: [This.GetName]: spain.246.b executed"
-
 		set_temp_variable = { culture_index = 3 }
 		set_temp_variable = { cultural_opinion = -2 }
 		SPR_modify_cultural_opinion = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # 2009 to 2011 - Completion of the Project
@@ -6716,11 +6059,12 @@ country_event = {
 	title = spain.247.t
 	desc = spain.247.d
 	picture = GFX_metropol_parasol_completed
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { has_country_flag = SPR_metropol_parasol_project_ignored }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.247.a
@@ -6733,9 +6077,7 @@ country_event = {
 		set_country_flag = SPR_metropol_parsol_project_complete
 		clr_country_flag = SPR_metropol_parasol_project_money
 		clr_country_flag = SPR_metropol_parasol_project_political
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -6746,9 +6088,8 @@ country_event = {
 	desc = spain.248.d
 	picture = GFX_FIshing_boat
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Deal
 	option = {
@@ -6787,9 +6128,8 @@ country_event = {
 	desc = spain.253.d
 	picture = GFX_Sagrada_Familia
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	option = {
 		name = spain.253.a
@@ -6814,18 +6154,12 @@ country_event = {
 			modify_treasury_effect = yes
 			add_stability = 0.04
 		}
-
 		custom_effect_tooltip = SPR_sagrada_familia_construction_finishes_sooner_tt
 		set_country_flag = SPR_sagra_familia_additional_funding_flag
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
-	option = {
-		name = spain.253.b
-	}
-
+	option = { name = spain.253.b }
 }
 
 # 2017-2028 - Construction of the Sagrada Famila Completes
@@ -6834,11 +6168,12 @@ country_event = {
 	title = spain.254.t
 	desc = spain.254.d
 	picture = GFX_Sagrada_Familia
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { has_country_flag = SPR_sagrada_familia_complete_flag }
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.253.a
@@ -6856,15 +6191,13 @@ country_event = {
 	desc = spain.255.d
 	picture = GFX_2004_madrid_train_bomb
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Blame the ETA
 	option = {
 		name = spain.255.a
 		log = "[GetDateText]: [This.GetName]: spain.255.a executed"
-
 		# Heavy Penalty to Basque Opinion and minor to others
 		# Reward for Support is MUCH larger in this event
 		random_list = {
@@ -6916,7 +6249,6 @@ country_event = {
 	option = {
 		name = spain.255.b
 		log = "[GetDateText]: [This.GetName]: spain.255.b executed"
-
 		# Reward for Support is MUCH larger in this event
 		random_list = {
 			# Manipulation
@@ -6958,7 +6290,6 @@ country_event = {
 	option = {
 		name = spain.255.c
 		log = "[GetDateText]: [This.GetName]: spain.255.c executed"
-
 		# Some money and political power
 		random_list = {
 			# Medium Popularity loss
@@ -6992,17 +6323,15 @@ country_event = {
 	title = spain.256.t
 	desc = {
 		text = spain.256.d1
-		trigger = {
-			has_country_flag = SPR_mdbombings_weak_government_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_weak_government_case }
 	}
 	desc = {
 		text = spain.256.d2
-		trigger = {
-			has_country_flag = SPR_mdbombings_supportive_government_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_supportive_government_case }
 	}
 	picture = GFX_politics_speak
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		OR = {
@@ -7010,7 +6339,6 @@ country_event = {
 			has_country_flag = SPR_mdbombings_supportive_government_case
 		}
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.256.a
@@ -7027,11 +6355,8 @@ country_event = {
 			change_relative_party_popularity = yes
 			add_stability = 0.05
 		}
-		else = {
-			add_political_power = 100
-		}
+		else = { add_political_power = 100 }
 	}
-
 }
 
 # Blame the ETA/Blame the Terrorists Response
@@ -7059,41 +6384,31 @@ country_event = {
 	}
 	desc = {
 		text = spain.257.d1
-		trigger = {
-			has_country_flag = SPR_mdbombings_eta_worst_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_eta_worst_case }
 	}
 	desc = {
 		text = spain.257.d2
-		trigger = {
-			has_country_flag = SPR_mdbombings_eta_best_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_eta_best_case }
 	}
 	desc = {
 		text = spain.257.d3
-		trigger = {
-			has_country_flag = SPR_mdbombings_eta_whatever_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_eta_whatever_case }
 	}
 	desc = {
 		text = spain.257.d4
-		trigger = {
-			has_country_flag = SPR_mdbombings_islamists_worst_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_islamists_worst_case }
 	}
 	desc = {
 		text = spain.257.d5
-		trigger = {
-			has_country_flag = SPR_mdbombings_islamists_best_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_islamists_best_case }
 	}
 	desc = {
 		text = spain.257.d6
-		trigger = {
-			has_country_flag = SPR_mdbombings_islamists_whatever_case
-		}
+		trigger = { has_country_flag = SPR_mdbombings_islamists_whatever_case }
 	}
 	picture = GFX_jose_speech
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		OR = {
@@ -7105,7 +6420,6 @@ country_event = {
 			has_country_flag = SPR_mdbombings_islamists_whatever_case
 		}
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.257.a
@@ -7146,9 +6460,7 @@ country_event = {
 		else_if = { limit = { has_country_flag = SPR_mdbombings_islamists_whatever_case }
 			add_political_power = -100
 		}
-		else = {
-			add_political_power = 100
-		}
+		else = { add_political_power = 100 }
 	}
 }
 
@@ -7158,11 +6470,12 @@ country_event = {
 	title = spain.258.t
 	desc = spain.258.d
 	picture = GFX_barcelona_terror
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 86
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.258.a
@@ -7172,7 +6485,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = 0.01
 	}
-
 }
 
 # 2017 - Barcelona Terror Attacks
@@ -7181,11 +6493,12 @@ country_event = {
 	title = spain.259.t
 	desc = spain.259.d
 	picture = GFX_barcelona_terror
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		owns_state = 86
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.259.a
@@ -7195,10 +6508,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		add_manpower = -15
 	}
-
 }
 
 # 2021 - Murcia Terror Attack
@@ -7207,13 +6518,14 @@ country_event = {
 	title = spain.260.t
 	desc = spain.260.d
 	picture = GFX_murcia_attack
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { has_government = fascism }
 		neutrality_neutral_muslim_brotherhood_are_in_power = no
 		owns_state = 969
 	}
-	is_triggered_only = yes
 
 	option = {
 		name = spain.260.a
@@ -7223,7 +6535,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		add_manpower = -6
 	}
 }
@@ -7234,22 +6545,21 @@ country_event = {
 	title = spain.261.t
 	desc = spain.261.d
 	picture = GFX_Gibraltar
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { owns_state = 19 }
 	}
-	is_triggered_only = yes
 
 	# Contest the Referendum
 	option = {
 		name = spain.261.a
 		log = "[GetDateText]: [This.GetName]: spain.261.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
 		add_political_power = -150
-
 		# Whomever Owns Gibraltar
 		if = { limit = { ENG = { owns_state = 19 } }
 			ENG = { country_event = { id = spain.262 random_days = 15 } }
@@ -7272,7 +6582,6 @@ country_event = {
 	# Gibnraltar Remains
 	option = {
 		name = spain.261.b
-
 		# Nothing for this option
 		ai_chance = {
 			base = 50
@@ -7291,16 +6600,14 @@ country_event = {
 	title = spain.262.t
 	desc = spain.262.d
 	picture = GFX_politics_protest # TODO: Replace with an image
-	trigger = {
-		owns_state = 19
-	}
 	is_triggered_only = yes
+
+	trigger = { owns_state = 19 }
 
 	# Concede the Rock to Spain
 	option = {
 		name = spain.262.a
 		log = "[GetDateText]: [This.GetName]: spain.262.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
@@ -7310,7 +6617,6 @@ country_event = {
 				transfer_state = 19
 			}
 		}
-
 		hidden_effect = {
 			SPR = {
 				set_country_flag = SPR_conecede_the_rock_referendum_flag
@@ -7330,16 +6636,11 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = spain.262.b
 		log = "[GetDateText]: [This.GetName]: spain.262.b executed"
-
-		effect_tooltip = {
-			SPR = {
-				add_political_power = -25
-			}
-		}
-
+		effect_tooltip = { SPR = { add_political_power = -25 } }
 		hidden_effect = {
 			SPR = {
 				set_country_flag = SPR_declined_the_rock_referendum_flag
@@ -7358,7 +6659,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Returned Response from England
@@ -7366,81 +6666,56 @@ country_event = {
 	id = spain.263
 	title = {
 		text = spain.263.t1
-		trigger = {
-			has_country_flag = SPR_declined_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_declined_the_rock_referendum_flag }
 	}
 	title = {
 		text = spain.263.t2
-		trigger = {
-			has_country_flag = SPR_conecede_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_conecede_the_rock_referendum_flag }
 	}
 	desc = {
 		text = spain.263.d1
-		trigger = {
-			has_country_flag = SPR_declined_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_declined_the_rock_referendum_flag }
 	}
 	desc = {
 		text = spain.263.d2
-		trigger = {
-			has_country_flag = SPR_conecede_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_conecede_the_rock_referendum_flag }
 	}
 	picture = GFX_politics_protest # TODO: Replace with an image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SPR
-	}
+
+	trigger = { original_tag = SPR }
 
 	# Issue a Insult
 	option = {
 		name = spain.263.a
-		trigger = {
-			has_country_flag = SPR_declined_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_declined_the_rock_referendum_flag }
 		log = "[GetDateText]: [This.GetName]: spain.263.a executed"
-
 		set_temp_variable = { percent_change = -2 }
 		set_temp_variable = { tag_index = SPR.id }
 		set_temp_variable = { influence_target = FROM.id }
 		change_influence_percentage = yes
-
 		add_opinion_modifier = { target = FROM modifier = SPR_declined_gibraltar_insult }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# The People Chose Their Path
 	option = {
 		name = spain.263.b
-		trigger = {
-			has_country_flag = SPR_declined_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_declined_the_rock_referendum_flag }
 		log = "[GetDateText]: [This.GetName]: spain.263.b executed"
-
 		add_opinion_modifier = { target = FROM modifier = SPR_declined_gibraltar }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# The Rock Is Ours!
 	option = {
 		name = spain.263.c
-		trigger = {
-			has_country_flag = SPR_conecede_the_rock_referendum_flag
-		}
+		trigger = { has_country_flag = SPR_conecede_the_rock_referendum_flag }
 		log = "[GetDateText]: [This.GetName]: spain.263.c executed"
 		add_state_core = 19
 		transfer_state = 19
 		add_stability = 0.02
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7450,6 +6725,8 @@ country_event = {
 	title = spain.264.t
 	desc = spain.264.d
 	picture = GFX_spain_throne # TODO: Replace with better image
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { # General conditionals to use any of these leaders in this group
@@ -7459,7 +6736,6 @@ country_event = {
 			}
 		}
 	}
-	is_triggered_only = yes
 
 	# Strip her of titles
 	option = {
@@ -7490,6 +6766,8 @@ country_event = {
 	title = spain.265.t
 	desc = spain.265.d
 	picture = GFX_spain_throne # TODO: Replace with better image
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { # General conditionals to use any of these leaders in this group
@@ -7499,7 +6777,6 @@ country_event = {
 			}
 		}
 	}
-	is_triggered_only = yes
 
 	# Unfortunate
 	option = {
@@ -7526,6 +6803,8 @@ country_event = {
 	title = spain.266.t
 	desc = spain.266.d
 	picture = GFX_spain_throne # TODO: Replace with better image
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		NOT = { has_government = nationalist }
@@ -7533,7 +6812,6 @@ country_event = {
 		owns_state = 495
 		owns_state = 632
 	}
-	is_triggered_only = yes
 
 	# Visit the Cities
 	option = {
@@ -7542,7 +6820,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		MOR = {
 			add_opinion_modifier = { target = SPR modifier = SPR_visited_ceuta }
 			country_event = { id = spain.267 days = 7 }
@@ -7559,7 +6836,6 @@ country_event = {
 	# Do not visit the Cities
 	option = {
 		name = spain.266.b
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -7576,6 +6852,8 @@ country_event = {
 	title = spain.267.t
 	desc = spain.267.d
 	picture = GFX_spain_throne # TODO: Replace with better image
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = MOR
 		SPR = {
@@ -7585,7 +6863,6 @@ country_event = {
 			owns_state = 632
 		}
 	}
-	is_triggered_only = yes
 
 	# Disavow the Visit
 	option = {
@@ -7595,15 +6872,11 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# It is their city...
@@ -7614,15 +6887,11 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-
 		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -7632,9 +6901,7 @@ country_event = {
 	title = spain.500.t
 	desc = {
 		text = spain.500.d
-		trigger = {
-			check_variable = { largest_party = 1 }
-		}
+		trigger = { check_variable = { largest_party = 1 } }
 	}
 	desc = {
 		text = spain.500.d3
@@ -7659,11 +6926,13 @@ country_event = {
 	}
 	picture = GFX_election_day
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = SPR
 		has_country_flag = generic_election_killswitch
 		has_country_flag = SPR_initial_election_flag
 	}
+
 	immediate = {
 		set_variable = { largest_party = -1 }
 		find_highest_in_array = {
@@ -7674,14 +6943,11 @@ country_event = {
 		# Value
 		set_variable = { largest_party = index }
 		set_variable = { largest_party_val = value }
-
 		log = "Largest Party: [?largest_party] and Largest Party Value: [?largest_party_val]"
-
 		# Checks if the United Left / PSOE are in coalition
 		if = { limit = { has_country_flag = SPR_psoe_united_coalition }
 			set_variable = { psoe_united_left = party_pop_array^3 }
 			add_to_variable = { psoe_united_left = party_pop_array^5 }
-
 			if = {
 				limit = {
 					check_variable = {
@@ -7702,10 +6968,8 @@ country_event = {
 			check_variable = { largest_party = 1 }
 		}
 		log = "[GetDateText]: [This.GetName]: spain.500.a executed"
-
 		add_political_power = 100
 		add_stability = 0.05
-
 		# Clearing Shit
 		clear_variable = largest_party
 		clear_variable = largest_party_val
@@ -7713,6 +6977,7 @@ country_event = {
 		clr_country_flag = SPR_psoe_united_coalition
 		clr_country_flag = SPR_initial_election_flag
 	}
+
 	option = {
 		name = spain.500.b
 		log = "[GetDateText]: [This.GetName]: spain.500.b executed"
@@ -7720,12 +6985,10 @@ country_event = {
 			NOT = { check_variable = { largest_party = 1 } }
 			NOT = { check_variable = { largest_party = 3 } }
 		}
-
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = largest_party }
 			change_ruling_party_effect = yes
 		}
-
 		# Clearing Shit
 		clear_variable = largest_party
 		clear_variable = largest_party_val
@@ -7733,13 +6996,13 @@ country_event = {
 		clr_country_flag = SPR_psoe_united_coalition
 		clr_country_flag = SPR_initial_election_flag
 	}
+
 	option = {
 		name = spain.500.c
 		log = "[GetDateText]: [This.GetName]: spain.500.c executed"
 		trigger = {
 			check_variable = { largest_party = 3 }
 		}
-
 		if = { limit = { has_country_flag = SPR_psoe_united_coalition }
 			hidden_effect = {
 				set_temp_variable = { rul_party_temp = 3 }
@@ -7753,7 +7016,6 @@ country_event = {
 				change_ruling_party_effect = yes
 			}
 		}
-
 		# Clearing Shit
 		clear_variable = largest_party
 		clear_variable = largest_party_val
@@ -7768,18 +7030,18 @@ country_event = {
 	id = spain.501
 	title = spain.501.t
 	desc = spain.501.d
+	picture = GFX_election_day
+	is_triggered_only = yes
+
 	trigger = {
 		tag = SPR
 		date < 2001.1.1
 	}
-	picture = GFX_election_day
-	is_triggered_only = yes
 
 	# Sign the Pre-Elect Pact
 	option = {
 		name = spain.501.a
 		log = "[GetDateText]: [This.GetName]: spain.501.b executed"
-
 		# PSOE Loses Support
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = -0.02 }
@@ -7794,7 +7056,6 @@ country_event = {
 		# Reactionries Gain Support
 		set_temp_variable = { party_index = 6 }
 		change_relative_party_popularity = yes
-
 		custom_effect_tooltip = SPR_psoe_united_coalition_forms_coalition
 		set_country_flag = SPR_psoe_united_coalition
 	}
@@ -7803,7 +7064,6 @@ country_event = {
 	option = {
 		name = spain.501.b
 		log = "[GetDateText]: [This.GetName]: spain.501.b executed"
-
 		# PSOE Gains Support
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.03 }

--- a/events/War.txt
+++ b/events/War.txt
@@ -7,8 +7,9 @@ add_namespace = anti_bully
 #Used just to trigger event 2, event 1 does not seem to work immediately via on action
 country_event = {
 	id = anti_bully.1
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
+
 	immediate = {
 		country_event = { id = anti_bully.2 days = 1 }
 	}
@@ -21,11 +22,9 @@ country_event = {
 	desc = anti_bully.2.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-	trigger = {
-		THIS = {
-			has_offensive_war_with = event_target:AB_DEFF
-		}
-	}
+
+	trigger = { THIS = { has_offensive_war_with = event_target:AB_DEFF } }
+
 	immediate = {
 		hidden_effect = {
 			if = { limit = { check_variable = { anti_bully_wars = 0 } } #Has 0 AB wars
@@ -44,28 +43,25 @@ country_event = {
 			}
 		}
 	}
-	option = {
-		name = anti_bully.2.a
-	}
+
+	option = { name = anti_bully.2.a }
 }
 
 country_event = {
 	id = anti_bully.3
-	hidden = yes
 	is_triggered_only = yes
-	immediate = {
-		AB_war_main = yes
-	}
+	hidden = yes
+
+	immediate = { AB_war_main = yes }
 }
 
 #Attacker offers white peace
 country_event = {
 	id = anti_bully.4
-	hidden = yes
 	is_triggered_only = yes
-	immediate = {
-		AB_war_second = yes
-	}
+	hidden = yes
+
+	immediate = { AB_war_second = yes }
 }
 
 #Civil war debuff improvements
@@ -74,11 +70,9 @@ country_event = {
 	title = civil_war_debuff.1.t
 	desc = civil_war_debuff.1.d
 	picture = GFX_treaty_rejected
-
-	trigger = {
-		NOT = { has_country_flag = manual_civil_war_debuff_removal }
-	}
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = manual_civil_war_debuff_removal } }
 
 	option = {
 		name = civil_war_debuff.1.a
@@ -88,6 +82,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.1.b
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.1.b"
@@ -96,6 +91,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.1.c
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.1.c"
@@ -110,11 +106,9 @@ country_event = {
 	title = civil_war_debuff.2.t
 	desc = civil_war_debuff.2.d
 	picture = GFX_treaty_rejected
-
-	trigger = {
-		NOT = { has_country_flag = manual_civil_war_debuff_removal }
-	}
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = manual_civil_war_debuff_removal } }
 
 	option = {
 		name = civil_war_debuff.2.a
@@ -124,6 +118,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.2.b
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.2.b"
@@ -132,6 +127,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.2.c
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.2.c"
@@ -146,11 +142,9 @@ country_event = {
 	title = civil_war_debuff.3.t
 	desc = civil_war_debuff.3.d
 	picture = GFX_treaty_rejected
-
-	trigger = {
-		NOT = { has_country_flag = manual_civil_war_debuff_removal }
-	}
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = manual_civil_war_debuff_removal } }
 
 	option = {
 		name = civil_war_debuff.3.a
@@ -160,6 +154,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.3.b
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.3.b"
@@ -168,6 +163,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.3.c
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.3.c"
@@ -182,11 +178,9 @@ country_event = {
 	title = civil_war_debuff.4.t
 	desc = civil_war_debuff.4.d
 	picture = GFX_treaty_rejected
-
-	trigger = {
-		NOT = { has_country_flag = manual_civil_war_debuff_removal }
-	}
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = manual_civil_war_debuff_removal } }
 
 	option = {
 		name = civil_war_debuff.4.a
@@ -196,6 +190,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.4.b
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.4.b"
@@ -204,6 +199,7 @@ country_event = {
 			days = 150
 		}
 	}
+
 	option = {
 		name = civil_war_debuff.4.c
 		log = "[GetDateText]: [This.GetName]: civil_war_debuff.4.c"
@@ -218,28 +214,21 @@ country_event = {
 	title = civil_war_debuff.5.t
 	desc = civil_war_debuff.5.d
 	picture = GFX_Military_Reform
-
-	trigger = {
-		NOT = { has_country_flag = manual_civil_war_debuff_removal }
-	}
 	is_triggered_only = yes
 
-	option = {
-		name = civil_war_debuff.5.a
-	}
+	trigger = { NOT = { has_country_flag = manual_civil_war_debuff_removal } }
+
+	option = { name = civil_war_debuff.5.a }
 }
 
 country_event = {
 	id = god_of_war_event.1
 	title = god_of_war_event.1.t
 	desc = god_of_war_event.1.d
-
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
-	option = {
-		name = god_of_war_event.1.a
-	}
+	option = { name = god_of_war_event.1.a }
 
 	option = {
 		name = god_of_war_event.1.b
@@ -273,7 +262,6 @@ country_event = {
 	id = world_war.1
 	title = world_war.1.t
 	desc = world_war.1.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
@@ -290,7 +278,6 @@ country_event = {
 	id = world_war.2
 	title = world_war.2.t
 	desc = world_war.2.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -320,9 +307,7 @@ country_event = {
 			if = {
 				limit = {
 					country_exists = KOR
-					KOR = {
-						is_subject = no
-					}
+					KOR = { is_subject = no }
 					NKO = {
 						OR = {
 							is_subject = no
@@ -339,9 +324,7 @@ country_event = {
 				if = {
 					limit = {
 						country_exists = SOV
-						NOT = {
-							has_global_flag = world_war_russia_start
-						}
+						NOT = { has_global_flag = world_war_russia_start }
 					}
 					SOV = {
 						country_event = {
@@ -352,16 +335,12 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.2.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -369,7 +348,6 @@ country_event = {
 	id = world_war.4
 	title = world_war.4.t
 	desc = world_war.4.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -387,21 +365,13 @@ country_event = {
 			target = KOR
 			type = annex_everything
 		}
-		hidden_effect = {
-			JAP = {
-				country_event = world_war.6
-			}
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { JAP = { country_event = world_war.6 } }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.4.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -409,7 +379,6 @@ country_event = {
 	id = world_war.6
 	title = world_war.6.t
 	desc = world_war.6.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -431,19 +400,13 @@ country_event = {
 			target = CHI
 			type = topple_government
 		}
-		hidden_effect = {
-			news_event = world_war.5
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { news_event = world_war.5 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.6.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -451,7 +414,6 @@ country_event = {
 	id = world_war.7
 	title = world_war.7.t
 	desc = world_war.7.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -469,19 +431,13 @@ country_event = {
 			target = SOV
 			type = topple_government
 		}
-		hidden_effect = {
-			news_event = world_war.8
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { news_event = world_war.8 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.7.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -489,7 +445,6 @@ country_event = {
 	id = world_war.9
 	title = world_war.9.t
 	desc = world_war.9.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -515,11 +470,7 @@ country_event = {
 				}
 			}
 			if = {
-				limit = {
-					NOT = {
-						has_global_flag = world_war_china_start
-					}
-				}
+				limit = { NOT = { has_global_flag = world_war_china_start } }
 				CHI = {
 					country_event = {
 						id = world_war.12
@@ -528,16 +479,12 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.9.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -545,7 +492,6 @@ country_event = {
 	id = world_war.11
 	title = world_war.11.t
 	desc = world_war.11.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -560,27 +506,19 @@ country_event = {
 		name = world_war.11.a
 		log = "[GetDateText]: [This.GetName]: world_war.11.a executed"
 		every_country = {
-			limit = {
-				has_idea = faction_resistance_axis_member
-			}
+			limit = { has_idea = faction_resistance_axis_member }
 			declare_war_on = {
 				target = ISR
 				type = topple_government
 			}
 		}
-		hidden_effect = {
-			news_event = world_war.10
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { news_event = world_war.10 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.11.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -605,16 +543,12 @@ country_event = {
 			target = TAI
 			type = topple_government
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = world_war.12.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -625,46 +559,42 @@ news_event = {
 	id = world_war.3
 	title = world_war.3.t
 	desc = world_war.3.d
-	major = yes
-	is_triggered_only = yes
 	picture = GFX_united_states_army
-	option = {
-		name = world_war.3.a
-	}
+	is_triggered_only = yes
+	major = yes
+
+	option = { name = world_war.3.a }
 }
 
 news_event = {
 	id = world_war.5
 	title = world_war.5.t
 	desc = world_war.5.d
-	major = yes
-	is_triggered_only = yes
 	picture = GFX_CHI_chinese_soldiers_news
-	option = {
-		name = world_war.5.a
-	}
+	is_triggered_only = yes
+	major = yes
+
+	option = { name = world_war.5.a }
 }
 
 news_event = {
 	id = world_war.8
 	title = world_war.8.t
 	desc = world_war.8.d
-	major = yes
-	is_triggered_only = yes
 	picture = GFX_sov_nationalist_news14
-	option = {
-		name = world_war.8.a
-	}
+	is_triggered_only = yes
+	major = yes
+
+	option = { name = world_war.8.a }
 }
 
 news_event = {
 	id = world_war.10
 	title = world_war.10.t
 	desc = world_war.10.d
-	major = yes
-	is_triggered_only = yes
 	picture = GFX_civil_war_world
-	option = {
-		name = world_war.10.a
-	}
+	is_triggered_only = yes
+	major = yes
+
+	option = { name = world_war.10.a }
 }


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,633 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.