### PR TITLE
Standardize event files — batch 08/14

### DIFF
--- a/events/Global Reactions.txt
+++ b/events/Global Reactions.txt
@@ -7,6 +7,7 @@ country_event = {
 	desc = SOV_Global.2.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.2.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.2.a executed"
@@ -16,15 +17,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = SOV_Global.2.b
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 #Turkey when Russia Attack Azer Reaction and Armenia Join
@@ -34,6 +32,7 @@ country_event = {
 	desc = SOV_Global.3.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.3.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.3.a executed"
@@ -41,7 +40,7 @@ country_event = {
 			is_neighbor_of = SOV
 			TUR = {
 				is_subject = no
-				NOT = {	has_idea = NATO_member	}
+				NOT = { has_idea = NATO_member }
 			}
 		}
 		declare_war_on = {
@@ -50,19 +49,18 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
+
 	option = {
 		name = SOV_Global.3.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.3.b executed"
 		trigger = {
 			country_exists = ARM
-			TUR = { NOT = {	has_idea = NATO_member	} }
+			TUR = { NOT = { has_idea = NATO_member } }
 			ARM = {
 				is_subject = no
-				NOT = {	is_in_faction = yes	}
+				NOT = { is_in_faction = yes }
 			}
 		}
 		declare_war_on = {
@@ -71,10 +69,9 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
+
 	option = {
 		name = SOV_Global.3.c
 		log = "[GetDateText]: [This.GetName]: SOV_Global.3.c executed"
@@ -106,10 +103,9 @@ country_event = {
 				value = 45
 			}
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
+
 	option = {
 		name = SOV_Global.3.f
 		log = "[GetDateText]: [This.GetName]: SOV_Global.3.f executed"
@@ -123,9 +119,7 @@ country_event = {
 				modifier = recent_actions_negative
 			}
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 #Iran when Russia Attack Azer Reaction
@@ -135,6 +129,7 @@ country_event = {
 	desc = SOV_Global.4.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.4.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.4.a executed"
@@ -144,15 +139,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = SOV_Global.4.b
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 }
 #Baltic when Russia Attack Belarus Reaction
@@ -162,15 +154,14 @@ country_event = {
 	desc = SOV_Global.5.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.5.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.5.a executed"
 		add_ideas = Baltic_defence_prepare_anti_sov
 		SOV = { country_event = SOV_Global.6 }
 		if = {
-			limit = {
-				original_tag = EST
-			}
+			limit = { original_tag = EST }
 			diplomatic_relation = {
 				country = LIT
 				relation = guarantee
@@ -181,9 +172,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = LIT
-			}
+			limit = { original_tag = LIT }
 			diplomatic_relation = {
 				country = LAT
 				relation = guarantee
@@ -194,9 +183,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = LAT
-			}
+			limit = { original_tag = LAT }
 			diplomatic_relation = {
 				country = LIT
 				relation = guarantee
@@ -221,10 +208,9 @@ country_event = {
 			id = "SOV"
 			value = 45
 		}
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = SOV_Global.5.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.5.b executed"
@@ -238,9 +224,7 @@ country_event = {
 				modifier = recent_actions_positive
 			}
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 #Ukraine when Russia Attack Belarus Reaction
@@ -250,6 +234,7 @@ country_event = {
 	desc = SOV_Global.17.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.17.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.17.a executed"
@@ -270,10 +255,9 @@ country_event = {
 			id = "SOV"
 			value = 45
 		}
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = SOV_Global.17.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.17.b executed"
@@ -287,9 +271,7 @@ country_event = {
 				modifier = recent_actions_positive
 			}
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 #Russia reaction about Baltic Defence
@@ -299,9 +281,8 @@ country_event = {
 	desc = SOV_Global.6.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-	option = {
-		name = SOV_Global.6.a
-	}
+
+	option = { name = SOV_Global.6.a }
 }
 #Kyrgyzstan when Russia Attack Tajikistan Reaction
 country_event = {
@@ -310,6 +291,7 @@ country_event = {
 	desc = SOV_Global.7.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.7.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.7.a executed"
@@ -319,15 +301,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = SOV_Global.7.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Tajikistan when Russia Attack Kyrgyzstan Reaction
@@ -337,6 +316,7 @@ country_event = {
 	desc = SOV_Global.8.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.8.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.8.a executed"
@@ -346,15 +326,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = SOV_Global.8.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Iran when Russia Attack Turkmenia Reaction
@@ -364,6 +341,7 @@ country_event = {
 	desc = SOV_Global.9.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.9.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.9.a executed"
@@ -373,15 +351,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = SOV_Global.9.b
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 }
 #Belarus Poznyak when Russia Attack Lithinia Reaction
@@ -391,6 +366,7 @@ country_event = {
 	desc = SOV_Global.10.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.10.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.10.a executed"
@@ -400,15 +376,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = SOV_Global.10.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Kyrgyzstan  when Russia Attack Uzbekistan Reaction
@@ -418,6 +391,7 @@ country_event = {
 	desc = SOV_Global.11.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.11.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.11.a executed"
@@ -427,15 +401,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = SOV_Global.11.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Iran when Russia Attack Uzbekistan Reaction
@@ -445,6 +416,7 @@ country_event = {
 	desc = SOV_Global.12.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.3.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.3.a executed"
@@ -476,15 +448,12 @@ country_event = {
 				value = 25
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = SOV_Global.12.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Turkey when Russia Attack Uzbekistan Reaction
@@ -494,6 +463,7 @@ country_event = {
 	desc = SOV_Global.13.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.13.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.13.a executed"
@@ -525,15 +495,12 @@ country_event = {
 				value = 25
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = SOV_Global.13.b
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Baltic when Russia Take wargoal Focus on them
@@ -543,15 +510,14 @@ country_event = {
 	desc = SOV_Global.14.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.14.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.14.a executed"
 		add_ideas = Baltic_defence_prepare_anti_sov
 		SOV = { country_event = SOV_Global.6 }
 		if = {
-			limit = {
-				original_tag = EST
-			}
+			limit = { original_tag = EST }
 			diplomatic_relation = {
 				country = LIT
 				relation = guarantee
@@ -562,9 +528,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = LIT
-			}
+			limit = { original_tag = LIT }
 			diplomatic_relation = {
 				country = LAT
 				relation = guarantee
@@ -575,9 +539,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = LAT
-			}
+			limit = { original_tag = LAT }
 			diplomatic_relation = {
 				country = LIT
 				relation = guarantee
@@ -602,10 +564,9 @@ country_event = {
 			id = "SOV"
 			value = 45
 		}
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = SOV_Global.14.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.14.b executed"
@@ -619,9 +580,7 @@ country_event = {
 				modifier = recent_actions_positive
 			}
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 #Belarus when Russia attack Ukraine
@@ -631,6 +590,7 @@ country_event = {
 	desc = SOV_Global.15.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.15.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.15.a executed"
@@ -651,16 +611,12 @@ country_event = {
 			id = "SOV"
 			value = 45
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
+
 	option = {
 		name = SOV_Global.15.b
-
-		ai_chance = {
-			base = 40
-		}
+		ai_chance = { base = 40 }
 	}
 }
 #Russia reaction about Baltic Defence
@@ -670,9 +626,8 @@ country_event = {
 	desc = SOV_Global.16.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-	option = {
-		name = SOV_Global.16.a
-	}
+
+	option = { name = SOV_Global.16.a }
 }
 
 #Belarus Try to attack Ukraine when she loose
@@ -682,6 +637,7 @@ country_event = {
 	desc = SOV_Global.19.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = SOV_Global.19.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.19.a executed"
@@ -706,15 +662,12 @@ country_event = {
 		}
 		add_political_power = -100
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
+
 	option = {
 		name = SOV_Global.19.b
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 }
 
@@ -724,15 +677,13 @@ country_event = {
 	id = SOV_Global.18
 	title = SOV_Global.18.t
 	desc = SOV_Global.18.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.18.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.18.a executed"
-		hidden_effect = {
-			GLOBAL_russian_create_georgia_revoult_script = yes
-		}
+		hidden_effect = { GLOBAL_russian_create_georgia_revoult_script = yes }
 		add_opinion_modifier = { target = SOV modifier = supports_rival }
 		reverse_add_opinion_modifier = { target = SOV modifier = supports_rival }
 	}
@@ -742,25 +693,22 @@ country_event = {
 	id = SOV_Global.20
 	title = SOV_Global.20.t
 	desc = SOV_Global.20.d
-	is_triggered_only = yes
 	picture = GFX_aze_georgia
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.20.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.20.a executed"
 		AZE = { country_event = SOV_Global.21 }
 		give_guarantee = AZE
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = SOV_Global.20.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.20.b executed"
 		AZE = { country_event = SOV_Global.22 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 #Azer try create faction against Armenia - Georgia Agree
@@ -768,8 +716,8 @@ country_event = {
 	id = SOV_Global.21
 	title = SOV_Global.21.t
 	desc = SOV_Global.21.d
-	is_triggered_only = yes
 	picture = GFX_aze_georgia
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.21.a
@@ -789,41 +737,33 @@ country_event = {
 	id = SOV_Global.22
 	title = SOV_Global.22.t
 	desc = SOV_Global.22.d
-	is_triggered_only = yes
 	picture = GFX_aze_georgia
+	is_triggered_only = yes
 
-	option = {
-		name = SOV_Global.22.a
-	}
+	option = { name = SOV_Global.22.a }
 }
 #Azer try create faction against Armenia - Message to Armenia
 country_event = {
 	id = SOV_Global.23
 	title = SOV_Global.23.t
 	desc = SOV_Global.23.d
-	is_triggered_only = yes
 	picture = GFX_aze_georgia
+	is_triggered_only = yes
 
-	option = {
-		name = SOV_Global.23.a
-	}
+	option = { name = SOV_Global.23.a }
 }
 #Georgian Revoult Russians Create again
 country_event = {
 	id = SOV_Global.24
 	title = SOV_Global.24.t
 	desc = SOV_Global.24.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.24.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.24.a executed"
-		707 = {
-			add_dynamic_modifier = {
-				modifier = GLOBAL_geo_resistance_modifier
-			}
-		}
+		707 = { add_dynamic_modifier = { modifier = GLOBAL_geo_resistance_modifier } }
 		set_country_flag = GLOBAL_arm_geo_resistance
 		hidden_effect = {
 			set_temp_variable = { percent_change = 3 }
@@ -842,17 +782,13 @@ country_event = {
 	id = SOV_Global.25
 	title = SOV_Global.25.t
 	desc = SOV_Global.25.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.25.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.25.a executed"
-		713 = {
-			add_dynamic_modifier = {
-				modifier = GLOBAL_azer_resistance_modifier
-			}
-		}
+		713 = { add_dynamic_modifier = { modifier = GLOBAL_azer_resistance_modifier } }
 		set_country_flag = GLOBAL_arm_aze_resistance
 		hidden_effect = {
 			set_temp_variable = { percent_change = 3 }
@@ -871,15 +807,13 @@ country_event = {
 	id = SOV_Global.26
 	title = SOV_Global.26.t
 	desc = SOV_Global.26.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.26.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.26.a executed"
-		hidden_effect = {
-			GLOBAL_russian_create_azer_revoult_script = yes
-		}
+		hidden_effect = { GLOBAL_russian_create_azer_revoult_script = yes }
 		add_opinion_modifier = { target = SOV modifier = supports_rival }
 		reverse_add_opinion_modifier = { target = SOV modifier = supports_rival }
 	}
@@ -890,17 +824,13 @@ country_event = {
 	id = SOV_Global.27
 	title = SOV_Global.27.t
 	desc = SOV_Global.27.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.27.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.27.a executed"
-		706 = {
-			add_dynamic_modifier = {
-				modifier = GLOBAL_abk_resistance_modifier
-			}
-		}
+		706 = { add_dynamic_modifier = { modifier = GLOBAL_abk_resistance_modifier } }
 		set_country_flag = GLOBAL_arm_abk_resistance
 		hidden_effect = {
 			set_temp_variable = { percent_change = 3 }
@@ -919,15 +849,13 @@ country_event = {
 	id = SOV_Global.28
 	title = SOV_Global.28.t
 	desc = SOV_Global.28.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.28.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.28.a executed"
-		hidden_effect = {
-			GLOBAL_russian_create_abk_revoult_script = yes
-		}
+		hidden_effect = { GLOBAL_russian_create_abk_revoult_script = yes }
 		add_opinion_modifier = { target = SOV modifier = supports_rival }
 		reverse_add_opinion_modifier = { target = SOV modifier = supports_rival }
 	}
@@ -937,15 +865,13 @@ country_event = {
 	id = SOV_Global.29
 	title = SOV_Global.29.t
 	desc = SOV_Global.29.d
-	is_triggered_only = yes
 	picture = GFX_armenian_fight
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.29.a
 		log = "[GetDateText]: [This.GetName]: SOV_Global.29.a executed"
-		hidden_effect = {
-			GLOBAL_turkey_create_adj_revoult_script = yes
-		}
+		hidden_effect = { GLOBAL_turkey_create_adj_revoult_script = yes }
 		add_opinion_modifier = { target = TUR modifier = supports_rival }
 		reverse_add_opinion_modifier = { target = TUR modifier = supports_rival }
 	}
@@ -955,8 +881,8 @@ country_event = {
 	id = SOV_Global.30
 	title = SOV_Global.30.t
 	desc = SOV_Global.30.d
-	is_triggered_only = yes
 	picture = GFX_TUR_attack_PKK
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.30.a
@@ -967,17 +893,14 @@ country_event = {
 		set_temp_variable = { tag_index = TUR }
 		set_temp_variable = { influence_target = ADJ }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = SOV_Global.30.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.30.b executed"
 		TUR = { country_event = SOV_Global.32 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Turkey Send Advisors to - Agree
@@ -985,8 +908,8 @@ country_event = {
 	id = SOV_Global.31
 	title = SOV_Global.31.t
 	desc = SOV_Global.31.d
-	is_triggered_only = yes
 	picture = GFX_TUR_attack_PKK
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.31.a
@@ -1004,21 +927,18 @@ country_event = {
 	id = SOV_Global.32
 	title = SOV_Global.32.t
 	desc = SOV_Global.32.d
-	is_triggered_only = yes
 	picture = GFX_TUR_attack_PKK
+	is_triggered_only = yes
 
-	option = {
-		name = SOV_Global.32.a
-
-	}
+	option = { name = SOV_Global.32.a }
 }
 #Putin Start Pro-Russian Rebellion in Armenia
 country_event = {
 	id = SOV_Global.33
 	title = SOV_Global.33.t
 	desc = SOV_Global.33.d
-	is_triggered_only = yes
 	picture = GFX_SOV_generic
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.33.a
@@ -1083,13 +1003,11 @@ country_event = {
 					the_clergy
 					officer_military_school
 					nuclear_energy
-
 					# Armenian Unique
 					armenian_perseverance
 					ARM_victory_karabakh
 					ARM_corrupt_military
 					ARM_102st_base
-
 				}
 				add_dynamic_modifier = { modifier = ARM_landforce_modifier }
 				add_dynamic_modifier = { modifier = ARM_airforce_modifier }
@@ -1122,8 +1040,8 @@ country_event = {
 	id = SOV_Global.34
 	title = SOV_Global.34.t
 	desc = SOV_Global.34.d
-	is_triggered_only = yes
 	picture = GFX_armaze_negot
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.34.a
@@ -1141,6 +1059,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SOV_Global.34.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.34.b executed"
@@ -1162,12 +1081,10 @@ country_event = {
 	id = SOV_Global.35
 	title = SOV_Global.35.t
 	desc = SOV_Global.35.d
-	is_triggered_only = yes
 	picture = GFX_armaze_negot
+	is_triggered_only = yes
 
-	option = {
-		name = SOV_Global.35.a
-	}
+	option = { name = SOV_Global.35.a }
 }
 
 #Armenia Demand Nakhichevan - Disagree
@@ -1175,8 +1092,8 @@ country_event = {
 	id = SOV_Global.36
 	title = SOV_Global.36.t
 	desc = SOV_Global.36.d
-	is_triggered_only = yes
 	picture = GFX_armaze_negot
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.36.a
@@ -1195,8 +1112,8 @@ country_event = {
 	id = SOV_Global.37
 	title = SOV_Global.37.t
 	desc = SOV_Global.37.d
-	is_triggered_only = yes
 	picture = GFX_raiding_pkk
+	is_triggered_only = yes
 
 	option = {
 		name = SOV_Global.37.a
@@ -1211,13 +1128,10 @@ country_event = {
 				modifier = strategic_rivals
 			}
 		}
-		trigger = {
-			tag = AZE
-		}
-		ai_chance = {
-			base = 1
-		}
+		trigger = { tag = AZE }
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = SOV_Global.37.b
 		log = "[GetDateText]: [This.GetName]: SOV_Global.37.b executed"
@@ -1231,9 +1145,7 @@ country_event = {
 				modifier = strategic_rivals
 			}
 		}
-		trigger = {
-			tag = ARM
-		}
+		trigger = { tag = ARM }
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -1245,12 +1157,11 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SOV_Global.37.c
 		log = "[GetDateText]: [This.GetName]: SOV_Global.37.c executed"
-		trigger = {
-			tag = ARM
-		}
+		trigger = { tag = ARM }
 		add_opinion_modifier = {
 			target = TUR
 			modifier = strategic_rivals

--- a/events/Haiti.txt
+++ b/events/Haiti.txt
@@ -7,18 +7,15 @@ country_event = {
 	desc = haiti.1.d
 	picture = GFX_election_day
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
+
+	trigger = { original_tag = HAI }
 
 	# Sore Losers!
 	option = {
 		name = haiti.1.a
 		log = "[GetDateText]: [This.GetName]: haiti.1.a executed"
 		country_event = { id = haiti.2 days = 5 random_days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Recount the Votes
@@ -26,9 +23,7 @@ country_event = {
 		name = haiti.1.b
 		log = "[GetDateText]: [This.GetName]: haiti.1.b executed"
 		country_event = { id = haiti.3 days = 5 random_days = 7 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -39,9 +34,8 @@ country_event = {
 	desc = haiti.2.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
+
+	trigger = { original_tag = HAI }
 
 	# Absolutely Sore Losers! (Not nice, - DROID)
 	option = {
@@ -51,11 +45,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.06 }
 		set_temp_variable = { temp_outlook_increase = 0.06 }
 		change_relative_party_popularity = yes
-
 		set_country_flag = HAI_opposition_boycotts_the_election
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -66,9 +57,8 @@ country_event = {
 	desc = haiti.3.d
 	picture = GFX_politics_negotiations
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
+
+	trigger = { original_tag = HAI }
 
 	# A Fair & Free Election
 	option = {
@@ -78,10 +68,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.06 }
 		set_temp_variable = { temp_outlook_increase = 0.06 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -92,12 +79,10 @@ country_event = {
 	desc = haiti.4.d
 	picture = GFX_election_day
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
-	immediate = {
-		clr_country_flag = generic_election_killswitch
-	}
+
+	trigger = { original_tag = HAI }
+
+	immediate = { clr_country_flag = generic_election_killswitch }
 
 	# Arisitide
 	option = {
@@ -112,30 +97,20 @@ country_event = {
 			ruling_party = democratic
 			elections_allowed = yes
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Other
 	option = {
 		name = haiti.4.b
 		log = "[GetDateText]: [This.GetName]: haiti.4.b executed"
-		trigger = {
-			NOT = { has_country_flag = HAI_opposition_boycotts_the_election }
-		}
-
+		trigger = { NOT = { has_country_flag = HAI_opposition_boycotts_the_election } }
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = 18 }
 			change_ruling_party_effect = yes
-
 			add_popularity = { ideology = neutrality popularity = 0.15 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -147,6 +122,7 @@ country_event = {
 	desc = haiti.5.d
 	picture = GFX_haitian_student_protests
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -158,10 +134,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: haiti.5.a executed"
 		add_political_power = -50
 		add_stability = 0.03
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Quell the Protests
@@ -169,10 +142,7 @@ country_event = {
 		name = haiti.5.b
 		log = "[GetDateText]: [This.GetName]: haiti.5.b executed"
 		add_stability = -0.03
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -184,6 +154,7 @@ country_event = {
 	desc = haiti.6.d
 	picture = GFX_haitian_student_protests
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -195,10 +166,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: haiti.6.a executed"
 		add_political_power = -50
 		add_stability = 0.03
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Quell the Protests
@@ -206,10 +174,7 @@ country_event = {
 		name = haiti.6.b
 		log = "[GetDateText]: [This.GetName]: haiti.6.b executed"
 		add_stability = -0.03
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -221,6 +186,7 @@ country_event = {
 	desc = haiti.7.d
 	picture = GFX_jean_bertrand_aristride
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -233,17 +199,13 @@ country_event = {
 		reverse_add_opinion_modifier = { target = FRA modifier = FRA_haiti_demands_reparations_opinion }
 		FRA = { country_event = { id = haiti.8 days = 3 } }
 		set_country_flag = HAI_demands_french_reparations
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Don't Pursue the Reparations
 	option = {
 		name = haiti.7.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -254,18 +216,15 @@ country_event = {
 	desc = haiti.17.d
 	picture = GFX_tropical_flight_way
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
+
+	trigger = { original_tag = HAI }
 
 	# Truly a Tragedy
 	option = {
 		name = haiti.17.a
 		log = "[GetDateText]: [This.GetName]: haiti.17.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -276,9 +235,8 @@ country_event = {
 	desc = haiti.8.d
 	picture = GFX_united_states_dollar
 	is_triggered_only = yes
-	trigger = {
-		original_tag = FRA
-	}
+
+	trigger = { original_tag = FRA }
 
 	# Pay the Reparations
 	option = {
@@ -292,14 +250,11 @@ country_event = {
 				modify_treasury_effect = yes
 			}
 		}
-
 		set_country_flag = FRA_pays_the_haitian_reps
 		hidden_effect = {
 			HAI = { country_event = { id = haiti.9 days = 3 } }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Deny the Reparations
@@ -309,9 +264,7 @@ country_event = {
 		hidden_effect = {
 			HAI = { country_event = { id = haiti.9 days = 3 } }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -336,18 +289,14 @@ country_event = {
 	}
 	picture = GFx_message_signing
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
+
+	trigger = { original_tag = HAI }
 
 	# France Pays the Reparations
 	option = {
 		name = haiti.9.a
 		log = "[GetDateText]: [This.GetName]: haiti.9.a executed"
-		trigger = {
-			FRA = { has_country_flag = FRA_pays_the_haitian_reps }
-		}
-
+		trigger = { FRA = { has_country_flag = FRA_pays_the_haitian_reps } }
 		set_temp_variable = { treasury_change = 21 }
 		modify_treasury_effect = yes
 		FRA = {
@@ -359,9 +308,7 @@ country_event = {
 	# France Denies the Reparations
 	option = {
 		name = haiti.9.b
-		trigger = {
-			NOT = { FRA = { has_country_flag = FRA_pays_the_haitian_reps } }
-		}
+		trigger = { NOT = { FRA = { has_country_flag = FRA_pays_the_haitian_reps } } }
 	}
 }
 
@@ -372,6 +319,7 @@ country_event = {
 	desc = haiti.10.d
 	picture = GFX_politics_protest # TODO: Replace with more appropriate image
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -382,9 +330,7 @@ country_event = {
 		name = haiti.10.a
 		log = "[GetDateText]: [This.GetName]: haiti.10.a executed"
 		country_event = { id = haiti.11 days = 8 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Let Him Live
@@ -392,9 +338,7 @@ country_event = {
 		name = haiti.10.b
 		log = "[GetDateText]: [This.GetName]: haiti.10.b executed"
 		set_country_flag = HAI_ignores_amiot
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -405,6 +349,7 @@ country_event = {
 	desc = haiti.11.d
 	picture = GFX_politics_protest # TODO: Replace with more appropriate image
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -416,9 +361,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: haiti.11.a executed"
 		set_country_flag = HAI_amiot_killed
 		add_stability = -0.03
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -429,6 +372,7 @@ country_event = {
 	desc = haiti.12.d
 	picture = GFX_kurd_riot
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -439,9 +383,7 @@ country_event = {
 		name = haiti.12.a
 		log = "[GetDateText]: [This.GetName]: haiti.12.a executed"
 		add_stability = -0.02
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -453,6 +395,7 @@ country_event = {
 	desc = haiti.13.d
 	picture = GFX_haitian_student_protests
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_leader = { name = "Jean-Bertrand Aristide" ruling_only = yes }
@@ -464,10 +407,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: haiti.13.a executed"
 		add_political_power = -50
 		add_stability = 0.03
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Quell the Protests
@@ -475,10 +415,7 @@ country_event = {
 		name = haiti.13.b
 		log = "[GetDateText]: [This.GetName]: haiti.13.b executed"
 		add_stability = -0.03
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -489,6 +426,7 @@ country_event = {
 	desc = haiti.14.d
 	picture = GFX_buteur_mateyer_cannibal_army
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_flag = HAI_amiot_killed
@@ -500,11 +438,8 @@ country_event = {
 		name = haiti.14.a
 		log = "[GetDateText]: [This.GetName]: haiti.14.a executed"
 		custom_effect_tooltip = haiti.14.tt
-
 		country_event = { id = haiti.15 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Mobilize the Troops - Civil War Option
@@ -512,9 +447,7 @@ country_event = {
 		name = haiti.14.b
 		log = "[GetDateText]: [This.GetName]: haiti.14.b executed"
 		FRA = { country_event = { id = haiti.16 days = 7 } }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -525,6 +458,7 @@ country_event = {
 	desc = haiti.15.d
 	picture = GFX_buteur_mateyer_cannibal_army
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_country_flag = HAI_amiot_killed
@@ -546,11 +480,8 @@ country_event = {
 				judiciary
 			}
 		}
-
 		FRA = { country_event = { id = haiti.16 days = 7 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Mobilize the Troops! - Civil War Option
@@ -563,7 +494,6 @@ country_event = {
 			size = 0.3
 			states = { 859 }
 		}
-
 		set_temp_variable = { rul_party_temp = 13 }
 		change_ruling_party_effect = yes
 		set_politics = {
@@ -572,7 +502,6 @@ country_event = {
 			election_frequency = 60
 			elections_allowed = yes
 		}
-
 		create_country_leader = {
 			name = "Buteur Métayer"
 			picture = "buteur_metayer.dds"
@@ -581,7 +510,6 @@ country_event = {
 				neutrality_Neutral_Autocracy
 			}
 		}
-
 		division_template = {
 			name = "Rebel Forces"
 			is_locked = yes
@@ -592,7 +520,6 @@ country_event = {
 				Militia_Bat = { x = 0 y = 3 }
 			}
 		}
-
 		860 = {
 			create_unit = {
 				division = "name = \"1. Rebel Forces\" division_template = \"Rebel Forces\" start_experience_factor = 0.5 start_equipment_factor = 1"
@@ -603,13 +530,11 @@ country_event = {
 				owner = HAI
 			}
 		}
-
 		random_other_country = {
 			limit = {
 				original_tag = HAI
 				has_government = democratic
 			}
-
 			create_country_leader = {
 				name = "Jean-Bertrand Aristide"
 				picture = "jean-bertrand_artistide.dds"
@@ -619,7 +544,6 @@ country_event = {
 					cleric
 				}
 			}
-
 			division_template = {
 				name = "Police Forces"
 				is_locked = yes
@@ -630,7 +554,6 @@ country_event = {
 					Militia_Bat = { x = 0 y = 3 }
 				}
 			}
-
 			859 = {
 				create_unit = {
 					division = "name = \"1. Police Forces\" division_template = \"Police Forces\" start_experience_factor = 0.5 start_equipment_factor = 1"
@@ -646,7 +569,6 @@ country_event = {
 				change_tag_from = HAI
 			}
 		}
-
 		FRA = { country_event = { id = haiti.16 days = 7 } }
 		ai_chance = {
 			base = 0
@@ -661,28 +583,22 @@ country_event = {
 	desc = haiti.16.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-	trigger = {
-		original_tag = FRA
-	}
+
+	trigger = { original_tag = FRA }
 
 	# Intervene in the Country!
 	option = {
 		name = haiti.16.a
 		log = "[GetDateText]: [This.GetName]: haiti.16.a executed"
-		HAI = {
-			add_manpower = 300
-		}
+		HAI = { add_manpower = 300 }
 		add_manpower = -300
 		add_relation_modifier = {
 			target = HAI
 			modifier = generic_increased_military_support
 		}
-
 		set_country_flag = FRA_intervening_in_haiti
 		USA = { country_event = { id = haiti.18 days = 7 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Stay out of it
@@ -690,9 +606,7 @@ country_event = {
 		name = haiti.16.b
 		log = "[GetDateText]: [This.GetName]: haiti.16.b executed"
 		USA = { country_event = { id = haiti.18 days = 7 } }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -703,9 +617,8 @@ country_event = {
 	desc = haiti.18.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = USA
-	}
+
+	trigger = { original_tag = USA }
 
 	# Support the Operation
 	option = {
@@ -715,7 +628,6 @@ country_event = {
 			target = HAI
 			modifier = generic_increased_military_support
 		}
-
 		set_country_flag = USA_intervene_in_haiti
 		hidden_effect = {
 			FRA = { country_event = { id = haiti.19 days = 5 } }
@@ -787,9 +699,8 @@ country_event = {
 	}
 	picture = GFX_treaty
 	is_triggered_only = yes
-	trigger = {
-		original_tag = FRA
-	}
+
+	trigger = { original_tag = FRA }
 
 	# America Supports France
 	option = {
@@ -799,11 +710,8 @@ country_event = {
 			USA = { has_country_flag = USA_intervene_in_haiti }
 			has_country_flag = FRA_intervening_in_haiti
 		}
-
 		HAI = { country_event = { id = haiti.20 days = 7 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# America Doesn't Supports Us
@@ -814,11 +722,8 @@ country_event = {
 			NOT = { USA = { has_country_flag = USA_intervene_in_haiti } }
 			has_country_flag = FRA_intervening_in_haiti
 		}
-
 		HAI = { country_event = { id = haiti.20 days = 7 } }
-		ai_chance = {
-				base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# We Really Should Avoid Getting Involved
@@ -829,11 +734,8 @@ country_event = {
 			USA = { has_country_flag = USA_intervene_in_haiti }
 			NOT = { has_country_flag = FRA_intervening_in_haiti }
 		}
-
 		HAI = { country_event = { id = haiti.20 days = 7 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -844,9 +746,8 @@ country_event = {
 	desc = haiti.20.d
 	picture = GFX_american_troops
 	is_triggered_only = yes
-	trigger = {
-		original_tag = HAI
-	}
+
+	trigger = { original_tag = HAI }
 
 	option = {
 		name = haiti.20.a
@@ -864,9 +765,7 @@ country_event = {
 			custom_effect_tooltip = haiti.20.tt2
 		}
 		add_war_support = 0.05
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -877,10 +776,7 @@ country_event = {
 			NOT = { FRA = { has_country_flag = FRA_intervening_in_haiti } }
 		}
 		add_war_support = -0.05
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -902,6 +798,7 @@ country_event = {
 	}
 	picture = GFX_jean_bertrand_aristide_resigns
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = HAI
 		has_global_flag = GLOBAL_haitian_civil_war
@@ -916,7 +813,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		hidden_effect = {
 			if = { limit = { tag = HAI }
 				delete_unit_template_and_units = {

--- a/events/Iraq.txt
+++ b/events/Iraq.txt
@@ -165,9 +165,7 @@ country_event = {
 
 	option = {
 		name = iraqi_events.4.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -193,9 +191,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -519,9 +515,7 @@ country_event = {
 			subtract_from_variable = { number_of_iraq_economic_union_members = 1 }
 			IRQ_update_economic_union_modifiers = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -567,12 +561,8 @@ country_event = {
 	option = {
 		name = iraqi_events.15.b
 		log = "[GetDateText]: [This.GetName]: iraqi_events.15.b executed"
-		IRQ = {
-			country_event = iraqi_events.17
-		}
-		ai_chance = {
-			base = 10
-		}
+		IRQ = { country_event = iraqi_events.17 }
+		ai_chance = { base = 10 }
 	}
 }
 country_event = {
@@ -584,9 +574,7 @@ country_event = {
 
 	option = {
 		name = iraqi_events.16.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -598,9 +586,7 @@ country_event = {
 
 	option = {
 		name = iraqi_events.17.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -658,9 +644,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -672,9 +656,7 @@ country_event = {
 
 	option = {
 		name = iraqi_events.20.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1048,9 +1030,7 @@ country_event = {
 		name = iraqi_events.29.a
 		log = "[GetDateText]: [This.GetName]: iraqi_events.29.a executed"
 		add_political_power = -50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1404,9 +1384,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_war.100.a executed"
 		custom_effect_tooltip = TT_IF_WE_ACCEPT
 		activate_decision = usa_operation_iraqi_freedom
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	# I Don't Care
@@ -1522,9 +1500,7 @@ country_event = {
 	#
 	option = {
 		name = iraq_war.11.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # (For USA)
@@ -1541,12 +1517,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_war.2.a executed"
 		custom_effect_tooltip = IRQ_gets_ultimatum
 		newline = yes
-		IRQ = {
-			country_event = iraq_war.3
-		}
-		ai_chance = {
-			base = 1
-		}
+		IRQ = { country_event = iraq_war.3 }
+		ai_chance = { base = 1 }
 	}
 
 	# No, dictators can't be negotiated with
@@ -1554,21 +1526,15 @@ country_event = {
 		name = iraq_war.2.b
 		log = "[GetDateText]: [This.GetName]: iraq_war.2.b executed"
 		set_country_flag = USA_wot_iraqi_freedom
-		IRQ = {
-			set_country_flag = IRQ_iraq_war_ongoing
-		}
+		IRQ = { set_country_flag = IRQ_iraq_war_ongoing }
 		set_temp_variable = { wargoal_on = IRQ }
 		add_threat_from_wargoal_effect = yes
 		create_wargoal = {
 			target = IRQ
 			type = puppet_wargoal_focus
 		}
-		hidden_effect = {
-			IRQ_MNF_setup = yes
-		}
-		KUR = {
-			country_event = iraq_md.91
-		}
+		hidden_effect = { IRQ_MNF_setup = yes }
+		KUR = { country_event = iraq_md.91 }
 		PUK = {
 			country_event = {
 				id = iraq_md.91
@@ -1576,9 +1542,7 @@ country_event = {
 			}
 		}
 		hidden_effect = { news_event = { id = wotnews.11 hours = 6 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # (For Iraq)
@@ -1611,9 +1575,7 @@ country_event = {
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Shit, pack the bags we're going to Jordan!
@@ -1686,9 +1648,7 @@ country_event = {
 		name = iraq_war.4.a
 		log = "[GetDateText]: [This.GetName]: iraq_war.4.a executed"
 		set_country_flag = USA_wot_iraqi_freedom
-		IRQ = {
-			set_country_flag = IRQ_iraq_war_ongoing
-		}
+		IRQ = { set_country_flag = IRQ_iraq_war_ongoing }
 		set_temp_variable = { wargoal_on = IRQ }
 		add_threat_from_wargoal_effect = yes
 		create_wargoal = {
@@ -1697,9 +1657,7 @@ country_event = {
 		}
 		hidden_effect = {
 			IRQ_MNF_setup = yes
-			KUR = {
-				country_event = iraq_md.91
-			}
+			KUR = { country_event = iraq_md.91 }
 			PUK = {
 				country_event = {
 					id = iraq_md.91
@@ -1708,9 +1666,7 @@ country_event = {
 			}
 		}
 		hidden_effect = { news_event = { id = wotnews.11 hours = 6 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Saddam related events
@@ -1731,9 +1687,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1757,11 +1711,7 @@ country_event = {
 		ai_chance = {
 			base = 5
 			modifier = {
-				IRQ = {
-					KUW = {
-						influence_higher_30 = yes
-					}
-				}
+				IRQ = { KUW = { influence_higher_30 = yes } }
 				add = 20
 			}
 		}
@@ -1777,9 +1727,7 @@ country_event = {
 	# Good
 	option = {
 		name = iraq_saddam.2.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -1812,9 +1760,7 @@ country_event = {
 				modifier = no_diplomatic_ties
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1862,9 +1808,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1928,9 +1872,7 @@ country_event = {
 		set_temp_variable = { tag_index = IRQ }
 		set_temp_variable = { influence_target = KUR }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1944,9 +1886,7 @@ country_event = {
 	# Great
 	option = {
 		name = iraq_saddam.6.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1974,9 +1914,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1996,11 +1934,7 @@ country_event = {
 				id = iraq_war.6
 				days = 1
 			}
-			hidden_effect = {
-				annex_country = {
-					target = MNF
-				}
-			}
+			hidden_effect = { annex_country = { target = MNF } }
 		}
 		newline = yes
 		USA = {
@@ -2047,9 +1981,7 @@ country_event = {
 		change_influence_percentage = yes
 		hidden_effect = {
 			if = {
-				limit = {
-					USA = { has_idea = USA_afghan_mission_cost }
-				}
+				limit = { USA = { has_idea = USA_afghan_mission_cost } }
 				USA = {
 					country_event = {
 						id = iraq_war.24
@@ -2058,9 +1990,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# We will push on!
@@ -2115,14 +2045,8 @@ country_event = {
 		add_ideas = IRQ_aftermath_of_war
 		set_country_flag = IRQ_victory_against_america
 		news_event = iraqi_flavor_events.3
-		IRQ = {
-			clr_country_flag = IRQ_war_with_america
-		}
-		hidden_effect = {
-			488 = {
-				transfer_state_to = IRQ
-			}
-		}
+		IRQ = { clr_country_flag = IRQ_war_with_america }
+		hidden_effect = { 488 = { transfer_state_to = IRQ } }
 		newline = yes
 		add_stability = 0.10
 		newline = yes
@@ -2166,9 +2090,7 @@ country_event = {
 		set_temp_variable = { tag_index = IRQ }
 		set_temp_variable = { influence_target = PAL }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2197,9 +2119,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2220,11 +2140,7 @@ country_event = {
 				id = iraq_war.6
 				days = 1
 			}
-			hidden_effect = {
-				annex_country = {
-					target = MNF
-				}
-			}
+			hidden_effect = { annex_country = { target = MNF } }
 		}
 		newline = yes
 		set_temp_variable = { temp_opinion = -35 }
@@ -2232,9 +2148,7 @@ country_event = {
 		newline = yes
 		add_stability = -0.10
 		newline = yes
-		USA = {
-			white_peace = IRQ
-		}
+		USA = { white_peace = IRQ }
 		newline = yes
 		set_temp_variable = { temp_opinion = -25 }
 		change_defense_industry_opinion = yes
@@ -2280,9 +2194,7 @@ country_event = {
 		change_influence_percentage = yes
 		hidden_effect = {
 			if = {
-				limit = {
-					USA = { has_idea = USA_afghan_mission_cost }
-				}
+				limit = { USA = { has_idea = USA_afghan_mission_cost } }
 				USA = {
 					country_event = {
 						id = iraq_war.24
@@ -2291,9 +2203,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2579,67 +2489,35 @@ country_event = { # Question of Language
 			modifier = huge_increase
 		}
 		if = {
-			limit = {
-				633 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 633 = { is_owned_and_controlled_by = IRQ } }
 			633 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				164 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 164 = { is_owned_and_controlled_by = IRQ } }
 			164 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				630 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 630 = { is_owned_and_controlled_by = IRQ } }
 			630 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				641 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 641 = { is_owned_and_controlled_by = IRQ } }
 			641 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				165 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 165 = { is_owned_and_controlled_by = IRQ } }
 			165 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				408 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 408 = { is_owned_and_controlled_by = IRQ } }
 			408 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				1139 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 1139 = { is_owned_and_controlled_by = IRQ } }
 			1139 = { transfer_state_to = KUR }
 		}
 		if = {
-			limit = {
-				1138 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 1138 = { is_owned_and_controlled_by = IRQ } }
 			1138 = { transfer_state_to = KUR }
 		}
 		custom_effect_tooltip = IRQ_cant_influence_kurdistan_TT
@@ -2723,9 +2601,7 @@ country_event = { # Iraqi Democracy
 		newline = yes
 		add_ideas = IRQ_parliamentary_idea
 		set_country_flag = IRQ_federalized
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Presidential Republic
@@ -2736,9 +2612,7 @@ country_event = { # Iraqi Democracy
 		custom_effect_tooltip = IRQ_president_chosen
 		newline = yes
 		add_ideas = IRQ_presidential_idea
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2758,9 +2632,7 @@ country_event = { # Question of Militias
 		custom_effect_tooltip = IRQ_militias_banned_chosen
 		newline = yes
 		custom_effect_tooltip = IRQ_suffer_no_militia_TT
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Permit Militias
@@ -2796,9 +2668,7 @@ country_event = { # Question of Militias
 		set_temp_variable = { tag_index = SYR }
 		set_temp_variable = { influence_target = IRQ }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2821,9 +2691,7 @@ country_event = { # Iraqi Identity
 		newline = yes
 		add_popularity = { ideology = nationalist popularity = 0.05 }
 		recalculate_party = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Multi-Ethnic State
@@ -2838,9 +2706,7 @@ country_event = { # Iraqi Identity
 		}
 		newline = yes
 		add_ideas = multi_ethnic_state_idea
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Outcomes for constitution end
@@ -2926,9 +2792,7 @@ country_event = {
 				change_ruling_party_effect = yes
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Orders
@@ -2951,9 +2815,7 @@ country_event = { # De-Ba'athification of Iraqi Society
 		set_temp_variable = { party_popularity_increase = -0.055 }
 		set_temp_variable = { temp_outlook_increase = -0.045 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -2965,9 +2827,7 @@ country_event = { # De-Ba'athification of Iraqi Society
 		if = { limit = { has_character = IRQ_hamid_raja_shalah } retire_character = IRQ_hamid_raja_shalah }
 		if = { limit = { has_character = IRQ_sultan_hashim_ahmad_al_tai } retire_character = IRQ_sultan_hashim_ahmad_al_tai }
 		if = { limit = { has_character = IRQ_ali_hassan_al_majid } retire_character = IRQ_ali_hassan_al_majid }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2988,9 +2848,7 @@ country_event = { # Dissolution of Entities
 		modify_treasury_effect = yes
 		newline = yes
 		increase_corruption = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Keep 'em
@@ -3005,9 +2863,7 @@ country_event = { # Dissolution of Entities
 		change_international_bankers_opinion = yes
 		set_temp_variable = { temp_opinion = 15 }
 		change_fossil_fuel_industry_opinion = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3024,9 +2880,7 @@ country_event = { # Management of Property and Assets of the Iraqi Baath Party
 		name = iraq_war.22.a
 		log = "[GetDateText]: [This.GetName]: iraq_war.22.a executed"
 		two_office_construction = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Keep 'em
@@ -3039,9 +2893,7 @@ country_event = { # Management of Property and Assets of the Iraqi Baath Party
 		}
 		newline = yes
 		add_stability = 0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3064,9 +2916,7 @@ country_event = { # Establishment of the Iraqi De-Baathification Council
 		custom_effect_tooltip = IRQ_decrease_sunni_satisfaction_10_TT
 		add_to_variable = { var = IRQ_sunni_satisfaction value = -10 }
 		clamp_variable = { var = IRQ_sunni_satisfaction min = 0 max = 50 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Keep 'em
@@ -3080,9 +2930,7 @@ country_event = { # Establishment of the Iraqi De-Baathification Council
 		custom_effect_tooltip = IRQ_increase_sunni_satisfaction_5_TT
 		add_to_variable = { var = IRQ_sunni_satisfaction value = 5 }
 		clamp_variable = { var = IRQ_sunni_satisfaction min = 0 max = 50 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3303,9 +3151,7 @@ country_event = { # Successful Attack
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3353,9 +3199,7 @@ country_event = { # Small success
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3386,9 +3230,7 @@ country_event = { # Small fail
 			IRQ_update_insurgency_level = yes
 			IRQ_states_keep_above_0 = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3419,9 +3261,7 @@ country_event = { # Massive Failure
 			IRQ_update_insurgency_level = yes
 			IRQ_states_keep_above_0 = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3437,29 +3277,21 @@ country_event = { # Propose Alliance with the Shi'ites
 		log = "[GetDateText]: [This.GetName]: iraq_civil_war.6.a executed"
 		hidden_effect = {
 			if = {
-				limit = {
-					NOT = {
-						has_country_flag = IRQ_allow_militias_selected
-					}
-				}
+				limit = { NOT = { has_country_flag = IRQ_allow_militias_selected } }
 				country_event = {
 					id = iraq_civil_war.7
 					days = 2
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = IRQ_allow_militias_selected
-				}
+				limit = { has_country_flag = IRQ_allow_militias_selected }
 				country_event = {
 					id = iraq_civil_war.8
 					days = 2
 				}
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	# We Will Crush Them Too!
@@ -3472,9 +3304,7 @@ country_event = { # Propose Alliance with the Shi'ites
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # (If Militias Banned)
@@ -3489,9 +3319,7 @@ country_event = { # Shi'ites Demand Preservation of Militias even after the Insu
 		name = iraq_civil_war.7.a
 		log = "[GetDateText]: [This.GetName]: iraq_civil_war.7.a executed"
 		set_country_flag = IRQ_shias_allied
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# No! We Would Rather Fight
@@ -3504,9 +3332,7 @@ country_event = { # Shi'ites Demand Preservation of Militias even after the Insu
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # (If Militias Legal)
@@ -3521,9 +3347,7 @@ country_event = { # Shi'ites Militias Demand Government Representation
 		name = iraq_civil_war.8.a
 		log = "[GetDateText]: [This.GetName]: iraq_civil_war.8.a executed"
 		set_country_flag = IRQ_shias_allied
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# No! We Would Rather Fight
@@ -3536,9 +3360,7 @@ country_event = { # Shi'ites Militias Demand Government Representation
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = { # Shi'ites Begin Attacks
@@ -3563,9 +3385,7 @@ country_event = { # Shi'ites Begin Attacks
 				days = 200
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = { # Shi'ites will Begin Attacks Soon!
@@ -3588,9 +3408,7 @@ country_event = { # Shi'ites will Begin Attacks Soon!
 	# Damn
 	option = {
 		name = iraq_civil_war.10.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #
@@ -3610,9 +3428,7 @@ country_event = { # Victory over Insurgency!
 		newline = yes
 		custom_effect_tooltip = IRQ_end_of_insurgency
 		clr_country_flag = IRQ_insurgency_active
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4052,23 +3868,17 @@ country_event = { # Return of Ba'athism
 		name = iraq_civil_war.202.a
 		log = "[GetDateText]: [This.GetName]: iraq_civil_war.202.a executed"
 		if = {
-			limit = {
-				has_idea = shia
-			}
+			limit = { has_idea = shia }
 			swap_ideas = {
 				remove_idea = shia
 				add_idea = sunni
 			}
 		}
-		else = {
-			add_ideas = sunni
-		}
+		else = { add_ideas = sunni }
 		news_event = iraqi_flavor_events.6
 		custom_effect_tooltip = IRQ_shia_triggered_TT
 		set_country_flag = IRQ_war_with_shias
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4085,9 +3895,7 @@ country_event = { # End of Sectarian Earthquake
 		name = iraq_civil_war.203.a
 		log = "[GetDateText]: [This.GetName]: iraq_civil_war.203.a executed"
 		add_stability = 0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4308,9 +4116,7 @@ country_event = { # Small Anti-Government Gathering
 		set_temp_variable = { temp_outlook_increase = -0.025 }
 		change_relative_party_popularity = yes
 		IRQ_update_dynamic_modifier = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4332,9 +4138,7 @@ country_event = { # Small Anti-Government Sermon
 		newline = yes
 		add_stability = -0.01
 		IRQ_update_dynamic_modifier = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4359,9 +4163,7 @@ country_event = { # Large Anti-Government Gathering
 		set_temp_variable = { temp_outlook_increase = -0.035 }
 		change_relative_party_popularity = yes
 		IRQ_update_dynamic_modifier = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4383,51 +4185,33 @@ country_event = { # Unions Go On Strike
 		IRQ_update_dynamic_modifier = yes
 		newline = yes
 		if = {
-			limit = {
-				NOT = {
-					emerging_communist_state_are_in_power = yes
-				}
-			}
+			limit = { NOT = { emerging_communist_state_are_in_power = yes } }
 			set_temp_variable = { party_index = 4 }
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			change_relative_party_popularity = yes
 			newline = yes
 		}
 		if = {
-			limit = {
-				NOT = {
-					emerging_anarchist_communism_are_in_power = yes
-				}
-			}
+			limit = { NOT = { emerging_anarchist_communism_are_in_power = yes } }
 			set_temp_variable = { party_index = 5 }
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			change_relative_party_popularity = yes
 			newline = yes
 		}
 		if = {
-			limit = {
-				NOT = {
-					neutrality_neutral_social_are_in_power = yes
-				}
-			}
+			limit = { NOT = { neutrality_neutral_social_are_in_power = yes } }
 			set_temp_variable = { party_index = 18 }
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			change_relative_party_popularity = yes
 			newline = yes
 		}
 		if = {
-			limit = {
-				NOT = {
-					neutrality_neutral_communism_are_in_power = yes
-				}
-			}
+			limit = { NOT = { neutrality_neutral_communism_are_in_power = yes } }
 			set_temp_variable = { party_index = 19 }
 			set_temp_variable = { party_popularity_increase = 0.015 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4452,9 +4236,7 @@ country_event = { # Nationwide Protests
 		set_temp_variable = { party_popularity_increase = -0.055 }
 		set_temp_variable = { temp_outlook_increase = -0.045 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4476,9 +4258,7 @@ country_event = { # Nationwide Protests
 		IRQ_update_dynamic_modifier = yes
 		newline = yes
 		add_stability = -0.03
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4524,9 +4304,7 @@ country_event = { # Car Bombings in Major Cities
 				}
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4560,9 +4338,7 @@ country_event = { # Suicide Bombers Attack Military Bases
 		}
 		newline = yes
 		add_manpower = -5000
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4581,27 +4357,15 @@ country_event = { # AIQ In Iraq Begins Attacks
 		custom_effect_tooltip = IRQ_aid_launches_war_TT
 		hidden_effect = {
 			if = {
-				limit = {
-					168 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 168 = { is_owned_and_controlled_by = IRQ } }
 				168 = { transfer_state_to = ISI }
 			}
 			if = {
-				limit = {
-					166 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 166 = { is_owned_and_controlled_by = IRQ } }
 				166 = { transfer_state_to = ISI }
 			}
 			if = {
-				limit = {
-					167 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 167 = { is_owned_and_controlled_by = IRQ } }
 				167 = { transfer_state_to = ISI }
 			}
 			ISI = {
@@ -4726,15 +4490,11 @@ country_event = { # AIQ In Iraq Begins Attacks
 					type = civil_war
 				}
 			}
-			ISI = {
-				set_cosmetic_tag = ISI_aiq_iraq
-			}
+			ISI = { set_cosmetic_tag = ISI_aiq_iraq }
 			set_country_flag = is_IRAQ
 			mark_formed_country_formable = yes
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# It's Time.. (Play as AIQ)
@@ -4746,27 +4506,15 @@ country_event = { # AIQ In Iraq Begins Attacks
 		custom_effect_tooltip = IRQ_play_as_aiq_TT
 		hidden_effect = {
 			if = {
-				limit = {
-					168 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 168 = { is_owned_and_controlled_by = IRQ } }
 				168 = { transfer_state_to = ISI }
 			}
 			if = {
-				limit = {
-					166 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 166 = { is_owned_and_controlled_by = IRQ } }
 				166 = { transfer_state_to = ISI }
 			}
 			if = {
-				limit = {
-					167 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 167 = { is_owned_and_controlled_by = IRQ } }
 				167 = { transfer_state_to = ISI }
 			}
 			ISI = {
@@ -4898,9 +4646,7 @@ country_event = { # AIQ In Iraq Begins Attacks
 			IRQ = { every_core_state = { add_core_of = ISI } }
 			ISI = { change_tag_from = IRQ }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -5031,27 +4777,19 @@ news_event = { # Rise of Al-Qaeda in Iraq
 	id = iraqi_flavor_events.11
 	title = {
 		text = iraqi_flavor_events.11.t
-		trigger = {
-			ISI = { has_cosmetic_tag = ISI_aiq_iraq }
-		}
+		trigger = { ISI = { has_cosmetic_tag = ISI_aiq_iraq } }
 	}
 	title = {
 		text = iraqi_flavor_events.11.t1
-		trigger = {
-			ISI = { has_cosmetic_tag = IRQ_ISI }
-		}
+		trigger = { ISI = { has_cosmetic_tag = IRQ_ISI } }
 	}
 	desc = {
 		text = iraqi_flavor_events.11.d
-		trigger = {
-			ISI = { has_cosmetic_tag = ISI_aiq_iraq }
-		}
+		trigger = { ISI = { has_cosmetic_tag = ISI_aiq_iraq } }
 	}
 	desc = {
 		text = iraqi_flavor_events.11.d1
-		trigger = {
-			ISI = { has_cosmetic_tag = IRQ_ISI }
-		}
+		trigger = { ISI = { has_cosmetic_tag = IRQ_ISI } }
 	}
 	picture = GFX_AIQ_prepares_attacks_on_Iraq_news2
 	is_triggered_only = yes
@@ -5081,16 +4819,12 @@ news_event = { # Iraqi Baathist Civil war
 
 	option = {
 		name = iraqi_flavor_events.13.a1
-		trigger = {
-			tag = PER
-		}
+		trigger = { tag = PER }
 	}
 
 	option = {
 		name = iraqi_flavor_events.13.a2
-		trigger = {
-			NOT = { tag = PER }
-		}
+		trigger = { NOT = { tag = PER } }
 	}
 }
 
@@ -5106,27 +4840,21 @@ country_event = {
 		name = iraq_md.1.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.1.a executed"
 		one_random_arms_factory = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = iraq_md.1.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.1.b executed"
 		two_random_industrial_complex = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
 	option = {
 		name = iraq_md.1.c
 		log = "[GetDateText]: [This.GetName]: iraq_md.1.c executed"
 		one_office_construction = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 
@@ -5151,9 +4879,7 @@ country_event = {
 		add_coalition_members_effect = yes
 		set_temp_variable = { add_col_one = 23 }
 		add_coalition_members_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5164,9 +4890,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		newline = yes
 		decrease_corruption = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5184,18 +4908,14 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = iraq_md.3.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.3.b executed"
 		add_ideas = IRQ_raad_bin_zeid
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Launch A Drug Raid?
@@ -5230,9 +4950,7 @@ country_event = {
 				on_cancel = iraq_md.8
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5242,9 +4960,7 @@ country_event = {
 		set_temp_variable = { tag_index = IRQ }
 		set_temp_variable = { influence_target = KUR }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5269,9 +4985,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { percent_change = 5 }
 		change_domestic_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5296,9 +5010,7 @@ country_event = {
 			type = cnc_equipment_1
 			amount = -120
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5321,9 +5033,7 @@ country_event = {
 			type = cnc_equipment_1
 			amount = 120
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5347,9 +5057,7 @@ country_event = {
 			type = cnc_equipment_1
 			amount = -120
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5364,9 +5072,7 @@ country_event = {
 	option = {
 		name = iraq_md.11.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.11.a executed"
-		399 = {
-			transfer_state_to = ARA
-		}
+		399 = { transfer_state_to = ARA }
 		ARA = {
 			division_template = {
 				name = "Arabistani Militia"
@@ -5396,9 +5102,7 @@ country_event = {
 				type = puppet_wargoal_focus
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Nah We'll Keep the Weapons
@@ -5430,9 +5134,7 @@ country_event = {
 		}
 		newline = yes
 		increase_corruption = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5451,51 +5153,27 @@ country_event = {
 		if = {
 			limit = {
 				country_exists = PER
-				PER = {
-					NOT = {
-						PER = {
-							influence_less_10 = yes
-						}
-					}
-				}
+				PER = { NOT = { PER = { influence_less_10 = yes } } }
 			}
 			activate_mission = IRQ_lower_iranian_influence_1
 		}
 		else_if = {
 			limit = {
-				168 = {
-					is_owned_and_controlled_by = IRQ
-				}
-				NOT = {
-					168 = {
-						infrastructure > 1
-					}
-				}
+				168 = { is_owned_and_controlled_by = IRQ }
+				NOT = { 168 = { infrastructure > 1 } }
 			}
 			activate_mission = IRQ_anbar_infrastructure
 		}
 		else_if = {
 			limit = {
-				166 = {
-					is_owned_and_controlled_by = IRQ
-				}
-				167 = {
-					is_owned_and_controlled_by = IRQ
-				}
-				168 = {
-					is_owned_and_controlled_by = IRQ
-				}
+				166 = { is_owned_and_controlled_by = IRQ }
+				167 = { is_owned_and_controlled_by = IRQ }
+				168 = { is_owned_and_controlled_by = IRQ }
 				NOT = {
 					OR = {
-						166 = {
-							internet_station > 0
-						}
-						167 = {
-							internet_station > 0
-						}
-						168 = {
-							internet_station > 0
-						}
+						166 = { internet_station > 0 }
+						167 = { internet_station > 0 }
+						168 = { internet_station > 0 }
 					}
 				}
 			}
@@ -5514,9 +5192,7 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				166 = {
-					is_owned_and_controlled_by = IRQ
-				}
+				166 = { is_owned_and_controlled_by = IRQ }
 				NOT = {
 					166 = {
 						air_base > 4
@@ -5528,14 +5204,8 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				166 = {
-					is_owned_and_controlled_by = IRQ
-				}
-				NOT = {
-					166 = {
-						infrastructure > 1
-					}
-				}
+				166 = { is_owned_and_controlled_by = IRQ }
+				NOT = { 166 = { infrastructure > 1 } }
 			}
 			activate_mission = IRQ_nineveh_infrastructure
 		}
@@ -5553,9 +5223,7 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				168 = {
-					is_owned_and_controlled_by = IRQ
-				}
+				168 = { is_owned_and_controlled_by = IRQ }
 				NOT = {
 					168 = {
 						air_base > 4
@@ -5567,22 +5235,14 @@ country_event = {
 		}
 		else_if = {
 			limit = {
-				167 = {
-					is_owned_and_controlled_by = IRQ
-				}
-				NOT = {
-					167 = {
-						infrastructure > 1
-					}
-				}
+				167 = { is_owned_and_controlled_by = IRQ }
+				NOT = { 167 = { infrastructure > 1 } }
 			}
 			activate_mission = IRQ_salahuddin_infrastructure
 		}
 		else_if = {
 			limit = {
-				167 = {
-					is_owned_and_controlled_by = IRQ
-				}
+				167 = { is_owned_and_controlled_by = IRQ }
 				NOT = {
 					167 = {
 						air_base > 4
@@ -5596,9 +5256,7 @@ country_event = {
 			custom_effect_tooltip = IRQ_no_missions_available_TT
 			add_stability = 0.02
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5629,9 +5287,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
@@ -5644,9 +5300,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5661,9 +5315,7 @@ country_event = {
 		name = iraq_md.14.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.14.a executed"
 		add_ideas = iranian_aid_custom
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5676,9 +5328,7 @@ country_event = {
 
 	option = {
 		name = iraq_md.15.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5700,16 +5350,12 @@ country_event = {
 				send_embargo = IRQ
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = iraq_md.16.b
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Syrian Defense Pact
@@ -5735,9 +5381,7 @@ country_event = {
 			relation = guarantee
 			active = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5749,9 +5393,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5770,9 +5412,7 @@ country_event = {
 			relation = guarantee
 			active = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5790,9 +5430,7 @@ country_event = {
 			target = SYR
 			modifier = recent_actions_negative
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # FAO Alliance Invitation
@@ -5809,9 +5447,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.20.a executed"
 		custom_effect_tooltip = TT_IF_WE_ACCEPT
 		FROM = { country_event = { id = md4.17 days = 1 } }
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	# No
@@ -5820,9 +5456,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.20.b executed"
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		FROM = { country_event = { id = md4.18 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Iraq asks for guns (Iran)
@@ -5928,9 +5562,7 @@ country_event = {
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5964,9 +5596,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
@@ -5979,9 +5609,7 @@ country_event = {
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Iran Denies Aid
@@ -5995,9 +5623,7 @@ country_event = {
 	# Damn it
 	option = {
 		name = iraq_md.23.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Iran Grants Weapons
@@ -6074,9 +5700,7 @@ country_event = {
 		set_temp_variable = { tag_index = PER }
 		set_temp_variable = { influence_target = IRQ }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Iraq is meddling in our politics!
@@ -6090,9 +5714,7 @@ country_event = {
 	# Damn it
 	option = {
 		name = iraq_md.26.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Iraq invites us to their coalition against Israel
@@ -6109,24 +5731,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.27.a executed"
 		add_ideas = IRQ_palestinian_vengeance
 		set_country_flag = IRQ_war_against_israeli
-		IRQ = {
-			country_event = iraq_md.28
-		}
-		ai_chance = {
-			base = 1
-		}
+		IRQ = { country_event = iraq_md.28 }
+		ai_chance = { base = 1 }
 	}
 
 	# No
 	option = {
 		name = iraq_md.27.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.27.b executed"
-		IRQ = {
-			country_event = iraq_md.29
-		}
-		ai_chance = {
-			base = 1
-		}
+		IRQ = { country_event = iraq_md.29 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6140,9 +5754,7 @@ country_event = {
 	# Ok
 	option = {
 		name = iraq_md.28.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6156,9 +5768,7 @@ country_event = {
 	# Ok
 	option = {
 		name = iraq_md.29.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6175,9 +5785,7 @@ country_event = {
 		name = iraq_md.30.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.30.a executed"
 		add_war_support = 0.10
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6241,9 +5849,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # X accepts
@@ -6274,9 +5880,7 @@ country_event = {
 		set_temp_variable = { target_nation = FROM }
 		set_temp_variable = { adding_nation = IRQ }
 		change_permanent_investment_target = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # X Rejects
@@ -6304,9 +5908,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Weapons cache detected!
@@ -6323,9 +5925,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.34.a executed"
 		add_stability = -0.01
 		if = {
-			limit = {
-				has_country_flag = IRQ_was_sending_to_JOR
-			}
+			limit = { has_country_flag = IRQ_was_sending_to_JOR }
 			set_temp_variable = { percent_change = -2 }
 			set_temp_variable = { tag_index = IRQ }
 			set_temp_variable = { influence_target = JOR }
@@ -6340,9 +5940,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_country_flag = IRQ_was_sending_to_KUW
-			}
+			limit = { has_country_flag = IRQ_was_sending_to_KUW }
 			set_temp_variable = { percent_change = -2 }
 			set_temp_variable = { tag_index = IRQ }
 			set_temp_variable = { influence_target = KUW }
@@ -6357,9 +5955,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_country_flag = IRQ_was_sending_to_TUR
-			}
+			limit = { has_country_flag = IRQ_was_sending_to_TUR }
 			set_temp_variable = { percent_change = -2 }
 			set_temp_variable = { tag_index = IRQ }
 			set_temp_variable = { influence_target = TUR }
@@ -6374,9 +5970,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_country_flag = IRQ_was_sending_to_AFG
-			}
+			limit = { has_country_flag = IRQ_was_sending_to_AFG }
 			set_temp_variable = { percent_change = -2 }
 			set_temp_variable = { tag_index = IRQ }
 			set_temp_variable = { influence_target = AFG }
@@ -6395,9 +5989,7 @@ country_event = {
 			type = infantry_weapons_type
 			amount = -500
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Weapons cache seized!
@@ -6416,9 +6008,7 @@ country_event = {
 			type = infantry_weapons_type
 			amount = 500
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6577,9 +6167,7 @@ country_event = {
 	# I Don't Give a Shit
 	option = {
 		name = iraq_md.36.b
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Iraq for USAID
@@ -6594,9 +6182,7 @@ country_event = {
 	option = {
 		name = iraq_md.37.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.37.a executed"
-		IRQ = {
-			add_ideas = USA_usaid
-		}
+		IRQ = { add_ideas = USA_usaid }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -6609,9 +6195,7 @@ country_event = {
 	# No
 	option = {
 		name = iraq_md.37.b
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -6626,9 +6210,7 @@ country_event = {
 	option = {
 		name = iraq_md.38.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.38.a executed"
-		IRQ = {
-			one_office_construction = yes
-		}
+		IRQ = { one_office_construction = yes }
 		newline = yes
 		set_temp_variable = { percent_change = 2 }
 		set_temp_variable = { influence_target = IRQ }
@@ -6645,9 +6227,7 @@ country_event = {
 	# No
 	option = {
 		name = iraq_md.38.b
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Iraq wants to meet
@@ -6687,9 +6267,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -6704,9 +6282,7 @@ country_event = {
 	# Okay
 	option = {
 		name = iraq_md.40.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -6725,9 +6301,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Military Support
@@ -6735,9 +6309,7 @@ country_event = {
 		name = iraq_md.41.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.41.b executed"
 		one_random_arms_factory = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Economic Support
@@ -6745,9 +6317,7 @@ country_event = {
 		name = iraq_md.41.c
 		log = "[GetDateText]: [This.GetName]: iraq_md.41.c executed"
 		one_random_industrial_complex = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Shi'ites Begin Protesting
@@ -6771,9 +6341,7 @@ country_event = {
 			id = iraq_md.51
 			days = 4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Send in the Riot Police with Deadly Force (Full Revolution)
@@ -6788,9 +6356,7 @@ country_event = {
 			id = iraq_md.51
 			days = 4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Rioters Stage Plans insde of Mosques in Najaf and Karbala
@@ -6814,9 +6380,7 @@ country_event = {
 			id = iraq_md.52
 			days = 4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Close and Garrison the Mosques
@@ -6831,9 +6395,7 @@ country_event = {
 			id = iraq_md.52
 			days = 4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Protesters Occupy Airports
@@ -6857,9 +6419,7 @@ country_event = {
 			id = iraq_md.53
 			days = 4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Close and Garrison the Mosques
@@ -6874,9 +6434,7 @@ country_event = {
 			id = iraq_md.53
 			days = 4
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -6894,30 +6452,20 @@ country_event = {
 		name = iraq_md.53.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.53.a executed"
 		if = {
-			limit = {
-				check_variable = {
-					IRQ_shia_revolution_badr > IRQ_shia_revolution_sadr
-				}
-			}
+			limit = { check_variable = { IRQ_shia_revolution_badr > IRQ_shia_revolution_sadr } }
 			country_event = {
 				id = iraq_md.55
 				days = 2
 			}
 		}
 		if = {
-			limit = {
-				check_variable = {
-					IRQ_shia_revolution_sadr > IRQ_shia_revolution_badr
-				}
-			}
+			limit = { check_variable = { IRQ_shia_revolution_sadr > IRQ_shia_revolution_badr } }
 			country_event = {
 				id = iraq_md.54
 				days = 2
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -7643,7 +7191,6 @@ country_event = {
 			557 = { transfer_state_to = IRR }
 			1122 = { transfer_state_to = IRR }
 			641 = { transfer_state_to = IRR }
-
 			hidden_effect = {
 				IRR = {
 					division_template = {
@@ -7893,9 +7440,7 @@ country_event = {
 			id = iraq_md.58
 			days = 1
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -7926,9 +7471,7 @@ country_event = {
 		set_temp_variable = { tag_index = IRQ }
 		set_temp_variable = { influence_target = FROM }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -7942,9 +7485,7 @@ country_event = {
 	# We Will Sign
 	option = {
 		name = iraq_md.58.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -7962,9 +7503,7 @@ country_event = {
 		custom_effect_tooltip = IRQ_effect_if_we_accept_TT
 		effect_tooltip = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = KUR
 					autonomy_state = autonomy_autonomous_state_colored
@@ -7982,38 +7521,22 @@ country_event = {
 			}
 			newline = yes
 			if = {
-				limit = {
-					641 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 641 = { is_owned_and_controlled_by = IRQ } }
 				641 = { transfer_state_to = KUR }
 				newline = yes
 			}
 			if = {
-				limit = {
-					166 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 166 = { is_owned_and_controlled_by = IRQ } }
 				166 = { transfer_state_to = KUR }
 				newline = yes
 			}
 			if = {
-				limit = {
-					165 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 165 = { is_owned_and_controlled_by = IRQ } }
 				165 = { transfer_state_to = KUR }
 				newline = yes
 			}
 			if = {
-				limit = {
-					170 = {
-						is_owned_and_controlled_by = IRQ
-					}
-				}
+				limit = { 170 = { is_owned_and_controlled_by = IRQ } }
 				170 = { transfer_state_to = KUR }
 				newline = yes
 			}
@@ -8053,9 +7576,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 # They Accepted
@@ -8071,9 +7592,7 @@ country_event = {
 		name = iraq_md.60.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.60.a executed"
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = KUR
 				autonomy_state = autonomy_autonomous_state_colored
@@ -8091,38 +7610,22 @@ country_event = {
 		}
 		newline = yes
 		if = {
-			limit = {
-				641 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 641 = { is_owned_and_controlled_by = IRQ } }
 			641 = { transfer_state_to = KUR }
 			newline = yes
 		}
 		if = {
-			limit = {
-				166 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 166 = { is_owned_and_controlled_by = IRQ } }
 			166 = { transfer_state_to = KUR }
 			newline = yes
 		}
 		if = {
-			limit = {
-				165 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 165 = { is_owned_and_controlled_by = IRQ } }
 			165 = { transfer_state_to = KUR }
 			newline = yes
 		}
 		if = {
-			limit = {
-				170 = {
-					is_owned_and_controlled_by = IRQ
-				}
-			}
+			limit = { 170 = { is_owned_and_controlled_by = IRQ } }
 			170 = { transfer_state_to = KUR }
 			newline = yes
 		}
@@ -8131,9 +7634,7 @@ country_event = {
 		custom_effect_tooltip = IRQ_willingness_to_accept_low_TT
 		newline = yes
 		custom_effect_tooltip = IRQ_willingness_to_accept2_TT
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8148,9 +7649,7 @@ country_event = {
 	# Shit
 	option = {
 		name = iraq_md.61.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8169,9 +7668,7 @@ country_event = {
 		custom_effect_tooltip = IRQ_progress_delayed_by_1_TT
 		add_to_variable = { IRQ_shipments_to_rojava = -1 }
 		clamp_variable = { var = IRQ_shipments_to_rojava min = 0 max = 12 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	# Try and Bribe the Guards
@@ -8179,118 +7676,60 @@ country_event = {
 		name = iraq_md.62.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.62.b executed"
 		if = {
-			limit = {
-				SYR = {
-					influence_less_10 = yes
-				}
-			}
+			limit = { SYR = { influence_less_10 = yes } }
 			random_list = {
-				30 = {
-					country_event = iraq_md.63
-				}
-				70 = {
-					country_event = iraq_md.64
-				}
+				30 = { country_event = iraq_md.63 }
+				70 = { country_event = iraq_md.64 }
 			}
 		}
 		if = {
 			limit = {
-				SYR = {
-					influence_higher_10 = yes
-				}
-				NOT = {
-					SYR = {
-						influence_higher_20 = yes
-					}
-				}
+				SYR = { influence_higher_10 = yes }
+				NOT = { SYR = { influence_higher_20 = yes } }
 			}
 			random_list = {
-				50 = {
-					country_event = iraq_md.63
-				}
-				50 = {
-					country_event = iraq_md.64
-				}
+				50 = { country_event = iraq_md.63 }
+				50 = { country_event = iraq_md.64 }
 			}
 		}
 		if = {
 			limit = {
-				SYR = {
-					influence_higher_20 = yes
-				}
-				NOT = {
-					SYR = {
-						influence_higher_30 = yes
-					}
-				}
+				SYR = { influence_higher_20 = yes }
+				NOT = { SYR = { influence_higher_30 = yes } }
 			}
 			random_list = {
-				60 = {
-					country_event = iraq_md.63
-				}
-				40 = {
-					country_event = iraq_md.64
-				}
+				60 = { country_event = iraq_md.63 }
+				40 = { country_event = iraq_md.64 }
 			}
 		}
 		if = {
 			limit = {
-				SYR = {
-					influence_higher_30 = yes
-				}
-				NOT = {
-					SYR = {
-						influence_higher_40 = yes
-					}
-				}
+				SYR = { influence_higher_30 = yes }
+				NOT = { SYR = { influence_higher_40 = yes } }
 			}
 			random_list = {
-				70 = {
-					country_event = iraq_md.63
-				}
-				30 = {
-					country_event = iraq_md.64
-				}
+				70 = { country_event = iraq_md.63 }
+				30 = { country_event = iraq_md.64 }
 			}
 		}
 		if = {
 			limit = {
-				SYR = {
-					influence_higher_40 = yes
-				}
-				NOT = {
-					SYR = {
-						influence_higher_50 = yes
-					}
-				}
+				SYR = { influence_higher_40 = yes }
+				NOT = { SYR = { influence_higher_50 = yes } }
 			}
 			random_list = {
-				80 = {
-					country_event = iraq_md.63
-				}
-				20 = {
-					country_event = iraq_md.64
-				}
+				80 = { country_event = iraq_md.63 }
+				20 = { country_event = iraq_md.64 }
 			}
 		}
 		if = {
-			limit = {
-				SYR = {
-					influence_higher_50 = yes
-				}
-			}
+			limit = { SYR = { influence_higher_50 = yes } }
 			random_list = {
-				90 = {
-					country_event = iraq_md.63
-				}
-				10 = {
-					country_event = iraq_md.64
-				}
+				90 = { country_event = iraq_md.63 }
+				10 = { country_event = iraq_md.64 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Bribe was accepted
@@ -8306,9 +7745,7 @@ country_event = {
 		name = iraq_md.63.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.63.a executed"
 		set_country_flag = IRQ_shipping_to_rojava
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Our Men Were Arrested
@@ -8327,9 +7764,7 @@ country_event = {
 		add_to_variable = { IRQ_shipments_to_rojava = -3 }
 		clamp_variable = { var = IRQ_shipments_to_rojava min = 0 max = 12 }
 		set_country_flag = IRQ_shipping_to_rojava
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # The Rebels are Ready!
@@ -8349,9 +7784,7 @@ country_event = {
 		193 = { add_core_of = ROJ }
 		newline = yes
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = ROJ
 				autonomy_state = autonomy_autonomous_state_colored
@@ -8374,9 +7807,7 @@ country_event = {
 				type = civil_war
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 country_event = {
@@ -8390,9 +7821,7 @@ country_event = {
 	option = {
 		name = iraq_md.66.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.66.a executed"
-		KUR = {
-			country_event = MD4_election_campaign.0
-		}
+		KUR = { country_event = MD4_election_campaign.0 }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -8425,9 +7854,7 @@ country_event = {
 	# Shit
 	option = {
 		name = iraq_md.67.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Iraq Arms Seperatists in the West
@@ -8441,9 +7868,7 @@ country_event = {
 	# Shit
 	option = {
 		name = iraq_md.68.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Iraq asks us to attack Iran
@@ -8490,9 +7915,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # X Accepts
@@ -8506,9 +7929,7 @@ country_event = {
 	# Okay
 	option = {
 		name = iraq_md.70.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8537,9 +7958,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8554,12 +7973,8 @@ country_event = {
 	option = {
 		name = iraq_md.72.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.72.a executed"
-		IRQ = {
-			country_event = iraq_md.73
-		}
-		ai_chance = {
-			base = 5
-		}
+		IRQ = { country_event = iraq_md.73 }
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8576,9 +7991,7 @@ country_event = {
 		name = iraq_md.73.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.72.a executed"
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = FROM
 				autonomy_state = autonomy_autonomous_state_colored
@@ -8594,9 +8007,7 @@ country_event = {
 				end_civil_wars = no
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Saddam Hussein Dies
@@ -8613,9 +8024,7 @@ country_event = {
 		name = iraq_md.74.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.74.a executed"
 		if = {
-			limit = {
-				has_country_flag = IRQ_qusay
-			}
+			limit = { has_country_flag = IRQ_qusay }
 			create_country_leader = {
 				name = "Qusay Hussein"
 				picture = "qussay_hussein.dds"
@@ -8642,17 +8051,13 @@ country_event = {
 				days = 1979
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = iraq_md.74.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.74.b executed"
-		trigger = {
-			has_country_flag = IRQ_alzheimers
-		}
+		trigger = { has_country_flag = IRQ_alzheimers }
 		hidden_effect = {
 			create_country_leader = {
 				name = "Saddam Hussein"
@@ -8676,9 +8081,7 @@ country_event = {
 				days = 120
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8693,9 +8096,7 @@ country_event = {
 	# Okay
 	option = {
 		name = iraq_md.744.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8735,9 +8136,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # China Accepts
@@ -8754,45 +8153,23 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: iraq_md.76.a executed"
 		custom_effect_tooltip = IRQ_chinese_investments_note_TT
 		if = {
-			limit = {
-				CHI = {
-					IRQ = {
-						influence_higher_30 = yes
-					}
-				}
-			}
+			limit = { CHI = { IRQ = { influence_higher_30 = yes } } }
 			one_office_construction = yes
 			three_random_infrastructure = yes
 			two_random_network_infrastructure = yes
 		}
 		else_if = {
-			limit = {
-				CHI = {
-					IRQ = {
-						influence_higher_20 = yes
-					}
-				}
-			}
+			limit = { CHI = { IRQ = { influence_higher_20 = yes } } }
 			three_random_infrastructure = yes
 			two_random_network_infrastructure = yes
 		}
 		else_if = {
-			limit = {
-				CHI = {
-					IRQ = {
-						influence_higher_10 = yes
-					}
-				}
-			}
+			limit = { CHI = { IRQ = { influence_higher_10 = yes } } }
 			two_random_infrastructure = yes
 			one_random_network_infrastructure = yes
 		}
-		else = {
-			one_random_infrastructure = yes
-		}
-		ai_chance = {
-			base = 5
-		}
+		else = { one_random_infrastructure = yes }
+		ai_chance = { base = 5 }
 	}
 }
 # China Rejects
@@ -8820,9 +8197,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -8877,9 +8252,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # X Acceprts
@@ -8893,9 +8266,7 @@ country_event = {
 	# Okay
 	option = {
 		name = iraq_md.79.a
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # X Rejects
@@ -8923,9 +8294,7 @@ country_event = {
 				clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 # Saddam Orders Attacks Against Kurds
@@ -8992,9 +8361,7 @@ country_event = {
 		name = iraq_md.82.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.82.a executed"
 		if = {
-			limit = {
-				original_tag = IRQ
-			}
+			limit = { original_tag = IRQ }
 			custom_effect_tooltip = IRQ_saddam_rage_lower_by_1_TT
 			hidden_effect = {
 				add_to_variable = { var = IRQ_saddam_pissboy value = -0.01 }
@@ -9002,9 +8369,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = KUR
-			}
+			limit = { original_tag = KUR }
 			add_stability = -1
 		}
 	}
@@ -9050,9 +8415,7 @@ country_event = {
 				}
 			}
 		}
-		effect_tooltip = {
-			add_to_faction = FROM
-		}
+		effect_tooltip = { add_to_faction = FROM }
 		FROM = { country_event = { id = iraq_md.84 hours = 3 } }
 	}
 
@@ -9103,9 +8466,7 @@ country_event = {
 		ai_chance = { base = 100 }
 		FROM = { add_to_faction = ROOT }
 		add_ideas = faction_resistance_axis_member
-		every_subject_country = {
-			add_ideas = faction_resistance_axis_member
-		}
+		every_subject_country = { add_ideas = faction_resistance_axis_member }
 	}
 }
 
@@ -9135,9 +8496,7 @@ country_event = {
 		name = iraq_md.86.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.86.a executed"
 		if = {
-			limit = {
-				original_tag = IRQ
-			}
+			limit = { original_tag = IRQ }
 			custom_effect_tooltip = IRQ_saddam_rage_increase_by_2_TT
 			hidden_effect = {
 				add_to_variable = { var = IRQ_saddam_pissboy value = 0.02 }
@@ -9145,14 +8504,10 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = KUR
-			}
+			limit = { original_tag = KUR }
 			add_stability = 1
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Saddams Orders Troops to Sack Local Markets
@@ -9195,9 +8550,7 @@ country_event = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = -0.02 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# We Can't Afford This..
@@ -9209,9 +8562,7 @@ country_event = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = 0.03 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Saddam Wants to Splurge
@@ -9234,9 +8585,7 @@ country_event = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = -0.02 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# We Can't Afford This..
@@ -9248,9 +8597,7 @@ country_event = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = 0.03 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Saddam Want's to Purge Certain Officials
@@ -9275,9 +8622,7 @@ country_event = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = -0.02 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# We Can't Afford This..
@@ -9289,9 +8634,7 @@ country_event = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = 0.03 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -9305,18 +8648,14 @@ country_event = {
 	option = {
 		name = iraq_md.90.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.90.a executed"
-		random_army_leader = {
-			retire = yes
-		}
+		random_army_leader = { retire = yes }
 		newline = yes
 		custom_effect_tooltip = IRQ_saddam_rage_lower_by_25_TT
 		hidden_effect = {
 			add_to_variable = { var = IRQ_saddam_pissboy value = -0.25 }
 			clamp_variable = { var = IRQ_saddam_pissboy min = 0 max = 0.50 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -9371,11 +8710,7 @@ country_event = {
 		name = iraq_yearly.1.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.1.a executed"
 		custom_effect_tooltip = IRQ_2_level_al_douri_TT
-		hidden_effect = {
-			IRQ_izzat_ibrahim_al_douri = {
-				add_skill_level = 2
-			}
-		}
+		hidden_effect = { IRQ_izzat_ibrahim_al_douri = { add_skill_level = 2 } }
 		newline = yes
 		set_temp_variable = { treasury_change = -21.50 }
 		modify_treasury_effect = yes
@@ -9426,12 +8761,8 @@ country_event = {
 	is_triggered_only = yes
 
 	trigger = {
-		NOT = {
-			has_war_with = PER
-		}
-		171 = {
-			is_owned_and_controlled_by = IRQ
-		}
+		NOT = { has_war_with = PER }
+		171 = { is_owned_and_controlled_by = IRQ }
 	}
 
 	option = {
@@ -9564,9 +8895,7 @@ country_event = {
 	option = {
 		name = iraq_md.201.b
 		log = "[GetDateText]: [This.GetName]: iraq_md.201.b executed"
-		IRQ = {
-			country_event = iraq_md.203
-		}
+		IRQ = { country_event = iraq_md.203 }
 		ai_chance = { base = 1 }
 	}
 }
@@ -9976,9 +9305,7 @@ country_event = {
 		name = iraq_md.316.a
 		log = "[GetDateText]: [This.GetName]: iraq_md.316.a executed"
 		if = {
-			limit = {
-				has_country_flag = IRQ_qusay
-			}
+			limit = { has_country_flag = IRQ_qusay }
 			create_country_leader = {
 				name = "Qusay Hussein"
 				picture = "qussay_hussein.dds"

--- a/events/Turkey.txt
+++ b/events/Turkey.txt
@@ -13,13 +13,11 @@ country_event = { #Turkey offers investments IRAN
 	id = Turkish_Economy.1
 	title = Turkish_Economy.1.t
 	desc = Turkish_Economy.1.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.1.a #YES
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.1.a executed"
@@ -37,6 +35,7 @@ country_event = { #Turkey offers investments IRAN
 			base = 10
 		}
 	}
+
 	option = {
 		name = Turkish_Economy.1.b #NO
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.1.b executed"
@@ -52,13 +51,11 @@ country_event = { #IRAN ACCEPTS
 	id = Turkish_Economy.11
 	title = Turkish_Economy.11.t
 	desc = Turkish_Economy.11.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.11.a #Good
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.11.a executed"
@@ -77,13 +74,11 @@ country_event = { #IRAN DENIES
 	id = Turkish_Economy.111
 	title = Turkish_Economy.111.t
 	desc = Turkish_Economy.111.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.111.a #Their loss
 		ai_chance = {
@@ -96,13 +91,11 @@ country_event = { #Turkey offers investments ARMENIA
 	id = Turkish_Economy.2
 	title = Turkish_Economy.2.t
 	desc = Turkish_Economy.2.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.2.a #YES
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.2.a executed"
@@ -120,6 +113,7 @@ country_event = { #Turkey offers investments ARMENIA
 			base = 10
 		}
 	}
+
 	option = {
 		name = Turkish_Economy.2.b #NO
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.2.b executed"
@@ -136,13 +130,11 @@ country_event = { #ARMENIA ACCEPTS
 	id = Turkish_Economy.22
 	title = Turkish_Economy.22.t
 	desc = Turkish_Economy.22.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.22.a #Good
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.22.a executed"
@@ -161,13 +153,11 @@ country_event = { #ARMENIA DENIES
 	id = Turkish_Economy.222
 	title = Turkish_Economy.222.t
 	desc = Turkish_Economy.222.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.222.a #Their loss
 		ai_chance = {
@@ -180,13 +170,11 @@ country_event = { #Turkey offers investments GEORGIA
 	id = Turkish_Economy.3
 	title = Turkish_Economy.3.t
 	desc = Turkish_Economy.3.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.3.a #YES
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.3.a executed"
@@ -204,6 +192,7 @@ country_event = { #Turkey offers investments GEORGIA
 			base = 10
 		}
 	}
+
 	option = {
 		name = Turkish_Economy.3.b #NO
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.3.b executed"
@@ -220,13 +209,11 @@ country_event = { #GEORGIA ACCEPTS
 	id = Turkish_Economy.33
 	title = Turkish_Economy.33.t
 	desc = Turkish_Economy.33.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.33.a #Good
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.33.a executed"
@@ -245,13 +232,11 @@ country_event = { #GEORGIA DENIES
 	id = Turkish_Economy.333
 	title = Turkish_Economy.333.t
 	desc = Turkish_Economy.333.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.333.a #Their loss
 		ai_chance = {
@@ -264,13 +249,11 @@ country_event = { #Turkey offers investments BULGARIA
 	id = Turkish_Economy.4
 	title = Turkish_Economy.4.t
 	desc = Turkish_Economy.4.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.4.a #YES
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.4.a executed"
@@ -288,6 +271,7 @@ country_event = { #Turkey offers investments BULGARIA
 			base = 10
 		}
 	}
+
 	option = {
 		name = Turkish_Economy.4.b #NO
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.4.b executed"
@@ -304,13 +288,11 @@ country_event = { #BULGARIA ACCEPTS
 	id = Turkish_Economy.44
 	title = Turkish_Economy.44.t
 	desc = Turkish_Economy.44.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.44.a #Good
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.44.a executed"
@@ -329,13 +311,11 @@ country_event = { #BULGARIA DENIES
 	id = Turkish_Economy.444
 	title = Turkish_Economy.444.t
 	desc = Turkish_Economy.444.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.444.a #Their loss
 		ai_chance = {
@@ -348,13 +328,11 @@ country_event = { #Turkey offers investments GREECE
 	id = Turkish_Economy.5
 	title = Turkish_Economy.5.t
 	desc = Turkish_Economy.4.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.5.a #YES
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.5.a executed"
@@ -372,6 +350,7 @@ country_event = { #Turkey offers investments GREECE
 			base = 10
 		}
 	}
+
 	option = {
 		name = Turkish_Economy.5.b #NO
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.5.b executed"
@@ -389,13 +368,11 @@ country_event = { #GREECE ACCEPTS
 	id = Turkish_Economy.55
 	title = Turkish_Economy.55.t
 	desc = Turkish_Economy.55.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.55.a #Good
 		log = "[GetDateText]: [This.GetName]: Turkish_Economy.55.a executed"
@@ -414,13 +391,11 @@ country_event = { #GREECE DENIES
 	id = Turkish_Economy.555
 	title = Turkish_Economy.555.t
 	desc = Turkish_Economy.555.desc
-	#picture
-
-	fire_only_once = yes
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture
 	option = {
 		name = Turkish_Economy.555.a #Their loss
 		ai_chance = {
@@ -479,6 +454,7 @@ country_event = { #How do we appraoch our operation
 			}
 		}
 	}
+
 	option = {
 		name = TUR_pkk.1.b
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.1.b executed"
@@ -497,6 +473,7 @@ country_event = { #How do we appraoch our operation
 			}
 		}
 	}
+
 	option = {
 		name = TUR_pkk.1.c
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.1.c executed"
@@ -537,6 +514,7 @@ country_event = { #Diyarabakir Summit
 			base = 10
 		}
 	}
+
 	option = { # We abstain
 		name = TUR_pkk.2.b
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.2.b executed"
@@ -564,9 +542,7 @@ country_event = { #X Country agrees to the terms
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.3.a executed"
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_2
 		add_to_variable = { TUR_PKK_strength = -2 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -579,9 +555,7 @@ country_event = { #X Country leaves the summit
 
 	option = {
 		name = TUR_pkk.4.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -593,6 +567,7 @@ country_event = {
 	desc = TUR_pkk.100.d
 	picture = GFX_TUR_pre_op_brief
 	is_triggered_only = yes
+
 	# Call in an airstrike
 	option = {
 		name = TUR_pkk.100.a
@@ -628,6 +603,7 @@ country_event = {
 			base = 1
 		}
 	}
+
 	# Distrupt their supply lines
 	option = {
 		name = TUR_pkk.100.b
@@ -664,6 +640,7 @@ country_event = {
 			base = 1
 		}
 	}
+
 	# Shell them with artillery
 	option = {
 		name = TUR_pkk.100.c
@@ -770,12 +747,11 @@ country_event = {
 			base = 1
 		}
 	}
+
 	# Do nothing
 	option = {
 		name = TUR_pkk.100.d1
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -824,10 +800,9 @@ country_event = {
 			idea = TUR_supply_disruption
 			days = 180
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Ask locals to transport some equipment
 	option = {
 		name = TUR_pkk.200.b
@@ -838,21 +813,16 @@ country_event = {
 		hidden_effect = {
 			random = {
 				chance = 50
-
 					add_equipment_to_stockpile = { type = infantry_weapons_1 amount = -500 producer = TUR }
 					add_equipment_to_stockpile = { type = util_vehicle_type amount = -75 producer = TUR }
-
 			}
-
 		}
 		newline = yes
 		add_timed_idea = {
 			idea = TUR_supply_disruption
 			days = 90
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # PKK entrench themselves in residential area
@@ -862,6 +832,7 @@ country_event = {
 	desc = TUR_pkk.201.d
 	picture = GFX_TUR_PKK_generic
 	is_triggered_only = yes
+
 	# Commandos
 	option = {
 		name = TUR_pkk.201.a
@@ -885,10 +856,9 @@ country_event = {
 		add_command_power = -50
 		newline = yes
 		TUR_PKK_attack = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Night Attack
 	option = {
 		name = TUR_pkk.201.b
@@ -913,18 +883,15 @@ country_event = {
 		add_equipment_to_stockpile = { type = util_vehicle_type amount = -175 producer = TUR }
 		newline = yes
 		TUR_PKK_attack = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Just attack
 	option = {
 		name = TUR_pkk.201.c
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.201.c executed"
 		if = {
-			limit = {
-				935 = { is_owned_and_controlled_by = TUR }
-			}
+			limit = { 935 = { is_owned_and_controlled_by = TUR } }
 			935 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -943,9 +910,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				162 = { is_owned_and_controlled_by = TUR }
-			}
+			limit = { 162 = { is_owned_and_controlled_by = TUR } }
 			162 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -967,9 +932,7 @@ country_event = {
 		add_manpower = -700
 		newline = yes
 		TUR_PKK_attack = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -996,18 +959,15 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Defend
 	option = {
 		name = TUR_pkk.202.b
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.202.b executed"
 		if = {
-			limit = {
-				935 = { is_owned_and_controlled_by = TUR }
-			}
+			limit = { 935 = { is_owned_and_controlled_by = TUR } }
 			935 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1033,9 +993,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				162 = { is_owned_and_controlled_by = TUR }
-			}
+			limit = { 162 = { is_owned_and_controlled_by = TUR } }
 			162 = {
 				if = {
 					limit = { infrastructure > 0 }
@@ -1073,10 +1031,9 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Run
 	option = {
 		name = TUR_pkk.202.c
@@ -1094,9 +1051,7 @@ country_event = {
 		}
 		newline = yes
 		TUR_PKK_attack = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Massive PKK Convoy Ambushed
@@ -1115,7 +1070,6 @@ country_event = {
 		hidden_effect = {
 			random = {
 				chance = 50
-
 					935 = {
 						if = {
 							limit = { industrial_complex > 0 }
@@ -1125,9 +1079,7 @@ country_event = {
 							}
 						}
 					}
-
 			}
-
 			TUR_PKK_attack = yes
 		}
 		newline = yes
@@ -1136,10 +1088,9 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Launch a careful attack, and seize the equipment
 	option = {
 		name = TUR_pkk.203.b
@@ -1156,10 +1107,9 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Starve them out until they surrender
 	option = {
 		name = TUR_pkk.203.c
@@ -1168,9 +1118,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # PKK is Trying to Sow Division!
@@ -1191,10 +1139,9 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Use this to our advantage
 	option = {
 		name = TUR_pkk.204.b
@@ -1205,10 +1152,9 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Pass Certain Laws
 	option = {
 		name = TUR_pkk.204.c
@@ -1217,9 +1163,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1232,28 +1176,24 @@ country_event = {
 	picture = GFX_TUR_PKK_generic2
 	is_triggered_only = yes
 
-	trigger = {
-		has_country_flag = TUR_targeting_van
-	}
+	trigger = { has_country_flag = TUR_targeting_van }
 
 	# Leave them be
 	option = {
 		name = TUR_pkk.205.a
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.205.a executed"
 		army_experience = 25
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Coarse them into coming back
 	option = {
 		name = TUR_pkk.205.b
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.205.b executed"
 		TUR_PKK_attack = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Cross the Armenian Border
 	option = {
 		name = TUR_pkk.205.c
@@ -1301,9 +1241,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.206.a executed"
 		custom_effect_tooltip = TUR_INCREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = 3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1319,9 +1257,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.207.a executed"
 		TUR_PKK_attack = yes
 		add_stability = -0.05
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1339,9 +1275,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1351,6 +1285,7 @@ country_event = {
 	desc = TUR_pkk.209.d
 	picture = GFX_TUR_PKK_generic2
 	is_triggered_only = yes
+
 	# Units Lack Proper Transport
 	option = {
 		name = TUR_pkk.209.a
@@ -1360,9 +1295,7 @@ country_event = {
 			amount = -75
 			producer = TUR
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1371,9 +1304,7 @@ country_event = {
 		army_experience = -75
 		newline = yes
 		TUR_PKK_attack = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1386,9 +1317,7 @@ country_event = {
 			amount = 175
 			producer = TUR
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1403,10 +1332,9 @@ country_event = {
 		name = TUR_pkk.210.a
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.210.a executed"
 		army_experience = 20
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = TUR_pkk.210.b
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.210.b executed"
@@ -1424,9 +1352,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1448,9 +1374,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1465,9 +1389,7 @@ country_event = {
 		name = TUR_pkk.211.a
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.211.a executed"
 		army_experience = -20
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1485,9 +1407,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_3
 		add_to_variable = { TUR_PKK_strength = -3 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1516,9 +1436,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_10
 		add_to_variable = { TUR_PKK_strength = -10 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1547,9 +1465,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_10
 		add_to_variable = { TUR_PKK_strength = -10 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1578,9 +1494,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = TUR_DECREASE_PKK_STRENGTH_10
 		add_to_variable = { TUR_PKK_strength = -10 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1591,11 +1505,10 @@ news_event = {
 	picture = GFX_failed_coup
 	is_triggered_only = yes
 	major = yes
+
 	option = {
 		name = TUR_pkk.217.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1661,7 +1574,6 @@ country_event = { # Failed Promise
 				}
 				division_template = {
 					name = "Lîwaya Rizgariya Kurdistanê"
-
 					regiments = {
 						L_Inf_Bat = { x = 0 y = 0 }
 						L_Inf_Bat = { x = 0 y = 1 }
@@ -1677,7 +1589,6 @@ country_event = { # Failed Promise
 				}
 				division_template = {
 					name = "Tabûra Jinan"
-
 					regiments = {
 						Militia_Bat = { x = 0 y = 0 }
 						Militia_Bat = { x = 0 y = 1 }
@@ -1687,7 +1598,6 @@ country_event = { # Failed Promise
 					}
 				}
 			}
-
 			# PKK Units
 			935 = {
 				create_unit = {
@@ -1715,7 +1625,6 @@ country_event = { # Failed Promise
 					owner = PKK
 				}
 			}
-
 			162 = {
 				create_unit = {
 					division = "name = \"Şehîd Kendal Lîwa\" division_template = \"Lîwaya Rizgariya Kurdistanê\"start_experience_factor = 1.0"
@@ -1742,7 +1651,6 @@ country_event = { # Failed Promise
 					owner = PKK
 				}
 			}
-
 			1205 = {
 				create_unit = {
 					division = "name = \"Şehîd Bêrîtan Lîwa\" division_template = \"Tabûra Jinan\"start_experience_factor = 1.0"
@@ -1903,7 +1811,6 @@ country_event = { # Failed Promise
 				}
 				division_template = {
 					name = "Lîwaya Rizgariya Kurdistanê"
-
 					regiments = {
 						L_Inf_Bat = { x = 0 y = 0 }
 						L_Inf_Bat = { x = 0 y = 1 }
@@ -1919,7 +1826,6 @@ country_event = { # Failed Promise
 				}
 				division_template = {
 					name = "Tabûra Jinan"
-
 					regiments = {
 						Militia_Bat = { x = 0 y = 0 }
 						Militia_Bat = { x = 0 y = 1 }
@@ -1929,7 +1835,6 @@ country_event = { # Failed Promise
 					}
 				}
 			}
-
 			# PKK Units
 			935 = {
 				create_unit = {
@@ -1957,7 +1862,6 @@ country_event = { # Failed Promise
 					owner = PKK
 				}
 			}
-
 			162 = {
 				create_unit = {
 					division = "name = \"Şehîd Kendal Lîwa\" division_template = \"Lîwaya Rizgariya Kurdistanê\"start_experience_factor = 1.0"
@@ -1984,7 +1888,6 @@ country_event = { # Failed Promise
 					owner = PKK
 				}
 			}
-
 			1205 = {
 				create_unit = {
 					division = "name = \"Şehîd Bêrîtan Lîwa\" division_template = \"Tabûra Jinan\"start_experience_factor = 1.0"
@@ -2025,11 +1928,9 @@ country_event = { # PKK Breaks Free
 	picture = GFX_TUR_PKK_generic
 	is_triggered_only = yes
 	fire_only_once = yes
-	trigger = {
-		NOT = {
-			has_country_flag = TUR_PKK_gone
-		}
-	}
+
+	trigger = { NOT = { has_country_flag = TUR_PKK_gone } }
+
 	option = {
 		name = TUR_pkk.604.a
 		log = "[GetDateText]: [This.GetName]: TUR_pkk.604.a executed"
@@ -2143,7 +2044,6 @@ country_event = { # PKK Breaks Free
 				}
 				division_template = {
 					name = "Lîwaya Rizgariya Kurdistanê"
-
 					regiments = {
 						L_Inf_Bat = { x = 0 y = 0 }
 						L_Inf_Bat = { x = 0 y = 1 }
@@ -2159,7 +2059,6 @@ country_event = { # PKK Breaks Free
 				}
 				division_template = {
 					name = "Tabûra Jinan"
-
 					regiments = {
 						Militia_Bat = { x = 0 y = 0 }
 						Militia_Bat = { x = 0 y = 1 }
@@ -2169,7 +2068,6 @@ country_event = { # PKK Breaks Free
 					}
 				}
 			}
-
 			# PKK Units
 			935 = {
 				create_unit = {
@@ -2197,7 +2095,6 @@ country_event = { # PKK Breaks Free
 					owner = PKK
 				}
 			}
-
 			162 = {
 				create_unit = {
 					division = "name = \"Şehîd Kendal Lîwa\" division_template = \"Lîwaya Rizgariya Kurdistanê\"start_experience_factor = 1.0"
@@ -2224,7 +2121,6 @@ country_event = { # PKK Breaks Free
 					owner = PKK
 				}
 			}
-
 			1205 = {
 				create_unit = {
 					division = "name = \"Şehîd Bêrîtan Lîwa\" division_template = \"Tabûra Jinan\"start_experience_factor = 1.0"
@@ -2251,7 +2147,6 @@ country_event = { # PKK Breaks Free
 					owner = PKK
 				}
 			}
-
 			TUR = {
 				declare_war_on = {
 					target = PKK
@@ -2272,9 +2167,7 @@ country_event = { # Renewed offensive in the southeast
 	picture = GFX_TUR_PKK_generic2
 	is_triggered_only = yes
 
-	trigger = {
-		NOT = { has_country_flag = TUR_PKK_gone }
-	}
+	trigger = { NOT = { has_country_flag = TUR_PKK_gone } }
 
 	option = {
 		name = TUR_pkk.605.a
@@ -2288,9 +2181,7 @@ country_event = { # Renewed offensive in the southeast
 		custom_effect_tooltip = TUR_PKK_OFFENSIVE_TT
 		set_variable = { TUR_PKK_strength = TUR_PKK_min_strength }
 		add_to_variable = { TUR_PKK_strength = 20 }
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -2300,13 +2191,11 @@ country_event = {
 	title = Turkey.1.t
 	desc = Turkey.1.desc
 	picture = GFX_message_signing
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.1.a	#Let them go
+		name = Turkey.1.a #Let them go
 		log = "[GetDateText]: [This.GetName]: Turkey.1.a executed"
 		ai_chance = {
 			base = 80
@@ -2330,8 +2219,9 @@ country_event = {
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = TUR_CHP_BOOST_TT
 	}
+
 	option = {
-		name = Turkey.1.b	#Backroom deals
+		name = Turkey.1.b #Backroom deals
 		log = "[GetDateText]: [This.GetName]: Turkey.1.b executed"
 		ai_chance = {
 			base = 20
@@ -2351,26 +2241,22 @@ country_event = {
 	title = Turkey.2.t
 	desc = Turkey.2.desc
 	picture = GFX_message_signing
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = Turkey.2.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
 #Özakan's coup
 country_event = {
 	id = Turkey.3
-
 	title = Turkey.3.t
 	desc = Turkey.3.desc
-
+	picture = GFX_news_generic_soldiers
+	is_triggered_only = yes
 	fire_only_once = yes
 
 	trigger = {
@@ -2383,22 +2269,14 @@ country_event = {
 		}
 	}
 
-	picture = GFX_news_generic_soldiers
-	is_triggered_only = yes
-
 	option = {
 		name = Turkey.3.a
 		log = "[GetDateText]: [This.GetName]: Turkey.3.a executed"
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-		hidden_effect = {
-			set_leader = yes
-		}
-
-		ai_chance = {
-			base = 100
-		}
+		hidden_effect = { set_leader = yes }
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -2407,7 +2285,8 @@ country_event = {
 	id = Turkey.4
 	title = Turkey.4.t
 	desc = Turkey.4.desc
-
+	picture = GFX_election_day
+	is_triggered_only = yes
 	fire_only_once = yes
 
 	trigger = {
@@ -2424,13 +2303,9 @@ country_event = {
 		}
 	}
 
-	picture = GFX_election_day
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.4.a	#Arrange a new election
+		name = Turkey.4.a #Arrange a new election
 		log = "[GetDateText]: [This.GetName]: Turkey.4.a executed"
-
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
@@ -2445,15 +2320,14 @@ country_event = {
 		}
 		recalculate_party = yes
 		set_country_flag = TUR_Turkey4_fired
-
 		ai_chance = {
 			base = 80
 		}
 	}
-	option = {
-		name = Turkey.4.b	#No election
-		log = "[GetDateText]: [This.GetName]: Turkey.4.b executed"
 
+	option = {
+		name = Turkey.4.b #No election
+		log = "[GetDateText]: [This.GetName]: Turkey.4.b executed"
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
@@ -2465,7 +2339,6 @@ country_event = {
 		add_ideas = TUR_minority_government
 		recalculate_party = yes
 		set_country_flag = TUR_Turkey4_fired
-
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -2482,7 +2355,7 @@ country_event = {
 	title = Turkey.5.t
 	desc = Turkey.5.desc
 	picture = GFX_TUR_generic
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
 	trigger = {
@@ -2490,10 +2363,8 @@ country_event = {
 		is_ai = no
 	}
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.5.a	#Özkan negotiates (historical)
+		name = Turkey.5.a #Özkan negotiates (historical)
 		log = "[GetDateText]: [This.GetName]: Turkey.5.a executed"
 		trigger = { NOT = { has_country_flag = Turkey_Ozkan_purged } }
 		ai_chance = {
@@ -2502,6 +2373,7 @@ country_event = {
 		custom_effect_tooltip = TUR_COMPROMISE_PRESIDENT_TT
 		hidden_effect = { country_event = { id = Turkey.6 days = 7 } }
 	}
+
 	option = {
 		name = Turkey.5.b #Hope for the best
 		log = "[GetDateText]: [This.GetName]: Turkey.5.b executed"
@@ -2530,7 +2402,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Ahmed Necdet Sezer elected president
@@ -2538,14 +2409,12 @@ country_event = {
 	id = Turkey.6
 	title = Turkey.6.t
 	desc = Turkey.6.desc
-
-	fire_only_once = yes
-
 	picture = GFX_election_day
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
-		name = Turkey.6.a	#ok
+		name = Turkey.6.a #ok
 		log = "[GetDateText]: [This.GetName]: Turkey.6.a executed"
 		ai_chance = {
 			base = 100
@@ -2557,7 +2426,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #DSP candidate wins
@@ -2566,13 +2434,11 @@ country_event = {
 	title = Turkey.7.t
 	desc = Turkey.7.desc
 	picture = GFX_TUR_generic
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.7.a	#ok
+		name = Turkey.7.a #ok
 		log = "[GetDateText]: [This.GetName]: Turkey.7.a executed"
 		ai_chance = {
 			base = 100
@@ -2583,7 +2449,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #Voting goes to fourth round
@@ -2592,13 +2457,11 @@ country_event = {
 	title = Turkey.8.t
 	desc = Turkey.8.desc
 	picture = GFX_TUR_generic
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.8.a	#go with the voting
+		name = Turkey.8.a #go with the voting
 		log = "[GetDateText]: [This.GetName]: Turkey.8.a executed"
 		ai_chance = {
 			base = 100
@@ -2629,8 +2492,9 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
-		name = Turkey.8.b	#Support FP
+		name = Turkey.8.b #Support FP
 		log = "[GetDateText]: [This.GetName]: Turkey.8.b executed"
 		ai_chance = {
 			base = 100
@@ -2655,7 +2519,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #FP candidate wins
@@ -2664,13 +2527,11 @@ country_event = {
 	title = Turkey.9.t
 	desc = Turkey.9.desc
 	picture = GFX_TUR_generic
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.9.a	#ok
+		name = Turkey.9.a #ok
 		log = "[GetDateText]: [This.GetName]: Turkey.9.a executed"
 		ai_chance = {
 			base = 100
@@ -2683,7 +2544,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #Constitution requires snap elections
@@ -2692,13 +2552,11 @@ country_event = {
 	title = Turkey.10.t
 	desc = Turkey.10.desc
 	picture = GFX_TUR_generic
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.10.a	#ok
+		name = Turkey.10.a #ok
 		log = "[GetDateText]: [This.GetName]: Turkey.10.a executed"
 		ai_chance = {
 			base = 100
@@ -2716,10 +2574,8 @@ country_event = {
 	title = Turkey.11.t
 	desc = Turkey.11.desc
 	picture = GFX_turkeycoup
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	immediate = {
 		#Determine the strength of the military (sum of pro-military Kemalists)
@@ -2729,7 +2585,6 @@ country_event = {
 		add_to_variable = { military_support = party_pop_array^4 } #IP
 		add_to_variable = { military_support = party_pop_array^18 }
 		add_to_variable = { military_support = party_pop_array^22 } #Military
-
 		#Determine the strength of the islamists (sum of conservative islamic parties)
 		set_variable = { islamist_support = 0 }
 		if = {
@@ -2750,7 +2605,6 @@ country_event = {
 		add_to_variable = { islamist_support = party_pop_array^20 } #MHP
 		add_to_variable = { islamist_support = party_pop_array^21 } #Grey Wolves
 		add_to_variable = { islamist_support = party_pop_array^23 } #Monarchists
-
 		#Modify based on Military's opinion
 		set_temp_variable = { military_opinion_coup = the_military_opinion }
 		subtract_from_temp_variable = { military_opinion_coup = 50 }
@@ -2759,7 +2613,6 @@ country_event = {
 		multiply_variable = { islamist_support = military_opinion_coup }
 		clamp_temp_variable = { var = military_opinion_coup min = 0.001 }
 		divide_variable = { military_support = military_opinion_coup }
-
 		#Clamp to 1 in case
 		clamp_variable = {
 			var = military_support
@@ -2774,7 +2627,7 @@ country_event = {
 	}
 
 	option = {
-		name = Turkey.11.a	#Side with government
+		name = Turkey.11.a #Side with government
 		log = "[GetDateText]: [This.GetName]: Turkey.11.a executed"
 		if = {
 			limit = { has_idea = TUR_guards_of_kemalism }
@@ -2795,7 +2648,6 @@ country_event = {
 				hidden_effect = {
 					random_other_country = {
 						limit = { original_tag = TUR }
-
 						add_ideas = TUR_guards_of_kemalism
 						set_temp_variable = { rul_party_temp = 22 }
 						change_ruling_party_effect = yes
@@ -2817,8 +2669,9 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
-		name = Turkey.11.b	#Side with military
+		name = Turkey.11.b #Side with military
 		log = "[GetDateText]: [This.GetName]: Turkey.11.b executed"
 		if = {
 			limit = { NOT = { has_idea = TUR_guards_of_kemalism } }
@@ -2880,13 +2733,12 @@ news_event = { #Military Coup in Turkey Succeeds
 	title = Turkey.12.t
 	desc = Turkey.12.d
 	picture = GFX_coup_success
+	is_triggered_only = yes
 	major = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.12.a	#ok
+		name = Turkey.12.a #ok
 		ai_chance = {
 			base = 100
 		}
@@ -2898,13 +2750,12 @@ news_event = { #Military Coup in Turkey Fails
 	title = Turkey.14.t
 	desc = Turkey.14.d
 	picture = GFX_failed_coup
+	is_triggered_only = yes
 	major = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.14.a	#ok
+		name = Turkey.14.a #ok
 		ai_chance = {
 			base = 100
 		}
@@ -2916,13 +2767,12 @@ news_event = { #Military Coup plunges Turkey into civilwar
 	title = Turkey.15.t
 	desc = Turkey.15.d
 	picture = GFX_civilwar_turkey
+	is_triggered_only = yes
 	major = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = Turkey.15.a	#ok
+		name = Turkey.15.a #ok
 		ai_chance = {
 			base = 100
 		}
@@ -2934,19 +2784,17 @@ country_event = {
 	id = TurkeyRandomEvents.1
 	title = TurkeyRandomEvents.1.t
 	desc = TurkeyRandomEvents.1.desc
+	picture = GFX_court
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		original_tag = TUR
 		NOT = { has_country_flag = TUR_Baykal_scandal }
 	}
 
-	fire_only_once = yes
-
-	picture = GFX_court
-	is_triggered_only = yes
-
 	option = {
-		name = TurkeyRandomEvents.1.a	#He resings
+		name = TurkeyRandomEvents.1.a #He resings
 		log = "[GetDateText]: [This.GetName]: TurkeyRandomEvents.1.a executed"
 		trigger = { NOT = { has_country_leader = { name = "Deniz Baykal" ruling_only = yes } } }
 		ai_chance = { base = 100 }
@@ -2956,8 +2804,9 @@ country_event = {
 		change_relative_party_popularity = yes
 		set_country_flag = TUR_Baykal_scandal
 	}
+
 	option = {
-		name = TurkeyRandomEvents.1.b	#He's not going to
+		name = TurkeyRandomEvents.1.b #He's not going to
 		log = "[GetDateText]: [This.GetName]: TurkeyRandomEvents.1.b executed"
 		trigger = { has_country_leader = { name = "Deniz Baykal" ruling_only = yes } }
 		ai_chance = { base = 50 }
@@ -2967,8 +2816,9 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		change_relative_party_popularity = yes
 	}
+
 	option = {
-		name = TurkeyRandomEvents.1.c	#I guess we have to have new elections
+		name = TurkeyRandomEvents.1.c #I guess we have to have new elections
 		log = "[GetDateText]: [This.GetName]: TurkeyRandomEvents.1.c executed"
 		trigger = { has_country_leader = { name = "Deniz Baykal" ruling_only = yes } }
 		ai_chance = { base = 50 }
@@ -2985,7 +2835,6 @@ country_event = {
 			set_elections_60_months = yes
 		}
 	}
-
 }
 
 #Invite Azerbaijan to the Vanguard
@@ -2994,7 +2843,6 @@ country_event = {
 	title = TurkeyFocusEvents.1.t
 	desc = TurkeyFocusEvents.1.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3017,6 +2865,7 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.1.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.1.b executed"
@@ -3037,7 +2886,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Turkey Demands Nagorno Karabakh
@@ -3046,7 +2894,6 @@ country_event = {
 	title = TurkeyFocusEvents.2.t
 	desc = TurkeyFocusEvents.2.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3064,12 +2911,11 @@ country_event = {
 			limit = { country_exists = NKR }
 			AZE = { annex_country = { target = NKR } }
 		}
-		else = {
-			AZE = { transfer_state = 710 }
-		}
+		else = { AZE = { transfer_state = 710 } }
 		FROM = { country_event = { id = TurkeyFocusEvents.3 hours = 6 } }
 		AZE = { country_event = { id = TurkeyFocusEvents.3 hours = 6 } }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.2.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.2.b executed"
@@ -3083,7 +2929,6 @@ country_event = {
 		FROM = { country_event = { id = TurkeyFocusEvents.4 hours = 6 } }
 		AZE = { country_event = { id = TurkeyFocusEvents.4 hours = 6 } }
 	}
-
 }
 
 #Armenia returns Nagorno-Karabak
@@ -3092,14 +2937,12 @@ country_event = {
 	title = TurkeyFocusEvents.3.t
 	desc = TurkeyFocusEvents.3.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
 		name = TurkeyFocusEvents.3.a
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Armenia refuses to withdraw
@@ -3108,7 +2951,6 @@ country_event = {
 	title = TurkeyFocusEvents.4.t
 	desc = TurkeyFocusEvents.4.desc
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = {
@@ -3121,6 +2963,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = TurkeyFocusEvents.4.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.4.a executed"
@@ -3131,7 +2974,6 @@ country_event = {
 			type = annex_everything
 		}
 	}
-
 }
 
 #Invite Iran to the Vanguard
@@ -3140,7 +2982,6 @@ country_event = {
 	title = TurkeyFocusEvents.5.t
 	desc = TurkeyFocusEvents.5.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3189,6 +3030,7 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.5.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.5.b executed"
@@ -3235,7 +3077,6 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
-
 }
 
 #Invite Iraq to the Vanguard
@@ -3244,7 +3085,6 @@ country_event = {
 	title = TurkeyFocusEvents.6.t
 	desc = TurkeyFocusEvents.6.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3293,6 +3133,7 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.6.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.6.b executed"
@@ -3339,7 +3180,6 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
-
 }
 
 #Invite Syria to the Vanguard
@@ -3348,7 +3188,6 @@ country_event = {
 	title = TurkeyFocusEvents.7.t
 	desc = TurkeyFocusEvents.7.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3397,6 +3236,7 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.7.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.7.b executed"
@@ -3451,7 +3291,6 @@ country_event = {
 	title = TurkeyFocusEvents.81.t
 	desc = TurkeyFocusEvents.81.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Only for a little something in return...
@@ -3462,6 +3301,7 @@ country_event = {
 		}
 		ai_chance = { base = 100 }
 	}
+
 	option = { #No way
 		name = TurkeyFocusEvents.81.b
 		ai_chance = { base = 1 }
@@ -3473,7 +3313,6 @@ country_event = {
 	title = TurkeyFocusEvents.8.t
 	desc = TurkeyFocusEvents.8.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3485,16 +3324,14 @@ country_event = {
 			limit = { ALA = { is_subject_of = ROOT } }
 			FROM = { annex_country = { target = ALA transfer_troops = yes } }
 		}
-		else = {
-			FROM = { transfer_state = 158 }
-		}
+		else = { FROM = { transfer_state = 158 } }
 		FROM = { country_event = { id = TurkeyFocusEvents.9 hours = 3 } }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.8.b
 		ai_chance = { base = 60 }
 	}
-
 }
 
 #Hatay given back
@@ -3503,7 +3340,6 @@ country_event = {
 	title = TurkeyFocusEvents.9.t
 	desc = TurkeyFocusEvents.9.desc
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3519,7 +3355,6 @@ country_event = { #Greece event
 	title = TurkeyFocusEvents.10.t
 	desc = TurkeyFocusEvents.10.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3543,7 +3378,6 @@ country_event = { #Turkey demands we establish buffer zones
 	title = TurkeyFocusEvents.19.t
 	desc = TurkeyFocusEvents.19.d
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
 
 	option = {
@@ -3559,6 +3393,7 @@ country_event = { #Turkey demands we establish buffer zones
 		189 = { set_demilitarized_zone = yes }
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.19.b #No!
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.19.b executed"
@@ -3574,7 +3409,6 @@ country_event = { #Syria permits the buffer zone
 	title = TurkeyFocusEvents.191.t
 	desc = TurkeyFocusEvents.191.d
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
 
 	option = {
@@ -3588,7 +3422,6 @@ country_event = { #Syria permits the buffer zone
 	title = TurkeyFocusEvents.192.t
 	desc = TurkeyFocusEvents.192.d
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
 
 	option = {
@@ -3612,12 +3445,13 @@ country_event = { #Turkey Send back Migrants
 	title = TurkeyFocusEvents.20.t
 	desc = TurkeyFocusEvents.20.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
+
 	option = {
 		name = TurkeyFocusEvents.20.a #Sure
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.20.b #Sure
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.20.b executed"
@@ -3639,6 +3473,7 @@ country_event = { #Turkey Send back Migrants
 		974 = { add_manpower = 15000 }
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.20.c #Sure
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.20.c executed"
@@ -3667,7 +3502,6 @@ country_event = { #Potential settlement for Karabakh?
 	title = TurkeyFocusEvents.21.t
 	desc = TurkeyFocusEvents.21.d
 	picture = GFX_hills_azerbaijani
-
 	is_triggered_only = yes
 
 	option = {
@@ -3681,6 +3515,7 @@ country_event = { #Potential settlement for Karabakh?
 		}
 		ai_chance = { base = 7 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.21.b #No, absolutely not
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.21.b executed"
@@ -3699,7 +3534,6 @@ country_event = { #Azerbaijan proposes settlement for Karabakh
 	title = TurkeyFocusEvents.212.t
 	desc = TurkeyFocusEvents.212.d
 	picture = GFX_hills_azerbaijani
-
 	is_triggered_only = yes
 
 	option = {
@@ -3725,6 +3559,7 @@ country_event = { #Azerbaijan proposes settlement for Karabakh
 			}
 		}
 	}
+
 	option = {
 		name = TurkeyFocusEvents.212.b #No, absolutely not
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.212.b executed"
@@ -3749,7 +3584,6 @@ country_event = { #Azerbaijan and Armenia come to an agreement!
 	title = TurkeyFocusEvents.213.t
 	desc = TurkeyFocusEvents.213.d
 	picture = GFX_hills_azerbaijani
-
 	is_triggered_only = yes
 
 	option = {
@@ -3763,7 +3597,6 @@ country_event = { #Azerbaijan and Armenia fail to come to an agreement!
 	title = TurkeyFocusEvents.214.t
 	desc = TurkeyFocusEvents.214.d
 	picture = GFX_hills_azerbaijani
-
 	is_triggered_only = yes
 
 	option = {
@@ -3777,7 +3610,6 @@ country_event = { #Through the Troubles
 	title = TurkeyFocusEvents.69420.t
 	desc = TurkeyFocusEvents.69420.d
 	picture = GFX_TUR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3793,7 +3625,6 @@ country_event = { #Pro AKP rally
 	title = TurkeyFocusEvents.22.t
 	desc = TurkeyFocusEvents.22.d
 	picture = GFX_TUR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3814,7 +3645,6 @@ country_event = { #Pro Hizmet rally
 	title = TurkeyFocusEvents.23.t
 	desc = TurkeyFocusEvents.23.d
 	picture = GFX_TUR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3835,7 +3665,6 @@ country_event = { #Alliance with the FPI?
 	title = TurkeyFocusEvents.24.t
 	desc = TurkeyFocusEvents.24.d
 	picture = GFX_TUR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3848,6 +3677,7 @@ country_event = { #Alliance with the FPI?
 		europeanism_change = yes
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.24.b #Ehh its better we don't
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.24.b executed"
@@ -3864,7 +3694,6 @@ country_event = { #Investments
 	title = TurkeyFocusEvents.25.t
 	desc = TurkeyFocusEvents.25.d
 	picture = GFX_hung_2020
-
 	is_triggered_only = yes
 
 	option = {
@@ -3894,6 +3723,7 @@ country_event = { #Investments
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.25.b #Warm up relations with our Shia friends
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.25.b executed"
@@ -3928,7 +3758,6 @@ country_event = { #Kosovo Matter
 	title = TurkeyFocusEvents.26.t
 	desc = TurkeyFocusEvents.26.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { #Military mission
@@ -3939,6 +3768,7 @@ country_event = { #Kosovo Matter
 		add_command_power = 10
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.26.b #Sanctions
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.26.b executed"
@@ -3956,7 +3786,6 @@ country_event = { #Against the Gulf Monarchies!
 	title = TurkeyFocusEvents.27.t
 	desc = TurkeyFocusEvents.27.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { #Fund strikes
@@ -3972,6 +3801,7 @@ country_event = { #Against the Gulf Monarchies!
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.27.b #Fund democratic groups
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.27.b executed"
@@ -3992,7 +3822,6 @@ country_event = { #Turkey Wants us to Deport PKK members!
 	title = TurkeyFocusEvents.28.t
 	desc = TurkeyFocusEvents.28.d
 	picture = GFX_kurdistan
-
 	is_triggered_only = yes
 
 	option = { #Uhh sure..
@@ -4019,6 +3848,7 @@ country_event = { #Turkey Wants us to Deport PKK members!
 		}
 		ai_chance = { base = 4 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.28.b #They cannot be trusted with human rights!
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.28.b executed"
@@ -4038,7 +3868,6 @@ country_event = { #Sweden sends them back!
 	title = TurkeyFocusEvents.29.t
 	desc = TurkeyFocusEvents.29.d
 	picture = GFX_kurdistan
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -4055,7 +3884,6 @@ country_event = { #Sweden does not send them back!
 	title = TurkeyFocusEvents.30.t
 	desc = TurkeyFocusEvents.30.d
 	picture = GFX_kurdistan
-
 	is_triggered_only = yes
 
 	option = { #Damn
@@ -4072,7 +3900,6 @@ country_event = { #Who Revolts?
 	title = TurkeyFocusEvents.31.t
 	desc = TurkeyFocusEvents.31.d
 	picture = GFX_aban_protests_iran
-
 	is_triggered_only = yes
 
 	option = { #Some support
@@ -4117,6 +3944,7 @@ country_event = { #Who Revolts?
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { #A lot of support
 		name = TurkeyFocusEvents.31.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.31.b executed"
@@ -4166,7 +3994,6 @@ country_event = { #Peshmerga Stance
 	title = TurkeyFocusEvents.32.t
 	desc = TurkeyFocusEvents.32.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # We'll be good
@@ -4179,6 +4006,7 @@ country_event = { #Peshmerga Stance
 		diplomatic_relation = { country = PKK relation = non_aggression_pact active = yes }
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.32.b #No! Their our enemies!
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.32.b executed"
@@ -4202,7 +4030,6 @@ country_event = { #Peshmerga maintain hostility
 	title = TurkeyFocusEvents.321.t
 	desc = TurkeyFocusEvents.321.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # Damn
@@ -4216,7 +4043,6 @@ country_event = { #Peshmerga drop hostility
 	title = TurkeyFocusEvents.322.t
 	desc = TurkeyFocusEvents.322.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # Damn
@@ -4230,7 +4056,6 @@ country_event = { #Dealing with Peshmerga
 	title = TurkeyFocusEvents.33.t
 	desc = TurkeyFocusEvents.33.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # We'll do it ourselves
@@ -4244,6 +4069,7 @@ country_event = { #Dealing with Peshmerga
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.33.b #Operation with Iraq..
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.33.b executed"
@@ -4259,7 +4085,6 @@ country_event = { #Dealing with Peshmerga (IRQ)
 	title = TurkeyFocusEvents.331.t
 	desc = TurkeyFocusEvents.331.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # Okay
@@ -4279,6 +4104,7 @@ country_event = { #Dealing with Peshmerga (IRQ)
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = TurkeyFocusEvents.331.b #No
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.331.b executed"
@@ -4294,7 +4120,6 @@ country_event = { #Dealing with Peshmerga (IRQ)
 	title = TurkeyFocusEvents.332.t
 	desc = TurkeyFocusEvents.332.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # Okay
@@ -4315,7 +4140,6 @@ country_event = { #The Turkish Medias
 	title = TurkeyFocusEvents.34.t
 	desc = TurkeyFocusEvents.34.d
 	picture = GFX_computer
-
 	is_triggered_only = yes
 
 	option = { # Okay
@@ -4341,6 +4165,7 @@ country_event = { #The Turkish Medias
 		modify_treasury_effect = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { # Okay
 		name = TurkeyFocusEvents.34.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.34.b executed"
@@ -4395,7 +4220,6 @@ country_event = { #Turko Syrian Union
 	title = TurkeyFocusEvents.35.t
 	desc = TurkeyFocusEvents.35.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { # Okay
@@ -4406,6 +4230,7 @@ country_event = { #Turko Syrian Union
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { # No
 		name = TurkeyFocusEvents.35.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.35.b executed"
@@ -4421,7 +4246,6 @@ country_event = { #They accept
 	title = TurkeyFocusEvents.351.t
 	desc = TurkeyFocusEvents.351.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { # Great
@@ -4444,7 +4268,6 @@ country_event = { #They don't accept
 	title = TurkeyFocusEvents.352.t
 	desc = TurkeyFocusEvents.352.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = { # Great
@@ -4466,7 +4289,6 @@ country_event = { #
 	title = TurkeyFocusEvents.36.t
 	desc = TurkeyFocusEvents.36.d
 	picture = GFX_hung_2020
-
 	is_triggered_only = yes
 
 	option = { #
@@ -4484,6 +4306,7 @@ country_event = { #
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { #
 		name = TurkeyFocusEvents.36.b
 		ai_chance = { base = 0 }
@@ -4495,7 +4318,6 @@ country_event = { #Turkey Mafia warns us of Australia (Indonesia)
 	title = TurkeyFocusEvents.37.t
 	desc = TurkeyFocusEvents.37.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { #
@@ -4509,6 +4331,7 @@ country_event = { #Turkey Mafia warns us of Australia (Indonesia)
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { #
 		name = TurkeyFocusEvents.37.b
 		ai_chance = { base = 0 }
@@ -4520,7 +4343,6 @@ country_event = { #Turkey Wants us to fight Israel
 	title = TurkeyFocusEvents.38.t
 	desc = TurkeyFocusEvents.38.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # Yes
@@ -4538,6 +4360,7 @@ country_event = { #Turkey Wants us to fight Israel
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { # No
 		name = TurkeyFocusEvents.38.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.38.b executed"
@@ -4553,7 +4376,6 @@ country_event = { #Iran is fighting Israel with Turkey
 	title = TurkeyFocusEvents.381.t
 	desc = TurkeyFocusEvents.381.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = { # Yes
@@ -4565,6 +4387,7 @@ country_event = { #Iran is fighting Israel with Turkey
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { # No
 		name = TurkeyFocusEvents.381.b
 		ai_chance = { base = 0 }
@@ -4575,7 +4398,6 @@ country_event = { #Iran Agrees
 	id = TurkeyFocusEvents.39
 	title = TurkeyFocusEvents.39.t
 	desc = TurkeyFocusEvents.39.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -4589,7 +4411,6 @@ country_event = { #Iran Rejects
 	id = TurkeyFocusEvents.40
 	title = TurkeyFocusEvents.40.t
 	desc = TurkeyFocusEvents.40.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
@@ -4604,7 +4425,6 @@ country_event = { #Turkey is inviting us to CIW (Iraq)
 	title = TurkeyFocusEvents.41.t
 	desc = TurkeyFocusEvents.41.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Good Idea
@@ -4619,6 +4439,7 @@ country_event = { #Turkey is inviting us to CIW (Iraq)
 			}
 		}
 	}
+
 	option = { #No
 		name = TurkeyFocusEvents.41.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.41.b executed"
@@ -4634,7 +4455,6 @@ country_event = { #Iraq is not interested
 	title = TurkeyFocusEvents.411.t
 	desc = TurkeyFocusEvents.411.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -4648,7 +4468,6 @@ country_event = { #Turkey is inviting us to CIW (Egypt)
 	title = TurkeyFocusEvents.42.t
 	desc = TurkeyFocusEvents.42.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Good Idea
@@ -4663,6 +4482,7 @@ country_event = { #Turkey is inviting us to CIW (Egypt)
 			}
 		}
 	}
+
 	option = { #No
 		name = TurkeyFocusEvents.42.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.42.b executed"
@@ -4678,7 +4498,6 @@ country_event = { #Egypt is not interested
 	title = TurkeyFocusEvents.421.t
 	desc = TurkeyFocusEvents.421.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Good Idea
@@ -4692,7 +4511,6 @@ country_event = { #Invitation to the CIW
 	title = TurkeyFocusEvents.43.t
 	desc = TurkeyFocusEvents.43.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Sign me up
@@ -4701,6 +4519,7 @@ country_event = { #Invitation to the CIW
 		add_ideas = CIW_member
 		ai_chance = { base = 7 }
 	}
+
 	option = { #No
 		name = TurkeyFocusEvents.43.b
 		ai_chance = { base = 3 }
@@ -4712,7 +4531,6 @@ country_event = { #Turkey is investing in Infrastructure
 	title = TurkeyFocusEvents.44.t
 	desc = TurkeyFocusEvents.44.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Great!
@@ -4731,7 +4549,6 @@ country_event = { #Turkey is investing in Disaster Relief
 	title = TurkeyFocusEvents.45.t
 	desc = TurkeyFocusEvents.45.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Great!
@@ -4750,7 +4567,6 @@ country_event = { #Turkey is investing in Education
 	title = TurkeyFocusEvents.46.t
 	desc = TurkeyFocusEvents.46.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Great!
@@ -4769,7 +4585,6 @@ country_event = { #Turkey is investing in Healthcare
 	title = TurkeyFocusEvents.47.t
 	desc = TurkeyFocusEvents.47.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Great!
@@ -4788,7 +4603,6 @@ country_event = { #Turkey is investing in Industries
 	title = TurkeyFocusEvents.48.t
 	desc = TurkeyFocusEvents.48.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Great!
@@ -4807,7 +4621,6 @@ country_event = { #Leave CIW
 	title = TurkeyFocusEvents.49.t
 	desc = TurkeyFocusEvents.49.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #
@@ -4821,7 +4634,6 @@ country_event = { #Turkey wants to establish military bases
 	title = TurkeyFocusEvents.50.t
 	desc = TurkeyFocusEvents.50.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = { #Ok
@@ -4848,6 +4660,7 @@ country_event = { #Turkey wants to establish military bases
 			}
 		}
 	}
+
 	option = { #No
 		name = TurkeyFocusEvents.50.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.50.b executed"
@@ -4863,7 +4676,6 @@ country_event = { #Qatar does not grants a base
 	title = TurkeyFocusEvents.501.t
 	desc = TurkeyFocusEvents.501.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = { #Ok
@@ -4876,13 +4688,15 @@ country_event = { #Osman V Dies
 	id = TurkeyFocusEvents.53
 	title = TurkeyFocusEvents.53.t
 	desc = TurkeyFocusEvents.53.d
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	trigger = {
 		nationalist_monarchists_are_in_power = yes
 		has_government = nationalist
 		tag = TUR
 	}
+
 	option = { #Ok
 		name = TurkeyFocusEvents.53.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.53.a executed"
@@ -4903,20 +4717,22 @@ country_event = { #Beyezid III Dies
 	id = TurkeyFocusEvents.54
 	title = TurkeyFocusEvents.54.t
 	desc = TurkeyFocusEvents.54.d
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	trigger = {
 		nationalist_monarchists_are_in_power = yes
 		has_government = nationalist
 		tag = TUR
 	}
+
 	option = { #Ok
 		name = TurkeyFocusEvents.54.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.54.a executed"
 		retire_country_leader = yes
 		create_country_leader = {
 			name = "Dündar I"
-			picture = "Dundar_I.dds"	#WIP
+			picture = "Dundar_I.dds" #WIP
 			ideology = Monarchist
 			traits = {
 				nationalist_Monarchist
@@ -4930,9 +4746,10 @@ country_event = { #Turkey asks for Hejaz
 	id = TurkeyFocusEvents.55
 	title = TurkeyFocusEvents.55.t
 	desc = TurkeyFocusEvents.55.d
-	fire_only_once = yes
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	option = { #No
 		name = TurkeyFocusEvents.55.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.55.a executed"
@@ -4941,6 +4758,7 @@ country_event = { #Turkey asks for Hejaz
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = { #Ok
 		name = TurkeyFocusEvents.55.b
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.55.b executed"
@@ -4955,9 +4773,10 @@ country_event = { #Turkey asks for Hejaz
 	id = TurkeyFocusEvents.56
 	title = TurkeyFocusEvents.56.t
 	desc = TurkeyFocusEvents.56.d
-	fire_only_once = yes
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	option = { #No
 		name = TurkeyFocusEvents.56.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.56.a executed"
@@ -4975,9 +4794,10 @@ country_event = { #Turkey asks for Hejaz
 	id = TurkeyFocusEvents.57
 	title = TurkeyFocusEvents.57.t
 	desc = TurkeyFocusEvents.57.d
-	fire_only_once = yes
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	option = { #No
 		name = TurkeyFocusEvents.57.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.57.a executed"
@@ -4996,9 +4816,10 @@ country_event = { #Turkey how should we move in on Abdul Mustafa?
 	id = TurkeyFocusEvents.58
 	title = TurkeyFocusEvents.58.t
 	desc = TurkeyFocusEvents.58.d
-	fire_only_once = yes
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	option = { #Send hooded agents to get the guy!
 		name = TurkeyFocusEvents.58.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.58.a executed"
@@ -5018,6 +4839,7 @@ country_event = { #Turkey how should we move in on Abdul Mustafa?
 		}
 		ai_chance = { base = 10 }
 	}
+
 	#
 	option = { #Proper planning, and a good escape plan to avoid detection
 		name = TurkeyFocusEvents.58.b
@@ -5040,6 +4862,7 @@ country_event = { #Turkey how should we move in on Abdul Mustafa?
 		}
 		ai_chance = { base = 0 }
 	}
+
 	option = { #Actually, this is probably a bad idea..
 		name = TurkeyFocusEvents.58.c
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.58.c executed"
@@ -5052,9 +4875,10 @@ country_event = { #Mustafa assassinated
 	id = TurkeyFocusEvents.59
 	title = TurkeyFocusEvents.59.t
 	desc = TurkeyFocusEvents.59.d
-	fire_only_once = yes
 	picture = GFX_court
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	option = { #Good
 		name = TurkeyFocusEvents.59.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.59.a executed"
@@ -5069,9 +4893,10 @@ country_event = { #Cover blown, and soldiers arrested!
 	id = TurkeyFocusEvents.60
 	title = TurkeyFocusEvents.60.t
 	desc = TurkeyFocusEvents.60.d
-	fire_only_once = yes
 	picture = GFX_politics_surveillence
 	is_triggered_only = yes
+	fire_only_once = yes
+
 	option = { #Shit
 		name = TurkeyFocusEvents.60.a
 		log = "[GetDateText]: [This.GetName]: TurkeyFocusEvents.60.a executed"
@@ -5098,7 +4923,6 @@ country_event = { #2001 Economic Crash
 	title = TUR_flavor_event.1.t
 	desc = TUR_flavor_event.1.d
 	picture = GFX_economy_crisis
-
 	is_triggered_only = yes
 
 	option = { # Okay
@@ -5117,7 +4941,6 @@ country_event = { #2003 Earthquake in Bingol
 	title = TUR_flavor_event.2.t
 	desc = TUR_flavor_event.2.d
 	picture = GFX_bingol
-
 	is_triggered_only = yes
 
 	option = { # Okay
@@ -5135,7 +4958,6 @@ country_event = { #2003 Kurdish laws for EU
 	title = TUR_flavor_event.17.t
 	desc = TUR_flavor_event.17.d
 	picture = GFX_court
-
 	is_triggered_only = yes
 
 	option = { # No, keep them!
@@ -5146,6 +4968,7 @@ country_event = { #2003 Kurdish laws for EU
 		change_relative_party_popularity = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { # Ease restrictions
 		name = TUR_flavor_event.17.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.17.b executed"
@@ -5161,7 +4984,6 @@ country_event = { #2002 Men not regarded as head of family January
 	title = TUR_flavor_event.18.t
 	desc = TUR_flavor_event.18.d
 	picture = GFX_court
-
 	is_triggered_only = yes
 
 	option = { # We must maintain our traditions
@@ -5174,6 +4996,7 @@ country_event = { #2002 Men not regarded as head of family January
 		change_the_military_opinion = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { # We are all for this change
 		name = TUR_flavor_event.18.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.18.b executed"
@@ -5192,9 +5015,8 @@ country_event = { # 2009 Normalizing relations with Armenia October
 	desc = TUR_flavor_event.19.d
 	picture = GFX_arm_tur_prot_ev
 	is_triggered_only = yes
-	trigger = {
-		country_exists = ARM
-	}
+
+	trigger = { country_exists = ARM }
 
 	option = { # I don't care
 		name = TUR_flavor_event.19.a
@@ -5206,6 +5028,7 @@ country_event = { # 2009 Normalizing relations with Armenia October
 		change_the_military_opinion = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { # Let us move past
 		name = TUR_flavor_event.19.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.19.b executed"
@@ -5222,7 +5045,6 @@ country_event = { # 2005 Caspian oil pipeline
 	title = TUR_flavor_event.20.t
 	desc = TUR_flavor_event.20.d
 	picture = GFX_gas_tanker
-
 	is_triggered_only = yes
 
 	option = { # Build it
@@ -5288,6 +5110,7 @@ country_event = { # 2005 Caspian oil pipeline
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { # Let us save the money
 		name = TUR_flavor_event.20.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.20.b executed"
@@ -5303,7 +5126,6 @@ country_event = { #2003 Istanbul bombings
 	title = TUR_flavor_event.3.t
 	desc = TUR_flavor_event.3.d
 	picture = GFX_istanbul_bombings
-
 	is_triggered_only = yes
 
 	option = { #No response
@@ -5312,12 +5134,14 @@ country_event = { #2003 Istanbul bombings
 		add_stability = -0.05
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Medium Response
 		name = TUR_flavor_event.3.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.3.b executed"
 		add_political_power = -100
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Major response
 		name = TUR_flavor_event.3.c
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.3.c executed"
@@ -5332,7 +5156,6 @@ country_event = { #2005 New Lira
 	title = TUR_flavor_event.4.t
 	desc = TUR_flavor_event.4.d
 	picture = GFX_newlira
-
 	is_triggered_only = yes
 
 	option = { #Graet
@@ -5343,6 +5166,7 @@ country_event = { #2005 New Lira
 		change_industrial_conglomerates_opinion = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Old is Gold
 		name = TUR_flavor_event.4.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.4.b executed"
@@ -5357,7 +5181,6 @@ country_event = { #2007 Armenian Hrat Dink
 	title = TUR_flavor_event.5.t
 	desc = TUR_flavor_event.5.d
 	picture = GFX_nowruz_protests
-
 	is_triggered_only = yes
 
 	option = { #Damn
@@ -5381,6 +5204,7 @@ country_event = { #2007 Armenian Hrat Dink
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Armenia
 	name = TUR_flavor_event.5.b
 	log = "[GetDateText]: [This.GetName]: TUR_flavor_event.5.b executed"
@@ -5402,7 +5226,6 @@ country_event = { #2008 Refugee Crisis
 	title = TUR_flavor_event.6.t
 	desc = TUR_flavor_event.6.d
 	picture = GFX_refugees_turkey
-
 	is_triggered_only = yes
 
 	option = { #Damn
@@ -5445,7 +5268,6 @@ country_event = { #2012 Drug Stuff
 	title = TUR_flavor_event.7.t
 	desc = TUR_flavor_event.7.d
 	picture = GFX_court
-
 	is_triggered_only = yes
 
 	option = { #Damn
@@ -5463,7 +5285,6 @@ country_event = { #2010 Gaza flotilla raid
 	title = TUR_flavor_event.8.t
 	desc = TUR_flavor_event.8.d
 	picture = GFX_gazaflotilla
-
 	is_triggered_only = yes
 
 	option = { #Demand Israel pay for reparations
@@ -5481,6 +5302,7 @@ country_event = { #2010 Gaza flotilla raid
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #It does not matter
 		name = TUR_flavor_event.8.b
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.8.b executed"
@@ -5494,7 +5316,6 @@ country_event = { #Turkey demands that we pay reparations for the Flotilla raid
 	title = TUR_flavor_event.81.t
 	desc = TUR_flavor_event.81.d
 	picture = GFX_gazaflotilla #TO DO GFX
-
 	is_triggered_only = yes
 
 	option = { #Okay
@@ -5507,6 +5328,7 @@ country_event = { #Turkey demands that we pay reparations for the Flotilla raid
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #No
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.81.b executed"
 		name = TUR_flavor_event.81.b
@@ -5522,7 +5344,6 @@ country_event = { #Israel pays reparations
 	title = TUR_flavor_event.811.t
 	desc = TUR_flavor_event.811.d
 	picture = GFX_gazaflotilla #TO DO GFX
-
 	is_triggered_only = yes
 
 	option = { #Okay
@@ -5539,7 +5360,6 @@ country_event = { #Israel does not pays reparations
 	title = TUR_flavor_event.812.t
 	desc = TUR_flavor_event.812.d
 	picture = GFX_gazaflotilla #TO DO GFX
-
 	is_triggered_only = yes
 
 	option = { #Okay
@@ -5565,7 +5385,6 @@ country_event = { #2011 Van Earthquake
 	title = TUR_flavor_event.9.t
 	desc = TUR_flavor_event.9.d
 	picture = GFX_bingol
-
 	is_triggered_only = yes
 
 	option = { #Sad
@@ -5581,6 +5400,7 @@ country_event = { #2011 Van Earthquake
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Mobilize disaster relief
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.9.b executed"
 		name = TUR_flavor_event.9.b
@@ -5596,7 +5416,6 @@ country_event = { #2012 Nowruz protests
 	title = TUR_flavor_event.10.t
 	desc = TUR_flavor_event.10.d
 	picture = GFX_nowruz_protests
-
 	is_triggered_only = yes
 
 	option = { #Send in the police
@@ -5609,6 +5428,7 @@ country_event = { #2012 Nowruz protests
 		change_relative_party_popularity = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Let them demonstrate
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.10.b executed"
 		name = TUR_flavor_event.10.b
@@ -5626,7 +5446,6 @@ country_event = { #2013 attack on U.S. Embassy
 	title = TUR_flavor_event.11.t
 	desc = TUR_flavor_event.11.d
 	picture = GFX_embasyattack
-
 	is_triggered_only = yes
 
 	option = { #Our condolences
@@ -5638,6 +5457,7 @@ country_event = { #2013 attack on U.S. Embassy
 		add_stability = -0.05
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Launch a complete investigation
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.11.b executed"
 		name = TUR_flavor_event.11.b
@@ -5652,7 +5472,6 @@ country_event = { #2014 May coal fire
 	title = TUR_flavor_event.12.t
 	desc = TUR_flavor_event.12.d
 	picture = GFX_coalfire
-
 	is_triggered_only = yes
 
 	option = { #Tragic
@@ -5668,6 +5487,7 @@ country_event = { #2014 May coal fire
 		name = TUR_flavor_event.12.a
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Save what we can
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.12.b executed"
 		name = TUR_flavor_event.12.b
@@ -5682,7 +5502,6 @@ country_event = { #2015 Ankara bombings
 	title = TUR_flavor_event.13.t
 	desc = TUR_flavor_event.13.d
 	picture = GFX_ankara_bombings
-
 	is_triggered_only = yes
 
 	option = { #Okay
@@ -5698,6 +5517,7 @@ country_event = { #2015 Ankara bombings
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Okay
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.13.b executed"
 		name = TUR_flavor_event.13.b
@@ -5712,7 +5532,6 @@ country_event = { #2017 Removing evolution from textbooks
 	title = TUR_flavor_event.14.t
 	desc = TUR_flavor_event.14.d
 	picture = GFX_jury
-
 	is_triggered_only = yes
 
 	option = { #Remove it, and do it now!
@@ -5724,6 +5543,7 @@ country_event = { #2017 Removing evolution from textbooks
 		block_edu_increase = yes
 		ai_chance = { base = 5 }
 	}
+
 	option = { #No, lets keep it
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.14.b executed"
 		name = TUR_flavor_event.14.b
@@ -5740,7 +5560,6 @@ country_event = { #2018 CASA CN 235 Crash
 	title = TUR_flavor_event.15.t
 	desc = TUR_flavor_event.15.d
 	picture = GFX_aircrash_casa
-
 	is_triggered_only = yes
 
 	option = { #Okay
@@ -5755,6 +5574,7 @@ country_event = { #2018 CASA CN 235 Crash
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Salvage what we can
 		log = "[GetDateText]: [This.GetName]: TUR_flavor_event.15.b executed"
 		name = TUR_flavor_event.15.b
@@ -5769,7 +5589,6 @@ country_event = { #2019 Base in antarctica
 	title = TUR_flavor_event.16.t
 	desc = TUR_flavor_event.16.d
 	picture = GFX_TUR_generic
-
 	is_triggered_only = yes
 
 	option = { #Okay
@@ -5785,7 +5604,6 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Azerbaijan)
 	title = TurkicConfederation.1.t
 	desc = TurkicConfederation.1.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #We will join
@@ -5808,8 +5626,8 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Azerbaijan)
 				add = 10
 			}
 		}
-
 	}
+
 	option = { #It's better we don't
 		name = TurkicConfederation.1.b
 		log = "[GetDateText]: [This.GetName]: TurkicConfederation.1.b executed"
@@ -5822,11 +5640,9 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Azerbaijan)
 #
 country_event = { #Azerbaijan Joins!
 	id = TurkicConfederation.11
-
 	title = TurkicConfederation.11.t
 	desc = TurkicConfederation.11.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -5839,11 +5655,9 @@ country_event = { #Azerbaijan Joins!
 #
 country_event = { #Azerbaijan Refuses offer!
 	id = TurkicConfederation.12
-
 	title = TurkicConfederation.12.t
 	desc = TurkicConfederation.12.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -5856,11 +5670,9 @@ country_event = { #Azerbaijan Refuses offer!
 #
 country_event = { #Turkey Invites us to the Turkic Confederation (Kazakhstan)
 	id = TurkicConfederation.2
-
 	title = TurkicConfederation.2.t
 	desc = TurkicConfederation.2.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #We will join
@@ -5883,8 +5695,8 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Kazakhstan)
 				add = 10
 			}
 		}
-
 	}
+
 	option = { #It's better we don't
 		name = TurkicConfederation.2.b
 		log = "[GetDateText]: [This.GetName]: TurkicConfederation.2.b executed"
@@ -5900,7 +5712,6 @@ country_event = { #Kazakhstan Joins!
 	title = TurkicConfederation.21.t
 	desc = TurkicConfederation.21.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -5916,7 +5727,6 @@ country_event = { #Kazakhstan refuses offer!
 	title = TurkicConfederation.22.t
 	desc = TurkicConfederation.22.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -5932,7 +5742,6 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Uzbekistan)
 	title = TurkicConfederation.3.t
 	desc = TurkicConfederation.3.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #We will join
@@ -5955,8 +5764,8 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Uzbekistan)
 				add = 10
 			}
 		}
-
 	}
+
 	option = { #It's better we don't
 		name = TurkicConfederation.3.b
 		log = "[GetDateText]: [This.GetName]: TurkicConfederation.3.b executed"
@@ -5972,7 +5781,6 @@ country_event = { #Uzbekistan Joins!
 	title = TurkicConfederation.31.t
 	desc = TurkicConfederation.31.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -5988,7 +5796,6 @@ country_event = { #Uzbekistan Refuses Offer!
 	title = TurkicConfederation.32.t
 	desc = TurkicConfederation.32.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -6004,7 +5811,6 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Turkmenistan)
 	title = TurkicConfederation.4.t
 	desc = TurkicConfederation.4.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #We will join
@@ -6027,8 +5833,8 @@ country_event = { #Turkey Invites us to the Turkic Confederation (Turkmenistan)
 				add = 10
 			}
 		}
-
 	}
+
 	option = { #It's better we don't
 		name = TurkicConfederation.4.b
 		log = "[GetDateText]: [This.GetName]: TurkicConfederation.4.b executed"
@@ -6044,7 +5850,6 @@ country_event = { #Turkmenistan Joins!
 	title = TurkicConfederation.41.t
 	desc = TurkicConfederation.41.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -6060,7 +5865,6 @@ country_event = { #Turkemnistan Refuses Offer!
 	title = TurkicConfederation.42.t
 	desc = TurkicConfederation.42.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	option = { #Good
@@ -6076,8 +5880,8 @@ news_event = { #Cyprus Unifies under NCY
 	title = Turkey.77.t
 	desc = Turkey.77.d
 	picture = GFX_trade_agreement
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = { #Good!
 		name = Turkey.77.a
@@ -6087,12 +5891,11 @@ news_event = { #Cyprus Unifies under NCY
 #
 news_event = { #Cyprus Unifies under SCY
 	id = Turkey.88
-
 	title = Turkey.88.t
 	desc = Turkey.88.d
 	picture = GFX_trade_agreement
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = { #Good!
 		name = Turkey.88.a
@@ -6106,9 +5909,9 @@ country_event = { #2002 General Elections (FOR AI)
 	desc = Turkey.100.d
 	picture = GFX_TUR_generic
 	is_triggered_only = yes
-	trigger = {
-		is_ai = yes
-	}
+
+	trigger = { is_ai = yes }
+
 	option = { # AKP
 		name = Turkey.100.a
 		log = "[GetDateText]: [This.GetName]: Turkey.100.a executed"
@@ -6129,6 +5932,7 @@ country_event = { #2002 General Elections (FOR AI)
 			}
 		}
 	}
+
 	option = { # CHP
 		name = Turkey.100.b
 		log = "[GetDateText]: [This.GetName]: Turkey.100.b executed"
@@ -6146,6 +5950,7 @@ country_event = { #2002 General Elections (FOR AI)
 			}
 		}
 	}
+
 	option = { # The Party needs another term!
 		name = Turkey.100.c
 		ai_chance = {
@@ -6164,9 +5969,9 @@ country_event = { # Turkish Mafia cause a scene!
 	desc = Turkish_mafia.1.d
 	picture = GFX_report_event_Gun_1
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
+
 	option = { #Damn!
 		name = Turkish_mafia.1.a
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.1.a executed"
@@ -6176,6 +5981,7 @@ country_event = { # Turkish Mafia cause a scene!
 		custom_effect_tooltip = TUR_mafia_increase_1
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Launch a full investigation
 		name = Turkish_mafia.1.b
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.1.b executed"
@@ -6201,6 +6007,7 @@ country_event = { # Turkish Mafia cause a scene!
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Launch a full investigation
 	name = Turkish_mafia.1.c
 	log = "[GetDateText]: [This.GetName]: Turkish_mafia.1.c executed"
@@ -6268,9 +6075,9 @@ country_event = { # FOR AI ONLY
 	desc = Turkish_mafia.1200.d
 	picture = GFX_report_event_Gun_1
 	is_triggered_only = yes
-	trigger = {
-		is_ai = yes
-	}
+
+	trigger = { is_ai = yes }
+
 	option = { #Damn!
 		name = Turkish_mafia.1200.a
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.1200.a executed"
@@ -6353,9 +6160,9 @@ country_event = { # Mafia hideout discovered by police
 	desc = Turkish_mafia.2.d
 	picture = GFX_report_event_Hideout
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
+
 	option = { #Damn!
 		name = Turkish_mafia.2.a
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.2.a executed"
@@ -6365,6 +6172,7 @@ country_event = { # Mafia hideout discovered by police
 		custom_effect_tooltip = TUR_mafia_increase_1
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Send in the police
 		name = Turkish_mafia.2.b
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.2.b executed"
@@ -6390,6 +6198,7 @@ country_event = { # Mafia hideout discovered by police
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Send in the police
 		name = Turkish_mafia.2.c
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.2.c executed"
@@ -6460,9 +6269,9 @@ country_event = { # Turkish mafia weapon cache discovered
 	desc = Turkish_mafia.3.d
 	picture = GFX_guns
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
+
 	option = { #Take the guns..
 		name = Turkish_mafia.3.a
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.3.a executed"
@@ -6477,6 +6286,7 @@ country_event = { # Turkish mafia weapon cache discovered
 		custom_effect_tooltip = TUR_mafia_increase_2
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Send in the police
 		name = Turkish_mafia.3.b
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.3.b executed"
@@ -6502,6 +6312,7 @@ country_event = { # Turkish mafia weapon cache discovered
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Send in the police
 	name = Turkish_mafia.3.c
 	log = "[GetDateText]: [This.GetName]: Turkish_mafia.3.c executed"
@@ -6554,7 +6365,6 @@ country_event = { # Police Lose
 #
 country_event = { # Police Win
 	id = Turkish_mafia.32
-
 	title = Turkish_mafia.32.t
 	desc = Turkish_mafia.32.d
 	picture = GFX_report_event_Gun_2
@@ -6577,9 +6387,9 @@ country_event = { # Turkish mafia caught smuggling drugs
 	desc = Turkish_mafia.4.d
 	picture = GFX_report_event_Cigarette_Smuggling_2
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
+
 	option = { #Take the cash..
 		name = Turkish_mafia.4.a
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.4.a executed"
@@ -6591,6 +6401,7 @@ country_event = { # Turkish mafia caught smuggling drugs
 		custom_effect_tooltip = TUR_mafia_increase_2
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Send in the police
 		name = Turkish_mafia.4.b
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.4.b executed"
@@ -6616,6 +6427,7 @@ country_event = { # Turkish mafia caught smuggling drugs
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = { #Send in the police
 	name = Turkish_mafia.4.c
 	log = "[GetDateText]: [This.GetName]: Turkish_mafia.4.c executed"
@@ -6685,9 +6497,8 @@ country_event = { #assassination attempt by the Mafia
 	desc = Turkish_mafia.5.d
 	picture = GFX_report_event_Gun_2
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
 
 	option = { #Close one
 		name = Turkish_mafia.5.a
@@ -6702,13 +6513,12 @@ country_event = { #assassination attempt by the Mafia
 #
 country_event = { #Heist by the Mafia
 	id = Turkish_mafia.6
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
 	title = Turkish_mafia.6.t
 	desc = Turkish_mafia.6.d
 	picture = GFX_report_event_Gun_2
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
 
 	option = { #Damn
 		name = Turkish_mafia.6.a
@@ -6721,13 +6531,12 @@ country_event = { #Heist by the Mafia
 #
 country_event = { #Attack on commercial center
 	id = Turkish_mafia.7
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
 	title = Turkish_mafia.7.t
 	desc = Turkish_mafia.7.d
 	picture = GFX_report_event_Gun_2
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
 
 	option = { #Damn
 		name = Turkish_mafia.7.a
@@ -6746,13 +6555,12 @@ country_event = { #Attack on commercial center
 #
 country_event = { #Attack on commercial center
 	id = Turkish_mafia.8
-	trigger = {
-		NOT = { has_country_flag = TUR_mafia_gone }
-	}
 	title = Turkish_mafia.8.t
 	desc = Turkish_mafia.8.d
 	picture = GFX_report_event_Gun_2
 	is_triggered_only = yes
+
+	trigger = { NOT = { has_country_flag = TUR_mafia_gone } }
 
 	option = { #Damn
 		name = Turkish_mafia.8.a
@@ -6765,21 +6573,19 @@ country_event = { #Attack on commercial center
 #
 country_event = { #The rise of the Mafia
 	id = Turkish_mafia.9
-	trigger = {
-		NOT = {
-			is_ai = yes
-		}
-	}
 	title = Turkish_mafia.9.t
 	desc = Turkish_mafia.9.d
 	picture = GFX_turkishmafia
 	is_triggered_only = yes
 	fire_only_once = yes
 
+	trigger = { NOT = { is_ai = yes } }
+
 	option = { # The fight will continue!
 		name = Turkish_mafia.9.a
 		ai_chance = { base = 5 }
 	}
+
 	option = { # We give up
 		name = Turkish_mafia.9.b
 		log = "[GetDateText]: [This.GetName]: Turkish_mafia.9.b executed"
@@ -6908,7 +6714,6 @@ country_event = { #Conservative parties gain traction
 #
 country_event = { #Left-wing parties gain traction
 	id = Turkish_parties.3
-
 	title = Turkish_parties.3.t
 	desc = Turkish_parties.3.d
 	picture = GFX_political_deal
@@ -6989,7 +6794,6 @@ country_event = { #Right-wing parties gain traction
 ##
 country_event = { #Left-wing parties gain traction
 	id = Turkish_parties.9
-
 	title = Turkish_parties.9.t
 	desc = Turkish_parties.9.d
 	picture = GFX_political_deal
@@ -7052,9 +6856,8 @@ country_event = { # Rise of Mr.No Good Economy
 	desc = Turkish_parties.10.d
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		is_ai = yes
-	}
+
+	trigger = { is_ai = yes }
 
 	option = { #
 		name = Turkish_parties.10.a

--- a/events/education_events.txt
+++ b/events/education_events.txt
@@ -3,13 +3,12 @@ add_namespace = education_literacy_pulse
 
 # LITERACY PULSE EVENTS
 	# LOST LITERACY PULSE
-		country_event = {
-			id = education.1
-			title = education.1.t
-			desc = education.1.d
-
-			picture = GFX_generic_education_event_picture
-			is_triggered_only = yes
+country_event = {
+	id = education.1
+	title = education.1.t
+	desc = education.1.d
+	picture = GFX_generic_education_event_picture
+	is_triggered_only = yes
 
 			option = {
 				name = education.1.A
@@ -17,15 +16,14 @@ add_namespace = education_literacy_pulse
 				clr_country_flag = education_mechanic
 				set_country_flag = EDU_cleared_previously
 			}
-		}
+}
 	# GAINED LITERACY PULSE
-		country_event = {
-			id = education.2
-			title = education.2.t
-			desc = education.2.d
-
-			picture = GFX_generic_education_event_picture
-			is_triggered_only = yes
+country_event = {
+	id = education.2
+	title = education.2.t
+	desc = education.2.d
+	picture = GFX_generic_education_event_picture
+	is_triggered_only = yes
 
 			option = {
 				name = education.2.A
@@ -34,25 +32,22 @@ add_namespace = education_literacy_pulse
 				clr_country_flag = EDU_cleared_previously
 				EDU_update_education_idea_DYNMOD = yes
 			}
-		}
-	country_event = {
-		id = education_literacy_pulse.1
-		title = education_literacy_pulse.1.t
-		desc = education_literacy_pulse.1.d
+}
+country_event = {
+	id = education_literacy_pulse.1
+	title = education_literacy_pulse.1.t
+	desc = education_literacy_pulse.1.d
+	picture = GFX_generic_education_event_picture
+	is_triggered_only = yes
 
-		picture = GFX_generic_education_event_picture
-		is_triggered_only = yes
-
-		immediate = {
-			EDU_check_education_spending = yes
-		}
+		immediate = { EDU_check_education_spending = yes }
 
 		option = {
 			name = education_literacy_pulse.1.A
 			log = "[GetDateText]: [This.GetName]: education_literacy_pulse.1.A executed"
 			update_literacy_rate_event = yes
 		}
-	}
+}
 
 # ADDITIONAL EVENT IDEAS TO ADD IN TIME
 	# school strikes | high lit rate & low spending


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,604 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.