### PR TITLE
Standardize event files — batch 14/14

### DIFF
--- a/events/05_australia_events.txt
+++ b/events/05_australia_events.txt
@@ -20,7 +20,6 @@ country_event = {
 		name = corroboree_event.1.a
 		add_political_power = -20
 	}
-
 }
 
 add_namespace = mining_giants_talk
@@ -65,7 +64,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -20 }
 		change_fossil_fuel_industry_opinion = yes
 	}
-
 }
 
 add_namespace = civil_partnership_act
@@ -83,7 +81,6 @@ news_event = {
 		add_stability = 0.03
 		set_country_flag = gay_law_1_done
 	}
-
 }
 
 add_namespace = the_national_apology
@@ -95,8 +92,11 @@ news_event = {
 	picture = GFX_national_apology_image
 	is_triggered_only = yes
 
-	option = { name = the_national_apology.1.a add_stability = 0.03 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: the_national_apology.1.a executed"
+		name = the_national_apology.1.a
+		add_stability = 0.03
+	}
 }
 
 add_namespace = pacific_solution
@@ -148,15 +148,12 @@ country_event = {
 	option = {
 			log = "[GetDateText]: [This.GetName]: pacific_solution.1.b executed"
 		name = pacific_solution.1.b
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		AST = {
 			add_opinion_modifier = { target = ROOT modifier = denied_pacific_solution }
 			country_event = { id = pacific_solution.4 days = 1 }
 		}
 	}
-
 }
 
 # Event for Nauru
@@ -207,13 +204,10 @@ country_event = {
 	option = {
 			log = "[GetDateText]: [This.GetName]: pacific_solution.1.b executed"
 		name = pacific_solution.1.b
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		AST = { add_opinion_modifier = { target = ROOT modifier = denied_pacific_solution } }
 		country_event = { id = pacific_solution.6 days = 3 }
 	}
-
 }
 
 # Australia Receives Papau Response: Proposal Accepted
@@ -238,7 +232,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Australia Receives Papau Response: Proposal Denied
@@ -252,7 +245,6 @@ country_event = {
 	option = {
 		name = pacific_solution.4.a # "Disappointing."
 	}
-
 }
 
 # Australia Receives Nauru Response: Proposal Accepted
@@ -304,7 +296,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Australia Receives Nauru Response: Proposal Denied
@@ -318,7 +309,6 @@ country_event = {
 	option = {
 		name = pacific_solution.6.a # "Disappointing."
 	}
-
 }
 
 add_namespace = stomp_out_the_roots
@@ -381,7 +371,6 @@ country_event = {
 		}
 		AST = { country_event = { id = stomp_out_the_roots.3 days = 1 } }
 	}
-
 }
 
 # Australia Receives: Success
@@ -395,9 +384,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: stomp_out_the_roots.2.a executed"
 		name = stomp_out_the_roots.2.a
-		IND = {
-			give_military_access = AST
-		}
+		IND = { give_military_access = AST }
 		add_doctrine_cost_reduction = {
 			name = stomp_out_the_roots.2.t
 			cost_reduction = 0.4
@@ -405,7 +392,6 @@ country_event = {
 			category = land_doctrine
 		}
 	}
-
 }
 
 # Australia Receives: Failure
@@ -417,7 +403,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = stomp_out_the_roots.3.a }
-
 }
 
 add_namespace = ast_off_to_delhi
@@ -444,7 +429,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = marks_trade
@@ -460,9 +444,7 @@ country_event = {
 	option = {
 			log = "[GetDateText]: [This.GetName]: marks_trade.1.a executed"
 		name = marks_trade.1.a
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		add_opinion_modifier = {
 			target = AST
 			modifier = ast_trade_deal
@@ -498,7 +480,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = ast_our_capacity_for_peace
@@ -545,7 +526,6 @@ country_event = {
 		# Tells Aus they said no
 		country_event = { id = ast_our_capacity_for_peace.3 days = 1 }
 	}
-
 }
 
 # Success Notification
@@ -566,7 +546,6 @@ country_event = {
 				change_influence_percentage = yes
 		}
 	}
-
 }
 
 # Failure Notification
@@ -578,7 +557,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = ast_our_capacity_for_peace.3.a }
-
 }
 
 add_namespace = fossil_fuels
@@ -609,7 +587,6 @@ country_event = {
 		ai_chance = { base = 0 }
 		AST = { country_event = { id = fossil_fuels.4 days = 1 } } # Failure Notification
 	}
-
 }
 
 # Event 2: The Chinese-AST Trade Pact (Peace Version)
@@ -638,7 +615,6 @@ country_event = {
 		ai_chance = { base = 0 }
 		AST = { country_event = { id = fossil_fuels.4 days = 1 } } # Generic Failure
 	}
-
 }
 
 # Success - Standard
@@ -656,7 +632,6 @@ country_event = {
 			add_opinion_modifier = { target = AST modifier = ast_trade_deal }
 		}
 	}
-
 }
 
 # Standard Failure
@@ -671,7 +646,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: fossil_fuels.4.a executed"
 		name = fossil_fuels.4.a add_political_power = -20
 	}
-
 }
 
 # Success - Special Pact
@@ -694,7 +668,6 @@ country_event = {
 			change_influence_percentage = yes
 		}
 	}
-
 }
 
 
@@ -712,9 +685,7 @@ country_event = {
 	option = {
 			log = "[GetDateText]: [This.GetName]: ast_jap_trade.1.a executed"
 		name = ast_jap_trade.1.a
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 		AST = { country_event = { id = ast_jap_trade.2 days = 1 } }
 	}
 
@@ -737,7 +708,6 @@ country_event = {
 		}
 		AST = { country_event = { id = ast_jap_trade.4 days = 1 } } # Notification: Failure
 	}
-
 }
 
 # Success Notification (Japan Accepted)
@@ -757,7 +727,6 @@ country_event = {
 		}
 		add_ideas = japanese_export_deal_ast
 	}
-
 }
 
 # Counter-Offer Notification (Japan wants Minerals)
@@ -777,9 +746,7 @@ country_event = {
 			add_opinion_modifier = { target = ROOT modifier = ast_trade_deal }
 		}
 		add_ideas = japanese_export_deal_ast_1
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Hold stance / Demand original deal
@@ -791,7 +758,6 @@ country_event = {
 				base = 0
 			}
 	}
-
 }
 
 # Failure Notification
@@ -802,8 +768,11 @@ country_event = {
 	picture = GFX_jap_flag
 	is_triggered_only = yes
 
-	option = { name = ast_jap_trade.4.a add_political_power = -5 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: ast_jap_trade.4.a executed"
+		name = ast_jap_trade.4.a
+		add_political_power = -5
+	}
 }
 
 # Japan decides on the original deal
@@ -829,7 +798,6 @@ country_event = {
 		ai_chance = { base = 30 }
 		AST = { country_event = { id = ast_jap_trade.4 days = 2 } } # Triggers the Failure event for you
 	}
-
 }
 
 add_namespace = base_state_visit
@@ -848,7 +816,6 @@ country_event = {
 	}
 
 	option = { name = base_state_visit.1.a }
-
 }
 
 country_event = {
@@ -865,7 +832,6 @@ country_event = {
 	}
 
 	option = { name = base_state_visit.2.a }
-
 }
 
 country_event = {
@@ -882,7 +848,6 @@ country_event = {
 	}
 
 	option = { name = base_state_visit.3.a }
-
 }
 
 country_event = {
@@ -906,7 +871,6 @@ country_event = {
 			add_opinion_modifier = { target = ROOT modifier = free_trade_agreement }
 		}
 	}
-
 }
 
 country_event = {
@@ -923,7 +887,6 @@ country_event = {
 	}
 
 	option = { name = base_state_visit.5.a }
-
 }
 
 news_event = {
@@ -940,7 +903,6 @@ news_event = {
 	}
 
 	option = { name = base_state_visit.6.a }
-
 }
 
 country_event = {
@@ -957,7 +919,6 @@ country_event = {
 	}
 
 	option = { name = base_state_visit.7.a }
-
 }
 
 
@@ -977,7 +938,6 @@ country_event = {
 	}
 
 	option = { name = rudd_state_visit.1.a }
-
 }
 
 add_namespace = leaked_memo
@@ -1000,7 +960,6 @@ country_event = {
 		name = leaked_memo.1.a
 		add_political_power = -50
 	}
-
 }
 
 add_namespace = reconciliation_journey
@@ -1032,7 +991,6 @@ country_event = {
 			add_idea = rekindled_hope_ast
 		}
 	}
-
 }
 
 add_namespace = ast_the_coalition_convention
@@ -1056,7 +1014,6 @@ country_event = {
 		add_political_power = 150
 		custom_effect_tooltip = focus_tree_has_changed_ast_tt
 	}
-
 }
 
 add_namespace = the_white_paper
@@ -1100,7 +1057,6 @@ country_event = {
 			days = 1460
 		}
 	}
-
 }
 
 country_event = {
@@ -1144,7 +1100,6 @@ country_event = {
 			category = land_doctrine
 		}
 	}
-
 }
 
 add_namespace = lithgow_arms
@@ -1187,7 +1142,6 @@ country_event = {
 				}
 			}
 	}
-
 }
 
 add_namespace = governor_general_sacked
@@ -1199,8 +1153,11 @@ news_event = {
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
-	option = { name = governor_general_sacked.1.a add_political_power = 90 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: governor_general_sacked.1.a executed"
+		name = governor_general_sacked.1.a
+		add_political_power = 90
+	}
 }
 
 add_namespace = rus_deal_ast
@@ -1254,7 +1211,6 @@ country_event = {
 			country_event = { id = rus_deal_ast.3 days = 1 }
 		}
 	}
-
 }
 
 country_event = {
@@ -1275,7 +1231,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -1294,7 +1249,6 @@ country_event = {
 					modifier = refused_trade_deal
 		}
 	}
-
 }
 
 add_namespace = isr_ast_visit
@@ -1307,7 +1261,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = isr_ast_visit.1.a }
-
 }
 
 add_namespace = adf_acq_astuirement
@@ -1339,7 +1292,6 @@ country_event = {
 		name = adf_acq_astuirement.1.c
 		add_ideas = adf_acq_ast_3
 	}
-
 }
 
 add_namespace = ast_high_speed_rail
@@ -1371,7 +1323,6 @@ country_event = {
 		}
 		custom_effect_tooltip = ast_rail_tt
 	}
-
 }
 
 country_event = {
@@ -1401,7 +1352,6 @@ country_event = {
 		}
 		custom_effect_tooltip = ast_rail_tt
 	}
-
 }
 
 country_event = {
@@ -1431,7 +1381,6 @@ country_event = {
 		}
 		custom_effect_tooltip = ast_rail_tt
 	}
-
 }
 
 country_event = {
@@ -1458,7 +1407,6 @@ country_event = {
 		}
 		custom_effect_tooltip = ast_rail_tt
 	}
-
 }
 
 news_event = {
@@ -1469,7 +1417,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = ast_high_speed_rail.5.a }
-
 }
 
 add_namespace = closing_the_gap_event
@@ -1493,7 +1440,6 @@ country_event = {
 					}
 				}
 	}
-
 }
 
 country_event = {
@@ -1503,9 +1449,17 @@ country_event = {
 	picture = GFX_generic_education_event_picture
 	is_triggered_only = yes
 
-	option = { name = closing_the_gap_event.2.a add_ideas = literacy_progress_the_gap_ast_1 }
+	option = {
+		log = "[GetDateText]: [This.GetName]: closing_the_gap_event.2.a executed"
+		name = closing_the_gap_event.2.a
+		add_ideas = literacy_progress_the_gap_ast_1
+	}
 
-	option = { name = closing_the_gap_event.2.b add_political_power = 80 }
+	option = {
+		log = "[GetDateText]: [This.GetName]: closing_the_gap_event.2.b executed"
+		name = closing_the_gap_event.2.b
+		add_political_power = 80
+	}
 }
 
 country_event = {
@@ -1515,7 +1469,12 @@ country_event = {
 	picture = GFX_generic_education_event_picture
 	is_triggered_only = yes
 
-	option = { name = closing_the_gap_event.3.a add_stability = 0.03 add_ideas = literacy_progress_the_gap_ast }
+	option = {
+		log = "[GetDateText]: [This.GetName]: closing_the_gap_event.3.a executed"
+		name = closing_the_gap_event.3.a
+		add_stability = 0.03
+		add_ideas = literacy_progress_the_gap_ast
+	}
 }
 
 add_namespace = papua_affair
@@ -1531,13 +1490,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: papua_affair.1.a executed"
 		name = papua_affair.1.a
 		add_political_power = -150
-		PAP = {
-			country_event = papua_affair.2
-		}
-		ai_chance = {
-			base = 1
-		}
-
+		PAP = { country_event = papua_affair.2 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1550,11 +1504,8 @@ country_event = {
 				modifier = insult
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -1574,9 +1525,7 @@ country_event = {
 		AST = {
 			country_event = { id = papua_affair.3 days = 1 }
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -1594,11 +1543,8 @@ country_event = {
 			}
 			country_event = { id = papua_affair.4 days = 1 }
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
-
 }
 
 #png accepts
@@ -1656,9 +1602,7 @@ country_event = {
 			log = "[GetDateText]: [This.GetName]: ast_howard_of_arabia.1.a executed"
 		name = ast_howard_of_arabia.1.a
 		give_guarantee = ISR
-		ISR = {
-			give_military_access = AST
-		}
+		ISR = { give_military_access = AST }
 	}
 
 	option = {
@@ -1671,7 +1615,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = indonesian_ultimatum
@@ -1692,9 +1635,7 @@ country_event = {
 			country_event = { id = indonesian_ultimatum.2 days = 1 }
 			add_threat = 6
 		}
-		622 = {
-			transfer_state_to = AST
-		}
+		622 = { transfer_state_to = AST }
 		add_opinion_modifier = {
 			target = AST
 			modifier = peacekeepers_occupying_our_territory
@@ -1729,7 +1670,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Ind says yes
@@ -1741,7 +1681,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = indonesian_ultimatum.2.a }
-
 }
 
 #Ind says no
@@ -1763,12 +1702,9 @@ country_event = {
 			limit = { has_dlc = "By Blood Alone" }
 			send_embargo = IND
 		}
-		IND = {
-			add_ideas = australian_sanctions
-		}
+		IND = { add_ideas = australian_sanctions }
 		add_threat = 2
 	}
-
 }
 
 #if aceh exists
@@ -1790,9 +1726,7 @@ country_event = {
 		}
 		AST = {
 			country_event = { id = indonesian_ultimatum.2 days = 1 }
-			annex_country = {
-				target = ACE
-			}
+			annex_country = { target = ACE }
 			add_threat = 6
 		}
 		ai_chance = {
@@ -1825,7 +1759,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = us_aus_trade_howrd
@@ -1848,9 +1781,7 @@ country_event = {
 				modifier = ast_trade_deal
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1863,11 +1794,8 @@ country_event = {
 				modifier = refused_trade_deal
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 #US accepts
@@ -1888,7 +1816,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #US refuses
@@ -1900,7 +1827,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = us_aus_trade_howrd.3.a }
-
 }
 
 add_namespace = trip_to_malaysia_ast
@@ -1934,7 +1860,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = internal_talk_liberal
@@ -1946,8 +1871,11 @@ country_event = {
 	picture = GFX_howard_peter
 	is_triggered_only = yes
 
-	option = { name = internal_talk_liberal.1.a add_political_power = 50 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: internal_talk_liberal.1.a executed"
+		name = internal_talk_liberal.1.a
+		add_political_power = 50
+	}
 }
 
 country_event = {
@@ -1962,7 +1890,6 @@ country_event = {
 		name = internal_talk_liberal.2.a
 		add_ideas = decreased_bulk_billing_coverage_ast
 	}
-
 }
 
 country_event = {
@@ -1993,7 +1920,6 @@ country_event = {
 		add_stability = -0.02
 		custom_effect_tooltip = internal_talk_liberal.3.c_tt
 	}
-
 }
 
 country_event = {
@@ -2013,7 +1939,6 @@ country_event = {
 				keep_completed = yes
 			}
 	}
-
 }
 
 country_event = {
@@ -2033,7 +1958,6 @@ country_event = {
 				keep_completed = yes
 			}
 	}
-
 }
 
 add_namespace = detention_centres_full
@@ -2067,7 +1991,6 @@ country_event = {
 			days = 230
 		}
 	}
-
 }
 
 add_namespace = howard_rumblings_in_dark
@@ -2086,7 +2009,6 @@ country_event = {
 		name = howard_rumblings_in_dark.1.a
 		custom_effect_tooltip = howard_rumblings_in_dark_tt
 	}
-
 }
 
 ######################
@@ -2111,7 +2033,6 @@ country_event = {
 				keep_completed = yes
 			}
 	}
-
 }
 
 add_namespace = abbott_gov_event
@@ -2129,7 +2050,6 @@ news_event = {
 		name = abbott_gov_event.1.a
 		add_political_power = -20
 	}
-
 }
 
 #consitutional amendment
@@ -2150,11 +2070,8 @@ news_event = {
 					add_idea = reconciliation_discontent
 				}
 			}
-		else = {
-			add_stability = 0.05
-		}
+		else = { add_stability = 0.05 }
 	}
-
 }
 
 #onion incident
@@ -2171,7 +2088,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #bauxite mine
@@ -2205,7 +2121,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -20 }
 		change_fossil_fuel_industry_opinion = yes
 	}
-
 }
 
 #suppository event
@@ -2229,7 +2144,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #national audit
@@ -2256,7 +2170,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 add_namespace = malcolm_abbott_event
@@ -2281,7 +2194,6 @@ country_event = {
 		name = malcolm_abbott_event.1.b
 		add_political_power = -30
 	}
-
 }
 
 news_event = {
@@ -2304,11 +2216,7 @@ news_event = {
 		add_stability = -0.03
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		change_relative_party_popularity = yes
-		trigger = {
-			NOT = {
-				has_country_flag = malcolm_abbott_promise_made
-			}
-		}
+		trigger = { NOT = { has_country_flag = malcolm_abbott_promise_made } }
 	}
 
 	option = {
@@ -2317,11 +2225,8 @@ news_event = {
 		add_stability = -0.05
 		set_temp_variable = { party_popularity_increase = -0.06 }
 		change_relative_party_popularity = yes
-		trigger = {
-			has_country_flag = malcolm_abbott_promise_made
-		}
+		trigger = { has_country_flag = malcolm_abbott_promise_made }
 	}
-
 }
 
 country_event = {
@@ -2351,7 +2256,6 @@ country_event = {
 		name = malcolm_abbott_event.3.a
 		add_political_power = -80
 	}
-
 }
 
 #overthrow
@@ -2365,9 +2269,7 @@ country_event = {
 
 	trigger = {
 		has_focus_tree = australia_abbottgov_focus
-		NOT = {
-			has_country_flag = abbott_war_declared_china
-		}
+		NOT = { has_country_flag = abbott_war_declared_china }
 	}
 
 	option = {
@@ -2376,7 +2278,6 @@ country_event = {
 		add_stability = -0.03
 		news_event = { id = malcolm_abbott_event.5 days = 2 }
 	}
-
 }
 
 news_event = {
@@ -2407,7 +2308,6 @@ news_event = {
 		}
 		custom_effect_tooltip = focus_tree_has_changed_ast_tt
 	}
-
 }
 
 
@@ -2435,7 +2335,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = knights_and_dames_ast_event
@@ -2453,7 +2352,6 @@ news_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 add_namespace = o_canada_abbott
@@ -2472,18 +2370,13 @@ country_event = {
 		AST = {
 			country_event = { id = o_canada_abbott.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = o_canada_abbott.1.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -2505,7 +2398,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = abbott_navy_exercises_event
@@ -2540,7 +2432,6 @@ country_event = {
 				category = CAT_air_eqp
 				}
 	}
-
 }
 
 
@@ -2581,7 +2472,6 @@ country_event = {
 		}
 		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -2597,7 +2487,6 @@ country_event = {
 		add_ideas = chinese_export_bonus_ast_4
 		add_war_support = -0.05
 	}
-
 }
 
 country_event = {
@@ -2612,7 +2501,6 @@ country_event = {
 		name = abbott_china_trade.3.a
 		add_political_power = -50
 	}
-
 }
 
 add_namespace = abbott_japan_trade_deal
@@ -2664,7 +2552,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #yes
@@ -2692,11 +2579,8 @@ country_event = {
 				add_idea = japanese_export_deal_ast_2
 			}
 		}
-		else = {
-			add_ideas = japanese_export_deal_ast_2
-		}
+		else = { add_ideas = japanese_export_deal_ast_2 }
 	}
-
 }
 
 #no
@@ -2708,7 +2592,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = ast_jap_trade.4.a }
-
 }
 
 add_namespace = abbott_saf_event
@@ -2718,15 +2601,11 @@ country_event = {
 	title = abbott_saf_event.1.t
 	desc = {
 		text = abbott_saf_event.1.d.a
-		trigger = {
-			date < 2013.12.05
-		}
+		trigger = { date < 2013.12.05 }
 	}
 	desc = {
 		text = abbott_saf_event.1.d.b
-		trigger = {
-			date > 2013.12.05
-		}
+		trigger = { date > 2013.12.05 }
 	}
 	picture = GFX_saf_abott_pic
 	is_triggered_only = yes
@@ -2758,7 +2637,6 @@ country_event = {
 			days = 340
 		}
 	}
-
 }
 
 add_namespace = indonesian_intervention_abbott
@@ -2780,9 +2658,7 @@ country_event = {
 				modifier = denied_us_ast
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2791,11 +2667,8 @@ country_event = {
 		AST = {
 			country_event = { id = indonesian_intervention_abbott.3 days = 1 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -2816,7 +2689,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = oceanic_alliance_ast
@@ -2841,17 +2713,13 @@ country_event = {
 				add = 90
 			}
 		}
-		AST = {
-			add_to_faction = ROOT
-		}
+		AST = { add_to_faction = ROOT }
 	}
 
 	option = {
 		log = "[GetDateText]: [This.GetName]: oceanic_alliance_ast.1.b executed"
 		name = oceanic_alliance_ast.1.b
-		trigger = {
-			tag = NZL
-		}
+		trigger = { tag = NZL }
 		AST = {
 			country_event = { id = oceanic_alliance_ast.2 days = 2 }
 		}
@@ -2870,9 +2738,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: oceanic_alliance_ast.1.b executed"
 		name = oceanic_alliance_ast.1.b
-		trigger = {
-			tag = IND
-		}
+		trigger = { tag = IND }
 		AST = {
 			country_event = { id = oceanic_alliance_ast.3 days = 2 }
 		}
@@ -2891,9 +2757,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: oceanic_alliance_ast.1.b executed"
 		name = oceanic_alliance_ast.1.b
-		trigger = {
-			tag = PAP
-		}
+		trigger = { tag = PAP }
 		AST = {
 			country_event = { id = oceanic_alliance_ast.4 days = 2 }
 		}
@@ -2912,9 +2776,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: oceanic_alliance_ast.1.b executed"
 		name = oceanic_alliance_ast.1.b
-		trigger = {
-			tag = VAN
-		}
+		trigger = { tag = VAN }
 		AST = {
 			country_event = { id = oceanic_alliance_ast.5 days = 2 }
 		}
@@ -2929,7 +2791,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #nzl refuses
@@ -2941,7 +2802,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = oceanic_alliance_ast.2.a }
-
 }
 
 #ind refuses
@@ -2953,7 +2813,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = oceanic_alliance_ast.2.a }
-
 }
 
 #pap refuses
