### PR TITLE
Standardize event files — batch 13/14

### DIFF
--- a/events/Brazilian.txt
+++ b/events/Brazilian.txt
@@ -10,6 +10,7 @@ country_event = {
 	desc = brazil.3.d
 	picture = GFX_mining
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		NOT = {
@@ -27,18 +28,15 @@ country_event = {
 		add_stability = -0.05
 		set_country_flag = amazonian_development_project
 		add_ideas = BRA_idea_amazonian_development_project
-
 		set_temp_variable = { temp_opinion = 10 }
 		change_industrial_conglomerates_opinion = yes
 		change_small_medium_business_owners_opinion = yes
 		change_fossil_fuel_industry_opinion = yes
-
 		unlock_decision_tooltip = BRA_decision_the_road_to_el_dorado
 		unlock_decision_tooltip = BRA_decision_expand_the_mining_industry
 		unlock_decision_tooltip = BRA_decision_increase_the_oil_production
 		unlock_decision_tooltip = BRA_decision_increase_military_production
 		unlock_decision_tooltip = BRA_decision_tech_metal_industry_in_the_amazon
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -73,10 +71,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		change_relative_party_popularity = yes
 		set_country_flag = denied_amazonian_development_project
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_industrial_conglomerates_opinion = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -102,9 +98,8 @@ country_event = {
 	desc = brazil.6.d
 	picture = GFX_country_event_amazon_rainforest_devastation
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# Business is more important than some silly trees
 	option = {
@@ -116,14 +111,10 @@ country_event = {
 		change_industrial_conglomerates_opinion = yes
 		change_small_medium_business_owners_opinion = yes
 		change_landowners_opinion = yes
-
 		set_temp_variable = { temp_change = -50 }
 		BRA_wild_acreage_effect = yes
 		BRA_acres_conserved_change_effect = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# We must preserve our national treasure for future generations
@@ -135,12 +126,10 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_change = 50 }
 		BRA_conserv_acreage_effect = yes
 		set_temp_variable = { temp_change = -50 }
 		BRA_wild_acreage_effect = yes
-
 		# Take the stability here and get the conservation lands on lock
 		ai_chance = {
 			base = 10
@@ -155,6 +144,7 @@ country_event = {
 	desc = brazil.4.d
 	picture = GFX_country_event_lula
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		NOT = { has_idea = BRA_idea_well_balanced }
@@ -176,6 +166,7 @@ country_event = {
 	picture = GFX_politics_communism_lenin
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = {
 		original_tag = BRA
 		has_idea = BRA_idea_radical_leftist
@@ -200,6 +191,7 @@ country_event = {
 	picture = GFX_politics_left_wing
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = {
 		original_tag = BRA
 		OR = {
@@ -234,6 +226,8 @@ country_event = {
 	title = brazil.9.t
 	desc = brazil.9.d
 	picture = GFX_politics_left_wing
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		tag = BRA
@@ -244,25 +238,19 @@ country_event = {
 		check_variable = { var = BRA_brazilian_party_alignment value = 30 compare = greater_than_or_equals }
 		check_variable = { var = BRA_brazilian_party_alignment value = 45 compare = less_than_or_equals }
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
 
 	option = {
 		name = brazil.9.a
 		log = "[GetDateText]: [This.GetName]: brazil.9.a executed"
 		if = {
-			limit = {
-				has_idea = BRA_idea_well_balanced
-			}
+			limit = { has_idea = BRA_idea_well_balanced }
 			swap_ideas = {
 				add_idea = BRA_idea_slightly_radical
 				remove_idea = BRA_idea_well_balanced
 			}
 		}
 		if = {
-			limit = {
-				has_idea = BRA_idea_radical_leftist
-			}
+			limit = { has_idea = BRA_idea_radical_leftist }
 			swap_ideas = {
 				add_idea = BRA_idea_slightly_radical
 				remove_idea = BRA_idea_radical_leftist
@@ -277,6 +265,8 @@ country_event = {
 	title = brazil.10.t
 	desc = brazil.10.d
 	picture = GFX_politics_left_wing
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		tag = BRA
@@ -287,25 +277,19 @@ country_event = {
 		check_variable = { var = BRA_brazilian_party_alignment value = 45 compare = greater_than_or_equals }
 		check_variable = { var = BRA_brazilian_party_alignment value = 55 compare = less_than_or_equals }
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
 
 	option = {
 		name = brazil.10.a
 		log = "[GetDateText]: [This.GetName]: brazil.10.a executed"
 		if = {
-			limit = {
-				has_idea = BRA_idea_slightly_radical
-			}
+			limit = { has_idea = BRA_idea_slightly_radical }
 			swap_ideas = {
 				add_idea = BRA_idea_well_balanced
 				remove_idea = BRA_idea_slightly_radical
 			}
 		}
 		if = {
-			limit = {
-				has_idea = BRA_idea_slightly_reformist
-			}
+			limit = { has_idea = BRA_idea_slightly_reformist }
 			swap_ideas = {
 				add_idea = BRA_idea_well_balanced
 				remove_idea = BRA_idea_slightly_reformist
@@ -320,6 +304,8 @@ country_event = {
 	title = brazil.11.t
 	desc = brazil.11.d
 	picture = GFX_politics_left_wing
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		tag = BRA
@@ -330,25 +316,19 @@ country_event = {
 		check_variable = { var = BRA_brazilian_party_alignment value = 55 compare = greater_than_or_equals }
 		check_variable = { var = BRA_brazilian_party_alignment value = 70 compare = less_than_or_equals }
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
 
 	option = {
 		name = brazil.11.a
 		log = "[GetDateText]: [This.GetName]: brazil.11.a executed"
 		if = {
-			limit = {
-				has_idea = BRA_idea_well_balanced
-			}
+			limit = { has_idea = BRA_idea_well_balanced }
 			swap_ideas = {
 				add_idea = BRA_idea_slightly_reformist
 				remove_idea = BRA_idea_well_balanced
 			}
 		}
 		if = {
-			limit = {
-				has_idea = BRA_idea_modern_reformist
-			}
+			limit = { has_idea = BRA_idea_modern_reformist }
 			swap_ideas = {
 				add_idea = BRA_idea_slightly_reformist
 				remove_idea = BRA_idea_modern_reformist
@@ -363,6 +343,8 @@ country_event = {
 	title = brazil.12.t
 	desc = brazil.12.d
 	picture = GFX_politics_left_wing
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		tag = BRA
@@ -373,25 +355,19 @@ country_event = {
 		check_variable = { var = BRA_brazilian_party_alignment value = 70 compare = greater_than_or_equals }
 		check_variable = { var = BRA_brazilian_party_alignment value = 90 compare = less_than_or_equals }
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
 
 	option = {
 		name = brazil.12.a
 		log = "[GetDateText]: [This.GetName]: brazil.12.a executed"
 		if = {
-			limit = {
-				has_idea = BRA_idea_slightly_reformist
-			}
+			limit = { has_idea = BRA_idea_slightly_reformist }
 			swap_ideas = {
 				add_idea = BRA_idea_modern_reformist
 				remove_idea = BRA_idea_slightly_reformist
 			}
 		}
 		if = {
-			limit = {
-				has_idea = BRA_idea_party_of_progress
-			}
+			limit = { has_idea = BRA_idea_party_of_progress }
 			swap_ideas = {
 				add_idea = BRA_idea_modern_reformist
 				remove_idea = BRA_idea_party_of_progress
@@ -405,14 +381,14 @@ country_event = {
 	title = brazil.13.t
 	desc = brazil.13.d
 	picture = GFX_politics_left_wing
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		tag = BRA
 		has_idea = BRA_idea_modern_reformist
 		check_variable = { var = BRA_brazilian_party_alignment value = 90 compare = greater_than_or_equals }
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
 
 	option = {
 		name = brazil.13.a
@@ -431,19 +407,15 @@ country_event = {
 	desc = brazil.14.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# Allow the Protest
 	option = {
 		name = brazil.14.a
 		log = "[GetDateText]: [This.GetName]: brazil.14.a executed"
 		add_stability = -0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Crackdown on the March
@@ -452,10 +424,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: brazil.14.b executed"
 		add_stability = -0.04
 		add_political_power = 75
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -466,6 +435,7 @@ country_event = {
 	desc = brazil.15.d
 	picture = GFX_country_event_french_navy
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = FRA
 		country_exists = BRA
@@ -481,7 +451,6 @@ country_event = {
 			country_event = diplomatic_response.1
 		}
 		add_opinion_modifier = { target = BRA modifier = french_naval_studies }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -572,7 +541,6 @@ country_event = {
 			add_opinion_modifier = { target = ROOT modifier = france_denies_studies }
 			country_event = diplomatic_response.2
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -593,7 +561,6 @@ country_event = {
 	title = brazil.18.t
 	desc = brazil.18.d
 	picture = GFX_BRA_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -608,7 +575,6 @@ country_event = {
 			ideology = nationalist
 			popularity = 0.10
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -651,7 +617,6 @@ country_event = {
 				emerging_anarchist_communism
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -686,7 +651,6 @@ country_event = {
 			ideology = democratic
 			popularity = 0.10
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -715,7 +679,6 @@ country_event = {
 	title = brazil.19.t
 	desc = brazil.19.d
 	picture = GFX_court
-
 	is_triggered_only = yes
 
 	option = {
@@ -729,7 +692,6 @@ country_event = {
 	title = brazil.45.t
 	desc = brazil.45.d
 	picture = GFX_BRA_op_car_wash_event
-
 	is_triggered_only = yes
 
 	option = {
@@ -744,11 +706,10 @@ country_event = {
 	id = brazil.20
 	title = brazil.20.t
 	desc = brazil.20.d
-#	picture = -
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
+#	picture = -
 	option = {
 		name = brazil.20.a
 		log = "[GetDateText]: [This.GetName]: brazil.20.a executed"
@@ -761,7 +722,6 @@ country_event = {
 	title = brazil.21.t
 	desc = brazil.21.d
 	picture = GFX_BRA_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -777,12 +737,9 @@ country_event = {
 	title = brazil.22.t
 	desc = brazil.22.d
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
-	option = {
-		name = brazil.22.a
-	}
+	option = { name = brazil.22.a }
 }
 
 #Rise of Nationalist Movements
@@ -791,14 +748,15 @@ country_event = {
 	title = brazil.23.t
 	desc = brazil.23.d
 	picture = GFX_BRA_generic
+	is_triggered_only = yes
+	fire_only_once = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2017.01.03
 		has_government = nationalist
 		nationalist > 0.5
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
 
 	option = {
 		name = brazil.23.a
@@ -819,7 +777,6 @@ country_event = {
 	title = brazil.24.t
 	desc = brazil.24.d
 	picture = GFX_country_event_brazil_empire_restauration
-
 	is_triggered_only = yes
 
 	option = {
@@ -831,7 +788,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #Government Influences globo
@@ -839,11 +795,10 @@ country_event = {
 	id = brazil.25
 	title = brazil.25.t
 	desc = brazil.25.d
-	#	picture = -
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
+	#	picture = -
 	option = {
 		name = brazil.25.a
 		log = "[GetDateText]: [This.GetName]: brazil.25.a executed"
@@ -857,11 +812,10 @@ country_event = {
 	id = brazil.26
 	title = brazil.26.t
 	desc = brazil.26.d
-#	picture = -
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+#	picture = -
 	option = {
 		name = brazil.26.a
 		log = "[GetDateText]: [This.GetName]: brazil.26.a executed"
@@ -881,9 +835,9 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			change_relative_party_popularity = yes
 		}
-
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = brazil.26.b
 		log = "[GetDateText]: [This.GetName]: brazil.26.b executed"
@@ -898,9 +852,9 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			change_relative_party_popularity = yes
 		}
-
 		ai_chance = { base = 3 }
 	}
+
 	option = {
 		name = brazil.26.c
 		log = "[GetDateText]: [This.GetName]: brazil.26.c executed"
@@ -909,7 +863,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.08 }
 		change_relative_party_popularity = yes
 		add_political_power = 300
-
 		ai_chance = {
 			base = 2
 			modifier = {
@@ -936,7 +889,6 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 		}
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -947,7 +899,6 @@ country_event = {
 	title = brazil.27.t
 	desc = brazil.27.d
 	picture = GFX_politics_dictatorship
-
 	is_triggered_only = yes
 
 	option = {
@@ -956,6 +907,7 @@ country_event = {
 		trigger = { NOT = { has_idea = BRA_idea_opposition_media } }
 		add_ideas = censored_nation_01
 	}
+
 	option = {
 		name = brazil.27.b
 		log = "[GetDateText]: [This.GetName]: brazil.27.b executed"
@@ -967,6 +919,7 @@ country_event = {
 		add_ideas = censored_nation_02
 		add_stability = -0.05
 	}
+
 	option = {
 		name = brazil.27.c
 		log = "[GetDateText]: [This.GetName]: brazil.27.c executed"
@@ -984,14 +937,13 @@ country_event = {
 	title = brazil.28.t
 	desc = brazil.28.d
 	picture = GFX_country_event_greve_caminhoneiros
+	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		original_tag = BRA
 		date > 2018.05.01
 	}
-
-	fire_only_once = yes
-	is_triggered_only = yes
 
 	option = {
 		name = brazil.28.a
@@ -1003,6 +955,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -20 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = brazil.28.b
 		log = "[GetDateText]: [This.GetName]: brazil.28.b executed"
@@ -1017,12 +970,11 @@ country_event = {
 	id = brazil.29
 	title = brazil.29.t
 	desc = brazil.29.d
-	# picture = - # TODO: Replace with event image at some point
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	# picture = - # TODO: Replace with event image at some point
+	trigger = { original_tag = BRA }
 
 	option = {
 		name = brazil.29.a
@@ -1033,6 +985,7 @@ country_event = {
 		}
 		add_political_power = 50
 	}
+
 	option = {
 		name = brazil.29.b
 		log = "[GetDateText]: [This.GetName]: brazil.29.b executed"
@@ -1048,12 +1001,11 @@ country_event = {
 	id = brazil.30
 	title = brazil.30.t
 	desc = brazil.30.d
-	# picture = - # TODO: Replace with event image at some point
 	picture = GFX_treaty
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	# picture = - # TODO: Replace with event image at some point
+	trigger = { original_tag = BRA }
 
 	option = {
 		name = brazil.30.a
@@ -1072,9 +1024,8 @@ country_event = {
 	desc = brazil.31.d
 	picture = GFX_mining
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# Begin the Logging Reforms
 	option = {
@@ -1095,10 +1046,10 @@ country_event = {
 	id = brazil.35
 	title = brazil.35.t
 	desc = brazil.35.d
-	#	picture = -
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
+	#	picture = -
 	option = {
 		log = "[GetDateText]: [This.GetName]: brazil.35.a executed"
 		custom_effect_tooltip = BRA_coalition_dem_one_tt
@@ -1113,7 +1064,6 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			change_relative_party_popularity = yes
 		}
-
 		ai_chance = { base = 2 }
 	}
 
@@ -1124,7 +1074,6 @@ country_event = {
 		add_political_power = 100
 		add_stability = 0.1
 		add_popularity = { ideology = democratic popularity = 0.1 }
-
 		ai_chance = { base = 1 }
 	}
 
@@ -1144,7 +1093,6 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.1 }
 			change_relative_party_popularity = yes
 		}
-
 		ai_chance = { base = 5 }
 	}
 }
@@ -1156,6 +1104,7 @@ country_event = {
 	desc = brazil.37.d
 	picture = GFX_country_event_brazilian_impeachment_dilma
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2016.9.05
@@ -1181,13 +1130,13 @@ country_event = {
 	title = brazil.38.t
 	desc = brazil.38.d
 	picture = GFX_country_event_brazilian_lula_arrested
+	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2018.4.07
 		date < 2018.4.10
 	}
-
-	is_triggered_only = yes
 
 	option = {
 		name = brazil.38.a
@@ -1203,9 +1152,9 @@ country_event = {
 	title = brazil.39.t
 	desc = brazil.39.d
 	picture = GFX_political_activist
-
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2002.3.1
@@ -1213,6 +1162,7 @@ country_event = {
 		NOT = { has_country_flag = BRA_election_2002 }
 		has_country_flag = generic_election_killswitch
 	}
+
 	immediate = {
 		set_country_flag = BRA_election_2002
 		complete_national_focus = BRA_2002_elections
@@ -1236,14 +1186,10 @@ country_event = {
 				pro_american
 			}
 		}
-
 		add_popularity = { ideology = democratic popularity = 0.1 }
 		recalculate_party = yes
-
 		add_political_power = 150
-
 		clr_country_flag = generic_election_killswitch
-
 		ai_chance = {
 			base = 3
 			modifier = {
@@ -1274,7 +1220,6 @@ country_event = {
 		name = brazil.39.b
 		log = "[GetDateText]: [This.GetName]: brazil.39.b executed"
 		retire_country_leader = yes
-
 		complete_national_focus = BRA_lula
 		hidden_effect = {
 			set_temp_variable = { rul_party_temp = 5 }
@@ -1289,15 +1234,11 @@ country_event = {
 				union_man
 			}
 		}
-
 		add_popularity = { ideology = communism popularity = 0.1 }
 		recalculate_party = yes
-
 		add_political_power = 150
-
 		# Unlocks the custom mechanic for Lula and co.
 		unlock_decision_category_tooltip = BRA_workers_party_alignment_decision_category
-
 		clr_country_flag = generic_election_killswitch
 		ai_chance = {
 			base = 5
@@ -1337,6 +1278,7 @@ country_event = {
 	desc = brazil.40.d
 	picture = GFX_country_event_brazilian_impeachment_protests
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2016.8.31
@@ -1357,6 +1299,7 @@ country_event = {
 	desc = brazil.41.d
 	picture = GFX_country_event_brazilian_bolsonaro_stabbed
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2018.9.06
@@ -1369,10 +1312,7 @@ country_event = {
 		add_popularity = { ideology = nationalist popularity = 0.02 }
 		recalculate_party = yes
 		add_stability = -0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1381,10 +1321,7 @@ country_event = {
 		add_popularity = { ideology = communism popularity = 0.02 }
 		recalculate_party = yes
 		add_stability = -0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1395,9 +1332,8 @@ country_event = {
 	desc = brazil.42.d
 	picture = GFX_country_event_brazilian_lula_arrested # TODO: Temp, replace with something else
 	is_triggered_only = yes
-	trigger = {
-		original_tag = USA
-	}
+
+	trigger = { original_tag = USA }
 
 	option = {
 		name = brazil.42.a
@@ -1421,7 +1357,6 @@ country_event = {
 		hidden_effect = {
 			BRA = { country_event = { id = brazil.43 days = 3 } }
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1476,7 +1411,6 @@ country_event = {
 				add_idea = BRA_idea_worsening_debt_crisis
 			}
 		}
-
 		hidden_effect = {
 			BRA = { country_event = { id = brazil.43 days = 3 } }
 		}
@@ -1497,41 +1431,29 @@ country_event = {
 	id = brazil.43
 	title = {
 		text = brazil.43.t1
-		trigger = {
-			USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance }
-		}
+		trigger = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } }
 	}
 	title = {
 		text = brazil.43.t2
-		trigger = {
-			NOT = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } }
-		}
+		trigger = { NOT = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } } }
 	}
 	desc = {
 		text = brazil.43.d1
-		trigger = {
-			USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance }
-		}
+		trigger = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } }
 	}
 	desc = {
 		text = brazil.43.d2
-		trigger = {
-			NOT = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } }
-		}
+		trigger = { NOT = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } } }
 	}
 	picture = GFX_country_event_brazilian_lula_arrested # TODO: Temp, replace with something else
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	option = {
 		name = brazil.43.a
 		log = "[GetDateText]: [This.GetName]: brazil.43.a executed"
-		trigger = {
-			USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance }
-		}
-
+		trigger = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } }
 		USA = {
 			set_temp_variable = { treasury_change = -75 }
 			modify_treasury_effect = yes
@@ -1547,19 +1469,13 @@ country_event = {
 				add_idea = BRA_idea_foreign_debt_assistance
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = brazil.43.b
 		log = "[GetDateText]: [This.GetName]: brazil.43.b executed"
-		trigger = {
-			NOT = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } }
-		}
-
+		trigger = { NOT = { USA = { has_country_flag = BRA_USA_accepted_the_foreign_debt_assistance } } }
 		BRA = {
 			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
@@ -1568,10 +1484,7 @@ country_event = {
 				add_idea = BRA_idea_worsening_debt_crisis
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1582,9 +1495,8 @@ country_event = {
 	desc = brazil.44.d
 	picture = GFX_country_event_brazilian_impeachment_protests
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# Allow the Slash-n-Burn
 	option = {
@@ -1599,19 +1511,13 @@ country_event = {
 				instant_build = yes
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Deny the Slash-n-Burn
 	option = {
 		name = brazil.44.b
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1623,6 +1529,7 @@ country_event = {
 	desc = brazil_flavour_events.1.d
 	picture = GFX_court
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2001.1.01
@@ -1633,18 +1540,17 @@ country_event = {
 		name = brazil_flavour_events.1.a
 		log = "[GetDateText]: [This.GetName]: brazil_flavour_events.1.a executed"
 		add_political_power = 15
-
 		hidden_effect = {
 			random_list = {
 				65 = {
 					country_event = {
-						id = brazil_flavour_events.2	#Kidnapping of Silvio Santos
+						id = brazil_flavour_events.2 #Kidnapping of Silvio Santos
 						days = 7
 					}
 				}
 				35 = {
 					country_event = {
-						id = brazil_flavour_events.3	#Murder of Silvio Santos
+						id = brazil_flavour_events.3 #Murder of Silvio Santos
 						days = 7
 					}
 				}
@@ -1661,13 +1567,13 @@ country_event = {
 			random_list = {
 				85 = {
 					country_event = {
-						id = brazil_flavour_events.2	#Kidnapping of Silvio Santos
+						id = brazil_flavour_events.2 #Kidnapping of Silvio Santos
 						days = 7
 					}
 				}
 				15 = {
 					country_event = {
-						id = brazil_flavour_events.3	#Murder of Silvio Santos
+						id = brazil_flavour_events.3 #Murder of Silvio Santos
 						days = 7
 					}
 				}
@@ -1698,9 +1604,8 @@ country_event = {
 	desc = brazil_flavour_events.3.d
 	picture = GFX_court
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	option = {
 		name = brazil_flavour_events.3.a
@@ -1716,6 +1621,7 @@ country_event = {
 	desc = brazil_flavour_events.4.d
 	picture = GFX_BRA_event_toninho_pt
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2001.1.01
@@ -1746,6 +1652,7 @@ country_event = {
 	desc = brazil_flavour_events.5.d
 	picture = GFX_BRA_event_copa_2002
 	is_triggered_only = yes
+
 	trigger = {
 		tag = BRA
 		date > 2002.1.01
@@ -1772,6 +1679,7 @@ country_event = {
 	desc = brazil_flavour_events.6.d
 	picture = GFX_BRA_event_canal_hotel_bomb
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2003.1.01
@@ -1786,7 +1694,7 @@ country_event = {
 		add_manpower = -1
 		hidden_effect = {
 			country_event = {
-				id = brazil_flavour_events.10	#Sérgio Vieira de Mello Medal
+				id = brazil_flavour_events.10 #Sérgio Vieira de Mello Medal
 				days = 2200
 				random_days = 360
 			}
@@ -1810,6 +1718,7 @@ country_event = {
 	desc = brazil_flavour_events.7.d
 	picture = GFX_BRA_event_cyclone_catarina
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2004.1.01
@@ -1842,6 +1751,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = brazil_flavour_events.7.b
 		log = "[GetDateText]: [This.GetName]: brazil_flavour_events.7.b executed"
@@ -1875,6 +1785,7 @@ country_event = {
 	desc = brazil_flavour_events.8.d
 	picture = GFX_BRA_event_putim_prison
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2000.1.01
@@ -1887,6 +1798,7 @@ country_event = {
 		add_stability = 0.02
 		add_political_power = -75
 	}
+
 	option = {
 		name = brazil_flavour_events.8.b
 		log = "[GetDateText]: [This.GetName]: brazil_flavour_events.8.b executed"
@@ -1902,6 +1814,7 @@ country_event = {
 	desc = brazil_flavour_events.9.d
 	picture = GFX_banking_crisis
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2005.1.01
@@ -1916,7 +1829,6 @@ country_event = {
 		modify_treasury_effect = yes
 		add_political_power = -50
 		increase_policing_budget = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1932,10 +1844,7 @@ country_event = {
 		add_stability = -0.02
 		set_temp_variable = { treasury_change = -0.716 }
 		modify_treasury_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1946,9 +1855,8 @@ country_event = {
 	desc = brazil_flavour_events.10.d
 	picture = GFX_BRA_event_canal_hotel_bomb
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	option = {
 		name = brazil_flavour_events.10.a
@@ -1965,6 +1873,7 @@ country_event = {
 	desc = brazil_flavour_events.11.d
 	picture = GFX_plane_crash
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2007.1.01
@@ -1976,10 +1885,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: brazil_flavour_events.11.a executed"
 		add_stability = -0.02
 		add_manpower = -199
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1987,11 +1893,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: brazil_flavour_events.11.b executed"
 		add_stability = 0.01
 		add_manpower = -199
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2009,6 +1913,7 @@ country_event = {
 	desc = brazil_flavour_events.12.d
 	picture = GFX_country_event_brazilian_carnaval
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2017.1.01
@@ -2019,10 +1924,7 @@ country_event = {
 		name = brazil_flavour_events.12.a
 		log = "[GetDateText]: [This.GetName]: brazil_flavour_events.12.a executed"
 		add_political_power = 25
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2033,6 +1935,7 @@ country_event = {
 	desc = brazil_flavour_events.13.d
 	picture = GFX_country_event_brazilian_new_year
 	is_triggered_only = yes
+
 	trigger = {
 		tag = BRA
 		date > 2007.1.01
@@ -2060,6 +1963,7 @@ country_event = {
 	desc = brazil_flavour_events.14.d
 	picture = GFX_BRA_event_putim_prison # TODO: Replace with a better icon
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		date > 2007.1.01
@@ -2085,13 +1989,6 @@ country_event = {
 	desc = brazil_amazon.1.d
 	picture = GFX_amazon_wildforest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_amazon_rampant_wildfires }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_amazon_rampant_wildfires value = 1 days = 90 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2128,17 +2025,23 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_amazon_rampant_wildfires }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_amazon_rampant_wildfires value = 1 days = 90 }
+	}
+
 	# Do What We Can with What We Have
 	option = {
 		name = brazil_amazon.1.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.1.a executed"
-
 		if = {
 			limit = { NOT = { has_country_flag = BRA_established_amazon_park_service } }
 			random_owned_state = {
-				limit = {
-					is_brazilian_amazon_state = yes
-				}
+				limit = { is_brazilian_amazon_state = yes }
 				random_list = {
 					10 = {
 						if = {
@@ -2184,9 +2087,7 @@ country_event = {
 		}
 		else = {
 			random_owned_state = {
-				limit = {
-					is_brazilian_amazon_state = yes
-				}
+				limit = { is_brazilian_amazon_state = yes }
 				random_list = {
 					10 = {
 						if = {
@@ -2238,16 +2139,13 @@ country_event = {
 			set_temp_variable = { temp_change = -15 }
 			BRA_wild_acreage_effect = yes
 		}
-
 	}
 
 	# Deploy the Army
 	option = {
 		name = brazil_amazon.1.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.1.b executed"
-		trigger = {
-			has_country_flag = BRA_amazon_military_high_command
-		}
+		trigger = { has_country_flag = BRA_amazon_military_high_command }
 		add_command_power = -30
 		set_temp_variable = { temp_change = -10 }
 		BRA_wild_acreage_effect = yes
@@ -2261,13 +2159,6 @@ country_event = {
 	desc = brazil_amazon.2.d
 	picture = GFX_amazon_rainforest_flooding
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_amazon_river_flooded }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_amazon_river_flooded value = 1 days = 90 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2304,32 +2195,33 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_amazon_river_flooded }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_amazon_river_flooded value = 1 days = 90 }
+	}
+
 	# Do What We Can with What We have
 	option = {
 		name = brazil_amazon.2.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.2.a executed"
-
 		set_temp_variable = { temp_change = -20 }
 		BRA_wild_acreage_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Deploy the army to assist with search and rescue, quickly!
 	option = {
 		name = brazil_amazon.2.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.2.b executed"
-		trigger = {
-			has_country_flag = BRA_amazon_military_high_command
-		}
-
+		trigger = { has_country_flag = BRA_amazon_military_high_command }
 		add_command_power = -25
 		set_temp_variable = { temp_change = -15 }
 		BRA_wild_acreage_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2340,13 +2232,6 @@ country_event = {
 	desc = brazil_amazon.3.d
 	picture = GFX_amazon_rainforest_drought
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_drought_in_amazon_border_regions }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_drought_in_amazon_border_regions value = 1 days = 120 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2379,38 +2264,39 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_drought_in_amazon_border_regions }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_drought_in_amazon_border_regions value = 1 days = 120 }
+	}
+
 	# They Should Manage Their Water Better
 	option = {
 		name = brazil_amazon.3.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.3.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
 		set_temp_variable = { temp_change = -40 }
 		BRA_wild_acreage_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Deploy as Much Disaster Relief as We Can Spare, quickly!
 	option = {
 		name = brazil_amazon.3.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.3.b executed"
-		trigger = {
-			has_country_flag = BRA_amazon_military_high_command
-		}
+		trigger = { has_country_flag = BRA_amazon_military_high_command }
 		add_political_power = -25
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_change = -15 }
 		BRA_wild_acreage_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2421,13 +2307,6 @@ country_event = {
 	desc = brazil_amazon.4.d
 	picture = GFX_amazon_rainforest_tropical_storm
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_tropical_storm_strikes_amazon_regions }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_tropical_storm_strikes_amazon_regions value = 1 days = 280 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2460,15 +2339,22 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_tropical_storm_strikes_amazon_regions }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_tropical_storm_strikes_amazon_regions value = 1 days = 280 }
+	}
+
 	# They Should Build Things Sturdier
 	option = {
 		name = brazil_amazon.4.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.4.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_change = -60 }
 		BRA_wild_acreage_effect = yes
 	}
@@ -2478,11 +2364,9 @@ country_event = {
 		name = brazil_amazon.4.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.4.b executed"
 		add_political_power = -50
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.003 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_change = -40 }
 		BRA_wild_acreage_effect = yes
 	}
@@ -2495,13 +2379,6 @@ country_event = {
 	desc = brazil_amazon.5.d
 	picture = GFX_amazon_rainforest_logging
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_illegal_clear_cutting }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_illegal_clear_cutting value = 1 days = 120 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2546,11 +2423,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_illegal_clear_cutting }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_illegal_clear_cutting value = 1 days = 120 }
+	}
+
 	# Do what little we can at this point.
 	option = {
 		name = brazil_amazon.5.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.5.a executed"
-
 		set_temp_variable = { temp_change = -15 }
 		BRA_wild_acreage_effect = yes
 	}
@@ -2559,15 +2444,9 @@ country_event = {
 	option = {
 		name = brazil_amazon.5.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.5.b executed"
-		trigger = {
-			has_dynamic_modifier = {
-				modifier = narco_state_bonuses
-			}
-		}
-
+		trigger = { has_dynamic_modifier = { modifier = narco_state_bonuses } }
 		set_temp_variable = { temp_change = -20 }
 		BRA_wild_acreage_effect = yes
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.008 }
 		modify_treasury_effect = yes
@@ -2581,13 +2460,6 @@ country_event = {
 	desc = brazil_amazon.6.d
 	picture = GFX_amazon_slash_n_burn
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_illegal_slash_n_burn }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_illegal_slash_n_burn value = 1 days = 120 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2632,59 +2504,47 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_illegal_slash_n_burn }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_illegal_slash_n_burn value = 1 days = 120 }
+	}
+
 	# Do what little we can at this point.
 	option = {
 		name = brazil_amazon.6.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.6.a executed"
-
 		set_temp_variable = { temp_change = -15 }
 		BRA_wild_acreage_effect = yes
-
 		hidden_effect = {
 			random = {
 				chance = 5
-
 					country_event = { id = brazil_amazon.8 days = 7 }
-
 			}
-
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# They know the deal, where’s our cut?
 	option = {
 		name = brazil_amazon.6.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.6.b executed"
-		trigger = {
-			has_dynamic_modifier = {
-				modifier = narco_state_bonuses
-			}
-		}
-
+		trigger = { has_dynamic_modifier = { modifier = narco_state_bonuses } }
 		set_temp_variable = { temp_change = -5 }
 		BRA_wild_acreage_effect = yes
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 		hidden_effect = {
 			random = {
 				chance = 15
-
 					country_event = { id = brazil_amazon.8 days = 7 }
-
 			}
-
 		}
-
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2696,13 +2556,6 @@ country_event = {
 	desc = brazil_amazon.7.d
 	picture = GFX_court
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_local_company_purchases_conservation_land }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_local_company_purchases_conservation_land value = 1 days = 120 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2743,6 +2596,15 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_local_company_purchases_conservation_land }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_local_company_purchases_conservation_land value = 1 days = 120 }
+	}
+
 	# Do what little we can at this point.
 	option = {
 		name = brazil_amazon.7.a
@@ -2750,9 +2612,7 @@ country_event = {
 		random_list = {
 			20 = {
 				random_owned_controlled_state = {
-					limit = {
-						is_brazilian_amazon_state = yes
-					}
+					limit = { is_brazilian_amazon_state = yes }
 					add_resource = {
 						type = chromium
 						amount = 8
@@ -2761,9 +2621,7 @@ country_event = {
 			}
 			20 = {
 				random_owned_controlled_state = {
-					limit = {
-						is_brazilian_amazon_state = yes
-					}
+					limit = { is_brazilian_amazon_state = yes }
 					add_resource = {
 						type = oil
 						amount = 8
@@ -2772,9 +2630,7 @@ country_event = {
 			}
 			20 = {
 				random_owned_controlled_state = {
-					limit = {
-						is_brazilian_amazon_state = yes
-					}
+					limit = { is_brazilian_amazon_state = yes }
 					add_resource = {
 						type = aluminium
 						amount = 8
@@ -2783,9 +2639,7 @@ country_event = {
 			}
 			20 = {
 				random_owned_controlled_state = {
-					limit = {
-						is_brazilian_amazon_state = yes
-					}
+					limit = { is_brazilian_amazon_state = yes }
 					add_resource = {
 						type = rubber
 						amount = 8
@@ -2793,13 +2647,9 @@ country_event = {
 				}
 			}
 		}
-
 		set_temp_variable = { temp_change = -20 }
 		BRA_conserv_acreage_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2810,10 +2660,12 @@ country_event = {
 	desc = brazil_amazon.8.d
 	picture = GFX_amazon_wildforest
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		NOT = { has_country_flag = BRA_slah_n_burn_triggers_wildfires }
 	}
+
 	immediate = {
 		set_country_flag = { flag = BRA_slah_n_burn_triggers_wildfires value = 1 days = 120 }
 	}
@@ -2822,7 +2674,6 @@ country_event = {
 	option = {
 		name = brazil_amazon.8.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.8.a executed"
-
 		set_temp_variable = { temp_change = -20 }
 		BRA_wild_acreage_effect = yes
 	}
@@ -2831,14 +2682,10 @@ country_event = {
 	option = {
 		name = brazil_amazon.8.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.8.b executed"
-		trigger = {
-			has_country_flag = BRA_established_amazon_park_service
-		}
-
+		trigger = { has_country_flag = BRA_established_amazon_park_service }
 		add_political_power = -15
 		set_temp_variable = { temp_change = -5 }
 		BRA_wild_acreage_effect = yes
-
 	}
 }
 
@@ -2849,13 +2696,6 @@ country_event = {
 	desc = brazil_amazon.9.d
 	picture = GFX_illegal_poaching
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_poaching_leads_to_local_ecosystem_collapse }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_poaching_leads_to_local_ecosystem_collapse value = 1 days = 150 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2870,6 +2710,15 @@ country_event = {
 			factor = 1.5
 			has_idea = stagnation
 		}
+	}
+
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_poaching_leads_to_local_ecosystem_collapse }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_poaching_leads_to_local_ecosystem_collapse value = 1 days = 150 }
 	}
 
 	# Do what little we can at this point.
@@ -2887,21 +2736,15 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.001 }
 		modify_treasury_effect = yes
-
 	}
 
 	# They know the deal, where’s our cut?
 	option = {
 		name = brazil_amazon.9.c
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.9.c executed"
-		trigger = {
-			has_dynamic_modifier = {
-				modifier = narco_state_bonuses
-			}
-		}
+		trigger = { has_dynamic_modifier = { modifier = narco_state_bonuses } }
 		set_temp_variable = { temp_change = -15 }
 		BRA_wild_acreage_effect = yes
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.003 }
 		modify_treasury_effect = yes
@@ -2915,13 +2758,6 @@ country_event = {
 	desc = brazil_amazon.10.d
 	picture = GFX_brazilian_nativers
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_illegal_incursions_onto_native_land }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_illegal_incursions_onto_native_land value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2936,6 +2772,15 @@ country_event = {
 			factor = 1.5
 			has_idea = stagnation
 		}
+	}
+
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_illegal_incursions_onto_native_land }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_illegal_incursions_onto_native_land value = 1 days = 180 }
 	}
 
 	# They say it’s their land, let them deal with it.
@@ -2993,7 +2838,6 @@ country_event = {
 			has_country_flag = BRA_amazon_military_high_command
 		}
 		add_command_power = -25
-
 		# Natives Express Thanks
 		country_event = { id = brazil_amazon.12 days = 7 }
 		ai_chance = {
@@ -3009,24 +2853,20 @@ country_event = {
 	desc = brazil_amazon.11.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# We can do to nothing about that, may God save their souls.
 	option = {
 		name = brazil_amazon.11.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.11.a executed"
-
 		var:BRA.incursion_state = {
 			add_dynamic_modifier = {
 				modifier = BRA_native_violence_modifier
 				days = 90
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# A textbook case of criminals killing natives.
@@ -3034,7 +2874,6 @@ country_event = {
 		name = brazil_amazon.11.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.11.b executed"
 		add_political_power = -50
-
 		hidden_effect = {
 			random = {
 				chance = 50
@@ -3046,20 +2885,15 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Send in the army to break this up.
 	option = {
 		name = brazil_amazon.11.c
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.11.c executed"
-		trigger = {
-			has_country_flag = BRA_amazon_military_high_command
-		}
+		trigger = { has_country_flag = BRA_amazon_military_high_command }
 		add_command_power = -35
-
 		hidden_effect = {
 			random = {
 				chance = 15
@@ -3071,9 +2905,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3084,9 +2916,8 @@ country_event = {
 	desc = brazil_amazon.12.d
 	picture = GFX_brazilian_nativers
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# They are law-abiding citizens, they deserve our protection
 	option = {
@@ -3103,18 +2934,6 @@ country_event = {
 	desc = brazil_amazon.13.d
 	picture = GFX_BRA_event_pcc # TODO: Replace this with a proper image
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-
-		NOT = { has_country_flag = BRA_jungle_narcotics_field_located }
-		OR = {
-			has_dynamic_modifier = { modifier = cartel_penalties }
-			has_dynamic_modifier = { modifier = narco_state_bonuses }
-		}
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_jungle_narcotics_field_located value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3135,6 +2954,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_jungle_narcotics_field_located }
+		OR = {
+			has_dynamic_modifier = { modifier = cartel_penalties }
+			has_dynamic_modifier = { modifier = narco_state_bonuses }
+		}
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_jungle_narcotics_field_located value = 1 days = 180 }
+	}
+
 	# Try to get in there and do what we can
 	option = {
 		name = brazil_amazon.13.a
@@ -3143,46 +2975,32 @@ country_event = {
 		BRA_wild_acreage_effect = yes
 		set_temp_variable = { cart_strength_change = -3 }
 		modify_cartel_variables_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Have our policing forces cooperate with the local army command
 	option = {
 		name = brazil_amazon.13.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.13.b executed"
-		trigger = {
-			has_country_flag = BRA_amazon_military_high_command
-		}
+		trigger = { has_country_flag = BRA_amazon_military_high_command }
 		set_temp_variable = { temp_change = -15 }
 		BRA_wild_acreage_effect = yes
 		set_temp_variable = { cart_strength_change = -7 }
 		modify_cartel_variables_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Oh! That's where that field was, clever.
 	option = {
 		name = brazil_amazon.13.c
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.13.c executed"
-		trigger = {
-			has_dynamic_modifier = { modifier = narco_state_bonuses }
-		}
+		trigger = { has_dynamic_modifier = { modifier = narco_state_bonuses } }
 		set_temp_variable = { temp_change = -30 }
 		BRA_wild_acreage_effect = yes
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.03 }
 		modify_treasury_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3193,6 +3011,7 @@ country_event = {
 	desc = brazil_amazon.14.d
 	picture = GFX_BRA_event_pcc # TODO: Replace this with a proper image
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		NOT = { check_variable = { influence_array^0 = 0 } }
@@ -3206,10 +3025,7 @@ country_event = {
 		set_temp_variable = { percent_change = 3 }
 		set_temp_variable = { tag_index = influence_array^0 }
 		change_influence_percentage = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Striking a Lucrative Deal is always beneficial
@@ -3221,10 +3037,7 @@ country_event = {
 		set_temp_variable = { percent_change = -5 }
 		set_temp_variable = { tag_index = influence_array^0 }
 		change_influence_percentage = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3235,13 +3048,6 @@ country_event = {
 	desc = brazil_amazon.15.d
 	picture = GFX_amazon_rainforest_dam
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_country_flag = BRA_critical_amazon_dam_overflows }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_critical_amazon_dam_overflows value = 1 days = 210 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3274,11 +3080,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_country_flag = BRA_critical_amazon_dam_overflows }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_critical_amazon_dam_overflows value = 1 days = 210 }
+	}
+
 	# The chances are slim, we should only deploy what is necessary now
 	option = {
 		name = brazil_amazon.15.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.15.a executed"
-
 		random_list = {
 			25 = {
 				country_event = { id = brazil_amazon.16 days = 7 }
@@ -3287,21 +3101,17 @@ country_event = {
 				country_event = { id = brazil_amazon.18 days = 7 }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Plan for the worst, begin an evacuation of downstream regions
 	option = {
 		name = brazil_amazon.15.b
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.15.b executed"
-
 		add_political_power = -50
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.005 }
 		modify_treasury_effect = yes
-
 		random_list = {
 			25 = {
 				country_event = { id = brazil_amazon.17 days = 7 }
@@ -3310,9 +3120,7 @@ country_event = {
 				country_event = { id = brazil_amazon.19 days = 7 }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3323,21 +3131,18 @@ country_event = {
 	desc = brazil_amazon.16.d
 	picture = GFX_amazon_rainforest_flooding_two
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# This-This Wasn't Supposed to Happen...
 	option = {
 		name = brazil_amazon.16.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.16.a executed"
-
 		set_temp_variable = { temp_change = -30 }
 		BRA_wild_acreage_effect = yes
 		set_temp_variable = { party_popularity_increase = -0.08 }
 		set_temp_variable = { temp_outlook_increase = -0.08 }
 		change_relative_party_popularity = yes
-
 		random_owned_controlled_state = {
 			limit = { is_in_array = { BRA.amazon_states = THIS.id } }
 			if = {
@@ -3376,10 +3181,7 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Hell on Earth, Deploy as Much as We Can to the Area
@@ -3390,11 +3192,9 @@ country_event = {
 		add_command_power = -25
 		set_temp_variable = { temp_change = -20 }
 		BRA_wild_acreage_effect = yes
-
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		random_owned_controlled_state = {
 			limit = { is_in_array = { BRA.amazon_states = THIS.id } }
 			if = {
@@ -3433,10 +3233,7 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3447,9 +3244,8 @@ country_event = {
 	desc = brazil_amazon.17.d
 	picture = GFX_amazon_rainforest_flooding_two
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# I can only imagine a world where we did nothing
 	option = {
@@ -3457,15 +3253,11 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.17.a executed"
 		set_temp_variable = { temp_change = -10 }
 		BRA_wild_acreage_effect = yes
-
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		random_owned_state = {
-			limit = {
-				is_brazilian_amazon_state = yes
-			}
+			limit = { is_brazilian_amazon_state = yes }
 			if = {
 				limit = { infrastructure > 0 }
 				damage_building = {
@@ -3514,22 +3306,17 @@ country_event = {
 	desc = brazil_amazon.18.d
 	picture = GFX_amazon_rainforest_flooding_two
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# And, we saved money by doing nothing
 	option = {
 		name = brazil_amazon.18.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.18.a executed"
-
 		set_temp_variable = { temp_change = -5 }
 		BRA_wild_acreage_effect = yes
-
 		random_owned_state = {
-			limit = {
-				is_brazilian_amazon_state = yes
-			}
+			limit = { is_brazilian_amazon_state = yes }
 			if = {
 				limit = { infrastructure > 0 }
 				damage_building = {
@@ -3578,22 +3365,17 @@ country_event = {
 	desc = brazil_amazon.19.d
 	picture = GFX_amazon_rainforest_flooding_two
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# In moments like these, you almost enjoy being a public servant
 	option = {
 		name = brazil_amazon.19.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.19.a executed"
-
 		set_temp_variable = { temp_change = -5 }
 		BRA_wild_acreage_effect = yes
-
 		random_owned_state = {
-			limit = {
-				is_brazilian_amazon_state = yes
-			}
+			limit = { is_brazilian_amazon_state = yes }
 			if = {
 				limit = { infrastructure > 0 }
 				damage_building = {
@@ -3643,19 +3425,6 @@ country_event = {
 	desc = brazil_amazon.20.d
 	picture = GFX_amazon_logo
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
-
-		# Check if the total buildings is over 10
-		892 = {
-			set_temp_variable = { total_building = building_level@industrial_complex }
-			add_to_temp_variable = { total_building = building_level@arms_factory }
-			add_to_temp_variable = { total_building = building_level@agriculture_district }
-			add_to_temp_variable = { total_building = building_level@offices }
-		}
-		check_variable = { total_building > 9 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3708,6 +3477,19 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
+		# Check if the total buildings is over 10
+		892 = {
+			set_temp_variable = { total_building = building_level@industrial_complex }
+			add_to_temp_variable = { total_building = building_level@arms_factory }
+			add_to_temp_variable = { total_building = building_level@agriculture_district }
+			add_to_temp_variable = { total_building = building_level@offices }
+		}
+		check_variable = { total_building > 9 }
+	}
+
 	# This is getting out of hand, now there are two of them
 	option = {
 		name = brazil_amazon.20.a
@@ -3722,13 +3504,8 @@ country_event = {
 				}
 			}
 		}
-		else = {
-			add_political_power = 100
-		}
-
-		ai_chance = {
-			base = 1
-		}
+		else = { add_political_power = 100 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3739,6 +3516,7 @@ country_event = {
 	desc = brazil_amazon.21.d
 	picture = GFX_country_event_amazon_rainforest_devastation
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = BRA
 		check_variable = { BRA.BRA_acres_current < 50 }
@@ -3752,10 +3530,7 @@ country_event = {
 		set_global_flag = BRA_amazon_rainforest_fully_devastated
 		add_stability = -0.05
 		news_event = brazil_news.5
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3766,15 +3541,6 @@ country_event = {
 	desc = brazil_amazon.22.d
 	picture = GFX_grain_silo_investments
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		has_country_flag = BRA_legalized_independent_development
-		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
-		NOT = { has_country_flag = BRA_private_company_clears_and_builds_new_fields }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_private_company_clears_and_builds_new_fields value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3819,6 +3585,17 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		has_country_flag = BRA_legalized_independent_development
+		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
+		NOT = { has_country_flag = BRA_private_company_clears_and_builds_new_fields }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_private_company_clears_and_builds_new_fields value = 1 days = 180 }
+	}
+
 	# Awesome!
 	option = {
 		name = brazil_amazon.22.a
@@ -3826,9 +3603,7 @@ country_event = {
 		set_temp_variable = { temp_change = -12 }
 		BRA_wild_acreage_effect = yes
 		random_owned_controlled_state = {
-			limit = {
-				is_brazilian_amazon_state = yes
-			}
+			limit = { is_brazilian_amazon_state = yes }
 			add_building_construction = {
 				type = agriculture_district
 				level = 1
@@ -3855,15 +3630,6 @@ country_event = {
 	desc = brazil_amazon.23.d
 	picture = GFX_amazon_rainforest_mining_two
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		has_country_flag = BRA_legalized_independent_development
-		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
-		NOT = { has_country_flag = BRA_private_company_exploits_resource_reserves }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_private_company_exploits_resource_reserves value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -3908,6 +3674,17 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		has_country_flag = BRA_legalized_independent_development
+		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
+		NOT = { has_country_flag = BRA_private_company_exploits_resource_reserves }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_private_company_exploits_resource_reserves value = 1 days = 180 }
+	}
+
 	# Awesome!
 	option = {
 		name = brazil_amazon.23.a
@@ -3915,9 +3692,7 @@ country_event = {
 		set_temp_variable = { temp_change = -5 }
 		BRA_wild_acreage_effect = yes
 		random_owned_controlled_state = {
-			limit = {
-				is_brazilian_amazon_state = yes
-			}
+			limit = { is_brazilian_amazon_state = yes }
 			random_list = {
 				20 = {
 					add_resource = {
@@ -3959,15 +3734,6 @@ country_event = {
 	desc = brazil_amazon.24.d
 	picture = GFX_amazon_road_paving
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		has_country_flag = BRA_legalized_independent_development
-		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
-		NOT = { has_country_flag = BRA_private_company_invests_in_infrastructure }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_private_company_invests_in_infrastructure value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4010,6 +3776,17 @@ country_event = {
 			factor = 1.15
 			check_variable = { BRA.BRA_acres_current > 1500 }
 		}
+	}
+
+	trigger = {
+		original_tag = BRA
+		has_country_flag = BRA_legalized_independent_development
+		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
+		NOT = { has_country_flag = BRA_private_company_invests_in_infrastructure }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_private_company_invests_in_infrastructure value = 1 days = 180 }
 	}
 
 	# Awesome!
@@ -4049,15 +3826,6 @@ country_event = {
 	desc = brazil_amazon.25.d
 	picture = GFX_amazon_road_paving
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		has_country_flag = BRA_legalized_independent_development
-		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
-		NOT = { has_country_flag = BRA_private_company_creates_new_construction_company }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_private_company_creates_new_construction_company value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4102,6 +3870,17 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		has_country_flag = BRA_legalized_independent_development
+		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
+		NOT = { has_country_flag = BRA_private_company_creates_new_construction_company }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_private_company_creates_new_construction_company value = 1 days = 180 }
+	}
+
 	# Awesome!
 	option = {
 		name = brazil_amazon.25.a
@@ -4109,9 +3888,7 @@ country_event = {
 		set_temp_variable = { temp_change = -12 }
 		BRA_wild_acreage_effect = yes
 		random_owned_controlled_state = {
-			limit = {
-				is_brazilian_amazon_state = yes
-			}
+			limit = { is_brazilian_amazon_state = yes }
 			add_building_construction = {
 				type = industrial_complex
 				level = 1
@@ -4138,15 +3915,6 @@ country_event = {
 	desc = brazil_amazon.26.d
 	picture = GFX_amazon_rainforest_replanting
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-		has_country_flag = BRA_legalized_independent_development
-		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
-		NOT = { has_country_flag = BRA_no_conservation_land_for_me }
-	}
-	immediate = {
-		set_country_flag = { flag = BRA_no_conservation_land_for_me value = 1 days = 180 }
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -4199,22 +3967,28 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		original_tag = BRA
+		has_country_flag = BRA_legalized_independent_development
+		NOT = { has_global_flag = BRA_amazon_rainforest_fully_devastated }
+		NOT = { has_country_flag = BRA_no_conservation_land_for_me }
+	}
+
+	immediate = {
+		set_country_flag = { flag = BRA_no_conservation_land_for_me value = 1 days = 180 }
+	}
+
 	# Awesome!
 	option = {
 		name = brazil_amazon.26.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.26.a executed"
-
 		set_temp_variable = { temp_change = 75 }
 		BRA_conserv_acreage_effect = yes
-
 		set_temp_variable = { party_index = 17 }
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Deny the Patent
@@ -4225,7 +3999,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_small_medium_business_owners_opinion = yes
 		change_industrial_conglomerates_opinion = yes
@@ -4239,25 +4012,20 @@ country_event = {
 	desc = brazil_amazon.27.d
 	picture = GFX_BRA_generic
 	is_triggered_only = yes
-	trigger = {
-		original_tag = BRA
-	}
+
+	trigger = { original_tag = BRA }
 
 	# Awesome! Thank you Johan!
 	option = {
 		name = brazil_amazon.27.a
 		log = "[GetDateText]: [This.GetName]: brazil_amazon.27.a executed"
-
 		set_temp_variable = { temp_change = 50 }
 		BRA_conserv_acreage_effect = yes
 		set_temp_variable = { party_index = 17 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4268,7 +4036,6 @@ news_event = {
 	title = brazil_news.1.t
 	desc = brazil_news.1.d
 	picture = GFX_news_election_rally
-
 	is_triggered_only = yes
 	major = yes
 
@@ -4276,6 +4043,7 @@ news_event = {
 		name = brazil_news.1.a
 		trigger = { original_tag = BRA }
 	}
+
 	option = {
 		name = brazil_news.1.b
 		trigger = { NOT = { original_tag = BRA } }
@@ -4288,7 +4056,6 @@ news_event = {
 	title = brazil_news.2.t
 	desc = brazil_news.2.d
 	picture = GFX_BRA_Petrobras_news
-
 	is_triggered_only = yes
 	major = yes
 
@@ -4296,6 +4063,7 @@ news_event = {
 		name = brazil_news.2.a
 		trigger = { original_tag = BRA }
 	}
+
 	option = {
 		name = brazil_news.2.b
 		trigger = { NOT = { original_tag = BRA } }
@@ -4308,7 +4076,6 @@ news_event = {
 	title = brazil_news.3.t
 	desc = brazil_news.3.d
 	picture = GFX_brazilian_flag
-
 	is_triggered_only = yes
 	major = yes
 
@@ -4316,6 +4083,7 @@ news_event = {
 		name = brazil_news.3.a
 		trigger = { original_tag = BRA }
 	}
+
 	option = {
 		name = brazil_news.3.b
 		trigger = { NOT = { original_tag = BRA } }
@@ -4330,7 +4098,5 @@ news_event = {
 	picture = GFX_BRA_amazon_devastated_news
 	is_triggered_only = yes
 
-	option = {
-		name = brazil_news.5.a
-	}
+	option = { name = brazil_news.5.a }
 }

--- a/events/Middle East Peace Plan.txt
+++ b/events/Middle East Peace Plan.txt
@@ -6,7 +6,6 @@ add_namespace = iraqi_MNF
 #[FROM.GetName] Proposes Middle East Peace Plan
 news_event = {
 	id = peace_plan.1
-	major = yes
 	title = peace_plan.1.t
 	desc = {
 		text = peace_plan.1.d
@@ -16,10 +15,9 @@ news_event = {
 		text = peace_plan.1.d1
 		trigger = { FROM = { has_completed_focus = GCC_favor_resistance } }
 	}
-
 	picture = GFX_news_press_conference
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = peace_plan.1.a #Not another doomed peace deal...
@@ -34,9 +32,7 @@ country_event = {
 	id = peace_plan.2
 	title = peace_plan.2.t
 	desc = peace_plan.2.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -74,9 +70,7 @@ country_event = {
 	id = peace_plan.3
 	title = peace_plan.3.t
 	desc = peace_plan.3.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -128,9 +122,7 @@ country_event = {
 	id = peace_plan.4
 	title = peace_plan.4.t
 	desc = peace_plan.4.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -186,9 +178,7 @@ country_event = {
 	id = peace_plan.5
 	title = peace_plan.5.t
 	desc = peace_plan.5.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -233,9 +223,7 @@ country_event = {
 	id = peace_plan.6
 	title = peace_plan.6.t
 	desc = peace_plan.6.d
-
 	picture = GFX_politics_speak
-
 	is_triggered_only = yes
 
 	option = {
@@ -338,7 +326,6 @@ country_event = {
 				}
 				HAM = { remove_ideas = israeli_blockade }
 			}
-
 		}
 		if = {
 			limit = {
@@ -464,6 +451,7 @@ country_event = {
 	desc = peace_plan.7.d
 	picture = GFX_trade_agreement # TODO: Replace with a picture
 	is_triggered_only = yes
+
 	trigger = {
 		PAL = { has_country_flag = peace_deal_accepted_@ROOT }
 		ISR = { has_country_flag = peace_deal_accepted_@ROOT }
@@ -487,9 +475,7 @@ country_event = {
 	is_triggered_only = yes
 
 	# Our Initiative Has Failed...
-	option = {
-		name = peace_plan.8.a
-	}
+	option = { name = peace_plan.8.a }
 }
 
 #Israel and Palestinian Authority Sign Landmark Peace Deal
@@ -502,16 +488,13 @@ news_event = {
 	major = yes
 
 	# A Historic Moment!
-	option = {
-		name = peace_plan.7.a
-	}
+	option = { name = peace_plan.7.a }
 }
 
 country_event = {
 	id = iraqi_MNF.2
 	title = iraqi_MNF.2.t
 	desc = iraqi_MNF.2.d
-
 	is_triggered_only = yes
 
 	option = { # We surrender
@@ -537,7 +520,6 @@ country_event = {
 					days = 400
 				}
 			}
-
 			if = {
 				limit = {
 					any_country_with_original_tag = {
@@ -554,7 +536,6 @@ country_event = {
 					copy_tag = IRQ
 					set_country_flag = IRQ_POZ
 					set_cosmetic_tag = IRQ_POZ
-
 					set_politics = { ruling_party = democratic elections_allowed = no }
 					set_political_party = { ideology = democratic popularity = 100 }
 					set_variable = { party_pop_array^0 = 1 }
@@ -562,7 +543,6 @@ country_event = {
 					set_variable = { ruling_party = 0 }
 					startup_politics = yes
 					ingame_startup_nations_effect = yes
-
 					add_ideas = {
 						non_state_actor
 						shia
@@ -579,26 +559,22 @@ country_event = {
 						officer_basic_training
 					}
 				}
-
 				169 = { transfer_state_to = POZ }
 				1142 = { transfer_state_to = POZ }
 				1141 = { transfer_state_to = POZ }
 				1143 = { transfer_state_to = POZ }
-
 				POL = {
 					set_autonomy = {
 						target = POZ
 						autonomy_state = autonomy_occupation_zone_IRQ
 					}
 				}
-
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 0 }
 				set_temp_variable = { party_popularity_increase = 0.15 }
 				set_temp_variable = { temp_outlook_increase = 0.25 }
 				change_relative_party_popularity = yes
-
 				POZ = {
 					create_country_leader = {
 						name = "Andrzej Tyszkiewicz"
@@ -610,9 +586,7 @@ country_event = {
 						}
 					}
 				}
-
 			}
-
 			if = {
 				limit = {
 					any_country_with_original_tag = {
@@ -629,7 +603,6 @@ country_event = {
 					copy_tag = IRQ
 					set_country_flag = IRQ_BOZ
 					set_cosmetic_tag = IRQ_BOZ
-
 					set_politics = { ruling_party = democratic elections_allowed = no }
 					set_political_party = { ideology = democratic popularity = 100 }
 					set_variable = { party_pop_array^0 = 1 }
@@ -637,7 +610,6 @@ country_event = {
 					set_variable = { ruling_party = 0 }
 					startup_politics = yes
 					ingame_startup_nations_effect = yes
-
 					add_ideas = {
 						non_state_actor
 						shia
@@ -654,26 +626,22 @@ country_event = {
 						officer_basic_training
 					}
 				}
-
 				171 = { transfer_state_to = BOZ }
 				1122 = { transfer_state_to = BOZ }
 				1123 = { transfer_state_to = BOZ }
 				1124 = { transfer_state_to = BOZ }
-
 				ENG = {
 					set_autonomy = {
 						target = BOZ
 						autonomy_state = autonomy_occupation_zone_IRQ
 					}
 				}
-
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 0 }
 				set_temp_variable = { party_popularity_increase = 0.15 }
 				set_temp_variable = { temp_outlook_increase = 0.25 }
 				change_relative_party_popularity = yes
-
 				BOZ = {
 					create_country_leader = {
 						name = "Graeme Lamb"
@@ -686,16 +654,13 @@ country_event = {
 					}
 				}
 			}
-
 			hidden_effect = {
 				white_peace = KUR
 				white_peace = PUK
 			}
-
 			annex_country = {
 				target = MNF
 			}
-
 			country_event = {
 				id = iraq_md.200
 				days = 2190
@@ -723,7 +688,6 @@ country_event = {
 				days = 90
 			}
 			if = { limit = { has_character = IRQ_izzat_ibrahim_al_douri } retire_character = IRQ_izzat_ibrahim_al_douri }
-
 			# Changes in Internal Factions:
 		}
 		news_event = iraqi_flavor_events.4
@@ -731,6 +695,7 @@ country_event = {
 			base = 1
 		}
 	}
+
 	option = { # Relocate to Mosul (meant for the player mostly, I don't want the AI to do it)
 		name = iraqi_MNF.2.b
 		ai_chance = {
@@ -743,7 +708,6 @@ country_event = {
 	id = iraqi_MNF.3
 	title = iraqi_MNF.3.t
 	desc = iraqi_MNF.3.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -771,13 +735,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = iraqi_MNF.3.b
 		log = "[GetDateText]: [This.GetName]: iraqi_MNF.3.b executed"
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -785,7 +748,6 @@ country_event = {
 	id = iraqi_MNF.4
 	title = iraqi_MNF.4.t
 	desc = iraqi_MNF.4.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -809,6 +771,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # Okay, but with some strings attached
 		name = iraqi_MNF.4.b
 		log = "[GetDateText]: [This.GetName]: iraqi_MNF.4.b executed"
@@ -822,6 +785,7 @@ country_event = {
 			base = 1
 		}
 	}
+
 	option = { # Never!
 		name = iraqi_MNF.4.b
 		log = "[GetDateText]: [This.GetName]: iraqi_MNF.4.b executed"
@@ -841,7 +805,6 @@ country_event = { # X Country Agrees To Withdraw Unconditionally!
 	id = iraqi_MNF.5
 	title = iraqi_MNF.5.t
 	desc = iraqi_MNF.5.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -878,7 +841,6 @@ country_event = { # X Country Agrees To Withdraw.. With Conditions!
 	id = iraqi_MNF.6
 	title = iraqi_MNF.6.t
 	desc = iraqi_MNF.6.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -934,7 +896,6 @@ country_event = { # X Country Refuses To Withdraw..
 	id = iraqi_MNF.7
 	title = iraqi_MNF.7.t
 	desc = iraqi_MNF.7.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
@@ -979,7 +940,6 @@ country_event = { # Resource Rights Contract Expires
 	id = iraqi_MNF.8
 	title = iraqi_MNF.8.t
 	desc = iraqi_MNF.8.d
-
 	picture = GFX_oil_refinery
 	is_triggered_only = yes
 
@@ -999,7 +959,6 @@ country_event = { # Resource Rights Contract Expires - IRQ
 	id = iraqi_MNF.9
 	title = iraqi_MNF.9.t
 	desc = iraqi_MNF.9.d
-
 	picture = GFX_oil_refinery
 	is_triggered_only = yes
 
@@ -1058,7 +1017,6 @@ country_event = { # Qusay Captured!
 	id = iraqi_MNF.11
 	title = iraqi_MNF.11.t
 	desc = iraqi_MNF.11.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1077,7 +1035,6 @@ country_event = { # Uday Captured!
 	id = iraqi_MNF.12
 	title = iraqi_MNF.12.t
 	desc = iraqi_MNF.12.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1096,7 +1053,6 @@ country_event = { # Abid Captured!
 	id = iraqi_MNF.13
 	title = iraqi_MNF.13.t
 	desc = iraqi_MNF.13.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1115,7 +1071,6 @@ country_event = { # Majid Captured!
 	id = iraqi_MNF.14
 	title = iraqi_MNF.14.t
 	desc = iraqi_MNF.14.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1134,7 +1089,6 @@ country_event = { # Walter Captured!
 	id = iraqi_MNF.15
 	title = iraqi_MNF.15.t
 	desc = iraqi_MNF.15.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1153,7 +1107,6 @@ country_event = { # Tilfah Captured!
 	id = iraqi_MNF.16
 	title = iraqi_MNF.16.t
 	desc = iraqi_MNF.16.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1172,7 +1125,6 @@ country_event = { # Salih Captured!
 	id = iraqi_MNF.17
 	title = iraqi_MNF.17.t
 	desc = iraqi_MNF.17.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -1251,8 +1203,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.18
 	title = iraqi_MNF.18.t
 	desc = iraqi_MNF.18.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		IRQ = {
@@ -1276,8 +1228,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.19
 	title = iraqi_MNF.19.t
 	desc = iraqi_MNF.19.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1301,8 +1253,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.20
 	title = iraqi_MNF.20.t
 	desc = iraqi_MNF.20.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		IRQ = {
@@ -1326,8 +1278,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.21
 	title = iraqi_MNF.21.t
 	desc = iraqi_MNF.21.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1351,8 +1303,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.22
 	title = iraqi_MNF.22.t
 	desc = iraqi_MNF.22.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1377,8 +1329,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.23
 	title = iraqi_MNF.23.t
 	desc = iraqi_MNF.23.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1403,8 +1355,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.24
 	title = iraqi_MNF.24.t
 	desc = iraqi_MNF.24.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1429,8 +1381,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.25
 	title = iraqi_MNF.25.t
 	desc = iraqi_MNF.25.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1455,8 +1407,8 @@ country_event = { # Initiation of state flags
 	id = iraqi_MNF.250
 	title = iraqi_MNF.250.t
 	desc = iraqi_MNF.250.d
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = { # Okay
 		IRQ = {
@@ -1484,15 +1436,11 @@ country_event = { # Saddam Relocation (bi-monthly)
 	id = iraqi_MNF.251
 	title = iraqi_MNF.251.t
 	desc = iraqi_MNF.251.d
-	hidden = yes
 	is_triggered_only = yes
-	trigger = {
-		NOT = {
-			USA = {
-				has_country_flag = IRQ_saddam_caught
-			}
-		}
-	}
+	hidden = yes
+
+	trigger = { NOT = { USA = { has_country_flag = IRQ_saddam_caught } } }
+
 	immediate = {
 		IRQ = {
 			country_event = {
@@ -1500,9 +1448,7 @@ country_event = { # Saddam Relocation (bi-monthly)
 				days = 60
 			}
 			random_owned_state = {
-				limit = {
-					has_state_flag = IRQ_saddam_here
-				}
+				limit = { has_state_flag = IRQ_saddam_here }
 				set_state_flag = { flag = IRQ_saddam_was_here days = 70 value = 1 }
 				clr_state_flag = IRQ_saddam_here
 			}

--- a/events/Syria.txt
+++ b/events/Syria.txt
@@ -8,20 +8,16 @@ add_namespace = SyriaFocusNews
 
 #Situation with Tahrir Al-Sham and FSA
 country_event = {
-
 	id = Syria.2
-
 	title = Syria.2.t
 	desc = Syria.2.desc
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = Syria.2.a
-		log = "[GetDateText]: [This.GetName]: Syria.2.a executed"		#Offer them representation
+		log = "[GetDateText]: [This.GetName]: Syria.2.a executed" #Offer them representation
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -46,9 +42,10 @@ country_event = {
 		add_political_power = -50
 		NUS = { country_event = { days = 3 id = Syria.3 } }
 	}
+
 	option = {
 		name = Syria.2.b
-		log = "[GetDateText]: [This.GetName]: Syria.2.b executed"		#Take them out
+		log = "[GetDateText]: [This.GetName]: Syria.2.b executed" #Take them out
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -80,17 +77,15 @@ country_event = {
 
 #FSA offers representation
 country_event = {
-
 	id = Syria.3
 	title = Syria.3.t
 	desc = Syria.3.desc
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	option = {
 		name = Syria.3.a
-		log = "[GetDateText]: [This.GetName]: Syria.3.a executed"			#Agree
+		log = "[GetDateText]: [This.GetName]: Syria.3.a executed" #Agree
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -104,9 +99,10 @@ country_event = {
 		}
 		custom_effect_tooltip = GAME_OVER_TT
 	}
+
 	option = {
 		name = Syria.3.b
-		log = "[GetDateText]: [This.GetName]: Syria.3.b executed"			#Refuse
+		log = "[GetDateText]: [This.GetName]: Syria.3.b executed" #Refuse
 		ai_chance = {
 			base = 75
 			modifier = {
@@ -124,12 +120,10 @@ country_event = {
 
 #NUS agrees
 country_event = {
-
 	id = Syria.4
 	title = Syria.4.t
 	desc = Syria.4.desc
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	option = {
@@ -140,17 +134,14 @@ country_event = {
 		add_popularity = { ideology = fascism popularity = 0.1 }
 		hidden_effect = { news_event = { id = SyriaNews.3 hours = 6 } }
 	}
-
 }
 
 #NUS refuses
 country_event = {
-
 	id = Syria.5
 	title = Syria.5.t
 	desc = Syria.5.desc
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	option = {
@@ -163,7 +154,6 @@ country_event = {
 		create_wargoal = { type = annex_everything target = NUS }
 		hidden_effect = { news_event = { id = SyriaNews.2 hours = 6 } }
 	}
-
 }
 
 #FSA is alive, but Tahrir al Sham is close to defeat
@@ -173,7 +163,6 @@ country_event = {
 	title = Syria.15.t
 	desc = Syria.15.d
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	option = {
@@ -192,7 +181,6 @@ country_event = {
 	title = Syria.16.t
 	desc = Syria.16.d
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	option = {
@@ -209,57 +197,41 @@ country_event = {
 
 #End of civil war
 news_event = {
-
 	id = SyriaNews.1
 	title = SyriaNews.1.t
 	desc = SyriaNews.1.d
 	picture = GFX_news_Syria_civil_war_victory
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	trigger = {
 	}
 
-	option = {
-		name = SyriaNews.1.a
-	}
-
+	option = { name = SyriaNews.1.a }
 }
 
 #FSA and Al-Nusra hostile towards each other
 news_event = {
-
 	id = SyriaNews.2
 	title = SyriaNews.2.t
 	desc = SyriaNews.2.d
 	picture = GFX_news_fsa_and_al_nusra
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaNews.2.a
-	}
+	option = { name = SyriaNews.2.a }
 }
 
 #FSA and Al-Nusra friendly towards each other
 news_event = {
-
 	id = SyriaNews.3
 	title = SyriaNews.3.t
 	desc = SyriaNews.3.d
 	picture = GFX_news_fsa_and_al_nusra
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaNews.3.a
-	}
+	option = { name = SyriaNews.3.a }
 }
 
 #FSA annexes Tahrir al Sham
@@ -268,14 +240,10 @@ news_event = {
 	title = SyriaNews.8.t
 	desc = SyriaNews.8.d
 	picture = GFX_news_rise_of_taliban
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaNews.8.a
-	}
+	option = { name = SyriaNews.8.a }
 }
 
 #NUS annexes FSA
@@ -284,14 +252,10 @@ news_event = {
 	title = SyriaNews.9.t
 	desc = SyriaNews.9.d
 	picture = GFX_news_rise_of_taliban
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaNews.9.a
-	}
+	option = { name = SyriaNews.9.a }
 }
 
 add_namespace = SyriaFocus
@@ -307,7 +271,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.0.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.0.a executed"		#The area belongs to Syria
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.0.a executed" #The area belongs to Syria
 		ai_chance = {
 			base = 75
 			modifier = {
@@ -317,9 +281,10 @@ country_event = {
 		}
 		ROJ = { country_event = { days = 5 id = SyriaFocus.1 } }
 	}
+
 	option = {
 		name = SyriaFocus.0.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.0.b executed"		#Offer them federal status
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.0.b executed" #Offer them federal status
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -338,9 +303,10 @@ country_event = {
 		}
 		ROJ = { country_event = { days = 5 id = SyriaFocus.4 } }
 	}
+
 	option = {
 		name = SyriaFocus.0.c
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.0.c executed"		#Let them be independent
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.0.c executed" #Let them be independent
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -375,7 +341,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.1.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.1.a executed"		#Reject demands
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.1.a executed" #Reject demands
 		ai_chance = {
 			base = 80
 			modifier = {
@@ -385,9 +351,10 @@ country_event = {
 		}
 		FROM = { country_event = { days = 5 id = SyriaFocus.2 } }
 	}
+
 	option = {
 		name = SyriaFocus.1.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.1.b executed"		#Agree
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.1.b executed" #Agree
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -414,7 +381,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.2.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.2.a executed"		#Damn them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.2.a executed" #Damn them
 		ai_chance = {
 			base = 90
 		}
@@ -439,9 +406,10 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SyriaFocus.2.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.2.b executed"		#Let them go
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.2.b executed" #Let them go
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -467,17 +435,15 @@ country_event = {
 	title = SyriaFocus.3.t
 	desc = SyriaFocus.3.desc
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.3.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.3.a executed"		#Huzzah
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.3.a executed" #Huzzah
 		ai_chance = { base = 100 }
 		annex_country = { target = ROJ }
 		hidden_effect = { news_event = { id = SyriaFocusNews.1 hours = 6 } }
 	}
-
 }
 
 #Federal Status offered
@@ -490,21 +456,20 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.4.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.4.a executed"		#This is what we wanted
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.4.a executed" #This is what we wanted
 		FROM = {
 			country_event = { days = 5 id = SyriaFocus.5 }
 			set_country_flag = Promised_Federated_Syria
 		}
-
 		ai_chance = {
 			base = 80
 		}
 	}
+
 	option = {
 		name = SyriaFocus.4.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.4.b executed"		#We have new goals
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.4.b executed" #We have new goals
 		FROM = { country_event = { days = 5 id = SyriaFocus.2 } }
-
 		ai_chance = {
 			base = 20
 		}
@@ -521,7 +486,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.5.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.5.a executed"		#Huzzah
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.5.a executed" #Huzzah
 		ai_chance = { base = 100 }
 		every_owned_state = {
 			limit = {
@@ -562,7 +527,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.6.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.6.a executed"		#Keep SSNP around
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.6.a executed" #Keep SSNP around
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -577,9 +542,10 @@ country_event = {
 		set_country_flag = Opinion_On_SSNP_Keep
 		SYR = { country_event = SyriaFocus.7 }
 	}
+
 	option = {
 		name = SyriaFocus.6.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.6.b executed"		#Purge SSNP
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.6.b executed" #Purge SSNP
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -601,13 +567,11 @@ country_event = {
 	title = SyriaFocus.7.t
 	desc = {
 		text = SyriaFocus.7.Keep.desc
-		trigger = { FROM = { has_country_flag = Opinion_On_SSNP_Keep }
-		}
+		trigger = { FROM = { has_country_flag = Opinion_On_SSNP_Keep } }
 	}
 	desc = {
 		text = SyriaFocus.7.Purge.desc
-		trigger = { FROM = { has_country_flag = Opinion_On_SSNP_Purge }
-		}
+		trigger = { FROM = { has_country_flag = Opinion_On_SSNP_Purge } }
 	}
 	picture = GFX_SYR_ssnp
 	is_triggered_only = yes
@@ -621,9 +585,11 @@ country_event = {
 #SSNP Coup
 country_event = {
 	id = SyriaFocus.8
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 	fire_only_once = yes
+
+	trigger = { tag = SYR }
 
 	immediate = {
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.8 executed"
@@ -633,10 +599,6 @@ country_event = {
 			20 = { country_event = SyriaFocus.11 }
 		}
 	}
-
-	trigger = {
-		tag = SYR
-	}
 }
 
 country_event = {
@@ -644,7 +606,6 @@ country_event = {
 	title = SyriaFocus.9.t
 	desc = SyriaFocus.9.d
 	picture = GFX_Assad_parade
-
 	is_triggered_only = yes
 
 	option = {
@@ -701,9 +662,7 @@ country_event = {
 			set_country_flag = Second_Syrian_Civil_War
 		}
 		if = {
-			limit = {
-				NOT = { has_country_flag = Second_Syrian_Civil_War }
-			}
+			limit = { NOT = { has_country_flag = Second_Syrian_Civil_War } }
 			start_civil_war = {
 				ideology = nationalist
 				size = 0.10
@@ -759,9 +718,7 @@ country_event = {
 			set_country_flag = Second_Syrian_Civil_War
 		}
 		if = {
-			limit = {
-				NOT = { has_country_flag = Second_Syrian_Civil_War }
-			}
+			limit = { NOT = { has_country_flag = Second_Syrian_Civil_War } }
 			start_civil_war = {
 				ideology = nationalist
 				size = 0.10
@@ -806,9 +763,7 @@ country_event = {
 			set_country_flag = Second_Syrian_Civil_War
 		}
 		if = {
-			limit = {
-				NOT = { has_country_flag = Second_Syrian_Civil_War }
-			}
+			limit = { NOT = { has_country_flag = Second_Syrian_Civil_War } }
 			start_civil_war = {
 				ideology = nationalist
 				size = 0.10
@@ -829,7 +784,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.12.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.12.a executed"		#Keep Palestinian groups around
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.12.a executed" #Keep Palestinian groups around
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -844,9 +799,10 @@ country_event = {
 		set_country_flag = Opinion_On_Palestinian_Groups_Keep
 		SYR = { country_event = SyriaFocus.13 }
 	}
+
 	option = {
 		name = SyriaFocus.12.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.12.b executed"		#Purge Palestinian groups
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.12.b executed" #Purge Palestinian groups
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -868,13 +824,11 @@ country_event = {
 	title = SyriaFocus.13.t
 	desc = {
 		text = SyriaFocus.13.Keep.desc
-		trigger = { FROM = { has_country_flag = Opinion_On_Palestinian_Groups_Keep }
-		}
+		trigger = { FROM = { has_country_flag = Opinion_On_Palestinian_Groups_Keep } }
 	}
 	desc = {
 		text = SyriaFocus.13.Purge.desc
-		trigger = { FROM = { has_country_flag = Opinion_On_Palestinian_Groups_Purge }
-		}
+		trigger = { FROM = { has_country_flag = Opinion_On_Palestinian_Groups_Purge } }
 	}
 	picture = GFX_palestinians_in_syria
 	is_triggered_only = yes
@@ -895,7 +849,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.14.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.14.a executed"		#Keep Shiite groups around
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.14.a executed" #Keep Shiite groups around
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -910,9 +864,10 @@ country_event = {
 		set_country_flag = Opinion_On_Shiite_Groups_Keep
 		SYR = { country_event = SyriaFocus.15 }
 	}
+
 	option = {
 		name = SyriaFocus.14.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.14.b executed"		#Purge Shiite groups
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.14.b executed" #Purge Shiite groups
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -934,13 +889,11 @@ country_event = {
 	title = SyriaFocus.15.t
 	desc = {
 		text = SyriaFocus.15.Keep.desc
-		trigger = { FROM = { has_country_flag = Opinion_On_Shiite_Groups_Keep }
-		}
+		trigger = { FROM = { has_country_flag = Opinion_On_Shiite_Groups_Keep } }
 	}
 	desc = {
 		text = SyriaFocus.15.Purge.desc
-		trigger = { FROM = { has_country_flag = Opinion_On_Shiite_Groups_Purge }
-		}
+		trigger = { FROM = { has_country_flag = Opinion_On_Shiite_Groups_Purge } }
 	}
 	picture = GFX_palestinians_in_syria
 	is_triggered_only = yes
@@ -961,7 +914,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.16.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.16.a executed"		#Agree to their request
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.16.a executed" #Agree to their request
 		ai_chance = { base = 90 }
 		FROM = {
 			set_temp_variable = { percent_change = 5 }
@@ -973,9 +926,10 @@ country_event = {
 		}
 		give_guarantee = FROM
 	}
+
 	option = {
 		name = SyriaFocus.16.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.16.b executed"		#Don't agree to their request
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.16.b executed" #Don't agree to their request
 		ai_chance = { base = 10 }
 		SYR = {
 			set_country_flag = SYR_Request_Rejected
@@ -993,7 +947,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.17.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.17.a executed"		#Noted
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.17.a executed" #Noted
 		ai_chance = { base = 100 }
 		if = {
 			limit = {
@@ -1016,7 +970,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.18.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.18.a executed"		#Noted
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.18.a executed" #Noted
 		ai_chance = { base = 100 }
 		if = {
 			limit = {
@@ -1044,12 +998,12 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.19.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.19.a executed"				#Integrate them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.19.a executed" #Integrate them
 		ai_chance = {
 			base = 25
 			modifier = {
 				factor = 3
-				num_divisions < 15			#If we took heavy casualties, integrate
+				num_divisions < 15 #If we took heavy casualties, integrate
 			}
 		}
 		add_popularity = { ideology = communism popularity = 0.1 }
@@ -1057,14 +1011,12 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.20 }
 		set_temp_variable = { temp_outlook_increase = -0.10 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
 		custom_effect_tooltip = TT_SYRIAN_ARAB_ARMY_REMNANTS
 		hidden_effect = {
 			if = {
 				limit = { has_dlc = "No Step Back" }
-
 				load_oob = Syrian_Arab_Army_Remnants_nsb
 			}
 			else = {
@@ -1072,9 +1024,10 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SyriaFocus.19.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.19.b executed"				#Disband them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.19.b executed" #Disband them
 		ai_chance = {
 			base = 75
 			modifier = {
@@ -1098,13 +1051,12 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.20.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.20.a executed"				#Let them join
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.20.a executed" #Let them join
 		ai_chance = { base = 30 }
 		add_popularity = { ideology = communism popularity = 0.05 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
 		set_country_flag = SYR_unlock_ayyoub_qudsiyeh
@@ -1121,16 +1073,17 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SyriaFocus.20.b
 		ai_chance = { base = 60 }
 	}
+
 	option = {
 		name = SyriaFocus.20.c
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.20.c executed"				#Send them to the hangman
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.20.c executed" #Send them to the hangman
 		ai_chance = { base = 10 }
 		add_popularity = { ideology = fascism popularity = 0.05 }
-
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
@@ -1178,20 +1131,20 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.21.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.21.a executed"		#Ban them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.21.a executed" #Ban them
 		ai_chance = { base = 80 }
 		add_ideas = baath_party_banned
 		set_temp_variable = { temp_opinion = -5 }
 		change_oligarchs_opinion = yes
 	}
+
 	option = {
 		name = SyriaFocus.21.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.21.b executed"		#Allow them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.21.b executed" #Allow them
 		ai_chance = { base = 20 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_oligarchs_opinion = yes
 	}
@@ -1211,20 +1164,20 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.22.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.22.a executed"		#Ban them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.22.a executed" #Ban them
 		ai_chance = { base = 70 }
 		add_ideas = ssnp_party_banned
 		set_temp_variable = { temp_opinion = -5 }
 		change_the_military_opinion = yes
 	}
+
 	option = {
 		name = SyriaFocus.22.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.22.b executed"		#Allow them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.22.b executed" #Allow them
 		ai_chance = { base = 30 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
 	}
@@ -1240,7 +1193,7 @@ country_event = {
 
 	option = {
 		name = SyriaFocus.23.a
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.23.a executed"		#Ban them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.23.a executed" #Ban them
 		ai_chance = { base = 70 }
 		add_ideas = salafist_party_banned
 		set_temp_variable = { temp_opinion = -5 }
@@ -1251,14 +1204,14 @@ country_event = {
 			start_civil_war = { ideology = fascism }
 		}
 	}
+
 	option = {
 		name = SyriaFocus.23.b
-		log = "[GetDateText]: [This.GetName]: SyriaFocus.23.b executed"		#Allow them
+		log = "[GetDateText]: [This.GetName]: SyriaFocus.23.b executed" #Allow them
 		ai_chance = { base = 30 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_ulema_opinion = yes
 	}
@@ -1298,7 +1251,6 @@ country_event = {
 		hidden_effect = { country_event = { id = SyriaFocus.25 days = 30 random_days = 60 } }
 		hidden_effect = { news_event = { id = SyriaFocusNews.6 hours = 6 } }
 	}
-
 }
 
 #Druze rise up
@@ -1307,14 +1259,12 @@ country_event = {
 	title = SyriaFocus.25.t
 	desc = SyriaFocus.25.d
 	picture = GFX_Druze
+	is_triggered_only = yes
+
 	trigger = {
-		any_controlled_state = {
-			is_core_of = DRU
-		}
+		any_controlled_state = { is_core_of = DRU }
 		has_war_with = ROJ
 	}
-
-	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.25.a
@@ -1361,7 +1311,6 @@ country_event = {
 		}
 		hidden_effect = { country_event = { id = SyriaFocus.26 days = 30 random_days = 60 } }
 	}
-
 }
 
 #Alawites rise up
@@ -1416,7 +1365,6 @@ country_event = {
 			type = annex_everything
 		}
 	}
-
 }
 
 #Lebanese support against Hezbollah
@@ -1428,7 +1376,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.27.a		#Deal
+		name = SyriaFocus.27.a #Deal
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.27.a executed"
 		ai_chance = {
 			base = 80
@@ -1444,15 +1392,15 @@ country_event = {
 			set_country_flag = LEB_agreed_to_help_SYR
 		}
 	}
+
 	option = {
-		name = SyriaFocus.27.b		#No deal
+		name = SyriaFocus.27.b #No deal
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.27.b executed"
 		ai_chance = {
 			base = 20
 		}
 		FROM = { country_event = SyriaFocus.29 }
 	}
-
 }
 
 #Lebanon agrees
@@ -1464,10 +1412,9 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.28.a		#Ok
+		name = SyriaFocus.28.a #Ok
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Lebanon disagrees
@@ -1479,10 +1426,9 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.29.a		#Ok
+		name = SyriaFocus.29.a #Ok
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Pressuring Lebanon
@@ -1494,7 +1440,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.30.a		#Submit
+		name = SyriaFocus.30.a #Submit
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.30.a executed"
 		ai_chance = {
 			base = 20
@@ -1505,8 +1451,9 @@ country_event = {
 		}
 		FROM = { country_event = { id = SyriaFocus.31 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaFocus.30.b		#Resist
+		name = SyriaFocus.30.b #Resist
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.30.b executed"
 		ai_chance = {
 			base = 80
@@ -1521,7 +1468,6 @@ country_event = {
 			country_event = { id = SyriaFocus.32 hours = 6 }
 		}
 	}
-
 }
 
 #Lebanon agrees
@@ -1533,7 +1479,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.31.a		#Great
+		name = SyriaFocus.31.a #Great
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.31.a executed"
 		ai_chance = { base = 100 }
 		if = {
@@ -1557,7 +1503,6 @@ country_event = {
 		}
 		hidden_effect = { news_event = { id = SyriaFocusNews.7 hours = 6 } }
 	}
-
 }
 
 #Lebanon Resists
@@ -1569,7 +1514,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.32.a		#Damn
+		name = SyriaFocus.32.a #Damn
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.32.a executed"
 		ai_chance = { base = 100 }
 		set_temp_variable = { wargoal_on = LEB }
@@ -1580,7 +1525,6 @@ country_event = {
 		}
 		set_country_flag = Occupy_Lebanon
 	}
-
 }
 
 #Succesful Hezbollah coup
@@ -1607,7 +1551,6 @@ country_event = {
 		}
 		hidden_effect = { news_event = { id = SyriaFocusNews.8 hours = 6 } }
 	}
-
 }
 
 #Unsuccesful Hezbollah coup
@@ -1619,7 +1562,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.34.a			#Retaliate
+		name = SyriaFocus.34.a #Retaliate
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.34.a executed"
 		ai_chance = {
 			base = 80
@@ -1634,13 +1577,13 @@ country_event = {
 		}
 		hidden_effect = { news_event = { id = SyriaFocusNews.9 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaFocus.34.b			#Do nothing
+		name = SyriaFocus.34.b #Do nothing
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.34.b executed"
 		ai_chance = { base = 20 }
 		hidden_effect = { news_event = { id = SyriaFocusNews.9 hours = 6 } }
 	}
-
 }
 
 #Pressuring Hezbollah
@@ -1652,22 +1595,22 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.35.a		#Submit
+		name = SyriaFocus.35.a #Submit
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.35.a executed"
 		ai_chance = {
 			base = 60
 		}
 		FROM = { country_event = { id = SyriaFocus.36 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaFocus.35.b		#Resist
+		name = SyriaFocus.35.b #Resist
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.35.b executed"
 		ai_chance = {
 			base = 40
 		}
 		FROM = { country_event = { id = SyriaFocus.37 hours = 6 } }
 	}
-
 }
 
 #Hezbollah agrees
@@ -1679,13 +1622,12 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.36.a		#Great
+		name = SyriaFocus.36.a #Great
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.36.a executed"
 		ai_chance = { base = 100 }
 		set_autonomy = { target = HEZ autonomy_state = autonomy_satellite_state }
 		hidden_effect = { news_event = { id = SyriaFocusNews.7 hours = 6 } }
 	}
-
 }
 
 #Hezbollah Resists
@@ -1697,7 +1639,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.37.a		#Damn
+		name = SyriaFocus.37.a #Damn
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.37.a executed"
 		ai_chance = { base = 100 }
 		set_temp_variable = { wargoal_on = HEZ }
@@ -1708,7 +1650,6 @@ country_event = {
 		}
 		set_country_flag = Occupy_Lebanon
 	}
-
 }
 
 #Syria Demands Golan
@@ -1719,18 +1660,17 @@ country_event = {
 	picture = GFX_Golan
 	is_triggered_only = yes
 
-	immediate = {
-		FROM = { save_event_target_as = golan_claimant }
-	}
+	immediate = { FROM = { save_event_target_as = golan_claimant } }
 
 	option = {
-		name = SyriaFocus.38.a		#Never
+		name = SyriaFocus.38.a #Never
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.38.a executed"
 		ai_chance = { base = 70 }
 		FROM = { country_event = { id = md4.20 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaFocus.38.b		#In exchange for support over the Palestinians
+		name = SyriaFocus.38.b #In exchange for support over the Palestinians
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.38.b executed"
 		ai_chance = {
 			base = 20
@@ -1758,8 +1698,9 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.19 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaFocus.38.c		#Sure
+		name = SyriaFocus.38.c #Sure
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.38.c executed"
 		ai_chance = {
 			base = 10
@@ -1784,14 +1725,12 @@ country_event = {
 	title = SyriaFocus.39.t
 	desc = SyriaFocus.39.d
 	picture = GFX_death_of_hafez_al_assad
-	trigger = {
-		has_country_leader = { name = "Hafez al-Assad" }
-	}
-
 	is_triggered_only = yes
 
+	trigger = { has_country_leader = { name = "Hafez al-Assad" } }
+
 	option = {
-		name = SyriaFocus.39.a		#
+		name = SyriaFocus.39.a #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.39.a executed"
 		ai_chance = { base = 100 }
 		kill_country_leader = yes
@@ -1810,7 +1749,6 @@ country_event = {
 		hidden_effect = { country_event = { id = SyriaFocus.43 hours = 12 } }
 		hidden_effect = { country_event = { id = SyriaFocus.45 days = 60 random_hours = 1440 } }
 	}
-
 }
 
 #Bashar Al-Assad Meets with military and security personnel
@@ -1819,16 +1757,15 @@ country_event = {
 	title = SyriaFocus.40.t
 	desc = SyriaFocus.40.d
 	picture = GFX_Assad_parade
+	is_triggered_only = yes
 
 	trigger = {
 		original_tag = SYR
 		has_country_leader = { name = "Hafez al-Assad" }
 	}
 
-	is_triggered_only = yes
-
 	option = {
-		name = SyriaFocus.40.a		#
+		name = SyriaFocus.40.a #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.40.a executed"
 		ai_chance = { base = 30 }
 		add_political_power = -100
@@ -1839,8 +1776,9 @@ country_event = {
 		}
 		add_popularity = { ideology = communism popularity = 0.10 }
 	}
+
 	option = {
-		name = SyriaFocus.40.b		#
+		name = SyriaFocus.40.b #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.40.b executed"
 		ai_chance = { base = 30 }
 		custom_effect_tooltip = TT_SYRIA_GATHER_PUBLIC_SUPPORT
@@ -1850,13 +1788,13 @@ country_event = {
 		}
 		add_popularity = { ideology = communism popularity = 0.05 }
 	}
+
 	option = {
-		name = SyriaFocus.40.c		#
+		name = SyriaFocus.40.c #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.40.c executed"
 		ai_chance = { base = 30 }
 		add_political_power = -50
 	}
-
 }
 
 #Bushra Al-Assad does charity and tours the country
@@ -1865,16 +1803,15 @@ country_event = {
 	title = SyriaFocus.41.t
 	desc = SyriaFocus.41.d
 	picture = GFX_bushra_al_assad
+	is_triggered_only = yes
 
 	trigger = {
 		original_tag = SYR
 		has_country_leader = { name = "Hafez al-Assad" }
 	}
 
-	is_triggered_only = yes
-
 	option = {
-		name = SyriaFocus.41.a		#
+		name = SyriaFocus.41.a #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.41.a executed"
 		ai_chance = { base = 30 }
 		add_political_power = -100
@@ -1885,8 +1822,9 @@ country_event = {
 		}
 		add_popularity = { ideology = neutrality popularity = 0.10 }
 	}
+
 	option = {
-		name = SyriaFocus.41.b		#
+		name = SyriaFocus.41.b #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.41.b executed"
 		ai_chance = { base = 30 }
 		custom_effect_tooltip = TT_SYRIA_GATHER_PUBLIC_SUPPORT
@@ -1896,13 +1834,13 @@ country_event = {
 		}
 		add_popularity = { ideology = neutrality popularity = 0.05 }
 	}
+
 	option = {
-		name = SyriaFocus.41.c		#
+		name = SyriaFocus.41.c #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.41.c executed"
 		ai_chance = { base = 30 }
 		add_political_power = -50
 	}
-
 }
 
 #Maher Al-Assad displays the military
@@ -1911,16 +1849,15 @@ country_event = {
 	title = SyriaFocus.42.t
 	desc = SyriaFocus.42.d
 	picture = GFX_maher_al_assad
+	is_triggered_only = yes
 
 	trigger = {
 		original_tag = SYR
 		has_country_leader = { name = "Hafez al-Assad" }
 	}
 
-	is_triggered_only = yes
-
 	option = {
-		name = SyriaFocus.42.a		#
+		name = SyriaFocus.42.a #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.42.a executed"
 		ai_chance = { base = 30 }
 		add_political_power = -100
@@ -1931,8 +1868,9 @@ country_event = {
 		}
 		add_popularity = { ideology = nationalist popularity = 0.10 }
 	}
+
 	option = {
-		name = SyriaFocus.42.b		#
+		name = SyriaFocus.42.b #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.42.b executed"
 		ai_chance = { base = 30 }
 		custom_effect_tooltip = TT_SYRIA_GATHER_PUBLIC_SUPPORT
@@ -1942,21 +1880,20 @@ country_event = {
 		}
 		add_popularity = { ideology = nationalist popularity = 0.05 }
 	}
+
 	option = {
-		name = SyriaFocus.42.c		#
+		name = SyriaFocus.42.c #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.42.c executed"
 		ai_chance = { base = 30 }
 		add_political_power = -50
 	}
-
 }
 
 #Rifaat al-Assad looks for support
 country_event = {
 	id = SyriaFocus.43
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -2051,9 +1988,7 @@ country_event = {
 			limit = {
 				has_country_flag = Rifaat_visited_saudi_arabia
 				has_country_flag = Rifaat_visited_Israel
-				NOT = {
-					has_country_flag = Rifaat_visited_USA
-				}
+				NOT = { has_country_flag = Rifaat_visited_USA }
 			}
 			USA = { country_event = { id = SyriaFocus.44 days = 3 } }
 			set_country_flag = Rifaat_visited_USA
@@ -2062,9 +1997,7 @@ country_event = {
 			limit = {
 				has_country_flag = Rifaat_visited_saudi_arabia
 				has_country_flag = Rifaat_visited_USA
-				NOT = {
-					has_country_flag = Rifaat_visited_Israel
-				}
+				NOT = { has_country_flag = Rifaat_visited_Israel }
 			}
 			ISR = { country_event = { id = SyriaFocus.44 days = 3 } }
 			set_country_flag = Rifaat_visited_Israel
@@ -2073,16 +2006,12 @@ country_event = {
 			limit = {
 				has_country_flag = Rifaat_visited_Israel
 				has_country_flag = Rifaat_visited_USA
-				NOT = {
-					has_country_flag = Rifaat_visited_saudi_arabia
-				}
+				NOT = { has_country_flag = Rifaat_visited_saudi_arabia }
 			}
 			SAU = { country_event = { id = SyriaFocus.44 days = 3 } }
 			set_country_flag = Rifaat_visited_saudi_arabia
 		}
-		else = {
-			set_country_flag = Rifaat_no_international_support
-		}
+		else = { set_country_flag = Rifaat_no_international_support }
 	}
 }
 
@@ -2092,11 +2021,10 @@ country_event = {
 	title = SyriaFocus.44.t
 	desc = SyriaFocus.44.d
 	picture = GFX_rifaat_al_assad
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaFocus.44.a		#
+		name = SyriaFocus.44.a #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.44.a executed"
 		ai_chance = { base = 60 }
 		lose_pp_for_month = yes
@@ -2119,13 +2047,13 @@ country_event = {
 			SYR = { set_country_flag = Rifaat_nationalist }
 		}
 	}
+
 	option = {
-		name = SyriaFocus.44.b		#
+		name = SyriaFocus.44.b #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.44.b executed"
 		ai_chance = { base = 40 }
 		hidden_effect = { FROM = { country_event = { id = SyriaFocus.43 days = 3 } } }
 	}
-
 }
 
 #Statement of 99
@@ -2134,7 +2062,6 @@ country_event = {
 	title = SyriaFocus.45.t
 	desc = SyriaFocus.45.d
 	picture = GFX_damascus_spring
-
 	is_triggered_only = yes
 
 	immediate = {
@@ -2142,7 +2069,7 @@ country_event = {
 	}
 
 	option = {
-		name = SyriaFocus.45.a		#
+		name = SyriaFocus.45.a #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.45.a executed"
 		ai_chance = {
 			base = 70
@@ -2159,8 +2086,9 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
 	}
+
 	option = {
-		name = SyriaFocus.45.b		#
+		name = SyriaFocus.45.b #
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.45.b executed"
 		ai_chance = {
 			base = 30
@@ -2184,7 +2112,6 @@ country_event = {
 	title = SyriaFocus.46.t
 	desc = SyriaFocus.46.d
 	picture = GFX_damascus_spring
-
 	is_triggered_only = yes
 
 	option = {
@@ -2244,9 +2171,7 @@ country_event = {
 			}
 			set_global_flag = GLOBAL_syrian_civil_war_started
 			if = {
-				limit = {
-					LEB = { is_subject_of = ROOT }
-				}
+				limit = { LEB = { is_subject_of = ROOT } }
 				set_autonomy = {
 					target = LEB
 					autonomy_state = autonomy_free
@@ -2256,6 +2181,7 @@ country_event = {
 		complete_national_focus = SYR_flowers_of_damascus_spring
 		hidden_effect = { news_event = { id = SyriaFocusNews.12 hours = 6 } }
 	}
+
 	option = {
 		name = SyriaFocus.46.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.46.b executed"
@@ -2290,17 +2216,13 @@ country_event = {
 				hidden_effect = {
 					random_country_with_original_tag = {
 						original_tag_to_check = SYR
-						limit = {
-							NOT = { tag = SYR }
-						}
+						limit = { NOT = { tag = SYR } }
 						set_country_flag = Syrian_rebels
 					}
 				}
 				set_global_flag = GLOBAL_syrian_civil_war_started
 				if = {
-					limit = {
-						LEB = { is_subject_of = ROOT }
-					}
+					limit = { LEB = { is_subject_of = ROOT } }
 					set_autonomy = {
 						target = LEB
 						autonomy_state = autonomy_free
@@ -2329,24 +2251,18 @@ country_event = {
 				hidden_effect = {
 					random_country_with_original_tag = {
 						original_tag_to_check = SYR
-						limit = {
-							NOT = { tag = SYR }
-						}
+						limit = { NOT = { tag = SYR } }
 						set_country_flag = Syrian_rebels
 					}
 				}
 				set_global_flag = GLOBAL_syrian_civil_war_started
 				every_country_with_original_tag = {
 					original_tag_to_check = SYR
-					limit = {
-						NOT = { has_idea = divided_syria }
-					}
+					limit = { NOT = { has_idea = divided_syria } }
 					add_ideas = divided_syria
 				}
 				if = {
-					limit = {
-						LEB = { is_subject_of = ROOT }
-					}
+					limit = { LEB = { is_subject_of = ROOT } }
 					set_autonomy = {
 						target = LEB
 						autonomy_state = autonomy_free
@@ -2356,7 +2272,6 @@ country_event = {
 		}
 		hidden_effect = { news_event = { id = SyriaFocusNews.13 hours = 6 } }
 	}
-
 }
 
 #Succesful assassination of Rafic Hariri
@@ -2365,7 +2280,6 @@ country_event = {
 	title = SyriaFocus.47.t
 	desc = SyriaFocus.47.d
 	picture = GFX_rafic_hariri_assassination
-
 	is_triggered_only = yes
 
 	option = {
@@ -2380,7 +2294,6 @@ country_event = {
 		hidden_effect = { news_event = { id = SyriaFocusNews.14 hours = 6 } }
 		hidden_effect = { SYR = { country_event = { id = SyriaFocus.49 days = 14 } } }
 	}
-
 }
 
 #Unsuccesful assassination of Rafic Hariri
@@ -2389,7 +2302,6 @@ country_event = {
 	title = SyriaFocus.48.t
 	desc = SyriaFocus.48.d
 	picture = GFX_rafic_hariri_assassination
-
 	is_triggered_only = yes
 
 	option = {
@@ -2403,7 +2315,6 @@ country_event = {
 		hidden_effect = { news_event = { id = SyriaFocusNews.15 hours = 6 } }
 		hidden_effect = { SYR = { country_event = { id = SyriaFocus.49 days = 14 } } }
 	}
-
 }
 
 #Cedar Revolution
@@ -2412,7 +2323,6 @@ country_event = {
 	title = SyriaFocus.49.t
 	desc = SyriaFocus.49.d
 	picture = GFX_Syrian_Occupation_Lebanon
-
 	is_triggered_only = yes
 
 	option = {
@@ -2468,7 +2378,6 @@ country_event = {
 		}
 		hidden_effect = { news_event = { id = SyriaFocusNews.16 hours = 6 } }
 	}
-
 }
 
 #Hezbollah Raids
@@ -2477,7 +2386,6 @@ country_event = {
 	title = SyriaFocus.50.t
 	desc = SyriaFocus.50.d
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
@@ -2490,7 +2398,6 @@ country_event = {
 		}
 		HEZ = { country_event = { id = SyriaFocus.51 hours = 3 } }
 	}
-
 }
 
 #Lebanon retaliates
@@ -2499,14 +2406,12 @@ country_event = {
 	title = SyriaFocus.51.t
 	desc = SyriaFocus.51.d
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.51.a
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Syria demands submission
@@ -2515,7 +2420,6 @@ country_event = {
 	title = SyriaFocus.52.t
 	desc = SyriaFocus.52.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	option = {
@@ -2532,7 +2436,6 @@ country_event = {
 		ai_chance = { base = 20 }
 		FROM = { country_event = { id = SyriaFocus.54 days = 1 } }
 	}
-
 }
 
 #Lebanon submits
@@ -2541,7 +2444,6 @@ country_event = {
 	title = SyriaFocus.53.t
 	desc = SyriaFocus.53.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	option = {
@@ -2554,7 +2456,6 @@ country_event = {
 		201 = { add_core_of = ROOT }
 		annex_country = { target = FROM transfer_troops = yes }
 	}
-
 }
 
 #Lebanon refuses
@@ -2563,7 +2464,6 @@ country_event = {
 	title = SyriaFocus.54.t
 	desc = SyriaFocus.54.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	option = {
@@ -2578,6 +2478,7 @@ country_event = {
 			target = FROM
 		}
 	}
+
 	option = {
 		name = SyriaFocus.54.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.54.b executed"
@@ -2587,7 +2488,6 @@ country_event = {
 		553 = { remove_claim_by = ROOT }
 		201 = { remove_claim_by = ROOT }
 	}
-
 }
 
 #SSNP Coup in Jordan
@@ -2596,7 +2496,6 @@ country_event = {
 	title = SyriaFocus.55.t
 	desc = SyriaFocus.55.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	option = {
@@ -2607,8 +2506,9 @@ country_event = {
 		change_ruling_party_effect = yes
 		FROM = { country_event = SyriaFocus.56 }
 	}
+
 	option = {
-		name = SyriaFocus.55.b		#Can resist as player
+		name = SyriaFocus.55.b #Can resist as player
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.55.b executed"
 		ai_chance = { base = 0 }
 		declare_war_on = {
@@ -2616,7 +2516,6 @@ country_event = {
 			type = annex_everything
 		}
 	}
-
 }
 
 #SSNP Coup in Jordan
@@ -2625,7 +2524,6 @@ country_event = {
 	title = SyriaFocus.56.t
 	desc = SyriaFocus.56.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	immediate = {
@@ -2647,8 +2545,9 @@ country_event = {
 			name = SYR.Jordan_coup
 		}
 	}
+
 	option = {
-		name = SyriaFocus.56.b		#Can resist as player
+		name = SyriaFocus.56.b #Can resist as player
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.56.b executed"
 		ai_chance = { base = 20 }
 		if = {
@@ -2671,7 +2570,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #SSNP civil war in Jordan
@@ -2680,21 +2578,16 @@ country_event = {
 	title = SyriaFocus.57.t
 	desc = SyriaFocus.57.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.57.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.57.a executed"
 		ai_chance = { base = 100 }
-		start_civil_war = {
-			ideology = nationalist
-		}
+		start_civil_war = { ideology = nationalist }
 		random_country_with_original_tag = {
 			original_tag_to_check = JOR
-			limit = {
-				has_government = nationalist
-			}
+			limit = { has_government = nationalist }
 			SYR = {
 				211 = { add_core_of = SYR }
 				210 = { add_core_of = SYR }
@@ -2710,7 +2603,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #War between Jordan and Syria
@@ -2719,7 +2611,6 @@ country_event = {
 	title = SyriaFocus.58.t
 	desc = SyriaFocus.58.d
 	picture = GFX_SYR_ssnp
-
 	is_triggered_only = yes
 
 	option = {
@@ -2736,7 +2627,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Palestinians Raid Israel from Jordan
@@ -2745,7 +2635,6 @@ country_event = {
 	title = SyriaFocus.59.t
 	desc = SyriaFocus.59.d
 	picture = GFX_palestinians_in_syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -2753,13 +2642,10 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.59.a executed"
 		ai_chance = { base = 100 }
 		if = {
-			limit = {
-				original_tag = ISR
-			}
+			limit = { original_tag = ISR }
 			add_stability = -0.10
 		}
 	}
-
 }
 
 #Palestinians Raid Israel from Jordan
@@ -2768,7 +2654,6 @@ country_event = {
 	title = SyriaFocus.60.t
 	desc = SyriaFocus.60.d
 	picture = GFX_palestinians_in_syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -2797,7 +2682,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Join Syria in a war against Israel
@@ -2806,7 +2690,6 @@ country_event = {
 	title = SyriaFocus.61.t
 	desc = SyriaFocus.61.d
 	picture = GFX_palestinians_in_syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -2815,11 +2698,11 @@ country_event = {
 		ai_chance = { base = 90 }
 		SYR = { country_event = { id = SyriaFocus.62 hours = 6 } }
 	}
+
 	option = {
 		name = SyriaFocus.61.b
 		ai_chance = { base = 10 }
 	}
-
 }
 
 #Join Syria in a war against Israel
@@ -2828,7 +2711,6 @@ country_event = {
 	title = SyriaFocus.62.t
 	desc = SyriaFocus.62.d
 	picture = GFX_palestinians_in_syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -2836,9 +2718,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.62.a executed"
 		ai_chance = { base = 90 }
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = PREV
 				autonomy_state = autonomy_puppet_state_colored
@@ -2855,11 +2735,11 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SyriaFocus.62.b
 		ai_chance = { base = 10 }
 	}
-
 }
 
 #Syria asks Sudan for alliance
@@ -2868,7 +2748,6 @@ country_event = {
 	title = SyriaFocus.63.t
 	desc = SyriaFocus.63.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -2904,6 +2783,7 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 	}
+
 	option = {
 		name = SyriaFocus.63.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.63.b executed"
@@ -2937,7 +2817,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Syria demands Sinai
@@ -2946,7 +2825,6 @@ country_event = {
 	title = SyriaFocus.64.t
 	desc = SyriaFocus.64.d
 	picture = GFX_Greater_Syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -2956,9 +2834,7 @@ country_event = {
 			base = 20
 			modifier = {
 				factor = 0
-				TUR = {
-					has_idea = NATO_member
-				}
+				TUR = { has_idea = NATO_member }
 			}
 			modifier = {
 				factor = 0.5
@@ -3010,6 +2886,7 @@ country_event = {
 		set_country_flag = STATE_TRANSFER_ADD_CORES
 		FROM = { country_event = { id = md4.19 hours = 6 } }
 	}
+
 	option = {
 		name = SyriaFocus.64.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.64.b executed"
@@ -3017,9 +2894,7 @@ country_event = {
 			base = 80
 			modifier = {
 				factor = 10
-				TUR = {
-					has_idea = NATO_member
-				}
+				TUR = { has_idea = NATO_member }
 			}
 			modifier = {
 				factor = 2
@@ -3065,7 +2940,6 @@ country_event = {
 		213 = { set_state_flag = SET_STATE_FOR_TRANSFER }
 		FROM = { country_event = { id = md4.20 hours = 6 } }
 	}
-
 }
 
 #Religious uprising in Iraq
@@ -3074,14 +2948,12 @@ country_event = {
 	title = SyriaFocus.65.t
 	desc = SyriaFocus.65.d
 	picture = GFX_Greater_Syria
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.65.a
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Syria willing to make concessions to Kurdistan
@@ -3090,7 +2962,6 @@ country_event = {
 	title = SyriaFocus.66.t
 	desc = SyriaFocus.66.d
 	picture = GFX_kurdistan
-
 	is_triggered_only = yes
 
 	option = {
@@ -3099,13 +2970,13 @@ country_event = {
 		ai_chance = { base = 80 }
 		FROM = { country_event = { id = SyriaFocus.67 hours = 6 } }
 	}
+
 	option = {
 		name = SyriaFocus.66.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.66.b executed"
 		ai_chance = { base = 20 }
 		FROM = { country_event = { id = SyriaFocus.68 hours = 6 } }
 	}
-
 }
 
 #Syria willing to make concessions to Kurdistan - Kurdistan agrees
@@ -3114,7 +2985,6 @@ country_event = {
 	title = SyriaFocus.67.t
 	desc = SyriaFocus.67.d
 	picture = GFX_kurdistan
-
 	is_triggered_only = yes
 
 	option = {
@@ -3144,20 +3014,11 @@ country_event = {
 				}
 				KUR = { transfer_state = PREV }
 			}
-			KUR = {
-				every_core_state = {
-					add_core_of = ROOT
-				}
-			}
-			ROJ = {
-				every_core_state = {
-					add_core_of = ROOT
-				}
-			}
+			KUR = { every_core_state = { add_core_of = ROOT } }
+			ROJ = { every_core_state = { add_core_of = ROOT } }
 		}
 		puppet = KUR
 	}
-
 }
 
 #Syria willing to make concessions to Kurdistan - Kurdistan refuses
@@ -3166,14 +3027,12 @@ country_event = {
 	title = SyriaFocus.68.t
 	desc = SyriaFocus.68.d
 	picture = GFX_kurdistan
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.68.a
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Syria demands Northern Saudi Arabia
@@ -3182,7 +3041,6 @@ country_event = {
 	title = SyriaFocus.69.t
 	desc = SyriaFocus.69.d
 	picture = GFX_Greater_Syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -3210,6 +3068,7 @@ country_event = {
 		set_country_flag = STATE_TRANSFER_ADD_CORES
 		FROM = { country_event = { id = md4.19 hours = 6 } }
 	}
+
 	option = {
 		name = SyriaFocus.69.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.69.b executed"
@@ -3234,7 +3093,6 @@ country_event = {
 		933 = { set_state_flag = SET_STATE_FOR_TRANSFER }
 		FROM = { country_event = { id = md4.20 hours = 6 } }
 	}
-
 }
 
 #Syria asks Houthis for alliance
@@ -3243,7 +3101,6 @@ country_event = {
 	title = SyriaFocus.70.t
 	desc = SyriaFocus.70.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3258,6 +3115,7 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 	}
+
 	option = {
 		name = SyriaFocus.70.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.70.b executed"
@@ -3270,7 +3128,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Shia uprising in Saudi Arabia
@@ -3279,7 +3136,6 @@ country_event = {
 	title = SyriaFocus.71.t
 	desc = SyriaFocus.71.d
 	picture = GFX_politics_shiite
-
 	is_triggered_only = yes
 
 	option = {
@@ -3291,7 +3147,6 @@ country_event = {
 			FROM = { country_event = { id = md4.17 hours = 3 } }
 		}
 	}
-
 }
 
 #Syria asks Azerbaijan for alliance
@@ -3300,7 +3155,6 @@ country_event = {
 	title = SyriaFocus.72.t
 	desc = SyriaFocus.72.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	#Azerbaijan is pro-Israel and pro-Turkey, while Iran supports Armenia, meaning that the base chances are slightly for Azerbaijan joining Syria
@@ -3356,6 +3210,7 @@ country_event = {
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 		add_state_core = 710
 	}
+
 	option = {
 		name = SyriaFocus.72.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.72.b executed"
@@ -3409,7 +3264,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Syria asks Armenia for alliance
@@ -3418,7 +3272,6 @@ country_event = {
 	title = SyriaFocus.73.t
 	desc = SyriaFocus.73.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3443,6 +3296,7 @@ country_event = {
 		add_state_claim = 163
 		add_state_claim = 935
 	}
+
 	option = {
 		name = SyriaFocus.73.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.73.b executed"
@@ -3463,7 +3317,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Syria asks Greece for alliance
@@ -3472,7 +3325,6 @@ country_event = {
 	title = SyriaFocus.74.t
 	desc = SyriaFocus.74.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3512,31 +3364,14 @@ country_event = {
 					NOT = { is_core_of = TUR }
 				}
 			}
-			modifier = {
-				factor = 0.2
-				OR = {
-					FROM = {
-						owns_any_state_of = {
-							145
-							146
-						}
-					}
-					FROM = {
-						any_subject_country = {
-							owns_any_state_of = {
-								145
-								146
-							}
-						}
-					}
-				}
-			}
+			modifier = { factor = 0.2 OR = { FROM = { owns_any_state_of = { 145 146 } } FROM = { any_subject_country = { owns_any_state_of = { 145 146 } } } } }
 		}
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 		add_state_claim = 156
 		add_state_claim = 934
 		NATO_leave = yes
 	}
+
 	option = {
 		name = SyriaFocus.74.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.74.b executed"
@@ -3574,29 +3409,10 @@ country_event = {
 					NOT = { is_core_of = TUR }
 				}
 			}
-			modifier = {
-				factor = 5
-				OR = {
-					FROM = {
-						owns_any_state_of = {
-							145
-							146
-						}
-					}
-					FROM = {
-						any_subject_country = {
-							owns_any_state_of = {
-								145
-								146
-							}
-						}
-					}
-				}
-			}
+			modifier = { factor = 5 OR = { FROM = { owns_any_state_of = { 145 146 } } FROM = { any_subject_country = { owns_any_state_of = { 145 146 } } } } }
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Syria demands Southern Turkey
@@ -3605,7 +3421,6 @@ country_event = {
 	title = SyriaFocus.75.t
 	desc = SyriaFocus.75.d
 	picture = GFX_Greater_Syria
-
 	is_triggered_only = yes
 
 	option = {
@@ -3671,6 +3486,7 @@ country_event = {
 		set_country_flag = STATE_TRANSFER_ADD_CORES
 		SYR = { country_event = { id = md4.19 hours = 6 } }
 	}
+
 	option = {
 		name = SyriaFocus.75.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.75.b executed"
@@ -3716,7 +3532,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.20 hours = 6 } }
 	}
-
 }
 
 #Hamas takes control of Gaza
@@ -3725,7 +3540,6 @@ country_event = {
 	title = SyriaFocus.76.t
 	desc = SyriaFocus.76.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -3740,7 +3554,6 @@ country_event = {
 	title = SyriaFocus.77.t
 	desc = SyriaFocus.77.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -3774,7 +3587,6 @@ country_event = {
 	title = SyriaFocus.78.t
 	desc = SyriaFocus.78.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3817,6 +3629,7 @@ country_event = {
 		SYR = { add_to_faction = PREV }
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 	}
+
 	option = {
 		name = SyriaFocus.78.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.78.b executed"
@@ -3856,7 +3669,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Syria invites to Jerusalem Defence Pact
@@ -3865,7 +3677,6 @@ country_event = {
 	title = SyriaFocus.79.t
 	desc = SyriaFocus.79.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3889,6 +3700,7 @@ country_event = {
 		SYR = { add_to_faction = PREV }
 		FROM = { country_event = { id = md4.17 hours = 3 } }
 	}
+
 	option = {
 		name = SyriaFocus.79.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.79.b executed"
@@ -3909,7 +3721,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = md4.18 hours = 3 } }
 	}
-
 }
 
 #Syria wants to join Peninshula shield
@@ -3918,7 +3729,6 @@ country_event = {
 	title = SyriaFocus.80.t
 	desc = SyriaFocus.80.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -3984,11 +3794,10 @@ country_event = {
 				}
 			}
 		}
-		effect_tooltip = {
-			add_to_faction = FROM
-		}
+		effect_tooltip = { add_to_faction = FROM }
 		FROM = { country_event = { id = SyriaFocus.81 hours = 3 } }
 	}
+
 	option = {
 		name = SyriaFocus.80.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.80.b executed"
@@ -4054,7 +3863,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = SyriaFocus.82 hours = 3 } }
 	}
-
 }
 
 #Syria Joins Peninsula Shield
@@ -4063,7 +3871,6 @@ country_event = {
 	title = SyriaFocus.81.t
 	desc = SyriaFocus.81.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -4072,7 +3879,6 @@ country_event = {
 		ai_chance = { base = 100 }
 		FROM = { add_to_faction = ROOT }
 	}
-
 }
 
 #Syria Doesn't join Peninsula Shield
@@ -4081,14 +3887,12 @@ country_event = {
 	title = SyriaFocus.82.t
 	desc = SyriaFocus.82.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.82.a
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Syria wants to join Resistance Axis
@@ -4097,7 +3901,6 @@ country_event = {
 	title = SyriaFocus.83.t
 	desc = SyriaFocus.83.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -4129,11 +3932,10 @@ country_event = {
 				}
 			}
 		}
-		effect_tooltip = {
-			add_to_faction = FROM
-		}
+		effect_tooltip = { add_to_faction = FROM }
 		FROM = { country_event = { id = SyriaFocus.84 hours = 3 } }
 	}
+
 	option = {
 		name = SyriaFocus.83.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.83.b executed"
@@ -4165,7 +3967,6 @@ country_event = {
 		}
 		FROM = { country_event = { id = SyriaFocus.85 hours = 3 } }
 	}
-
 }
 
 #Syria Joins Resistance Axis
@@ -4174,7 +3975,6 @@ country_event = {
 	title = SyriaFocus.84.t
 	desc = SyriaFocus.84.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
@@ -4183,11 +3983,8 @@ country_event = {
 		ai_chance = { base = 100 }
 		FROM = { add_to_faction = ROOT }
 		add_ideas = faction_resistance_axis_member
-		every_subject_country = {
-			add_ideas = faction_resistance_axis_member
-		}
+		every_subject_country = { add_ideas = faction_resistance_axis_member }
 	}
-
 }
 
 #Syria Doesn't join Resistance Axis
@@ -4196,14 +3993,12 @@ country_event = {
 	title = SyriaFocus.85.t
 	desc = SyriaFocus.85.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.85.a
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #fund voluntary organizations success
@@ -4211,11 +4006,10 @@ country_event = {
 	id = SyriaFocus.86
 	title = SyriaFocus.86.t
 	desc = SyriaFocus.86.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.86.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.86.a executed"
@@ -4238,11 +4032,10 @@ country_event = {
 	id = SyriaFocus.87
 	title = SyriaFocus.87.t
 	desc = SyriaFocus.87.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.87.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.87.a executed"
@@ -4262,7 +4055,6 @@ country_event = {
 	title = SyriaFocus.88.t
 	desc = SyriaFocus.88.d
 	picture = GFX_election
-
 	is_triggered_only = yes
 
 	option = {
@@ -4307,6 +4099,7 @@ country_event = {
 			add_idea = the_military
 		}
 	}
+
 	option = {
 		name = SyriaFocus.88.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.88.b executed"
@@ -4413,18 +4206,18 @@ country_event = {
 			country_event = SyriaFocus.98
 		}
 	}
+
 	option = {
 		name = SyriaFocus.89.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.89.b executed"
 		ai_chance = { base = 25 }
 		country_event = SyriaFocus.90
 		if = {
-			limit = {
-				has_idea = alawite_high_command_strengthened
-			}
+			limit = { has_idea = alawite_high_command_strengthened }
 			country_event = SyriaFocus.98
 		}
 	}
+
 	option = {
 		name = SyriaFocus.89.c
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.89.c executed"
@@ -4439,7 +4232,6 @@ country_event = {
 	title = SyriaFocus.90.t
 	desc = SyriaFocus.90.d
 	picture = GFX_election
-
 	is_triggered_only = yes
 
 	option = {
@@ -4489,6 +4281,7 @@ country_event = {
 			add_idea = farmers
 		}
 	}
+
 	option = {
 		name = SyriaFocus.90.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.90.b executed"
@@ -4543,7 +4336,6 @@ country_event = {
 	id = SyriaFocus.91
 	title = SyriaFocus.91.t
 	desc = SyriaFocus.91.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -4559,6 +4351,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = SYR_GOVERNMENT_EXPANSION_EVENT_FED_EFFECT
 	}
+
 	option = {
 		name = SyriaFocus.91.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.91.b executed"
@@ -4578,11 +4371,10 @@ country_event = {
 	id = SyriaFocus.92
 	title = SyriaFocus.92.t
 	desc = SyriaFocus.92.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.92.a
 		ai_chance = { base = 100 }
@@ -4594,11 +4386,10 @@ country_event = {
 	id = SyriaFocus.93
 	title = SyriaFocus.93.t
 	desc = SyriaFocus.93.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_court
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.93.a
 		ai_chance = { base = 100 }
@@ -4610,11 +4401,10 @@ country_event = {
 	id = SyriaFocus.94
 	title = SyriaFocus.94.t
 	desc = SyriaFocus.94.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_court
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.94.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.94.a executed"
@@ -4635,7 +4425,6 @@ country_event = {
 	id = SyriaFocus.95
 	title = SyriaFocus.95.t
 	desc = SyriaFocus.95.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -4661,7 +4450,6 @@ country_event = {
 	id = SyriaFocus.96
 	title = SyriaFocus.96.t
 	desc = SyriaFocus.96.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -4678,13 +4466,10 @@ country_event = {
 	desc = SyriaFocus.97.d
 	picture = GFX_election
 	is_triggered_only = yes
-	trigger = {
-		original_tag = SYR
-	}
 
-	immediate = {
-		set_country_flag = SYR_druze_has_spawned
-	}
+	trigger = { original_tag = SYR }
+
+	immediate = { set_country_flag = SYR_druze_has_spawned }
 
 	# Alright
 	option = {
@@ -4728,6 +4513,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SyriaFocus.97.b #fight them
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.97.a executed"
@@ -4808,9 +4594,7 @@ country_event = {
 			if = {
 				limit = { NOT = { country_exists = ALA } }
 				release = ALA
-				hidden_effect = {
-					ALA = { load_oob = ALA_2017 }
-				}
+				hidden_effect = { ALA = { load_oob = ALA_2017 } }
 			}
 			if = {
 				limit = { ALA = { is_subject_of = ROOT } }
@@ -4851,15 +4635,11 @@ country_event = {
 			}
 			every_country_with_original_tag = {
 				original_tag_to_check = SYR
-				limit = {
-					NOT = { has_idea = alawite_high_command_strengthened }
-				}
+				limit = { NOT = { has_idea = alawite_high_command_strengthened } }
 				remove_state_core = 189
 			}
 			if = {
-				limit = {
-					LEB = { is_subject_of = ROOT }
-				}
+				limit = { LEB = { is_subject_of = ROOT } }
 				set_autonomy = {
 					target = LEB
 					autonomy_state = autonomy_free
@@ -4895,11 +4675,10 @@ country_event = {
 	id = SyriaFocus.100
 	title = SyriaFocus.100.t
 	desc = SyriaFocus.100.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.100.a
 		ai_chance = { base = 100 }
@@ -4911,11 +4690,10 @@ country_event = {
 	id = SyriaFocus.101
 	title = SyriaFocus.101.t
 	desc = SyriaFocus.101.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.101.a
 		ai_chance = { base = 100 }
@@ -4927,11 +4705,10 @@ country_event = {
 	id = SyriaFocus.102
 	title = SyriaFocus.102.t
 	desc = SyriaFocus.102.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.102.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.102.a executed"
@@ -4950,11 +4727,10 @@ country_event = {
 	id = SyriaFocus.103
 	title = SyriaFocus.103.t
 	desc = SyriaFocus.103.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.103.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.103.a executed"
@@ -4963,9 +4739,7 @@ country_event = {
 		add_stability = alawite_status_stability_modifier
 		add_stability = druze_status_stability_modifier
 		add_ideas = syria_federal_government
-		remove_power_balance = {
-			id = Syria_centralization_balance_of_power_category
-		}
+		remove_power_balance = { id = Syria_centralization_balance_of_power_category }
 	}
 }
 
@@ -4974,11 +4748,10 @@ country_event = {
 	id = SyriaFocus.104
 	title = SyriaFocus.104.t
 	desc = SyriaFocus.104.d
-#	picture = GFX_army_coup_event
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+#	picture = GFX_army_coup_event
 	option = {
 		name = SyriaFocus.104.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.104.a executed"
@@ -4987,9 +4760,7 @@ country_event = {
 		add_stability = alawite_status_stability_modifier
 		add_stability = druze_status_stability_modifier
 		add_ideas = syria_bureaucratic_government
-		remove_power_balance = {
-			id = Syria_centralization_balance_of_power_category
-		}
+		remove_power_balance = { id = Syria_centralization_balance_of_power_category }
 	}
 }
 
@@ -5007,6 +4778,7 @@ country_event = {
 		ai_chance = { base = 100 }
 		remove_ideas = idea_syrian_kurds_without_citizenships
 	}
+
 	option = {
 		name = SyriaFocus.106.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.106.b executed"
@@ -5021,32 +4793,23 @@ country_event = {
 	title = SyriaFocus.108.t
 	desc = {
 		text = SyriaFocus.108.d1
-		trigger = {
-			has_idea = syria_japanese_anime
-		}
+		trigger = { has_idea = syria_japanese_anime }
 	}
 	desc = {
 		text = SyriaFocus.108.d2
-		trigger = {
-			has_idea = syria_chinese_anime
-		}
+		trigger = { has_idea = syria_chinese_anime }
 	}
 		desc = {
 		text = SyriaFocus.108.d3
-		trigger = {
-			has_idea = syria_domestic_anime
-		}
+		trigger = { has_idea = syria_domestic_anime }
 	}
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
 	option = {
 		name = SyriaFocus.108.a
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.108.a executed"
-		trigger = {
-			has_idea = syria_japanese_anime
-		}
+		trigger = { has_idea = syria_japanese_anime }
 		swap_ideas = {
 			remove_idea = syria_japanese_anime
 			add_idea = syria_japanese_anime_success
@@ -5057,18 +4820,13 @@ country_event = {
 		set_temp_variable = { tag_index = JAP.id }
 		set_temp_variable = { influence_target = SYR.id }
 		change_influence_percentage = yes
-
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = SyriaFocus.108.b
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.108.b executed"
-		trigger = {
-			has_idea = syria_chinese_anime
-		}
+		trigger = { has_idea = syria_chinese_anime }
 		swap_ideas = {
 			remove_idea = syria_chinese_anime
 			add_idea = syria_chinese_anime_success
@@ -5079,28 +4837,20 @@ country_event = {
 		set_temp_variable = { tag_index = CHI.id }
 		set_temp_variable = { influence_target = SYR.id }
 		change_influence_percentage = yes
-
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = SyriaFocus.108.c
 		log = "[GetDateText]: [This.GetName]: SyriaFocus.108.c executed"
-		trigger = {
-			has_idea = syria_domestic_anime
-		}
+		trigger = { has_idea = syria_domestic_anime }
 		swap_ideas = {
 			remove_idea = syria_domestic_anime
 			add_idea = syria_domestic_anime_success
 		}
 		set_temp_variable = { percent_change = 5 }
 		change_domestic_influence_percentage = yes
-
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -5110,7 +4860,6 @@ country_event = {
 	title = SyriaFocus.111.t
 	desc = SyriaFocus.111.d
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
 
 	option = {
@@ -5136,7 +4885,6 @@ country_event = {
 			type = annex_everything
 		}
 	}
-
 }
 
 ###################
@@ -5145,15 +4893,12 @@ country_event = {
 
 #Rojava allowed to be independent
 news_event = {
-
 	id = SyriaFocusNews.0
 	title = SyriaFocusNews.0.t
 	desc = SyriaFocusNews.0.d
 	picture = GFX_news_rojava_victory
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.0.a
@@ -5163,15 +4908,12 @@ news_event = {
 
 #Rojava annexed
 news_event = {
-
 	id = SyriaFocusNews.1
 	title = SyriaFocusNews.1.t
 	desc = SyriaFocusNews.1.d
 	picture = GFX_news_rojava_victory
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.1.a
@@ -5181,15 +4923,12 @@ news_event = {
 
 #Rojava puppeted
 news_event = {
-
 	id = SyriaFocusNews.2
 	title = SyriaFocusNews.2.t
 	desc = SyriaFocusNews.2.d
 	picture = GFX_news_rojava_victory
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.2.a
@@ -5199,15 +4938,12 @@ news_event = {
 
 #Rojava resists
 news_event = {
-
 	id = SyriaFocusNews.3
 	title = SyriaFocusNews.3.t
 	desc = SyriaFocusNews.3.d
 	picture = GFX_news_rojava_victory
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.3.a
@@ -5217,7 +4953,6 @@ news_event = {
 
 #Attempted SSNP coup
 news_event = {
-
 	id = SyriaFocusNews.4
 	title = SyriaFocusNews.4.t
 	desc = {
@@ -5229,14 +4964,10 @@ news_event = {
 		trigger = { SYR = { NOT = { has_global_flag = Al_Assad_Dead } } }
 	}
 	picture = GFX_news_SSNP
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	trigger = {
-		NOT = { tag = SYR }
-	}
+	trigger = { NOT = { tag = SYR } }
 
 	option = {
 		name = SyriaFocusNews.4.a
@@ -5246,19 +4977,14 @@ news_event = {
 
 #Syria Federal Republic formed
 news_event = {
-
 	id = SyriaFocusNews.5
 	title = SyriaFocusNews.5.t
 	desc = SyriaFocusNews.5.d
 	picture = GFX_news_Syria_federal_republic
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	trigger = {
-		NOT = { tag = FSA }
-	}
+	trigger = { NOT = { tag = FSA } }
 
 	option = {
 		name = SyriaFocusNews.5.a
@@ -5268,19 +4994,14 @@ news_event = {
 
 #Ethnic conflict in Syria
 news_event = {
-
 	id = SyriaFocusNews.6
 	title = SyriaFocusNews.6.t
 	desc = SyriaFocusNews.6.d
 	picture = GFX_news_event_war
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	trigger = {
-		NOT = { tag = FSA }
-	}
+	trigger = { NOT = { tag = FSA } }
 
 	option = {
 		name = SyriaFocusNews.6.a
@@ -5290,15 +5011,12 @@ news_event = {
 
 #Puppeting of Lebanon
 news_event = {
-
 	id = SyriaFocusNews.7
 	title = SyriaFocusNews.7.t
 	desc = SyriaFocusNews.7.d
 	picture = GFX_news_Syrian_Occupation_Lebanon
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.7.a
@@ -5308,15 +5026,12 @@ news_event = {
 
 #Hezbollah coup in Lebanon
 news_event = {
-
 	id = SyriaFocusNews.8
 	title = SyriaFocusNews.8.t
 	desc = SyriaFocusNews.8.d
 	picture = GFX_news_Hezbollah_Coup
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.8.a
@@ -5326,15 +5041,12 @@ news_event = {
 
 #Hezbollah coup in Lebanon - failed
 news_event = {
-
 	id = SyriaFocusNews.9
 	title = SyriaFocusNews.9.t
 	desc = SyriaFocusNews.9.d
 	picture = GFX_news_Hezbollah_Coup
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.9.a
@@ -5344,15 +5056,12 @@ news_event = {
 
 #Syria renounces claim on Golan
 news_event = {
-
 	id = SyriaFocusNews.10
 	title = SyriaFocusNews.10.t
 	desc = SyriaFocusNews.10.d
 	picture = GFX_news_Golan
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.10.a
@@ -5362,15 +5071,12 @@ news_event = {
 
 #Hafez al-Assad Dies
 news_event = {
-
 	id = SyriaFocusNews.11
 	title = SyriaFocusNews.11.t
 	desc = SyriaFocusNews.11.d
 	picture = GFX_news_death_of_hafez_al_assad
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.11.a
@@ -5380,15 +5086,12 @@ news_event = {
 
 #Syria adopts democracy
 news_event = {
-
 	id = SyriaFocusNews.12
 	title = SyriaFocusNews.12.t
 	desc = SyriaFocusNews.12.d
 	picture = GFX_news_damascus_spring
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.12.a
@@ -5398,15 +5101,12 @@ news_event = {
 
 #Damascus Spring
 news_event = {
-
 	id = SyriaFocusNews.13
 	title = SyriaFocusNews.13.t
 	desc = SyriaFocusNews.13.d
 	picture = GFX_news_damascus_spring
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.13.a
@@ -5416,15 +5116,12 @@ news_event = {
 
 #Assassination of Rafic Hariri
 news_event = {
-
 	id = SyriaFocusNews.14
 	title = SyriaFocusNews.14.t
 	desc = SyriaFocusNews.14.d
 	picture = GFX_news_rafic_hariri_assassination
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.14.a
@@ -5434,15 +5131,12 @@ news_event = {
 
 #Unsuccessful assassination of Rafic Hariri
 news_event = {
-
 	id = SyriaFocusNews.15
 	title = SyriaFocusNews.15.t
 	desc = SyriaFocusNews.15.d
 	picture = GFX_news_rafic_hariri_assassination
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.15.a
@@ -5452,15 +5146,12 @@ news_event = {
 
 #Cedar Revolution
 news_event = {
-
 	id = SyriaFocusNews.16
 	title = SyriaFocusNews.16.t
 	desc = SyriaFocusNews.16.d
 	picture = GFX_news_Syrian_Occupation_Lebanon
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.16.a
@@ -5470,15 +5161,12 @@ news_event = {
 
 #Syria Annexes Lebanon
 news_event = {
-
 	id = SyriaFocusNews.17
 	title = SyriaFocusNews.17.t
 	desc = SyriaFocusNews.17.d
 	picture = GFX_news_Syrian_Occupation_Lebanon
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.17.a
@@ -5488,15 +5176,12 @@ news_event = {
 
 #Syria withdraws from Lebanon
 news_event = {
-
 	id = SyriaFocusNews.18
 	title = SyriaFocusNews.18.t
 	desc = SyriaFocusNews.18.d
 	picture = GFX_news_Syrian_Occupation_Lebanon
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.18.a
@@ -5506,15 +5191,12 @@ news_event = {
 
 #Declaration of Greater Syria
 news_event = {
-
 	id = SyriaFocusNews.19
 	title = SyriaFocusNews.19.t
 	desc = SyriaFocusNews.19.d
 	picture = GFX_news_Greater_Syria
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.19.a
@@ -5524,15 +5206,12 @@ news_event = {
 
 #New Intifada
 news_event = {
-
 	id = SyriaFocusNews.20
 	title = SyriaFocusNews.20.t
 	desc = SyriaFocusNews.20.d
 	picture = GFX_news_3rd_Intifada
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.20.a
@@ -5542,15 +5221,12 @@ news_event = {
 
 #Formation of a new United Arab Republic
 news_event = {
-
 	id = SyriaFocusNews.21
 	title = SyriaFocusNews.21.t
 	desc = SyriaFocusNews.21.d
 	picture = GFX_news_united_arab_republic
-
-	major = yes
-
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = SyriaFocusNews.21.a
@@ -5561,23 +5237,20 @@ news_event = {
 ### Druzes or FSA are willing to let go of Golan ###
 #Start negotiations
 country_event = {
-
 	id = SyriaDecisions.0
 	title = SyriaDecisions.0.t
 	desc = SyriaDecisions.0.desc
 	picture = GFX_Golan
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.0.a
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.0.a executed"		#Agree
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.0.a executed" #Agree
 		ai_chance = {
 			base = 60
 			modifier = {
-				factor = 2			#More helpful if it's the Druze asking
+				factor = 2 #More helpful if it's the Druze asking
 				FROM = {
 					original_tag = DRU
 				}
@@ -5615,9 +5288,10 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = SyriaDecisions.0.b
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.0.b executed"		#No
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.0.b executed" #No
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -5633,20 +5307,16 @@ country_event = {
 
 #Israel agrees
 country_event = {
-
 	id = SyriaDecisions.1
-
 	title = SyriaDecisions.1.t
 	desc = SyriaDecisions.1.desc
 	picture = GFX_Golan
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.1.a
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.1.a executed"		#Ok
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.1.a executed" #Ok
 		ai_chance = {
 			base = 100
 		}
@@ -5659,42 +5329,32 @@ country_event = {
 
 #Israel refuses
 country_event = {
-
 	id = SyriaDecisions.2
-
 	title = SyriaDecisions.2.t
 	desc = SyriaDecisions.2.desc
 	picture = GFX_Golan
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.2.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
 ### Alawite state is willing to let go of Hatay ###
 #Start negotiations
 country_event = {
-
 	id = SyriaDecisions.3
-
 	title = SyriaDecisions.3.t
 	desc = SyriaDecisions.3.desc
 	picture = GFX_Hatay
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.3.a
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.3.a executed"		#Agree
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.3.a executed" #Agree
 		ai_chance = {
 			base = 80
 		}
@@ -5703,7 +5363,6 @@ country_event = {
 			set_temp_variable = { percent_change = 2 }
 			change_influence_percentage = yes
 		}
-
 		add_ai_strategy = {
 			type = support
 			id = "ALA"
@@ -5715,9 +5374,10 @@ country_event = {
 			value = 200
 		}
 	}
+
 	option = {
 		name = SyriaDecisions.3.b
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.3.b executed"		#No
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.3.b executed" #No
 		ai_chance = {
 			base = 20
 		}
@@ -5727,20 +5387,16 @@ country_event = {
 
 #Turkey agrees
 country_event = {
-
 	id = SyriaDecisions.4
-
 	title = SyriaDecisions.4.t
 	desc = SyriaDecisions.4.desc
 	picture = GFX_Hatay
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.4.a
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.4.a executed"		#Ok
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.4.a executed" #Ok
 		ai_chance = {
 			base = 100
 		}
@@ -5753,41 +5409,31 @@ country_event = {
 
 #Turkey refuses
 country_event = {
-
 	id = SyriaDecisions.5
-
 	title = SyriaDecisions.5.t
 	desc = SyriaDecisions.5.desc
 	picture = GFX_Hatay
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.5.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
 ### Offer Rojava a deal ###
 country_event = {
-
 	id = SyriaDecisions.6
-
 	title = SyriaDecisions.6.t
 	desc = SyriaDecisions.6.desc
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.6.a
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.6.a executed"		#Join the war
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.6.a executed" #Join the war
 		ai_chance = {
 			base = 80
 			modifier = {
@@ -5849,9 +5495,10 @@ country_event = {
 		}
 		FROM = { country_event = { id = SyriaDecisions.7 days = 3 } }
 	}
+
 	option = {
 		name = SyriaDecisions.6.b
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.6.b executed"		#No
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.6.b executed" #No
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -5869,20 +5516,16 @@ country_event = {
 
 #Rojava agrees
 country_event = {
-
 	id = SyriaDecisions.7
-
 	title = SyriaDecisions.7.t
 	desc = SyriaDecisions.7.desc
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.7.a
-		log = "[GetDateText]: [This.GetName]: SyriaDecisions.7.a executed"		#Ok
+		log = "[GetDateText]: [This.GetName]: SyriaDecisions.7.a executed" #Ok
 		ai_chance = {
 			base = 100
 		}
@@ -5908,40 +5551,30 @@ country_event = {
 
 #Rojava refuses
 country_event = {
-
 	id = SyriaDecisions.8
-
 	title = SyriaDecisions.8.t
 	desc = SyriaDecisions.8.desc
 	picture = GFX_SYR_rojava
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
 		name = SyriaDecisions.8.a
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
 #Hezbollah discovers Syrian spies
 country_event = {
-
 	id = SyriaDecisions.9
-
 	title = SyriaDecisions.9.t
 	desc = SyriaDecisions.9.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
 	option = {
-		name = SyriaDecisions.9.a		#Execute them and strike back
+		name = SyriaDecisions.9.a #Execute them and strike back
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.9.a executed"
 		ai_chance = { base = 80 }
 		random_country = {
@@ -5981,8 +5614,9 @@ country_event = {
 		clr_country_flag = HEZ_Infiltrated_by_SYR
 		hidden_effect = { news_event = { id = SyriaDecisionsNews.3 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaDecisions.9.b		#Return them and request compensation
+		name = SyriaDecisions.9.b #Return them and request compensation
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.9.b executed"
 		ai_chance = { base = 20 }
 		random_country = {
@@ -5995,38 +5629,30 @@ country_event = {
 		}
 		clr_country_flag = HEZ_Infiltrated_by_SYR
 	}
-
 }
 #Hezbollah attacks
 country_event = {
-
 	id = SyriaDecisions.10
-
 	title = SyriaDecisions.10.t
 	desc = SyriaDecisions.10.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaDecisions.10.a		#Damn
+		name = SyriaDecisions.10.a #Damn
 		ai_chance = { base = 100 }
 	}
-
 }
 #Hezbollah demands ransom for spies
 country_event = {
-
 	id = SyriaDecisions.11
-
 	title = SyriaDecisions.11.t
 	desc = SyriaDecisions.11.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaDecisions.11.a		#Pay up
+		name = SyriaDecisions.11.a #Pay up
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.11.a executed"
 		ai_chance = { base = 80 }
 		set_temp_variable = { treasury_change = -1 }
@@ -6034,50 +5660,43 @@ country_event = {
 		add_political_power = -50
 		FROM = { country_event = SyriaDecisions.12 }
 	}
+
 	option = {
-		name = SyriaDecisions.11.b		#Don't pay
+		name = SyriaDecisions.11.b #Don't pay
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.11.b executed"
 		ai_chance = { base = 20 }
 		FROM = { country_event = SyriaDecisions.13 }
 		set_temp_variable = { temp_opinion = -5 }
 		change_intelligence_community_opinion = yes
 	}
-
 }
 #Syria pays
 country_event = {
-
 	id = SyriaDecisions.12
-
 	title = SyriaDecisions.12.t
 	desc = SyriaDecisions.12.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaDecisions.12.a		#Good
+		name = SyriaDecisions.12.a #Good
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.12.a executed"
 		ai_chance = { base = 100 }
 		set_temp_variable = { treasury_change = 1 }
 		modify_treasury_effect = yes
 		add_political_power = 50
 	}
-
 }
 #Syria refuses to pay
 country_event = {
-
 	id = SyriaDecisions.13
-
 	title = SyriaDecisions.13.t
 	desc = SyriaDecisions.13.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaDecisions.13.a		#Attack
+		name = SyriaDecisions.13.a #Attack
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.13.a executed"
 		ai_chance = { base = 80 }
 		if = {
@@ -6108,34 +5727,26 @@ country_event = {
 		}
 		hidden_effect = { news_event = { id = SyriaDecisionsNews.3 hours = 6 } }
 	}
+
 	option = {
-		name = SyriaDecisions.13.b		#Back down
+		name = SyriaDecisions.13.b #Back down
 		ai_chance = { base = 20 }
 	}
-
 }
 
 #Corruption in Hezbollah
 country_event = {
-
 	id = SyriaDecisions.14
-
 	title = SyriaDecisions.14.t
 	desc = SyriaDecisions.14.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
-
 	fire_only_once = yes
 
-	immediate = {
-		hidden_effect = {
-			retire_country_leader = yes
-		}
-	}
+	immediate = { hidden_effect = { retire_country_leader = yes } }
 
 	option = {
-		name = SyriaDecisions.14.a		#Very suspicious
+		name = SyriaDecisions.14.a #Very suspicious
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.14.a executed"
 		ai_chance = { base = 100 }
 		clr_country_flag = Discord_Between_HEZ_PER
@@ -6147,45 +5758,36 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Border war victory
 country_event = {
-
 	id = SyriaDecisions.16
-
 	title = SyriaDecisions.16.t
 	desc = SyriaDecisions.16.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaDecisions.16.a		#
+		name = SyriaDecisions.16.a #
 		log = "[GetDateText]: [This.GetName]: SyriaDecisions.16.a executed"
 		ai_chance = { base = 100 }
 		add_political_power = 100
 	}
-
 }
 
 #Border war defeat/failure
 country_event = {
-
 	id = SyriaDecisions.17
-
 	title = SyriaDecisions.17.t
 	desc = SyriaDecisions.17.desc
 	picture = GFX_Hezbollah_Spies
-
 	is_triggered_only = yes
 
 	option = {
-		name = SyriaDecisions.17.a		#
+		name = SyriaDecisions.17.a #
 		ai_chance = { base = 100 }
 	}
-
 }
 
 #Golan deal
@@ -6194,14 +5796,10 @@ news_event = {
 	title = SyriaDecisionsNews.0.t
 	desc = SyriaDecisionsNews.0.d
 	picture = GFX_news_Golan
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaDecisionsNews.0.a
-	}
+	option = { name = SyriaDecisionsNews.0.a }
 }
 
 #Hatay deal
@@ -6210,14 +5808,10 @@ news_event = {
 	title = SyriaDecisionsNews.1.t
 	desc = SyriaDecisionsNews.1.d
 	picture = GFX_news_Hatay
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaDecisionsNews.1.a
-	}
+	option = { name = SyriaDecisionsNews.1.a }
 }
 
 #Rojava deal
@@ -6226,14 +5820,10 @@ news_event = {
 	title = SyriaDecisionsNews.2.t
 	desc = SyriaDecisionsNews.2.d
 	picture = GFX_news_rojava_victory
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaDecisionsNews.2.a
-	}
+	option = { name = SyriaDecisionsNews.2.a }
 }
 
 #Border war between Hezbollah and Syria
@@ -6242,12 +5832,8 @@ news_event = {
 	title = SyriaDecisionsNews.3.t
 	desc = SyriaDecisionsNews.3.d
 	picture = GFX_news_Hezbollah_Syria
-
+	is_triggered_only = yes
 	major = yes
 
-	is_triggered_only = yes
-
-	option = {
-		name = SyriaDecisionsNews.3.a
-	}
+	option = { name = SyriaDecisionsNews.3.a }
 }

--- a/events/UN_Voting_Events.txt
+++ b/events/UN_Voting_Events.txt
@@ -44,7 +44,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 #event for SC votes
 country_event = {
@@ -287,9 +286,7 @@ country_event = {
 			limit = { has_global_flag = current_ongoing_sc_vote }
 			add_to_array = { global.security_council_vote_no = THIS }
 			if = {
-				limit = {
-					is_in_array = { global.p5_sc_members = THIS }
-				}
+				limit = { is_in_array = { global.p5_sc_members = THIS } }
 				set_global_flag = security_council_veto
 			}
 		}
@@ -390,7 +387,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #SC Resolution Passed - Notification to Security Council members
@@ -401,10 +397,7 @@ country_event = {
 	picture = GFX_UN_gen_assembly
 	is_triggered_only = yes
 
-	option = {
-		name = UNSC.10.a
-	}
-
+	option = { name = UNSC.10.a }
 }
 
 #SC Resolution Passed - Warning to subject nation
@@ -415,10 +408,7 @@ country_event = {
 	picture = GFX_UN_gen_assembly
 	is_triggered_only = yes
 
-	option = {
-		name = UNSC.11.a
-	}
-
+	option = { name = UNSC.11.a }
 }
 
 #SC Resolution Failed - generic news for types 1-4
@@ -430,7 +420,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = UNSC.12.a }
-
 }
 
 news_event = {
@@ -442,7 +431,6 @@ news_event = {
 	major = yes
 
 	option = { name = UNSC.13.a }
-
 }
 
 #event to scope GA votes
@@ -479,7 +467,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 #events for GA votes
 country_event = {
@@ -911,9 +898,7 @@ country_event = {
 			modifier = {
 				add = 50
 				check_variable = { global.current_ga_vote_type = 6 }
-				FROM = {
-					has_war = yes
-				}
+				FROM = { has_war = yes }
 			}
 			modifier = {
 				add = 10
@@ -1127,7 +1112,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #400 series events - events that fire after a UN GA Vote is held over implementing something
@@ -1498,7 +1482,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #UNSC sway scoping event
@@ -1519,9 +1502,7 @@ country_event = {
 		custom_effect_tooltip = un_change_vote_too_offer_1
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -1534,9 +1515,7 @@ country_event = {
 		custom_effect_tooltip = un_change_vote_too_offer_2
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -1549,37 +1528,26 @@ country_event = {
 		custom_effect_tooltip = un_change_vote_too_offer_3
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
 		name = UNSC.200.e
 		log = "[GetDateText]: [This.GetName]: UNSC.200.e"
-		trigger = {
-			NOT = { has_idea = un_vote_sway_cost }
-		}
+		trigger = { NOT = { has_idea = un_vote_sway_cost } }
 		custom_effect_tooltip = un_change_vote_too_offer_4
 		var:sway_target = {
 			country_event = UNSC.204
 			set_variable = { current_sway_direction = ROOT.current_vote_sway }
 			custom_effect_tooltip = nation_will_receive_tt
-			effect_tooltip = {
-				add_ideas = un_vote_sway_assistance
-			}
+			effect_tooltip = { add_ideas = un_vote_sway_assistance }
 		}
 		custom_effect_tooltip = nation_will_receive_tt
-		effect_tooltip = {
-			add_ideas = un_vote_sway_cost
-		}
+		effect_tooltip = { add_ideas = un_vote_sway_cost }
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 1000
-		}
+		ai_chance = { base = 1000 }
 	}
-
 }
 #UNSC Sway Events
 country_event = {
@@ -1601,9 +1569,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -1737,7 +1703,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = UNSC.202
@@ -1758,9 +1723,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -1828,7 +1791,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = UNSC.203
@@ -1849,9 +1811,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -1961,7 +1921,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = UNSC.204
@@ -1982,9 +1941,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -2064,7 +2021,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #UNGA sway scoping event
@@ -2085,9 +2041,7 @@ country_event = {
 		custom_effect_tooltip = un_change_vote_too_offer_1
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -2100,9 +2054,7 @@ country_event = {
 		custom_effect_tooltip = un_change_vote_too_offer_2
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -2115,37 +2067,26 @@ country_event = {
 		custom_effect_tooltip = un_change_vote_too_offer_3
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
 		name = UN.200.e
 		log = "[GetDateText]: [This.GetName]: UN.200.e"
-		trigger = {
-			NOT = { has_idea = un_vote_sway_cost }
-		}
+		trigger = { NOT = { has_idea = un_vote_sway_cost } }
 		custom_effect_tooltip = un_change_vote_too_offer_4
 		var:sway_target = {
 			country_event = UN.204
 			set_variable = { current_sway_direction = ROOT.current_vote_sway }
 			custom_effect_tooltip = nation_will_receive_tt
-			effect_tooltip = {
-				add_ideas = un_vote_sway_assistance
-			}
+			effect_tooltip = { add_ideas = un_vote_sway_assistance }
 		}
 		custom_effect_tooltip = nation_will_receive_tt
-		effect_tooltip = {
-			add_ideas = un_vote_sway_cost
-		}
+		effect_tooltip = { add_ideas = un_vote_sway_cost }
 		clear_variable = sway_target
 		clear_variable = current_vote_sway
-		ai_chance = {
-			base = 1000
-		}
+		ai_chance = { base = 1000 }
 	}
-
 }
 #UNGA Sway Events
 country_event = {
@@ -2167,9 +2108,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -2303,7 +2242,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = UN.202
@@ -2324,9 +2262,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -2394,7 +2330,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = UN.203
@@ -2415,9 +2350,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -2527,7 +2460,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 country_event = {
 	id = UN.204
@@ -2548,9 +2480,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				sender_influence_higher_50 = yes
-			}
+			limit = { sender_influence_higher_50 = yes }
 			add_political_power = -250
 		}
 		ai_chance = {
@@ -2630,7 +2560,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Removed from Programs for Requirements
@@ -2642,7 +2571,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = UN.300.a }
-
 }
 
 country_event = {
@@ -2653,7 +2581,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = UN.301.a }
-
 }
 
 country_event = {
@@ -2664,5 +2591,4 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = UN.302.a }
-
 }

--- a/events/Ukraine.txt
+++ b/events/Ukraine.txt
@@ -77,9 +77,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.3.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.3.a executed"
-		trigger = {
-			has_completed_focus = UKR_party_regions_berkut_extreme_training
-		}
+		trigger = { has_completed_focus = UKR_party_regions_berkut_extreme_training }
 		add_stability = -0.06
 		hidden_effect = {
 			country_event = { id = ukraine_maidan_west.4 days = 10 }
@@ -90,11 +88,7 @@ country_event = {
 		name = ukraine_maidan_west.3.b
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.3.b executed"
 		add_stability = -0.01
-		trigger = {
-			NOT = {
-				has_completed_focus = UKR_party_regions_berkut_extreme_training
-			}
-		}
+		trigger = { NOT = { has_completed_focus = UKR_party_regions_berkut_extreme_training } }
 		hidden_effect = {
 			country_event = { id = ukraine_maidan_west.5 days = 10 }
 		}
@@ -219,16 +213,12 @@ country_event = {
 			clr_country_flag = dynamic_flag
 			set_country_flag = UKR_subject_agree
 			if = {
-				limit = {
-					UKR = { owns_state = 1075 }
-				}
+				limit = { UKR = { owns_state = 1075 } }
 				transfer_state = 1075
 				add_state_core = 1075
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 1076 }
-				}
+				limit = { UKR = { owns_state = 1076 } }
 				transfer_state = 1076
 				add_state_core = 1076
 			}
@@ -266,19 +256,11 @@ country_event = {
 				type = annex_everything
 			}
 			if = {
-				limit = {
-					NOT = {
-						has_completed_focus = UKR_finance_vv
-					}
-				}
+				limit = { NOT = { has_completed_focus = UKR_finance_vv } }
 				country_event = { id = ukraine_maidan_west.11 days = 2 }
 			}
 			if = {
-				limit = {
-					NOT = {
-						has_completed_focus = UKR_sbu_alpha
-					}
-				}
+				limit = { NOT = { has_completed_focus = UKR_sbu_alpha } }
 				country_event = { id = ukraine_maidan_west.12 days = 2 }
 			}
 		}
@@ -295,9 +277,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.11.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.11.a executed"
-		hidden_effect = {
-			UKR_spawn_HPR_war = yes
-		}
+		hidden_effect = { UKR_spawn_HPR_war = yes }
 	}
 }
 #Not Razgon Rise Odessa
@@ -311,9 +291,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.12.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.12.a executed"
-		hidden_effect = {
-			UKR_spawn_OPR_war = yes
-		}
+		hidden_effect = { UKR_spawn_OPR_war = yes }
 	}
 }
 #Silovoi Razgon Continue
@@ -384,9 +362,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.16.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.16.a executed"
-		trigger = {
-			check_variable = { UKR_army_reform_level > 4 }
-		}
+		trigger = { check_variable = { UKR_army_reform_level > 4 } }
 		hidden_effect = {
 			country_event = { id = ukraine_maidan_west.17 days = 10 }
 		}
@@ -395,9 +371,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_west.16.b
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_west.16.b executed"
-		trigger = {
-			check_variable = { UKR_army_reform_level < 5 }
-		}
+		trigger = { check_variable = { UKR_army_reform_level < 5 } }
 		hidden_effect = {
 			country_event = { id = ukraine_maidan_west.20 days = 10 }
 		}
@@ -430,9 +404,7 @@ country_event = {
 	picture = GFX_ukrainian_civil_war
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_maidan_west.18.a
-	}
+	option = { name = ukraine_maidan_west.18.a }
 }
 #Silovoi Razgon Army Loose
 country_event = {
@@ -688,9 +660,7 @@ country_event = {
 				limit = { date > 2013.12.31 }
 				country_event = { id = ukraine_maidan_east.9 days = 12 }
 			}
-			else = {
-				set_country_flag = UKR_maidan_east_odessa_deferred
-			}
+			else = { set_country_flag = UKR_maidan_east_odessa_deferred }
 		}
 	}
 
@@ -698,17 +668,13 @@ country_event = {
 	option = {
 		name = ukraine_maidan_east.8.b
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.8.b executed"
-		trigger = {
-			has_completed_focus = UKR_party_regions_berkut_extreme_training
-		}
+		trigger = { has_completed_focus = UKR_party_regions_berkut_extreme_training }
 		hidden_effect = {
 			if = {
 				limit = { date > 2013.12.31 }
 				country_event = { id = ukraine_maidan_east.10 days = 12 }
 			}
-			else = {
-				set_country_flag = UKR_maidan_east_donbass_deferred
-			}
+			else = { set_country_flag = UKR_maidan_east_donbass_deferred }
 		}
 	}
 
@@ -716,17 +682,13 @@ country_event = {
 	option = {
 		name = ukraine_maidan_east.8.c
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.8.c executed"
-		trigger = {
-			NOT = { has_completed_focus = UKR_party_regions_berkut_extreme_training }
-		}
+		trigger = { NOT = { has_completed_focus = UKR_party_regions_berkut_extreme_training } }
 		hidden_effect = {
 			if = {
 				limit = { date > 2013.12.31 }
 				country_event = { id = ukraine_maidan_east.11 days = 12 }
 			}
-			else = {
-				set_country_flag = UKR_maidan_east_prepare_deferred
-			}
+			else = { set_country_flag = UKR_maidan_east_prepare_deferred }
 		}
 	}
 }
@@ -757,20 +719,14 @@ country_event = {
 			}
 			country_event = { id = ukraine_maidan_east.12 days = 3 }
 			if = {
-				limit = {
-					NOT = {
-						has_completed_focus = UKR_finance_vv
-					}
-				}
+				limit = { NOT = { has_completed_focus = UKR_finance_vv } }
 				country_event = { id = ukraine_maidan_east.13 days = 4 }
 			}
 		}
 		if = {
-			limit = {
-				owns_state = 669
-			}
+			limit = { owns_state = 669 }
 			set_country_flag = UKR_crimea_2014_chain_active
-			SOV = {	country_event = { id = ukraine_maidan.1 days = 1 } }
+			SOV = { country_event = { id = ukraine_maidan.1 days = 1 } }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				SOV = {
@@ -779,9 +735,7 @@ country_event = {
 				}
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				SOV = { add_state_core = 669 }
-			}
+			effect_tooltip = { SOV = { add_state_core = 669 } }
 		}
 	}
 }
@@ -800,9 +754,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.15 }
 		change_relative_party_popularity = yes
 		add_stability = -0.10
-		hidden_effect = {
-			UKR_change_ukraine_nati = yes
-		}
+		hidden_effect = { UKR_change_ukraine_nati = yes }
 	}
 }
 #Odessa Done(HPR rises)
@@ -816,9 +768,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_east.13.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.13.a executed"
-		hidden_effect = {
-			UKR_spawn_HPR_war = yes
-		}
+		hidden_effect = { UKR_spawn_HPR_war = yes }
 	}
 }
 #Go to Donbass
@@ -835,11 +785,7 @@ country_event = {
 		hidden_effect = {
 			country_event = { id = ukraine_maidan_east.17 days = 6 }
 			if = {
-				limit = {
-					NOT = {
-						has_completed_focus = UKR_sbu_alpha
-					}
-				}
+				limit = { NOT = { has_completed_focus = UKR_sbu_alpha } }
 				country_event = { id = ukraine_maidan_east.18 days = 2 }
 			}
 		}
@@ -883,9 +829,7 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = TT_IF_THEY_REJECT
-		effect_tooltip = {
-			SOV = { add_state_core = 669 }
-		}
+		effect_tooltip = { SOV = { add_state_core = 669 } }
 	}
 }
 #Donbass Done(OPR Rises)
@@ -899,9 +843,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_east.18.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.18.a executed"
-		hidden_effect = {
-			UKR_spawn_OPR_war = yes
-		}
+		hidden_effect = { UKR_spawn_OPR_war = yes }
 	}
 }
 #Prepare More Forces(All Rises)
@@ -932,9 +874,7 @@ country_event = {
 			}
 		}
 		custom_effect_tooltip = TT_IF_THEY_REJECT
-		effect_tooltip = {
-			SOV = { add_state_core = 669 }
-		}
+		effect_tooltip = { SOV = { add_state_core = 669 } }
 		add_timed_idea = { idea = UKR_maidan_temporary_attack_idea days = 465 }
 		hidden_effect = {
 			if = {
@@ -1033,9 +973,7 @@ country_event = {
 	is_triggered_only = yes
 
 	#We are sami
-	option = {
-		name = ukraine_maidan_east.21.a
-	}
+	option = { name = ukraine_maidan_east.21.a }
 
 	#Russia help
 	option = {
@@ -1100,25 +1038,19 @@ country_event = {
 	option = {
 		name = ukraine_maidan_east.24.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.24.a executed"
-		trigger = {
-			has_completed_focus = SOV_alpha_omon_exp
-		}
+		trigger = { has_completed_focus = SOV_alpha_omon_exp }
 		set_temp_variable = { percent_change = 1.03 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = UKR }
 		change_influence_percentage = yes
-		UKR = {
-			add_ideas = UKR_russia_help_battalions
-		}
+		UKR = { add_ideas = UKR_russia_help_battalions }
 	}
 
 	#Send Rosguard
 	option = {
 		name = ukraine_maidan_east.24.b
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.24.b executed"
-		trigger = {
-			has_completed_focus = SOV_rosgvardia
-		}
+		trigger = { has_completed_focus = SOV_rosgvardia }
 		set_temp_variable = { percent_change = 2.03 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = UKR }
@@ -1169,9 +1101,7 @@ country_event = {
 	option = {
 		name = ukraine_maidan_east.24.c
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_east.24.c executed"
-		trigger = {
-			has_completed_focus = SOV_slavic_corps
-		}
+		trigger = { has_completed_focus = SOV_slavic_corps }
 		set_temp_variable = { percent_change = 4.03 }
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = UKR }
@@ -1229,9 +1159,7 @@ country_event = {
 	picture = GFX_t90
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_maidan_east.25.a
-	}
+	option = { name = ukraine_maidan_east.25.a }
 }
 #Negotiate Win
 country_event = {
@@ -1292,30 +1220,22 @@ country_event = {
 			clr_country_flag = dynamic_flag
 			set_country_flag = UKR_subject_agree
 			if = {
-				limit = {
-					UKR = { owns_state = 1030 }
-				}
+				limit = { UKR = { owns_state = 1030 } }
 				transfer_state = 1030
 				add_state_core = 1030
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 693 }
-				}
+				limit = { UKR = { owns_state = 693 } }
 				transfer_state = 693
 				add_state_core = 693
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 1075 }
-				}
+				limit = { UKR = { owns_state = 1075 } }
 				transfer_state = 1075
 				add_state_core = 1075
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 1076 }
-				}
+				limit = { UKR = { owns_state = 1076 } }
 				transfer_state = 1076
 				add_state_core = 1076
 			}
@@ -1491,9 +1411,7 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			CRM = {
-				add_ideas = SUB_small_taxes
-			}
+			CRM = { add_ideas = SUB_small_taxes }
 			set_temp_variable = { modify_subjectnalogs = 3 }
 			modify_subjectnalogs_support = yes
 			SUB_separatism_minus_subject = yes
@@ -1652,12 +1570,8 @@ country_event = {
 			limit = { original_tag = UKR }
 			add_ideas = UKR_poroh_osce_ukr
 		}
-		else = {
-			add_ideas = UKR_poroh_osce_donbass
-		}
-		ai_chance = {
-			base = 100
-		}
+		else = { add_ideas = UKR_poroh_osce_donbass }
+		ai_chance = { base = 100 }
 	}
 }
 ###Minsk Federalisation
@@ -1789,9 +1703,7 @@ country_event = {
 		name = ukraine_maidan_overthrow.1.a
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_overthrow.1.a executed"
 		set_country_flag = UKR_maidan_go_western
-		hidden_effect = {
-			country_event = ukraine_maidan_overthrow.2
-		}
+		hidden_effect = { country_event = ukraine_maidan_overthrow.2 }
 		ai_chance = {
 			base = 70
 			modifier = {
@@ -1809,9 +1721,7 @@ country_event = {
 		name = ukraine_maidan_overthrow.1.b
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_overthrow.1.b executed"
 		set_country_flag = UKR_maidan_go_emerging
-		hidden_effect = {
-			country_event = ukraine_maidan_overthrow.2
-		}
+		hidden_effect = { country_event = ukraine_maidan_overthrow.2 }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -1829,9 +1739,7 @@ country_event = {
 		name = ukraine_maidan_overthrow.1.c
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_overthrow.1.c executed"
 		set_country_flag = UKR_maidan_go_non_aligned
-		hidden_effect = {
-			country_event = ukraine_maidan_overthrow.2
-		}
+		hidden_effect = { country_event = ukraine_maidan_overthrow.2 }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -1849,9 +1757,7 @@ country_event = {
 		name = ukraine_maidan_overthrow.1.e
 		log = "[GetDateText]: [This.GetName]: ukraine_maidan_overthrow.1.e executed"
 		set_country_flag = UKR_maidan_go_nationalist
-		hidden_effect = {
-			country_event = ukraine_maidan_overthrow.2
-		}
+		hidden_effect = { country_event = ukraine_maidan_overthrow.2 }
 		ai_chance = {
 			base = 2
 			modifier = {
@@ -2049,9 +1955,7 @@ news_event = {
 
 	option = {
 		name = ukraine_news.7.a
-		trigger = {
-			tag = UKR
-		}
+		trigger = { tag = UKR }
 	}
 
 	option = {
@@ -2132,9 +2036,7 @@ country_event = {
 		}
 		add_political_power = -45
 		if = {
-			limit = {
-				NOT = { has_country_flag = ukr_revoult_bilo }
-			}
+			limit = { NOT = { has_country_flag = ukr_revoult_bilo } }
 			set_temp_variable = { tension_change = 3 }
 			UKR_add_political_tension = yes
 		}
@@ -2151,9 +2053,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				NOT = { has_country_flag = ukr_revoult_bilo }
-			}
+			limit = { NOT = { has_country_flag = ukr_revoult_bilo } }
 			set_temp_variable = { tension_change = 1 }
 			UKR_add_political_tension = yes
 		}
@@ -2171,9 +2071,7 @@ country_event = {
 		name = ukraine_kuchma.11.a
 		log = "[GetDateText]: [This.GetName]: ukraine_kuchma.11.a executed"
 		if = {
-			limit = {
-				NOT = { has_country_flag = ukr_revoult_bilo }
-			}
+			limit = { NOT = { has_country_flag = ukr_revoult_bilo } }
 			set_temp_variable = { tension_change = 10 }
 			UKR_add_political_tension = yes
 		}
@@ -2199,9 +2097,7 @@ country_event = {
 		}
 		add_political_power = -75
 		if = {
-			limit = {
-				NOT = { has_country_flag = ukr_revoult_bilo }
-			}
+			limit = { NOT = { has_country_flag = ukr_revoult_bilo } }
 			set_temp_variable = { tension_change = 3 }
 			UKR_add_political_tension = yes
 		}
@@ -2218,9 +2114,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				NOT = { has_country_flag = ukr_revoult_bilo }
-			}
+			limit = { NOT = { has_country_flag = ukr_revoult_bilo } }
 			set_temp_variable = { tension_change = 5 }
 			UKR_add_political_tension = yes
 		}
@@ -2435,9 +2329,7 @@ country_event = {
 					load_focus_tree = { tree = ukr_provisional_republic_focus keep_completed = yes }
 				}
 				if = {
-					limit = {
-						NOT = { has_country_leader = { name = "Viktor Yanukovych" } }
-					}
+					limit = { NOT = { has_country_leader = { name = "Viktor Yanukovych" } } }
 					create_country_leader = {
 						name = "Viktor Yanukovych"
 						picture = "gfx/leaders/UKR/Viktor_Yanukovych.dds"
@@ -2744,8 +2636,8 @@ country_event = {
 #2013 Association dispatch
 country_event = {
 	id = ukraine_revolution.19
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		tag = UKR
@@ -2767,9 +2659,7 @@ country_event = {
 				country_event = ukraine_revolution.21
 			}
 		}
-		else = {
-			country_event = ukraine_revolution.20
-		}
+		else = { country_event = ukraine_revolution.20 }
 	}
 }
 #2013 Association decision
@@ -2797,9 +2687,7 @@ country_event = {
 		set_temp_variable = { modify_europeanism = -0.1 }
 		set_temp_variable = { modify_europeanism_target = ROOT }
 		europeanism_change = yes
-		hidden_effect = {
-			UKR_start_euromaidan = yes
-		}
+		hidden_effect = { UKR_start_euromaidan = yes }
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -3117,9 +3005,7 @@ country_event = {
 			limit = { has_country_flag = UKR_euromaidan_severe }
 			country_event = { id = ukraine_revolution.43 days = 3 }
 		}
-		else = {
-			UKR_finish_republic_wave = yes
-		}
+		else = { UKR_finish_republic_wave = yes }
 		ai_chance = {
 			base = 80
 			modifier = {
@@ -3149,9 +3035,7 @@ country_event = {
 			limit = { has_country_flag = UKR_euromaidan_severe }
 			country_event = { id = ukraine_revolution.43 days = 3 }
 		}
-		else = {
-			UKR_finish_republic_wave = yes
-		}
+		else = { UKR_finish_republic_wave = yes }
 		ai_chance = { base = 15 }
 	}
 
@@ -3170,9 +3054,7 @@ country_event = {
 			set_country_flag = UKR_crimea_2014_chain_active
 			SOV = { country_event = { id = ukraine_maidan.1 days = 1 } }
 		}
-		else = {
-			set_country_flag = UKR_republic_council_crimea
-		}
+		else = { set_country_flag = UKR_republic_council_crimea }
 		set_temp_variable = { tension_change = 8 }
 		UKR_add_political_tension = yes
 		UKR_setup_euromaidan_severity = yes
@@ -3180,9 +3062,7 @@ country_event = {
 			limit = { has_country_flag = UKR_euromaidan_severe }
 			country_event = { id = ukraine_revolution.43 days = 3 }
 		}
-		else = {
-			UKR_finish_republic_wave = yes
-		}
+		else = { UKR_finish_republic_wave = yes }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -3656,9 +3536,7 @@ country_event = {
 				autonomy_state = autonomy_free
 			}
 		}
-		NOV = {
-			clr_country_flag = UKR_subject_agree
-		}
+		NOV = { clr_country_flag = UKR_subject_agree }
 		set_temp_variable = { tension_change = 8 }
 		UKR_add_political_tension = yes
 		UKR_queue_provisional_novorossiya_flavor = yes
@@ -4126,9 +4004,7 @@ country_event = {
 			UKR_add_political_tension = yes
 			UKR_queue_provisional_crimea_flavor = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #Protests in the Southeast
@@ -4655,9 +4531,7 @@ country_event = {
 	picture = GFX_paris_convention
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_our_ukraine.6.a
-	}
+	option = { name = ukraine_our_ukraine.6.a }
 }
 
 country_event = {
@@ -4718,9 +4592,7 @@ country_event = {
 	picture = GFX_negotiations
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_our_ukraine.8.a
-	}
+	option = { name = ukraine_our_ukraine.8.a }
 }
 country_event = {
 	id = ukraine_our_ukraine.9
@@ -4729,9 +4601,7 @@ country_event = {
 	picture = GFX_negotiations
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_our_ukraine.9.a
-	}
+	option = { name = ukraine_our_ukraine.9.a }
 }
 #Bucharest Summit
 country_event = {
@@ -4803,7 +4673,7 @@ country_event = {
 				has_opinion = { target = FROM value < 0 }
 			}
 		}
-		UKR = { country_event = { id = ukraine_regions.8	days = 1 } }
+		UKR = { country_event = { id = ukraine_regions.8 days = 1 } }
 	}
 
 	option = {
@@ -4820,7 +4690,7 @@ country_event = {
 				has_opinion = { target = FROM value < 0 }
 			}
 		}
-		UKR = { country_event = { id = ukraine_regions.9	days = 1 } }
+		UKR = { country_event = { id = ukraine_regions.9 days = 1 } }
 	}
 }
 #Russian Investition Agree
@@ -4963,9 +4833,7 @@ country_event = {
 				tag = UKR
 				date > 2013.10.31
 			}
-			hidden_effect = {
-				UKR_start_euromaidan = yes
-			}
+			hidden_effect = { UKR_start_euromaidan = yes }
 		}
 	}
 }
@@ -5000,27 +4868,19 @@ country_event = {
 			transfer_state = 693
 			transfer_state = 1030
 			if = {
-				limit = {
-					UKR = { owns_state = 1030 }
-				}
+				limit = { UKR = { owns_state = 1030 } }
 				DPR = { transfer_state = 1030 }
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 693 }
-				}
+				limit = { UKR = { owns_state = 693 } }
 				DPR = { transfer_state = 693 }
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 1075 }
-				}
+				limit = { UKR = { owns_state = 1075 } }
 				DPR = { transfer_state = 1075 }
 			}
 			if = {
-				limit = {
-					UKR = { owns_state = 1076 }
-				}
+				limit = { UKR = { owns_state = 1076 } }
 				DPR = { transfer_state = 1076 }
 			}
 			LPR = { every_core_state = { add_core_of = DPR } }
@@ -5228,9 +5088,7 @@ country_event = {
 	option = {
 		name = ukraine_congress.2.a
 		log = "[GetDateText]: [This.GetName]: ukraine_congress.2.a executed"
-		UKR = {
-			transfer_state = 1112
-		}
+		UKR = { transfer_state = 1112 }
 	}
 }
 #Open Conversation about a Baltic Black Sea Alliance
@@ -5428,9 +5286,7 @@ country_event = {
 				effect_tooltip = { add_equipment_to_stockpile = { type = small_plane_strike_airframe amount = UKR_aid_report_strike } }
 			}
 		}
-		hidden_effect = {
-			UKR_clear_nato_aid_report = yes
-		}
+		hidden_effect = { UKR_clear_nato_aid_report = yes }
 	}
 }
 ##############HUR##############
@@ -5741,9 +5597,7 @@ country_event = {
 	picture = GFX_poroh_belarus_pact
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_poroh.3.a
-	}
+	option = { name = ukraine_poroh.3.a }
 }
 #Greece Kefalia
 country_event = {
@@ -5787,9 +5641,7 @@ country_event = {
 	picture = GFX_poroh_cerkov
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_poroh.6.a
-	}
+	option = { name = ukraine_poroh.6.a }
 }
 #Visegrad Co op
 country_event = {
@@ -5876,9 +5728,7 @@ country_event = {
 	picture = GFX_visegrad_ukr
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_poroh.9.a
-	}
+	option = { name = ukraine_poroh.9.a }
 }
 ##############KOLOMOISKYI##############
 #Start Republic
@@ -6059,9 +5909,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				has_dlc = "Gotterdammerung"
-			}
+			limit = { has_dlc = "Gotterdammerung" }
 			send_equipment = {
 				type = nuclear_missile_equipment
 				amount = 15
@@ -6136,9 +5984,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: ukraine_kommi.4.a executed"
 		UKR = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = ROOT
 					autonomy_state = autonomy_associated_state_colored
@@ -6248,9 +6094,7 @@ country_event = {
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_kommi.7.a
-	}
+	option = { name = ukraine_kommi.7.a }
 }
 #Create Union Soc Dem
 country_event = {
@@ -6289,9 +6133,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				tag = PMR
-			}
+			limit = { tag = PMR }
 			UKR = {
 				add_political_power = -100
 				set_temp_variable = { treasury_change = -8 }
@@ -6330,9 +6172,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				tag = BLR
-			}
+			limit = { tag = BLR }
 			UKR = {
 				add_political_power = -100
 				set_temp_variable = { treasury_change = -8 }
@@ -6347,9 +6187,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				tag = MLV
-			}
+			limit = { tag = MLV }
 			UKR = {
 				add_political_power = -100
 				set_temp_variable = { treasury_change = -8 }
@@ -6409,9 +6247,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_kommi.9.a
-	}
+	option = { name = ukraine_kommi.9.a }
 }
 #Protect Help
 country_event = {
@@ -6490,9 +6326,7 @@ country_event = {
 	picture = GFX_treaty
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_kommi.12.a
-	}
+	option = { name = ukraine_kommi.12.a }
 }
 #Gas Oil with Russia
 country_event = {
@@ -6526,7 +6360,7 @@ country_event = {
 		change_influence_percentage = yes
 		UKR = { UKR_idea_ukraine_gas = yes }
 		UKR_idea_russia_gas = yes
-		UKR = { country_event = { id = ukraine_kommi.14	days = 1 } }
+		UKR = { country_event = { id = ukraine_kommi.14 days = 1 } }
 	}
 
 	option = {
@@ -6551,7 +6385,7 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = UKR }
 		change_influence_percentage = yes
-		UKR = { country_event = { id = ukraine_kommi.15	days = 1 } }
+		UKR = { country_event = { id = ukraine_kommi.15 days = 1 } }
 	}
 }
 country_event = {
@@ -6561,9 +6395,7 @@ country_event = {
 	picture = GFX_negotiations
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_kommi.14.a
-	}
+	option = { name = ukraine_kommi.14.a }
 }
 country_event = {
 	id = ukraine_kommi.15
@@ -6572,9 +6404,7 @@ country_event = {
 	picture = GFX_negotiations
 	is_triggered_only = yes
 
-	option = {
-		name = ukraine_kommi.15.a
-	}
+	option = { name = ukraine_kommi.15.a }
 }
 #Russia notified of communist uprising sponsored by Ukraine
 country_event = {
@@ -6736,9 +6566,7 @@ country_event = {
 		NATO_join_via_event = yes
 		UKR = {
 			if = {
-				limit = {
-					NOT = { has_country_flag = ukr_revoult_bilo }
-				}
+				limit = { NOT = { has_country_flag = ukr_revoult_bilo } }
 				set_temp_variable = { tension_change = 3 }
 				UKR_add_political_tension = yes
 			}
@@ -6814,9 +6642,7 @@ country_event = {
 		add_coalition_members_effect = yes
 	}
 
-	option = {
-		name = ukraine_rada.1.b
-	}
+	option = { name = ukraine_rada.1.b }
 }
 country_event = {
 	id = ukraine_rada.2
@@ -6832,9 +6658,7 @@ country_event = {
 		add_coalition_members_effect = yes
 	}
 
-	option = {
-		name = ukraine_rada.2.b
-	}
+	option = { name = ukraine_rada.2.b }
 }
 ##############NAZBOLS##############
 #Puppet
@@ -6849,9 +6673,7 @@ country_event = {
 		name = ukraine_nazbol.1.a
 		log = "[GetDateText]: [This.GetName]: ukraine_nazbol.1.a executed"
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = ROOT
 				autonomy_state = autonomy_autonomous_state_colored
@@ -6869,9 +6691,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = ukraine_nazbol.1.b
-	}
+	option = { name = ukraine_nazbol.1.b }
 }
 #Puppet
 country_event = {
@@ -7092,9 +6912,7 @@ country_event = { #Parliament approves bureaucracy increase
 		name = ukraine_parliament.1.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.1.a executed"
 		increase_centralization = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7109,9 +6927,7 @@ country_event = { #Parliament denies bureaucracy increase
 
 	option = {
 		name = ukraine_parliament.2.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7144,9 +6960,7 @@ country_event = { #Parliament approves bureaucracy decrease
 		name = ukraine_parliament.3.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.3.a executed"
 		decrease_centralization = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7161,9 +6975,7 @@ country_event = { #Parliament denies bureaucracy decrease
 
 	option = {
 		name = ukraine_parliament.4.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7196,9 +7008,7 @@ country_event = { #Parliament approves military spending increase
 		name = ukraine_parliament.5.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.5.a executed"
 		increase_military_spending = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7213,9 +7023,7 @@ country_event = { #Parliament denies military spending increase
 
 	option = {
 		name = ukraine_parliament.7.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7248,9 +7056,7 @@ country_event = { #Parliament approves military spending decrease
 		name = ukraine_parliament.8.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.8.a executed"
 		decrease_military_spending = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7265,9 +7071,7 @@ country_event = { #Parliament denies military spending increase
 
 	option = {
 		name = ukraine_parliament.9.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7300,9 +7104,7 @@ country_event = { #Parliament approves security spending increase
 		name = ukraine_parliament.10.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.10.a executed"
 		increase_policing_budget = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7317,9 +7119,7 @@ country_event = { #Parliament denies military spending increase
 
 	option = {
 		name = ukraine_parliament.11.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7352,9 +7152,7 @@ country_event = { #Parliament approves security spending increase
 		name = ukraine_parliament.12.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.12.a executed"
 		decrease_policing_budget = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7369,9 +7167,7 @@ country_event = { #Parliament denies policing spending increase
 
 	option = {
 		name = ukraine_parliament.14.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7404,9 +7200,7 @@ country_event = { #Parliament approves education spending increase
 		name = ukraine_parliament.15.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.15.a executed"
 		increase_education_budget = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7421,9 +7215,7 @@ country_event = { #Parliament denies education spending increase
 
 	option = {
 		name = ukraine_parliament.16.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7456,9 +7248,7 @@ country_event = { #Parliament approves education spending decrease
 		name = ukraine_parliament.17.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.17.a executed"
 		decrease_education_budget = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7473,9 +7263,7 @@ country_event = { #Parliament denies education spending decrease
 
 	option = {
 		name = ukraine_parliament.18.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7508,9 +7296,7 @@ country_event = { #Parliament approves healthcare spending increase
 		name = ukraine_parliament.19.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.19.a executed"
 		increase_healthcare_budget = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7525,9 +7311,7 @@ country_event = { #Parliament denies education spending increase
 
 	option = {
 		name = ukraine_parliament.20.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7560,9 +7344,7 @@ country_event = { #Parliament approves healthcare spending decrease
 		name = ukraine_parliament.21.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.22.a executed"
 		decrease_healthcare_budget = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7577,9 +7359,7 @@ country_event = { #Parliament denies healthcare spending increase
 
 	option = {
 		name = ukraine_parliament.22.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7612,9 +7392,7 @@ country_event = { #Parliament approves pension spending increase
 		name = ukraine_parliament.23.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.23.a executed"
 		increase_social_spending = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7629,9 +7407,7 @@ country_event = { #Parliament denies pension spending increase
 
 	option = {
 		name = ukraine_parliament.24.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -7664,9 +7440,7 @@ country_event = { #Parliament approves pension spending decrease
 		name = ukraine_parliament.25.a
 		log = "[GetDateText]: [This.GetName]:ukraine_parliament.25.a executed"
 		decrease_social_spending = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -7681,9 +7455,7 @@ country_event = { #Parliament denies pension spending decrease
 
 	option = {
 		name = ukraine_parliament.26.a
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -8218,9 +7990,7 @@ country_event = {
 		FROM = { country_event = { id = subject_ukr.2 days = 1 } }
 		set_temp_variable = { percent_change = 6 }
 		UKR_patron_offer_accepted = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -8229,9 +7999,7 @@ country_event = {
 		FROM = { country_event = { id = subject_ukr.3 days = 1 } }
 		set_temp_variable = { percent_change = -6 }
 		UKR_patron_offer_declined = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Buildings Gives
@@ -8250,9 +8018,7 @@ country_event = {
 		modify_subjectavtoritet_support = yes
 		one_random_industrial_complex = yes
 		one_random_fossil_fuel_powerplant = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #Buildings Not Gives
@@ -8286,9 +8052,7 @@ country_event = {
 		modify_treasury_effect = yes
 		set_temp_variable = { percent_change = 3 }
 		UKR_patron_offer_accepted = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -8297,9 +8061,7 @@ country_event = {
 		FROM = { country_event = { id = subject_ukr.6 days = 1 } }
 		set_temp_variable = { percent_change = -3 }
 		UKR_patron_offer_declined = yes
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #Subsidies Gives
@@ -8318,9 +8080,7 @@ country_event = {
 		modify_subjectavtoritet_support = yes
 		set_temp_variable = { treasury_change = 20 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 #Subsidies Not Gives
@@ -8404,15 +8164,13 @@ country_event = {
 	desc = ukraine_amber.1.d
 	picture = GFX_mining
 	is_triggered_only = yes
-	minor_flavor = yes
 
+	minor_flavor = yes
 	option = {
 		name = ukraine_amber.1.a
 		log = "[GetDateText]: [This.GetName]: ukraine_amber.1.a executed"
 		custom_effect_tooltip = { localization_key = adds_dynamic_modifier_tt MODIFIER = UKR_amber_kopach_truce }
-		1248 = {
-			add_dynamic_modifier = { modifier = UKR_amber_kopach_truce }
-		}
+		1248 = { add_dynamic_modifier = { modifier = UKR_amber_kopach_truce } }
 		country_event = { id = ukraine_amber.2 days = 180 }
 	}
 }
@@ -8480,8 +8238,8 @@ country_event = {
 	desc = ukraine_amber.2.d
 	picture = GFX_mining
 	is_triggered_only = yes
-	minor_flavor = yes
 
+	minor_flavor = yes
 	option = {
 		name = ukraine_amber.2.a
 		log = "[GetDateText]: [This.GetName]: ukraine_amber.2.a executed"
@@ -8491,7 +8249,6 @@ country_event = {
 	}
 }
 country_event = {
-
 	id = ukraine_tech.301
 	title = ukraine_tech.301.t
 	desc = ukraine_tech.301.d
@@ -8759,9 +8516,7 @@ country_event = {
 	picture = GFX_ukr_army
 	is_triggered_only = yes
 
-	trigger = {
-		UKR_strategic_industry_outcome_settled = no
-	}
+	trigger = { UKR_strategic_industry_outcome_settled = no }
 
 	option = {
 		name = ukraine_tech.305.a


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,605 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.