### PR TITLE
Standardize event files — batch 10/14

### DIFF
--- a/events/05_japan.txt
+++ b/events/05_japan.txt
@@ -442,7 +442,7 @@ country_event = {
 		hidden_effect = { country_event = { id = japan_classic.16 days = 4 } }
 	}
 
-	option = {	#Let's pray for the best
+	option = { #Let's pray for the best
 		name = japan_classic.15.o1
 		log = "[GetDateText]: [This.GetName]: japan_classic.15.o1 executed"
 		add_stability = -0.02
@@ -484,7 +484,7 @@ country_event = {
 
 	immediate = { log = "[GetDateText]: [Root.GetName]: event japan_classic.18" }
 
-	option = {	#What a fool!
+	option = { #What a fool!
 		name = japan_classic.18.o1
 		log = "[GetDateText]: [This.GetName]: japan_classic.18.o1 executed"
 		add_stability = -0.01
@@ -494,7 +494,7 @@ country_event = {
 		ai_chance = { base = 90 }
 	}
 
-	option = {	#Double down on his statement
+	option = { #Double down on his statement
 		name = japan_classic.18.o2
 		log = "[GetDateText]: [This.GetName]: japan_classic.18.o2 executed"
 		set_temp_variable = { party_index = 23 }
@@ -527,17 +527,17 @@ country_event = {
 	id = Japan.01
 	title = Japan.01.t
 	desc = Japan.01.d
+	picture = GFX_JAP_event_ultranationalism
 	is_triggered_only = yes
 
-	picture = GFX_JAP_event_ultranationalism
-	option = {	#What a fool!
+	option = { #What a fool!
 		name = Japan.01.a
 		log = "[GetDateText]: [This.GetName]: Japan.01.a executed"
 		add_stability = 0.02
 		ai_chance = { base = 1 }
 	}
 
-	option = {	#Double down on his statement
+	option = { #Double down on his statement
 		name = Japan.01.b
 		log = "[GetDateText]: [This.GetName]: Japan.01.b executed"
 		add_timed_idea = {
@@ -564,10 +564,10 @@ country_event = {
 	id = JAP_historical.121006001
 	title = JAP_historical.121006001.t
 	desc = JAP_historical.121006001.d
+	picture = GFX_JAP_event_tottori_earthquake
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	picture = GFX_JAP_event_tottori_earthquake
 	trigger = {
 		controls_state = 611
 		NOT = { 611 = { has_dynamic_modifier = { modifier = JAP_seismic_retrofit } } }
@@ -588,9 +588,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			 base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -625,10 +623,10 @@ country_event = {
 	id = JAP_historical.130210001
 	title = JAP_historical.130210001.t
 	desc = JAP_historical.130210001.d
+	picture = GFX_JAP_event_ehime_maru_disaster
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	picture = GFX_JAP_event_ehime_maru_disaster
 	#action
 	option = {
 		name = JAP_historical.130210001.oA
@@ -652,17 +650,11 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.05 }
 		change_relative_party_popularity = yes
 		if = {
-			limit = {
-				has_country_leader = {
-					 name = "Yoshiro Mori"
-				}
-			}
+			limit = { has_country_leader = { name = "Yoshiro Mori" } }
 			set_country_flag = MDMOSJAP_PROGOLFER_MORI
 			custom_effect_tooltip = JAP_koizumi_appear_TT
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -716,9 +708,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			base = 75
-		 }
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -771,10 +761,10 @@ country_event = {
 	id = JAP_historical.20010426
 	title = JAP_historical.20010426.t
 	desc = JAP_historical.20010426.d
+	picture = GFX_JAP_event_junichiro_pm
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	picture = GFX_JAP_event_junichiro_pm
 	trigger = {
 		has_country_leader = { name = "Yoshiro Mori" }
 		has_country_flag = MDMOSJAP_PROGOLFER_MORI
@@ -790,9 +780,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		change_relative_party_popularity = yes
 		set_country_flag = JAP_KOIZUMI_HISTRICAL_APPEARANCE
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -863,9 +851,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			 base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -939,9 +925,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			 base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1029,9 +1013,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1119,9 +1101,7 @@ country_event = {
 		}
 		newline = yes
 		medium_expenditure = yes
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1202,9 +1182,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1257,9 +1235,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.170425001 - disaster_help"
 		add_political_power = -50
 		add_stability = -0.01
-		ai_chance = {
-			 base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 
 	#Self-Determination
@@ -1267,9 +1243,7 @@ country_event = {
 		name = JAP_historical.disaster_leave
 		log = "[GetDateText]: [Root.GetName]: JAP_historical.170425001 - disaster_leave"
 		add_stability = -0.05
-		ai_chance = {
-			 base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1298,9 +1272,9 @@ country_event = {
 	id = JAP_historical.20060926
 	title = JAP_historical.20060926.t
 	desc = JAP_historical.20060926.d
+	picture = GFX_JAP_event_junichiro_abe
 	is_triggered_only = yes
 
-	picture = GFX_JAP_event_junichiro_abe
 	trigger = {
 		has_country_leader = { name = "Junichiro Koizumi" }
 		has_country_flag = JAP_KOIZUMI_HISTRICAL_APPEARANCE
@@ -1325,9 +1299,7 @@ country_event = {
 		custom_effect_tooltip = JAP_pm_abe_takes_office_tt
 		set_leader = yes
 		set_country_flag = JAP_ABE_FIRST_HISTRICAL_APPEARANCE
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -1357,10 +1329,10 @@ country_event = {
 	id = JAP_historical.20070307
 	title = JAP_historical.20070307.t
 	desc = JAP_historical.20070307.d
+	picture = GFX_JAP_event_matsuoka_scandal
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	picture = GFX_JAP_event_matsuoka_scandal
 	trigger = { check_variable = { ruling_party = 1 } }
 
 	option = {
@@ -1383,9 +1355,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		change_relative_party_popularity = yes
 		set_country_flag = JAP_MATSUOKA_SCANDAL
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1426,9 +1396,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			 base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1480,9 +1448,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070528.oA executed"
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1502,9 +1468,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070704.oA executed"
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1538,9 +1502,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1585,9 +1547,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20070801.oA executed"
 		set_temp_variable = { party_popularity_increase = -0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1596,10 +1556,10 @@ country_event = {
 	id = JAP_historical.20070926
 	title = JAP_historical.20070926.t
 	desc = JAP_historical.20070926.d
+	picture = GFX_JAP_event_abe_fukuda
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	picture = GFX_JAP_event_abe_fukuda
 	trigger = {
 		has_country_leader = { name = "Shinzo Abe" }
 		has_country_flag = JAP_ABE_FIRST_HISTRICAL_APPEARANCE
@@ -1624,9 +1584,7 @@ country_event = {
 		custom_effect_tooltip = JAP_pm_fukuda_takes_office_tt
 		set_leader = yes
 		set_country_flag = JAP_FUKUDA_HISTRICAL_APPEARANCE
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -1660,9 +1618,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			 base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -1697,10 +1653,10 @@ country_event = {
 	id = JAP_historical.20080924
 	title = JAP_historical.20080924.t
 	desc = JAP_historical.20080924.d
+	picture = GFX_JAP_event_fukuda_aso
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	picture = GFX_JAP_event_fukuda_aso
 	trigger = {
 		has_country_leader = { name = "Yasuo Fukuda" }
 		has_country_flag = JAP_FUKUDA_HISTRICAL_APPEARANCE
@@ -1724,9 +1680,7 @@ country_event = {
 		set_variable = { conservatism_leader = 0 }
 		custom_effect_tooltip = JAP_pm_aso_takes_office_tt
 		set_leader = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -1760,9 +1714,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = tmp_liberal }
 		set_temp_variable = { temp_outlook_increase = tmp_liberal }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1777,9 +1729,7 @@ country_event = {
 	trigger = {
 		tag = JAP
 		neutrality_neutral_conservatism_in_power_or_coalition = no
-		NOT = {
-			has_country_flag = JAP_your_party_end_flag
-		}
+		NOT = { has_country_flag = JAP_your_party_end_flag }
 	}
 
 	immediate = {
@@ -1797,9 +1747,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1814,9 +1762,7 @@ country_event = {
 	trigger = {
 		tag = JAP
 		neutrality_neutral_libertarian_in_power_or_coalition = no
-		NOT = {
-			has_country_flag = JAP_innovation_party_flag
-		}
+		NOT = { has_country_flag = JAP_innovation_party_flag }
 	}
 
 	immediate = { set_country_flag = JAP_innovation_party_flag }
@@ -1828,9 +1774,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.12 }
 		set_temp_variable = { temp_outlook_increase = 0.12 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1862,9 +1806,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = tmp_your }
 		set_temp_variable = { temp_outlook_increase = tmp_your }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1880,9 +1822,7 @@ country_event = {
 		tag = JAP
 		neutrality_neutral_conservatism_in_power_or_coalition = no
 		western_liberal_are_in_power_or_coalition = no
-		NOT = {
-			has_country_flag = JAP_constitutional_democratic_party_flag
-		}
+		NOT = { has_country_flag = JAP_constitutional_democratic_party_flag }
 	}
 
 	immediate = {
@@ -1899,9 +1839,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		newline = yes
 		custom_effect_tooltip = JAP_historical.20170925_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1916,9 +1854,7 @@ country_event = {
 	trigger = {
 		tag = JAP
 		neutrality_neutral_conservatism_in_power_or_coalition = no
-		NOT = {
-			has_country_flag = JAP_democratic_party_for_the_people_flag
-		}
+		NOT = { has_country_flag = JAP_democratic_party_for_the_people_flag }
 	}
 
 	immediate = {
@@ -1930,9 +1866,7 @@ country_event = {
 		name = JAP_historical.20180507.a
 		log = "[GetDateText]: [This.GetName]: JAP_historical.20180507.a executed"
 		custom_effect_tooltip = JAP_historical.20180507_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1947,9 +1881,7 @@ country_event = {
 	trigger = {
 		tag = JAP
 		emerging_anarchist_communism_in_power_or_coalition = no
-		NOT = {
-			has_country_flag = JAP_reiwa_shinsengumi_flag
-		}
+		NOT = { has_country_flag = JAP_reiwa_shinsengumi_flag }
 	}
 
 	immediate = { set_country_flag = JAP_reiwa_shinsengumi_flag }
@@ -1961,9 +1893,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1978,9 +1908,7 @@ country_event = {
 	trigger = {
 		tag = JAP
 		nationalist_right_wing_populists_are_in_power_or_coalition = no
-		NOT = {
-			has_country_flag = JAP_party_of_do_it_yourself_flag
-		}
+		NOT = { has_country_flag = JAP_party_of_do_it_yourself_flag }
 	}
 
 	immediate = { set_country_flag = JAP_party_of_do_it_yourself_flag }
@@ -1992,9 +1920,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2042,9 +1968,7 @@ country_event = {
 		}
 		newline = yes
 		small_expenditure = yes
-		ai_chance = {
-			 base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	#Self-Determination
@@ -2195,9 +2119,7 @@ country_event = {
 					damage_building = { type = offices damage = 5.0 }
 				}
 			}
-			add_dynamic_modifier = {
-					modifier = JAP_scars_earthquake_and_tsunami
-			}
+			add_dynamic_modifier = { modifier = JAP_scars_earthquake_and_tsunami }
 		}
 		newline = yes
 		615 = {
@@ -2258,16 +2180,12 @@ country_event = {
 					damage_building = { type = offices damage = 2.0 }
 				}
 			}
-			add_dynamic_modifier = {
-					modifier = JAP_scars_earthquake
-			}
+			add_dynamic_modifier = { modifier = JAP_scars_earthquake }
 		}
 		newline = yes
 		decrease_economic_growth = yes
 		newline = yes
-		add_dynamic_modifier = {
-			modifier = JAP_once_millennium_disaster
-		}
+		add_dynamic_modifier = { modifier = JAP_once_millennium_disaster }
 		newline = yes
 		add_manpower = -18420
 		newline = yes
@@ -2276,26 +2194,22 @@ country_event = {
 			news_event = JAP_news.02
 			country_event = { id = Japan.2011031150 days = 1 }
 		}
-		ai_chance = {
-			 base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
 news_event = {
 	id = JAP_news.02
-	major = yes
 	title = JAP_news.02.t
 	desc = JAP_news.02.d
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
+	major = yes
 
 	#picture
 	option = {
 		name = JAP_news.02.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2313,16 +2227,10 @@ country_event = {
 		add_stability = 0.1
 		newline = yes
 		if = {
-			limit = {
-				NOT = {
-					has_idea = economic_boom
-				}
-			}
+			limit = { NOT = { has_idea = economic_boom } }
 			increase_economic_growth = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2351,9 +2259,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_and_tsunami_state_production_speed_buildings_factor = 0.10 tooltip = state_production_speed_buildings_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2382,9 +2288,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_and_tsunami_state_production_speed_buildings_factor = 0.10 tooltip = state_production_speed_buildings_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2413,9 +2317,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_state_production_speed_buildings_factor = 0.05 tooltip = state_production_speed_buildings_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2444,9 +2346,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_state_production_speed_buildings_factor = 0.05 tooltip = state_production_speed_buildings_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2475,9 +2375,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_and_tsunami_state_production_speed_buildings_factor = 0.10 tooltip = state_production_speed_buildings_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2506,9 +2404,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_and_tsunami_state_productivity_growth_modifier = 0.10 tooltip = state_productivity_growth_modifier_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2537,9 +2433,7 @@ country_event = {
 				add_to_variable = { JAP_scars_earthquake_state_productivity_growth_modifier = 0.05 tooltip = state_productivity_growth_modifier_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2568,9 +2462,7 @@ country_event = {
 				add_to_variable = { JAP_once_millennium_disaster_consumer_goods_factor = -0.02 tooltip = consumer_goods_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2599,9 +2491,7 @@ country_event = {
 				add_to_variable = { JAP_once_millennium_disaster_consumer_goods_factor = -0.02 tooltip = consumer_goods_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2630,9 +2520,7 @@ country_event = {
 				add_to_variable = { JAP_once_millennium_disaster_consumer_goods_factor = -0.02 tooltip = consumer_goods_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2661,9 +2549,7 @@ country_event = {
 				add_to_variable = { JAP_once_millennium_disaster_consumer_goods_factor = -0.02 tooltip = consumer_goods_factor_tt }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2696,33 +2582,27 @@ country_event = {
 				add_idea = JAP_anxiety_nuclear_power
 			}
 		}
-		else = {
-			add_ideas = JAP_anxiety_nuclear_power
-		}
+		else = { add_ideas = JAP_anxiety_nuclear_power }
 		hidden_effect = {
 			country_event = { id = Japan.2011031151 days = 30 }
 			news_event = JAP_news.03
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
 news_event = {
 	id = JAP_news.03
-	major = yes
 	title = JAP_news.03.t
 	desc = JAP_news.03.d
 	picture = GFX_fukushima
 	is_triggered_only = yes
+	major = yes
 
 	#picture
 	option = {
 		name = JAP_news.03.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2758,9 +2638,7 @@ country_event = {
 		remove_ideas = JAP_anxiety_nuclear_power
 		newline = yes
 		add_ideas = JAP_nuclear_strict_examination
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2796,11 +2674,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Japan.101.a executed"
 		country_event = MD4_election_campaign.0
 		hidden_effect = {
-			country_event = { id = Japan.102 days = 15	}
+			country_event = { id = Japan.102 days = 15 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2901,9 +2777,7 @@ country_event = {
 		name = Japan.103.a
 		log = "[GetDateText]: [This.GetName]: Japan.103.a executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 2 }
-			}
+			limit = { check_variable = { ruling_party = 2 } }
 			set_temp_variable = { party_index = 2 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -2928,9 +2802,7 @@ country_event = {
 		name = Japan.103.b
 		log = "[GetDateText]: [This.GetName]: Japan.103.b executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 18 }
-			}
+			limit = { check_variable = { ruling_party = 18 } }
 			set_temp_variable = { party_index = 18 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -2955,9 +2827,7 @@ country_event = {
 		name = Japan.103.c
 		log = "[GetDateText]: [This.GetName]: Japan.103.c executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 19 }
-			}
+			limit = { check_variable = { ruling_party = 19 } }
 			set_temp_variable = { party_index = 19 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -2981,13 +2851,9 @@ country_event = {
 	option = {
 		name = Japan.103.e
 		log = "[GetDateText]: [This.GetName]: Japan.103.e executed"
-		trigger = {
-			has_country_flag = JAP_reiwa_shinsengumi_flag
-		}
+		trigger = { has_country_flag = JAP_reiwa_shinsengumi_flag }
 		if = {
-			limit = {
-				check_variable = { ruling_party = 5 }
-			}
+			limit = { check_variable = { ruling_party = 5 } }
 			set_temp_variable = { party_index = 5 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -3021,9 +2887,7 @@ country_event = {
 		name = Japan.104.a
 		log = "[GetDateText]: [This.GetName]: Japan.104.a executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 1 }
-			}
+			limit = { check_variable = { ruling_party = 1 } }
 			set_temp_variable = { party_index = 1 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -3052,9 +2916,7 @@ country_event = {
 		name = Japan.104.b
 		log = "[GetDateText]: [This.GetName]: Japan.104.b executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 3 }
-			}
+			limit = { check_variable = { ruling_party = 3 } }
 			set_temp_variable = { party_index = 3 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -3091,9 +2953,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				check_variable = { ruling_party = 14 }
-			}
+			limit = { check_variable = { ruling_party = 14 } }
 			set_temp_variable = { party_index = 14 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -3121,13 +2981,9 @@ country_event = {
 	option = {
 		name = Japan.104.e
 		log = "[GetDateText]: [This.GetName]: Japan.104.e executed"
-		trigger = {
-			has_country_flag = JAP_innovation_party_flag
-		}
+		trigger = { has_country_flag = JAP_innovation_party_flag }
 		if = {
-			limit = {
-				check_variable = { ruling_party = 16 }
-			}
+			limit = { check_variable = { ruling_party = 16 } }
 			set_temp_variable = { party_index = 16 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -3151,13 +3007,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Japan.104.f
 		log = "[GetDateText]: [This.GetName]: Japan.104.f executed"
 		if = {
-			limit = {
-				check_variable = { ruling_party = 23 }
-			}
+			limit = { check_variable = { ruling_party = 23 } }
 			set_temp_variable = { party_index = 23 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -3195,9 +3050,7 @@ country_event = {
 		name = JAP_territorial.01.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.01.oA executed"
 		SOV = { country_event = JAP_territorial.02 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3301,9 +3154,7 @@ country_event = {
 				days = 5
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3322,12 +3173,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
 		JAP_escalate_territorial_disputes = yes
-		hidden_effect = {
-			set_country_flag = JAP_kuril_islands_solve
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { set_country_flag = JAP_kuril_islands_solve }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3346,9 +3193,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = JAP_renegotiation_territory
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3364,9 +3209,7 @@ country_event = {
 		name = JAP_territorial.05.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.05.oA executed"
 		CHI = { country_event = JAP_territorial.06 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3469,9 +3312,7 @@ country_event = {
 				days = 5
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3490,12 +3331,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
 		JAP_escalate_territorial_disputes = yes
-		hidden_effect = {
-			set_country_flag = JAP_chi_senkaku_solve
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { set_country_flag = JAP_chi_senkaku_solve }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3514,9 +3351,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = JAP_renegotiation_territory
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3532,9 +3367,7 @@ country_event = {
 		name = JAP_territorial.09.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.09.oA executed"
 		TAI = { country_event = JAP_territorial.10 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3637,9 +3470,7 @@ country_event = {
 				days = 5
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3658,12 +3489,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
 		JAP_escalate_territorial_disputes = yes
-		hidden_effect = {
-			set_country_flag = JAP_tai_senkaku_solve
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { set_country_flag = JAP_tai_senkaku_solve }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3682,9 +3509,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = JAP_renegotiation_territory
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3700,9 +3525,7 @@ country_event = {
 		name = JAP_territorial.13.oA
 		log = "[GetDateText]: [This.GetName]: JAP_territorial.13.oA executed"
 		KOR = { country_event = JAP_territorial.14 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3802,9 +3625,7 @@ country_event = {
 				days = 5
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3823,12 +3644,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
 		JAP_escalate_territorial_disputes = yes
-		hidden_effect = {
-			set_country_flag = JAP_liancourt_rocks_solve
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { set_country_flag = JAP_liancourt_rocks_solve }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3847,9 +3664,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = JAP_renegotiation_territory
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3868,9 +3683,7 @@ country_event = {
 		name = JAP_diplomacy.01.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.01.a executed"
 		USA = { country_event = JAP_diplomacy.02 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3878,9 +3691,9 @@ country_event = {
 	id = JAP_diplomacy.02
 	title = JAP_diplomacy.02.t
 	desc = JAP_diplomacy.02.d
+	picture = GFX_JAP_event_okinawa_base
 	is_triggered_only = yes
 
-	picture = GFX_JAP_event_okinawa_base
 	option = {
 		name = JAP_diplomacy.02.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.02.a executed"
@@ -4006,9 +3819,7 @@ country_event = {
 				modifier = review_relationship
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4026,9 +3837,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.05 }
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = JAP_renegotiation_territory
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4043,15 +3852,11 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.05.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.05.a executed"
-		KOR = {
-			country_event = JAP_diplomacy.06
-		}
+		KOR = { country_event = JAP_diplomacy.06 }
 		CHI = {
 			country_event = { id = JAP_diplomacy.07 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4066,15 +3871,9 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.06.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.06.a executed"
-		JAP = {
-			set_country_flag = JAP_kor_accept_intellectual_platform
-		}
-		KOR = {
-			set_country_flag = KOR_jap_accept_intellectual_platform
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { set_country_flag = JAP_kor_accept_intellectual_platform }
+		KOR = { set_country_flag = KOR_jap_accept_intellectual_platform }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -4112,12 +3911,8 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.06.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.06.a executed"
-		JAP = {
-			set_country_flag = JAP_chi_accept_intellectual_platform
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { set_country_flag = JAP_chi_accept_intellectual_platform }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -4149,21 +3944,13 @@ country_event = {
 		name = JAP_diplomacy.08.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.08.a executed"
 		add_ideas = JAP_chi_kor_intellectual_platform
-		KOR = {
-			add_ideas = JAP_chi_kor_intellectual_platform
-		}
-		CHI = {
-			add_ideas = JAP_chi_kor_intellectual_platform
-		}
+		KOR = { add_ideas = JAP_chi_kor_intellectual_platform }
+		CHI = { add_ideas = JAP_chi_kor_intellectual_platform }
 		set_temp_variable = { treasury_change = gdp_total }
 		multiply_temp_variable = { treasury_change = -0.01 }
 		modify_treasury_effect = yes
-		hidden_effect = {
-			clr_country_flag = intellectual_platform_rejected
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { clr_country_flag = intellectual_platform_rejected }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4179,12 +3966,8 @@ country_event = {
 		name = JAP_diplomacy.09.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.09.a executed"
 		unlock_decision_tooltip = JAP_intellectual_platform_decision
-		hidden_effect = {
-			set_country_flag = intellectual_platform_rejected
-		}
-		ai_chance = {
-			base = 1
-		}
+		hidden_effect = { set_country_flag = intellectual_platform_rejected }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4228,20 +4011,14 @@ country_event = {
 		name = JAP_diplomacy.34.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.34.a executed"
 		add_ideas = JAP_chiang_mai_initiative
-		JAP = {
-			country_event = JAP_diplomacy.35
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { country_event = JAP_diplomacy.35 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = JAP_diplomacy.34.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.34.b executed"
-		JAP = {
-			country_event = JAP_diplomacy.36
-		}
+		JAP = { country_event = JAP_diplomacy.36 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4271,9 +4048,7 @@ country_event = {
 				modifier = diplomatic_support
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4286,9 +4061,7 @@ country_event = {
 	#picture
 	option = {
 		name = JAP_diplomacy.36.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4306,20 +4079,14 @@ country_event = {
 			idea = JAP_quantitative_oda_idea
 			days = 730
 		}
-		JAP = {
-			country_event = JAP_diplomacy.38
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { country_event = JAP_diplomacy.38 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = JAP_diplomacy.37.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.37.b executed"
-		JAP = {
-			country_event = JAP_diplomacy.39
-		}
+		JAP = { country_event = JAP_diplomacy.39 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4350,13 +4117,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -3.5 }
 		modify_treasury_effect = yes
 		if = {
-			limit = {
-				FROM = {
-					NOT = {
-						has_country_flag = JAP_development_aid_flag
-					}
-				}
-			}
+			limit = { FROM = { NOT = { has_country_flag = JAP_development_aid_flag } } }
 			FROM = {
 				add_opinion_modifier = {
 					target = JAP
@@ -4365,9 +4126,7 @@ country_event = {
 				set_country_flag = JAP_development_aid_flag
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4380,9 +4139,7 @@ country_event = {
 	#picture
 	option = {
 		name = JAP_diplomacy.39.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4397,20 +4154,14 @@ country_event = {
 		name = JAP_diplomacy.40.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.40.a executed"
 		add_ideas = JAP_qualitative_oda_idea
-		JAP = {
-			country_event = JAP_diplomacy.41
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { country_event = JAP_diplomacy.41 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = JAP_diplomacy.40.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.40.b executed"
-		JAP = {
-			country_event = JAP_diplomacy.42
-		}
+		JAP = { country_event = JAP_diplomacy.42 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4439,13 +4190,7 @@ country_event = {
 		set_temp_variable = { influence_target = FROM }
 		change_influence_percentage = yes
 		if = {
-			limit = {
-				FROM = {
-					NOT = {
-						has_country_flag = JAP_development_aid_flag
-					}
-				}
-			}
+			limit = { FROM = { NOT = { has_country_flag = JAP_development_aid_flag } } }
 			FROM = {
 				add_opinion_modifier = {
 					target = JAP
@@ -4454,9 +4199,7 @@ country_event = {
 				set_country_flag = JAP_development_aid_flag
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4469,9 +4212,7 @@ country_event = {
 	#picture
 	option = {
 		name = JAP_diplomacy.42.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4486,20 +4227,14 @@ country_event = {
 		name = JAP_diplomacy.43.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.43.a executed"
 		add_ideas = JAP_security_south_china_sea_idea
-		JAP = {
-			country_event = JAP_diplomacy.44
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { country_event = JAP_diplomacy.44 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = JAP_diplomacy.43.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.43.b executed"
-		JAP = {
-			country_event = JAP_diplomacy.45
-		}
+		JAP = { country_event = JAP_diplomacy.45 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4533,9 +4268,7 @@ country_event = {
 				modifier = trade_security
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4548,9 +4281,7 @@ country_event = {
 	#picture
 	option = {
 		name = JAP_diplomacy.45.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4565,9 +4296,7 @@ country_event = {
 		name = JAP_diplomacy.46.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.46.a executed"
 		add_ideas = JAP_jap_education
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4585,9 +4314,7 @@ country_event = {
 			remove_idea = JAP_jap_education
 			add_idea = JAP_jap_education_culture
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4602,9 +4329,7 @@ country_event = {
 		name = JAP_diplomacy.48.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.48.a executed"
 		add_ideas = JAP_dual_use_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4619,9 +4344,7 @@ country_event = {
 		name = JAP_diplomacy.49.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.49.a executed"
 		add_ideas = JAP_disaster_countermeasure_cooperation_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4636,9 +4359,7 @@ country_event = {
 		name = JAP_diplomacy.50.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.50.a executed"
 		add_ideas = JAP_tai_high_technology_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4653,9 +4374,7 @@ country_event = {
 		name = JAP_diplomacy.51.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.51.a executed"
 		add_ideas = JAP_tai_international_student_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4670,20 +4389,14 @@ country_event = {
 		name = JAP_diplomacy.52.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.52.a executed"
 		add_ideas = JAP_chi_trade_support_idea
-		JAP = {
-			country_event = JAP_diplomacy.53
-		}
-		ai_chance = {
-			base = 1
-		}
+		JAP = { country_event = JAP_diplomacy.53 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = JAP_diplomacy.52.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.52.b executed"
-		JAP = {
-			country_event = JAP_diplomacy.54
-		}
+		JAP = { country_event = JAP_diplomacy.54 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4711,9 +4424,7 @@ country_event = {
 		set_temp_variable = { tag_index = JAP }
 		set_temp_variable = { influence_target = CHI }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4726,9 +4437,7 @@ country_event = {
 	#picture
 	option = {
 		name = JAP_diplomacy.54.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4743,9 +4452,7 @@ country_event = {
 		name = JAP_diplomacy.55.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.55.a executed"
 		add_ideas = JAP_chi_advancement_companies_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4760,9 +4467,7 @@ country_event = {
 		name = JAP_diplomacy.56.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.56.a executed"
 		add_ideas = JAP_chi_kanji_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4777,9 +4482,7 @@ country_event = {
 		name = JAP_diplomacy.57.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.57.a executed"
 		add_ideas = JAP_chi_temple_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4794,9 +4497,7 @@ country_event = {
 		name = JAP_diplomacy.58.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.58.a executed"
 		add_ideas = JAP_kor_accelerator_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4811,9 +4512,7 @@ country_event = {
 		name = JAP_diplomacy.59.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.59.a executed"
 		add_ideas = JAP_kor_local_companies_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4839,17 +4538,13 @@ country_event = {
 			country_event = JAP_diplomacy.61
 		}
 		custom_effect_tooltip = JAP_diplomacy_60_TT2
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = JAP_diplomacy.60.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.60.b executed"
-		JAP = {
-			country_event = JAP_diplomacy.62
-		}
+		JAP = { country_event = JAP_diplomacy.62 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4883,9 +4578,7 @@ country_event = {
 				modifier = opinion_cultural_exchange
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4898,9 +4591,7 @@ country_event = {
 	#picture
 	option = {
 		name = JAP_diplomacy.62.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4915,9 +4606,7 @@ country_event = {
 		name = JAP_diplomacy.63.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.63.a executed"
 		add_ideas = JAP_kor_aging_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4947,9 +4636,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4971,9 +4658,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -4991,9 +4676,7 @@ country_event = {
 			idea = JAP_sov_logistics_corridor_idea
 			days = 730
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5011,9 +4694,7 @@ country_event = {
 			idea = JAP_sov_it_corridor_idea
 			days = 730
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -5215,16 +4896,10 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = JAP_diplomacy.16.a
-	}
+	option = { name = JAP_diplomacy.16.a }
 
 	option = {
-		trigger = {
-			JAP = {
-				is_guaranteed_by = USA
-			}
-		}
+		trigger = { JAP = { is_guaranteed_by = USA } }
 		name = JAP_diplomacy.16.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.16.b executed"
 		diplomatic_relation = {
@@ -5316,9 +4991,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = JAP_diplomacy.20.a
-	}
+	option = { name = JAP_diplomacy.20.a }
 }
 country_event = {
 	id = JAP_diplomacy.21
@@ -5368,9 +5041,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = JAP_diplomacy.23.a
-	}
+	option = { name = JAP_diplomacy.23.a }
 }
 country_event = {
 	id = JAP_diplomacy.24
@@ -5639,9 +5310,7 @@ country_event = {
 		name = JAP_diplomacy.68.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.68.b"
 		JAP = { country_event = { id = JAP_diplomacy.70 days = 1 } }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5669,9 +5338,7 @@ country_event = {
 
 	option = {
 		name = JAP_diplomacy.70.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -5679,9 +5346,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.70.b"
 		custom_effect_tooltip = JAP_unlock_sikhalin_raid_tt
 		set_country_flag = JAP_sakhalin_raid_unlocked
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -5692,9 +5357,7 @@ country_event = {
 			type = take_claimed_state
 			generator = { 691 690 1168 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5708,22 +5371,16 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.71.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.71.a"
-		effect_tooltip = {
-			JAP = { transfer_state = 690 }
-		}
+		effect_tooltip = { JAP = { transfer_state = 690 } }
 		JAP = { country_event = { id = JAP_diplomacy.72 days = 1 } }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = JAP_diplomacy.71.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.71.b"
 		JAP = { country_event = { id = JAP_diplomacy.73 days = 1 } }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5738,9 +5395,7 @@ country_event = {
 		name = JAP_diplomacy.72.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.72.a"
 		JAP = { transfer_state = 690 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5753,17 +5408,13 @@ country_event = {
 
 	option = {
 		name = JAP_diplomacy.73.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = JAP_diplomacy.73.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.73.b"
-		trigger = {
-			owns_state = 1168
-		}
+		trigger = { owns_state = 1168 }
 		if = {
 			limit = {
 				controls_state = 1168
@@ -5790,9 +5441,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -5824,9 +5473,7 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.74.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.74.a"
-		effect_tooltip = {
-				JAP = { transfer_state = 1168 }
-			}
+		effect_tooltip = { JAP = { transfer_state = 1168 } }
 		JAP = { country_event = { id = JAP_diplomacy.75 days = 1 } }
 		ai_chance = {
 			base = 10
@@ -5869,9 +5516,7 @@ country_event = {
 		name = JAP_diplomacy.75.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.75.a"
 		transfer_state = 1168
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -5887,9 +5532,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.76.a"
 		add_political_power = -125
 		add_stability = -0.05
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -5921,9 +5564,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -5934,9 +5575,7 @@ country_event = {
 			type = take_claimed_state
 			generator = { 691 690 1168 }
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 country_event = {
@@ -6031,16 +5670,10 @@ country_event = {
 		name = JAP_diplomacy.78.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.78.a"
 		SOV = {
-			white_peace = {
-				tag = JAP
-			}
+			white_peace = { tag = JAP }
 			every_other_country = {
-				limit = {
-					is_in_faction_with = PREV
-				}
-				white_peace = {
-					tag = JAP
-				}
+				limit = { is_in_faction_with = PREV }
+				white_peace = { tag = JAP }
 			}
 		}
 		JAP = {
@@ -6048,9 +5681,7 @@ country_event = {
 			transfer_state = 1168
 			transfer_state = 690
 			}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6064,9 +5695,7 @@ country_event = {
 	#Damnit!
 	option = {
 		name = JAP_diplomacy.79.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 country_event = {
@@ -6114,9 +5743,7 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.80.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.80.b"
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 		FROM = {
 			country_event = {
 				id = JAP_diplomacy.82
@@ -6136,22 +5763,14 @@ country_event = {
 	option = {
 		name = JAP_diplomacy.81.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.81.a"
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 		add_stability = -0.1
 		add_war_support = -0.05
 		JAP = {
-			white_peace = {
-				tag = SOV
-			}
+			white_peace = { tag = SOV }
 			every_other_country = {
-				limit = {
-					is_in_faction_with = SOV
-				}
-				white_peace = {
-					tag = JAP
-				}
+				limit = { is_in_faction_with = SOV }
+				white_peace = { tag = JAP }
 			}
 			transfer_state = 691
 			transfer_state = 1168
@@ -6170,9 +5789,7 @@ country_event = {
 	#Damnit!
 	option = {
 		name = JAP_diplomacy.82.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6188,9 +5805,7 @@ country_event = {
 		name = JAP_diplomacy.83.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.83.a"
 		transfer_state = 1168
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Lose borderwar in South Kurils as Japan
@@ -6205,9 +5820,7 @@ country_event = {
 		name = JAP_diplomacy.84.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.84.a"
 		army_experience = 15
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 # Lose borderwar in South Kurils as Russia
@@ -6222,12 +5835,8 @@ country_event = {
 		name = JAP_diplomacy.85.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.85.a"
 		army_experience = 15
-		effect_tooltip = {
-			transfer_state = 1168
-		}
-		ai_chance = {
-			base = 10
-		}
+		effect_tooltip = { transfer_state = 1168 }
+		ai_chance = { base = 10 }
 	}
 }
 #Win borderwar in South Kurils as Russia
@@ -6242,9 +5851,7 @@ country_event = {
 		name = JAP_diplomacy.86.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.86.a"
 		army_experience = 50
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6260,9 +5867,7 @@ country_event = {
 		name = JAP_diplomacy.87.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.87.a"
 		transfer_state = 690
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 #Lose borderwar in North Kurils as Japan
@@ -6277,9 +5882,7 @@ country_event = {
 		name = JAP_diplomacy.88.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.88.a"
 		army_experience = 15
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 # Lose borderwar in North Kurils as Russia
@@ -6294,12 +5897,8 @@ country_event = {
 		name = JAP_diplomacy.89.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.89.a"
 		army_experience = 15
-		effect_tooltip = {
-			transfer_state = 690
-		}
-		ai_chance = {
-			base = 10
-		}
+		effect_tooltip = { transfer_state = 690 }
+		ai_chance = { base = 10 }
 	}
 }
 #Win borderwar in North Kurils as Russia
@@ -6314,9 +5913,7 @@ country_event = {
 		name = JAP_diplomacy.90.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.90.a"
 		army_experience = 50
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6338,9 +5935,7 @@ country_event = {
 				generator = { 691 690 1168 }
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -6354,9 +5949,7 @@ country_event = {
 			country = JAP
 			relation = naval_blockade
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6379,31 +5972,21 @@ country_event = {
 				generator = { 691 690 1168 }
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = JAP_diplomacy.92.b
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.92.b"
 		JAP = {
-			white_peace = {
-				tag = SOV
-			}
+			white_peace = { tag = SOV }
 			every_other_country = {
-				limit = {
-					is_in_faction_with = SOV
-				}
-				white_peace = {
-					tag = JAP
-				}
+				limit = { is_in_faction_with = SOV }
+				white_peace = { tag = JAP }
 			}
 			transfer_state = 691
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6703,9 +6286,7 @@ country_event = {
 			target = TAI
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6811,9 +6392,7 @@ country_event = {
 			target = PHI
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -6930,9 +6509,7 @@ country_event = {
 			target = MAY
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7048,9 +6625,7 @@ country_event = {
 			target = IND
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7182,9 +6757,7 @@ country_event = {
 			target = VIE
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7316,9 +6889,7 @@ country_event = {
 			target = CBD
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7450,9 +7021,7 @@ country_event = {
 			target = LAO
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7584,9 +7153,7 @@ country_event = {
 			target = AST
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7718,9 +7285,7 @@ country_event = {
 			target = NZL
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7852,9 +7417,7 @@ country_event = {
 			target = BRM
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -7986,9 +7549,7 @@ country_event = {
 			target = KAC
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8109,9 +7670,7 @@ country_event = {
 			target = WAA
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8233,9 +7792,7 @@ country_event = {
 			target = SHN
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8357,9 +7914,7 @@ country_event = {
 			target = KAR
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8481,9 +8036,7 @@ country_event = {
 			target = PAU
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8605,9 +8158,7 @@ country_event = {
 			target = MIC
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8729,9 +8280,7 @@ country_event = {
 			target = NAU
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8853,9 +8402,7 @@ country_event = {
 			target = KIR
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -8977,9 +8524,7 @@ country_event = {
 			target = MAR
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9101,9 +8646,7 @@ country_event = {
 			target = TUL
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9226,9 +8769,7 @@ country_event = {
 			target = SOL
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9351,9 +8892,7 @@ country_event = {
 			target = PAP
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9475,9 +9014,7 @@ country_event = {
 			target = VAN
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9599,9 +9136,7 @@ country_event = {
 			target = FIJ
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9723,9 +9258,7 @@ country_event = {
 			target = SAM
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9847,9 +9380,7 @@ country_event = {
 			target = TON
 			end_wars = yes
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -9973,9 +9504,7 @@ country_event = {
 		transfer_state = 822
 		transfer_state = 825
 		transfer_state = 827
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10101,9 +9630,7 @@ country_event = {
 		transfer_state = 71
 		transfer_state = 1215
 		transfer_state = 69
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10223,9 +9750,7 @@ country_event = {
 		name = JAP_diplomacy.197.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.197.a"
 		transfer_state = 18
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10285,9 +9810,7 @@ country_event = {
 			idea = JAP_dprk_policy_idea
 			years = 5
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10303,16 +9826,10 @@ country_event = {
 		name = JAP_diplomacy.200.a
 		log = "[GetDateText]: [This.GetName]: JAP_diplomacy.200.a executed"
 		JAP = {
-			white_peace = {
-				tag = SOV
-			}
+			white_peace = { tag = SOV }
 			every_other_country = {
-				limit = {
-					is_in_faction_with = SOV
-				}
-				white_peace = {
-					tag = JAP
-				}
+				limit = { is_in_faction_with = SOV }
+				white_peace = { tag = JAP }
 			}
 			add_stability = -0.15
 			add_war_support = -0.10
@@ -10321,9 +9838,7 @@ country_event = {
 				years = 5
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10338,12 +9853,8 @@ news_event = {
 
 	option = {
 		name = JAP_news.01.a
-		trigger = {
-			tag = JAP
-		}
-		ai_chance = {
-			base = 1
-		}
+		trigger = { tag = JAP }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10354,9 +9865,7 @@ news_event = {
 				tag = CHI
 			}
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -10370,9 +9879,7 @@ news_event = {
 
 	option = {
 		name = JAP_news.04.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10387,9 +9894,7 @@ country_event = {
 		name = Japan_economy.02.a
 		log = "[GetDateText]: [This.GetName]: Japan_economy.02.a executed"
 		add_ideas = JAP_improvement_private_investment_climate_idea
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10412,9 +9917,7 @@ country_event = {
 		}
 		set_temp_variable = { temp_opinion = -2 }
 		change_small_medium_business_owners_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10431,9 +9934,7 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		set_temp_variable = { temp_opinion = -3 }
 		change_industrial_conglomerates_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -10446,9 +9947,7 @@ country_event = {
 				75 = { set_country_flag = JAP_wage_negotiations_failure_flag }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10471,9 +9970,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10496,9 +9993,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10522,9 +10017,7 @@ country_event = {
 
 	option = {
 		name = Japan_economy.17.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10537,9 +10030,7 @@ country_event = {
 
 	option = {
 		name = Japan_economy.18.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10552,9 +10043,7 @@ country_event = {
 
 	option = {
 		name = Japan_economy.19.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10567,9 +10056,7 @@ country_event = {
 
 	option = {
 		name = Japan_economy.20.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10582,9 +10069,7 @@ country_event = {
 
 	option = {
 		name = Japan_economy.21.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10597,9 +10082,7 @@ country_event = {
 
 	option = {
 		name = Japan_economy.22.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -10615,18 +10098,14 @@ country_event = {
 		name = Japan_economy.32.a
 		log = "[GetDateText]: [This.GetName]: Japan_economy.32.a executed"
 		add_political_power = -30
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = Japan_economy.32.b
 		log = "[GetDateText]: [This.GetName]: Japan_economy.32.b executed"
 		add_stability = -0.02
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -11442,15 +10921,12 @@ country_event = {
 			set_variable = { conservatism_leader = 0 }
 			set_temp_variable = { rul_party_temp = 1 }
 		}
-
 		if = {
 			limit = { NOT = { check_variable = { ruling_party = rul_party_temp } } }
 			change_ruling_party_effect = yes
 			set_elections_48_months = yes
 		}
-		else = {
-			set_leader = yes
-		}
+		else = { set_leader = yes }
 	}
 }
 
@@ -11814,9 +11290,7 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 
-	trigger = {
-		JAP_sony_outcome_settled = no
-	}
+	trigger = { JAP_sony_outcome_settled = no }
 
 	option = {
 		name = JAP_electronics.305.a
@@ -12163,9 +11637,7 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 
-	trigger = {
-		JAP_nintendo_outcome_settled = no
-	}
+	trigger = { JAP_nintendo_outcome_settled = no }
 
 	option = {
 		name = JAP_electronics.315.a
@@ -12518,9 +11990,7 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 
-	trigger = {
-		JAP_konami_outcome_settled = no
-	}
+	trigger = { JAP_konami_outcome_settled = no }
 
 	option = {
 		name = JAP_electronics.325.a
@@ -12874,9 +12344,7 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
-	trigger = {
-		JAP_softbank_outcome_settled = no
-	}
+	trigger = { JAP_softbank_outcome_settled = no }
 
 	option = {
 		name = JAP_electronics.335.a

--- a/events/Serbia.txt
+++ b/events/Serbia.txt
@@ -21,6 +21,7 @@ country_event = {
 	desc = ser_invest.1.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.1.a executed"
 		name = ser_invest.1.a
@@ -57,9 +58,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = ITA
-			}
+			limit = { original_tag = ITA }
 			set_temp_variable = { percent_change = 3.5 }
 			set_temp_variable = { influence_target = SER }
 			change_influence_percentage = yes
@@ -71,9 +70,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = AUS
-			}
+			limit = { original_tag = AUS }
 			set_temp_variable = { percent_change = 3.5 }
 			set_temp_variable = { influence_target = SER }
 			change_influence_percentage = yes
@@ -85,9 +82,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = SOV
-			}
+			limit = { original_tag = SOV }
 			set_temp_variable = { percent_change = 3.5 }
 			set_temp_variable = { influence_target = SER }
 			change_influence_percentage = yes
@@ -99,9 +94,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = CHI
-			}
+			limit = { original_tag = CHI }
 			set_temp_variable = { percent_change = 3.5 }
 			set_temp_variable = { influence_target = SER }
 			change_influence_percentage = yes
@@ -113,6 +106,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.1.b executed"
 		name = ser_invest.1.b
@@ -138,6 +132,7 @@ country_event = {
 	desc = ser_invest.2.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.2.a executed"
 		name = ser_invest.2.a
@@ -152,6 +147,7 @@ country_event = {
 	desc = ser_invest.3.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.3.a executed"
 		name = ser_invest.3.a
@@ -166,6 +162,7 @@ country_event = {
 	desc = ser_invest.4.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.4.a executed"
 		name = ser_invest.4.a
@@ -187,9 +184,8 @@ country_event = {
 	desc = ser_invest.5.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
-	option = {
-		name = ser_invest.5.a
-	}
+
+	option = { name = ser_invest.5.a }
 }
 #Serbia Requere Invest Russia
 country_event = {
@@ -198,6 +194,7 @@ country_event = {
 	desc = ser_invest.6.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.6.a executed"
 		name = ser_invest.6.a
@@ -211,6 +208,7 @@ country_event = {
 	desc = ser_invest.7.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: ser_invest.7.a executed"
 		name = ser_invest.7.a
@@ -228,12 +226,9 @@ country_event = { #Arkan Assassination
 	title = "Arkan Assassination Attempt"
 	desc = Serbia.1.d
 	picture = GFX_Arkan_Assassination
-
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SER
-	}
+	trigger = { original_tag = SER }
 
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.1.a executed"
@@ -261,7 +256,6 @@ country_event = {
 	title = Serbia.2.t
 	desc = Serbia.2.d
 	picture = GFX_Arkan_Assassination
-
 	is_triggered_only = yes
 
 	option = {
@@ -280,6 +274,7 @@ country_event = {
 			change_relative_party_popularity = yes
 		}
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.2.b executed"
 		name = Serbia.2.b
@@ -292,11 +287,10 @@ country_event = { #Zoran Đinđić Assassinate Plot
 	id = Serbia.3 #WIP
 	title = "Uncovered Plot to Kill Zoran Đinđić"
 	desc = Serbia.3.d
-	#picture = GFX_Arkan_Assassination
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
+	#picture = GFX_Arkan_Assassination
 	trigger = {
 		original_tag = SER
 		has_country_flag = SER_bulldozer_revolution
@@ -344,13 +338,10 @@ country_event = { #2010 Earthquake
 	id = Serbia.5
 	title = "5.5 Magnitude Earthquake Hits Kraljevo!"
 	desc = Serbia.5.d
-
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SER
-	}
+	trigger = { original_tag = SER }
 
 	immediate = {
 		add_stability = -0.05
@@ -370,7 +361,7 @@ country_event = { #2010 Earthquake
 				NOT = { state = 134 }
 				industrial_complex > 0
 			}
-			remove_building = { type = industrial_complex  level = 1 }
+			remove_building = { type = industrial_complex level = 1 }
 		}
 	}
 
@@ -383,7 +374,7 @@ country_event = { #2010 Earthquake
 				NOT = { state = 134 }
 				infrastructure > 0
 			}
-			remove_building = { type = infrastructure  level = 1 }
+			remove_building = { type = infrastructure level = 1 }
 		}
 		add_manpower = -2000
 		custom_effect_tooltip = Serbia.5.tt
@@ -393,14 +384,11 @@ country_event = { #2014 Floods
 	id = Serbia.6 #WIP
 	title = "Cyclone Tamara Causes Massive Flooding!"
 	desc = Serbia.6.d
-	#picture = GFX_Arkan_Assassination
-
 	picture = GFX_typhoon
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SER
-	}
+	#picture = GFX_Arkan_Assassination
+	trigger = { original_tag = SER }
 
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.6.a executed"
@@ -411,7 +399,7 @@ country_event = { #2014 Floods
 				NOT = { state = 134 }
 				infrastructure > 0
 			}
-			remove_building = { type = infrastructure  level = 1 }
+			remove_building = { type = infrastructure level = 1 }
 		}
 		ai_chance = { base = 50 }
 	}
@@ -420,14 +408,11 @@ country_event = { #2018 Floods
 	id = Serbia.7 #WIP
 	title = "Flash Floods Damage Agriculture!"
 	desc = Serbia.7.d
-	#picture = GFX_Arkan_Assassination
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SER
-	}
+	#picture = GFX_Arkan_Assassination
+	trigger = { original_tag = SER }
 
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.7.a executed"
@@ -451,13 +436,11 @@ country_event = { #Cyanide Spills in Danube
 	id = Serbia.8 #WIP
 	title = Serbia.8.t
 	desc = Serbia.8.d
-	#picture = GFX_Arkan_Assassination
-
-	fire_only_once = yes
-
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture = GFX_Arkan_Assassination
 	immediate = {
 		BUL = {
 			country_event = { id = Serbia.8 days = 1 }
@@ -526,16 +509,12 @@ country_event = { #Zoran Đinđić Assassinated
 	id = Serbia.9
 	title = "Zoran Đinđić Assassinated!"
 	desc = Serbia.9.d
-	#picture = GFX_Arkan_Assassination
-
-	fire_only_once = yes
-
 	picture = GFX_court
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	trigger = {
-		has_country_flag = SER_Zoran_Die
-	}
+	#picture = GFX_Arkan_Assassination
+	trigger = { has_country_flag = SER_Zoran_Die }
 
 	option = { #Operation Sabre decisions (you get to arrest people as you wish kinda maybe idk yet just brainstorming rn)
 		name = Serbia.9.a
@@ -555,16 +534,9 @@ country_event = { #Zoran Đinđić Assassinated Prevention With Đinđić In Pow
 	id = Serbia.10 #WIP
 	title = "Assassination Attempt Prevented"
 	desc = Serbia.10.d
-	#picture = GFX_Arkan_Assassination
-
-	fire_only_once = yes
-
 	picture = GFX_court
 	is_triggered_only = yes
-
-	immediate = {
-		set_country_flag = Serbia.10_fired_first
-	}
+	fire_only_once = yes
 
 	trigger = {
 		has_country_flag = SER_Zoran_Live
@@ -572,6 +544,8 @@ country_event = { #Zoran Đinđić Assassinated Prevention With Đinđić In Pow
 		NOT = { has_country_flag = Serbia.11_fired_first }
 	}
 
+	#picture = GFX_Arkan_Assassination
+	immediate = { set_country_flag = Serbia.10_fired_first }
 
 	option = {
 		name = Serbia.10.a
@@ -587,16 +561,9 @@ country_event = { #Zoran Đinđić Assassinated Prevention With Kostunica In Pow
 	id = Serbia.11 #WIP
 	title = "Assassination Attempt Prevented"
 	desc = Serbia.11.d
-	#picture = GFX_Arkan_Assassination
-
-	fire_only_once = yes
-
 	picture = GFX_court
 	is_triggered_only = yes
-
-	immediate = {
-		set_country_flag = Serbia.11_fired_first
-	}
+	fire_only_once = yes
 
 	trigger = {
 		has_country_flag = SER_Zoran_Live
@@ -604,6 +571,8 @@ country_event = { #Zoran Đinđić Assassinated Prevention With Kostunica In Pow
 		NOT = { has_country_flag = Serbia.10_fired_first }
 	}
 
+	#picture = GFX_Arkan_Assassination
+	immediate = { set_country_flag = Serbia.11_fired_first }
 
 	option = {
 		name = Serbia.11.a
@@ -619,19 +588,16 @@ country_event = { #Zoran Đinđić Assassinated Prevention With Neither Đinđi�
 	id = Serbia.12 #WIP
 	title = "Assassination Attempt Prevented"
 	desc = Serbia.12.d
-	#picture = GFX_Arkan_Assassination
-
-	fire_only_once = yes
-
 	picture = GFX_court
 	is_triggered_only = yes
+	fire_only_once = yes
 
+	#picture = GFX_Arkan_Assassination
 	trigger = {
 		has_country_flag = SER_Zoran_Live
 		NOT = { has_country_flag = Serbia.10_fired_first }
 		NOT = { has_country_flag = Serbia.11_fired_first }
 	}
-
 
 	option = {
 		name = Serbia.12.a
@@ -649,8 +615,11 @@ country_event = {
 	id = Serbia.14
 	title = Serbia.14.t
 	desc = Serbia.14.d
-	#picture = GFX_Arkan_Assassination
+	picture = GFX_treaty
+	is_triggered_only = yes
 	fire_only_once = yes
+
+	#picture = GFX_Arkan_Assassination
 	trigger = {
 		OR = {
 			134 = { is_owned_and_controlled_by = SER }
@@ -658,15 +627,11 @@ country_event = {
 		}
 	}
 
-	picture = GFX_treaty
-	is_triggered_only = yes
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.14.a executed"
 		name = Serbia.14.a
 		set_country_flag = SER_montenegro_independence
-
 		unlock_decision_category_tooltip = SER_The_Montenegro_Confederacy
-
 		hidden_effect = {
 			country_event = {
 				id = Serbia.16
@@ -682,7 +647,10 @@ country_event = {
 	id = Serbia.15
 	title = Serbia.15.t
 	desc = Serbia.15.d
+	picture = GFX_treaty
+	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = {
 		OR = {
 			134 = { is_owned_and_controlled_by = SER }
@@ -690,8 +658,6 @@ country_event = {
 		}
 	}
 
-	picture = GFX_treaty
-	is_triggered_only = yes
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.15.a executed"
 		name = Serbia.15.a
@@ -705,9 +671,7 @@ country_event = {
 		}
 		else = {
 			release = MNT
-			MNT = {
-				ingame_startup_nations_effect = yes
-			}
+			MNT = { ingame_startup_nations_effect = yes }
 		}
 		ai_chance = { base = 75 }
 	}
@@ -717,16 +681,18 @@ country_event = { #Montenegrans become militarized
 	id = Serbia.16
 	title = Serbia.16.t
 	desc = Serbia.16.d
-	#picture = GFX_Arkan_Assassination
+	picture = GFX_news_generic_soldiers
+	is_triggered_only = yes
 	fire_only_once = yes
+
+	#picture = GFX_Arkan_Assassination
 	trigger = {
 		OR = {
 			134 = { is_owned_and_controlled_by = SER }
 			MNT = { is_subject_of = SER }
 		}
 	}
-	picture = GFX_news_generic_soldiers
-	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.16.a executed"
 		name = Serbia.16.a
@@ -739,6 +705,7 @@ country_event = { #Montenegrans become militarized
 		clamp_variable = { var = SER_Montenegro_combatants min = 0 max = 8000 }
 		ai_chance = { base = 75 }
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.16.b executed"
 		name = Serbia.16.b
@@ -752,9 +719,7 @@ country_event = { #Montenegrans become militarized
 		}
 		else = {
 			release = MNT
-			MNT = {
-				ingame_startup_nations_effect = yes
-			}
+			MNT = { ingame_startup_nations_effect = yes }
 		}
 		ai_chance = { base = 75 }
 	}
@@ -765,9 +730,10 @@ country_event = {
 	id = Serbia.17
 	title = Serbia.17.t
 	desc = Serbia.17.d
-	#picture = GFX_Arkan_Assassination # TODO: Add a picture here
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
+	#picture = GFX_Arkan_Assassination # TODO: Add a picture here
 	trigger = {
 		OR = {
 			134 = { is_owned_and_controlled_by = SER }
@@ -779,7 +745,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: Serbia.17.a executed"
 		name = Serbia.17.a
 		set_country_flag = SER_montenegro_independence_dead
-
 		clr_country_flag = SER_montenegro_independence
 		ai_chance = { base = 75 }
 	}
@@ -789,9 +754,9 @@ country_event = {
 	id = Serbia.18
 	title = Serbia.18.t
 	desc = Serbia.18.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.18.a executed"
 		name = Serbia.18.a
@@ -821,6 +786,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.18.b executed"
 		name = Serbia.18.b
@@ -844,11 +810,7 @@ country_event = {
 			add_political_power = -100
 			annex_country = { target = ROOT transfer_troops = yes }
 			hidden_effect = {
-				ROOT = {
-					every_unit_leader = {
-						set_nationality = SER
-					}
-				}
+				ROOT = { every_unit_leader = { set_nationality = SER } }
 			add_to_variable = { treasury = ROOT.treasury }
 			add_to_variable = { debt = ROOT.debt }
 			add_to_variable = { int_investments = ROOT.int_investments }
@@ -861,7 +823,6 @@ country_event = {
 	id = Serbia.19
 	title = Serbia.19.t
 	desc = Serbia.19.d
-
 	picture = GFX_news_crime_fighting
 	is_triggered_only = yes
 
@@ -870,14 +831,13 @@ country_event = {
 		has_country_flag = SER_bulldozer_revolution
 	}
 
-	immediate = {
-		set_country_flag = SER_milosevic_arrested
-	}
+	immediate = { set_country_flag = SER_milosevic_arrested }
 
 	option = {
 		name = Serbia.19.a
 		ai_chance = { base = 85 }
 	}
+
 	option = {
 		name = Serbia.19.b
 		ai_chance = { base = 85 }
@@ -890,6 +850,7 @@ country_event = {
 	desc = Serbia.20.d
 	picture = GFX_SER_generic
 	is_triggered_only = yes
+
 	option = {
 		name = Serbia.20.a
 		log = "[GetDateText]: [This.GetName]: Serbia.20.a executed"
@@ -907,6 +868,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.20.b executed"
 		name = Serbia.20.b
@@ -919,9 +881,7 @@ country_event = {
 			modifier = drama
 			target = SER
 		}
-		SER = {
-			country_event = Serbia.21
-		}
+		SER = { country_event = Serbia.21 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -940,6 +900,7 @@ country_event = {
 	desc = Serbia.21.d
 	picture = GFX_SER_generic
 	is_triggered_only = yes
+
 	option = {
 		name = Serbia.21.a
 		ai_chance = { base = 85 }
@@ -1008,12 +969,11 @@ country_event = {
 			modifier = { factor = 0.2 has_opinion = { target = SER value < 0 } }
 		}
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.22.b executed"
 		name = Serbia.22.b
-		SER = {
-			country_event = Serbia.24
-		}
+		SER = { country_event = Serbia.24 }
 		add_opinion_modifier = {
 			modifier = drama
 			target = SER
@@ -1036,9 +996,8 @@ country_event = {
 	desc = Serbia.23.d
 	picture = GFX_SER_generic
 	is_triggered_only = yes
-	option = {
-		name = Serbia.23.a
-	}
+
+	option = { name = Serbia.23.a }
 }
 
 country_event = {
@@ -1047,9 +1006,8 @@ country_event = {
 	desc = Serbia.24.d
 	picture = GFX_SER_generic
 	is_triggered_only = yes
-	option = {
-		name = Serbia.24.a
-	}
+
+	option = { name = Serbia.24.a }
 }
 country_event = {
 	id = Serbia.25
@@ -1057,9 +1015,8 @@ country_event = {
 	desc = Serbia.25.d
 	picture = GFX_SER_generic
 	is_triggered_only = yes
-	option = {
-		name = Serbia.25.a
-	}
+
+	option = { name = Serbia.25.a }
 }
 country_event = {
 	id = Serbia.26
@@ -1067,9 +1024,8 @@ country_event = {
 	desc = Serbia.26.d
 	picture = GFX_SER_generic
 	is_triggered_only = yes
-	option = {
-		name = Serbia.26.a
-	}
+
+	option = { name = Serbia.26.a }
 }
 country_event = {
 	id = Serbia.27
@@ -1077,6 +1033,7 @@ country_event = {
 	desc = Serbia.27.d
 	picture = GFX_ser_balkan_federation
 	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: Serbia.27.a executed"
 		name = Serbia.27.a
@@ -1370,6 +1327,7 @@ country_event = {
 	desc = SerbiaFocus.1.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.1.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.1.a executed"
@@ -1417,6 +1375,7 @@ country_event = {
 	desc = SerbiaFocus.2.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.2.a
 		ai_chance = { base = 75 }
@@ -1428,6 +1387,7 @@ country_event = {
 	desc = SerbiaFocus.3.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.3.a
 		ai_chance = { base = 75 }
@@ -1437,8 +1397,9 @@ country_event = {
 	id = SerbiaFocus.4
 	title = SerbiaFocus.4.t
 	desc = SerbiaFocus.4.d
-	is_triggered_only = yes
 	picture = GFX_ser_srpska
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.4.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.4.a executed"
@@ -1485,8 +1446,9 @@ country_event = {
 	id = SerbiaFocus.5
 	title = SerbiaFocus.5.t
 	desc = SerbiaFocus.5.d
-	is_triggered_only = yes
 	picture = GFX_ser_srpska
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.5.a
 		ai_chance = { base = 75 }
@@ -1497,8 +1459,9 @@ country_event = {
 	id = SerbiaFocus.6
 	title = SerbiaFocus.6.t
 	desc = SerbiaFocus.6.d
-	is_triggered_only = yes
 	picture = GFX_ser_srpska
+	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.6.a executed"
 		name = SerbiaFocus.6.a
@@ -1511,17 +1474,16 @@ country_event = {
 	id = SerbiaFocus.7
 	title = SerbiaFocus.7.t
 	desc = SerbiaFocus.7.d
-	is_triggered_only = yes
 	picture = GFX_ser_srpska
+	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.7.a executed"
 		name = SerbiaFocus.7.a
 		BOS = { release_puppet = RSK }
 		SER = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = RSK
 					autonomy_state = autonomy_autonomous_state_colored
@@ -1550,8 +1512,9 @@ country_event = {
 	id = SerbiaFocus.8
 	title = SerbiaFocus.8.t
 	desc = SerbiaFocus.8.d
-	is_triggered_only = yes
 	picture = GFX_ser_srpska
+	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.8.a executed"
 		name = SerbiaFocus.8.a
@@ -1561,6 +1524,7 @@ country_event = {
 		}
 		ai_chance = { base = 75 }
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.8.b executed"
 		name = SerbiaFocus.8.b
@@ -1574,8 +1538,9 @@ country_event = {
 	id = SerbiaFocus.9
 	title = SerbiaFocus.9.t
 	desc = SerbiaFocus.9.d
-	is_triggered_only = yes
 	picture = GFX_vojvodina_quest
+	is_triggered_only = yes
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.9.a executed"
 		name = SerbiaFocus.9.a
@@ -1594,6 +1559,7 @@ country_event = {
 		}
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.9.b executed"
 		name = SerbiaFocus.9.b
@@ -1611,6 +1577,7 @@ country_event = {
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	option = {
 		name = SerbiaFocus.99.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.99.a executed"
@@ -1646,6 +1613,7 @@ country_event = {
 	desc = SerbiaFocus.100.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.100.a
 		ai_chance = { base = 55 }
@@ -1655,6 +1623,7 @@ country_event = {
 			type = annex_everything
 		}
 	}
+
 	option = {
 		name = SerbiaFocus.100.b
 		ai_chance = { base = 45 }
@@ -1667,6 +1636,7 @@ country_event = {
 	desc = SerbiaFocus.101.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.101.a
 		ai_chance = { base = 55 }
@@ -1680,6 +1650,7 @@ country_event = {
 			modify_voj_separ_support = yes
 		}
 	}
+
 	option = {
 		name = SerbiaFocus.101.b
 		ai_chance = { base = 45 }
@@ -1701,6 +1672,7 @@ country_event = {
 	desc = SerbiaFocus.102.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.102.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.102.a executed"
@@ -1734,10 +1706,8 @@ country_event = {
 	desc = SerbiaFocus.103.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
-	option = {
-		name = SerbiaFocus.103.a
 
-	}
+	option = { name = SerbiaFocus.103.a }
 }
 #Vojvodina request Military
 country_event = {
@@ -1746,6 +1716,7 @@ country_event = {
 	desc = SerbiaFocus.104.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.104.a
 		ai_chance = { base = 55 }
@@ -1759,6 +1730,7 @@ country_event = {
 			modify_voj_separ_support = yes
 		}
 	}
+
 	option = {
 		name = SerbiaFocus.104.b
 		ai_chance = { base = 45 }
@@ -1780,6 +1752,7 @@ country_event = {
 	desc = SerbiaFocus.105.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.105.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.105.a executed"
@@ -1799,10 +1772,8 @@ country_event = {
 	desc = SerbiaFocus.106.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
-	option = {
-		name = SerbiaFocus.106.a
 
-	}
+	option = { name = SerbiaFocus.106.a }
 }
 #Vojvodina take Autonomy
 country_event = {
@@ -1811,6 +1782,7 @@ country_event = {
 	desc = SerbiaFocus.107.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.107.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.107.a executed"
@@ -1848,10 +1820,8 @@ country_event = {
 	desc = SerbiaFocus.108.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
-	option = {
-		name = SerbiaFocus.108.a
 
-	}
+	option = { name = SerbiaFocus.108.a }
 }
 #Vojvodina request more Autonomy
 country_event = {
@@ -1860,6 +1830,7 @@ country_event = {
 	desc = SerbiaFocus.109.d
 	picture = GFX_vojvodina_quest
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.109.a
 		ai_chance = { base = 55 }
@@ -1873,6 +1844,7 @@ country_event = {
 			modify_voj_separ_support = yes
 		}
 	}
+
 	option = {
 		name = SerbiaFocus.109.b
 		ai_chance = { base = 45 }
@@ -1890,8 +1862,8 @@ country_event = {
 # AI-only Milosevic strength boost, fired from SER_the_high_castle
 country_event = {
 	id = SerbiaFocus.113
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.113 executed"
@@ -1905,6 +1877,7 @@ country_event = {
 	desc = ser_reading.1.d
 	picture = GFX_ser_crisis
 	is_triggered_only = yes
+
 	option = {
 		name = ser_reading.1.a
 		ai_chance = { base = 75 }
@@ -1917,6 +1890,7 @@ country_event = {
 	desc = ser_deals.1.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	option = {
 		name = ser_deals.1.a
 		log = "[GetDateText]: [This.GetName]: ser_deals.1.a executed"
@@ -1949,6 +1923,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = ser_deals.1.b
 		log = "[GetDateText]: [This.GetName]: ser_deals.1.b executed"
@@ -1974,6 +1949,7 @@ country_event = {
 	desc = ser_deals.2.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = ser_deals.2.a
 		log = "[GetDateText]: [This.GetName]: ser_deals.2.a executed"
@@ -1993,9 +1969,8 @@ country_event = {
 	desc = ser_deals.3.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
-	option = {
-		name = ser_deals.3.a
-	}
+
+	option = { name = ser_deals.3.a }
 }
 ##################
 
@@ -2021,7 +1996,6 @@ country_event = {
 	title = SerbiaFocus.12.t
 	desc = SerbiaFocus.12.d
 	picture = GFX_SER_generic
-
 	is_triggered_only = yes
 
 	# Accept the Agreements
@@ -2054,7 +2028,6 @@ country_event = {
 				active = no
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2098,13 +2071,12 @@ country_event = {
 	desc = SerbiaFocus.13.d
 	picture = GFX_srpska_portests
 	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.13.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.13.a executed"
 		if = {
-			limit = {
-				tag = SER
-			}
+			limit = { tag = SER }
 			add_popularity = {
 				ideology = nationalist
 				popularity = -0.1
@@ -2128,7 +2100,6 @@ country_event = {
 	option = {
 		name = SerbiaFocus.14.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.14.a executed"
-
 		SER = {
 			random_owned_controlled_state = {
 				limit = { network_infrastructure_random_build_loc = yes }
@@ -2152,7 +2123,6 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2169,7 +2139,6 @@ country_event = {
 		name = SerbiaFocus.14.b
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.14.b executed"
 		SER = { country_event = SerbiaFocus.16 }
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2187,8 +2156,9 @@ country_event = {
 	id = SerbiaFocus.15
 	title = SerbiaFocus.15.t
 	desc = SerbiaFocus.15.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.15.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.15.a executed"
@@ -2201,8 +2171,9 @@ country_event = {
 	id = SerbiaFocus.16
 	title = SerbiaFocus.16.t
 	desc = SerbiaFocus.16.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.16.a
 		ai_chance = { base = 1 }
@@ -2213,8 +2184,9 @@ country_event = {
 	id = SerbiaFocus.17
 	title = SerbiaFocus.17.t
 	desc = SerbiaFocus.17.d
-	is_triggered_only = yes
 	picture = GFX_ser_balkan_federation
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.17.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.17.a executed"
@@ -2257,6 +2229,7 @@ country_event = {
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
 	}
+
 	option = {
 		name = SerbiaFocus.17.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.17.a executed"
@@ -2265,27 +2238,26 @@ country_event = {
 		set_temp_variable = { tag_index = SER }
 		set_temp_variable = { influence_target = ROOT }
 		change_influence_percentage = yes
-		SER = {	country_event = { id = SerbiaFocus.20 days = 1 } }
+		SER = { country_event = { id = SerbiaFocus.20 days = 1 } }
 	}
 }
 country_event = {
 	id = SerbiaFocus.20
 	title = SerbiaFocus.20.t
 	desc = SerbiaFocus.20.d
-	is_triggered_only = yes
 	picture = GFX_ser_balkan_federation
-	option = {
-		name = SerbiaFocus.20.a
-	}
+	is_triggered_only = yes
 
+	option = { name = SerbiaFocus.20.a }
 }
 
 country_event = {
 	id = SerbiaFocus.21
 	title = SerbiaFocus.21.t
 	desc = SerbiaFocus.21.d
-	is_triggered_only = yes
 	picture = GFX_generic_factory
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.21.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.21.a executed"
@@ -2319,7 +2291,6 @@ country_event = {
 		set_temp_variable = { tag_index = SER }
 		set_temp_variable = { influence_target = BOS }
 		change_influence_percentage = yes
-
 		BOS_srpska_attitude_increase_effect = yes
 		BOS_srpska_stability_increase_effect = yes
 		BOS_bosniak_attitude_decrease_effect = yes
@@ -2339,9 +2310,7 @@ country_event = {
 				}
 			}
 		}
-		SER = {
-			country_event = SerbiaFocus.23
-		}
+		SER = { country_event = SerbiaFocus.23 }
 		set_temp_variable = { percent_change = 5 }
 		change_domestic_influence_percentage = yes
 		add_opinion_modifier = {
@@ -2363,30 +2332,29 @@ country_event = {
 	id = SerbiaFocus.22
 	title = SerbiaFocus.22.t
 	desc = SerbiaFocus.22.d
-	is_triggered_only = yes
 	picture = GFX_generic_factory
-	option = {
-		name = SerbiaFocus.22.a
-	}
+	is_triggered_only = yes
+
+	option = { name = SerbiaFocus.22.a }
 }
 
 country_event = {
 	id = SerbiaFocus.23
 	title = SerbiaFocus.23.t
 	desc = SerbiaFocus.23.d
-	is_triggered_only = yes
 	picture = GFX_generic_factory
-	option = {
-		name = SerbiaFocus.23.a
-	}
+	is_triggered_only = yes
+
+	option = { name = SerbiaFocus.23.a }
 }
 
 country_event = {
 	id = SerbiaFocus.24
 	title = SerbiaFocus.24.t
 	desc = SerbiaFocus.24.d
-	is_triggered_only = yes
 	picture = GFX_t90
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.24.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.24.a executed"
@@ -2401,10 +2369,9 @@ country_event = {
 				has_war_with = SER
 			}
 		}
-		SER = {
-			country_event = SerbiaFocus.25
-		}
+		SER = { country_event = SerbiaFocus.25 }
 	}
+
 	option = {
 		name = SerbiaFocus.24.b
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.24.b executed"
@@ -2415,17 +2382,16 @@ country_event = {
 				has_opinion = { target = SER value < 0 }
 			}
 		}
-		SER = {
-			country_event = SerbiaFocus.26
-		}
+		SER = { country_event = SerbiaFocus.26 }
 	}
 }
 country_event = {
 	id = SerbiaFocus.25
 	title = SerbiaFocus.25.t
 	desc = SerbiaFocus.25.d
-	is_triggered_only = yes
 	picture = GFX_t90
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.25.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.25.a executed"
@@ -2440,8 +2406,9 @@ country_event = {
 	id = SerbiaFocus.26
 	title = SerbiaFocus.26.t
 	desc = SerbiaFocus.26.d
-	is_triggered_only = yes
 	picture = GFX_t90
+	is_triggered_only = yes
+
 	option = {
 		name = SerbiaFocus.26.a
 		log = "[GetDateText]: [This.GetName]: SerbiaFocus.26.a executed"
@@ -2456,13 +2423,10 @@ news_event = {
 	title = serbia_news.1.t
 	desc = serbia_news.1.d
 	picture = GFX_news_election_rally
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = serbia_news.1.o1
-	}
+	option = { name = serbia_news.1.o1 }
 }
 
 news_event = {
@@ -2470,13 +2434,10 @@ news_event = {
 	title = serbia_news.2.t
 	desc = serbia_news.2.d
 	picture = GFX_news_election_rally
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = serbia_news.2.o1
-	}
+	option = { name = serbia_news.2.o1 }
 }
 
 news_event = {
@@ -2484,21 +2445,19 @@ news_event = {
 	title = serbia_news.3.t
 	desc = serbia_news.3.d
 	picture = GFX_news_election_rally
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = serbia_news.3.o1
-	}
+	option = { name = serbia_news.3.o1 }
 }
 
 country_event = {
 	id = ser_dem.1
 	title = ser_dem.1.t
 	desc = ser_dem.1.d
-	is_triggered_only = yes
 	picture = GFX_message_signing
+	is_triggered_only = yes
+
 	option = {
 		name = ser_dem.1.a
 		log = "[GetDateText]: [This.GetName]: ser_dem.1.a executed"
@@ -2523,6 +2482,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -7.5 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = ser_dem.1.b
 		log = "[GetDateText]: [This.GetName]: ser_dem.1.b executed"
@@ -2547,6 +2507,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -3.5 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = ser_dem.1.c
 		log = "[GetDateText]: [This.GetName]: ser_dem.1.c executed"
@@ -2571,6 +2532,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -3 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = ser_dem.1.f
 		log = "[GetDateText]: [This.GetName]: ser_dem.1.f executed"
@@ -2592,8 +2554,9 @@ country_event = {
 	id = ser_dem.2
 	title = ser_dem.2.t
 	desc = ser_dem.2.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
+
 	option = {
 		name = ser_dem.2.a
 		ai_chance = { base = 1 }
@@ -2604,8 +2567,9 @@ country_event = {
 	id = ser_dem.3
 	title = ser_dem.3.t
 	desc = ser_dem.3.d
-	is_triggered_only = yes
 	picture = GFX_declined_offer_no
+	is_triggered_only = yes
+
 	option = {
 		name = ser_dem.3.a
 		ai_chance = { base = 1 }
@@ -2616,8 +2580,9 @@ country_event = {
 	id = ser_dem.4
 	title = ser_dem.4.t
 	desc = ser_dem.4.d
-	is_triggered_only = yes
 	picture = GFX_passenger_plane
+	is_triggered_only = yes
+
 	option = {
 		name = ser_dem.4.a
 		log = "[GetDateText]: [This.GetName]: ser_dem.4.a executed"
@@ -2625,6 +2590,7 @@ country_event = {
 		CHI = { country_event = ser_dem.1 }
 		SOV = { country_event = ser_dem.1 }
 	}
+
 	option = {
 		name = ser_dem.4.b
 		log = "[GetDateText]: [This.GetName]: ser_dem.4.b executed"
@@ -2632,6 +2598,7 @@ country_event = {
 		USA = { country_event = ser_dem.1 }
 		GER = { country_event = ser_dem.1 }
 	}
+
 	option = {
 		name = ser_dem.4.c
 		log = "[GetDateText]: [This.GetName]: ser_dem.4.c executed"
@@ -2644,7 +2611,6 @@ country_event = {
 				reverse_add_opinion_modifier = { target = PREV modifier = supports_us_2 }
 				change_influence_percentage = yes
 			}
-
 			custom_effect_tooltip = influence_on_neighbors_tt
 			set_temp_variable = { treasury_change = gdp_total }
 			multiply_temp_variable = { treasury_change = 0.05 }
@@ -2656,8 +2622,9 @@ country_event = {
 	id = ser_dem.5
 	title = ser_dem.5.t
 	desc = ser_dem.5.d
-	is_triggered_only = yes
 	picture = GFX_passenger_plane
+	is_triggered_only = yes
+
 	option = {
 		name = ser_dem.5.a
 		log = "[GetDateText]: [This.GetName]: ser_dem.5.a executed"
@@ -2671,6 +2638,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		custom_effect_tooltip = SER_radical_create_tt
 	}
+
 	option = {
 		name = ser_dem.5.b
 		log = "[GetDateText]: [This.GetName]: ser_dem.5.b executed"
@@ -2679,7 +2647,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-
 	}
 }
 ##########VOJVODINA##########
@@ -2687,8 +2654,9 @@ country_event = {
 	id = ser_voj.1
 	title = ser_voj.1.t
 	desc = ser_voj.1.d
-	is_triggered_only = yes
 	picture = GFX_vojvodina_quest
+	is_triggered_only = yes
+
 	option = {
 		name = ser_voj.1.a
 		log = "[GetDateText]: [This.GetName]: ser_voj.1.a executed"
@@ -2728,6 +2696,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = ser_voj.1.b
 		ai_chance = { base = 0 }
@@ -2737,8 +2706,9 @@ country_event = {
 	id = ser_voj.2
 	title = ser_voj.2.t
 	desc = ser_voj.2.d
-	is_triggered_only = yes
 	picture = GFX_vojvodina_quest
+	is_triggered_only = yes
+
 	option = {
 		name = ser_voj.2.a
 		log = "[GetDateText]: [This.GetName]: ser_voj.2.a executed"
@@ -2750,6 +2720,7 @@ country_event = {
 			active = no
 		}
 	}
+
 	option = {
 		name = ser_voj.2.b
 		ai_chance = { base = 0 }
@@ -2759,8 +2730,9 @@ country_event = {
 	id = ser_voj.3
 	title = ser_voj.3.t
 	desc = ser_voj.3.d
-	is_triggered_only = yes
 	picture = GFX_vojvodina_quest
+	is_triggered_only = yes
+
 	option = {
 		name = ser_voj.3.a
 		log = "[GetDateText]: [This.GetName]: ser_voj.3.a executed"
@@ -2776,8 +2748,9 @@ country_event = {
 	id = Montenegro.1
 	title = Montenegro.1.t
 	desc = Montenegro.1.d
-	is_triggered_only = yes
 	picture = GFX_message_signing
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.1.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.1.a executed"
@@ -2799,6 +2772,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -7.5 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = Montenegro.1.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.1.b executed"
@@ -2813,8 +2787,9 @@ country_event = {
 	id = Montenegro.2
 	title = Montenegro.2.t
 	desc = Montenegro.2.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.2.a
 		ai_chance = { base = 1 }
@@ -2824,8 +2799,9 @@ country_event = {
 	id = Montenegro.3
 	title = Montenegro.3.t
 	desc = Montenegro.3.d
-	is_triggered_only = yes
 	picture = GFX_declined_offer_no
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.3.a
 		ai_chance = { base = 1 }
@@ -2835,8 +2811,9 @@ country_event = {
 	id = Montenegro.4
 	title = Montenegro.4.t
 	desc = Montenegro.4.d
-	is_triggered_only = yes
 	picture = GFX_passenger_plane
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.4.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.4.a executed"
@@ -2847,6 +2824,7 @@ country_event = {
 		}
 		SOV = { country_event = Montenegro.1 }
 	}
+
 	option = {
 		name = Montenegro.4.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.4.b executed"
@@ -2861,8 +2839,9 @@ country_event = {
 	id = Montenegro.5
 	title = Montenegro.5.t
 	desc = Montenegro.5.d
-	is_triggered_only = yes
 	picture = GFX_message_signing
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.5.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.5.a executed"
@@ -2884,6 +2863,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -3.5 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = Montenegro.5.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.5.b executed"
@@ -2898,8 +2878,9 @@ country_event = {
 	id = Montenegro.6
 	title = Montenegro.6.t
 	desc = Montenegro.6.d
-	is_triggered_only = yes
 	picture = GFX_message_signing
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.6.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.6.a executed"
@@ -2926,6 +2907,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Montenegro.6.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.6.b executed"
@@ -2941,8 +2923,9 @@ country_event = {
 	id = Montenegro.7
 	title = Montenegro.7.t
 	desc = Montenegro.7.d
-	is_triggered_only = yes
 	picture = GFX_message_signing
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.7.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.7.a executed"
@@ -2957,6 +2940,7 @@ country_event = {
 			relation = non_aggression_pact
 		}
 	}
+
 	option = {
 		name = Montenegro.7.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.7.b executed"
@@ -2971,8 +2955,9 @@ country_event = {
 	id = Montenegro.8
 	title = Montenegro.8.t
 	desc = Montenegro.8.d
-	is_triggered_only = yes
 	picture = GFX_message_signing
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.8.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.8.a executed"
@@ -2980,7 +2965,6 @@ country_event = {
 			target = MNT
 			autonomy_state = autonomy_autonomous_province1
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = { add = 3 has_opinion = { target = MNT value > 25 } }
@@ -2993,11 +2977,11 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Montenegro.8.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.8.b executed"
 		MNT = { country_event = Montenegro.3 }
-
 		ai_chance = {
 			base = 2
 			modifier = { add = 3 has_opinion = { target = MNT value < 25 } }
@@ -3010,7 +2994,6 @@ country_event = {
 	title = Montenegro.9.t
 	desc = Montenegro.9.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3047,6 +3030,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.9.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.9.b executed"
@@ -3062,7 +3046,6 @@ country_event = {
 	title = Montenegro.10.t
 	desc = Montenegro.10.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3099,6 +3082,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.10.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.10.b executed"
@@ -3114,7 +3098,6 @@ country_event = {
 	title = Montenegro.11.t
 	desc = Montenegro.11.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3151,6 +3134,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.11.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.11.b executed"
@@ -3166,7 +3150,6 @@ country_event = {
 	title = Montenegro.12.t
 	desc = Montenegro.12.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3203,6 +3186,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.12.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.12.b executed"
@@ -3218,7 +3202,6 @@ country_event = {
 	title = Montenegro.13.t
 	desc = Montenegro.13.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3255,6 +3238,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.13.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.13.b executed"
@@ -3266,14 +3250,13 @@ country_event = {
 	}
 }
 country_event = {
-	#Creation of tara arms
 	id = Montenegro.14
 	title = Montenegro.14.t
 	desc = Montenegro.14.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
+	#Creation of tara arms
 	option = {
 		name = Montenegro.14.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.14.a executed"
@@ -3289,6 +3272,7 @@ country_event = {
 		add_ideas = MNT_tara_arms_ru
 		#cooperation with russia
 	}
+
 	option = {
 		name = Montenegro.14.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.14.b executed"
@@ -3320,8 +3304,8 @@ country_event = {
 	title = Montenegro.15.t
 	desc = Montenegro.15.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
+
 	#from whom you will buy
 	option = {
 		name = Montenegro.15.a
@@ -3332,6 +3316,7 @@ country_event = {
 		}
 		USA = { country_event = Montenegro.17 }
 	}
+
 	option = {
 		name = Montenegro.15.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.15.b executed"
@@ -3348,7 +3333,6 @@ country_event = {
 	title = Montenegro.16.t
 	desc = Montenegro.16.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3385,6 +3369,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.16.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.16.b executed"
@@ -3400,7 +3385,6 @@ country_event = {
 	title = Montenegro.17.t
 	desc = Montenegro.17.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3437,6 +3421,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.17.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.17.b executed"
@@ -3452,9 +3437,9 @@ country_event = {
 	title = Montenegro.18.t
 	desc = Montenegro.18.d
 	picture = GFX_israeli_soldiers_injured
-	#from whom you will buy
 	is_triggered_only = yes
 
+	#from whom you will buy
 	option = {
 		name = Montenegro.18.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.18.a executed"
@@ -3464,6 +3449,7 @@ country_event = {
 		}
 		USA = { country_event = Montenegro.19 }
 	}
+
 	option = {
 		name = Montenegro.18.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.18.b executed"
@@ -3480,7 +3466,6 @@ country_event = {
 	title = Montenegro.19.t
 	desc = Montenegro.19.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3517,6 +3502,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.19.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.19.b executed"
@@ -3532,7 +3518,6 @@ country_event = {
 	title = Montenegro.20.t
 	desc = Montenegro.20.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3569,6 +3554,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = MNT }
 		}
 	}
+
 	option = {
 		name = Montenegro.20.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.20.b executed"
@@ -3584,9 +3570,9 @@ country_event = {
 	title = Montenegro.21.t
 	desc = Montenegro.21.d
 	picture = GFX_israeli_soldiers_injured
-	#political support from sov
 	is_triggered_only = yes
 
+	#political support from sov
 	option = {
 		name = Montenegro.21.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.21.a executed"
@@ -3608,6 +3594,7 @@ country_event = {
 			modifier = { factor = 0 has_opinion = { target = MNT value < 0 } }
 		}
 	}
+
 	option = {
 		name = Montenegro.21.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.21.b executed"
@@ -3623,9 +3610,9 @@ country_event = {
 	title = Montenegro.22.t
 	desc = Montenegro.22.d
 	picture = GFX_israeli_soldiers_injured
-	#political support from us
 	is_triggered_only = yes
 
+	#political support from us
 	option = {
 		name = Montenegro.22.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.22.a executed"
@@ -3647,6 +3634,7 @@ country_event = {
 			modifier = { factor = 0 has_opinion = { target = MNT value < 0 } }
 		}
 	}
+
 	option = {
 		name = Montenegro.22.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.22.b executed"
@@ -3677,6 +3665,7 @@ country_event = {
 			modifier = { add = 2 MNT_ai_belgrade_path = yes }
 		}
 	}
+
 	option = {
 		name = Montenegro.23.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.23.b executed"
@@ -3720,6 +3709,7 @@ country_event = {
 			modifier = { add = 2 has_global_flag = MNT_EUROPEAN_REFORM_FOCUS_PATH }
 		}
 	}
+
 	option = {
 		name = Montenegro.24.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.24.b executed"
@@ -3734,8 +3724,9 @@ country_event = {
 	id = Montenegro.25
 	title = Montenegro.25.t
 	desc = Montenegro.25.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.25.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.25.a executed"
@@ -3747,12 +3738,11 @@ country_event = {
 			modifier = { factor = 0 MNT_ai_belgrade_path = yes }
 		}
 	}
+
 	option = {
 		name = Montenegro.25.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.25.b executed"
-		SER = {
-			country_event = Montenegro.26
-		}
+		SER = { country_event = Montenegro.26 }
 		ai_chance = {
 			base = 2
 			modifier = { add = 2 MNT_ai_belgrade_path = yes }
@@ -3763,8 +3753,9 @@ country_event = {
 	id = Montenegro.26
 	title = Montenegro.26.t
 	desc = Montenegro.26.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.26.a
 		log = "[GetDateText]: [This.GetName]: Montenegro.26.a executed"
@@ -3774,9 +3765,7 @@ country_event = {
 			relation = puppet
 			active = no
 		}
-		MNT = {
-			add_political_power = 150
-		}
+		MNT = { add_political_power = 150 }
 		ai_chance = {
 			base = 1
 			modifier = { add = 2 has_opinion = { target = MNT value > 25 } }
@@ -3784,12 +3773,11 @@ country_event = {
 			modifier = { factor = 0 has_opinion = { target = MNT value < 0 } }
 		}
 	}
+
 	option = {
 		name = Montenegro.26.b
 		log = "[GetDateText]: [This.GetName]: Montenegro.26.b executed"
-		MNT = {
-			country_event = Montenegro.27
-		}
+		MNT = { country_event = Montenegro.27 }
 		ai_chance = {
 			base = 2
 			modifier = { add = 3 has_opinion = { target = MNT value < 25 } }
@@ -3800,8 +3788,9 @@ country_event = {
 	id = Montenegro.27
 	title = Montenegro.27.t
 	desc = Montenegro.27.d
-	is_triggered_only = yes
 	picture = GFX_handshake_black
+	is_triggered_only = yes
+
 	option = {
 		name = Montenegro.27.a
 		ai_chance = { base = 1 }
@@ -3826,9 +3815,7 @@ country_event = {
 		}
 	}
 
-	immediate = {
-		add_stability = -0.03
-	}
+	immediate = { add_stability = -0.03 }
 
 	option = {
 		name = Montenegro.28.a
@@ -3887,8 +3874,9 @@ country_event = {
 	id = ser_kos.1
 	title = ser_kos.1.t
 	desc = ser_kos.1.d
-	is_triggered_only = yes
 	picture = GFX_politics_protest
+	is_triggered_only = yes
+
 	option = {
 		name = ser_kos.1.a
 		log = "[GetDateText]: [This.GetName]: ser_kos.1.a executed"
@@ -3920,6 +3908,7 @@ country_event = {
 			name = Kosovo_War
 		}
 	}
+
 	option = {
 		name = ser_kos.1.b
 		log = "[GetDateText]: [This.GetName]: ser_kos.1.b executed"
@@ -4025,9 +4014,7 @@ country_event = {
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
-	option = {
-		name = ser_kos.4.a
-	}
+	option = { name = ser_kos.4.a }
 }
 country_event = { #Struggle for recognition
 	id = kosovo.3
@@ -4074,6 +4061,7 @@ country_event = { #Kosovo wants to ease tensions
 			}
 		}
 	}
+
 	option = { #Okay
 		name = kosovo.4.b
 		log = "[GetDateText]: [This.GetName]: kosovo.4.b executed"
@@ -4161,6 +4149,7 @@ country_event = { #Kosovo wants to create a union state
 			}
 		}
 	}
+
 	option = { #Ok
 		name = kosovo.7.b
 		log = "[GetDateText]: [This.GetName]: kosovo.7.b executed"
@@ -4203,7 +4192,7 @@ country_event = { #Albania agrees
 		annex_country = { target = ALB transfer_troops = yes }
 		ALB = {
 			every_core_state = { add_core_of = KOS }
-			every_core_state = { transfer_state_to = KOS	}
+			every_core_state = { transfer_state_to = KOS }
 		}
 		hidden_effect = {
 			add_to_variable = { treasury = ALB.treasury }
@@ -4227,13 +4216,13 @@ country_event = { #Albania rejects
 		name = kosovo.9.a
 		ai_chance = {
 			base = 6
-
 			modifier = {
 				factor = 100
 				ALB = { OR = { has_faction_template = faction_template_nato has_faction_template = faction_template_csto } }
 			}
 		}
 	}
+
 	option = { #We'll do it through war
 		name = kosovo.9.b
 		log = "[GetDateText]: [This.GetName]: kosovo.9.b executed"
@@ -4249,22 +4238,18 @@ country_event = { #Albania rejects
 		ALB = { every_core_state = { add_core_of = KOS } }
 		ai_chance = {
 			base = 6
-
 			modifier = {
 				factor = 0
 				ALB = { OR = { has_faction_template = faction_template_nato has_faction_template = faction_template_csto } }
 			}
-
 			modifier = {
 				factor = 0
 				interest_rate_higher_than_8 = yes
 			}
-
 			modifier = {
 				add = -4
 				alliance_strength_ratio > 0.75
 			}
-
 			modifier = {
 				add = -3
 				strength_ratio = {
@@ -4422,6 +4407,7 @@ country_event = { #Kosovo requests recognition (China)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.1.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.1.b executed"
@@ -4456,6 +4442,7 @@ country_event = { #Kosovo requests recognition (India)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.4.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.4.b executed"
@@ -4490,6 +4477,7 @@ country_event = { #Kosovo requests recognition (Indonesia)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.5.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.5.b executed"
@@ -4524,6 +4512,7 @@ country_event = { #Kosovo requests recognition (Brazil)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.7.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.7.b executed"
@@ -4558,6 +4547,7 @@ country_event = { #Kosovo requests recognition (Argentina)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.8.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.8.b executed"
@@ -4592,6 +4582,7 @@ country_event = { #Kosovo requests recognition (Chile)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.9.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.9.b executed"
@@ -4626,6 +4617,7 @@ country_event = { #Kosovo requests recognition (Belarus)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.10.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.10.b executed"
@@ -4660,6 +4652,7 @@ country_event = { #Kosovo requests recognition (Ukraine)
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.11.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.11.b executed"
@@ -4695,6 +4688,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #No
 		name = kosovo_rec.12.b
 		log = "[GetDateText]: [This.GetName]: kosovo_rec.12.b executed"
@@ -4753,15 +4747,11 @@ country_event = {
 			limit = { NOT = { country_exists = MNT } }
 			SER = {
 				release = MNT
-				MNT = {
-					ingame_startup_nations_effect = yes
-				}
+				MNT = { ingame_startup_nations_effect = yes }
 			}
 			MNT = { country_event = { id = kosovo_rec.17 days = 1 } }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4843,6 +4833,7 @@ country_event = {
 			days = 600
 		}
 	}
+
 	option = {
 		name = kosovo_un.1.c
 		log = "[GetDateText]: [This.GetName]: kosovo_un.1.c executed"

--- a/events/Singapore.txt
+++ b/events/Singapore.txt
@@ -26,7 +26,6 @@ country_event = {
 		add_stability = 0.05
 		add_political_power = 100
 	}
-
 }
 
 # A New Singaporean March
@@ -66,15 +65,11 @@ news_event = {
 	title = singapore.4.t
 	desc = {
 		text = singapore.4.d1
-		trigger = {
-			SIN = { has_country_flag = SIN_nationalist_march }
-		}
+		trigger = { SIN = { has_country_flag = SIN_nationalist_march } }
 	}
 	desc = {
 		text = singapore.4.d2
-		trigger = {
-			SIN = { has_country_flag = SIN_collusion_pap_march }
-		}
+		trigger = { SIN = { has_country_flag = SIN_collusion_pap_march } }
 	}
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
@@ -89,7 +84,6 @@ news_event = {
 			clr_country_flag = SIN_nationalist_march
 		}
 	}
-
 }
 
 # Demand the Riau Islands
@@ -104,11 +98,7 @@ country_event = {
 	option = {
 		name = singapore.5.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.5.a"
-		effect_tooltip = {
-			SIN = {
-				transfer_state = 627
-			}
-		}
+		effect_tooltip = { SIN = { transfer_state = 627 } }
 		add_stability = -0.05
 		add_war_support = -0.10
 		SIN = {
@@ -144,9 +134,7 @@ country_event = {
 		SIN = {
 			country_event = { id = singapore.7 days = 2 random_days = 4 }
 		}
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 }
 
@@ -161,17 +149,12 @@ country_event = {
 	option = {
 		name = singapore.6.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.6.a"
-		SIN = {
-			transfer_state = 627
-		}
+		SIN = { transfer_state = 627 }
 		add_war_support = 0.05
 		add_political_power = 150
 		news_event = singapore.8
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # Indonesia Denies the Concession
@@ -189,7 +172,6 @@ country_event = {
 		activate_mission = SIN_riau_islands_crisis_mission
 		news_event = singapore.9
 	}
-
 }
 
 # Indonesia Rejects the Concessions
@@ -201,10 +183,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = singapore.8.a
-	}
-
+	option = { name = singapore.8.a }
 }
 
 # The Riau Islands Crisis Begins
@@ -216,10 +195,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = singapore.9.a
-	}
-
+	option = { name = singapore.9.a }
 }
 
 # Buy American Aircraft
@@ -282,9 +258,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = singapore.76.b
-	}
+	option = { name = singapore.76.b }
 }
 
 # Buy American Weapon
@@ -329,9 +303,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = singapore.77.b
-	}
+	option = { name = singapore.77.b }
 }
 
 # 2000 - Singapore Airlines 747
@@ -362,9 +334,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.01 }
 		set_temp_variable = { temp_outlook_increase = -0.01 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -372,9 +342,7 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: event singapore.101.c"
 		set_temp_variable = { treasury_change = -0.25 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -386,11 +354,8 @@ country_event = {
 			set_temp_variable = { treasury_change = 0.25 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # 2001 - Singapore Embassies Attack Plot
@@ -405,9 +370,7 @@ country_event = {
 		name = singapore.102.a
 		log = "[GetDateText]: [THIS.GetName]: event singapore.102.a"
 		add_political_power = -25
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
 	option = {
@@ -416,11 +379,8 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = -0.04 }
 		set_temp_variable = { temp_outlook_increase = -0.04 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # 2001 - End of Malaysian-Singaporean Disputes
@@ -446,7 +406,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 # Hidden Trigger Event for 104
@@ -465,7 +424,6 @@ country_event = {
 			country_event = { id = singapore.104 days = 1 }
 		}
 	}
-
 }
 
 # 2001 - Tropical Storm Varnei
@@ -514,7 +472,6 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.02 }
 		modify_treasury_effect = yes
 	}
-
 }
 
 # 2002 - The Esplanade
@@ -537,7 +494,6 @@ country_event = {
 		add_political_power = -15
 		add_stability = 0.03
 	}
-
 }
 
 # 2003 - Sars Virus Outbreak
@@ -555,9 +511,7 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.03 }
 		modify_treasury_effect = yes
 		add_stability = -0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -565,20 +519,15 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: event singapore.106.b"
 		add_political_power = -50
 		add_stability = -0.03
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
 		name = singapore.106.c
 		log = "[GetDateText]: [THIS.GetName]: event singapore.106.c"
 		add_stability = -0.05
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # 2003 - Major Research Center Opens
@@ -612,7 +561,6 @@ country_event = {
 			days = 180
 		}
 	}
-
 }
 
 # 2004 - Stepping Down of Goh Chok Tong
@@ -659,7 +607,6 @@ country_event = {
 			change_ruling_party_effect = yes
 		}
 	}
-
 }
 
 # 2004 - Nicoll Highway Collapses
@@ -706,7 +653,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_stability = 0.02
 	}
-
 }
 
 # 2005 - Marina Bay Floating Platform
@@ -722,7 +668,6 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: event singapore.110.a"
 		add_political_power = 50
 	}
-
 }
 
 # 2007 - An Execution
@@ -755,7 +700,6 @@ country_event = {
 		}
 		add_stability = 0.01
 	}
-
 }
 
 # 2008 - Reintroduce the Singaporean Grand Prix
@@ -788,7 +732,6 @@ country_event = {
 		}
 		add_stability = 0.01
 	}
-
 }
 
 # 2008 - Mas Selamat Kastari Escapes
@@ -806,7 +749,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 # 2009 50 Years of Self Governance
@@ -824,7 +766,6 @@ country_event = {
 		add_political_power = 100
 		add_stability = 0.05
 	}
-
 }
 
 # 2010 - City Harvest Church Case
@@ -848,20 +789,15 @@ country_event = {
 			chance = 25
 			increase_corruption = yes
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
 		name = singapore.115.b
 		log = "[GetDateText]: [THIS.GetName]: event singapore.115.b"
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # 2010 - Alan Shadrake Convicted for Insulting Judiciary
@@ -895,7 +831,6 @@ country_event = {
 			add_opinion_modifier = { target = SIN modifier = SIN_trial_by_jury_shadrake }
 		}
 	}
-
 }
 
 # 2012 - The Chinese Bus Driver Strike
@@ -933,7 +868,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 # 2013 - Little India Riot
@@ -976,7 +910,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.07 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 # 2013 - Foreign Worker Protests
@@ -1047,7 +980,6 @@ country_event = {
 		}
 		clr_country_flag = SIN_allowed_the_new_migration_policy
 	}
-
 }
 
 # 2013 - Anti-Migrant Worker Demonstrations
@@ -1085,7 +1017,6 @@ country_event = {
 		add_political_power = 100
 		add_stability = 0.05
 	}
-
 }
 
 # 2014 - Defamation around CPF
@@ -1116,7 +1047,6 @@ country_event = {
 		SIN_censorship_law_increase = yes
 		add_stability = 0.02
 	}
-
 }
 
 # 2014 - MRT Line Construction
@@ -1144,7 +1074,6 @@ country_event = {
 			days = 180
 		}
 	}
-
 }
 
 # 2015 - Death of Lee Kuan Yew
@@ -1160,7 +1089,6 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: event singapore.123.a"
 		add_stability = 0.02
 	}
-
 }
 
 # 2015 - 15 Suspected Militants of Jemaah Islami
@@ -1191,7 +1119,6 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.02 }
 		change_relative_party_popularity = yes
 	}
-
 }
 
 # 2015 - Reduction of Banned Books
@@ -1216,7 +1143,6 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: event singapore.125.b"
 		add_stability = 0.01
 	}
-
 }
 
 # 2016 - Eight Bangladeshi Men Arrested
@@ -1244,7 +1170,6 @@ country_event = {
 		}
 		add_political_power = 50
 	}
-
 }
 
 # 2017 - Protest Against Halimah Yacob
@@ -1271,7 +1196,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		add_political_power = -50
 	}
-
 }
 
 # 2024 - Stepping Down of Lee Hsien Loong
@@ -1318,7 +1242,6 @@ country_event = {
 			change_ruling_party_effect = yes
 		}
 	}
-
 }
 
 # 2008 - JB Jeyaretnam Dies of Heart Attack
@@ -1334,10 +1257,7 @@ country_event = {
 		set_country_flag = formation_of_reform_party
 	}
 
-	option = {
-		name = singapore.129.a
-	}
-
+	option = { name = singapore.129.a }
 }
 
 # Singapore Alignment Help Event
@@ -1351,7 +1271,6 @@ country_event = {
 	option = { # Okay
 		name = singapore_alignment_help.0.a
 	}
-
 }
 
 # Singaporean Custom Elections
@@ -1519,5 +1438,4 @@ country_event = {
 		clear_variable = largest_party
 		clear_variable = largest_party_val
 	}
-
 }

--- a/events/South Ossetia.txt
+++ b/events/South Ossetia.txt
@@ -6,6 +6,7 @@ country_event = {
 	desc = Ossetia.1.d
 	picture = GFX_election_day
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.1.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.1.a executed"
@@ -25,19 +26,16 @@ country_event = {
 		}
 		custom_effect_tooltip = SOV_subjectsepar_minus_tt
 		hidden_effect = {
-			SOO = {
-				add_ideas = SUB_small_taxes
-			}
+			SOO = { add_ideas = SUB_small_taxes }
 			SOV = {
 				set_temp_variable = { modify_subjectnalogs = 3 }
 				modify_subjectnalogs_support = yes
 			}
 			SUB_separatism_minus_subject = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = Ossetia.1.b
 		log = "[GetDateText]: [This.GetName]: Ossetia.1.b executed"
@@ -46,9 +44,7 @@ country_event = {
 			add_opinion_modifier = { target = SOO modifier = major_breach_of_trust }
 			reverse_add_opinion_modifier = { target = SOO modifier = major_breach_of_trust }
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 country_event = {
@@ -57,9 +53,8 @@ country_event = {
 	desc = Ossetia.2.d
 	picture = GFX_election_day
 	is_triggered_only = yes
-	option = {
-		name = Ossetia.2.a
-	}
+
+	option = { name = Ossetia.2.a }
 }
 country_event = {
 	id = Ossetia.3
@@ -67,9 +62,8 @@ country_event = {
 	desc = Ossetia.3.d
 	picture = GFX_election_day
 	is_triggered_only = yes
-	option = {
-		name = Ossetia.3.a
-	}
+
+	option = { name = Ossetia.3.a }
 }
 country_event = {
 	id = Ossetia.4
@@ -77,6 +71,7 @@ country_event = {
 	desc = Ossetia.4.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.4.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.4.a executed"
@@ -84,17 +79,14 @@ country_event = {
 			transfer_state = 673
 			country_event = Ossetia.5
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = Ossetia.4.b
 		log = "[GetDateText]: [This.GetName]: Ossetia.4.b executed"
 		SOO = { country_event = Ossetia.6 }
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -103,9 +95,8 @@ country_event = {
 	desc = Ossetia.5.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-	option = {
-		name = Ossetia.5.a
-	}
+
+	option = { name = Ossetia.5.a }
 }
 country_event = {
 	id = Ossetia.6
@@ -113,9 +104,8 @@ country_event = {
 	desc = Ossetia.6.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-	option = {
-		name = Ossetia.6.a
-	}
+
+	option = { name = Ossetia.6.a }
 }
 country_event = {
 	id = Ossetia.7
@@ -123,12 +113,11 @@ country_event = {
 	desc = Ossetia.7.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.7.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.7.a executed"
-		SOO = {
-			country_event = Ossetia.8
-		}
+		SOO = { country_event = Ossetia.8 }
 		ai_chance = {
 			base = 5
 			modifier = {
@@ -141,13 +130,12 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Ossetia.7.b
 		log = "[GetDateText]: [This.GetName]: Ossetia.7.b executed"
 		SOO = { country_event = Ossetia.9 }
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -156,6 +144,7 @@ country_event = {
 	desc = Ossetia.8.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.8.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.8.a executed"
@@ -172,9 +161,8 @@ country_event = {
 	desc = Ossetia.9.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-	option = {
-		name = Ossetia.9.a
-	}
+
+	option = { name = Ossetia.9.a }
 }
 
 country_event = {
@@ -183,6 +171,7 @@ country_event = {
 	desc = Ossetia.10.d
 	picture = GFX_ssg_geo
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.10.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.10.a executed"
@@ -196,6 +185,7 @@ country_event = {
 	desc = Ossetia.11.d
 	picture = GFX_southern_options
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.11.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.11.a executed"
@@ -208,8 +198,9 @@ country_event = {
 	id = Ossetia.12
 	title = Ossetia.12.t
 	desc = Ossetia.12.d
-#	picture = GFX_lego_store
 	is_triggered_only = yes
+
+#	picture = GFX_lego_store
 	option = {
 		name = Ossetia.12.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.12.a executed"
@@ -219,12 +210,10 @@ country_event = {
 			set_temp_variable = { disable_elections = 1 }
 			change_ruling_party_effect = yes
 		}
-
 		set_temp_variable = { party_index = 21 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		create_country_leader = {
 			name = "Daurbek fyrt Khiutsau I"
 			picture = "gfx/leaders/SOO/daurbek_makeev2.dds"
@@ -247,12 +236,10 @@ country_event = {
 			set_temp_variable = { disable_elections = 1 }
 			change_ruling_party_effect = yes
 		}
-
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		create_country_leader = {
 			name = "Marat Karabugaev"
 			picture = "gfx/leaders/SOO/marat_karabugaev.dds"
@@ -286,6 +273,7 @@ country_event = {
 	desc = Ossetia.13.d
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.13.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.13.a executed"
@@ -301,21 +289,15 @@ country_event = {
 		set_temp_variable = { tag_index = SOV }
 		set_temp_variable = { influence_target = SOO }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = Ossetia.13.b
 		log = "[GetDateText]: [This.GetName]: Ossetia.13.b executed"
-		SOO = {
-			country_event = Ossetia.15
-		}
-		ai_chance = {
-			base = 0
-		}
+		SOO = { country_event = Ossetia.15 }
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -324,12 +306,11 @@ country_event = {
 	desc = Ossetia.14.d
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.14.a
 		log = "[GetDateText]: [This.GetName]: Ossetia.14.a executed"
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 		set_temp_variable = { treasury_change = 10.00 }
 		modify_treasury_effect = yes
 		add_country_leader_trait = pro_russia
@@ -342,11 +323,10 @@ country_event = {
 	desc = Ossetia.15.d
 	picture = GFX_SOV_generic
 	is_triggered_only = yes
+
 	option = {
 		name = Ossetia.15.a
-		ai_chance = {
-			base = 00
-		}
+		ai_chance = { base = 00 }
 	}
 }
 country_event = {

--- a/events/belarus.txt
+++ b/events/belarus.txt
@@ -14,7 +14,6 @@ country_event = {
 	id = belarus_md.1
 	title = belarus_md.1.t
 	desc = belarus_md.1.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -26,9 +25,7 @@ country_event = {
 			days = 365
 		}
 		remove_ideas = BLR_agriculture
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -36,7 +33,6 @@ country_event = {
 	id = belarus_md.2
 	title = belarus_md.2.t
 	desc = belarus_md.2.d
-
 	picture = GFX_steel_mill
 	is_triggered_only = yes
 
@@ -59,10 +55,9 @@ country_event = {
 		newline = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_farmers_opinion = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = belarus_md.2.b
 		log = "[GetDateText]: [This.GetName]:belarus_md.2.b executed"
@@ -75,9 +70,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -85,7 +78,6 @@ country_event = {
 	id = belarus_md.3
 	title = belarus_md.3.t
 	desc = belarus_md.3.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -98,9 +90,7 @@ country_event = {
 			idea = BLR_disease_amongst_livestock
 			days = 365
 		}
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -110,7 +100,6 @@ country_event = {
 	title = belarus_character.1.t
 	desc = belarus_character.1.d
 	picture = GFX_era_lukashenko
-
 	is_triggered_only = yes
 
 	option = {
@@ -125,7 +114,6 @@ country_event = {
 	title = belarus_character.2.t
 	desc = belarus_character.2.d
 	picture = GFX_era_gaydukevich
-
 	is_triggered_only = yes
 
 	option = {
@@ -140,7 +128,6 @@ country_event = {
 	title = belarus_character.3.t
 	desc = belarus_character.3.d
 	picture = GFX_era_sannikov
-
 	is_triggered_only = yes
 
 	option = {
@@ -175,6 +162,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_character.3.b
 		log = "[GetDateText]: [This.GetName]: belarus_character.3.b executed"
@@ -206,7 +194,6 @@ country_event = {
 	title = belarus_character.4.t
 	desc = belarus_character.4.d
 	picture = GFX_era_zenon
-
 	is_triggered_only = yes
 
 	option = {
@@ -221,7 +208,6 @@ country_event = {
 	title = belarus_character.5.t
 	desc = belarus_character.5.d
 	picture = GFX_era_golubeva
-
 	is_triggered_only = yes
 
 	option = {
@@ -235,9 +221,10 @@ country_event = {
 	id = belarus_another.1
 	title = belarus_another.1.t
 	desc = belarus_another.1.d
+	picture = GFX_paris_convention
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_paris_convention
+
 	option = {
 		name = belarus_another.1.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.1.a executed"
@@ -257,10 +244,10 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_another.1.b
 		ai_chance = { base = 1 }
-
 	}
 }
 
@@ -269,9 +256,10 @@ country_event = {
 	id = belarus_another.4
 	title = belarus_another.4.t
 	desc = belarus_another.4.d
+	picture = GFX_paris_convention
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_paris_convention
+
 	option = {
 		name = belarus_another.4.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.4.a executed"
@@ -291,6 +279,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_another.4.b
 		ai_chance = { base = 1 }
@@ -303,7 +292,6 @@ country_event = {
 	title = belarus_ukraine.1.t
 	desc = belarus_ukraine.1.d
 	picture = GFX_belarus_kastus
-
 	is_triggered_only = yes
 
 	option = {
@@ -339,7 +327,6 @@ country_event = {
 	title = belarus_ukraine.2.t
 	desc = belarus_ukraine.2.d
 	picture = GFX_belarus_volunteers
-
 	is_triggered_only = yes
 
 	option = {
@@ -396,14 +383,12 @@ country_event = {
 	title = belarus_ukraine.3.t
 	desc = belarus_ukraine.3.d
 	picture = GFX_minsk_agreements
-
 	is_triggered_only = yes
 
 	option = {
-
 	name = belarus_ukraine.3.a
 		log = "[GetDateText]: [This.GetName]: belarus_ukraine.3.a executed"
-		UKR = {	white_peace = DPR }
+		UKR = { white_peace = DPR }
 		add_opinion_modifier = {
 			target = DPR
 			modifier = recent_actions_positive
@@ -421,6 +406,7 @@ country_event = {
 		modifier = recent_actions_positive
 		}
 	}
+
 	option = {
 	name = belarus_ukraine.3.b
 		log = "[GetDateText]: [This.GetName]: belarus_ukraine.3.b executed"
@@ -449,7 +435,6 @@ country_event = {
 	title = belarus_export.2.t
 	desc = belarus_export.2.d
 	picture = GFX_belarus_export_t72bm1
-
 	is_triggered_only = yes
 
 	option = {
@@ -473,9 +458,7 @@ country_event = {
 				special_type_slot_4 = tank_battlestation_2
 				special_type_slot_6 = reactive_armor_gen1
 			}
-			upgrades = {
-				tank_nsb_armor_upgrade = 2
-			}
+			upgrades = { tank_nsb_armor_upgrade = 2 }
 			icon = "GFX_SOV_MBT_2"
 		}
 		add_equipment_to_stockpile = {
@@ -493,7 +476,6 @@ country_event = {
 	title = belarus_export.3.t
 	desc = belarus_export.3.d
 	picture = GFX_belarus_export_belgrad
-
 	is_triggered_only = yes
 
 	option = {
@@ -510,13 +492,10 @@ country_event = {
 				ammunition_load_slot = artillery_medium_ammo_1
 				suspension_type_slot = tank_wheeled_suspension_medium
 				engine_type_slot = afv_gasoline_engine_gen2
-
 				special_type_slot_1 = fire_ammo_1
 				special_type_slot_4 = tank_battlestation_1
 			}
-			upgrades = {
-				tank_nsb_fire_upgrade = 1
-			}
+			upgrades = { tank_nsb_fire_upgrade = 1 }
 			icon = "GFX_medium_tank_artillery_chassis_0_t_r"
 		}
 		add_equipment_to_stockpile = {
@@ -533,7 +512,6 @@ country_event = {
 	title = belarus_export.4.t
 	desc = belarus_export.4.d
 	picture = GFX_belarus_export_vpk
-
 	is_triggered_only = yes
 
 	option = {
@@ -550,15 +528,12 @@ country_event = {
 				ammunition_load_slot = artillery_medium_ammo_1
 				suspension_type_slot = tank_wheeled_suspension_medium
 				engine_type_slot = tank_diesel_engine_gen3
-
 				special_type_slot_1 = mine_ammo_2
 				special_type_slot_2 = cluster_ammo_2
 				special_type_slot_3 = heat_ammo_2
 				special_type_slot_4 = tank_battlestation_3
 			}
-			upgrades = {
-				tank_nsb_fire_upgrade = 1
-			}
+			upgrades = { tank_nsb_fire_upgrade = 1 }
 			icon = "GFX_medium_tank_artillery_chassis_2_t_r"
 		}
 		add_equipment_to_stockpile = {
@@ -575,7 +550,6 @@ country_event = {
 	title = belarus_export.6.t
 	desc = belarus_export.6.d
 	picture = GFX_belarus_tracktors
-
 	is_triggered_only = yes
 
 	option = {
@@ -587,7 +561,6 @@ country_event = {
 			idea = BLR_agro_export
 			days = 1080
 		}
-
 		add_opinion_modifier = {
 			target = BLR
 			modifier = trade_mission
@@ -598,11 +571,10 @@ country_event = {
 		}
 		BLR = {
 			clr_country_flag = BLR_pending_tractor_offer
-			country_event = { id = belarus_export.7	days = 1 }
+			country_event = { id = belarus_export.7 days = 1 }
 		}
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > 10 } }
 				add = 10
@@ -613,19 +585,16 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_export.6.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.6.b executed"
 		BLR = {
 			clr_country_flag = BLR_pending_tractor_offer
-			country_event = { id = belarus_export.8	days = 1 }
+			country_event = { id = belarus_export.8 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Export Choose MTZ
@@ -633,7 +602,6 @@ country_event = {
 	id = belarus_export.7
 	title = belarus_export.7.t
 	desc = belarus_export.7.d
-
 	picture = GFX_belarus_tracktors
 	is_triggered_only = yes
 
@@ -651,14 +619,10 @@ country_event = {
 	id = belarus_export.8
 	title = belarus_export.8.t
 	desc = belarus_export.8.d
-
 	picture = GFX_belarus_tracktors
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.8.a
-
-	}
+	option = { name = belarus_export.8.a }
 }
 
 #Export Minotor
@@ -666,7 +630,6 @@ country_event = {
 	id = belarus_export.9
 	title = belarus_export.9.t
 	desc = belarus_export.9.d
-
 	picture = GFX_belarus_minotor
 	is_triggered_only = yes
 
@@ -684,7 +647,6 @@ country_event = {
 	title = belarus_export.10.t
 	desc = belarus_export.10.d
 	picture = GFX_belarus_558zavod
-
 	is_triggered_only = yes
 
 	option = {
@@ -697,7 +659,7 @@ country_event = {
 			days = 1400
 		}
 		BLR = {
-			country_event = { id = belarus_export.11	days = 1 }
+			country_event = { id = belarus_export.11 days = 1 }
 		}
 		add_opinion_modifier = {
 			target = BLR
@@ -709,7 +671,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > 10 } }
 				add = 10
@@ -720,16 +681,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_export.10.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.10.b executed"
 		BLR = {
-			country_event = { id = belarus_export.12	days = 1 }
+			country_event = { id = belarus_export.12 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -738,7 +697,6 @@ country_event = {
 	id = belarus_export.11
 	title = belarus_export.11.t
 	desc = belarus_export.11.d
-
 	picture = GFX_belarus_558zavod
 	is_triggered_only = yes
 
@@ -754,14 +712,10 @@ country_event = {
 	id = belarus_export.12
 	title = belarus_export.12.t
 	desc = belarus_export.12.d
-
 	picture = GFX_belarus_558zavod
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.12.a
-
-	}
+	option = { name = belarus_export.12.a }
 }
 
 #Export Peleng
@@ -770,7 +724,6 @@ country_event = {
 	title = belarus_export.13.t
 	desc = belarus_export.13.d
 	picture = GFX_belarus_peleng
-
 	is_triggered_only = yes
 
 	option = {
@@ -791,22 +744,18 @@ country_event = {
 			modifier = trade_mission
 		}
 		BLR = {
-			country_event = { id = belarus_export.14	days = 1 }
+			country_event = { id = belarus_export.14 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = belarus_export.13.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.13.b executed"
 		BLR = {
-			country_event = { id = belarus_export.15	days = 1 }
+			country_event = { id = belarus_export.15 days = 1 }
 		}
-		ai_chance = {
-			base = 0
-
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -815,7 +764,6 @@ country_event = {
 	id = belarus_export.14
 	title = belarus_export.14.t
 	desc = belarus_export.14.d
-
 	picture = GFX_belarus_peleng
 	is_triggered_only = yes
 
@@ -837,14 +785,10 @@ country_event = {
 	id = belarus_export.15
 	title = belarus_export.15.t
 	desc = belarus_export.15.d
-
 	picture = GFX_belarus_peleng
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.15.a
-
-	}
+	option = { name = belarus_export.15.a }
 }
 
 #Export PTRK
@@ -853,7 +797,6 @@ country_event = {
 	title = belarus_export.16.t
 	desc = belarus_export.16.d
 	picture = GFX_belarus_shershen
-
 	is_triggered_only = yes
 
 	option = {
@@ -862,7 +805,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -5 }
 		modify_treasury_effect = yes
 		add_equipment_to_stockpile = {
-			type = Anti_tank_2	#
+			type = Anti_tank_2 #
 			amount = 50
 			producer = BLR
 		}
@@ -879,7 +822,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > 10 } }
 				add = 10
@@ -890,16 +832,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_export.16.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.16.b executed"
 		BLR = {
-			country_event = { id = belarus_export.18	days = 1 }
+			country_event = { id = belarus_export.18 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -908,7 +848,6 @@ country_event = {
 	id = belarus_export.17
 	title = belarus_export.17.t
 	desc = belarus_export.17.d
-
 	picture = GFX_belarus_shershen
 	is_triggered_only = yes
 
@@ -917,7 +856,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: belarus_export.17.a executed"
 		set_temp_variable = { treasury_change = 5 }
 		modify_treasury_effect = yes
-
 	}
 }
 #Export PTRK
@@ -925,14 +863,10 @@ country_event = {
 	id = belarus_export.18
 	title = belarus_export.18.t
 	desc = belarus_export.18.d
-
 	picture = GFX_belarus_shershen
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.18.a
-
-	}
+	option = { name = belarus_export.18.a }
 }
 
 #Export MZKT
@@ -941,7 +875,6 @@ country_event = {
 	title = belarus_export.19.t
 	desc = belarus_export.19.d
 	picture = GFX_belarus_mzkt
-
 	is_triggered_only = yes
 
 	option = {
@@ -961,7 +894,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > 10 } }
 				add = 10
@@ -972,16 +904,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_export.19.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.19.b executed"
 		BLR = {
 			country_event = { id = belarus_export.21 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -990,7 +920,6 @@ country_event = {
 	id = belarus_export.20
 	title = belarus_export.20.t
 	desc = belarus_export.20.d
-
 	picture = GFX_belarus_mzkt
 	is_triggered_only = yes
 
@@ -998,7 +927,6 @@ country_event = {
 		name = belarus_export.20.a
 		log = "[GetDateText]: [This.GetName]: belarus_export.20.a executed"
 		add_ideas = BLR_mzkt_contract_blr
-
 	}
 }
 #Export MZKT
@@ -1006,14 +934,10 @@ country_event = {
 	id = belarus_export.21
 	title = belarus_export.21.t
 	desc = belarus_export.21.d
-
 	picture = GFX_belarus_mzkt
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.21.a
-
-	}
+	option = { name = belarus_export.21.a }
 }
 
 #Kobra K
@@ -1022,7 +946,6 @@ country_event = {
 	title = belarus_export.22.t
 	desc = belarus_export.22.d
 	picture = GFX_belarus_kobra_k
-
 	is_triggered_only = yes
 
 	option = {
@@ -1039,7 +962,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > 10 } }
 				add = 10
@@ -1050,16 +972,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_export.22.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.22.b executed"
 		BLR = {
 			country_event = { id = belarus_export.24 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1068,7 +988,6 @@ country_event = {
 	id = belarus_export.23
 	title = belarus_export.23.t
 	desc = belarus_export.23.d
-
 	picture = GFX_belarus_kobra_k
 	is_triggered_only = yes
 
@@ -1081,7 +1000,6 @@ country_event = {
 			uses = 1
 			category = CAT_apc
 		}
-
 	}
 }
 #Kobra K disagree
@@ -1089,14 +1007,10 @@ country_event = {
 	id = belarus_export.24
 	title = belarus_export.24.t
 	desc = belarus_export.24.d
-
 	picture = GFX_belarus_kobra_k
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.24.a
-
-	}
+	option = { name = belarus_export.24.a }
 }
 
 #Polonez
@@ -1105,7 +1019,6 @@ country_event = {
 	title = belarus_export.25.t
 	desc = belarus_export.25.d
 	picture = GFX_belarus_export_vpk
-
 	is_triggered_only = yes
 
 	option = {
@@ -1122,21 +1035,16 @@ country_event = {
 		BLR = {
 			country_event = { id = belarus_export.26 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = belarus_export.25.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.25.b executed"
 		BLR = {
 			country_event = { id = belarus_export.27 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1145,7 +1053,6 @@ country_event = {
 	id = belarus_export.26
 	title = belarus_export.26.t
 	desc = belarus_export.26.d
-
 	picture = GFX_belarus_export_vpk
 	is_triggered_only = yes
 
@@ -1154,7 +1061,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: belarus_export.26.a executed"
 		set_temp_variable = { treasury_change = 3 }
 		modify_treasury_effect = yes
-
 	}
 }
 #Polonez
@@ -1162,14 +1068,10 @@ country_event = {
 	id = belarus_export.27
 	title = belarus_export.27.t
 	desc = belarus_export.27.d
-
 	picture = GFX_belarus_export_vpk
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.27.a
-
-	}
+	option = { name = belarus_export.27.a }
 }
 
 #Export MZKT all
@@ -1178,7 +1080,6 @@ country_event = {
 	title = belarus_export.28.t
 	desc = belarus_export.28.d
 	picture = GFX_belarus_mzkt
-
 	is_triggered_only = yes
 
 	option = {
@@ -1203,7 +1104,6 @@ country_event = {
 		}
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > 10 } }
 				add = 10
@@ -1214,16 +1114,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_export.28.b
 		log = "[GetDateText]: [This.GetName]: belarus_export.28.b executed"
 		BLR = {
-			country_event = { id = belarus_export.30	days = 1 }
+			country_event = { id = belarus_export.30 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1232,7 +1130,6 @@ country_event = {
 	id = belarus_export.29
 	title = belarus_export.29.t
 	desc = belarus_export.29.d
-
 	picture = GFX_belarus_mzkt
 	is_triggered_only = yes
 
@@ -1241,7 +1138,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: belarus_export.29.a executed"
 		set_temp_variable = { treasury_change = 2 }
 		modify_treasury_effect = yes
-
 	}
 }
 #Export Choose  MZKT
@@ -1249,14 +1145,10 @@ country_event = {
 	id = belarus_export.30
 	title = belarus_export.30.t
 	desc = belarus_export.30.d
-
 	picture = GFX_belarus_mzkt
 	is_triggered_only = yes
 
-	option = {
-		name = belarus_export.30.a
-
-	}
+	option = { name = belarus_export.30.a }
 }
 
 #Poland situation
@@ -1264,10 +1156,9 @@ country_event = {
 	id = belarus_another.2
 	title = belarus_another.2.t
 	desc = belarus_another.2.d
-
-	fire_only_once = yes
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.2.a
@@ -1285,7 +1176,6 @@ country_event = {
 		set_temp_variable = { influence_target = BLR }
 		change_influence_percentage = yes
 	}
-
 }
 #Religion in Ukraine
 country_event = {
@@ -1293,9 +1183,8 @@ country_event = {
 	title = belarus_another.3.t
 	desc = belarus_another.3.d
 	picture = GFX_belarus_uniate
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.3.a
@@ -1305,11 +1194,11 @@ country_event = {
 			add_idea = uniate_church
 			}
 	}
+
 	option = {
 		name = belarus_another.3.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.3.b executed"
 		add_stability = -0.09
-
 	}
 }
 #Decree no3
@@ -1318,9 +1207,8 @@ country_event = {
 	title = belarus_another.5.t
 	desc = belarus_another.5.d
 	picture = GFX_belarus_decreee3
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.5.a
@@ -1329,6 +1217,7 @@ country_event = {
 		set_temp_variable = { modify_batka = -2 }
 		modify_batka_support = yes
 	}
+
 	option = {
 		name = belarus_another.5.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.5.b executed"
@@ -1344,22 +1233,20 @@ country_event = {
 	title = belarus_another.6.t
 	desc = belarus_another.6.d
 	picture = GFX_era_lukashenko
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = belarus_another.6.a
-	}
+	option = { name = belarus_another.6.a }
 }
 #Azerbaijan Investment
 country_event = {
 	id = belarus_another.7
 	title = belarus_another.7.t
 	desc = belarus_another.7.d
+	picture = GFX_belarus_aze_invest
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_aze_invest
+
 	option = {
 		name = belarus_another.7.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.7.a executed"
@@ -1382,6 +1269,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_another.7.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.7.b executed"
@@ -1400,9 +1288,10 @@ country_event = {
 	id = belarus_another.8
 	title = belarus_another.8.t
 	desc = belarus_another.8.d
+	picture = GFX_project_bombel
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_project_bombel
+
 	option = {
 		name = belarus_another.8.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.8.a executed"
@@ -1455,9 +1344,10 @@ country_event = {
 	id = belarus_another.9
 	title = belarus_another.9.t
 	desc = belarus_another.9.d
+	picture = GFX_belarus_ven_invest
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_ven_invest
+
 	option = {
 		name = belarus_another.9.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.9.a executed"
@@ -1486,6 +1376,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_another.9.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.9.b executed"
@@ -1505,13 +1396,13 @@ country_event = {
 	id = belarus_another.10
 	title = belarus_another.10.t
 	desc = belarus_another.10.d
+	picture = GFX_belarus_arrest_wagner
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_arrest_wagner
+
 	option = {
 		name = belarus_another.10.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.10.a executed"
-
 		for_each_scope_loop = {
 			array = global.EU_member
 			tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
@@ -1528,7 +1419,6 @@ country_event = {
 			modifier = recent_actions_positive
 			target = SOV
 		}
-
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -1573,6 +1463,7 @@ country_event = {
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	option = {
 		name = belarus_another.11.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.11.a executed"
@@ -1595,6 +1486,7 @@ country_event = {
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	option = {
 		name = belarus_another.45.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.45.a executed"
@@ -1614,9 +1506,10 @@ country_event = {
 	id = belarus_another.12
 	title = belarus_another.12.t
 	desc = belarus_another.12.d
+	picture = GFX_belarus_azarenok
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_azarenok
+
 	option = {
 		name = belarus_another.12.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.12.a executed"
@@ -1633,6 +1526,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.06 }
 		change_relative_party_popularity = yes
 	}
+
 	option = {
 		name = belarus_another.12.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.12.b executed"
@@ -1651,16 +1545,16 @@ country_event = {
 		add_stability = 0.05
 		add_political_power = 100
 	}
-
 }
 #Arrest Tihanovksogo
 country_event = {
 	id = belarus_another.14
 	title = belarus_another.14.t
 	desc = belarus_another.14.d
+	picture = GFX_tihanovskyi_arrest
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_tihanovskyi_arrest
+
 	option = {
 		name = belarus_another.14.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.14.a executed"
@@ -1675,6 +1569,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_another.14.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.14.b executed"
@@ -1709,7 +1604,6 @@ country_event = {
 			country_event = { id = belarus_another.16 days = 10 }
 		}
 	}
-
 }
 #Credit policy
 country_event = {
@@ -1726,34 +1620,27 @@ country_event = {
 		add_stability = 0.04
 		add_political_power = -20
 		if = {
-			limit = {
-				has_idea = BLR_unstable_national_currency2
-			}
+			limit = { has_idea = BLR_unstable_national_currency2 }
 			swap_ideas = {
 				remove_idea = BLR_unstable_national_currency2
 				add_idea = BLR_unstable_national_currency4
 			}
 		}
 		if = {
-			limit = {
-				has_idea = BLR_unstable_national_currency3
-			}
+			limit = { has_idea = BLR_unstable_national_currency3 }
 			swap_ideas = {
 				remove_idea = BLR_unstable_national_currency3
 				add_idea = BLR_unstable_national_currency4
 			}
 		}
 		if = {
-			limit = {
-				has_idea = BLR_unstable_national_currency
-			}
+			limit = { has_idea = BLR_unstable_national_currency }
 			swap_ideas = {
 				remove_idea = BLR_unstable_national_currency
 				add_idea = BLR_unstable_national_currency4
 			}
 		}
 	}
-
 }
 
 #Venezuela Military with Belarus
@@ -1761,9 +1648,10 @@ country_event = {
 	id = belarus_another.17
 	title = belarus_another.17.t
 	desc = belarus_another.17.d
+	picture = GFX_belarus_ven_invest
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_ven_invest
+
 	option = {
 		name = belarus_another.17.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.17.a executed"
@@ -1787,9 +1675,10 @@ country_event = {
 	id = belarus_another.18
 	title = belarus_another.18.t
 	desc = belarus_another.18.d
+	picture = GFX_belarus_latgale_or_war
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_latgale_or_war
+
 	option = {
 		name = belarus_another.18.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.18.a executed"
@@ -1840,25 +1729,22 @@ country_event = {
 	id = belarus_another.19
 	title = belarus_another.19.t
 	desc = belarus_another.19.d
+	picture = GFX_polish_nationalists1
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_polish_nationalists1
+
 	option = {
 		name = belarus_another.19.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.19.a executed"
 		ai_chance = {
 			base = 45
 			modifier = {
-				BLR = {
-					has_country_flag = BLR_poland_parlament_belarus_agent_flag
-				}
+				BLR = { has_country_flag = BLR_poland_parlament_belarus_agent_flag }
 				add = 10
 			}
 		}
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			FROM = {
 				set_autonomy = {
 					target = ROOT
@@ -1886,9 +1772,7 @@ country_event = {
 	}
 
 	option = {
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 		name = belarus_another.19.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.19.b executed"
 		BLR = {
@@ -1902,27 +1786,25 @@ country_event = {
 	id = belarus_another.20
 	title = belarus_another.20.t
 	desc = belarus_another.20.d
+	picture = GFX_polish_nationalists1
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_polish_nationalists1
-	option = {
-		name = belarus_another.20.a
-	}
+
+	option = { name = belarus_another.20.a }
 }
 #Poland Refuse Union state
 country_event = {
 	id = belarus_another.21
 	title = belarus_another.21.t
 	desc = belarus_another.21.d
+	picture = GFX_polish_nationalists1
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_polish_nationalists1
+
 	option = {
 		name = belarus_another.21.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.21.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		POL = {
 			start_civil_war = {
 				ideology = nationalist
@@ -1953,16 +1835,12 @@ country_event = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = BLR_silesian_help_flag
-				}
+				limit = { has_country_flag = BLR_silesian_help_flag }
 				SIL = { country_event = { id = belarus_another.22 days = 1 }
 						transfer_state = 115
 						transfer_state = 626 }
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = SIL
 					autonomy_state = autonomy_satellite_state_colored
@@ -1987,10 +1865,9 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
-		ai_chance = {
-			base = 45
-		}
+		ai_chance = { base = 45 }
 		name = belarus_another.21.b
 	}
 }
@@ -1999,15 +1876,14 @@ country_event = {
 	id = belarus_another.22
 	title = belarus_another.22.t
 	desc = belarus_another.22.d
+	picture = GFX_belarus_silesia
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_silesia
+
 	option = {
 		name = belarus_another.22.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.22.a executed"
-		hidden_effect = {
-		add_manpower = 3500
-		}
+		hidden_effect = { add_manpower = 3500 }
 		division_template = {
 			name = "Silesian Militia"
 			regiments = {
@@ -2042,25 +1918,23 @@ country_event = {
 	id = belarus_another.23
 	title = belarus_another.23.t
 	desc = belarus_another.23.d
+	picture = GFX_ace_promoted
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_ace_promoted
+
 	option = {
 		name = belarus_another.23.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.23.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		army_experience = 20
 		air_experience = 20
 		BLR = {
 			country_event = { id = belarus_another.24 days = 1 }
 		}
 	}
+
 	option = {
-		ai_chance = {
-			base = 45
-		}
+		ai_chance = { base = 45 }
 		name = belarus_another.23.b
 	}
 }
@@ -2070,15 +1944,14 @@ country_event = {
 	id = belarus_another.24
 	title = belarus_another.24.t
 	desc = belarus_another.24.d
+	picture = GFX_ace_promoted
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_ace_promoted
+
 	option = {
 		name = belarus_another.24.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.24.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		army_experience = 20
 		air_experience = 20
 	}
@@ -2089,9 +1962,10 @@ country_event = {
 	id = belarus_another.25
 	title = belarus_another.25.t
 	desc = belarus_another.25.d
+	picture = GFX_belarus_send_weapon_to_iraq
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_send_weapon_to_iraq
+
 	option = {
 		name = belarus_another.25.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.25.a executed"
@@ -2110,7 +1984,6 @@ country_event = {
 				amount = 1000
 				producer = BLR
 			}
-
 		}
 	}
 }
@@ -2120,12 +1993,11 @@ country_event = {
 	id = belarus_another.26
 	title = belarus_another.26.t
 	desc = belarus_another.26.d
+	picture = GFX_belarus_protasevich
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_protasevich
-	option = {
-		name = belarus_another.26.a
-	}
+
+	option = { name = belarus_another.26.a }
 }
 
 #Belarussian Church
@@ -2140,9 +2012,7 @@ country_event = {
 	option = {
 		name = belarus_another.27.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.27.a executed"
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 		add_opinion_modifier = {
 			modifier = recent_actions_negative
 			target = SOV
@@ -2159,17 +2029,15 @@ country_event = {
 		change_the_clergy_opinion = yes
 		set_temp_variable = { modify_batka = 6 }
 		modify_batka_support = yes
-
 		if = {
-			limit = {
-			has_idea = the_military
-			}
+			limit = { has_idea = the_military }
 			swap_ideas = {
 			remove_idea = the_military
 			add_idea = the_clergy
 			}
 		}
 	}
+
 	option = {
 		name = belarus_another.27.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.27.b executed"
@@ -2195,7 +2063,6 @@ country_event = {
 			target = SOV
 		}
 	}
-
 }
 
 #Union of Poles
@@ -2204,7 +2071,6 @@ country_event = {
 	title = belarus_another.28.t
 	desc = belarus_another.28.d
 	picture = GFX_belarus_union_of_poles
-
 	is_triggered_only = yes
 
 	option = {
@@ -2223,10 +2089,11 @@ country_event = {
 			modifier = recent_actions_negative
 		}
 	}
+
 	option = {
 		name = belarus_another.28.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.28.b executed"
-		add_timed_idea = { idea = BLR_Poles_goes  days = 300 }
+		add_timed_idea = { idea = BLR_Poles_goes days = 300 }
 		set_temp_variable = { percent_change = -5.30 }
 		set_temp_variable = { tag_index = POL }
 		set_temp_variable = { influence_target = BLR }
@@ -2239,7 +2106,6 @@ country_event = {
 			target = POL
 			modifier = recent_actions_negative
 		}
-
 	}
 }
 
@@ -2249,15 +2115,12 @@ country_event = {
 	title = belarus_another.31.t
 	desc = belarus_another.31.d
 	picture = GFX_belarus_milkwar
-
 	is_triggered_only = yes
 
 	option = {
 		name = belarus_another.31.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.31.a executed"
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 		set_temp_variable = { temp_opinion = 15 }
 		change_landowners_opinion = yes
 		set_temp_variable = { temp_opinion = 15 }
@@ -2281,6 +2144,7 @@ country_event = {
 			target = SOV
 		}
 	}
+
 	option = {
 		name = belarus_another.31.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.31.b executed"
@@ -2325,15 +2189,14 @@ country_event = {
 	id = belarus_another.34
 	title = belarus_another.34.t
 	desc = belarus_another.34.d
+	picture = GFX_belarus_taler
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_taler
+
 	option = {
 		name = belarus_another.34.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.34.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		set_temp_variable = { percent_change = 4.20 }
 		set_temp_variable = { tag_index = BLR }
 		set_temp_variable = { influence_target = POL }
@@ -2347,9 +2210,7 @@ country_event = {
 	}
 
 	option = {
-		ai_chance = {
-			base = 45
-		}
+		ai_chance = { base = 45 }
 		name = belarus_another.34.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.34.b executed"
 		set_temp_variable = { percent_change = -3.20 }
@@ -2365,15 +2226,14 @@ country_event = {
 	id = belarus_another.35
 	title = belarus_another.35.t
 	desc = belarus_another.35.d
+	picture = GFX_belarus_intermarium
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_belarus_intermarium
+
 	option = {
 		name = belarus_another.35.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.35.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		if = {
 			limit = { has_idea = NATO_member }
 			NATO_leave = yes
@@ -2387,12 +2247,10 @@ country_event = {
 			add_to_faction = ROOT
 		}
 	}
+
 	option = {
 		name = belarus_another.35.b
-
-		ai_chance = {
-			base = 45
-		}
+		ai_chance = { base = 45 }
 	}
 }
 
@@ -2401,23 +2259,20 @@ country_event = {
 	id = belarus_another.36
 	title = belarus_another.36.t
 	desc = belarus_another.36.d
+	picture = GFX_NATO_picture
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_NATO_picture
+
 	option = {
 		name = belarus_another.36.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.36.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		BLR = { country_event = { id = belarus_another.37 days = 1 } }
 		}
-	option = {
-		ai_chance = {
-			base = 45
-		}
-		name = belarus_another.36.b
 
+	option = {
+		ai_chance = { base = 45 }
+		name = belarus_another.36.b
 	}
 }
 
@@ -2426,15 +2281,14 @@ country_event = {
 	id = belarus_another.37
 	title = belarus_another.37.t
 	desc = belarus_another.37.d
+	picture = GFX_NATO_picture
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_NATO_picture
+
 	option = {
 		name = belarus_another.37.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.37.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		if = {
 			limit = { has_idea = CSTO_member }
 			CSTO_leave = yes
@@ -2454,26 +2308,22 @@ country_event = {
 	id = belarus_another.38
 	title = belarus_another.38.t
 	desc = belarus_another.38.d
+	picture = GFX_USA_generic
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_USA_generic
+
 	option = {
 		name = belarus_another.38.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.38.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		BLR = {
 			country_event = { id = belarus_another.39 days = 1 }
 		}
 	}
 
 	option = {
-		ai_chance = {
-			base = 45
-		}
+		ai_chance = { base = 45 }
 		name = belarus_another.38.b
-
 	}
 }
 
@@ -2482,15 +2332,14 @@ country_event = {
 	id = belarus_another.39
 	title = belarus_another.39.t
 	desc = belarus_another.39.d
+	picture = GFX_USA_generic
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_USA_generic
+
 	option = {
 		name = belarus_another.39.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.39.a executed"
-		ai_chance = {
-			base = 55
-		}
+		ai_chance = { base = 55 }
 		add_ideas = USA_usaid
 		set_temp_variable = { temp_opinion = 5 }
 		change_international_bankers_opinion = yes
@@ -2503,9 +2352,8 @@ country_event = {
 	title = belarus_another.40.t
 	desc = belarus_another.40.d
 	picture = GFX_stock_market
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.40.a
@@ -2535,6 +2383,7 @@ country_event = {
 			country_event = { id = belarus_another.15 days = 10 }
 		}
 	}
+
 	option = {
 		name = belarus_another.40.c
 		log = "[GetDateText]: [This.GetName]: belarus_another.40.c executed"
@@ -2545,7 +2394,6 @@ country_event = {
 			country_event = { id = belarus_another.15 days = 10 }
 		}
 	}
-
 }
 
 #Operation New day
@@ -2553,10 +2401,9 @@ country_event = {
 	id = belarus_another.41
 	title = belarus_another.41.t
 	desc = belarus_another.41.d
-
-	fire_only_once = yes
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.41.a
@@ -2568,10 +2415,9 @@ country_event = {
 			target = LIT
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
+
 	option = {
 		name = belarus_another.41.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.41.b executed"
@@ -2579,9 +2425,7 @@ country_event = {
 			target = BLR
 			modifier = recent_actions_negative
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -2590,25 +2434,21 @@ country_event = {
 	id = belarus_another.42
 	title = belarus_another.42.t
 	desc = belarus_another.42.d
-
-	fire_only_once = yes
 	picture = GFX_treaty
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.42.a
 		log = "[GetDateText]: [This.GetName]: belarus_another.42.a executed"
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 		BLR = { transfer_state = 110 }
 	}
+
 	option = {
 		name = belarus_another.42.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.42.b executed"
-		ai_chance = {
-			base = 40
-		}
+		ai_chance = { base = 40 }
 		add_opinion_modifier = {
 			target = BLR
 			modifier = recent_actions_negative
@@ -2622,8 +2462,8 @@ country_event = {
 	title = belarus_another.44.t
 	desc = belarus_another.44.d
 	picture = GFX_belarus_2020
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = belarus_another.44.a
@@ -2640,6 +2480,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.035 }
 		change_relative_party_popularity = yes
 	}
+
 	option = {
 		name = belarus_another.44.b
 		log = "[GetDateText]: [This.GetName]: belarus_another.44.b executed"
@@ -2683,13 +2524,14 @@ country_event = {
 }
 
 	#Jeans Revolution
-	country_event = {
-		id = belarus_another.52
-		title = belarus_another.52.t
-		desc = belarus_another.52.d
-		picture = GFX_belarus_jeans_revolution
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.52
+	title = belarus_another.52.t
+	desc = belarus_another.52.d
+	picture = GFX_belarus_jeans_revolution
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = { # Shiiiiiiet
 			name = belarus_another.52.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.52.a executed"
@@ -2708,30 +2550,24 @@ country_event = {
 				base = 100
 			}
 		}
+
 		option = {
 			name = belarus_another.52.b
 			log = "[GetDateText]: [This.GetName]:belarus_another.52.b executed"
-			trigger = {
-				NOT = {
-					has_completed_focus = BLR_occupation_management_strategies
-				}
-			}
+			trigger = { NOT = { has_completed_focus = BLR_occupation_management_strategies } }
 			hidden_effect = {
 				SOV = { country_event = { id = belarus_another.55 days = 10 } }
 			}
-			ai_chance = {
-				base = 1
-			}
+			ai_chance = { base = 1 }
 		}
-	}
-	country_event = {
-		id = belarus_another.53
-		title = belarus_another.53.t
-		desc = belarus_another.53.d
-		picture = GFX_belarus_nazbols_rule_russia
-		is_triggered_only = yes
-
-		fire_only_once = yes
+}
+country_event = {
+	id = belarus_another.53
+	title = belarus_another.53.t
+	desc = belarus_another.53.d
+	picture = GFX_belarus_nazbols_rule_russia
+	is_triggered_only = yes
+	fire_only_once = yes
 
 		option = { # Limonov
 			name = belarus_another.53.a
@@ -2747,15 +2583,14 @@ country_event = {
 				 }
 			 }
 		}
-	 }
-	 country_event = {
-		id = belarus_another.54
-		title = belarus_another.54.t
-		desc = belarus_another.54.d
-		picture = GFX_treaty
-		is_triggered_only = yes
-
-		fire_only_once = yes
+}
+country_event = {
+	id = belarus_another.54
+	title = belarus_another.54.t
+	desc = belarus_another.54.d
+	picture = GFX_treaty
+	is_triggered_only = yes
+	fire_only_once = yes
 
 		option = {
 			name = belarus_another.54.a
@@ -2770,15 +2605,16 @@ country_event = {
 			reverse_add_opinion_modifier = { target = ROOT modifier = has_expressed_loyalty }
 		}
 		}
-	}
+}
 	#Jeans Revolution
-	country_event = {
-		id = belarus_another.55
-		title = belarus_another.55.t
-		desc = belarus_another.55.d
-		picture = GFX_belarus_jeans_revolution
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.55
+	title = belarus_another.55.t
+	desc = belarus_another.55.d
+	picture = GFX_belarus_jeans_revolution
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.55.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.55.a executed"
@@ -2792,10 +2628,9 @@ country_event = {
 			hidden_effect = {
 				BLR = { country_event = { id = belarus_another.56 days = 10 } }
 			}
-			ai_chance = {
-				base = 50
-			}
+			ai_chance = { base = 50 }
 		}
+
 		option = {
 			name = belarus_another.55.b
 			log = "[GetDateText]: [This.GetName]:belarus_another.55.b executed"
@@ -2814,31 +2649,29 @@ country_event = {
 			hidden_effect = {
 				BLR = { country_event = { id = belarus_another.57 days = 10 } }
 			}
-			ai_chance = {
-				base = 50
-			}
+			ai_chance = { base = 50 }
 		}
-	}
+}
 	#Jeans Revolution
-	country_event = {
-		id = belarus_another.56
-		title = belarus_another.56.t
-		desc = belarus_another.56.d
-		picture = GFX_belarus_jeans_revolution
-		is_triggered_only = yes
-		fire_only_once = yes
-		option = {
-			name = belarus_another.56.a
-		}
-	}
+country_event = {
+	id = belarus_another.56
+	title = belarus_another.56.t
+	desc = belarus_another.56.d
+	picture = GFX_belarus_jeans_revolution
+	is_triggered_only = yes
+	fire_only_once = yes
+
+		option = { name = belarus_another.56.a }
+}
 	#Jeans Revolution
-	country_event = {
-		id = belarus_another.57
-		title = belarus_another.57.t
-		desc = belarus_another.57.d
-		picture = GFX_belarus_jeans_revolution
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.57
+	title = belarus_another.57.t
+	desc = belarus_another.57.d
+	picture = GFX_belarus_jeans_revolution
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.57.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.57.a executed"
@@ -2846,21 +2679,20 @@ country_event = {
 				BLR = { country_event = { id = belarus_another.58 days = 10 } }
 			}
 		}
-	}
+}
 	#Jeans Revolution
-	country_event = {
-		id = belarus_another.58
-		title = belarus_another.58.t
-		desc = belarus_another.58.d
-		picture = GFX_belarus_jeans_revolution
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.58
+	title = belarus_another.58.t
+	desc = belarus_another.58.d
+	picture = GFX_belarus_jeans_revolution
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.58.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.58.a executed"
-			ai_chance = {
-				base = 50
-			}
+			ai_chance = { base = 50 }
 			hidden_effect = {
 			random_list = {
 				70 = {
@@ -2882,23 +2714,20 @@ country_event = {
 			}
 			}
 		}
+
 		option = {
 			name = belarus_another.58.b
 			log = "[GetDateText]: [This.GetName]: belarus_another.58.b executed"
-			ai_chance = {
-				base = 50
-			}
+			ai_chance = { base = 50 }
 			hidden_effect = {
 				random_list = {
 					70 = {
-
 						if = {
 							limit = { NOT = { check_variable = { ruling_party = 2 } } }
 							set_temp_variable = { rul_party_temp = 2 }
 							set_temp_variable = { disable_elections = 0 }
 							change_ruling_party_effect = yes
 						}
-
 						set_temp_variable = { party_index = 2 }
 						set_temp_variable = { party_popularity_increase = 0.10 }
 						set_temp_variable = { temp_outlook_increase = 0.10 }
@@ -2911,7 +2740,6 @@ country_event = {
 							set_temp_variable = { disable_elections = 0 }
 							change_ruling_party_effect = yes
 						}
-
 						set_temp_variable = { party_index = 20 }
 						set_temp_variable = { party_popularity_increase = 0.10 }
 						set_temp_variable = { temp_outlook_increase = 0.10 }
@@ -2920,15 +2748,16 @@ country_event = {
 				}
 			}
 		}
-	}
+}
 	#Credit Russia
-	country_event = {
-		id = belarus_another.59
-		title = belarus_another.59.t
-		desc = belarus_another.59.d
-		picture = GFX_union_state
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.59
+	title = belarus_another.59.t
+	desc = belarus_another.59.d
+	picture = GFX_union_state
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.59.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.59.a executed"
@@ -2941,10 +2770,9 @@ country_event = {
 			set_temp_variable = { tag_index = SOV }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			ai_chance = {
-				base = 100
-			}
+			ai_chance = { base = 100 }
 		}
+
 		option = {
 			name = belarus_another.59.b
 			log = "[GetDateText]: [This.GetName]: belarus_another.59.b executed"
@@ -2953,47 +2781,45 @@ country_event = {
 			set_temp_variable = { tag_index = SOV }
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
-			ai_chance = {
-				base = 0
-			}
+			ai_chance = { base = 0 }
 		}
-	}
+}
 	#Credit Russia agree
-	country_event = {
-		id = belarus_another.60
-		title = belarus_another.60.t
-		desc = belarus_another.60.d
-		picture = GFX_union_state
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.60
+	title = belarus_another.60.t
+	desc = belarus_another.60.d
+	picture = GFX_union_state
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.60.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.60.a executed"
 			set_temp_variable = { treasury_change = 10 }
 			modify_treasury_effect = yes
-
 		}
-	}
+}
 	#Credit Russia disagree
-	country_event = {
-		id = belarus_another.61
-		title = belarus_another.61.t
-		desc = belarus_another.61.d
-		picture = GFX_union_state
-		is_triggered_only = yes
-		fire_only_once = yes
-		option = {
-			name = belarus_another.61.a
-		}
-	}
+country_event = {
+	id = belarus_another.61
+	title = belarus_another.61.t
+	desc = belarus_another.61.d
+	picture = GFX_union_state
+	is_triggered_only = yes
+	fire_only_once = yes
+
+		option = { name = belarus_another.61.a }
+}
 	#Create Kal
-	country_event = {
-		id = belarus_another.62
-		title = belarus_another.62.t
-		desc = belarus_another.62.d
-		picture = GFX_union_state
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.62
+	title = belarus_another.62.t
+	desc = belarus_another.62.d
+	picture = GFX_union_state
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.62.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.62.a executed"
@@ -3005,19 +2831,21 @@ country_event = {
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
 		}
+
 		option = {
 			name = belarus_another.62.b
 			ai_chance = { base = 0 }
 		}
-	}
+}
 	#Create Kal agree
-	country_event = {
-		id = belarus_another.63
-		title = belarus_another.63.t
-		desc = belarus_another.63.d
-		picture = GFX_union_state
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.63
+	title = belarus_another.63.t
+	desc = belarus_another.63.d
+	picture = GFX_union_state
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.63.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.63.a executed"
@@ -3027,15 +2855,16 @@ country_event = {
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
 		}
-	}
+}
 	#They Destroy Kal
-	country_event = {
-		id = belarus_another.64
-		title = belarus_another.64.t
-		desc = belarus_another.64.d
-		picture = GFX_union_state
-		is_triggered_only = yes
-		fire_only_once = yes
+country_event = {
+	id = belarus_another.64
+	title = belarus_another.64.t
+	desc = belarus_another.64.d
+	picture = GFX_union_state
+	is_triggered_only = yes
+	fire_only_once = yes
+
 		option = {
 			name = belarus_another.64.a
 			log = "[GetDateText]: [This.GetName]: belarus_another.64.a executed"
@@ -3054,14 +2883,13 @@ country_event = {
 			set_temp_variable = { influence_target = BLR }
 			change_influence_percentage = yes
 		}
-	}
+}
 
 #They agree callback
 country_event = {
 	id = belarus_azot.2
 	title = belarus_azot.2.t
 	desc = belarus_azot.2.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -3078,7 +2906,6 @@ country_event = {
 	id = belarus_azot.3
 	title = belarus_azot.3.t
 	desc = belarus_azot.3.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
@@ -3094,7 +2921,6 @@ country_event = {
 	id = belarus_azot.4
 	title = belarus_azot.4.t
 	desc = belarus_azot.4.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -3108,7 +2934,6 @@ country_event = {
 	id = belarus_azot.1
 	title = belarus_azot.1.t
 	desc = belarus_azot.1.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -3127,10 +2952,8 @@ country_event = {
 		BLR = {
 			country_event = { id = belarus_azot.2 days = 1 }
 		}
-
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = BLR value > -20 } }
 				add = 10
@@ -3141,16 +2964,14 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = belarus_azot.1.b
 		log = "[GetDateText]: [This.GetName]: belarus_azot.1.b executed"
 		BLR = {
 			country_event = { id = belarus_azot.3 days = 1 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -3188,18 +3009,15 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = belarus_politics.1.b
 		log = "[GetDateText]: [This.GetName]: belarus_politics.1.b executed"
 		add_stability = -0.05
 		add_political_power = -150
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3208,7 +3026,6 @@ country_event = {
 	id = belarus_LTB.1
 	title = belarus_LTB.1.t
 	desc = belarus_LTB.1.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -3216,9 +3033,7 @@ country_event = {
 		name = belarus_LTB.1.a
 		log = "[GetDateText]: [This.GetName]: belarus_LTB.1.a executed"
 		add_stability = -0.01
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3226,15 +3041,12 @@ country_event = {
 	id = belarus_LTB.2
 	title = belarus_LTB.2.t
 	desc = belarus_LTB.2.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
 	option = {
 		name = belarus_LTB.2.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3242,7 +3054,6 @@ country_event = {
 	id = belarus_LTB.3
 	title = belarus_LTB.3.t
 	desc = belarus_LTB.3.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -3251,9 +3062,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: belarus_LTB.3.a executed"
 		add_stability = -0.01
 		army_experience = -10
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3261,7 +3070,6 @@ country_event = {
 	id = belarus_LTB.4
 	title = belarus_LTB.4.t
 	desc = belarus_LTB.4.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -3270,9 +3078,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: belarus_LTB.4.a executed"
 		add_stability = -0.02
 		add_political_power = -50
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3280,14 +3086,11 @@ country_event = {
 	id = belarus_LTB.5
 	title = belarus_LTB.5.t
 	desc = belarus_LTB.5.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
 	option = {
 		name = belarus_LTB.5.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,600 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.