@@ -2965,7 +2824,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = oceanic_alliance_ast.2.a }
-
 }
 
 #van refuses
@@ -2977,7 +2835,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = oceanic_alliance_ast.2.a }
-
 }
 
 add_namespace = operation_sovereign_abbott
@@ -3017,7 +2874,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 add_namespace = japan_subs_abbott
@@ -3032,19 +2888,14 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: japan_subs_abbott.1.a executed"
 		name = japan_subs_abbott.1.a
-		JAP = {
-			country_event = japan_subs_abbott.2
-		}
+		JAP = { country_event = japan_subs_abbott.2 }
 	}
 
 	option = {
 		log = "[GetDateText]: [This.GetName]: japan_subs_abbott.1.b executed"
 		name = japan_subs_abbott.1.b
-		JAP = {
-			country_event = japan_subs_abbott.3
-		}
+		JAP = { country_event = japan_subs_abbott.3 }
 	}
-
 }
 
 #jap subs
@@ -3071,9 +2922,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3086,11 +2935,8 @@ country_event = {
 			}
 			country_event = { id = japan_subs_abbott.4 days = 1 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 #jap destroyers
@@ -3117,9 +2963,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3132,11 +2976,8 @@ country_event = {
 			}
 			country_event = { id = japan_subs_abbott.4 days = 1 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 #refusal
@@ -3148,7 +2989,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = japan_subs_abbott.4.a }
-
 }
 
 #accept subs
@@ -3204,7 +3044,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #accepts destroyers
@@ -3242,7 +3081,6 @@ country_event = {
 				}
 		}
 	}
-
 }
 
 add_namespace = abbott_condemns_china
@@ -3258,9 +3096,7 @@ news_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: abbott_condemns_china.1.a executed"
 		name = abbott_condemns_china.1.a
-		trigger = {
-			tag = AST
-		}
+		trigger = { tag = AST }
 		CHI = {
 			add_opinion_modifier = {
 				target = AST
@@ -3277,11 +3113,7 @@ news_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: abbott_condemns_china.1.a executed"
 		name = abbott_condemns_china.1.a
-		trigger = {
-			NOT = {
-				tag = AST
-			}
-		}
+		trigger = { NOT = { tag = AST } }
 		CHI = {
 			add_opinion_modifier = {
 				target = AST
@@ -3289,7 +3121,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = kuala_lumpur_abbott
@@ -3308,9 +3139,7 @@ country_event = {
 		AST = {
 			country_event = { id = kuala_lumpur_abbott.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3323,11 +3152,8 @@ country_event = {
 				modifier = refused_trade_deal
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 #agreed
@@ -3350,7 +3176,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #refused
@@ -3366,7 +3191,6 @@ country_event = {
 		name = kuala_lumpur_abbott.3.a
 		add_political_power = -20
 	}
-
 }
 
 add_namespace = jap_repar_abbott
@@ -3390,9 +3214,7 @@ country_event = {
 				modifier = reparations_paid_ast
 			}
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -3405,11 +3227,8 @@ country_event = {
 				modifier = denied_us_ast
 			}
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
-
 }
 
 country_event = {
@@ -3425,7 +3244,6 @@ country_event = {
 		set_temp_variable = { treasury_change = 53 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 country_event = {
@@ -3440,7 +3258,6 @@ country_event = {
 		name = jap_repar_abbott.3.a
 		add_political_power = -60
 	}
-
 }
 
 
@@ -3464,9 +3281,7 @@ country_event = {
 				modifier = military_cooperation
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -3479,11 +3294,8 @@ country_event = {
 				modifier = denied_us_ast
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -3500,12 +3312,9 @@ country_event = {
 		set_country_flag = jap_allied_abbott
 		hidden_effect = {
 			give_guarantee = JAP
-			JAP = {
-				give_guarantee = AST
-			}
+			JAP = { give_guarantee = AST }
 		}
 	}
-
 }
 
 country_event = {
@@ -3520,7 +3329,6 @@ country_event = {
 		name = jap_alliance_abbott.3.a
 		add_political_power = -50
 	}
-
 }
 
 
@@ -3578,7 +3386,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3591,11 +3398,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: france_abbott_ast.2.a executed"
 		name = france_abbott_ast.2.a
-		FRA = {
-			71 = {
-				transfer_state_to = AST
-			}
-		}
+		FRA = { 71 = { transfer_state_to = AST } }
 		set_temp_variable = { treasury_change = -39 }
 		modify_treasury_effect = yes
 		hidden_effect = {
@@ -3604,7 +3407,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -3615,7 +3417,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = france_abbott_ast.3.a }
-
 }
 
 #fra renew event
@@ -3629,19 +3430,14 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: france_abbott_ast.4.a executed"
 		name = france_abbott_ast.4.a
-		AST = {
-			country_event = france_abbott_ast.5
-		}
+		AST = { country_event = france_abbott_ast.5 }
 	}
 
 	option = {
 		log = "[GetDateText]: [This.GetName]: france_abbott_ast.4.b executed"
 		name = france_abbott_ast.4.b
-		AST = {
-			country_event = france_abbott_ast.6
-		}
+		AST = { country_event = france_abbott_ast.6 }
 	}
-
 }
 
 #renew or not
@@ -3669,14 +3465,9 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: france_abbott_ast.5.b executed"
 		name = france_abbott_ast.5.b
-		71 = {
-				transfer_state_to = FRA
-			}
-		FRA = {
-			country_event = france_abbott_ast.7
-		}
+		71 = { transfer_state_to = FRA }
+		FRA = { country_event = france_abbott_ast.7 }
 	}
-
 }
 
 #return or not
@@ -3690,12 +3481,8 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: france_abbott_ast.6.a executed"
 		name = france_abbott_ast.6.a
-		71 = {
-				transfer_state_to = FRA
-			}
-		FRA = {
-			country_event = france_abbott_ast.7
-		}
+		71 = { transfer_state_to = FRA }
+		FRA = { country_event = france_abbott_ast.7 }
 	}
 
 	option = {
@@ -3709,7 +3496,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #island returned
@@ -3721,7 +3507,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = france_abbott_ast.7.a }
-
 }
 
 #refuse to return
@@ -3740,7 +3525,6 @@ country_event = {
 			send_embargo = AST
 		}
 	}
-
 }
 
 add_namespace = middlepower_abbott
@@ -3778,11 +3562,8 @@ country_event = {
 		AST = {
 			country_event = { id = middlepower_abbott.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -3796,18 +3577,14 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: middlepower_abbott.2.a executed"
 		name = middlepower_abbott.2.a
-		KOR = {
-			country_event = middlepower_abbott.3
-		}
+		KOR = { country_event = middlepower_abbott.3 }
 	}
 
 	#bigly
 	option = {
 		log = "[GetDateText]: [This.GetName]: middlepower_abbott.2.b executed"
 		name = middlepower_abbott.2.b
-		KOR = {
-			country_event = middlepower_abbott.4
-		}
+		KOR = { country_event = middlepower_abbott.4 }
 		set_country_flag = {
 					flag = aus_kor_biggly
 					days = 30
@@ -3817,7 +3594,6 @@ country_event = {
 
 	#pull out
 	option = { name = middlepower_abbott.2.c }
-
 }
 
 country_event = {
@@ -3838,9 +3614,7 @@ country_event = {
 		AST = {
 			country_event = { id = middlepower_abbott.5 days = 1 }
 		}
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	#no
@@ -3850,11 +3624,8 @@ country_event = {
 		AST = {
 			country_event = { id = middlepower_abbott.6 days = 1 }
 		}
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
-
 }
 
 #bigly
@@ -3876,9 +3647,7 @@ country_event = {
 		AST = {
 			country_event = { id = middlepower_abbott.5 days = 1 }
 		}
-		ai_chance = {
-			base = 85
-		}
+		ai_chance = { base = 85 }
 	}
 
 	#no
@@ -3888,11 +3657,8 @@ country_event = {
 		AST = {
 			country_event = { id = middlepower_abbott.6 days = 1 }
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
-
 }
 
 #kor says yes
@@ -3927,7 +3693,6 @@ country_event = {
 		}
 		set_country_flag = kor_says_yes_abbott
 	}
-
 }
 
 #kor says no
@@ -3944,7 +3709,6 @@ country_event = {
 		add_political_power = -30
 		add_war_support = 0.02
 	}
-
 }
 
 
@@ -3965,7 +3729,6 @@ country_event = {
 		add_stability = -0.1
 		add_war_support = 0.05
 	}
-
 }
 
 add_namespace = abbott_shirtfronting_china
@@ -3989,9 +3752,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: abbott_shirtfronting_china.1.a executed"
 		name = abbott_shirtfronting_china.1.a
-		CHI = {
-			country_event = abbott_shirtfronting_china.2
-		}
+		CHI = { country_event = abbott_shirtfronting_china.2 }
 	}
 
 	option = {
@@ -4016,7 +3777,6 @@ country_event = {
 			mark_focus_tree_layout_dirty = yes
 		}
 	}
-
 }
 
 country_event = {
@@ -4034,9 +3794,7 @@ country_event = {
 		AST = {
 			country_event = { id = abbott_shirtfronting_china.3 days = 2 }
 		}
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -4046,11 +3804,8 @@ country_event = {
 		AST = {
 			country_event = { id = abbott_shirtfronting_china.4 days = 2 }
 		}
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
-
 }
 
 country_event = {
@@ -4066,7 +3821,6 @@ country_event = {
 		set_country_flag = shirtfront_success_abbott
 		mark_focus_tree_layout_dirty = yes
 	}
-
 }
 
 country_event = {
@@ -4104,7 +3858,6 @@ country_event = {
 			mark_focus_tree_layout_dirty = yes
 		}
 	}
-
 }
 
 add_namespace = abbott_call_to_arms
@@ -4125,7 +3878,6 @@ country_event = {
 			type = topple_government
 		}
 	}
-
 }
 
 add_namespace = aus_war_on_terror_abbott
@@ -4145,7 +3897,6 @@ country_event = {
 				target = IND
 			}
 	}
-
 }
 
 add_namespace = the_canberra_treaty_abbott
@@ -4163,9 +3914,7 @@ country_event = {
 		AST = {
 			country_event = { id = the_canberra_treaty_abbott.2 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -4184,11 +3933,8 @@ country_event = {
 			NZL = { send_embargo = CHI }
 			ENG = { send_embargo = CHI }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -4203,9 +3949,7 @@ country_event = {
 		name = the_canberra_treaty_abbott.2.a
 		add_political_power = 300
 		add_stability = 0.1
-		526 = {
-			set_demilitarized_zone = yes
-		}
+		526 = { set_demilitarized_zone = yes }
 		CHI = {
 			add_war_support = -0.1
 			add_timed_idea = {
@@ -4228,7 +3972,6 @@ country_event = {
 			add_political_power = 250
 		}
 	}
-
 }
 
 country_event = {
@@ -4244,7 +3987,6 @@ country_event = {
 		add_war_support = 0.05
 		add_political_power = 200
 	}
-
 }
 
 
@@ -4269,7 +4011,6 @@ country_event = {
 				days = 436
 			}
 	}
-
 }
 
 add_namespace = econ_costello_events
@@ -4294,7 +4035,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = 10 }
 		change_fossil_fuel_industry_opinion = yes
 	}
-
 }
 
 #china trade event
@@ -4319,7 +4059,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #our man in beijing
@@ -4337,7 +4076,6 @@ country_event = {
 		newline = yes
 		one_random_agriculture_district = yes
 	}
-
 }
 
 #housing corruption
@@ -4355,7 +4093,6 @@ news_event = {
 		change_relative_party_popularity = yes
 		increase_corruption = yes
 	}
-
 }
 
 add_namespace = costello_in_the_mines
@@ -4376,7 +4113,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -60 }
 		change_fossil_fuel_industry_opinion = yes
 	}
-
 }
 
 country_event = {
@@ -4392,7 +4128,6 @@ country_event = {
 		decrease_corruption = yes
 		set_country_flag = investigation_has_concluded_ast
 	}
-
 }
 
 country_event = {
@@ -4427,9 +4162,7 @@ country_event = {
 				add_idea = boat_arrivals_ast
 			}
 		}
-		else = {
-			add_stability = 0.02
-		}
+		else = { add_stability = 0.02 }
 		add_timed_idea = {
 			idea = mining_interruption_ast
 			days = 160
@@ -4452,7 +4185,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -4498,7 +4230,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #murdoch event
@@ -4516,7 +4247,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_fossil_fuel_industry_opinion = yes
 	}
-
 }
 
 add_namespace = costello_republic_events
@@ -4534,7 +4264,6 @@ country_event = {
 		add_political_power = -80
 		custom_effect_tooltip = costello_republic_events_abbott_tt
 	}
-
 }
 
 #rudd event
@@ -4556,7 +4285,6 @@ country_event = {
 			days = 240
 		}
 	}
-
 }
 
 #gov general
@@ -4572,7 +4300,6 @@ country_event = {
 		name = costello_republic_events.3.a
 		add_political_power = 100
 	}
-
 }
 
 #last push
@@ -4588,20 +4315,13 @@ news_event = {
 		log = "[GetDateText]: [This.GetName]: costello_republic_events.4.a executed"
 		name = costello_republic_events.4.a
 		add_political_power = 120
-		trigger = {
-			tag = AST
-		}
+		trigger = { tag = AST }
 	}
 
 	option = {
 		name = costello_republic_events.4.b
-		trigger = {
-			NOT = {
-				tag = AST
-			}
-		}
+		trigger = { NOT = { tag = AST } }
 	}
-
 }
 
 
@@ -4617,9 +4337,7 @@ country_event = {
 		name = costello_republic_events.5.a
 		custom_effect_tooltip = costello_republic_success_tt
 		newline = yes
-		hidden_effect = {
-			set_cosmetic_tag = AST_REPUB
-		}
+		hidden_effect = { set_cosmetic_tag = AST_REPUB }
 		if = {
 			limit = { has_completed_focus = AST_enshrine_the_protections }
 			add_ideas = bill_of_rights_ast
@@ -4629,18 +4347,14 @@ country_event = {
 		if = {
 			limit = { has_completed_focus = AST_with_heritage_to_remember }
 			if = {
-				limit = {
-					has_idea = reform_despair_ast
-			 	}
+				limit = { has_idea = reform_despair_ast }
 				swap_ideas = {
 					remove_idea = reform_despair_ast
 					add_idea = reconciliation_discontent
 				}
 			}
 			else_if = {
-				limit = {
-					has_idea = reconciliation_discontent
-				}
+				limit = { has_idea = reconciliation_discontent }
 				swap_ideas = {
 					remove_idea = reconciliation_discontent
 					add_idea = rekindled_hope_ast
@@ -4660,9 +4374,7 @@ country_event = {
 					add_idea = radical_protections_ast
 				}
 			}
-			else = {
-				add_stability = 0.04
-			}
+			else = { add_stability = 0.04 }
 			set_country_flag = itstheconst_bypass
 			newline = yes
 		}
@@ -4681,7 +4393,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #opening event
@@ -4697,7 +4408,6 @@ country_event = {
 		name = costello_republic_events.6.a
 		add_political_power = 60
 	}
-
 }
 
 add_namespace = commonwealth_games_ast
@@ -4713,9 +4423,7 @@ news_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: commonwealth_games_ast.1.a executed"
 		name = commonwealth_games_ast.1.a
-		trigger = {
-			tag = AST
-		}
+		trigger = { tag = AST }
 		every_country = {
 			limit = {
 				has_dynamic_modifier = Commonwealth_member_modifier
@@ -4731,9 +4439,7 @@ news_event = {
 	option = {
 		name = commonwealth_games_ast.1.a
 		trigger = {
-			NOT = {
-				tag = AST
-			}
+			NOT = { tag = AST }
 			has_dynamic_modifier = Commonwealth_member_modifier
 		}
 	}
@@ -4749,7 +4455,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 #############################
@@ -4790,7 +4495,6 @@ news_event = {
 	immediate = { set_country_flag = election_victory_2004_ast }
 
 	option = { name = ast_elections_howard_placeholders.2.a }
-
 }
 
 add_namespace = dissolution_election_rudd
@@ -4809,7 +4513,6 @@ country_event = {
 			country_event = { id = dissolution_election_rudd.2 days = 1 }
 		}
 	}
-
 }
 
 country_event = {
@@ -4845,7 +4548,6 @@ country_event = {
 			news_event = dissolution_election_rudd.4
 		}
 	}
-
 }
 
 #rudd wins
@@ -4861,7 +4563,6 @@ news_event = {
 		name = dissolution_election_rudd.3.a
 		clr_country_flag = legislation_blocked_ast
 	}
-
 }
 
 #abbott wins
@@ -4875,9 +4576,7 @@ news_event = {
 	immediate = {
 		hidden_effect = {
 			kill_country_leader = yes
-			remove_power_balance = {
-				id = rudd_bop
-			}
+			remove_power_balance = { id = rudd_bop }
 			create_country_leader = {
 					name = "Tony Abbott"
 					picture = "tony_abbott_1.dds"
@@ -4897,8 +4596,11 @@ news_event = {
 		}
 	}
 
-	option = { name = dissolution_election_rudd.3.a custom_effect_tooltip = focus_tree_has_changed_ast_tt }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: dissolution_election_rudd.3.a executed"
+		name = dissolution_election_rudd.3.a
+		custom_effect_tooltip = focus_tree_has_changed_ast_tt
+	}
 }
 
 add_namespace = ast_elections
@@ -4950,9 +4652,7 @@ country_event = {
 				elections_allowed = yes
 			}
 			kill_country_leader = yes
-			remove_power_balance = {
-				id = rudd_bop
-			}
+			remove_power_balance = { id = rudd_bop }
 			create_country_leader = {
 					name = "Tony Abbott"
 					picture = "tony_abbott_1.dds"
@@ -4972,11 +4672,8 @@ country_event = {
 				add_coalition_members_effect = yes
 			}
 		}
-		else = {
-			add_political_power = 50
-		}
+		else = { add_political_power = 50 }
 	}
-
 }
 
 #repeating general election
@@ -4990,9 +4687,7 @@ country_event = {
 	trigger = {
 		original_tag = AST
 		date > 2005.01.01
-		NOT = {
-			has_country_flag = election_cooldown_ast
-		}
+		NOT = { has_country_flag = election_cooldown_ast }
 	}
 
 	immediate = { set_country_flag = general_elections_start }
@@ -5044,7 +4739,6 @@ country_event = {
 				}
 		set_country_flag = election_ongoing_ast
 	}
-
 }
 
 #election day
@@ -5057,9 +4751,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				western_social_democrats_are_in_power = yes
-			}
+			limit = { western_social_democrats_are_in_power = yes }
 			set_country_flag = {
 					flag = labor_previously_in
 					days = 60
@@ -5067,9 +4759,7 @@ country_event = {
 				}
 		}
 		else_if = {
-			limit = {
-				western_conservatism_are_in_power = yes
-			}
+			limit = { western_conservatism_are_in_power = yes }
 			set_country_flag = {
 					flag = liberals_previously_in
 					days = 60
@@ -5077,9 +4767,7 @@ country_event = {
 				}
 		}
 		else_if = {
-			limit = {
-				nationalist_right_wing_populists_are_in_power = yes
-			}
+			limit = { nationalist_right_wing_populists_are_in_power = yes }
 			set_country_flag = {
 					flag = one_nation_previously_in
 					days = 60
@@ -5087,9 +4775,7 @@ country_event = {
 				}
 		}
 		else_if = {
-			limit = {
-				neutrality_neutral_green_are_in_power = yes
-			}
+			limit = { neutrality_neutral_green_are_in_power = yes }
 			set_country_flag = {
 					flag = greens_previously_in
 					days = 60
@@ -5105,7 +4791,6 @@ country_event = {
 			country_event = { id = ast_elections.4 days = 1 }
 		}
 	}
-
 }
 
 country_event = {
@@ -5174,7 +4859,6 @@ country_event = {
 		}
 		country_event = ast_elections.5 #chooses government
 	}
-
 }
 
 country_event = {
@@ -5287,7 +4971,6 @@ country_event = {
 			country_event = { id = ast_elections.6 days = 1 } #election day after effects
 		}
 	}
-
 }
 
 country_event = {
@@ -5305,12 +4988,9 @@ country_event = {
 					}
 				}
 			}
-			remove_power_balance = {
-				id = rudd_bop
-			}
+			remove_power_balance = { id = rudd_bop }
 		}
 	}
-
 }
 
 
@@ -5343,8 +5023,11 @@ news_event = {
 		}
 	}
 
-	option = { name = election_outcomes_ast.1.a custom_effect_tooltip = focus_tree_has_changed_ast_tt }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: election_outcomes_ast.1.a executed"
+		name = election_outcomes_ast.1.a
+		custom_effect_tooltip = focus_tree_has_changed_ast_tt
+	}
 }
 
 #coalition wins 2007
@@ -5356,7 +5039,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = election_outcomes_ast.2.a }
-
 }
 
 #generic labor reelection
@@ -5368,7 +5050,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = election_outcomes_ast.3.a }
-
 }
 
 #rudd reelected
@@ -5384,7 +5065,6 @@ news_event = {
 		name = election_outcomes_ast.3.a
 		set_country_flag = rudd_consecutive_win
 	}
-
 }
 
 #julia wins special election
@@ -5401,7 +5081,6 @@ news_event = {
 		add_ideas = hung_parliament_ast
 		set_country_flag = gillard_won_election_ast
 	}
-
 }
 
 #julia wins another term
@@ -5417,7 +5096,6 @@ news_event = {
 		name = election_outcomes_ast.6.a
 		set_country_flag = gillard_consecutive_win
 	}
-
 }
 
 #generic coalition reelection
@@ -5429,7 +5107,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = election_outcomes_ast.7.a }
-
 }
 
 #gillard wins 2013 nonconsecutive
@@ -5471,7 +5148,6 @@ news_event = {
 		set_country_flag = gillard_won_election_ast
 		custom_effect_tooltip = focus_tree_has_changed_ast_tt
 	}
-
 }
 
 #turnbull elected
@@ -5500,8 +5176,11 @@ news_event = {
 		}
 	}
 
-	option = { name = election_outcomes_ast.9.a custom_effect_tooltip = focus_tree_has_changed_ast_tt }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: election_outcomes_ast.9.a executed"
+		name = election_outcomes_ast.9.a
+		custom_effect_tooltip = focus_tree_has_changed_ast_tt
+	}
 }
 
 
@@ -5535,7 +5214,6 @@ country_event = {
 		set_country_flag = election_ongoing_ast
 		set_country_flag = gillard_election_ongoing_ast
 	}
-
 }
 
 #election day special
@@ -5553,7 +5231,6 @@ country_event = {
 			country_event = { id = special_gillard_election.3 days = 1 }
 		}
 	}
-
 }
 
 country_event = {
@@ -5590,7 +5267,6 @@ country_event = {
 			news_event = dissolution_election_rudd.4
 		}
 	}
-
 }
 
 ##############################
@@ -5611,7 +5287,6 @@ country_event = {
 			originator_name = kevin_rudd
 		}
 	}
-
 }
 
 country_event = {
@@ -5626,7 +5301,6 @@ country_event = {
 			originator_name = kevin_rudd
 		}
 	}
-
 }
 
 country_event = {
@@ -5641,7 +5315,6 @@ country_event = {
 			originator_name = kevin_rudd
 		}
 	}
-
 }
 
 country_event = {
@@ -5656,7 +5329,6 @@ country_event = {
 			originator_name = kevin_rudd
 		}
 	}
-
 }
 
 country_event = {
@@ -5681,7 +5353,6 @@ country_event = {
 			change_relative_party_popularity = yes
 		}
 	}
-
 }
 
 add_namespace = ast_fm_smith_focus
@@ -5698,7 +5369,6 @@ country_event = {
 			originator_name = stephen_smith
 		}
 	}
-
 }
 
 country_event = {
@@ -5713,7 +5383,6 @@ country_event = {
 			originator_name = stephen_smith
 		}
 	}
-
 }
 
 country_event = {
@@ -5728,7 +5397,6 @@ country_event = {
 			originator_name = stephen_smith
 		}
 	}
-
 }
 
 country_event = {
@@ -5743,7 +5411,6 @@ country_event = {
 			originator_name = stephen_smith
 		}
 	}
-
 }
 
 add_namespace = ast_fm_carr_focus
@@ -5760,7 +5427,6 @@ country_event = {
 			originator_name = bob_carr
 		}
 	}
-
 }
 
 country_event = {
@@ -5775,7 +5441,6 @@ country_event = {
 			originator_name = bob_carr
 		}
 	}
-
 }
 
 country_event = {
@@ -5790,7 +5455,6 @@ country_event = {
 			originator_name = bob_carr
 		}
 	}
-
 }
 
 country_event = {
@@ -5805,7 +5469,6 @@ country_event = {
 			originator_name = bob_carr
 		}
 	}
-
 }
 
 add_namespace = gillard_gov_event
@@ -5825,7 +5488,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -5845,7 +5507,6 @@ country_event = {
 				tooltip_side = gillard_power_side
 			}
 	}
-
 }
 
 add_namespace = forming_government_gil
@@ -5876,7 +5537,6 @@ country_event = {
 		}
 		complete_national_focus = AST_wrangle_liberal_defectors
 	}
-
 }
 
 add_namespace = forced_adoptions_gillard
@@ -5893,7 +5553,6 @@ news_event = {
 		name = forced_adoptions_gillard.1.a
 		add_stability = 0.03
 	}
-
 }
 
 add_namespace = let_debate_decide_gillard
@@ -5913,7 +5572,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -5929,7 +5587,6 @@ country_event = {
 		name = let_debate_decide_gillard.2.a
 		add_ideas = amended_sex_discrimination_act_ast
 	}
-
 }
 
 add_namespace = papua_residency_ast
@@ -5949,9 +5606,7 @@ country_event = {
 			country_event = { id = papua_residency_ast.2 days = 1 }
 			add_opinion_modifier = { target = PAP modifier = economic_union }
 		}
-		ai_chance = {
-				base = 1
-			}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -5960,11 +5615,8 @@ country_event = {
 		AST = {
 			country_event = { id = papua_residency_ast.3 days = 1 }
 		}
-		ai_chance = {
-				base = 0
-			}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -5984,7 +5636,6 @@ country_event = {
 		set_temp_variable = { influence_target = PAP.id }
 		change_influence_percentage = yes
 	}
-
 }
 
 country_event = {
@@ -6000,7 +5651,6 @@ country_event = {
 		name = papua_residency_ast.3.a
 		add_opinion_modifier = { target = PAP modifier = refused_trade_deal }
 	}
-
 }
 
 add_namespace = indo_ast_trade_deal
@@ -6049,7 +5699,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -6074,7 +5723,6 @@ country_event = {
 			active = yes
 		}
 	}
-
 }
 
 country_event = {
@@ -6090,7 +5738,6 @@ country_event = {
 		name = indo_ast_trade_deal.3.a
 		add_opinion_modifier = { target = IND modifier = refused_trade_deal }
 	}
-
 }
 
 
@@ -6112,7 +5759,6 @@ country_event = {
 			country_event = { id = opposition_attacks_ast.2 days = 210 }
 		}
 	}
-
 }
 
 country_event = {
@@ -6138,7 +5784,6 @@ country_event = {
 			country_event = { id = opposition_attacks_ast.3 days = 263 }
 		}
 	}
-
 }
 
 country_event = {
@@ -6163,7 +5808,6 @@ country_event = {
 		name = opposition_attacks_ast.3.b
 		add_political_power = 20
 	}
-
 }
 
 news_event = {
@@ -6179,7 +5823,6 @@ news_event = {
 		name = opposition_attacks_ast.4.a
 		add_political_power = 120
 	}
-
 }
 
 add_namespace = rudd_events_gillard
@@ -6208,7 +5851,6 @@ country_event = {
 		name = rudd_events_gillard.1.b
 		add_political_power = 30
 	}
-
 }
 
 country_event = {
@@ -6227,7 +5869,6 @@ country_event = {
 			country_event = { id = rudd_events_gillard.3 days = 182 }
 		}
 	}
-
 }
 
 #negative campaigning
@@ -6251,7 +5892,6 @@ country_event = {
 			country_event = { id = rudd_events_gillard.5 days = 113 }
 		}
 	}
-
 }
 
 #helpful campaigning
@@ -6270,7 +5910,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 #rudd out against gov
@@ -6299,7 +5938,6 @@ country_event = {
 			country_event = { id = rudd_events_gillard.7 days = 143 }
 		}
 	}
-
 }
 
 #leadership challenge ez win
@@ -6316,7 +5954,6 @@ country_event = {
 		name = rudd_events_gillard.6.a
 		add_political_power = 40
 	}
-
 }
 
 #mass resignations
@@ -6341,7 +5978,6 @@ country_event = {
 			country_event = { id = rudd_events_gillard.8 days = 232 }
 		}
 	}
-
 }
 
 #greens ditch/independents champion
@@ -6349,27 +5985,19 @@ country_event = {
 	id = rudd_events_gillard.8
 	title = {
 		text = rudd_events_gillard.8.t.a
-		trigger = {
-			has_completed_focus = AST_go_green
-		}
+		trigger = { has_completed_focus = AST_go_green }
 	}
 	title = {
 		text = rudd_events_gillard.8.t.b
-		trigger = {
-			has_completed_focus = AST_wrangle_liberal_defectors
-		}
+		trigger = { has_completed_focus = AST_wrangle_liberal_defectors }
 	}
 	desc = {
 		text = rudd_events_gillard.8.d.a
-		trigger = {
-			has_completed_focus = AST_go_green
-		}
+		trigger = { has_completed_focus = AST_go_green }
 	}
 	desc = {
 		text = rudd_events_gillard.8.d.b
-		trigger = {
-			has_completed_focus = AST_wrangle_liberal_defectors
-		}
+		trigger = { has_completed_focus = AST_wrangle_liberal_defectors }
 	}
 	picture = GFX_political_deal
 	is_triggered_only = yes
@@ -6377,9 +6005,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: rudd_events_gillard.8.a executed"
 		name = rudd_events_gillard.8.a
-		trigger = {
-			has_completed_focus = AST_go_green
-		}
+		trigger = { has_completed_focus = AST_go_green }
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
 		add_power_balance_value = {
@@ -6395,9 +6021,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: rudd_events_gillard.8.b executed"
 		name = rudd_events_gillard.8.b
-		trigger = {
-			has_completed_focus = AST_wrangle_liberal_defectors
-		}
+		trigger = { has_completed_focus = AST_wrangle_liberal_defectors }
 		add_power_balance_value = {
 				id = rudd_bop
 				value = 0.05
@@ -6407,7 +6031,6 @@ country_event = {
 			country_event = { id = rudd_events_gillard.9 days = 78 }
 		}
 	}
-
 }
 
 #last leadership challenge
@@ -6445,7 +6068,6 @@ country_event = {
 			country_event = { id = gillard_goodbye_ast.1 days = 3 }
 		}
 	}
-
 }
 
 add_namespace = gillard_goodbye_ast
@@ -6500,7 +6122,6 @@ country_event = {
 		name = gillard_goodbye_ast.2.a
 		add_political_power = 50
 	}
-
 }
 
 add_namespace = uranium_trade_deal_ast
@@ -6529,9 +6150,7 @@ country_event = {
 			}
 			country_event = { id = uranium_trade_deal_ast.2 days = 1 }
 		}
-		ai_chance = {
-				base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6544,11 +6163,8 @@ country_event = {
 			}
 			country_event = { id = uranium_trade_deal_ast.3 days = 1 }
 		}
-		ai_chance = {
-				base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -6574,7 +6190,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -6585,7 +6200,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = uranium_trade_deal_ast.3.a }
-
 }
 
 country_event = {
@@ -6639,7 +6253,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -6659,7 +6272,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -6670,7 +6282,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = uranium_trade_deal_ast.6.a }
-
 }
 
 add_namespace = rudd_in_korea
@@ -6699,18 +6310,13 @@ country_event = {
 			set_temp_variable = { additional_expenses_change = -0.25 }
 			modify_additional_expenses_effect = yes
 		}
-		ai_chance = {
-				base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = rudd_in_korea.1.b
-		ai_chance = {
-				base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 news_event = {
@@ -6733,7 +6339,6 @@ news_event = {
 		set_temp_variable = { additional_expenses_change = 0.25 }
 		modify_additional_expenses_effect = yes
 	}
-
 }
 
 add_namespace = vietnam_trade_gillard_ast
@@ -6755,9 +6360,7 @@ country_event = {
 			}
 			country_event = { id = vietnam_trade_gillard_ast.2 days = 1 }
 		}
-		ai_chance = {
-				base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6770,11 +6373,8 @@ country_event = {
 			}
 			country_event = { id = vietnam_trade_gillard_ast.3 days = 1 }
 		}
-		ai_chance = {
-				base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -6793,11 +6393,8 @@ country_event = {
 				modifier = free_trade_agreement
 			}
 		}
-		ai_chance = {
-				base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -6809,11 +6406,8 @@ country_event = {
 
 	option = {
 		name = vietnam_trade_gillard_ast.3.a
-		ai_chance = {
-				base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 add_namespace = stir_the_pot_event
@@ -6832,9 +6426,7 @@ country_event = {
 		AST = {
 			country_event = { id = stir_the_pot_event.2 days = 1 }
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
@@ -6843,11 +6435,8 @@ country_event = {
 		AST = {
 			country_event = { id = stir_the_pot_event.3 days = 1 }
 		}
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
-
 }
 
 country_event = {
@@ -6880,7 +6469,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -6899,7 +6487,6 @@ country_event = {
 			modifier = denied_us_ast
 		}
 	}
-
 }
 
 add_namespace = myanmar_intervention_gillard
@@ -6917,9 +6504,7 @@ country_event = {
 		AST = {
 			country_event = { id = myanmar_intervention_gillard.3 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6928,11 +6513,8 @@ country_event = {
 		AST = {
 			country_event = { id = myanmar_intervention_gillard.2 days = 1 }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -6955,7 +6537,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -6972,9 +6553,7 @@ country_event = {
 			limit = { has_dlc = "By Blood Alone" }
 			send_embargo = BRM
 		}
-		BRM = {
-			add_ideas = australian_sanctions
-		}
+		BRM = { add_ideas = australian_sanctions }
 	}
 
 	option = {
@@ -6985,7 +6564,6 @@ country_event = {
 			target = BRM
 		}
 	}
-
 }
 
 #Rudd events
@@ -7002,11 +6580,8 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: labor_factionalism.1.a executed"
 		name = labor_factionalism.1.a
-		set_power_balance = {
-			id = rudd_bop
-		}
+		set_power_balance = { id = rudd_bop }
 	}
-
 }
 
 add_namespace = rudd_apology
@@ -7023,7 +6598,6 @@ news_event = {
 		name = rudd_apology.1.a
 		add_stability = 0.03
 	}
-
 }
 
 add_namespace = unite_the_nation_speech_ast
@@ -7036,7 +6610,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = unite_the_nation_speech_ast.1.a }
-
 }
 
 add_namespace = pink_batts_ast
@@ -7054,7 +6627,6 @@ country_event = {
 		add_stability = -0.07
 		add_political_power = -90
 	}
-
 }
 
 add_namespace = bob_brown_event
@@ -7073,7 +6645,6 @@ country_event = {
 		newline = yes
 		add_political_power = 40
 	}
-
 }
 
 add_namespace = something_to_give_ast
@@ -7085,10 +6656,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	option = {
-		name = something_to_give_ast.1.a
-	}
-
+	option = { name = something_to_give_ast.1.a }
 }
 
 add_namespace = school_visit_rudd
@@ -7100,10 +6668,7 @@ country_event = {
 	picture = GFX_rudd_school_event
 	is_triggered_only = yes
 
-	option = {
-		name = school_visit_rudd.1.a
-	}
-
+	option = { name = school_visit_rudd.1.a }
 }
 
 add_namespace = gayvote_rudd
@@ -7121,7 +6686,6 @@ news_event = {
 		add_stability = 0.03
 		set_country_flag = gay_law_1_done
 	}
-
 }
 
 add_namespace = bill_of_rights_ast
@@ -7138,7 +6702,6 @@ country_event = {
 		name = bill_of_rights_ast.1.a
 		add_ideas = bill_of_rights_ast
 	}
-
 }
 
 add_namespace = tackle_mining_oligarchy_ast
@@ -7150,8 +6713,11 @@ country_event = {
 	picture = GFX_ken_henry_ast
 	is_triggered_only = yes
 
-	option = { name = tackle_mining_oligarchy_ast.1.a add_political_power = 30 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: tackle_mining_oligarchy_ast.1.a executed"
+		name = tackle_mining_oligarchy_ast.1.a
+		add_political_power = 30
+	}
 }
 
 country_event = {
@@ -7161,8 +6727,11 @@ country_event = {
 	picture = GFX_wayne_swan_rudd
 	is_triggered_only = yes
 
-	option = { name = tackle_mining_oligarchy_ast.2.a add_political_power = 50 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: tackle_mining_oligarchy_ast.2.a executed"
+		name = tackle_mining_oligarchy_ast.2.a
+		add_political_power = 50
+	}
 }
 
 add_namespace = rudd_nz_deal
@@ -7218,7 +6787,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = rudd_visit_ast
@@ -7234,14 +6802,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: rudd_visit_ast.1.a executed"
 		name = rudd_visit_ast.1.a
 		give_guarantee = KOR
-		hidden_effect = {
-			set_country_flag = rudd_agreement_done_1
-		}
-		trigger = {
-			NOT = {
-				has_guaranteed = KOR
-			}
-		}
+		hidden_effect = { set_country_flag = rudd_agreement_done_1 }
+		trigger = { NOT = { has_guaranteed = KOR } }
 	}
 
 	option = {
@@ -7253,11 +6815,7 @@ country_event = {
 				modifier = insult
 			}
 		}
-		trigger = {
-			NOT = {
-				has_guaranteed = KOR
-			}
-		}
+		trigger = { NOT = { has_guaranteed = KOR } }
 	}
 
 	option = {
@@ -7269,11 +6827,8 @@ country_event = {
 				modifier = gratitude
 			}
 		}
-		trigger = {
-			has_guaranteed = KOR
-		}
+		trigger = { has_guaranteed = KOR }
 	}
-
 }
 
 country_event = {
@@ -7286,11 +6841,8 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: rudd_visit_ast.2.a executed"
 		name = rudd_visit_ast.2.a
-		hidden_effect = {
-			set_country_flag = rudd_agreement_done_2
-		}
+		hidden_effect = { set_country_flag = rudd_agreement_done_2 }
 	}
-
 }
 
 country_event = {
@@ -7316,11 +6868,8 @@ country_event = {
 				add_idea = chinese_export_bonus_ast_3
 			}
 		}
-		else = {
-			add_ideas = chinese_export_bonus_ast
-		}
+		else = { add_ideas = chinese_export_bonus_ast }
 	}
-
 }
 
 country_event = {
@@ -7351,7 +6900,6 @@ country_event = {
 			change_influence_percentage = yes
 		}
 	}
-
 }
 
 add_namespace = gillard_talk
@@ -7363,8 +6911,11 @@ country_event = {
 	picture = GFX_julia_gillard_standard
 	is_triggered_only = yes
 
-	option = { name = gillard_talk.1.a add_political_power = 50 }
-
+	option = {
+		log = "[GetDateText]: [This.GetName]: gillard_talk.1.a executed"
+		name = gillard_talk.1.a
+		add_political_power = 50
+	}
 }
 
 add_namespace = papua_talks_rudd
@@ -7381,9 +6932,7 @@ country_event = {
 		name = papua_talks_rudd.1.a
 		set_temp_variable = { treasury_change = 3.5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		AST = {
 			country_event = { id = papua_talks_rudd.2 days = 1 }
 		}
@@ -7392,9 +6941,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: papua_talks_rudd.1.b executed"
 		name = papua_talks_rudd.1.b
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		AST = {
 			country_event = { id = papua_talks_rudd.3 days = 1 }
 			add_opinion_modifier = {
@@ -7403,7 +6950,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #accept
@@ -7440,7 +6986,6 @@ country_event = {
 			change_influence_percentage = yes
 		}
 	}
-
 }
 
 #refuse
@@ -7452,7 +6997,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = papua_talks_rudd.3.a }
-
 }
 
 add_namespace = address_the_tiger_event_ast
@@ -7477,7 +7021,6 @@ country_event = {
 			days = 980
 		}
 	}
-
 }
 
 add_namespace = legislation_rudd_blocked
@@ -7501,7 +7044,6 @@ country_event = {
 		set_country_flag = resubmitting_the_bill_rudd
 		custom_effect_tooltip = aus_legislation_decisions_tt
 	}
-
 }
 
 country_event = {
@@ -7509,15 +7051,11 @@ country_event = {
 	title = legislation_rudd_blocked.2.t
 	desc = {
 		text = legislation_rudd_blocked.2.d.a
-		trigger = {
-			NOT = { has_country_flag = greens_support_rudd }
-		}
+		trigger = { NOT = { has_country_flag = greens_support_rudd } }
 	}
 	desc = {
 		text = legislation_rudd_blocked.2.d.b
-		trigger = {
-			has_country_flag = greens_support_rudd
-		}
+		trigger = { has_country_flag = greens_support_rudd }
 	}
 	picture = GFX_aus_parliament
 	is_triggered_only = yes
@@ -7547,7 +7085,6 @@ country_event = {
 		name = legislation_rudd_blocked.2.b
 		add_political_power = -30
 	}
-
 }
 
 country_event = {
@@ -7569,7 +7106,6 @@ country_event = {
 				}
 		custom_effect_tooltip = election_is_on_decisions_tt
 	}
-
 }
 
 add_namespace = aus_gillard_overthrow
@@ -7607,7 +7143,6 @@ country_event = {
 		}
 		custom_effect_tooltip = focus_tree_has_changed_ast_tt
 	}
-
 }
 
 country_event = {
@@ -7624,7 +7159,6 @@ country_event = {
 		name = aus_gillard_overthrow.1.a
 		country_event = { id = aus_gillard_overthrow.2 days = 5 }
 	}
-
 }
 
 country_event = {
@@ -7641,7 +7175,6 @@ country_event = {
 		name = aus_gillard_overthrow.1.a
 		country_event = { id = aus_gillard_overthrow.2 days = 5 }
 	}
-
 }
 
 country_event = {
@@ -7649,21 +7182,15 @@ country_event = {
 	title = legislation_rudd_blocked.4.t
 	desc = {
 		text = legislation_rudd_blocked.4.d.a
-		trigger = {
-			has_country_flag = rudd_shelter_passed
-		}
+		trigger = { has_country_flag = rudd_shelter_passed }
 	}
 	desc = {
 		text = legislation_rudd_blocked.4.d.b
-		trigger = {
-			has_country_flag = rudd_super_passed
-		}
+		trigger = { has_country_flag = rudd_super_passed }
 	}
 	desc = {
 		text = legislation_rudd_blocked.4.d.c
-		trigger = {
-			has_country_flag = ets_completed_ast
-		}
+		trigger = { has_country_flag = ets_completed_ast }
 	}
 	picture = GFX_kevin_rudd_happy
 	is_triggered_only = yes
@@ -7674,7 +7201,6 @@ country_event = {
 		name = legislation_rudd_blocked.4.a
 		set_country_flag = legislation_passed_rudd
 	}
-
 }
 
 add_namespace = approach_parties_rudd
@@ -7691,7 +7217,6 @@ country_event = {
 		name = approach_parties_rudd.1.a
 		add_political_power = -10
 	}
-
 }
 
 country_event = {
@@ -7707,7 +7232,6 @@ country_event = {
 		set_country_flag = greens_support_rudd
 		add_political_power = -50
 	}
-
 }
 
 country_event = {
@@ -7722,7 +7246,6 @@ country_event = {
 		name = approach_parties_rudd.3.a
 		add_political_power = 10
 	}
-
 }
 
 
@@ -7743,7 +7266,6 @@ country_event = {
 			days = 350
 		}
 	}
-
 }
 
 add_namespace = whispers_in_the_crowd_ast
@@ -7758,7 +7280,6 @@ country_event = {
 	immediate = { set_country_flag = whispers_in_the_crowd_ast_1_done }
 
 	option = { name = whispers_in_the_crowd_ast.1.a }
-
 }
 
 add_namespace = mining_smear_campaign_ast
@@ -7782,7 +7303,6 @@ country_event = {
 			country_event = { id = mining_smear_campaign_ast.2 days = 280 }
 		}
 	}
-
 }
 
 country_event = {
@@ -7791,10 +7311,7 @@ country_event = {
 	hidden = yes
 	fire_only_once = yes
 
-	immediate = {
-		remove_ideas = mining_smear_campaign_idea_ast
-	}
-
+	immediate = { remove_ideas = mining_smear_campaign_idea_ast }
 }
 
 add_namespace = corruption_outcome_aus
@@ -7815,7 +7332,6 @@ country_event = {
 				popularity = -0.06
 			}
 	}
-
 }
 
 add_namespace = the_new_look_rudd
@@ -7852,7 +7368,6 @@ country_event = {
 	}
 
 	option = { name = the_new_look_rudd.1.b }
-
 }
 
 
@@ -7882,7 +7397,6 @@ country_event = {
 	}
 
 	option = { name = rudd_the_next_leader.1.b }
-
 }
 
 
@@ -7918,7 +7432,6 @@ country_event = {
 		}
 		custom_effect_tooltip = focus_tree_has_changed_ast_tt
 	}
-
 }
 
 add_namespace = rudd_campaigning_round_two
@@ -7937,7 +7450,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 ################
@@ -7978,7 +7490,6 @@ news_event = {
 		name = solomon_islands_intervention.1.a
 		country_event = { id = solomon_islands_intervention.2 days = 1 }
 	}
-
 }
 
 country_event = {
@@ -8003,7 +7514,6 @@ country_event = {
 			news_event = { id = solomon_islands_intervention.6 days = 268 }
 		}
 	}
-
 }
 
 #success
@@ -8020,11 +7530,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: solomon_islands_intervention.3.a executed"
 		name = solomon_islands_intervention.3.a
 		add_stability = 0.05
-		SOL = {
-			remove_ideas = collapsing_state_sol_1
-		}
+		SOL = { remove_ideas = collapsing_state_sol_1 }
 	}
-
 }
 
 #failure
@@ -8061,7 +7568,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -8072,7 +7578,6 @@ country_event = {
 	is_triggered_only = yes
 
 	option = { name = solomon_islands_intervention.5.a }
-
 }
 
 #eagles take over
@@ -8104,7 +7609,6 @@ news_event = {
 	}
 
 	option = { name = solomon_islands_intervention.6.a }
-
 }
 
 add_namespace = walk_for_reconciliation
@@ -8131,7 +7635,6 @@ news_event = {
 		name = walk_for_reconciliation.1.a
 		add_stability = -0.02
 	}
-
 }
 
 add_namespace = sydney_olympic_games
@@ -8140,8 +7643,8 @@ news_event = {
 	title = sydney_olympic_games.1.t
 	desc = sydney_olympic_games.1.d
 	picture = GFX_sydney_olympic_games
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	trigger = {
 		tag = AST
@@ -8153,7 +7656,6 @@ news_event = {
 	immediate = { set_global_flag = ast_olympics_done }
 
 	option = { name = sydney_olympic_games.1.a }
-
 }
 
 add_namespace = shell_takeover
@@ -8190,7 +7692,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = 20 }
 		change_fossil_fuel_industry_opinion = yes
 	}
-
 }
 
 add_namespace = tampa_affair
@@ -8214,7 +7715,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = bali_bombings
@@ -8240,7 +7740,6 @@ news_event = {
 		name = bali_bombings.1.a
 		add_stability = -0.05
 	}
-
 }
 
 add_namespace = embassy_attacked
@@ -8266,7 +7765,6 @@ country_event = {
 		name = embassy_attacked.1.a
 		add_stability = -0.03
 	}
-
 }
 
 add_namespace = asian_earthquakes
@@ -8302,7 +7800,6 @@ country_event = {
 	}
 
 	option = { name = asian_earthquakes.1.b }
-
 }
 
 country_event = {
@@ -8318,7 +7815,6 @@ country_event = {
 		set_temp_variable = { treasury_change = 4.5 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 add_namespace = cronulla_riots
@@ -8347,9 +7843,7 @@ news_event = {
 				ideology = nationalist
 				popularity = 0.03
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -8360,11 +7854,8 @@ news_event = {
 				ideology = nationalist
 				popularity = -0.04
 			}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 add_namespace = rip_steve_irwin
@@ -8386,7 +7877,6 @@ news_event = {
 	immediate = { set_country_flag = steve_die_rip }
 
 	option = { name = rip_steve_irwin.1.a }
-
 }
 
 add_namespace = a_global_financial_crisis
@@ -8428,7 +7918,6 @@ country_event = {
 			mark_focus_tree_layout_dirty = yes
 		}
 	}
-
 }
 
 country_event = {
@@ -8453,7 +7942,6 @@ country_event = {
 	}
 
 	option = { name = a_global_financial_crisis.2.a }
-
 }
 
 country_event = {
@@ -8468,7 +7956,6 @@ country_event = {
 		name = a_global_financial_crisis.3.a
 		remove_ideas = tfc_3
 	}
-
 }
 
 country_event = {
@@ -8489,7 +7976,6 @@ country_event = {
 				}
 			}
 	}
-
 }
 
 add_namespace = new_governor_general_ast
@@ -8513,7 +7999,6 @@ news_event = {
 	immediate = { set_country_flag = new_governor_general_ast_done }
 
 	option = { name = new_governor_general_ast.1.a }
-
 }
 
 add_namespace = turnbull_letter_ast
@@ -8544,7 +8029,6 @@ country_event = {
 			country_event = { id = turnbull_letter_ast.2 days = 26 }
 		}
 	}
-
 }
 
 country_event = {
@@ -8559,7 +8043,6 @@ country_event = {
 		name = turnbull_letter_ast.2.a
 		add_political_power = 30
 	}
-
 }
 
 add_namespace = oceanic_viking_ast
@@ -8595,7 +8078,6 @@ country_event = {
 			country_event = { id = oceanic_viking_ast.3 days = 5 }
 		}
 	}
-
 }
 
 country_event = {
@@ -8613,7 +8095,6 @@ country_event = {
 			country_event = { id = oceanic_viking_ast.4 days = 243 }
 		}
 	}
-
 }
 
 country_event = {
@@ -8631,7 +8112,6 @@ country_event = {
 			country_event = { id = oceanic_viking_ast.4 days = 243 }
 		}
 	}
-
 }
 
 country_event = {
@@ -8646,11 +8126,8 @@ country_event = {
 			limit = { has_idea = problem_with_the_boats_2 }
 			remove_ideas = problem_with_the_boats_2
 		}
-		else = {
-			remove_ideas = problem_with_the_boats
-		}
+		else = { remove_ideas = problem_with_the_boats }
 	}
-
 }
 
 add_namespace = migration_event_ast
@@ -8700,7 +8177,6 @@ country_event = {
 				popularity = 0.03
 			}
 	}
-
 }
 
 add_namespace = aus_cylcone
@@ -8744,7 +8220,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = great_barrier_reef
@@ -8777,7 +8252,6 @@ country_event = {
 					modifier = small_decrease
 				}
 	}
-
 }
 
 add_namespace = indo_cattle_drama
@@ -8811,7 +8285,6 @@ country_event = {
 		name = indo_cattle_drama.1.b
 		add_stability = -0.03
 	}
-
 }
 
 add_namespace = malaysia_solution_ast
@@ -8847,7 +8320,6 @@ country_event = {
 	}
 
 	option = { name = malaysia_solution_ast.1.b }
-
 }
 
 country_event = {
@@ -8862,7 +8334,6 @@ country_event = {
 		name = malaysia_solution_ast.2.a
 		add_political_power = -100
 	}
-
 }
 
 add_namespace = embassy_tent_protests
@@ -8887,9 +8358,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: embassy_tent_protests.1.b executed"
 		name = embassy_tent_protests.1.b
-		trigger = {
-			has_focus_tree = gillardgov_focus
-		}
+		trigger = { has_focus_tree = gillardgov_focus }
 		hidden_effect = {
 			country_event = { id = embassy_tent_protests.2 days = 1 }
 		}
@@ -8898,9 +8367,7 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: embassy_tent_protests.1.b executed"
 		name = embassy_tent_protests.1.b
-		trigger = {
-			has_focus_tree = ruddgov_focus
-		}
+		trigger = { has_focus_tree = ruddgov_focus }
 		hidden_effect = {
 			country_event = { id = embassy_tent_protests.3 days = 1 }
 		}
@@ -8909,14 +8376,11 @@ country_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: embassy_tent_protests.1.b executed"
 		name = embassy_tent_protests.1.b
-		trigger = {
-			has_focus_tree = australia_abbottgov_focus
-		}
+		trigger = { has_focus_tree = australia_abbottgov_focus }
 		hidden_effect = {
 			country_event = { id = embassy_tent_protests.4 days = 1 }
 		}
 	}
-
 }
 
 country_event = {
@@ -8942,7 +8406,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 country_event = {
@@ -8957,7 +8420,6 @@ country_event = {
 		name = embassy_tent_protests.3.a
 		add_political_power = 50
 	}
-
 }
 
 country_event = {
@@ -8972,7 +8434,6 @@ country_event = {
 		name = embassy_tent_protests.2.a
 		add_stability = -0.03
 	}
-
 }
 
 add_namespace = muslim_protests_sydney
@@ -9001,7 +8462,6 @@ news_event = {
 				popularity = 0.05
 			}
 	}
-
 }
 
 add_namespace = murrawarri_republic_event
@@ -9022,7 +8482,6 @@ country_event = {
 	immediate = { set_country_flag = murrawarri_republic_event_done }
 
 	option = { name = murrawarri_republic_event.1.a }
-
 }
 
 add_namespace = shark_attacks_ast
@@ -9043,7 +8502,6 @@ news_event = {
 	immediate = { set_country_flag = shark_attacks_ast_done }
 
 	option = { name = shark_attacks_ast.1.a }
-
 }
 
 add_namespace = aukus_formed_ast
@@ -9061,14 +8519,9 @@ news_event = {
 		name = aukus_formed_ast.1.a
 		add_ideas = aukus_proliferation_project
 		newline = yes
-		ENG = {
-			add_ideas = aukus_proliferation_project
-		}
-		USA = {
-			add_ideas = aukus_proliferation_project
-		}
+		ENG = { add_ideas = aukus_proliferation_project }
+		USA = { add_ideas = aukus_proliferation_project }
 	}
-
 }
 
 add_namespace = pukpuk_treaty_event
@@ -9088,7 +8541,6 @@ news_event = {
 		name = pukpuk_treaty_event.1.a
 		add_war_support = 0.03
 	}
-
 }
 
 add_namespace = ast_taiwan_recognition
@@ -9125,7 +8577,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 #temp fire events
@@ -9160,7 +8611,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 add_namespace = black_saturday_ast
@@ -9252,7 +8702,6 @@ country_event = {
 	title = syrian_refugees_event_ast.1.t
 	desc = syrian_refugees_event_ast.1.d
 	picture = GFX_failed_to_catch_migrants
-
 	is_triggered_only = yes
 
 	option = {
@@ -9282,7 +8731,6 @@ news_event = {
 	title = malaysianflight_event_ast.1.t
 	desc = malaysianflight_event_ast.1.d
 	picture = GFX_mh370_disappearance_event
-
 	is_triggered_only = yes
 
 	option = {
@@ -9290,5 +8738,4 @@ news_event = {
 		name = malaysianflight_event_ast.1.a
 		add_stability = -0.02
 	}
-
 }

--- a/events/EU_USoE_events.txt
+++ b/events/EU_USoE_events.txt
@@ -4,10 +4,10 @@ country_event = {
 	id = USoEevent.1
 	title = USoEevent.1.t
 	desc = USoEevent.1.d
-	# TODO: add a event picture
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.1.a
@@ -19,19 +19,13 @@ country_event = {
 				active = yes
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
 	option = {
 		name = USoEevent.1.b
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -39,10 +33,10 @@ country_event = {
 	id = USoEevent.2
 	title = USoEevent.2.t
 	desc = USoEevent.2.d
-	# TODO: add a event picture
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.2.a
@@ -57,30 +51,20 @@ country_event = {
 			FROM = { add_to_faction = ROOT }
 		}
 		else_if = {
-			limit = {
-				FROM = {
-					NOT = { is_in_faction = yes }
-				}
-			}
+			limit = { FROM = { NOT = { is_in_faction = yes } } }
 			FROM = {
 				leave_faction = yes
 				create_faction_from_template = faction_template_eurasian_alliance
 				add_to_faction = ROOT
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
 	option = {
 		name = USoEevent.2.b
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -88,10 +72,10 @@ country_event = {
 	id = USoEevent.3
 	title = USoEevent.3.t
 	desc = USoEevent.3.d
-	# TODO: add a event picture
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.3.a
@@ -106,20 +90,13 @@ country_event = {
 			FROM = { add_to_faction = ROOT }
 		}
 		else_if = {
-			limit = {
-				FROM = {
-					NOT = { is_in_faction = yes }
-				}
-			}
+			limit = { FROM = { NOT = { is_in_faction = yes } } }
 			FROM = {
 				create_faction_from_template = faction_template_western_alliance
 				add_to_faction = ROOT
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
@@ -135,10 +112,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -146,10 +120,10 @@ country_event = {
 	id = USoEevent.4
 	title = USoEevent.4.t
 	desc = USoEevent.4.d
-	# TODO: add a event picture
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.4.a
@@ -164,20 +138,13 @@ country_event = {
 			FROM = { add_to_faction = ROOT }
 		}
 		else_if = {
-			limit = {
-				FROM = {
-					NOT = { is_in_faction = yes }
-				}
-			}
+			limit = { FROM = { NOT = { is_in_faction = yes } } }
 			FROM = {
 				create_faction_from_template = faction_template_western_alliance
 				add_to_faction = ROOT
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# No
@@ -192,10 +159,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -203,10 +167,10 @@ country_event = {
 	id = USoEevent.5
 	title = USoEevent.5.t
 	desc = USoEevent.5.d
-	# TODO: add a event picture
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.5.a
@@ -215,10 +179,7 @@ country_event = {
 			set_temp_variable = { percent_change = 3 }
 			change_influence_percentage = yes
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -226,10 +187,10 @@ country_event = {
 	id = USoEevent.6
 	title = USoEevent.6.t
 	desc = USoEevent.6.d
-	# TODO: add a event picture
 	picture = GFX_raid_international_sanctions
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.6.a
@@ -244,10 +205,7 @@ country_event = {
 				modifier = sanctions_relations
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -255,16 +213,13 @@ country_event = {
 	id = USoEevent.7
 	title = USoEevent.7.t
 	desc = USoEevent.7.d
-	# TODO: add a event picture
 	picture = GFX_raid_international_sanctions
 	is_triggered_only = yes
 
+	# TODO: add a event picture
 	# Yes
 	option = {
 		name = USoEevent.7.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }

--- a/events/France.txt
+++ b/events/France.txt
@@ -156,9 +156,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -311,9 +309,7 @@ country_event = {
 			target = DRC
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -323,9 +319,7 @@ country_event = {
 			target = UGA
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -335,9 +329,7 @@ country_event = {
 			target = RWA
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -367,9 +359,7 @@ country_event = {
 			target = SEN
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -388,9 +378,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -404,9 +392,7 @@ country_event = {
 			target = CSM
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -428,9 +414,7 @@ country_event = {
 			target = CAR
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -543,9 +527,7 @@ country_event = {
 			target = MAL
 			modifier = generic_increased_military_support
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -579,9 +561,7 @@ country_event = {
 	option = {
 		name = france_md.108.a
 		log = "[GetDateText]: [This.GetName]: france_md.108.a executed"
-		trigger = {
-			country_exists = MAL
-		}
+		trigger = { country_exists = MAL }
 		if = {
 			limit = {
 				NOT = {
@@ -614,17 +594,13 @@ country_event = {
 			target = MAL
 			amount = 500
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = france_md.108.b
 		log = "[GetDateText]: [This.GetName]: france_md.108.b executed"
-		trigger = {
-			country_exists = TUA
-		}
+		trigger = { country_exists = TUA }
 		if = {
 			limit = {
 				NOT = {
@@ -862,9 +838,7 @@ country_event = {
 	option = {
 		name = france_md.109.b
 		log = "[GetDateText]: [This.GetName]: france_md.109.b executed"
-		trigger = {
-			has_global_flag = GLOBAL_haitian_civil_war
-		}
+		trigger = { has_global_flag = GLOBAL_haitian_civil_war }
 		add_relation_modifier = {
 			target = HAI
 			modifier = generic_increased_military_support
@@ -874,9 +848,7 @@ country_event = {
 			target = HAI
 			amount = 500
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -990,9 +962,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -1006,9 +976,7 @@ country_event = {
 			end_wars = no
 			end_civil_wars = no
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -1032,9 +1000,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: france_md.111.a executed"
 		if = {
 			limit = { original_tag = FRA }
-			FRA = {
-				add_stability = 0.02
-			}
+			FRA = { add_stability = 0.02 }
 		}
 		else = {
 			effect_tooltip = {
@@ -1056,9 +1022,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1073,9 +1037,7 @@ country_event = {
 		name = france_md.500.a
 		log = "[GetDateText]: [This.GetName]: france_md.500.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1090,9 +1052,7 @@ country_event = {
 		name = france_md.501.a
 		log = "[GetDateText]: [This.GetName]: france_md.501.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -1207,9 +1167,7 @@ country_event = {
 			country_event = diplomatic_response.2
 			add_political_power = -25
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -1251,9 +1209,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 85
-		}
+		ai_chance = { base = 85 }
 	}
 
 	option = {
@@ -1264,9 +1220,7 @@ country_event = {
 			country_event = diplomatic_response.2
 			add_political_power = -25
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -1308,9 +1262,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 85
-		}
+		ai_chance = { base = 85 }
 	}
 
 	option = {
@@ -1321,9 +1273,7 @@ country_event = {
 			country_event = diplomatic_response.2
 			add_political_power = -25
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -1362,9 +1312,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 200
-		}
+		ai_chance = { base = 200 }
 	}
 
 	option = {
@@ -1376,9 +1324,7 @@ country_event = {
 			country_event = diplomatic_response.2
 			add_political_power = -25
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -1404,9 +1350,7 @@ country_event = {
 			set_temp_variable = { treasury_change = 15 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 200
-		}
+		ai_chance = { base = 200 }
 	}
 
 	option = {
@@ -1418,9 +1362,7 @@ country_event = {
 			country_event = diplomatic_response.2
 			add_political_power = -25
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 country_event = {
@@ -1795,9 +1737,7 @@ country_event = {
 
 	option = {
 		name = france_md.20.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #war reparation to vietnam
@@ -1815,9 +1755,7 @@ country_event = {
 			modify_treasury_effect = yes
 			add_political_power = 150
 			add_stability = 0.05
-		ai_chance = {
-			factor = 200
-		}
+		ai_chance = { factor = 200 }
 	}
 }
 #war reparation to algeria
@@ -1835,9 +1773,7 @@ country_event = {
 			modify_treasury_effect = yes
 			add_political_power = 150
 			add_stability = 0.05
-		ai_chance = {
-			factor = 200
-		}
+		ai_chance = { factor = 200 }
 	}
 }
 #proposing nuclear expert to eu
@@ -1970,9 +1906,7 @@ country_event = {
 
 	option = {
 		name = france_md.21.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #event so when 2008 crisis pop up if you have the regulation idea or its equivalent you suffer least
@@ -2019,9 +1953,7 @@ country_event = {
 		newline = yes
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = FRA_lr_social_balance }
 		add_to_variable = { FRA_lr_social_stab = -0.1 tooltip = stability_factor_tt }
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 #PS-EELV nuclear accord
@@ -2047,9 +1979,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		change_relative_party_popularity = yes
 		add_stability = 0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -2065,9 +1995,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		change_relative_party_popularity = yes
 		add_stability = -0.05
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 #reaction to the same-sex marriage law
@@ -2092,9 +2020,7 @@ country_event = {
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 8
-		}
+		ai_chance = { base = 8 }
 	}
 
 	option = {
@@ -2107,9 +2033,7 @@ country_event = {
 		set_temp_variable = { party_index = 17 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 #gilets jaunes response
@@ -2133,9 +2057,7 @@ country_event = {
 		add_to_variable = { FRA_udf_balance_domestic_nationalist_drift = 0.03 tooltip = nationalist_drift_tt }
 		newline = yes
 		add_political_power = -100
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -2170,9 +2092,7 @@ country_event = {
 
 	option = {
 		name = france_md.22.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2254,9 +2174,7 @@ country_event = {
 				country_event = france_md.181
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2272,9 +2190,7 @@ country_event = {
 		set_temp_variable = { modify_europeanism = -0.15 }
 		set_temp_variable = { modify_europeanism_target = THIS.id }
 		europeanism_change = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2288,9 +2204,7 @@ country_event = {
 
 	option = {
 		name = france_md.23.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Socialist
@@ -2303,9 +2217,7 @@ country_event = {
 
 	option = {
 		name = france_md.24.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Choice between macron and ferrand economical policy
@@ -2313,10 +2225,10 @@ country_event = {
 	id = france_md.30
 	title = france_md.30.t
 	desc = france_md.30.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	option = {
 		name = france_md.30.a
 		log = "[GetDateText]: [This.GetName]: france_md.30.a executed"
@@ -2337,9 +2249,7 @@ country_event = {
 		name = france_md.30.b
 		log = "[GetDateText]: [This.GetName]: france_md.30.b executed"
 		add_ideas = FRA_Ferrand_eco
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Propose investment to greece
@@ -2363,17 +2273,13 @@ country_event = {
 			set_temp_variable = { treasury_change = 30 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			factor = 50
-		}
+		ai_chance = { factor = 50 }
 	}
 
 	option = {
 		name = france_md.150.b
 		log = "[GetDateText]: [This.GetName]: france_md.150.b executed"
-		FRA = {
-			country_event = diplomatic_response.2
-			}
+		FRA = { country_event = diplomatic_response.2 }
 		ai_chance = {
 			factor = 15
 			modifier = {
@@ -2403,9 +2309,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-		ai_chance = {
-			factor = 50
-		}
+		ai_chance = { factor = 50 }
 	}
 
 	option = {
@@ -2417,9 +2321,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-		ai_chance = {
-			factor = 15
-		}
+		ai_chance = { factor = 15 }
 	}
 }
 #Downfall of socialist party
@@ -2427,10 +2329,10 @@ country_event = {
 	id = france_md.162
 	title = france_md.162.t
 	desc = france_md.162.d
-	# picture = GFX_economic_crisis
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
+	# picture = GFX_economic_crisis
 	option = {
 		name = france_md.162.a
 		log = "[GetDateText]: [This.GetName]: france_md.162.a executed"
@@ -2440,9 +2342,7 @@ country_event = {
 		add_timed_idea = { idea = FRA_ineluctable_collapse days = 365 }
 		unlock_decision_category_tooltip = FRA_french_socialist_downfall_decision_category
 		country_event = { id = france_md.520 days = 3 }
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 #decrease your support during the crisis
@@ -2459,9 +2359,7 @@ country_event = {
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = -0.1 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -2486,9 +2384,7 @@ country_event = {
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -2511,9 +2407,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.1 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 
 	option = {
@@ -2529,9 +2423,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			factor = 4
-		}
+		ai_chance = { factor = 4 }
 	}
 }
 country_event = {
@@ -2549,9 +2441,7 @@ country_event = {
 			idea = FRA_ps_EUtrain
 			days = 730
 		}
-		ai_chance = {
-			factor = 100
-		}
+		ai_chance = { factor = 100 }
 	}
 
 	option = {
@@ -2578,9 +2468,7 @@ country_event = {
 
 	option = {
 		name = france_md.25.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #EELV
@@ -2593,9 +2481,7 @@ country_event = {
 
 	option = {
 		name = france_md.26.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #PCF
@@ -2608,9 +2494,7 @@ country_event = {
 
 	option = {
 		name = france_md.27.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2623,42 +2507,28 @@ country_event = {
 	option = {
 		name = france_md.183.a
 		log = "[GetDateText]: [This.GetName]: france_md.183.a executed"
-		FRA = {
-			country_event = france_md.184
-		}
-		SOV = {
-			add_ideas = FRA_russian_cooperation1
-		}
+		FRA = { country_event = france_md.184 }
+		SOV = { add_ideas = FRA_russian_cooperation1 }
 		add_stability = 0.1
-		ai_chance = {
-			factor = 3
-		}
+		ai_chance = { factor = 3 }
 	}
+
 	option = {
 		name = france_md.183.b
 		log = "[GetDateText]: [This.GetName]: france_md.183.b executed"
-		FRA = {
-			news_event = france_md.185
-		}
-		SOV = {
-			add_ideas = FRA_russian_cooperation2
-		}
+		FRA = { news_event = france_md.185 }
+		SOV = { add_ideas = FRA_russian_cooperation2 }
 		add_war_support = 0.075
-		ai_chance = {
-			factor = 4
-		}
+		ai_chance = { factor = 4 }
 	}
+
 	option = {
 		name = france_md.183.c
 		log = "[GetDateText]: [This.GetName]: france_md.183.c executed"
 		add_stability = 0.1
 		add_political_power = 150
-		FRA = {
-			country_event = france_md.187
-		}
-		ai_chance = {
-			factor = 1
-		}
+		FRA = { country_event = france_md.187 }
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -2672,9 +2542,7 @@ country_event = {
 		name = france_md.184.a
 		log = "[GetDateText]: [This.GetName]: france_md.184.a executed"
 		add_ideas = FRA_russian_cooperation1
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 news_event = {
@@ -2688,9 +2556,7 @@ news_event = {
 		name = france_md.185.a
 		log = "[GetDateText]: [This.GetName]: france_md.185.a executed"
 		add_ideas = FRA_russian_cooperation2
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2708,9 +2574,7 @@ country_event = {
 			target = SOV
 		}
 		add_political_power = -100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2723,9 +2587,7 @@ country_event = {
 	option = {
 		name = france_md.188.a
 		log = "[GetDateText]: [This.GetName]: france_md.188.a executed"
-		FRA = {
-			country_event = france_md.189
-		}
+		FRA = { country_event = france_md.189 }
 		add_political_power = -100
 		ai_chance = {
 			factor = 2
@@ -2747,9 +2609,7 @@ country_event = {
 	option = {
 		name = france_md.188.b
 		log = "[GetDateText]: [This.GetName]: france_md.188.b executed"
-		FRA = {
-			country_event = france_md.190
-		}
+		FRA = { country_event = france_md.190 }
 		add_timed_idea = { idea = FRA_blocade days = 1825 }
 		add_opinion_modifier = {
 			modifier = recent_actions_negative
@@ -2777,10 +2637,10 @@ country_event = {
 	id = france_md.189
 	title = france_md.189.t
 	desc = france_md.189.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	option = {
 		name = france_md.189.a
 		log = "[GetDateText]: [This.GetName]: france_md.189.a executed"
@@ -2790,9 +2650,7 @@ country_event = {
 		add_to_variable = { FRA_rpf_econ_mils_speed = 0.06 tooltip = production_speed_arms_factory_factor_tt }
 		newline = yes
 		add_political_power = 100
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -2811,9 +2669,7 @@ country_event = {
 		}
 		add_war_support = 0.075
 		add_political_power = -25
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2826,9 +2682,7 @@ country_event = {
 	option = {
 		name = france_md.191.a
 		log = "[GetDateText]: [This.GetName]: france_md.191.a executed"
-		FRA = {
-			country_event = france_md.192
-		}
+		FRA = { country_event = france_md.192 }
 		add_political_power = -100
 		ai_chance = {
 			factor = 2
@@ -2850,9 +2704,7 @@ country_event = {
 	option = {
 		name = france_md.191.b
 		log = "[GetDateText]: [This.GetName]: france_md.191.b executed"
-		FRA = {
-			country_event = france_md.193
-		}
+		FRA = { country_event = france_md.193 }
 		add_timed_idea = { idea = FRA_blocade days = 1825 }
 		add_war_support = 0.05
 		add_opinion_modifier = {
@@ -2880,10 +2732,10 @@ country_event = {
 	id = france_md.192
 	title = france_md.192.t
 	desc = france_md.192.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	option = {
 		name = france_md.192.a
 		log = "[GetDateText]: [This.GetName]: france_md.192.a executed"
@@ -2893,9 +2745,7 @@ country_event = {
 		add_to_variable = { FRA_rpf_migration_rate = -0.05 tooltip = migration_rate_value_factor_tt }
 		newline = yes
 		add_political_power = 100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2914,9 +2764,7 @@ country_event = {
 		}
 		add_war_support = 0.075
 		add_political_power = -100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -2929,9 +2777,7 @@ country_event = {
 	option = {
 		name = france_md.194.a
 		log = "[GetDateText]: [This.GetName]: france_md.194.a executed"
-		FRA = {
-			country_event = france_md.195
-		}
+		FRA = { country_event = france_md.195 }
 		add_political_power = -100
 		ai_chance = {
 			factor = 2
@@ -2953,9 +2799,7 @@ country_event = {
 	option = {
 		name = france_md.194.b
 		log = "[GetDateText]: [This.GetName]: france_md.194.b executed"
-		FRA = {
-			country_event = france_md.196
-		}
+		FRA = { country_event = france_md.196 }
 		add_timed_idea = { idea = FRA_blocade days = 1825 }
 		add_war_support = 0.05
 		add_opinion_modifier = {
@@ -2983,10 +2827,10 @@ country_event = {
 	id = france_md.195
 	title = france_md.195.t
 	desc = france_md.195.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	option = {
 		name = france_md.195.a
 		log = "[GetDateText]: [This.GetName]: france_md.195.a executed"
@@ -2995,9 +2839,7 @@ country_event = {
 		add_to_variable = { FRA_rpf_soc_bureaucracy_cost = -0.08 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		newline = yes
 		add_political_power = 100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3016,9 +2858,7 @@ country_event = {
 		}
 		add_war_support = 0.075
 		add_political_power = -100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3031,9 +2871,7 @@ country_event = {
 	option = {
 		name = france_md.197.a
 		log = "[GetDateText]: [This.GetName]: france_md.197.a executed"
-		FRA = {
-			country_event = france_md.198
-		}
+		FRA = { country_event = france_md.198 }
 		add_political_power = -100
 		ai_chance = {
 			factor = 2
@@ -3055,9 +2893,7 @@ country_event = {
 	option = {
 		name = france_md.197.b
 		log = "[GetDateText]: [This.GetName]: france_md.197.b executed"
-		FRA = {
-			country_event = france_md.199
-		}
+		FRA = { country_event = france_md.199 }
 		add_timed_idea = { idea = FRA_blocade days = 1825 }
 		add_war_support = 0.05
 		add_opinion_modifier = {
@@ -3085,10 +2921,10 @@ country_event = {
 	id = france_md.198
 	title = france_md.198.t
 	desc = france_md.198.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	option = {
 		name = france_md.198.a
 		log = "[GetDateText]: [This.GetName]: france_md.198.a executed"
@@ -3098,9 +2934,7 @@ country_event = {
 		add_to_variable = { FRA_rpf_econ_tax_efficiency = 0.05 tooltip = corporate_tax_income_multiplier_modifier_tt }
 		newline = yes
 		add_political_power = 100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3119,9 +2953,7 @@ country_event = {
 		}
 		add_war_support = 0.075
 		add_political_power = -100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3134,9 +2966,7 @@ country_event = {
 	option = {
 		name = france_md.200.a
 		log = "[GetDateText]: [This.GetName]: france_md.200.a executed"
-		FRA = {
-			country_event = france_md.201
-		}
+		FRA = { country_event = france_md.201 }
 		add_political_power = -100
 		ai_chance = {
 			factor = 2
@@ -3158,9 +2988,7 @@ country_event = {
 	option = {
 		name = france_md.200.b
 		log = "[GetDateText]: [This.GetName]: france_md.200.b executed"
-		FRA = {
-			country_event = france_md.202
-		}
+		FRA = { country_event = france_md.202 }
 		add_timed_idea = { idea = FRA_blocade days = 1825 }
 		add_war_support = 0.05
 		add_opinion_modifier = {
@@ -3188,10 +3016,10 @@ country_event = {
 	id = france_md.201
 	title = france_md.201.t
 	desc = france_md.201.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	option = {
 		name = france_md.201.a
 		log = "[GetDateText]: [This.GetName]: france_md.201.a executed"
@@ -3202,9 +3030,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = 10 }
 		change_farmers_opinion = yes
 		add_political_power = 100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3223,9 +3049,7 @@ country_event = {
 		}
 		add_war_support = 0.075
 		add_political_power = -100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3256,9 +3080,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			factor = 10
-		}
+		ai_chance = { factor = 10 }
 	}
 
 	option = {
@@ -3299,14 +3121,10 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.2 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		change_relative_party_popularity = yes
-		add_dynamic_modifier = {
-			modifier = FRA_6th_rep
-		}
+		add_dynamic_modifier = { modifier = FRA_6th_rep }
 		remove_ideas = FRA_5th_republic
 		add_ideas = FRA_sixth_republic_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3325,9 +3143,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.13 }
 		set_temp_variable = { temp_outlook_increase = -0.13 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3483,9 +3299,7 @@ country_event = {
 		add_to_variable = { FRA_commandpower_6 = -5 tooltip = max_command_power_tt }
 		newline = yes
 		country_event = { id = france_md.209 days = 7 }
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -3523,9 +3337,7 @@ country_event = {
 		add_to_variable = { FRA_commandpower_6 = -10 tooltip = max_command_power_tt }
 		newline = yes
 		country_event = { id = france_md.209 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3685,9 +3497,7 @@ country_event = {
 		add_to_variable = { FRA_6th_war_support_factor = -0.075 tooltip = war_support_factor_tt }
 		add_to_variable = { FRA_6threp_personnel_cost = 0.025 tooltip = personnel_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6threp_policecost = 0.025 tooltip = police_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3724,9 +3534,7 @@ country_event = {
 		add_to_variable = { FRA_6th_war_support_factor = 0.1 tooltip = war_support_factor_tt }
 		add_to_variable = { FRA_6threp_personnel_cost = -0.05 tooltip = personnel_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6threp_policecost = -0.05 tooltip = police_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3883,9 +3691,7 @@ country_event = {
 		add_to_variable = { FRA_6th_social_cost = 0.025 tooltip = social_cost_multiplier_modifier_tt }
 		newline = yes
 		country_event = { id = france_md.215 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3918,9 +3724,7 @@ country_event = {
 		add_to_variable = { FRA_6theducost = -0.025 tooltip = education_cost_multiplier_modifier_tt }
 		newline = yes
 		country_event = { id = france_md.215 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4075,9 +3879,7 @@ country_event = {
 		add_to_variable = { FRA_6th_health_cost = -0.075 tooltip = health_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6threp_policecost = 0.15 tooltip = police_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6th_neutrality_drift = 0.05 tooltip = neutrality_drift_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4109,9 +3911,7 @@ country_event = {
 		add_to_variable = { FRA_6th_health_cost = 0.075 tooltip = health_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6threp_policecost = -0.05 tooltip = police_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6th_natio_drift = 0.02 tooltip = nationalist_drift_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4367,9 +4167,7 @@ country_event = {
 		add_to_variable = { FRA_6thcivs_revenue = -0.075 tooltip = civilian_industry_tax_modifier_tt }
 		newline = yes
 		country_event = { id = france_md.222 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4406,9 +4204,7 @@ country_event = {
 		add_to_variable = { FRA_6thenergy_cons = -0.075 tooltip = energy_use_modifier_civs_tt }
 		newline = yes
 		country_event = { id = france_md.222 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4453,9 +4249,7 @@ country_event = {
 		add_to_variable = { FRA_6thcivs_revenue = 0.025 tooltip = civilian_industry_tax_modifier_tt }
 		newline = yes
 		country_event = { id = france_md.222 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4705,9 +4499,7 @@ country_event = {
 		add_to_variable = { FRA_6th_monthly_pop = 0.075 tooltip = monthly_population_tt }
 		add_to_variable = { FRA_6th_tax_corpo = 0.05 tooltip = corporate_tax_income_multiplier_modifier_tt }
 		add_to_variable = { FRA_6thcons_goo = 0.075 tooltip = consumer_goods_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4738,9 +4530,7 @@ country_event = {
 		add_to_variable = { FRA_6th_social_cost = 0.075 tooltip = social_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6th_monthly_pop = 0.05 tooltip = monthly_population_tt }
 		add_to_variable = { FRA_6thcons_goo = -0.05 tooltip = consumer_goods_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4773,9 +4563,7 @@ country_event = {
 		add_to_variable = { FRA_6th_bureaucracy_cost = -0.075 tooltip = bureaucracy_cost_multiplier_modifier_tt }
 		add_to_variable = { FRA_6th_monthly_pop = -0.025 tooltip = monthly_population_tt }
 		add_to_variable = { FRA_6th_research = -0.075 tooltip = research_speed_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4917,9 +4705,7 @@ country_event = {
 		add_to_variable = { FRA_6th_migrantrate = 0.075 tooltip = migration_rate_value_factor_tt }
 		newline = yes
 		country_event = { id = france_md.229 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4946,9 +4732,7 @@ country_event = {
 		add_to_variable = { FRA_6th_migrantrate = -0.075 tooltip = migration_rate_value_factor_tt }
 		newline = yes
 		country_event = { id = france_md.229 days = 7 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5091,9 +4875,7 @@ country_event = {
 		add_to_variable = { FRA_6th_driftdef = -0.1 tooltip = drift_defence_factor_tt }
 		add_to_variable = { FRA_6th_research = 0.075 tooltip = research_speed_factor_tt }
 		add_to_variable = { FRA_6threp_resistance_growth = -0.075 tooltip = resistance_growth_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5129,9 +4911,7 @@ country_event = {
 		add_to_variable = { FRA_6thcoredef = 0.075 tooltip = army_core_defence_factor_tt }
 		add_to_variable = { FRA_6thcoreatta = 0.05 tooltip = army_core_attack_factor_tt }
 		add_to_variable = { FRA_6th_corrupt = -0.075 tooltip = corruption_cost_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5200,10 +4980,7 @@ country_event = {
 			set_variable = { FRA_6th_tax_pop = 0 }
 			set_variable = { FRA_6th_tax_corpo = 0 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5222,9 +4999,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_political_power = -300
 		add_ideas = FRA_fail6threp
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5251,9 +5026,7 @@ country_event = {
 		set_temp_variable = { tag_index = FRA.id }
 		set_temp_variable = { influence_target = THIS.id }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	#refuse
@@ -5304,9 +5077,7 @@ country_event = {
 				country_event = france_md.239
 			}
 		}
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 #embargo on israel
@@ -5332,9 +5103,7 @@ country_event = {
 					target = PREV
 			}
 		}
-		ai_chance = {
-			factor = 4
-		}
+		ai_chance = { factor = 4 }
 	}
 
 	#refuse
@@ -5401,9 +5170,7 @@ country_event = {
 			modifier = supports_us
 			target = FRA
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	#refuse
@@ -5460,6 +5227,7 @@ country_event = {
 			}
 		}
 	}
+
 	#refuse
 	option = {
 		name = france_md.245.b
@@ -5501,9 +5269,7 @@ country_event = {
 		set_temp_variable = { modify_europeanism_target = THIS.id }
 		europeanism_change = yes
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5523,9 +5289,7 @@ country_event = {
 		set_temp_variable = { modify_europeanism = 0.1 }
 		set_temp_variable = { modify_europeanism_target = THIS.id }
 		europeanism_change = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #transition to green
@@ -6271,9 +6035,7 @@ country_event = {
 				target = UKR
 			}
 		}
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = {
@@ -6286,9 +6048,7 @@ country_event = {
 			}
 		}
 		add_war_support = 0.15
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -6329,9 +6089,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6355,9 +6113,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = {
@@ -6386,9 +6142,7 @@ country_event = {
 				target = ROOT
 			}
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -6411,9 +6165,7 @@ country_event = {
 					target = ROOT
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #faction with russia
@@ -6426,47 +6178,29 @@ country_event = { #faction with russia
 	option = {
 		name = france_md.261.a
 		log = "[GetDateText]: [This.GetName]: france_md.261.a executed"
-		FRA = {
-			country_event = france_md.262
-		}
-		SOV = {
-			add_ideas = FRA_russian_cooperation1
-		}
+		FRA = { country_event = france_md.262 }
+		SOV = { add_ideas = FRA_russian_cooperation1 }
 		add_stability = 0.1
-		ai_chance = {
-			factor = 3
-		}
+		ai_chance = { factor = 3 }
 	}
 
 	option = {
 		name = france_md.261.b
 		log = "[GetDateText]: [This.GetName]: france_md.261.b executed"
-		FRA = {
-			news_event = france_md.263
-		}
-		SOV = {
-			add_ideas = FRA_russian_cooperation2
-		}
+		FRA = { news_event = france_md.263 }
+		SOV = { add_ideas = FRA_russian_cooperation2 }
 		add_war_support = 0.15
-		ai_chance = {
-			factor = 4
-		}
+		ai_chance = { factor = 4 }
 	}
 
 	option = {
 		name = france_md.261.c
 		log = "[GetDateText]: [This.GetName]: france_md.261.c executed"
-		FRA = {
-			country_event = france_md.264
-		}
-		SOV = {
-			add_ideas = FRA_european_internationale
-		}
+		FRA = { country_event = france_md.264 }
+		SOV = { add_ideas = FRA_european_internationale }
 		add_war_support = 0.2
 		add_political_power = -100
-		ai_chance = {
-			factor = 3
-		}
+		ai_chance = { factor = 3 }
 	}
 
 	option = {
@@ -6474,9 +6208,7 @@ country_event = { #faction with russia
 		log = "[GetDateText]: [This.GetName]: france_md.261.d executed"
 		add_stability = 0.15
 		add_political_power = 150
-		FRA = {
-			country_event = france_md.265
-		}
+		FRA = { country_event = france_md.265 }
 		ai_chance = {
 			factor = 1
 			modifier = {
@@ -6497,9 +6229,7 @@ country_event = {
 		name = france_md.262.a
 		log = "[GetDateText]: [This.GetName]: france_md.262.a executed"
 		add_ideas = FRA_russian_cooperation1
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 news_event = {
@@ -6513,9 +6243,7 @@ news_event = {
 		name = france_md.263.a
 		log = "[GetDateText]: [This.GetName]: france_md.263.a executed"
 		add_ideas = FRA_russian_cooperation2
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -6541,9 +6269,7 @@ country_event = {
 			country = SOV
 			relation = guarantee
 		}
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -6562,9 +6288,7 @@ country_event = {
 		}
 		add_war_support = 0.3
 		add_political_power = -100
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -6586,9 +6310,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_political_power = 50
 		add_stability = 0.05
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 }
 country_event = {
@@ -6609,9 +6331,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.15 }
 		change_relative_party_popularity = yes
 		add_political_power = 50
-		ai_chance = {
-			factor = 1
-		}
+		ai_chance = { factor = 1 }
 	}
 
 	option = { #anger from nationalist
@@ -6652,9 +6372,7 @@ country_event = {
 		europeanism_change = yes
 		add_war_support = 0.075
 		add_political_power = -150
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	#refuse
@@ -6690,6 +6408,7 @@ country_event = {
 	desc = france_md.269.d
 	picture = GFX_european_union_flag
 	is_triggered_only = yes
+
 	option = {
 		name = france_md.269.a
 		log = "[GetDateText]: [This.GetName]: france_md.269.a executed"
@@ -6703,10 +6422,9 @@ country_event = {
 		add_stability = 0.025
 		add_war_support = -0.05
 		add_political_power = 50
-		ai_chance = {
-			factor = 2
-		}
+		ai_chance = { factor = 2 }
 	}
+
 	option = {
 		name = france_md.269.b
 		log = "[GetDateText]: [This.GetName]: france_md.269.b executed"
@@ -6719,9 +6437,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = -0.025
 		add_war_support = 0.075
-		ai_chance = {
-			factor = 4
-		}
+		ai_chance = { factor = 4 }
 	}
 }
 country_event = {
@@ -6749,9 +6465,7 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 
 	option = {
@@ -6760,9 +6474,7 @@ country_event = {
 		add_political_power = 35
 		add_stability = 0.1
 		add_war_support = 0.05
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -6801,9 +6513,7 @@ country_event = {
 			}
 		}
 		add_war_support = 0.075
-		ai_chance = {
-			factor = 6
-		}
+		ai_chance = { factor = 6 }
 	}
 
 	option = {
@@ -6842,47 +6552,29 @@ country_event = {
 	option = {
 		name = france_md.272.a
 		log = "[GetDateText]: [This.GetName]: france_md.272.a executed"
-		FRA = {
-			country_event = france_md.273
-		}
-		SOV = {
-			add_ideas = FRA_russian_cooperation1
-		}
+		FRA = { country_event = france_md.273 }
+		SOV = { add_ideas = FRA_russian_cooperation1 }
 		add_stability = 0.1
-		ai_chance = {
-			factor = 6
-		}
+		ai_chance = { factor = 6 }
 	}
 
 	option = {
 		name = france_md.272.b
 		log = "[GetDateText]: [This.GetName]: france_md.272.b executed"
-		FRA = {
-			news_event = france_md.274
-		}
-		SOV = {
-			add_ideas = FRA_russian_cooperation2
-		}
+		FRA = { news_event = france_md.274 }
+		SOV = { add_ideas = FRA_russian_cooperation2 }
 		add_war_support = 0.15
-		ai_chance = {
-			factor = 6
-		}
+		ai_chance = { factor = 6 }
 	}
 
 	option = {
 		name = france_md.272.c
 		log = "[GetDateText]: [This.GetName]: france_md.272.c executed"
-		FRA = {
-			country_event = france_md.275
-		}
-		SOV = {
-			add_ideas = FRA_Boreal_Space
-		}
+		FRA = { country_event = france_md.275 }
+		SOV = { add_ideas = FRA_Boreal_Space }
 		add_war_support = 0.2
 		add_political_power = -100
-		ai_chance = {
-			factor = 6
-		}
+		ai_chance = { factor = 6 }
 	}
 
 	option = {
@@ -6890,9 +6582,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: france_md.272.d executed"
 		add_stability = 0.15
 		add_political_power = 150
-		FRA = {
-			country_event = france_md.276
-		}
+		FRA = { country_event = france_md.276 }
 		ai_chance = {
 			factor = 2
 			modifier = {
@@ -6913,9 +6603,7 @@ country_event = {
 		name = france_md.273.a
 		log = "[GetDateText]: [This.GetName]: france_md.273.a executed"
 		add_ideas = FRA_russian_cooperation1
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 news_event = {
@@ -6929,9 +6617,7 @@ news_event = {
 		name = france_md.274.a
 		log = "[GetDateText]: [This.GetName]: france_md.274.a executed"
 		add_ideas = FRA_russian_cooperation2
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -6957,9 +6643,7 @@ country_event = {
 			country = SOV
 			relation = guarantee
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -6978,9 +6662,7 @@ country_event = {
 		}
 		add_stability = 0.05
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #propose help to africa to kick russia out
@@ -7016,9 +6698,7 @@ country_event = { #propose help to africa to kick russia out
 					target = ROOT
 			}
 		}
-		ai_chance = {
-			factor = 4
-		}
+		ai_chance = { factor = 4 }
 	}
 
 	#refuse
@@ -7076,9 +6756,7 @@ country_event = { #communist frexit reaction
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -7125,9 +6803,7 @@ country_event = {
 		add_war_support = -0.05
 		add_stability = 0.1
 		add_political_power = 50
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 	}
 }
 country_event = { #call for world revolution
@@ -7158,9 +6834,7 @@ country_event = { #call for world revolution
 		add_stability = -0.05
 		add_war_support = 0.15
 		add_political_power = 100
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	#refuse
@@ -7180,9 +6854,7 @@ country_event = { #call for world revolution
 		add_war_support = -0.1
 		add_stability = 0.15
 		add_political_power = 50
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 country_event = { #military reform
@@ -7203,9 +6875,7 @@ country_event = { #military reform
 		hidden_effect = {
 			country_event = { id = france_md.282 days = 250 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #military reform end
@@ -7221,9 +6891,7 @@ country_event = { #military reform end
 		log = "[GetDateText]: [This.GetName]: france_md.282.a executed"
 		add_ideas = FRA_army_reformed_1
 		set_variable = { FRA_grande_armee_reforms_completed = 1 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #infantry or cavalry
@@ -7245,9 +6913,7 @@ country_event = { #infantry or cavalry
 			}
 			set_variable = { FRA_grande_armee_reforms_completed = 2 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	#cavalry
@@ -7262,9 +6928,7 @@ country_event = { #infantry or cavalry
 			}
 			set_variable = { FRA_grande_armee_reforms_completed = 2 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #artillery or aircraft
@@ -7294,9 +6958,7 @@ country_event = { #artillery or aircraft
 			}
 			set_variable = { FRA_grande_armee_reforms_completed = 3 }
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
 	#air
@@ -7319,9 +6981,7 @@ country_event = { #artillery or aircraft
 			}
 			set_variable = { FRA_grande_armee_reforms_completed = 3 }
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 country_event = { #frexit or scam
@@ -7366,9 +7026,7 @@ country_event = { #frexit or scam
 					country_event = france_md.286
 				}
 			}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 country_event = { #same frexit but napoleon
@@ -7388,9 +7046,7 @@ country_event = { #same frexit but napoleon
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { # BCE scam give money
@@ -7417,9 +7073,7 @@ country_event = { # BCE scam give money
 		set_temp_variable = { party_popularity_increase = 0.1 }
 		set_temp_variable = { temp_outlook_increase = 0.1 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { # BCE refuse
@@ -7494,9 +7148,7 @@ country_event = { #EU member scam
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		change_relative_party_popularity = yes
 		add_political_power = -50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #proclamation empire
@@ -7575,6 +7227,7 @@ country_event = { #boost nationalism
 			}
 		}
 	}
+
 	option = {
 		name = france_md.291.b
 		log = "[GetDateText]: [This.GetName]: france_md.291.b executed"
@@ -7588,9 +7241,7 @@ country_event = { #boost nationalism
 		FRA = {
 			add_opinion_modifier = { target = ROOT modifier = major_breach_of_trust }
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = { #debuff non nationalism
@@ -7609,9 +7260,7 @@ country_event = { #debuff non nationalism
 		add_timed_idea = { idea = FRA_nationalism_in_europe days = 365 }
 		add_war_support = -0.1
 		add_stability = -0.15
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #surrounded by ennemy
@@ -7731,9 +7380,7 @@ country_event = {
 		FRA = {
 			add_opinion_modifier = { target = ROOT modifier = major_breach_of_trust }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #propose alliance to all communist state
@@ -8050,9 +7697,7 @@ country_event = { #other react to french attack
 				idea = FRA_defense_napoleon
 				days = 365
 		}
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = { #its fine
@@ -8176,9 +7821,7 @@ country_event = {
 		FRA = {
 			add_opinion_modifier = { target = ROOT modifier = major_breach_of_trust }
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -8245,9 +7888,7 @@ country_event = {
 		FRA = {
 			add_opinion_modifier = { target = FROM modifier = major_breach_of_trust }
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = {
@@ -8286,9 +7927,7 @@ country_event = {
 		name = france_md.302.b
 		log = "[GetDateText]: [This.GetName]: france_md.302.b executed"
 		add_stability = 0.05
-		USA = {
-			country_event = france_md.304
-		}
+		USA = { country_event = france_md.304 }
 		ai_chance = {
 			base = 3
 			modifier = {
@@ -8334,9 +7973,7 @@ country_event = {
 		name = france_md.302.d
 		log = "[GetDateText]: [This.GetName]: france_md.302.d executed"
 		add_political_power = 100
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -8431,9 +8068,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.025 }
 		change_relative_party_popularity = yes
-		FRA = {
-			add_ideas = FRA_trade_USA
-		}
+		FRA = { add_ideas = FRA_trade_USA }
 		add_ideas = FRA_trade_USA
 		ENG = {
 			add_opinion_modifier = { target = USA modifier = major_breach_of_trust }
@@ -8490,9 +8125,7 @@ country_event = { #react frexit royalist
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #boost monarch families nice
@@ -8511,9 +8144,7 @@ country_event = { #boost monarch families nice
 		change_relative_party_popularity = yes
 		add_stability = 0.1
 		add_political_power = 150
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #boost monarch families uncool
@@ -8532,9 +8163,7 @@ country_event = { #boost monarch families uncool
 		change_relative_party_popularity = yes
 		add_stability = -0.075
 		add_political_power = -50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #propose alliance to all eu christian
@@ -8584,6 +8213,7 @@ country_event = { #propose alliance to all eu christian
 			}
 		}
 	}
+
 	option = { #no
 		name = france_md.308.b
 		log = "[GetDateText]: [This.GetName]: france_md.308.b executed"
@@ -8619,6 +8249,7 @@ country_event = { #plan to reach jerusalem
 			base = 5
 		}
 	}
+
 	option = { #buildup navy
 		name = france_md.309.b
 		log = "[GetDateText]: [This.GetName]: france_md.309.b executed"
@@ -8893,9 +8524,7 @@ country_event = { #attack benelux
 		add_manpower = 10000
 		add_war_support = 0.05
 		add_timed_idea = { idea = FRA_attack_benelux days = 70 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #attack iberia
@@ -8912,9 +8541,7 @@ country_event = { #attack iberia
 		add_war_support = 0.075
 		add_timed_idea = { idea = FRA_attack_iberia days = 100 }
 		add_ideas = FRA_counter_insurgency
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #attack germany
@@ -8930,9 +8557,7 @@ country_event = { #attack germany
 		add_manpower = 20000
 		add_war_support = 0.1
 		add_timed_idea = { idea = FRA_attack_germany days = 130 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #attack mid europe
@@ -8948,9 +8573,7 @@ country_event = { #attack mid europe
 		add_manpower = 15000
 		add_war_support = 0.1
 		add_timed_idea = { idea = FRA_attack_holy_roman days = 150 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #french provide support
@@ -8966,9 +8589,7 @@ country_event = { #french provide support
 		add_manpower = 15000
 		add_war_support = 0.1
 		add_timed_idea = { idea = FRA_BON_support_allies days = 300 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #attack eastern
@@ -8984,9 +8605,7 @@ country_event = { #attack eastern
 		add_manpower = 20000
 		add_war_support = 0.12
 		add_timed_idea = { idea = FRA_attack_east days = 200 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #attack russia and neightbor
@@ -9002,9 +8621,7 @@ country_event = { #attack russia and neightbor
 		add_manpower = 50000
 		add_war_support = 0.15
 		add_timed_idea = { idea = FRA_attack_russia_fast days = 150 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -9038,10 +8655,9 @@ country_event = { #attack UK
 		add_manpower = 20000
 		add_war_support = 0.1
 		add_timed_idea = { idea = FRA_attack_UK_naval days = 130 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = france_md.476.b
 		log = "[GetDateText]: [This.GetName]: france_md.476.b executed"
@@ -9073,9 +8689,7 @@ country_event = { #victory napoleon
 		add_stability = 0.3
 		add_war_support = 0.2
 		add_ideas = FRA_BON_victory
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #TODO give king some traits about their model
@@ -9094,6 +8708,7 @@ country_event = { #choose expansion policy
 			base = 4
 		}
 	}
+
 	option = { #become saint louis start crusadind around
 		name = france_md.478.b
 		log = "[GetDateText]: [This.GetName]: france_md.478.b executed"
@@ -9184,6 +8799,7 @@ country_event = { #target said no
 			base = 3
 		}
 	}
+
 	option = { #nothing
 		name = france_md.481.b
 		log = "[GetDateText]: [This.GetName]: france_md.481.b executed"
@@ -9366,9 +8982,7 @@ country_event = { #victory charlemagne empire of occident
 		add_ideas = FRA_EMPIRE_occident
 		set_cosmetic_tag = FRA_Occident_Empire
 		remove_ideas = FRA_expansion_europe
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -9378,9 +8992,7 @@ country_event = { #victory charlemagne empire of occident
 		add_ideas = FRA_EMPIRE_occident
 		remove_ideas = FRA_expansion_europe
 		add_ideas = FRA_expansion_europe_crusades
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = { #france demand road to jerusalem
@@ -9611,9 +9223,7 @@ country_event = { #integration of natural border
 		40 = { add_core_of = FRA }
 		966 = { add_core_of = FRA }
 		967 = { add_core_of = FRA }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #integration of frank
@@ -9636,9 +9246,7 @@ country_event = { #integration of frank
 		40 = { add_core_of = FRA }
 		966 = { add_core_of = FRA }
 		72 = { add_core_of = FRA }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #integration of carolingian empire
@@ -9702,9 +9310,7 @@ country_event = { #integration of carolingian empire
 		92 = { add_core_of = FRA }
 		86 = { add_core_of = FRA }
 		945 = { add_core_of = FRA }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #integration of kindgom of heaven
@@ -9757,9 +9363,7 @@ country_event = { #integration of kindgom of heaven
 		161 = { add_core_of = FRA }
 		934 = { add_core_of = FRA }
 		146 = { add_core_of = FRA }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -9789,9 +9393,7 @@ country_event = { #core napoleon empire
 		46 = { add_core_of = FRA }
 		125 = { add_core_of = FRA }
 		126 = { add_core_of = FRA }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -9808,9 +9410,7 @@ country_event = { #attack colonies
 		add_manpower = 20000
 		add_war_support = 0.2
 		add_timed_idea = { idea = FRA_attack_colonies days = 200 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = { #france demand annexation
@@ -9989,9 +9589,7 @@ country_event = { #invest civ
 			set_temp_variable = { int_investment_change = 4 }
 			modify_international_investment_effect = yes
 		}
-		ai_chance = {
-			base = 8
-		}
+		ai_chance = { base = 8 }
 	}
 
 	option = {
@@ -10004,9 +9602,7 @@ country_event = { #invest civ
 			set_temp_variable = { treasury_change = 4 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 country_event = { #invest infrastructure
@@ -10035,9 +9631,7 @@ country_event = { #invest infrastructure
 			}
 		}
 		random_owned_controlled_state = {
-			limit = {
-				infrastructure < 5
-			}
+			limit = { infrastructure < 5 }
 			add_building_construction = {
 				type = infrastructure
 				level = 1
@@ -10058,9 +9652,7 @@ country_event = { #invest infrastructure
 			set_temp_variable = { int_investment_change = 3 }
 			modify_international_investment_effect = yes
 		}
-		ai_chance = {
-			base = 8
-		}
+		ai_chance = { base = 8 }
 	}
 
 	option = {
@@ -10073,9 +9665,7 @@ country_event = { #invest infrastructure
 			set_temp_variable = { treasury_change = 3 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 #invest ecology
@@ -10148,9 +9738,7 @@ country_event = {
 			set_temp_variable = { int_investment_change = 4 }
 			modify_international_investment_effect = yes
 		}
-		ai_chance = {
-			base = 8
-		}
+		ai_chance = { base = 8 }
 	}
 
 	option = {
@@ -10163,9 +9751,7 @@ country_event = {
 			set_temp_variable = { treasury_change = 4 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 
@@ -11615,7 +11201,6 @@ news_event = {
 				modifier = recent_actions_negative
 			}
 		}
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -11775,7 +11360,6 @@ news_event = {
 			}
 		}
 		country_event = { id = france_md.374 days = 5 }
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -12075,19 +11659,17 @@ country_event = {
 	id = france_md.801
 	title = france_md.801.t
 	desc = france_md.801.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	trigger = { original_tag = FRA }
 
 	# Reject American overtures
 	option = {
 		name = france_md.801.a
 		log = "[GetDateText]: [This.GetName]: france_md.801.a executed"
-		trigger = {
-			FRA_on_anti_american_path = yes
-		}
+		trigger = { FRA_on_anti_american_path = yes }
 		add_political_power = 25
 		add_stability = 0.02
 		USA = {
@@ -12103,9 +11685,7 @@ country_event = {
 	option = {
 		name = france_md.801.b
 		log = "[GetDateText]: [This.GetName]: france_md.801.b executed"
-		trigger = {
-			NOT = { FRA_on_far_left_path = yes }
-		}
+		trigger = { NOT = { FRA_on_far_left_path = yes } }
 		add_political_power = -25
 		USA = {
 			add_opinion_modifier = {
@@ -12389,9 +11969,7 @@ country_event = {
 	option = {
 		name = france_md.807.c
 		log = "[GetDateText]: [This.GetName]: france_md.807.c executed"
-		trigger = {
-			has_government = nationalist
-		}
+		trigger = { has_government = nationalist }
 		add_political_power = 50
 		add_stability = -0.15
 		add_war_support = -0.20
@@ -12506,10 +12084,10 @@ country_event = {
 	id = france_md.810
 	title = france_md.810.t
 	desc = france_md.810.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	trigger = { original_tag = GER }
 
 	# Express concern about Franco-German axis
@@ -13234,10 +12812,10 @@ country_event = {
 	id = france_md.931
 	title = france_md.931.t
 	desc = france_md.931.d
-	# picture = GFX_politics_negociations
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	# picture = GFX_politics_negociations
 	# Compromise reached
 	option = {
 		name = france_md.931.a
@@ -13623,9 +13201,7 @@ country_event = {
 		name = france_md.952.b
 		log = "[GetDateText]: [This.GetName]: france_md.952.b executed"
 		random_list = {
-			40 = {
-				add_stability = 0.02
-			}
+			40 = { add_stability = 0.02 }
 			60 = {
 				add_stability = -0.03
 				add_political_power = -50
@@ -13737,7 +13313,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: france_md.954.b executed"
 		add_stability = -0.05
 		add_political_power = -100
-
 		random_list = {
 			40 = { # Success
 				country_event = { id = france_md.556 days = 60 }
@@ -13943,9 +13518,7 @@ country_event = {
 				add_idea = FRA_terror_threat_critical
 			}
 		}
-		else = {
-			add_ideas = FRA_terror_threat_critical
-		}
+		else = { add_ideas = FRA_terror_threat_critical }
 		ai_chance = { base = 5 }
 	}
 
@@ -14910,6 +14483,7 @@ country_event = { #1st tour day
 	desc = france_md.511.d
 	picture = GFX_election_day
 	is_triggered_only = yes
+
 	timeout_days = 5
 	option = { #result
 		name = france_md.511.a
@@ -16011,9 +15585,7 @@ country_event = {
 			idea = FRA_PCF_EUtrain
 			days = 730
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -16039,9 +15611,7 @@ country_event = {
 
 	option = {
 		name = france_md.555.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -16059,9 +15629,7 @@ country_event = {
 		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -16100,6 +15668,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = france_md.600.b
 		log = "[GetDateText]: [Root.GetName]: france_md.600.b executed"
@@ -16420,15 +15989,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 
-	trigger = {
-		FRA_cs_outcome_settled = no
-	}
+	trigger = { FRA_cs_outcome_settled = no }
 
 	option = {
 		name = france_md.606.a
-		trigger = {
-			has_country_flag = FRA_cs_public_control
-		}
+		trigger = { has_country_flag = FRA_cs_public_control }
 		log = "[GetDateText]: [Root.GetName]: france_md.606.a executed"
 		effect_tooltip = { add_ideas = FRA_cs_nationalised_systems_champion }
 		hidden_effect = { FRA_cs_apply_nationalised_systems_champion = yes }
@@ -16489,7 +16054,6 @@ country_event = {
 		FRA_corporate_systems_event_1_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.1.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.1.a executed"
@@ -16529,7 +16093,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_3_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.3.a
@@ -16571,7 +16134,6 @@ country_event = {
 		FRA_corporate_systems_event_6_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.6.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.6.a executed"
@@ -16611,7 +16173,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_7_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.7.a
@@ -16653,7 +16214,6 @@ country_event = {
 		FRA_corporate_systems_event_10_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.10.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.10.a executed"
@@ -16693,7 +16253,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_11_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.11.a
@@ -16735,7 +16294,6 @@ country_event = {
 		FRA_corporate_systems_event_13_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.13.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.13.a executed"
@@ -16775,7 +16333,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_14_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.14.a
@@ -16822,7 +16379,6 @@ country_event = {
 		FRA_corporate_systems_event_16_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.16.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.16.a executed"
@@ -16862,7 +16418,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_17_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.17.a
@@ -16904,7 +16459,6 @@ country_event = {
 		FRA_corporate_systems_event_20_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.20.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.20.a executed"
@@ -16944,7 +16498,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_21_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.21.a
@@ -16986,7 +16539,6 @@ country_event = {
 		FRA_corporate_systems_event_22_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.22.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.22.a executed"
@@ -17026,7 +16578,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_24_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.24.a
@@ -17069,7 +16620,6 @@ country_event = {
 		FRA_corporate_systems_event_25_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.25.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.25.a executed"
@@ -17110,7 +16660,6 @@ country_event = {
 		FRA_corporate_systems_event_26_eligible = yes
 	}
 
-
 	option = {
 		name = FRA_corporate_systems_events.26.a
 		log = "[GetDateText]: [Root.GetName]: FRA_corporate_systems_events.26.a executed"
@@ -17150,7 +16699,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_27_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.27.a
@@ -17196,7 +16744,6 @@ country_event = {
 		NOT = { has_country_flag = collapsed_nation }
 		FRA_corporate_systems_event_28_eligible = yes
 	}
-
 
 	option = {
 		name = FRA_corporate_systems_events.28.a

--- a/events/Venezuela.txt
+++ b/events/Venezuela.txt
@@ -28,10 +28,7 @@ country_event = {
 	}
 
 	# Denounce the Recall Election
-	option = {
-		name = venezuela.1.b
-
-	}
+	option = { name = venezuela.1.b }
 }
 
 # 2004 - Recall Referendum Results
@@ -163,8 +160,8 @@ country_event = {
 	id = gca.1
 	title = gca.1.t
 	desc = gca.1.d
-	is_triggered_only = yes
 	picture = GFX_grancolo
+	is_triggered_only = yes
 
 	# We will join
 	option = {
@@ -204,7 +201,6 @@ country_event = {
 	option = {
 		name = gca.1.b
 		log = "[GetDateText]: [This.GetName]: gca.1.b executed"
-
 		VEN = {
 			country_event = { id = gca.3 days = 1 }
 		}
@@ -226,18 +222,14 @@ country_event = {
 	id = gca.2
 	title = gca.2.t
 	desc = gca.2.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
 
 	# Great they joined
 	option = {
 		name = gca.2.a
 		log = "[GetDateText]: [This.GetName]: gca.2.a executed"
-		effect_tooltip = {
-			VEN = {
-				add_to_faction = FROM
-			}
-		}
+		effect_tooltip = { VEN = { add_to_faction = FROM } }
 	}
 }
 
@@ -246,27 +238,24 @@ country_event = {
 	id = gca.3
 	title = gca.3.t
 	desc = gca.3.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
 
-	option = {
-		name = gca.3.a
-	}
+	option = { name = gca.3.a }
 }
 # Curacao Return
 country_event = {
 	id = venezuela.8
 	title = venezuela.8.t
 	desc = venezuela.8.d
-	is_triggered_only = yes
 	picture = GFX_venez_carac
+	is_triggered_only = yes
+
 	# Will give the state option
 	option = {
 		name = venezuela.8.a
 		log = "[GetDateText]: [This.GetName]: venezuela.8.a executed"
-		VEN = {
-			country_event = venezuela.9
-		}
+		VEN = { country_event = venezuela.9 }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -274,21 +263,16 @@ country_event = {
 				add = 10
 			}
 		}
-		VEN = {
-			add_state_claim = 49
-		}
+		VEN = { add_state_claim = 49 }
 	}
+
 	# Will not give the state option
 	option = {
 		name = venezuela.8.b
 		log = "[GetDateText]: [This.GetName]: venezuela.8.b executed"
-		VEN = {
-			country_event = venezuela.10
-		}
+		VEN = { country_event = venezuela.10 }
 		ai_chance = { base = 5 }
-		VEN = {
-			add_state_claim = 49
-		}
+		VEN = { add_state_claim = 49 }
 	}
 }
 
@@ -299,7 +283,6 @@ country_event = {
 	desc = venezuela.9.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-
 
 	option = {
 		name = venezuela.9.a
@@ -316,7 +299,6 @@ country_event = {
 	desc = venezuela.10.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
-
 
 	option = {
 		name = venezuela.10.a
@@ -352,32 +334,27 @@ country_event = {
 		name = venezuela.11.o1
 		log = "[GetDateText]: [This.GetName]: venezuela.11.o1 executed"
 		VEN = { country_event = { id = venezuela.12 days = 1 } }
-
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
+
 	# Peru Refuses!
 	option = {
 		name = venezuela.11.o2
 		log = "[GetDateText]: [This.GetName]: venezuela.11.o2 executed"
 		VEN = { country_event = { id = venezuela.13 days = 1 } }
-
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
 
 
 	# Good Choice
-	country_event = {
-		id = venezuela.12
-		title = venezuela.12.t
-		desc = venezuela.12.d
-		picture = GFX_treaty
-		is_triggered_only = yes
+country_event = {
+	id = venezuela.12
+	title = venezuela.12.t
+	desc = venezuela.12.d
+	picture = GFX_treaty
+	is_triggered_only = yes
 
 		option = {
 		name = venezuela.12.o1
@@ -386,18 +363,16 @@ country_event = {
 			limit = { PRU = { NOT = { is_subject_of = VEN } } }
 			VEN = { puppet = PRU }
 		}
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 }
 # That was a mistake
 country_event = {
-		id = venezuela.13
-		title = venezuela.13.t
-		desc = venezuela.13.d
-		picture = GFX_treaty_rejected
-		is_triggered_only = yes
+	id = venezuela.13
+	title = venezuela.13.t
+	desc = venezuela.13.d
+	picture = GFX_treaty_rejected
+	is_triggered_only = yes
 
 		option = {
 			name = venezuela.13.o1
@@ -414,10 +389,7 @@ country_event = {
 					add_opinion_modifier = { target = PRU modifier = threat_to_our_independence }
 				}
 			}
-
-			ai_chance = {
-				base = 25
-			}
+			ai_chance = { base = 25 }
 		}
 }
 
@@ -435,31 +407,25 @@ country_event = {
 		name = venezuela.16.o1
 		log = "[GetDateText]: [This.GetName]: venezuela.16.o1 executed"
 		VEN = { country_event = { id = venezuela.17 days = 1 } }
-
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	# Panama Refuses!
 	option = {
 		name = venezuela.16.o2
 		log = "[GetDateText]: [This.GetName]: venezuela.16.o2 executed"
 		VEN = { country_event = { id = venezuela.18 days = 1 } }
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
 # Good Choice
-	country_event = {
-		id = venezuela.17
-		title = venezuela.17.t
-		desc = venezuela.17.d
-		picture = GFX_treaty
-		is_triggered_only = yes
+country_event = {
+	id = venezuela.17
+	title = venezuela.17.t
+	desc = venezuela.17.d
+	picture = GFX_treaty
+	is_triggered_only = yes
 
 		option = {
 		name = venezuela.17.o1
@@ -468,9 +434,7 @@ country_event = {
 			limit = { PAN = { NOT = { is_subject_of = VEN } } }
 			VEN = { puppet = PAN }
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 # That was a mistake
@@ -496,9 +460,7 @@ country_event = {
 				add_opinion_modifier = { target = PAN modifier = threat_to_our_independence }
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #
@@ -508,6 +470,7 @@ country_event = {
 	desc = venezuela.19.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = venezuela.19.a
 		log = "[GetDateText]: [This.GetName]: venezuela.19.a executed"
@@ -536,6 +499,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = venezuela.19.b
 		log = "[GetDateText]: [This.GetName]: venezuela.19.b executed"
@@ -561,6 +525,7 @@ country_event = {
 	desc = venezuela.20.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = venezuela.20.a
 		log = "[GetDateText]: [This.GetName]: venezuela.20.a executed"
@@ -571,10 +536,7 @@ country_event = {
 				active = yes
 			}
 		}
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 #
@@ -584,12 +546,10 @@ country_event = {
 	desc = venezuela.21.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	option = {
 		name = venezuela.21.a
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 # Venezuela asks us to establish military bases
@@ -599,15 +559,12 @@ country_event = {
 	desc = venezuela.22.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = venezuela.22.a
 		log = "[GetDateText]: [This.GetName]: venezuela.22.a executed"
-		VEN = {
-			give_military_access = USA
-		}
-		USA = {
-			give_military_access = VEN
-		}
+		VEN = { give_military_access = USA }
+		USA = { give_military_access = VEN }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -616,6 +573,7 @@ country_event = {
 			}
 		}
 	}
+
 	#
 	option = {
 		name = venezuela.22.b
@@ -643,12 +601,10 @@ country_event = {
 	desc = venezuela.23.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = {
 		name = venezuela.23.a
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -658,6 +614,7 @@ country_event = {
 	title = venezuela.24.t
 	desc = venezuela.24.d
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = VEN
 		has_country_leader = { name = "Hugo Chávez" ruling_only = yes }
@@ -667,7 +624,6 @@ country_event = {
 	option = {
 		name = venezuela.24.a
 		log = "[GetDateText]: [This.GetName]: venezuela.24.a executed"
-
 		create_country_leader = {
 			name = "Nicolás Maduro"
 			picture = "Nicolas_Maduro.dds"
@@ -678,10 +634,7 @@ country_event = {
 				career_politician
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -693,6 +646,7 @@ country_event = {
 	desc = venezuela.100.d
 	picture = GFX_election_day
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = VEN
 		emerging_anarchist_communism_in_power_or_coalition = yes
@@ -702,12 +656,8 @@ country_event = {
 	option = {
 		name = venezuela.100.a
 		log = "[GetDateText]: [This.GetName]: venezuela.100.a executed"
-
 		country_event = MD4_election_campaign.0
-		hidden_effect = {
-			set_elections_72_months = yes
-		}
-
+		hidden_effect = { set_elections_72_months = yes }
 		ai_chance = { base = 50 }
 	}
 }
@@ -720,8 +670,8 @@ country_event = {
 	picture = GFX_election_day
 	is_triggered_only = yes
 	fire_only_once = yes
-	# picture =
 
+	# picture =
 	trigger = {
 		original_tag = VEN
 		emerging_anarchist_communism_in_power_or_coalition = yes
@@ -748,13 +698,12 @@ country_event = {
 	id = venezuela.200
 	title = venezuela.200.t
 	desc = venezuela.200.d
-	is_triggered_only = yes
 	picture = GFX_stock_market
+	is_triggered_only = yes
 
 	option = {
 		name = venezuela.200.a
 		log = "[GetDateText]: [This.GetName]: venezuela.200.a executed"
-
 		if = { limit = { original_tag = SOV }
 			SOV = {
 				add_opinion_modifier = { target = ROOT modifier = economic_mission }
@@ -810,7 +759,6 @@ country_event = {
 			set_temp_variable = { sender_nation = VEN.id }
 			set_improved_trade_agreement = yes
 		}
-
 		set_country_flag = VEN_accepted_deal
 		VEN = { country_event = venezuela.201 }
 	}
@@ -818,7 +766,6 @@ country_event = {
 	option = {
 		name = venezuela.200.b
 		log = "[GetDateText]: [This.GetName]: venezuela.200.b executed"
-
 		set_country_flag = VEN_refused_deal
 		VEN = { country_event = venezuela.201 }
 	}
@@ -827,39 +774,28 @@ country_event = {
 country_event = {
 	id = venezuela.201
 	title = {
-		trigger = {
-			FROM = { has_country_flag = VEN_accepted_deal }
-		}
+		trigger = { FROM = { has_country_flag = VEN_accepted_deal } }
 		text = venezuela.201.t1
 	}
 	title = {
-		trigger = {
-			FROM = { has_country_flag = VEN_refused_deal }
-		}
+		trigger = { FROM = { has_country_flag = VEN_refused_deal } }
 		text = venezuela.201.t2
 	}
 	desc = {
-		trigger = {
-			FROM = { has_country_flag = VEN_accepted_deal }
-		}
+		trigger = { FROM = { has_country_flag = VEN_accepted_deal } }
 		text = venezuela.201.d1
 	}
 	desc = {
-		trigger = {
-			FROM = { has_country_flag = VEN_refused_deal }
-		}
+		trigger = { FROM = { has_country_flag = VEN_refused_deal } }
 		text = venezuela.201.d2
 	}
-	is_triggered_only = yes
 	picture = GFX_stock_market
+	is_triggered_only = yes
 
 	option = {
 		name = venezuela.201.a
 		log = "[GetDateText]: [This.GetName]: venezuela.201.a executed"
-		trigger = {
-			FROM = { has_country_flag = VEN_accepted_deal }
-		}
-
+		trigger = { FROM = { has_country_flag = VEN_accepted_deal } }
 		effect_tooltip = {
 			if = { limit = { FROM = { original_tag = SOV } }
 				SOV = {
@@ -915,7 +851,6 @@ country_event = {
 				set_improved_trade_agreement = yes
 			}
 		}
-
 		hidden_effect = {
 			FROM = {
 				clr_country_flag = VEN_accepted_deal
@@ -927,10 +862,7 @@ country_event = {
 	option = {
 		name = venezuela.201.b
 		log = "[GetDateText]: [This.GetName]: venezuela.201.b executed"
-		trigger = {
-			FROM = { has_country_flag = VEN_refused_deal }
-		}
-
+		trigger = { FROM = { has_country_flag = VEN_refused_deal } }
 		hidden_effect = {
 			FROM = {
 				clr_country_flag = VEN_accepted_deal

--- a/events/cartel_events.txt
+++ b/events/cartel_events.txt
@@ -6,14 +6,13 @@ country_event = {
 	id = cartel_event.1
 	title = cartel_event.1.t
 	desc = cartel_event.1.d
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = cartel_event.1.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.1.a executed"
-
 		country_event = {
 			id = cartel_event.2
 			days = 7
@@ -25,9 +24,12 @@ country_event = {
 # Splitting Up Mexico
 country_event = {
 	id = cartel_event.2
+	is_triggered_only = yes
+	hidden = yes
+	fire_only_once = yes
+
 	immediate = {
 		log = "[GetDateText]: [Root.GetName]: event cartel_event.2"
-
 		# Baja California
 		if = {
 			limit = {
@@ -216,16 +218,11 @@ country_event = {
 			}
 		}
 		else = { MEX = { load_oob = "cartel_840" } }
-
 		country_event = {
 			id = cartel_event.14
 			days = 7
 		}
 	}
-
-	fire_only_once = yes
-	is_triggered_only = yes
-	hidden = yes
 }
 
 # Pick from All 3 factions
@@ -233,10 +230,9 @@ country_event = {
 	id = cartel_event.3
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with SLA
 	option = {
@@ -248,6 +244,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Side with TRC
 	option = {
 		name = cartel_event.3.b
@@ -258,6 +255,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Side with TAM
 	option = {
 		name = cartel_event.3.c
@@ -268,6 +266,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -284,10 +283,9 @@ country_event = {
 	id = cartel_event.4
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with SLA
 	option = {
@@ -299,6 +297,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Side with TRC
 	option = {
 		name = cartel_event.3.b
@@ -309,6 +308,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -325,10 +325,9 @@ country_event = {
 	id = cartel_event.5
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with SLA
 	option = {
@@ -340,6 +339,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Side with TRC
 	option = {
 		name = cartel_event.3.c
@@ -350,6 +350,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -366,10 +367,9 @@ country_event = {
 	id = cartel_event.6
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with SLA
 	option = {
@@ -381,6 +381,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -397,10 +398,9 @@ country_event = {
 	id = cartel_event.7
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with TRC
 	option = {
@@ -412,6 +412,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Side with TAM
 	option = {
 		name = cartel_event.3.c
@@ -422,6 +423,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -438,10 +440,9 @@ country_event = {
 	id = cartel_event.8
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with TRC
 	option = {
@@ -453,6 +454,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -469,10 +471,9 @@ country_event = {
 	id = cartel_event.9
 	title = cartel_event.3.t
 	desc = cartel_event.3.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Side with TAM
 	option = {
@@ -484,6 +485,7 @@ country_event = {
 			days = 1
 		}
 	}
+
 	# Stick with Mexico
 	option = {
 		name = cartel_event.3.e
@@ -500,10 +502,9 @@ country_event = {
 	id = cartel_event.10
 	title = cartel_event.10.t
 	desc = cartel_event.10.d
-
-	fire_only_once = yes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = cartel_event.10.a
@@ -516,6 +517,10 @@ country_event = {
 # This process is less AIDS. Unless PDX math says 0.99 = 1 then they really do want me to suffer
 country_event = {
 	id = cartel_event.11
+	is_triggered_only = yes
+	hidden = yes
+	fire_only_once = yes
+
 	immediate = {
 		log = "[GetDateText]: [Root.GetName]: event cartel_event.11"
 		if = {
@@ -696,31 +701,28 @@ country_event = {
 			}
 		}
 	}
-
-	fire_only_once = yes
-	is_triggered_only = yes
-	hidden = yes
 }
 
 country_event = {
 	id = cartel_event.12
 	title = cartel_event.12.t
 	desc = cartel_event.12.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
 	option = {
 		name = cartel_event.12.a
-
 		# Effect is handled by the remove effect of the decision
-
 	}
 }
 
 # Event to start the Mexican Cartel War
 country_event = {
 	id = cartel_event.13
+	is_triggered_only = yes
+	hidden = yes
+	fire_only_once = yes
+
 	immediate = {
 		log = "[GetDateText]: [Root.GetName]: event cartel_event.13"
 		if = {
@@ -781,13 +783,14 @@ country_event = {
 			}
 		}
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
-	hidden = yes
 }
 
 country_event = {
 	id = cartel_event.14
+	is_triggered_only = yes
+	hidden = yes
+	fire_only_once = yes
+
 	immediate = {
 		log = "[GetDateText]: [Root.GetName]: event cartel_event.14"
 		# goes to event based on which factions exist. I have to do it this way because there is no way to hide options so
@@ -994,9 +997,6 @@ country_event = {
 			}
 		}
 	}
-	is_triggered_only = yes
-	fire_only_once = yes
-	hidden = yes
 }
 
 
@@ -1007,14 +1007,6 @@ country_event = { # Infantry Equipment Stolen
 	desc = cartel_event.15.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
-
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-		has_equipment = {
-			infantry_weapons_type > 250
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1043,6 +1035,12 @@ country_event = { # Infantry Equipment Stolen
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+		has_equipment = { infantry_weapons_type > 250 }
+	}
+
 	option = {
 		name = cartel_event.15.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.15.a executed"
@@ -1062,7 +1060,6 @@ country_event = { # Infantry Equipment Stolen
 				}
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -1090,12 +1087,8 @@ country_event = { # Infantry Equipment Stolen
 				set_temp_variable = { cart_strength_change = 2 }
 				modify_cartel_variables_effect = yes
 			}
-
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1105,14 +1098,6 @@ country_event = { # Utility Vehicles Stolen
 	desc = cartel_event.16.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-		has_equipment = {
-			util_vehicle_type > 25
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1141,6 +1126,12 @@ country_event = { # Utility Vehicles Stolen
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+		has_equipment = { util_vehicle_type > 25 }
+	}
+
 	option = {
 		name = cartel_event.16.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.16.a executed"
@@ -1162,7 +1153,6 @@ country_event = { # Utility Vehicles Stolen
 				modify_cartel_variables_effect = yes
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -1191,10 +1181,7 @@ country_event = { # Utility Vehicles Stolen
 				modify_cartel_variables_effect = yes
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1204,14 +1191,6 @@ country_event = { # Transport Helicopters Stolen
 	desc = cartel_event.17.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
-
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-		has_equipment = {
-			transport_helicopter_1 > 5
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1240,6 +1219,12 @@ country_event = { # Transport Helicopters Stolen
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+		has_equipment = { transport_helicopter_1 > 5 }
+	}
+
 	option = {
 		name = cartel_event.17.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.17.a executed"
@@ -1261,7 +1246,6 @@ country_event = { # Transport Helicopters Stolen
 				modify_cartel_variables_effect = yes
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -1289,12 +1273,8 @@ country_event = { # Transport Helicopters Stolen
 				set_temp_variable = { cart_strength_change = 3 }
 				modify_cartel_variables_effect = yes
 			}
-
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1304,14 +1284,6 @@ country_event = { # Tanks Seized in Port
 	desc = cartel_event.18.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
-
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-		any_owned_state = {
-			is_coastal = yes
-		}
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -1338,6 +1310,12 @@ country_event = { # Tanks Seized in Port
 			factor = 2
 			check_variable = { strength_of_cartels > 69 }
 		}
+	}
+
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+		any_owned_state = { is_coastal = yes }
 	}
 
 	option = { # Sell Equipment
@@ -1374,7 +1352,6 @@ country_event = { # Tanks Seized in Port
 				amount = 5
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -1388,11 +1365,9 @@ country_event = { # Tanks Seized in Port
 				cartel_political_influence > 49
 			}
 		}
-
 		add_political_power = 25
 		set_temp_variable = { cart_strength_change = 5 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1409,7 +1384,6 @@ country_event = { # Body Dump Reaches National News
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
-
 	}
 
 	option = { # Lock down the site and let the police handle it
@@ -1417,7 +1391,6 @@ country_event = { # Body Dump Reaches National News
 		log = "[GetDateText]: [This.GetName]: cartel_event.19.a executed"
 		add_command_power = -50
 		add_stability = 0.01
-
 		ai_chance = {
 			base = 1
 		}
@@ -1426,12 +1399,9 @@ country_event = { # Body Dump Reaches National News
 	option = { # We have more pressing matters
 		name = cartel_event.19.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.19.b executed"
-
 		add_stability = -0.02
 		set_temp_variable = { cart_strength_change = 1 }
 		modify_cartel_variables_effect = yes
-
-
 		ai_chance = {
 			base = 1
 		}
@@ -1445,32 +1415,22 @@ country_event = { # Foreign Celebrity Death tied to Criminal Activity
 	picture = GFX_court
 	is_triggered_only = yes
 
-	immediate = {
-		hidden_effect = {
-			random_neighbor_country = {
-				set_variable = { PREV.foreign_celeb_country = THIS.id }
-			}
-		}
-	}
-
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
-
 	}
+
+	immediate = { hidden_effect = { random_neighbor_country = { set_variable = { PREV.foreign_celeb_country = THIS.id } } } }
 
 	option = { # Support charities in celebrity's name
 		name = cartel_event.20.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.20.a executed"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.006 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
 		clear_variable = foreign_celeb_country
 		ai_chance = {
 			base = 0
@@ -1480,7 +1440,6 @@ country_event = { # Foreign Celebrity Death tied to Criminal Activity
 	option = { # They shouldn't have associated with criminals
 		name = cartel_event.20.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.20.b executed"
-
 		# Random Country gets Upset
 		var:foreign_celeb_country = {
 			add_opinion_modifier = {
@@ -1488,7 +1447,6 @@ country_event = { # Foreign Celebrity Death tied to Criminal Activity
 				modifier = random_celebrity_death_opinion
 			}
 		}
-
 		clear_variable = foreign_celeb_country
 		ai_chance = {
 			base = 1
@@ -1506,17 +1464,14 @@ country_event = { # Cartels Begin Importing Exotic Animals
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
-
 	}
 
 	option = { # Shutdown new animal imports
 		name = cartel_event.21.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.21.a executed"
-
 		add_command_power = -25
 		set_temp_variable = { cart_influence_change = -3 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1533,7 +1488,6 @@ country_event = { # Cartels Begin Importing Exotic Animals
 	option = { # Ignore the trade
 		name = cartel_event.21.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.21.b executed"
-
 		set_temp_variable = { cart_influence_change = 5 }
 		modify_cartel_variables_effect = yes
 		ai_chance = {
@@ -1557,12 +1511,6 @@ country_event = { # Local Gang Clashes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-		NOT = { has_country_flag = CARTEL_local_gang_clashes_flag }
-	}
-
 	mean_time_to_happen = {
 		modifier = {
 			factor = 2
@@ -1570,13 +1518,17 @@ country_event = { # Local Gang Clashes
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+		NOT = { has_country_flag = CARTEL_local_gang_clashes_flag }
+	}
+
 	option = { # Send in the Police
 		name = cartel_event.22.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.22.a executed"
-
 		add_command_power = -50
 		add_manpower = -35
-
 		hidden_effect = {
 			set_country_flag = { flag = CARTEL_local_gang_clashes_flag value = 1 days = 90 }
 		}
@@ -1588,16 +1540,12 @@ country_event = { # Local Gang Clashes
 	option = { # Our hands are tied
 		name = cartel_event.22.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.22.b executed"
-
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
-
 		add_stability = -0.03
-
 		set_temp_variable = { cart_influence_change = 3 }
 		modify_cartel_variables_effect = yes
-
 		hidden_effect = {
 			set_country_flag = { flag = CARTEL_local_gang_clashes_flag value = 1 days = 90 }
 		}
@@ -1624,15 +1572,12 @@ country_event = { # USA Demands Extradition
 	option = { # Accept
 		name = cartel_event.23.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.23.a executed"
-
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = ROOT }
 		# Supported Scope: FROM, ROOT, PREV, TAG
 		change_influence_percentage = yes
-
 		add_political_power = 75
-
 		ai_chance = {
 			base = 1
 		}
@@ -1641,12 +1586,9 @@ country_event = { # USA Demands Extradition
 	option = { # Refuse
 		name = cartel_event.23.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.23.b executed"
-
 		set_temp_variable = { percent_change = 3 }
 		change_domestic_influence_percentage = yes
-
 		add_political_power = -50
-
 		ai_chance = {
 			base = 1
 		}
@@ -1668,7 +1610,6 @@ country_event = { # Informant Lands Movie Deal
 	option = { # Accept
 		name = cartel_event.24.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.24.a executed"
-
 		random_list = {
 			10 = {
 				country_event = { id = cartel_event.26 random_hours = 64 random_days = 30 }
@@ -1680,7 +1621,6 @@ country_event = { # Informant Lands Movie Deal
 				country_event = { id = cartel_event.28 random_hours = 64 random_days = 30 }
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -1689,14 +1629,12 @@ country_event = { # Informant Lands Movie Deal
 	option = { # Refuse
 		name = cartel_event.24.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.24.b executed"
-
 		hidden_effect = {
 			random = {
 				chance = 50
 				country_event = { id = cartel_event.25 random_hours = 64 random_days = 30 }
 			}
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -1718,10 +1656,8 @@ country_event = { # Informant Publishes Memoir
 	option = { # I Liked the Book
 		name = cartel_event.25.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.25.a executed"
-
 		set_temp_variable = { cart_influence_change = -5 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1743,10 +1679,8 @@ country_event = { # Informant Murdered on Set
 	option = { # A Shame, I liked him
 		name = cartel_event.26.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.26.a executed"
-
 		set_temp_variable = { cart_influence_change = 2 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1768,11 +1702,9 @@ country_event = { # Film Encourages Criminal Activity
 	option = { # Unfortunate
 		name = cartel_event.27.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.27.a executed"
-
 		set_temp_variable = { cart_strength_change = 3 }
 		set_temp_variable = { cart_influence_change = 3 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1794,10 +1726,8 @@ country_event = { # Film Discourages Criminal Activity
 	option = { # Excellent
 		name = cartel_event.28.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.28.a executed"
-
 		set_temp_variable = { cart_strength_change = -4 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1810,6 +1740,7 @@ country_event = { # Cartels Execute Border Crossing
 	desc = cartel_event.29.d
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
+
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
@@ -1819,7 +1750,6 @@ country_event = { # Cartels Execute Border Crossing
 	option = { # Demand stricter border control from neighbour
 		name = cartel_event.29.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.29.a executed"
-
 		# Sends to a Random Country w/
 		random_neighbor_country = {
 			limit = {
@@ -1828,7 +1758,6 @@ country_event = { # Cartels Execute Border Crossing
 			country_event = { id = cartel_event.30 random_hours = 24 random_days = 30 }
 		}
 		add_political_power = -50
-
 		ai_chance = {
 			base = 1
 		}
@@ -1837,10 +1766,8 @@ country_event = { # Cartels Execute Border Crossing
 	option = { # Inaction
 		name = cartel_event.29.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.29.b executed"
-
 		set_temp_variable = { cart_strength_change = 3 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1862,7 +1789,6 @@ country_event = { # Neighbour Demands Policing Increase
 	option = { # Fine, we will, but not because we like you or anything, baka!
 		name = cartel_event.30.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.30.a executed"
-
 		set_temp_variable = { cart_influence_change = -3 }
 		modify_cartel_variables_effect = yes
 		increase_policing_budget = yes # Yes? Maybe?
@@ -1872,7 +1798,6 @@ country_event = { # Neighbour Demands Policing Increase
 				country_event = { id = cartel_event.31 random_days = 7 }
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1891,7 +1816,6 @@ country_event = { # Neighbour Demands Policing Increase
 	option = { # Hej, fuck yo men! Hej fack you man, foucking betch
 		name = cartel_event.30.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.30.b executed"
-
 		FROM = {
 			add_opinion_modifier = { target = PREV modifier = random_denied_our_demands }
 		}
@@ -1900,7 +1824,6 @@ country_event = { # Neighbour Demands Policing Increase
 				country_event = { id = cartel_event.32 random_days = 7 }
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1932,11 +1855,9 @@ country_event = { # Neighbour Accedes to Demands
 	option = { # Good
 		name = cartel_event.31.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.31.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1958,13 +1879,11 @@ country_event = { # Neighbour Says NO to Demands
 	option = { # Daggumit
 		name = cartel_event.32.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.32.a executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
 		set_temp_variable = { cart_strength_change = 2 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -1986,7 +1905,6 @@ country_event = { # Suspicious Money Transfers tied to Foreign Oligarch
 	option = { # Seize their assets
 		name = cartel_event.33.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.33.a executed"
-
 		random_country = {
 			limit = {
 				OR = {
@@ -2008,9 +1926,7 @@ country_event = { # Suspicious Money Transfers tied to Foreign Oligarch
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.009 }
 		modify_treasury_effect = yes
-
 		add_political_power = -50
-
 		ai_chance = {
 			base = 1
 		}
@@ -2019,12 +1935,10 @@ country_event = { # Suspicious Money Transfers tied to Foreign Oligarch
 	option = { # We should leave them alone
 		name = cartel_event.33.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.33.b executed"
-
 		set_temp_variable = { temp_opinion = 3 }
 		change_oligarchs_opinion = yes
 		change_landowners_opinion = yes
 		change_international_bankers_opinion = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2046,12 +1960,10 @@ country_event = { # Cartel Tank Seen in Failed Raid
 	option = { # We should do something about that
 		name = cartel_event.34.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.34.a executed"
-
 		add_manpower = -10
 		hidden_effect = {
 			set_country_flag = cartels_narco_t34
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2074,14 +1986,12 @@ country_event = { # Cartel Tank Destroyed in Successful Raid
 	option = { # Thank God
 		name = cartel_event.35.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.35.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
 		hidden_effect = {
 			clr_country_flag = cartels_narco_t34
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2104,7 +2014,6 @@ country_event = { # Cartel Tank Used in Retaliatory Strike
 	option = { # We should do something about that
 		name = cartel_event.36.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.36.a executed"
-
 		add_manpower = -25
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
@@ -2112,7 +2021,6 @@ country_event = { # Cartel Tank Used in Retaliatory Strike
 		hidden_effect = {
 			set_country_flag = cartels_narco_t34
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2137,14 +2045,12 @@ country_event = { # Transportation Shell Company
 		set_temp_variable = { strength_modifier = ROOT.strength_of_cartels }
 		multiply_temp_variable = { strength_modifier = 0.01 }
 		add_to_temp_variable = { strength_modifier = 1 }
-
 		set_temp_variable = { equipment_change = 2 }
 		multiply_temp_variable = { equipment_change = strength_modifier }
 		add_equipment_to_stockpile = {
 			type = util_vehicle_1
 			amount = var:equipment_change
 		}
-
 		ai_chance = {
 			base = 1
 		}
@@ -2156,15 +2062,12 @@ country_event = { # Transportation Shell Company
 		set_temp_variable = { strength_modifier = ROOT.strength_of_cartels }
 		multiply_temp_variable = { strength_modifier = 0.01 }
 		add_to_temp_variable = { strength_modifier = 1 }
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.006 }
 		multiply_temp_variable = { treasury_change = strength_modifier }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_opinion = 5 }
 		change_small_medium_business_owners_opinion = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2186,14 +2089,12 @@ country_event = { # Arrested Lackey Turns Out to Be Important Cartel Leader
 	option = { # Ah, yes, all part of the plan
 		name = cartel_event.38.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.38.a executed"
-
 		set_temp_variable = { party_popularity_increase = 0.04 }
 		set_temp_variable = { temp_outlook_increase = 0.04 }
 		change_relative_party_popularity = yes
 		set_temp_variable = { cart_strength_change = -3 }
 		set_temp_variable = { cart_influence_change = -3 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2202,13 +2103,11 @@ country_event = { # Arrested Lackey Turns Out to Be Important Cartel Leader
 	option = { # Sorry about that, sir.
 		name = cartel_event.38.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.38.b executed"
-
 		set_temp_variable = { cart_influence_change = 2 }
 		modify_cartel_variables_effect = yes
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.002 }
 		modify_treasury_effect = yes
-
 		ai_chance = {
 			base = 1
 		}
@@ -2243,7 +2142,6 @@ country_event = { # Authorities Stumble on Drug Plantation
 	option = {
 		name = cartel_event.39.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.39.b executed"
-
 		add_command_power = -20
 		set_temp_variable = { cart_strength_change = -1 }
 		modify_cartel_variables_effect = yes
@@ -2253,7 +2151,6 @@ country_event = { # Authorities Stumble on Drug Plantation
 	option = {
 		name = cartel_event.39.c
 		log = "[GetDateText]: [This.GetName]: cartel_event.39.c executed"
-
 		add_political_power = 50
 		set_temp_variable = { cart_influence_change = 3 }
 		modify_cartel_variables_effect = yes
@@ -2276,19 +2173,14 @@ country_event = { # Anonymous Tip Off
 	option = {
 		name = cartel_event.40.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.40.a executed"
-
 		add_command_power = -35
 		random_list = {
 			75 = {
 				set_temp_variable = { cart_strength_change = -2 }
 				modify_cartel_variables_effect = yes
 			}
-			20 = {
-				add_political_power = -25
-			}
-			5 = {
-				add_manpower = -5
-			}
+			20 = { add_political_power = -25 }
+			5 = { add_manpower = -5 }
 		}
 	}
 
@@ -2296,16 +2188,12 @@ country_event = { # Anonymous Tip Off
 	option = {
 		name = cartel_event.40.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.40.b executed"
-
 		add_political_power = 50
 		random = {
 			chance = 75
-
 				set_temp_variable = { cart_influence_change = 2 }
 				modify_cartel_variables_effect = yes
-
 		}
-
 	}
 }
 
@@ -2337,7 +2225,6 @@ country_event = { # Local Business Cooperation
 	option = {
 		name = cartel_event.41.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.41.b executed"
-
 		add_political_power = 50
 		set_temp_variable = { cart_influence_change = 2 }
 		modify_cartel_variables_effect = yes
@@ -2404,11 +2291,6 @@ country_event = { # Corrupt Officials
 	picture = GFX_court
 	is_triggered_only = yes
 
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-	}
-
 	mean_time_to_happen = {
 		modifier = {
 			factor = 6
@@ -2441,6 +2323,11 @@ country_event = { # Corrupt Officials
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+	}
+
 	# Corruption Does Not Go Unpunished
 	option = {
 		name = cartel_event.43.a
@@ -2449,10 +2336,7 @@ country_event = { # Corrupt Officials
 		set_temp_variable = { cart_influence_change = -5 }
 		modify_cartel_variables_effect = yes
 		add_stability = 0.05
-
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	# Corruption? That's a soup, right?
@@ -2460,10 +2344,7 @@ country_event = { # Corrupt Officials
 		name = cartel_event.43.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.43.b executed"
 		increase_corruption = yes
-
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -2477,24 +2358,19 @@ country_event = { # Shipping Container of Contraband
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
-		any_owned_state = {
-			is_coastal = yes
-		}
+		any_owned_state = { is_coastal = yes }
 	}
 
 	# Seize the Ship
 	option = {
 		name = cartel_event.44.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.44.a executed"
-
 		add_command_power = -50
 		set_temp_variable = { cart_strength_change = -5 }
 		modify_cartel_variables_effect = yes
-
 		set_temp_variable = { temp_opinion = -10 }
 		change_maritime_industry_opinion = yes
 		change_industrial_conglomerates_opinion = yes
-
 		if = { limit = { NOT = { original_tag = PAN } }
 			PAN = {
 				add_opinion_modifier = {
@@ -2507,20 +2383,16 @@ country_event = { # Shipping Container of Contraband
 			type = convoy
 			amount = 1
 		}
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 
 	# Seize the Container
 	option = {
 		name = cartel_event.44.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.44.b executed"
-
 		add_command_power = -25
 		set_temp_variable = { cart_strength_change = -3 }
 		modify_cartel_variables_effect = yes
-
 		if = { limit = { NOT = { original_tag = PAN } }
 			PAN = {
 				add_opinion_modifier = {
@@ -2529,31 +2401,23 @@ country_event = { # Shipping Container of Contraband
 				}
 			}
 		}
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_maritime_industry_opinion = yes
 		change_industrial_conglomerates_opinion = yes
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	# Let it Slide
 	option = {
 		name = cartel_event.44.c
 		log = "[GetDateText]: [This.GetName]: cartel_event.44.c executed"
-
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
-
 		add_political_power = 50
 		set_temp_variable = { cart_influence_change = 5 }
 		modify_cartel_variables_effect = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -2563,11 +2427,6 @@ country_event = { # Bankers Turning a Blind Eye
 	desc = cartel_event.45.d
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
-
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-	}
 
 	mean_time_to_happen = {
 		modifier = {
@@ -2589,6 +2448,10 @@ country_event = { # Bankers Turning a Blind Eye
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+	}
 
 	# Issue Fines, Jail the Bankers
 	option = {
@@ -2597,7 +2460,6 @@ country_event = { # Bankers Turning a Blind Eye
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.007 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { temp_opinion = -5 }
 		change_international_bankers_opinion = yes
 		add_political_power = -50
@@ -2607,11 +2469,9 @@ country_event = { # Bankers Turning a Blind Eye
 	option = {
 		name = cartel_event.45.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.45.b executed"
-
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { cart_influence_change = 5 }
 		modify_cartel_variables_effect = yes
 	}
@@ -2624,11 +2484,6 @@ country_event = { # Take the Cartel's Bribes
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-	}
-
 	mean_time_to_happen = {
 		modifier = {
 			factor = 3
@@ -2649,40 +2504,35 @@ country_event = { # Take the Cartel's Bribes
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+	}
+
 	# We can take this to the grave
 	option = {
 		name = cartel_event.46.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.46.a executed"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = 0.014 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { cart_influence_change = 4 }
 		modify_cartel_variables_effect = yes
-
 		random = {
 			chance = 20
 			increase_corruption = yes
 		}
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# Outrageous! We'd only take it from lobbyists!
 	option = {
 		name = cartel_event.46.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.46.b executed"
-
 		add_political_power = 75
 		set_temp_variable = { cart_influence_change = -4 }
 		modify_cartel_variables_effect = yes
-
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -2693,12 +2543,6 @@ country_event = { # Deals with the Devils
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
-	trigger = {
-		has_cartels_penalties = yes
-		is_generic_cartel_event_nation = yes
-		NOT = { has_country_flag = CARTEL_deal_with_the_devil_flag }
-	}
-
 	mean_time_to_happen = {
 		modifier = {
 			factor = 3
@@ -2719,34 +2563,32 @@ country_event = { # Deals with the Devils
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		is_generic_cartel_event_nation = yes
+		NOT = { has_country_flag = CARTEL_deal_with_the_devil_flag }
+	}
+
 	# We can use some of that pie
 	option = {
 		name = cartel_event.47.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.47.a executed"
 		set_country_flag = { flag = CARTEL_deal_with_the_devil_flag days = 180 value = 1 }
-
 		set_temp_variable = { additional_income_change = gdp_total }
 		multiply_temp_variable = { additional_income_change = 0.005 }
 		custom_effect_tooltip = additional_income_rate_percent_tt
-
 		set_temp_variable = { cart_influence_change = 3 }
 		modify_cartel_variables_effect = yes
-
 		increase_corruption = yes
-
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	# They're Devils for a reason
 	option = {
 		name = cartel_event.47.b
 		log = "[GetDateText]: [This.GetName]: cartel_event.47.b executed"
-
 		set_temp_variable = { cart_influence_change = -2 }
 		modify_cartel_variables_effect = yes
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2780,7 +2622,6 @@ country_event = { # Regulate the Contraband
 		add_political_power = -25
 		set_temp_variable = { cart_influence_change = 2 }
 		modify_cartel_variables_effect = yes
-
 		add_timed_idea = {
 			idea = hard_drug_trade_restrictions
 			days = 180
@@ -2794,7 +2635,6 @@ country_event = { # Regulate the Contraband
 		add_political_power = -50
 		set_temp_variable = { cart_influence_change = 4 }
 		modify_cartel_variables_effect = yes
-
 		add_timed_idea = {
 			idea = light_drug_trade_restrictions
 			days = 180
@@ -2827,11 +2667,9 @@ country_event = { # Youth Losing Hope
 	option = {
 		name = cartel_event.49.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.49.a executed"
-
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-
 		set_temp_variable = { cart_influence_change = -5 }
 		set_temp_variable = { cart_strength_change = -3 }
 		modify_cartel_variables_effect = yes
@@ -2844,7 +2682,6 @@ country_event = { # Youth Losing Hope
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		set_temp_variable = { cart_influence_change = 4 }
 		set_temp_variable = { cart_strength_change = 2 }
 		modify_cartel_variables_effect = yes
@@ -2866,12 +2703,10 @@ country_event = { # Cartel Retaliatory Strike
 	option = { # Unfortunate
 		name = cartel_event.53.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.53.a executed"
-
 		add_manpower = -10
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		change_relative_party_popularity = yes
-
 	}
 }
 
@@ -2890,14 +2725,12 @@ country_event = { # Failed Cartel Retaliatory Strike
 	option = { # Unfortunate
 		name = cartel_event.54.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.54.a executed"
-
 		add_manpower = -5
 		set_temp_variable = { party_popularity_increase = 0.01 }
 		set_temp_variable = { temp_outlook_increase = 0.01 }
 		change_relative_party_popularity = yes
 		set_temp_variable = { cart_strength_change = -1 }
 		modify_cartel_variables_effect = yes
-
 	}
 }
 
@@ -2911,21 +2744,17 @@ country_event = { # Cartels Destroy Helicopter
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
-		has_equipment = {
-			transport_helicopter_1 > 2
-		}
+		has_equipment = { transport_helicopter_1 > 2 }
 	}
 
 	option = { # Unfortunate
 		name = cartel_event.55.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.55.a executed"
-
 		add_manpower = -3
 		add_equipment_to_stockpile = {
 			type = transport_helicopter_1
 			amount = -1
 		}
-
 	}
 }
 
@@ -2937,9 +2766,7 @@ country_event = { # El Fusilado Easter Egg Event
 	is_triggered_only = yes
 
 	trigger = {
-		NOT = {
-			tag = BRA
-		}
+		NOT = { tag = BRA }
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
 	}
@@ -2947,7 +2774,6 @@ country_event = { # El Fusilado Easter Egg Event
 	option = { #He will become our new El Fusilado!
 		name = cartel_event.56.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.56.a executed"
-
 		add_command_power = -5
 		set_temp_variable = { cart_influence_change = -1 }
 		modify_cartel_variables_effect = yes
@@ -2955,10 +2781,8 @@ country_event = { # El Fusilado Easter Egg Event
 
 	option = { #It is a shame our doctors could not save him...
 		name = cartel_event.56.b
-
 		#No Effect
 	}
-
 }
 
 ### Decision Events
@@ -3018,6 +2842,7 @@ country_event = {
 	}
 	picture = GFX_banking_crisis
 	is_triggered_only = yes
+
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
@@ -3029,18 +2854,15 @@ country_event = {
 		set_temp_variable = { strength_modifier = ROOT.strength_of_cartels }
 		multiply_temp_variable = { strength_modifier = 0.01 }
 		add_to_temp_variable = { strength_modifier = 1 }
-
 		set_temp_variable = { political_modifier = ROOT.cartel_political_influence }
 		multiply_temp_variable = { political_modifier = 0.01 }
 		add_to_temp_variable = { political_modifier = 1 }
-
 		# Effects
 		if = { limit = { has_country_flag = successful_investigation_casino }
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = 0.006 }
 			multiply_temp_variable = { treasury_change = strength_modifier }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cart_strength_change = -4 }
 			modify_cartel_variables_effect = yes
 		}
@@ -3048,10 +2870,8 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 2 }
 			modify_cartel_variables_effect = yes
-
 			add_stability = -0.03
 		}
 		if = { limit = { has_country_flag = successful_investigation_banks }
@@ -3059,11 +2879,9 @@ country_event = {
 			multiply_temp_variable = { treasury_change = 0.012 }
 			multiply_temp_variable = { treasury_change = strength_modifier }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cart_strength_change = -7 }
 			set_temp_variable = { cart_influence_change = -6 }
 			modify_cartel_variables_effect = yes
-
 			hidden_effect = {
 				random = {
 					chance = 10
@@ -3075,13 +2893,10 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 2 }
 			set_temp_variable = { cart_influence_change = 4 }
 			modify_cartel_variables_effect = yes
-
 			add_stability = -0.03
-
 			hidden_effect = {
 				random = {
 					chance = 10
@@ -3094,7 +2909,6 @@ country_event = {
 			multiply_temp_variable = { treasury_change = 0.003 }
 			multiply_temp_variable = { treasury_change = strength_modifier }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cart_strength_change = -12 }
 			modify_cartel_variables_effect = yes
 		}
@@ -3102,16 +2916,13 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 3 }
 			set_temp_variable = { cart_influence_change = 6 }
 			modify_cartel_variables_effect = yes
 			set_temp_variable = { temp_opinion = -5 }
 			change_international_bankers_opinion = yes
-
 			add_stability = -0.03
 		}
-
 		hidden_effect = {
 			if = { limit = { has_country_flag = successful_investigation_shell_companies }
 				random = {
@@ -3140,7 +2951,6 @@ country_event = {
 			clr_country_flag = failed_investigation_banks
 			clr_country_flag = failed_investigation_shell_companies
 			clr_country_flag = failed_investigation_casino
-
 			# Creamy: If you add flavor events make sure your clear your country flags after this note
 		}
 	}
@@ -3217,6 +3027,7 @@ country_event = {
 	}
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = {
 		has_cartels_penalties = yes
 		is_generic_cartel_event_nation = yes
@@ -3228,11 +3039,9 @@ country_event = {
 		set_temp_variable = { strength_modifier = ROOT.strength_of_cartels }
 		multiply_temp_variable = { strength_modifier = 0.01 }
 		add_to_temp_variable = { strength_modifier = 1 }
-
 		set_temp_variable = { political_modifier = ROOT.cartel_political_influence }
 		multiply_temp_variable = { political_modifier = 0.01 }
 		add_to_temp_variable = { political_modifier = 1 }
-
 		# Effects
 		if = { limit = { has_country_flag = successful_raid_drug_convoys }
 			set_temp_variable = { cart_strength_change = -2 }
@@ -3243,12 +3052,10 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 2 }
 			set_temp_variable = { cart_influence_change = 4 }
 			modify_cartel_variables_effect = yes
 			add_stability = -0.03
-
 			add_manpower = -10
 		}
 		if = { limit = { has_country_flag = successful_raid_cartel_hideouts }
@@ -3256,7 +3063,6 @@ country_event = {
 			multiply_temp_variable = { cart_strength_change = strength_modifier }
 			set_temp_variable = { cart_influence_change = -4 }
 			modify_cartel_variables_effect = yes
-
 			if = { limit = { has_country_flag = INF_seized }
 				set_temp_variable = { equipment_change = 10 }
 				multiply_temp_variable = { equipment_change = strength_modifier }
@@ -3278,12 +3084,10 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 2 }
 			set_temp_variable = { cart_influence_change = 4 }
 			modify_cartel_variables_effect = yes
 			add_stability = -0.03
-
 			add_manpower = -10
 		}
 		if = { limit = { has_country_flag = successful_raid_distribution_centres }
@@ -3291,7 +3095,6 @@ country_event = {
 			multiply_temp_variable = { treasury_change = 0.009 }
 			multiply_temp_variable = { treasury_change = strength_modifier }
 			modify_treasury_effect = yes
-
 			set_temp_variable = { cart_influence_change = -4 }
 			set_temp_variable = { cart_strength_change = -12 }
 			modify_cartel_variables_effect = yes
@@ -3300,18 +3103,15 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 2 }
 			modify_cartel_variables_effect = yes
 			add_stability = -0.03
-
 			add_manpower = -10
 		}
 		if = { limit = { has_country_flag = successful_raid_refinement_centres }
 			set_temp_variable = { strength_modifier = ROOT.strength_of_cartels }
 			multiply_temp_variable = { strength_modifier = 0.01 }
 			add_to_temp_variable = { strength_modifier = 3 }
-
 			set_temp_variable = { cart_strength_change = -2 }
 			multiply_temp_variable = { cart_strength_change = strength_modifier }
 			set_temp_variable = { cart_influence_change = -4 }
@@ -3321,17 +3121,12 @@ country_event = {
 			set_temp_variable = { party_popularity_increase = -0.04 }
 			set_temp_variable = { temp_outlook_increase = -0.04 }
 			change_relative_party_popularity = yes
-
 			set_temp_variable = { cart_strength_change = 2 }
 			modify_cartel_variables_effect = yes
-
 			add_manpower = -10
-
 			add_stability = -0.03
 		}
-
 		hidden_effect = {
-
 			# Cartel Tank Outcomes
 			if = {
 				limit = {
@@ -3347,7 +3142,6 @@ country_event = {
 					country_event = { id = cartel_event.34 days = 7 random_days = 15 random_hours = 24 }
 				}
 			}
-
 			if = {
 				limit = {
 					has_country_flag = cartels_narco_t34
@@ -3357,7 +3151,6 @@ country_event = {
 					country_event = { id = cartel_event.36 days = 7 random_days = 15 random_hours = 24 }
 				}
 			}
-
 			if = {
 				limit = {
 					OR = {
@@ -3372,18 +3165,15 @@ country_event = {
 					country_event = { id = cartel_event.35 days = 7 random_days = 15 random_hours = 24 }
 				}
 			}
-
 			# Random Raid Outcomes
 			random = {
 				chance = 5
 				country_event = { id = cartel_event.55 days = 7 random_days = 15 random_hours = 24 }
 			}
-
 			random = {
 				chance = 5
 				country_event = { id = cartel_event.38 days = 7 random_days = 15 random_hours = 24 }
 			}
-
 			# Retaliatory Strike Outcomes
 			if = {
 				limit = {
@@ -3412,7 +3202,6 @@ country_event = {
 				}
 			}
 		}
-
 		# Garbage Collection
 		hidden_effect = {
 			clr_country_flag = successful_raid_drug_convoys
@@ -3423,7 +3212,6 @@ country_event = {
 			clr_country_flag = failed_raid_cartel_hideouts
 			clr_country_flag = failed_raid_distribution_centres
 			clr_country_flag = failed_raid_refinement_centres
-
 			# Creamy: If you add flavor events make sure your clear your country flags after this note
 		}
 	}
@@ -3437,14 +3225,6 @@ country_event = {
 	picture = GFX_cartels_stacks
 	is_triggered_only = yes
 
-	trigger = {
-		has_cartels_penalties = yes
-		has_country_flag = is_cartel_nation
-		NOT = { has_country_flag = CARTEL_defeated_the_cartels }
-		check_variable = { cartel_political_influence < 5 }
-		check_variable = { strength_of_cartels < 5 }
-	}
-
 	# Ensures that the End of the Cartels Triggers
 	mean_time_to_happen = {
 		modifier = {
@@ -3454,15 +3234,21 @@ country_event = {
 		}
 	}
 
+	trigger = {
+		has_cartels_penalties = yes
+		has_country_flag = is_cartel_nation
+		NOT = { has_country_flag = CARTEL_defeated_the_cartels }
+		check_variable = { cartel_political_influence < 5 }
+		check_variable = { strength_of_cartels < 5 }
+	}
+
 	option = {
 		name = cartel_event.52.a
 		log = "[GetDateText]: [This.GetName]: cartel_event.52.a executed"
-
 		add_timed_idea = {
 			idea = defeated_the_cartels
 			days = 720
 		}
-
 		set_country_flag = CARTEL_defeated_the_cartels # Defeated the Cartels
 		removed_cartel_cleanup = yes
 		news_event = { id = cartel_event.100 days = 1 }
@@ -3483,13 +3269,11 @@ news_event = {
 	option = {
 		name = cartel_event.100.a
 		trigger = { has_dynamic_modifier = { modifier = narco_state_bonuses } }
-
 	}
 
 	# Stability in [FROM.GetName]
 	option = {
 		name = cartel_event.100.b
 		trigger = { NOT = { has_dynamic_modifier = { modifier = narco_state_bonuses } } }
-
 	}
 }


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,629 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.