### PR TITLE
Standardize event files — batch 09/14

### DIFF
--- a/events/05_united_kingdom.txt
+++ b/events/05_united_kingdom.txt
@@ -34,10 +34,8 @@ country_event = {
 	title = ENG_military.007.t
 	desc = ENG_military.007.d
 	picture = GFX_ENG_generic
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.007.a
@@ -54,10 +52,8 @@ country_event = {
 	title = ENG_military.008.t
 	desc = ENG_military.008.d
 	picture = GFX_moonbase_construction
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Science!
 		name = ENG_military.008.a
@@ -76,10 +72,8 @@ country_event = {
 	title = ENG_military.009.t
 	desc = ENG_military.009.d
 	picture = GFX_moonbase_construction
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #We're good at being pioneers
 		name = ENG_military.009.a
@@ -102,10 +96,8 @@ country_event = {
 	title = ENG_military.010.t
 	desc = ENG_military.010.d
 	picture = GFX_moonbase
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Send emergency aid!
 		name = ENG_military.010.a
@@ -116,6 +108,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ENG_advance_moon_base = yes
 	}
+
 	option = { #Abandon the project. It's not meant for us
 		name = ENG_military.010.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.010.b executed"
@@ -135,10 +128,8 @@ country_event = {
 	title = ENG_military.011.t
 	desc = ENG_military.011.d
 	picture = GFX_moonbase_construction
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Life continues on
 		name = ENG_military.011.a
@@ -161,10 +152,8 @@ country_event = {
 	title = ENG_military.012.t
 	desc = ENG_military.012.d
 	picture = GFX_moonbase
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Send more emergency aid!
 		name = ENG_military.012.a
@@ -177,6 +166,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ENG_advance_moon_base = yes
 	}
+
 	option = { #We can't continue doing things like this.
 		name = ENG_military.012.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.012.b executed"
@@ -196,10 +186,8 @@ country_event = {
 	title = ENG_military.013.t
 	desc = ENG_military.013.d
 	picture = GFX_moonbase
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Huzzah!
 		name = ENG_military.013.a
@@ -222,10 +210,8 @@ country_event = {
 	title = ENG_military.014.t
 	desc = ENG_military.014.d
 	picture = GFX_mars_mission
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.014.a
@@ -243,10 +229,8 @@ country_event = {
 	title = ENG_military.015.t
 	desc = ENG_military.015.d
 	picture = GFX_mars_colony_2
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.015.a
@@ -272,10 +256,8 @@ country_event = {
 	title = ENG_military.016.t
 	desc = ENG_military.016.d
 	picture = GFX_mars_colony_3
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #
 		name = ENG_military.016.a
@@ -290,10 +272,8 @@ country_event = {
 	title = ENG_military.017.t
 	desc = ENG_military.017.d
 	picture = GFX_mars_colony_4
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.017.a
@@ -308,10 +288,8 @@ country_event = {
 	title = ENG_military.018.t
 	desc = ENG_military.018.d
 	picture = GFX_mars_colony_5
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.018.a
@@ -326,10 +304,8 @@ country_event = {
 	title = ENG_military.019.t
 	desc = ENG_military.019.d
 	picture = GFX_mars_colony_6
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.019.a
@@ -344,10 +320,8 @@ country_event = {
 	title = ENG_military.020.t
 	desc = ENG_military.020.d
 	picture = GFX_mars_colony_7
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.020.a
@@ -362,10 +336,8 @@ country_event = {
 	title = ENG_military.021.t
 	desc = ENG_military.021.d
 	picture = GFX_mars_colony_8
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.021.a
@@ -380,10 +352,8 @@ country_event = {
 	title = ENG_military.022.t
 	desc = ENG_military.022.d
 	picture = GFX_mars_colony_9
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.022.a
@@ -398,10 +368,8 @@ country_event = {
 	title = ENG_military.023.t
 	desc = ENG_military.023.d
 	picture = GFX_mars_colony_10
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.023.a
@@ -416,10 +384,8 @@ country_event = {
 	title = ENG_military.024.t
 	desc = ENG_military.024.d
 	picture = GFX_mars_colony_11
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.024.a
@@ -428,17 +394,14 @@ country_event = {
 			country_event = { id = ENG_military.025 days = 20 random_hours = 480 }
 		}
 	}
-
 }
 country_event = {
 	id = ENG_military.025
 	title = ENG_military.025.t
 	desc = ENG_military.025.d
 	picture = GFX_mars_colony_12
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Evacuate
 		name = ENG_military.025.a
@@ -447,6 +410,7 @@ country_event = {
 			country_event = { id = ENG_military.026 days = 20 random_hours = 480 }
 		}
 	}
+
 	option = { #Fix Base
 		name = ENG_military.025.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.025.b executed"
@@ -460,10 +424,8 @@ country_event = {
 	title = ENG_military.026.t
 	desc = ENG_military.026.d
 	picture = GFX_mars_colony_13
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.026.a
@@ -478,10 +440,8 @@ country_event = {
 	title = ENG_military.027.t
 	desc = ENG_military.027.d
 	picture = GFX_mars_colony_14
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.027.a
@@ -496,10 +456,8 @@ country_event = {
 	title = ENG_military.028.t
 	desc = ENG_military.028.d
 	picture = GFX_mars_colony_15
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Yes
 		name = ENG_military.028.a
@@ -510,6 +468,7 @@ country_event = {
 			country_event = { id = ENG_military.029 days = 20 random_hours = 480 }
 		}
 	}
+
 	option = { #No
 		name = ENG_military.028.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.028.b executed"
@@ -523,10 +482,8 @@ country_event = {
 	title = ENG_military.029.t
 	desc = ENG_military.029.d
 	picture = GFX_mars_colony_16
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.029.a
@@ -541,10 +498,8 @@ country_event = {
 	title = ENG_military.030.t
 	desc = ENG_military.030.d
 	picture = GFX_mars_colony_17
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.030.a
@@ -559,10 +514,8 @@ country_event = {
 	title = ENG_military.031.t
 	desc = ENG_military.031.d
 	picture = GFX_mars_colony_18
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.031.a
@@ -578,10 +531,8 @@ country_event = {
 	title = ENG_military.032.t
 	desc = ENG_military.032.d
 	picture = GFX_mars_colony_19
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.032.a
@@ -597,10 +548,8 @@ country_event = {
 	title = ENG_military.033.t
 	desc = ENG_military.033.d
 	picture = GFX_mars_colony_20
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = { #Launch!
 		name = ENG_military.033.a
@@ -615,7 +564,6 @@ country_event = {
 	id = United_Kingdom.002
 	title = United_Kingdom.002.t
 	desc = United_Kingdom.002.d
-
 	picture = GFX_computer
 	is_triggered_only = yes
 
@@ -664,7 +612,6 @@ country_event = {
 	id = United_Kingdom.003
 	title = United_Kingdom.003.t
 	desc = United_Kingdom.003.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -685,7 +632,6 @@ country_event = {
 	id = United_Kingdom.004
 	title = United_Kingdom.004.t
 	desc = United_Kingdom.004.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -699,13 +645,10 @@ country_event = {
 	id = United_Kingdom.005
 	title = United_Kingdom.005.t
 	desc = United_Kingdom.005.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = United_Kingdom.005.a
-	}
+	option = { name = United_Kingdom.005.a }
 }
 
 news_event = {
@@ -713,13 +656,10 @@ news_event = {
 	title = United_Kingdom_News.2.t
 	desc = United_Kingdom_News.2.d
 	picture = GFX_ENG_riot
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = United_Kingdom_News.2.a
-	}
+	option = { name = United_Kingdom_News.2.a }
 }
 
 news_event = {
@@ -727,13 +667,10 @@ news_event = {
 	title = United_Kingdom_News.3.t
 	desc = United_Kingdom_News.3.d
 	picture = GFX_monarch_abolish
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = United_Kingdom_News.3.a
-	}
+	option = { name = United_Kingdom_News.3.a }
 }
 
 news_event = {
@@ -741,13 +678,10 @@ news_event = {
 	title = United_Kingdom_News.4.t
 	desc = United_Kingdom_News.4.d
 	picture = GFX_ENG_british_collapse
-
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = United_Kingdom_News.4.a
-	}
+	option = { name = United_Kingdom_News.4.a }
 }
 ########################## Political #########################
 
@@ -759,7 +693,6 @@ country_event = {
 	title = Mobile_Fires_Platorm_Program.1.t
 	desc = Mobile_Fires_Platorm_Program.1.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -774,16 +707,13 @@ country_event = {
 		ENG = {
 			add_opinion_modifier = { target = SWE modifier = ENG_Archer_Alliance }
 		}
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = ENG_military.034.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.034.b executed"
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		KOR = {
 			add_opinion_modifier = { target = ENG modifier = ENG_K9A1_Order }
 		}
@@ -791,6 +721,7 @@ country_event = {
 			add_opinion_modifier = { target = KOR modifier = ENG_K9A1_Order }
 		}
 	}
+
 	option = {
 		name = ENG_military.034.c
 		log = "[GetDateText]: [This.GetName]: ENG_military.034.c executed"
@@ -806,17 +737,13 @@ country_event = {
 			add_opinion_modifier = { target = GER modifier = ENG_Boxer_Development }
 			add_opinion_modifier = { target = HOL modifier = ENG_Boxer_Development }
 		}
-
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = ENG_military.034.e
 		log = "[GetDateText]: [This.GetName]: ENG_military.034.e executed"
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		FRA = {
 			add_opinion_modifier = {
 				target = ENG
@@ -856,6 +783,7 @@ country_event = {
 		navy_experience = 25
 		ENG = { country_event = ENG_military.036 }
 	}
+
 	option = {
 		name = ENG_military.035.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.035.b executed"
@@ -898,17 +826,15 @@ country_event = {
 	picture = GFX_ENG_generic
 	is_triggered_only = yes
 
-	option = {
-		name = ENG_military.037.a
-	}
+	option = { name = ENG_military.037.a }
 }
 country_event = {
 	id = ENG_military.038
 	title = ENG_military.038.t
 	desc = ENG_military.038.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = ENG_military.038.a
@@ -918,6 +844,7 @@ country_event = {
 			add_idea = ENG_royal_navy_Idea2
 		}
 	}
+
 	option = {
 		name = ENG_military.038.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.038.b executed"
@@ -932,8 +859,8 @@ country_event = {
 	title = ENG_military.039.t
 	desc = ENG_military.039.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = ENG_military.039.a
@@ -943,6 +870,7 @@ country_event = {
 			days = 3600
 		}
 	}
+
 	option = {
 		name = ENG_military.039.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.039.b executed"
@@ -951,6 +879,7 @@ country_event = {
 			days = 3600
 		}
 	}
+
 	option = {
 		name = ENG_military.039.c
 		log = "[GetDateText]: [This.GetName]: ENG_military.039.c executed"
@@ -959,6 +888,7 @@ country_event = {
 			days = 3600
 		}
 	}
+
 	option = {
 		name = ENG_military.039.e
 		log = "[GetDateText]: [This.GetName]: ENG_military.039.e executed"
@@ -973,8 +903,8 @@ country_event = {
 	title = ENG_military.040.t
 	desc = ENG_military.040.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = ENG_military.040.a
@@ -986,6 +916,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -15 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = ENG_military.040.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.040.b executed"
@@ -998,6 +929,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -8 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = ENG_military.040.c
 		log = "[GetDateText]: [This.GetName]: ENG_military.040.c executed"
@@ -1014,8 +946,8 @@ country_event = {
 	title = ENG_military.041.t
 	desc = ENG_military.041.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = ENG_military.041.a
@@ -1041,6 +973,7 @@ country_event = {
 			country_event = ENG_military.043
 		}
 	}
+
 	option = {
 		name = ENG_military.041.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.041.b executed"
@@ -1062,8 +995,8 @@ country_event = {
 	title = ENG_military.042.t
 	desc = ENG_military.042.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = ENG_military.042.a
@@ -1089,6 +1022,7 @@ country_event = {
 			country_event = ENG_military.043
 		}
 	}
+
 	option = {
 		name = ENG_military.042.b
 		log = "[GetDateText]: [This.GetName]: ENG_military.042.b executed"
@@ -1110,34 +1044,29 @@ country_event = {
 	title = ENG_military.043.t
 	desc = ENG_military.043.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = ENG_military.043.a
-	}
+	option = { name = ENG_military.043.a }
 }
 country_event = {
 	id = ENG_military.044
 	title = ENG_military.044.t
 	desc = ENG_military.044.d
 	picture = GFX_ENG_generic
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = ENG_military.044.a
-	}
+	option = { name = ENG_military.044.a }
 }
 country_event = {
 	id = ENG_military.045
 	title = ENG_military.045.t
 	desc = ENG_military.045.d
-	#picture = x # TODO: Replace me with an image
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
+	#picture = x # TODO: Replace me with an image
 	option = {
 		name = ENG_military.045.a # Accept
 		log = "[GetDateText]: [Root.GetName]: ENG_military.045.a executed"
@@ -1145,7 +1074,6 @@ country_event = {
 			NATO_major_non_nato_ally_join = yes
 			country_event = ENG_military.046
 		}
-
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -1171,12 +1099,9 @@ country_event = {
 	title = ENG_military.046.t
 	desc = ENG_military.046.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
-	option = {
-		name = ENG_military.046.a
-	}
+	option = { name = ENG_military.046.a }
 }
 
 country_event = {
@@ -1184,12 +1109,9 @@ country_event = {
 	title = ENG_military.047.t
 	desc = ENG_military.047.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
-	option = {
-		name = ENG_military.047.a
-	}
+	option = { name = ENG_military.047.a }
 }
 
 # AUKUS
@@ -1199,7 +1121,6 @@ country_event = {
 	title = ENG_military.048.t
 	desc = ENG_military.048.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = {
@@ -1217,7 +1138,6 @@ country_event = {
 		else = {
 			ENG = { country_event = ENG_military.053 }
 		}
-
 		ai_chance = {
 			base = 80
 			modifier = {
@@ -1240,7 +1160,6 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		add_political_power = 10
 		ENG = { country_event = ENG_military.052 }
-
 		ai_chance = { base = 10 }
 	}
 }
@@ -1250,7 +1169,6 @@ country_event = {
 	title = ENG_military.049.t
 	desc = ENG_military.049.d
 	picture = GFX_AST_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -1306,7 +1224,6 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -20 }
 		modify_treasury_effect = yes
-
 		ai_chance = {
 			base = 70
 			modifier = {
@@ -1329,7 +1246,6 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		add_political_power = 15
 		ENG = { country_event = ENG_military.053 }
-
 		ai_chance = { base = 20 }
 	}
 }
@@ -1339,12 +1255,9 @@ country_event = {
 	title = ENG_military.050.t
 	desc = ENG_military.050.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
-	option = {
-		name = ENG_military.050.a
-	}
+	option = { name = ENG_military.050.a }
 }
 
 country_event = {
@@ -1352,7 +1265,6 @@ country_event = {
 	title = ENG_military.051.t
 	desc = ENG_military.051.d
 	picture = GFX_FRA_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -1372,12 +1284,9 @@ country_event = {
 	title = ENG_military.052.t
 	desc = ENG_military.052.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
-	option = {
-		name = ENG_military.052.a
-	}
+	option = { name = ENG_military.052.a }
 }
 
 country_event = {
@@ -1385,12 +1294,9 @@ country_event = {
 	title = ENG_military.053.t
 	desc = ENG_military.053.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
-	option = {
-		name = ENG_military.053.a
-	}
+	option = { name = ENG_military.053.a }
 }
 
 news_event = {
@@ -1400,13 +1306,10 @@ news_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 	major = yes
-	trigger = {
-		is_ai = no
-	}
 
-	option = {
-		name = ENG_military.054.a
-	}
+	trigger = { is_ai = no }
+
+	option = { name = ENG_military.054.a }
 }
 
 # Political Events
@@ -1415,14 +1318,12 @@ country_event = {
 	id = britain_md.1
 	title = britain_md.1.t
 	desc = britain_md.1.d
-	is_triggered_only = yes
 	picture = GFX_2001_labour_victory
+	is_triggered_only = yes
+
 	option = {
 		name = britain_md.1.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1437,17 +1338,12 @@ country_event = {
 		name = britain_md.2.a
 		log = "[GetDateText]: [This.GetName]: britain_md.2.a executed"
 		random_list = {
-			50 = {
-				increase_economic_growth = yes
-			}
-			50 = {
-				decrease_economic_growth = yes
-			}
+			50 = { increase_economic_growth = yes }
+			50 = { decrease_economic_growth = yes }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.2.b
 		log = "[GetDateText]: [This.GetName]: britain_md.2.b executed"
@@ -1455,9 +1351,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1472,25 +1366,21 @@ country_event = {
 		name = britain_md.3.a
 		log = "[GetDateText]: [This.GetName]: britain_md.3.a executed"
 		activate_mission = ENG_promise_labour
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.3.b
 		log = "[GetDateText]: [This.GetName]: britain_md.3.b executed"
 		activate_mission = ENG_promise_military
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.3.c
 		log = "[GetDateText]: [This.GetName]: britain_md.3.c executed"
 		activate_mission = ENG_promise_fossil_fuel
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1512,10 +1402,9 @@ country_event = {
 		newline = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.4.b
 		log = "[GetDateText]: [This.GetName]: britain_md.4.b executed"
@@ -1526,10 +1415,9 @@ country_event = {
 		add_to_variable = { ENG_military_industry_tax_modifier = 0.05 tooltip = military_industry_tax_modifier_tt }
 		set_temp_variable = { temp_opinion = -5 }
 		change_defense_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.4.c
 		log = "[GetDateText]: [This.GetName]: britain_md.4.c executed"
@@ -1541,10 +1429,9 @@ country_event = {
 		newline = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_fossil_fuel_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.4.d1
 		log = "[GetDateText]: [This.GetName]: britain_md.4.d1 executed"
@@ -1554,9 +1441,7 @@ country_event = {
 		change_defense_industry_opinion = yes
 		newline = yes
 		change_fossil_fuel_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1565,14 +1450,12 @@ country_event = {
 	id = britain_md.5
 	title = britain_md.5.t
 	desc = britain_md.5.d
-	is_triggered_only = yes
 	picture = GFX_2005_labour_victory
+	is_triggered_only = yes
+
 	option = {
 		name = britain_md.5.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1634,9 +1517,7 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = needed_money }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1690,9 +1571,7 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = needed_money }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1746,9 +1625,7 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = needed_money }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1757,14 +1634,12 @@ country_event = {
 	id = britain_md.7
 	title = britain_md.7.t
 	desc = britain_md.7.d
-	is_triggered_only = yes
 	picture = GFX_2010_labour_victory
+	is_triggered_only = yes
+
 	option = {
 		name = britain_md.7.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1784,9 +1659,7 @@ country_event = {
 			}
 		add_to_variable = { ENG_migration_rate_value_factor = 0.10 tooltip = migration_rate_value_factor_tt }
 		add_to_variable = { ENG_police_cost_multiplier_modifier = 0.025 tooltip = police_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1798,9 +1671,7 @@ country_event = {
 			}
 		add_to_variable = { ENG_migration_rate_value_factor = -0.10 tooltip = migration_rate_value_factor_tt }
 		add_to_variable = { ENG_police_cost_multiplier_modifier = -0.025 tooltip = police_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1808,17 +1679,15 @@ country_event = {
 	id = britain_md.9
 	title = britain_md.9.t
 	desc = britain_md.9.d
-	is_triggered_only = yes
 	picture = GFX_2015_labour_victory
+	is_triggered_only = yes
+
 	option = {
 		name = britain_md.9.a
 		log = "[GetDateText]: [This.GetName]: britain_md.9.a executed"
 		add_political_power = 25
 		add_stability = 0.03
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1828,6 +1697,7 @@ country_event = {
 	desc = britain_md.10.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	option = {
 		name = britain_md.10.a
 		log = "[GetDateText]: [This.GetName]: britain_md.10.a executed"
@@ -1845,17 +1715,14 @@ country_event = {
 				MODIFIER = ENG_political_modifier
 			}
 		add_to_variable = { ENG_popularity_attack_modifier = 2 tooltip = popularity_attack_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.10.b
 		log = "[GetDateText]: [This.GetName]: britain_md.10.b executed"
 		add_stability = 0.05
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1863,14 +1730,12 @@ country_event = {
 	id = britain_md.11
 	title = britain_md.11.t
 	desc = britain_md.11.d
-	is_triggered_only = yes
 	picture = GFX_ENG_generic
+	is_triggered_only = yes
+
 	option = {
 		name = britain_md.11.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1900,12 +1765,10 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = britain_md.12.b
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1918,10 +1781,7 @@ country_event = {
 
 	option = {
 		name = britain_md.13.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1948,9 +1808,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1965,9 +1823,7 @@ country_event = {
 		name = britain_md.15.a
 		log = "[GetDateText]: [This.GetName]: britain_md.15.a executed"
 		ENG = { remove_resource_rights = 358 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1995,10 +1851,9 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = britain_md.16.b
 		log = "[GetDateText]: [This.GetName]: britain_md.16.b executed"
@@ -2016,9 +1871,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2050,9 +1903,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2068,9 +1919,7 @@ country_event = {
 		name = britain_md.18.a
 		log = "[GetDateText]: [This.GetName]: britain_md.18.a executed"
 		add_stability = -0.05
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2090,9 +1939,7 @@ country_event = {
 		set_temp_variable = { influence_target = GAM }
 		change_influence_percentage = yes
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = GAM
 				autonomy_state = autonomy_associated_state_colored
@@ -2117,9 +1964,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2141,9 +1986,7 @@ country_event = {
 				days = 5
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2156,9 +1999,7 @@ country_event = {
 
 	option = {
 		name = britain_md.21.a
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -2169,12 +2010,8 @@ country_event = {
 			target = ENG
 			type = liberate_wargoal
 		}
-		ENG = {
-			country_event = britain_md.22
-		}
-		ai_chance = {
-			base = 100
-		}
+		ENG = { country_event = britain_md.22 }
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -2189,9 +2026,7 @@ country_event = {
 		name = britain_md.22.a
 		log = "[GetDateText]: [This.GetName]: britain_md.22.a executed"
 		activate_mission = ENG_war_for_delta
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -2203,9 +2038,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2218,10 +2051,7 @@ country_event = {
 
 	option = {
 		name = britain_md.23.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2233,9 +2063,7 @@ country_event = {
 	picture = GFX_election_day
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = ENG
-	}
+	trigger = { original_tag = ENG }
 
 	# Labour agendas
 	option = {
@@ -2243,9 +2071,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: britain_md.24.a executed"
 		trigger = {
 			western_social_democrats_are_in_power = yes
-			NOT = {
-				has_completed_focus = ENG_ambitions_for_britain
-			}
+			NOT = { has_completed_focus = ENG_ambitions_for_britain }
 		}
 		complete_national_focus = ENG_ambitions_for_britain
 		ai_chance = {
@@ -2268,14 +2094,13 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = britain_md.24.b
 		log = "[GetDateText]: [This.GetName]: britain_md.24.b executed"
 		trigger = {
 			western_social_democrats_are_in_power = yes
-			NOT = {
-				has_completed_focus = ENG_britain_forward_not_back
-			}
+			NOT = { has_completed_focus = ENG_britain_forward_not_back }
 		}
 		complete_national_focus = ENG_britain_forward_not_back
 		ai_chance = {
@@ -2307,14 +2132,13 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = britain_md.24.c
 		log = "[GetDateText]: [This.GetName]: britain_md.24.c executed"
 		trigger = {
 			western_social_democrats_are_in_power = yes
-			NOT = {
-				has_completed_focus = ENG_a_future_fair_for_all
-			}
+			NOT = { has_completed_focus = ENG_a_future_fair_for_all }
 		}
 		complete_national_focus = ENG_a_future_fair_for_all
 		ai_chance = {
@@ -2337,15 +2161,14 @@ country_event = {
 			}
 		}
 	}
+
 	# Conservatives
 	option = {
 		name = britain_md.24.a1
 		log = "[GetDateText]: [This.GetName]: britain_md.24.a1 executed"
 		trigger = {
 			western_conservatism_are_in_power = yes
-			NOT = {
-				has_completed_focus = ENG_time_for_common_sense
-			}
+			NOT = { has_completed_focus = ENG_time_for_common_sense }
 		}
 		complete_national_focus = ENG_time_for_common_sense
 		ai_chance = {
@@ -2368,14 +2191,13 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = britain_md.24.b1
 		log = "[GetDateText]: [This.GetName]: britain_md.24.b1 executed"
 		trigger = {
 			western_conservatism_are_in_power = yes
-			NOT = {
-				has_completed_focus = ENG_are_you_thinking_what_were_thinking
-			}
+			NOT = { has_completed_focus = ENG_are_you_thinking_what_were_thinking }
 		}
 		complete_national_focus = ENG_are_you_thinking_what_were_thinking
 		ai_chance = {
@@ -2407,14 +2229,13 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = britain_md.24.c1
 		log = "[GetDateText]: [This.GetName]: britain_md.24.c1 executed"
 		trigger = {
 			western_conservatism_are_in_power = yes
-			NOT = {
-				has_completed_focus = ENG_invitation_to_the_government_of_britain
-			}
+			NOT = { has_completed_focus = ENG_invitation_to_the_government_of_britain }
 		}
 		complete_national_focus = ENG_invitation_to_the_government_of_britain
 		ai_chance = {
@@ -2448,9 +2269,7 @@ country_event = {
 
 	option = {
 		name = britain_md.25.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2458,7 +2277,6 @@ country_event = {
 	id = devolution.1
 	title = devolution.1.t
 	desc = devolution.1.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -2469,19 +2287,17 @@ country_event = {
 		name = devolution.1.a
 		log = "[GetDateText]: [This.GetName]: devolution.1.a executed"
 		ENG_lower_dependence_1 = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# No, Veto them
 	option = {
 		name = devolution.1.b
 		log = "[GetDateText]: [This.GetName]: devolution.1.b executed"
 		ENG_increase_agitation_2 = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# Show Ne the Individual Bills
 	option = {
 		name = devolution.1.c
@@ -2498,9 +2314,7 @@ country_event = {
 			id = devolution.4
 			days = 3
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2510,7 +2324,6 @@ country_event = {
 	id = devolution.2
 	title = devolution.2.t
 	desc = devolution.2.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -2522,19 +2335,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: devolution.2.a executed"
 		set_temp_variable = { ENG_dependency_change = -1 }
 		ENG_change_scottish_dependency = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# No, Veto it
 	option = {
 		name = devolution.2.b
 		log = "[GetDateText]: [This.GetName]: devolution.2.b executed"
 		set_temp_variable = { ENG_agitation_change = 1 }
 		ENG_change_scottish_agitation = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2544,7 +2354,6 @@ country_event = {
 	id = devolution.3
 	title = devolution.3.t
 	desc = devolution.3.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -2556,19 +2365,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: devolution.3.a executed"
 		set_temp_variable = { ENG_dependency_change = -1 }
 		ENG_change_north_irish_dependency = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# No, Veto it
 	option = {
 		name = devolution.3.b
 		log = "[GetDateText]: [This.GetName]: devolution.3.b executed"
 		set_temp_variable = { ENG_agitation_change = 1 }
 		ENG_change_north_irish_agitation = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2578,7 +2384,6 @@ country_event = {
 	id = devolution.4
 	title = devolution.4.t
 	desc = devolution.4.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -2590,19 +2395,16 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: devolution.4.a executed"
 		set_temp_variable = { ENG_dependency_change = -1 }
 		ENG_change_wales_dependency = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
+
 	# No, Veto it
 	option = {
 		name = devolution.4.b
 		log = "[GetDateText]: [This.GetName]: devolution.4.b executed"
 		set_temp_variable = { ENG_agitation_change = 1 }
 		ENG_change_wales_agitation = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2613,7 +2415,6 @@ country_event = {
 	id = devolution.5
 	title = devolution.5.t
 	desc = devolution.5.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -2636,6 +2437,7 @@ country_event = {
 			}
 		}
 	}
+
 	# No, Veto it
 	option = {
 		name = devolution.5.b
@@ -2643,9 +2445,7 @@ country_event = {
 		set_country_flag = ENG_scottish_rejected
 		add_stability = -0.10
 		every_owned_state = {
-			limit = {
-				is_core_of = SCO
-			}
+			limit = { is_core_of = SCO }
 			add_dynamic_modifier = { modifier = ENG_resistance_against_westminster }
 		}
 		ai_chance = {
@@ -2667,7 +2467,6 @@ country_event = {
 	id = devolution.6
 	title = devolution.6.t
 	desc = devolution.6.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -2690,15 +2489,14 @@ country_event = {
 			}
 		}
 	}
+
 	# No, Veto it
 	option = {
 		name = devolution.6.b
 		log = "[GetDateText]: [This.GetName]: devolution.6.b executed"
 		set_country_flag = ENG_irish_rejected
 		add_stability = -0.10
-		17 = {
-			add_dynamic_modifier = { modifier = ENG_resistance_against_westminster }
-		}
+		17 = { add_dynamic_modifier = { modifier = ENG_resistance_against_westminster } }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -2718,7 +2516,6 @@ country_event = {
 	id = devolution.7
 	title = devolution.7.t
 	desc = devolution.7.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -2741,6 +2538,7 @@ country_event = {
 			}
 		}
 	}
+
 	# No, Veto it
 	option = {
 		name = devolution.7.b
@@ -2748,9 +2546,7 @@ country_event = {
 		set_country_flag = ENG_welsh_rejected
 		add_stability = -0.10
 		every_owned_state = {
-			limit = {
-				is_core_of = WAS
-			}
+			limit = { is_core_of = WAS }
 			add_dynamic_modifier = { modifier = ENG_resistance_against_westminster }
 		}
 		ai_chance = {
@@ -2775,7 +2571,6 @@ country_event = {
 	title = devolution.11.t
 	desc = devolution.11.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -2793,7 +2588,6 @@ country_event = {
 	title = devolution.12.t
 	desc = devolution.12.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -2834,7 +2628,6 @@ country_event = {
 	title = devolution.13.t
 	desc = devolution.13.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -2852,7 +2645,6 @@ country_event = {
 	title = devolution.14.t
 	desc = devolution.14.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -2906,9 +2698,9 @@ country_event = {
 	id = devolution.10
 	title = devolution.10.t
 	desc = devolution.10.d
-
 	picture = GFX_election_day
 	is_triggered_only = yes
+
 	trigger = {
 		# Don't trigger if no one is in the Union anymore
 		NOT = {
@@ -2920,6 +2712,7 @@ country_event = {
 			}
 		}
 	}
+
 	# Okay, Fine
 	option = {
 		name = devolution.10.a
@@ -3088,7 +2881,6 @@ country_event = {
 				set_temp_variable = { ENG_nationalists_change = ENG_scottish_nationalists_election }
 				ENG_change_scottish_nationalists = yes
 			}
-
 		}
 		# Wales
 		if = {
@@ -3255,7 +3047,6 @@ country_event = {
 				set_temp_variable = { ENG_nationalists_change = ENG_wales_nationalists_election }
 				ENG_change_wales_nationalists = yes
 			}
-
 		}
 		# North Ireland
 		if = {
@@ -3422,7 +3213,6 @@ country_event = {
 				set_temp_variable = { ENG_nationalists_change = ENG_north_irish_nationalists_election }
 				ENG_change_north_irish_nationalists = yes
 			}
-
 		}
 		ai_chance = {
 			base = 1
@@ -3436,7 +3226,6 @@ country_event = {
 	title = devolution.20.t
 	desc = devolution.20.d
 	picture = GFX_ENG_riot
-
 	is_triggered_only = yes
 
 	option = {
@@ -3453,7 +3242,6 @@ country_event = {
 	title = devolution.21.t
 	desc = devolution.21.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3477,10 +3265,8 @@ country_event = {
 # Border Poll Result
 country_event = {
 	id = devolution.22
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	immediate = {
 		if = {
@@ -3513,7 +3299,6 @@ country_event = {
 	title = devolution.23.t
 	desc = devolution.23.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3552,12 +3337,9 @@ country_event = {
 	title = devolution.24.t
 	desc = devolution.24.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
-	option = {
-		name = devolution.24.a
-	}
+	option = { name = devolution.24.a }
 }
 
 # Dublin Accepts Unification
@@ -3566,7 +3348,6 @@ country_event = {
 	title = devolution.25.t
 	desc = devolution.25.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3585,7 +3366,6 @@ country_event = {
 	title = devolution.26.t
 	desc = devolution.26.d
 	picture = GFX_ENG_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -3603,7 +3383,6 @@ country_event = {
 	title = devolution.27.t
 	desc = devolution.27.d
 	picture = GFX_ENG_riot
-
 	is_triggered_only = yes
 
 	option = {
@@ -3612,9 +3391,7 @@ country_event = {
 		release = NIR
 		NIR = {
 			set_cosmetic_tag = NIR_nationalist
-			hidden_effect = {
-				ingame_startup_nations_effect = yes
-			}
+			hidden_effect = { ingame_startup_nations_effect = yes }
 		}
 		declare_war_on = {
 			target = NIR
@@ -3639,7 +3416,6 @@ country_event = {
 	title = devolution.28.t
 	desc = devolution.28.d
 	picture = GFX_ENG_riot
-
 	is_triggered_only = yes
 
 	option = {
@@ -3694,9 +3470,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: devolution.28.c executed"
 		add_opinion_modifier = { target = ENG modifier = small_increase }
 		ENG = { add_opinion_modifier = { target = IRE modifier = small_increase } }
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -3714,19 +3488,13 @@ country_event = {
 	title = ENG_inner_circle.01.t
 	desc = ENG_inner_circle.01.desc
 	picture = "[ENGGetAscendingAdvisorPortrait]"
-
 	is_triggered_only = yes
 
-	immediate = {
-		hidden_effect = {
-			set_country_flag = ENG_inner_circle_event_pending_flag
-		}
-	}
+	immediate = { hidden_effect = { set_country_flag = ENG_inner_circle_event_pending_flag } }
 
 	option = { #Replace Ascended Advisor 1
 		name = ENG_inner_circle.01.a
 		log = "[GetDateText]: [This.GetName]: ENG_inner_circle.01.a"
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -3735,14 +3503,10 @@ country_event = {
 				check_variable = { ENG_ascended_advisor_1 = 7 }
 			}
 		}
-
 		ENG_remove_replaced_advisor_1_effects = yes
-
 		newline = yes
-
 		set_variable = { ENG_ascended_advisor_1 = ENG_ascending_advisor }
 		ENG_add_replacing_advisor_effects = yes
-
 		hidden_effect = {
 			#Cleaning vars / flags / etc
 			clear_variable = ENG_ascending_advisor
@@ -3753,7 +3517,6 @@ country_event = {
 	option = { #Replace Ascended Advisor 2
 		name = ENG_inner_circle.01.b
 		log = "[GetDateText]: [This.GetName]: ENG_inner_circle.01.b"
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -3762,14 +3525,10 @@ country_event = {
 				check_variable = { ENG_ascended_advisor_2 = 7 }
 			}
 		}
-
 		ENG_remove_replaced_advisor_2_effects = yes
-
 		newline = yes
-
 		set_variable = { ENG_ascended_advisor_2 = ENG_ascending_advisor }
 		ENG_add_replacing_advisor_effects = yes
-
 		hidden_effect = {
 			#Cleaning vars / flags / etc
 			clear_variable = ENG_ascending_advisor
@@ -3780,7 +3539,6 @@ country_event = {
 	option = { #Replace Ascended Advisor 3
 		name = ENG_inner_circle.01.c
 		log = "[GetDateText]: [This.GetName]: ENG_inner_circle.01.c"
-
 		ai_chance = {
 			base = 1
 			modifier = { #Himmler should replace Bormann on Historical when he ascends
@@ -3789,14 +3547,10 @@ country_event = {
 				check_variable = { ENG_ascended_advisor_3 = 7 } #Bormann ascended in this slot
 			}
 		}
-
 		ENG_remove_replaced_advisor_3_effects = yes
-
 		newline = yes
-
 		set_variable = { ENG_ascended_advisor_3 = ENG_ascending_advisor }
 		ENG_add_replacing_advisor_effects = yes
-
 		hidden_effect = {
 			#Cleaning vars / flags / etc
 			clear_variable = ENG_ascending_advisor
@@ -3806,11 +3560,9 @@ country_event = {
 
 	option = { # Abort - Ditch this advisor
 		name = ENG_inner_circle.01.d
-
 		ai_chance = { #AI "knows" what its doing (pffff)
 			base = 0
 		}
-
 		if = {
 			limit = {
 				check_variable = { ENG_ascending_advisor = 1 }
@@ -3874,12 +3626,10 @@ country_event = {
 		else = {
 			log = "Something went terribly wrong with your royals (no wonder)"
 		}
-
 		hidden_effect = {
 			#Cleaning vars / flags / etc
 			clear_variable = ENG_ascending_advisor
 			clr_country_flag = ENG_inner_circle_event_pending_flag
-
 			clr_country_flag = ENG_inner_circle_cd_flag
 		}
 	}
@@ -3887,10 +3637,8 @@ country_event = {
 
 country_event = {
 	id = ENG_inner_circle_charles.01
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_the_prince_trust
@@ -3941,10 +3689,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_charles.02
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_the_prince_trust
@@ -4014,7 +3760,6 @@ country_event = {
 	title = ENG_inner_circle_charles.03.t
 	desc = ENG_inner_circle_charles.03.desc
 	picture = x
-
 	is_triggered_only = yes
 
 	option = {
@@ -4045,7 +3790,6 @@ country_event = {
 	title = ENG_inner_circle_charles.04.t
 	desc = ENG_inner_circle_charles.04.desc
 	picture = x
-
 	is_triggered_only = yes
 
 	option = {
@@ -4072,7 +3816,6 @@ country_event = {
 	title = ENG_inner_circle_charles.05.t
 	desc = ENG_inner_circle_charles.05.desc
 	picture = x
-
 	is_triggered_only = yes
 
 	option = {
@@ -4099,7 +3842,6 @@ country_event = {
 	title = ENG_inner_circle_charles.06.t
 	desc = ENG_inner_circle_charles.06.desc
 	picture = x
-
 	is_triggered_only = yes
 
 	option = {
@@ -4123,9 +3865,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_charles.07
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_the_prince_trust
@@ -4309,10 +4050,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_andrew.01
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_naval_prince
@@ -4363,10 +4102,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_andrew.02
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_naval_prince
@@ -4432,9 +4169,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_andrew.03
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_naval_prince
@@ -4555,7 +4291,6 @@ country_event = {
 	title = ENG_inner_circle_andrew.04.t
 	desc = ENG_inner_circle_andrew.04.desc
 	picture = x
-
 	is_triggered_only = yes
 
 	option = {
@@ -4576,7 +4311,6 @@ country_event = {
 	title = ENG_inner_circle_andrew.05.t
 	desc = ENG_inner_circle_andrew.05.desc
 	picture = x
-
 	is_triggered_only = yes
 
 	option = {
@@ -4592,7 +4326,6 @@ country_event = {
 	title = ENG_inner_circle_andrew.06.t
 	desc = ENG_inner_circle_andrew.06.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	trigger = {
@@ -4604,21 +4337,15 @@ country_event = {
 		name = ENG_inner_circle_andrew.06.a
 		log = "[GetDateText]: [This.GetName]: ENG_inner_circle_andrew.06.a"
 		set_country_flag = ENG_andrew_epstein_punishment
-
 		add_stability = -0.02
 		add_political_power = -15
-
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 country_event = {
 	id = ENG_inner_circle_anne.01
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_workhorse_of_the_crown
@@ -4679,10 +4406,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_anne.02
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_workhorse_of_the_crown
@@ -4695,9 +4420,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_carers_recognition_campaign
-			}
+			limit = { has_shine_effect_on_focus = ENG_carers_recognition_campaign }
 			complete_national_focus = {
 				focus = ENG_carers_recognition_campaign
 				use_side_message = yes
@@ -4707,9 +4430,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_anne.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_discipline_service
-			}
+			limit = { has_shine_effect_on_focus = ENG_discipline_service }
 			complete_national_focus = {
 				focus = ENG_discipline_service
 				use_side_message = yes
@@ -4719,9 +4440,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_anne.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_princess_admiral_royal_navy
-			}
+			limit = { has_shine_effect_on_focus = ENG_princess_admiral_royal_navy }
 			complete_national_focus = {
 				focus = ENG_princess_admiral_royal_navy
 				use_side_message = yes
@@ -4729,12 +4448,9 @@ country_event = {
 			}
 			clr_country_flag = ENG_princess_admiral_royal_navy_in_progress_flag
 			country_event = { id = ENG_inner_circle_anne.01 days = 180 random_days = 50 }
-
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_colonel_of_horse_logistics
-			}
+			limit = { has_shine_effect_on_focus = ENG_colonel_of_horse_logistics }
 			complete_national_focus = {
 				focus = ENG_colonel_of_horse_logistics
 				use_side_message = yes
@@ -4742,12 +4458,9 @@ country_event = {
 			}
 			clr_country_flag = ENG_colonel_of_horse_logistics_in_progress_flag
 			country_event = { id = ENG_inner_circle_anne.01 days = 180 random_days = 50 }
-
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_quiet_professionalism
-			}
+			limit = { has_shine_effect_on_focus = ENG_quiet_professionalism }
 			complete_national_focus = {
 				focus = ENG_quiet_professionalism
 				use_side_message = yes
@@ -4756,16 +4469,13 @@ country_event = {
 			clr_country_flag = ENG_quiet_professionalism_in_progress_flag
 			country_event = { id = ENG_inner_circle_anne.01 days = 180 random_days = 50 }
 		}
-		else = {
-			log = "SOMETHING WENT WRONG WITH ANNE's FOCUS BRANCH - Cannot complete focus"
-		}
+		else = { log = "SOMETHING WENT WRONG WITH ANNE's FOCUS BRANCH - Cannot complete focus" }
 	}
 }
 country_event = {
 	id = ENG_inner_circle_anne.03
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_naval_prince
@@ -4883,10 +4593,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_edward.01
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_chairman_international_award
@@ -4937,10 +4645,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_edward.02
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_chairman_international_award
@@ -4953,9 +4659,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_trustee_network
-			}
+			limit = { has_shine_effect_on_focus = ENG_trustee_network }
 			complete_national_focus = {
 				focus = ENG_trustee_network
 				use_side_message = yes
@@ -4965,9 +4669,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_edward.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_commonwealth_youth_outreach
-			}
+			limit = { has_shine_effect_on_focus = ENG_commonwealth_youth_outreach }
 			complete_national_focus = {
 				focus = ENG_commonwealth_youth_outreach
 				use_side_message = yes
@@ -4977,9 +4679,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_edward.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_production_guild_patronage
-			}
+			limit = { has_shine_effect_on_focus = ENG_production_guild_patronage }
 			complete_national_focus = {
 				focus = ENG_production_guild_patronage
 				use_side_message = yes
@@ -4987,12 +4687,9 @@ country_event = {
 			}
 			clr_country_flag = ENG_production_guild_patronage_in_progress_flag
 			country_event = { id = ENG_inner_circle_edward.01 days = 180 random_days = 50 }
-
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_steady_hand
-			}
+			limit = { has_shine_effect_on_focus = ENG_steady_hand }
 			complete_national_focus = {
 				focus = ENG_steady_hand
 				use_side_message = yes
@@ -5001,16 +4698,13 @@ country_event = {
 			clr_country_flag = ENG_steady_hand_in_progress_flag
 			country_event = { id = ENG_inner_circle_edward.01 days = 180 random_days = 50 }
 		}
-		else = {
-			log = "SOMETHING WENT WRONG WITH EDWARD's FOCUS BRANCH - Cannot complete focus"
-		}
+		else = { log = "SOMETHING WENT WRONG WITH EDWARD's FOCUS BRANCH - Cannot complete focus" }
 	}
 }
 country_event = {
 	id = ENG_inner_circle_edward.03
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_chairman_international_award
@@ -5159,10 +4853,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_philip.01
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_duke_charities
@@ -5213,10 +4905,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_philip.02
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_chairman_international_award
@@ -5229,9 +4919,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_international_award_conference
-			}
+			limit = { has_shine_effect_on_focus = ENG_international_award_conference }
 			complete_national_focus = {
 				focus = ENG_international_award_conference
 				use_side_message = yes
@@ -5241,9 +4929,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_philip.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_wwf_president_emeritus
-			}
+			limit = { has_shine_effect_on_focus = ENG_wwf_president_emeritus }
 			complete_national_focus = {
 				focus = ENG_wwf_president_emeritus
 				use_side_message = yes
@@ -5253,9 +4939,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_philip.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_prince_phillip_medal
-			}
+			limit = { has_shine_effect_on_focus = ENG_prince_phillip_medal }
 			complete_national_focus = {
 				focus = ENG_prince_phillip_medal
 				use_side_message = yes
@@ -5263,12 +4947,9 @@ country_event = {
 			}
 			clr_country_flag = ENG_prince_phillip_medal_in_progress_flag
 			country_event = { id = ENG_inner_circle_philip.01 days = 180 random_days = 50 }
-
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_strength_and_stay
-			}
+			limit = { has_shine_effect_on_focus = ENG_strength_and_stay }
 			complete_national_focus = {
 				focus = ENG_strength_and_stay
 				use_side_message = yes
@@ -5277,16 +4958,13 @@ country_event = {
 			clr_country_flag = ENG_strength_and_stay_in_progress_flag
 			country_event = { id = ENG_inner_circle_philip.01 days = 180 random_days = 50 }
 		}
-		else = {
-			log = "SOMETHING WENT WRONG WITH PHILIP's FOCUS BRANCH - Cannot complete focus"
-		}
+		else = { log = "SOMETHING WENT WRONG WITH PHILIP's FOCUS BRANCH - Cannot complete focus" }
 	}
 }
 country_event = {
 	id = ENG_inner_circle_philip.03
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_duke_charities
@@ -5299,9 +4977,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_completed_focus = ENG_duke_charities
-			}
+			limit = { has_completed_focus = ENG_duke_charities }
 			random_list = {
 				25 = {
 					modifier = {
@@ -5417,26 +5093,19 @@ country_event = {
 	title = ENG_inner_circle_philip.04.t
 	desc = ENG_inner_circle_philip.04.d
 	picture = GFX_news_press_conference
-
 	is_triggered_only = yes
 
 	option = {
 		name = ENG_inner_circle_philip.04.a
 		log = "[GetDateText]: [This.GetName]: ENG_inner_circle_philip.04.a"
-
 		set_country_flag = ENG_philip_passed
-
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 country_event = {
 	id = ENG_inner_circle_william.01
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_from_sandhurst_to_service
@@ -5487,10 +5156,8 @@ country_event = {
 }
 country_event = {
 	id = ENG_inner_circle_william.02
-
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_from_sandhurst_to_service
@@ -5503,9 +5170,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_royal_foundation
-			}
+			limit = { has_shine_effect_on_focus = ENG_royal_foundation }
 			complete_national_focus = {
 				focus = ENG_royal_foundation
 				use_side_message = yes
@@ -5515,9 +5180,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_william.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_heads_together
-			}
+			limit = { has_shine_effect_on_focus = ENG_heads_together }
 			complete_national_focus = {
 				focus = ENG_heads_together
 				use_side_message = yes
@@ -5527,9 +5190,7 @@ country_event = {
 			country_event = { id = ENG_inner_circle_william.01 days = 180 random_days = 50 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_veteran_armed_forces_support
-			}
+			limit = { has_shine_effect_on_focus = ENG_veteran_armed_forces_support }
 			complete_national_focus = {
 				focus = ENG_veteran_armed_forces_support
 				use_side_message = yes
@@ -5537,12 +5198,9 @@ country_event = {
 			}
 			clr_country_flag = ENG_veteran_armed_forces_support_in_progress_flag
 			country_event = { id = ENG_inner_circle_william.01 days = 180 random_days = 50 }
-
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = ENG_bridge_to_the_future
-			}
+			limit = { has_shine_effect_on_focus = ENG_bridge_to_the_future }
 			complete_national_focus = {
 				focus = ENG_bridge_to_the_future
 				use_side_message = yes
@@ -5551,16 +5209,13 @@ country_event = {
 			clr_country_flag = ENG_bridge_to_the_future_in_progress_flag
 			country_event = { id = ENG_inner_circle_william.01 days = 180 random_days = 50 }
 		}
-		else = {
-			log = "SOMETHING WENT WRONG WITH WILLIAMS's FOCUS BRANCH - Cannot complete focus"
-		}
+		else = { log = "SOMETHING WENT WRONG WITH WILLIAMS's FOCUS BRANCH - Cannot complete focus" }
 	}
 }
 country_event = {
 	id = ENG_inner_circle_william.03
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		has_completed_focus = ENG_from_sandhurst_to_service
@@ -5573,9 +5228,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_completed_focus = ENG_from_sandhurst_to_service
-			}
+			limit = { has_completed_focus = ENG_from_sandhurst_to_service }
 			random_list = {
 				25 = {
 					modifier = {
@@ -5711,6 +5364,7 @@ country_event = { # Approaching Operation Dagger
 			base = 1
 		}
 	}
+
 	option = { # Move In, Fuck the Omani's
 		name = britain_md.100.b
 		log = "[GetDateText]: [This.GetName]: britain_md.100.b executed"
@@ -5750,6 +5404,7 @@ country_event = { # United Kingdom Approaches Us for Musandam
 			base = 1
 		}
 	}
+
 	option = { # Well, it's not free....
 		name = britain_md.101.b
 		log = "[GetDateText]: [This.GetName]: britain_md.101.b executed"
@@ -5805,9 +5460,9 @@ country_event = { # Oman Rejects Negotiations
 			base = 1
 		}
 	}
+
 	option = { # Just forget it
 		name = britain_md.102.b
-
 		ai_chance = {
 			base = 1
 		}
@@ -5841,6 +5496,7 @@ country_event = { # Oman Gives Us Terms
 			base = 1
 		}
 	}
+
 	option = { # This is an insult!
 		name = britain_md.103.b
 		log = "[GetDateText]: [This.GetName]: britain_md.103.b executed"
@@ -5858,9 +5514,9 @@ country_event = { # Oman Gives Us Terms
 			base = 1
 		}
 	}
+
 	option = { # Just forget it
 		name = britain_md.103.c
-
 		ai_chance = {
 			base = 1
 		}
@@ -5873,29 +5529,24 @@ country_event = {
 	desc = britain_md.26.d
 	picture = GFX_falkland_islands
 	is_triggered_only = yes
+
 	option = {
 		name = britain_md.26.a
 		log = "[GetDateText]: [This.GetName]: britain_md.26.a executed"
-		26 = {
-			add_core_of = ENG
-		}
+		26 = { add_core_of = ENG }
 		newline = yes
 		custom_effect_tooltip = {
 				localization_key = modifies_dynamic_modifier_tt
 				MODIFIER = ENG_political_modifier
 			}
 		add_to_variable = { ENG_political_power_factor = -0.01 tooltip = political_power_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = britain_md.26.b
 		log = "[GetDateText]: [This.GetName]: britain_md.26.b executed"
-		457 = {
-			add_claim_by = ENG
-		}
+		457 = { add_claim_by = ENG }
 		newline = yes
 		declare_war_on = {
 			target = ARG
@@ -5903,17 +5554,13 @@ country_event = {
 		}
 		newline = yes
 		activate_mission = ENG_end_of_the_world
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = britain_md.26.c
 		log = "[GetDateText]: [This.GetName]: britain_md.26.c executed"
-		26 = {
-			transfer_state_to = ARG
-		}
+		26 = { transfer_state_to = ARG }
 		newline = yes
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = ENG }
@@ -5932,9 +5579,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5947,9 +5592,7 @@ country_event = { # Britain Returns the Falklands
 
 	option = {
 		name = britain_md.27.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5980,9 +5623,7 @@ country_event = { # Successful Regime Change Operation Against Zimbabwe!
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5995,9 +5636,7 @@ country_event = {
 
 	option = {
 		name = britain_md.29.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6017,9 +5656,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6027,9 +5664,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: britain_md.30.b executed"
 		custom_effect_tooltip = ENG_raid_enabled_3_TT
 		set_country_flag = ENG_raid_Egypt
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6049,9 +5684,7 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6090,9 +5723,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -6108,9 +5739,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: britain_md.32.a executed"
 		custom_effect_tooltip = ENG_raid_enabled_3_TT
 		set_country_flag = ENG_raid_Egypt
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = { # Do nothing
@@ -6154,9 +5783,7 @@ country_event = {
 				active = yes
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6164,9 +5791,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: britain_md.33.b executed"
 		custom_effect_tooltip = ENG_raid_enabled_3_TT
 		set_country_flag = ENG_raid_Egypt
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6180,9 +5805,7 @@ country_event = {
 	option = {
 		name = britain_md.34.a
 		log = "[GetDateText]: [This.GetName]: britain_md.34.a executed"
-		213 = {
-			add_claim_by = ENG
-		}
+		213 = { add_claim_by = ENG }
 		newline = yes
 		ENG = {
 			declare_war_on = {
@@ -6191,9 +5814,7 @@ country_event = {
 			}
 		}
 		newline = yes
-		ENG = {
-			set_province_controller = 4161
-		}
+		ENG = { set_province_controller = 4161 }
 		hidden_effect = {
 			division_template = {
 				name = "Suez Special Forces Brigade"
@@ -6230,11 +5851,8 @@ country_event = {
 		}
 		newline = yes
 		activate_mission = ENG_operation_eastern_divide
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 country_event = {
@@ -6263,9 +5881,7 @@ country_event = {
 				add = 10
 			}
 			modifier = {
-				ENG = {
-					has_war = no
-				}
+				ENG = { has_war = no }
 				add = 10
 			}
 		}
@@ -6290,9 +5906,7 @@ country_event = {
 				add = 10
 			}
 			modifier = {
-				ENG = {
-					has_war = yes
-				}
+				ENG = { has_war = yes }
 				add = 10
 			}
 		}
@@ -6316,9 +5930,7 @@ country_event = {
 				autonomy_state = autonomy_constituent_country_very_low_devolution
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6333,9 +5945,7 @@ country_event = {
 		name = britain_md.37.a
 		log = "[GetDateText]: [This.GetName]: britain_md.37.a executed"
 		custom_effect_tooltip = ENG_still_can_TT
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6361,9 +5971,7 @@ country_event = {
 				emotional
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6378,9 +5986,7 @@ country_event = {
 				puppet_ruler
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6395,16 +6001,12 @@ country_event = {
 				puppet_ruler
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = britain_md.39.d1
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6424,40 +6026,31 @@ country_event = {
 				days = 1
 			}
 		}
-
 		EGU = {
 			country_event = {
 				id = britain_md.43
 				days = 1
 			}
 		}
-
-		ai_chance = {
-			base = 40
-		}
+		ai_chance = { base = 40 }
 	}
 
 	option = {
 		name = britain_md.40.b
 		log = "[GetDateText]: [This.GetName]: britain_md.40.b executed"
-
 		ENG = {
 			country_event = {
 				id = britain_md.42
 				days = 1
 			}
 		}
-
 		EGU = {
 			country_event = {
 				id = britain_md.44
 				days = 1
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6471,7 +6064,6 @@ country_event = {
 	option = {
 		name = britain_md.41.a
 		log = "[GetDateText]: [This.GetName]: britain_md.41.a executed"
-
 		effect_tooltip = {
 			EGU = {
 				add_opinion_modifier = {
@@ -6479,10 +6071,7 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6495,16 +6084,11 @@ country_event = {
 	option = {
 		name = britain_md.42.a
 		log = "[GetDateText]: [This.GetName]: britain_md.42.a executed"
-
 		effect_tooltip = {
 			EGU = {
-				hidden_effect = {
-					retire_country_leader = yes
-				}
-
+				hidden_effect = { retire_country_leader = yes }
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
-
 				create_country_leader = {
 					name = "Severo Moto Nsá"
 					picture = "Severo_Moto_Nsa.dds"
@@ -6514,20 +6098,16 @@ country_event = {
 						journalist
 					}
 				}
-
 				set_temp_variable = { party_index = 0 }
 				set_temp_variable = { party_popularity_increase = 0.10 }
 				set_temp_variable = { temp_outlook_increase = 0.10 }
 				change_relative_party_popularity = yes
-
 				add_opinion_modifier = {
 					target = ENG modifier = ENG_british_loyalist
 				}
-
 				add_opinion_modifier = {
 					target = ENG modifier = ENG_british_loyalist_trade
 				}
-
 				give_resource_rights = {
 					receiver = ENG
 					state = 319
@@ -6539,10 +6119,7 @@ country_event = {
 				change_influence_percentage = yes
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6556,18 +6133,13 @@ country_event = {
 	option = {
 		name = britain_md.43.a
 		log = "[GetDateText]: [This.GetName]: britain_md.43.a executed"
-
 		add_opinion_modifier = {
 			target = ENG modifier = ENG_british_attempted_coup_on_us
 		}
-
 		hidden_effect = {
 			news_event = { id = britain_md.46 hours = 6 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6581,14 +6153,9 @@ country_event = {
 	option = {
 		name = britain_md.44.a
 		log = "[GetDateText]: [This.GetName]: britain_md.44.a executed"
-
-		hidden_effect = {
-			retire_country_leader = yes
-		}
-
+		hidden_effect = { retire_country_leader = yes }
 		set_temp_variable = { rul_party_temp = 0 }
 		change_ruling_party_effect = yes
-
 		create_country_leader = {
 			name = "Severo Moto Nsá"
 			picture = "Severo_Moto_Nsa.dds"
@@ -6598,38 +6165,29 @@ country_event = {
 				journalist
 			}
 		}
-
 		set_temp_variable = { party_index = 0 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		change_relative_party_popularity = yes
-
 		add_opinion_modifier = {
 			target = ENG modifier = ENG_british_loyalist
 		}
-
 		add_opinion_modifier = {
 			target = ENG modifier = ENG_british_loyalist_trade
 		}
-
 		give_resource_rights = {
 			receiver = ENG
 			state = 319
 		}
-
 		ENG = {
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { influence_target = EGU.id }
 			change_influence_percentage = yes
 		}
-
 		hidden_effect = {
 			news_event = { id = britain_md.45 hours = 6 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6643,10 +6201,7 @@ news_event = {
 
 	option = {
 		name = britain_md.45.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6660,10 +6215,7 @@ news_event = {
 
 	option = {
 		name = britain_md.46.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6676,7 +6228,6 @@ country_event = {
 	id = british_flavor.1
 	title = british_flavor.1.t
 	desc = british_flavor.1.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
@@ -6697,9 +6248,7 @@ country_event = {
 		set_temp_variable = { tag_index = JAP }
 		set_temp_variable = { influence_target = ENG }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6707,9 +6256,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: british_flavor.1.b executed"
 		set_temp_variable = { treasury_change = 7.50 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6718,7 +6265,6 @@ country_event = {
 	id = british_flavor.2
 	title = british_flavor.2.t
 	desc = british_flavor.2.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -6729,18 +6275,14 @@ country_event = {
 		set_temp_variable = { tag_index = ENG }
 		set_temp_variable = { influence_target = CHL }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = british_flavor.2.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.2.b executed"
 		add_stability = 0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6749,7 +6291,6 @@ country_event = {
 	id = british_flavor.3
 	title = british_flavor.3.t
 	desc = british_flavor.3.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -6760,9 +6301,7 @@ country_event = {
 			set_temp_variable = { ENG_agitation_change = 2 }
 			ENG_change_scottish_agitation = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6770,9 +6309,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: british_flavor.3.b executed"
 		set_temp_variable = { treasury_change = -7.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6783,7 +6320,6 @@ country_event = {
 	id = british_flavor.4
 	title = british_flavor.4.t
 	desc = british_flavor.4.d
-
 	picture = GFX_passenger_plane
 	is_triggered_only = yes
 
@@ -6794,9 +6330,7 @@ country_event = {
 		set_temp_variable = { tag_index = ENG }
 		set_temp_variable = { influence_target = AFG }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6805,9 +6339,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.025 }
 		set_temp_variable = { temp_outlook_increase = 0.015 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6816,7 +6348,6 @@ country_event = {
 	id = british_flavor.5
 	title = british_flavor.5.t
 	desc = british_flavor.5.d
-
 	picture = GFX_banking_crisis
 	is_triggered_only = yes
 
@@ -6827,9 +6358,7 @@ country_event = {
 			set_temp_variable = { ENG_dependency_change = -2 }
 			ENG_change_scottish_dependency = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6845,9 +6374,7 @@ country_event = {
 				MODIFIER = ENG_economy_modifier
 			}
 		add_to_variable = { ENG_interest_rate_multiplier_modifier = -0.025 tooltip = interest_rate_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6858,7 +6385,6 @@ country_event = {
 	id = british_flavor.6
 	title = british_flavor.6.t
 	desc = british_flavor.6.d
-
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
@@ -6875,9 +6401,7 @@ country_event = {
 				MODIFIER = ENG_economy_modifier
 			}
 		add_to_variable = { ENG_office_park_income_tax_modifier = 0.02 tooltip = office_park_income_tax_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6888,9 +6412,7 @@ country_event = {
 				MODIFIER = ENG_economy_modifier
 			}
 		add_to_variable = { ENG_research_speed_factor = 0.05 tooltip = research_speed_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6899,7 +6421,6 @@ country_event = {
 	id = british_flavor.7
 	title = british_flavor.7.t
 	desc = british_flavor.7.d
-
 	picture = GFX_election_day
 	is_triggered_only = yes
 
@@ -6910,9 +6431,7 @@ country_event = {
 			set_temp_variable = { ENG_agitation_change = 2 }
 			ENG_change_north_irish_agitation = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6922,7 +6441,6 @@ country_event = {
 	id = british_flavor.8
 	title = british_flavor.8.t
 	desc = british_flavor.8.d
-
 	picture = GFX_european_migrant_crisis
 	is_triggered_only = yes
 
@@ -6936,9 +6454,7 @@ country_event = {
 		add_to_variable = { ENG_population_tax_income_multiplier_modifier = -0.025 tooltip = population_tax_income_multiplier_modifier_tt }
 		newline = yes
 		add_stability = 0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6948,9 +6464,7 @@ country_event = {
 			set_temp_variable = { ENG_agitation_change = 2 }
 			ENG_change_wales_agitation = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6960,7 +6474,6 @@ country_event = {
 	id = british_flavor.9
 	title = british_flavor.9.t
 	desc = british_flavor.9.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -6971,9 +6484,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.055 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -6981,9 +6492,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: british_flavor.9.b executed"
 		set_temp_variable = { treasury_change = -12.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -6994,25 +6503,19 @@ country_event = {
 	id = british_flavor.10
 	title = british_flavor.10.t
 	desc = british_flavor.10.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
 	option = {
 		name = british_flavor.10.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = british_flavor.10.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.10.b executed"
 		add_political_power = -200
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7020,7 +6523,6 @@ country_event = {
 	id = british_flavor.11
 	title = british_flavor.11.t
 	desc = british_flavor.11.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -7035,9 +6537,7 @@ country_event = {
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7047,9 +6547,7 @@ country_event = {
 			set_temp_variable = { ENG_dependency_change = -2 }
 			ENG_change_scottish_dependency = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7060,7 +6558,6 @@ country_event = {
 	id = british_flavor.12
 	title = british_flavor.12.t
 	desc = british_flavor.12.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -7071,9 +6568,7 @@ country_event = {
 			set_temp_variable = { ENG_agitation_change = 2 }
 			ENG_change_scottish_agitation = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7083,9 +6578,7 @@ country_event = {
 			set_temp_variable = { ENG_dependency_change = -2 }
 			ENG_change_scottish_dependency = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7094,7 +6587,6 @@ country_event = {
 	id = british_flavor.13
 	title = british_flavor.13.t
 	desc = british_flavor.13.d
-
 	picture = GFX_court
 	is_triggered_only = yes
 
@@ -7105,18 +6597,14 @@ country_event = {
 			set_temp_variable = { ENG_agitation_change = 4 }
 			ENG_change_north_irish_agitation = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = british_flavor.13.b
 		log = "[GetDateText]: [This.GetName]: british_flavor.13.b executed"
 		add_stability = -0.04
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7126,7 +6614,6 @@ country_event = {
 	id = british_flavor.14
 	title = british_flavor.14.t
 	desc = british_flavor.14.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -7145,9 +6632,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -4.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7158,9 +6643,7 @@ country_event = {
 			MODIFIER = ENG_political_modifier
 		}
 		add_to_variable = { ENG_police_cost_multiplier_modifier = 0.01 tooltip = police_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7170,7 +6653,6 @@ country_event = {
 	id = british_flavor.15
 	title = british_flavor.15.t
 	desc = british_flavor.15.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -7179,9 +6661,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: british_flavor.15.a executed"
 		set_temp_variable = { temp_opinion = -15 }
 		change_fossil_fuel_industry_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7195,9 +6675,7 @@ country_event = {
 				MODIFIER = ENG_economy_modifier
 			}
 		add_to_variable = { ENG_max_fuel_factor = -0.05 tooltip = max_fuel_factor_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7229,7 +6707,6 @@ country_event = {
 	id = british_flavor.151
 	title = british_flavor.151.t
 	desc = british_flavor.151.d
-
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
@@ -7243,9 +6720,7 @@ country_event = {
 				days = 4
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7253,7 +6728,6 @@ country_event = {
 	id = british_flavor.152
 	title = british_flavor.152.t
 	desc = british_flavor.152.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -7267,9 +6741,7 @@ country_event = {
 				days = 4
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7277,7 +6749,6 @@ country_event = {
 	id = british_flavor.153
 	title = british_flavor.153.t
 	desc = british_flavor.153.d
-
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
@@ -7292,9 +6763,7 @@ country_event = {
 			}
 			news_event = United_Kingdom_News.2
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7302,7 +6771,6 @@ country_event = {
 	id = british_flavor.154
 	title = british_flavor.154.t
 	desc = british_flavor.154.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -7317,9 +6785,7 @@ country_event = {
 			}
 			news_event = United_Kingdom_News.3
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7327,7 +6793,6 @@ country_event = {
 	id = british_flavor.155
 	title = british_flavor.155.t
 	desc = british_flavor.155.d
-
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
@@ -7341,9 +6806,7 @@ country_event = {
 				days = 4
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7351,7 +6814,6 @@ country_event = {
 	id = british_flavor.156
 	title = british_flavor.156.t
 	desc = british_flavor.156.d
-
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
@@ -7375,9 +6837,7 @@ country_event = {
 				change_ruling_party_effect = yes
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7395,9 +6855,7 @@ country_event = {
 			set_cosmetic_tag = ENG_evil_britain
 			set_country_flag = ENG_overthrown
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7405,7 +6863,6 @@ country_event = {
 	id = british_flavor.16
 	title = british_flavor.16.t
 	desc = british_flavor.16.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -7415,9 +6872,7 @@ country_event = {
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.075 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7425,7 +6880,6 @@ country_event = {
 	id = british_flavor.17
 	title = british_flavor.17.t
 	desc = british_flavor.17.d
-
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
@@ -7448,9 +6902,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7468,9 +6920,7 @@ country_event = {
 		newline = yes
 		set_temp_variable = { treasury_change = -8.00 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7480,7 +6930,6 @@ country_event = {
 	id = british_flavor.18
 	title = british_flavor.18.t
 	desc = british_flavor.18.d
-
 	picture = GFX_hospital
 	is_triggered_only = yes
 
@@ -7491,9 +6940,7 @@ country_event = {
 			set_temp_variable = { ENG_agitation_change = 2 }
 			ENG_change_scottish_agitation = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7504,9 +6951,7 @@ country_event = {
 				MODIFIER = ENG_economy_modifier
 			}
 		add_to_variable = { ENG_health_cost = 0.015 tooltip = health_cost_multiplier_modifier_tt }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -7516,7 +6961,6 @@ country_event = {
 	title = ENG_royal_visits.1.t
 	desc = ENG_royal_visits.1.d
 	picture = GFX_politics_speak
-
 	is_triggered_only = yes
 
 	option = {
@@ -7552,9 +6996,7 @@ country_event = {
 				reverse_add_opinion_modifier = { target = ENG modifier = ENG_monarch_outreach }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7590,9 +7032,7 @@ country_event = {
 				reverse_add_opinion_modifier = { target = ENG modifier = ENG_monarch_outreach }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7628,9 +7068,7 @@ country_event = {
 				reverse_add_opinion_modifier = { target = ENG modifier = ENG_monarch_outreach }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -7666,9 +7104,7 @@ country_event = {
 				reverse_add_opinion_modifier = { target = ENG modifier = ENG_monarch_outreach }
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -8028,15 +7464,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 
-	trigger = {
-		ENG_arm_outcome_settled = no
-	}
+	trigger = { ENG_arm_outcome_settled = no }
 
 	option = {
 		name = britain_md.306.a
-		trigger = {
-			has_country_flag = ENG_arm_public_stake
-		}
+		trigger = { has_country_flag = ENG_arm_public_stake }
 		log = "[GetDateText]: [Root.GetName]: britain_md.306.a executed"
 		effect_tooltip = { add_ideas = ENG_arm_sovereign_architecture_stake }
 		hidden_effect = { ENG_arm_apply_sovereign_architecture_stake = yes }
@@ -8085,9 +7517,8 @@ country_event = {
 # Elections resolve on raw popularity: Labour's 0.507 start wins forever without this.
 country_event = {
 	id = britain_md.400
-	hidden = yes
-
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		is_ai = yes

--- a/events/Econ_events.txt
+++ b/events/Econ_events.txt
@@ -73,9 +73,7 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	#Crisis?! What crisis!?
@@ -91,11 +89,8 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 #### Collapsing housing prices ####
@@ -149,9 +144,7 @@ country_event = {
 		set_country_flag = { flag = housing_crash value = 1 days = 180 }
 		if = { limit = { OR = { has_idea = economic_boom has_idea = fast_growth has_idea = stable_growth } }
 			random_list = {
-				70 = {
-					decrease_economic_growth = yes
-				}
+				70 = { decrease_economic_growth = yes }
 				30 = {
 					modifier = {
 						factor = 1.5
@@ -171,25 +164,15 @@ country_event = {
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				50 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				40 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				50 = { custom_effect_tooltip = NO_EFFECT_TT }
+				40 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				60 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				40 = {
-					decrease_economic_growth = yes
-				}
+				60 = { custom_effect_tooltip = NO_EFFECT_TT }
+				40 = { decrease_economic_growth = yes }
 			}
 		}
 		clr_country_flag = possible_housing_bubble
@@ -228,12 +211,10 @@ country_event = {
 	option = {
 		name = econvent.2.b
 		log = "[GetDateText]: [This.GetName]: econvent.2.b executed"
-		set_country_flag = { flag = housing_crash value = 2  days = 365 }
+		set_country_flag = { flag = housing_crash value = 2 days = 365 }
 		if = { limit = { OR = { has_idea = economic_boom has_idea = fast_growth has_idea = stable_growth } }
 			random_list = {
-				50 = {
-					decrease_economic_growth = yes
-				}
+				50 = { decrease_economic_growth = yes }
 				50 = {
 					modifier = {
 						factor = 1.5
@@ -249,12 +230,8 @@ country_event = {
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				70 = {
-					decrease_economic_growth = yes
-				}
-				30 = {
-					decrease_two_level_economic_growth = yes
-				}
+				70 = { decrease_economic_growth = yes }
+				30 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
@@ -271,11 +248,8 @@ country_event = {
 		change_wall_street_opinion = yes
 		change_farmers_opinion = yes
 		change_landowners_opinion = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
-
 }
 
 # Stock Market Crash
@@ -350,42 +324,26 @@ country_event = {
 		set_country_flag = { flag = stock_market_crash value = 1 days = 365 }
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				70 = {
-					decrease_economic_growth = yes
-				}
-				30 = {
-					decrease_two_level_economic_growth = yes
-				}
+				70 = { decrease_economic_growth = yes }
+				30 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				75 = {
-					decrease_economic_growth = yes
-				}
-				25 = {
-					decrease_two_level_economic_growth = yes
-				}
+				75 = { decrease_economic_growth = yes }
+				25 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				80 = {
-					decrease_economic_growth = yes
-				}
-				20 = {
-					decrease_two_level_economic_growth = yes
-				}
+				80 = { decrease_economic_growth = yes }
+				20 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				90 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				90 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
@@ -403,9 +361,7 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_fossil_fuel_industry_opinion = yes
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 2.0
-		}
+		ai_chance = { base = 2.0 }
 	}
 
 	# Issue Bailouts
@@ -427,11 +383,8 @@ country_event = {
 		change_oligarchs_opinion = yes
 		change_fossil_fuel_industry_opinion = yes
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 0.25
-		}
+		ai_chance = { base = 0.25 }
 	}
-
 }
 
 # Bank Crisis
@@ -482,52 +435,32 @@ country_event = {
 		small_expenditure = yes
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				60 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				40 = {
-					decrease_economic_growth = yes
-				}
+				60 = { custom_effect_tooltip = NO_EFFECT_TT }
+				40 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				60 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				40 = {
-					decrease_economic_growth = yes
-				}
+				60 = { custom_effect_tooltip = NO_EFFECT_TT }
+				40 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				70 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				30 = {
-					decrease_economic_growth = yes
-				}
+				70 = { custom_effect_tooltip = NO_EFFECT_TT }
+				30 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				80 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				20 = {
-					decrease_economic_growth = yes
-				}
+				80 = { custom_effect_tooltip = NO_EFFECT_TT }
+				20 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				90 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				10 = {
-					decrease_economic_growth = yes
-				}
+				90 = { custom_effect_tooltip = NO_EFFECT_TT }
+				10 = { decrease_economic_growth = yes }
 			}
 		}
 		set_temp_variable = { temp_opinion = 5 }
@@ -536,9 +469,7 @@ country_event = {
 		change_chaebols_opinion = yes
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	#Avoid bailouts, but help savers if banks go bankrupt
@@ -549,55 +480,33 @@ country_event = {
 		add_political_power = -75
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				80 = {
-					decrease_economic_growth = yes
-				}
-				20 = {
-					decrease_two_level_economic_growth = yes
-				}
+				80 = { decrease_economic_growth = yes }
+				20 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				85 = {
-					decrease_economic_growth = yes
-				}
-				15 = {
-					decrease_two_level_economic_growth = yes
-				}
+				85 = { decrease_economic_growth = yes }
+				15 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				90 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				90 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				70 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				70 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				30 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				70 = {
-					decrease_economic_growth = yes
-				}
+				30 = { custom_effect_tooltip = NO_EFFECT_TT }
+				70 = { decrease_economic_growth = yes }
 			}
 		}
 		set_temp_variable = { temp_opinion = 5 }
@@ -607,9 +516,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = -10 }
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	#Survival of the fittest is what makes capitalism beautiful
@@ -619,42 +526,26 @@ country_event = {
 		set_country_flag = { flag = bank_crisis value = 2 days = 365 }
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				60 = {
-					decrease_economic_growth = yes
-				}
-				40 = {
-					decrease_two_level_economic_growth = yes
-				}
+				60 = { decrease_economic_growth = yes }
+				40 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				65 = {
-					decrease_economic_growth = yes
-				}
-				35 = {
-					decrease_two_level_economic_growth = yes
-				}
+				65 = { decrease_economic_growth = yes }
+				35 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				70 = {
-					decrease_economic_growth = yes
-				}
-				30 = {
-					decrease_two_level_economic_growth = yes
-				}
+				70 = { decrease_economic_growth = yes }
+				30 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				80 = {
-					decrease_economic_growth = yes
-				}
-				20 = {
-					decrease_two_level_economic_growth = yes
-				}
+				80 = { decrease_economic_growth = yes }
+				20 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
@@ -667,11 +558,8 @@ country_event = {
 		change_chaebols_opinion = yes
 		change_wall_street_opinion = yes
 		change_international_bankers_opinion = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 
@@ -733,12 +621,8 @@ country_event = {
 		set_country_flag = { flag = consumption_slowdown value = 1 days = 365 }
 		if = { limit = { NOT = { has_idea = depression } }
 			random_list = {
-				60 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				40 = {
-					decrease_economic_growth = yes
-				}
+				60 = { custom_effect_tooltip = NO_EFFECT_TT }
+				40 = { decrease_economic_growth = yes }
 			}
 		}
 		set_temp_variable = { temp_opinion = 5 }
@@ -754,55 +638,33 @@ country_event = {
 		set_country_flag = { flag = consumption_slowdown value = 1 days = 365 }
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				80 = {
-					decrease_economic_growth = yes
-				}
-				20 = {
-					decrease_two_level_economic_growth = yes
-				}
+				80 = { decrease_economic_growth = yes }
+				20 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				85 = {
-					decrease_economic_growth = yes
-				}
-				15 = {
-					decrease_two_level_economic_growth = yes
-				}
+				85 = { decrease_economic_growth = yes }
+				15 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				90 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				90 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				10 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				80 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				10 = { custom_effect_tooltip = NO_EFFECT_TT }
+				80 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				80 = {
-					decrease_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				80 = { decrease_economic_growth = yes }
 			}
 		}
 		set_temp_variable = { temp_opinion = -5 }
@@ -810,7 +672,6 @@ country_event = {
 		change_the_donju_opinion = yes
 		change_chaebols_opinion = yes
 	}
-
 }
 
 ### Lower demand for our goods in int. markets
@@ -861,62 +722,37 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: econvent.6.a executed"
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				70 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				70 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				75 = {
-					decrease_economic_growth = yes
-				}
-				5 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				75 = { decrease_economic_growth = yes }
+				5 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				80 = {
-					decrease_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				80 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				25 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				75 = {
-					decrease_economic_growth = yes
-				}
+				25 = { custom_effect_tooltip = NO_EFFECT_TT }
+				75 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				50 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				50 = {
-					decrease_economic_growth = yes
-				}
+				50 = { custom_effect_tooltip = NO_EFFECT_TT }
+				50 = { decrease_economic_growth = yes }
 			}
 		}
 	}
-
 }
 
 #### Things for poor countries ####
@@ -962,62 +798,37 @@ country_event = {
 		set_country_flag = { flag = drought value = 1 days = 120 }
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				70 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				70 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				75 = {
-					decrease_economic_growth = yes
-				}
-				5 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				75 = { decrease_economic_growth = yes }
+				5 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				80 = {
-					decrease_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				80 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				25 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				75 = {
-					decrease_economic_growth = yes
-				}
+				25 = { custom_effect_tooltip = NO_EFFECT_TT }
+				75 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				50 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				50 = {
-					decrease_economic_growth = yes
-				}
+				50 = { custom_effect_tooltip = NO_EFFECT_TT }
+				50 = { decrease_economic_growth = yes }
 			}
 		}
 	}
-
 }
 
 ### Drought causes famine
@@ -1056,64 +867,39 @@ country_event = {
 		set_country_flag = { flag = famine value = 1 days = 200 }
 		if = { limit = { has_idea = economic_boom }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				70 = {
-					decrease_economic_growth = yes
-				}
-				10 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				70 = { decrease_economic_growth = yes }
+				10 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = fast_growth }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				75 = {
-					decrease_economic_growth = yes
-				}
-				5 = {
-					decrease_two_level_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				75 = { decrease_economic_growth = yes }
+				5 = { decrease_two_level_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stable_growth }
 			random_list = {
-				20 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				80 = {
-					decrease_economic_growth = yes
-				}
+				20 = { custom_effect_tooltip = NO_EFFECT_TT }
+				80 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = stagnation }
 			random_list = {
-				25 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				75 = {
-					decrease_economic_growth = yes
-				}
+				25 = { custom_effect_tooltip = NO_EFFECT_TT }
+				75 = { decrease_economic_growth = yes }
 			}
 		}
 		else_if = { limit = { has_idea = recession }
 			random_list = {
-				50 = {
-					custom_effect_tooltip = NO_EFFECT_TT
-				}
-				50 = {
-					decrease_economic_growth = yes
-				}
+				50 = { custom_effect_tooltip = NO_EFFECT_TT }
+				50 = { decrease_economic_growth = yes }
 			}
 		}
 		set_temp_variable = { temp_opinion = -15 }
 		change_farmers_opinion = yes
 	}
-
 }
 
 ##Positive Economic Events
@@ -1202,7 +988,6 @@ country_event = {
 		change_maritime_industry_opinion = yes
 		set_country_flag = { flag = increased_consumer_confidence value = 1 days = 180 }
 	}
-
 }
 
 #Stock Market Boom
@@ -1287,9 +1072,7 @@ country_event = {
 		change_international_bankers_opinion = yes
 		change_small_medium_business_owners_opinion = yes
 		set_country_flag = { flag = stock_market_boom_accelerate value = 1 days = 200 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 
 	option = {
@@ -1301,9 +1084,7 @@ country_event = {
 		change_international_bankers_opinion = yes
 		change_small_medium_business_owners_opinion = yes
 		set_country_flag = { flag = stock_market_boom value = 1 days = 200 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1314,11 +1095,8 @@ country_event = {
 		change_small_medium_business_owners_opinion = yes
 		custom_effect_tooltip = econvent.10.c_tt
 		set_country_flag = { flag = stock_market_boom_slowed value = 1 days = 200 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # Major Financial Institution Requires a Bailout
@@ -1478,15 +1256,9 @@ country_event = {
 		}
 		set_country_flag = disable_cycle_costs
 		random_list = {
-			40 = {
-				add_ideas = stagnation
-			}
-			40 = {
-				add_ideas = recession
-			}
-			20 = {
-				add_ideas = depression
-			}
+			40 = { add_ideas = stagnation }
+			40 = { add_ideas = recession }
+			20 = { add_ideas = depression }
 		}
 		if = {
 			limit = { is_subject_of = ROOT }
@@ -1519,11 +1291,8 @@ country_event = {
 		}
 		clr_country_flag = disable_cycle_costs
 		set_country_flag = { flag = ECON_recent_financial_institution_crash days = 365 value = 1 }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # [FROM.GetName] Recent Economic Crisis has rippled through our nation
@@ -1556,9 +1325,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1580,11 +1347,8 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
 		decrease_economic_growth = yes
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 # High Debt Causes Companies to Leave
@@ -1641,9 +1405,7 @@ country_event = {
 		name = econvent.13.a
 		log = "[GetDateText]: [This.GetName]: econvent.13.a executed"
 		random_owned_controlled_state = {
-			limit = {
-				check_variable = { building_level@industrial_complex > 0 }
-			}
+			limit = { check_variable = { building_level@industrial_complex > 0 } }
 			remove_building = {
 				type = industrial_complex
 				level = -1
@@ -1695,7 +1457,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Private Investors Invest Civilian Industry
@@ -1785,7 +1546,6 @@ country_event = {
 		}
 		set_country_flag = { flag = private_investor_civilian_industry value = 1 days = 365 }
 	}
-
 }
 
 # Private Investors Invest in Office Park
@@ -1878,7 +1638,6 @@ country_event = {
 		}
 		set_country_flag = { flag = private_investor_office_park value = 1 days = 365 }
 	}
-
 }
 
 # Modern Production Methods Spread
@@ -1928,7 +1687,6 @@ country_event = {
 		set_temp_variable = { temp_productivity_change = 10 }
 		flat_productivity_change_effect = yes
 	}
-
 }
 
 # Education Investments Bear Fruit
@@ -1975,7 +1733,6 @@ country_event = {
 		set_temp_variable = { temp_productivity_change = 10 }
 		flat_productivity_change_effect = yes
 	}
-
 }
 
 # Foreign Technology Spreads Domestically
@@ -2023,7 +1780,6 @@ country_event = {
 		set_temp_variable = { temp_productivity_change = 10 }
 		flat_productivity_change_effect = yes
 	}
-
 }
 
 # Semiconductor Foundry Investment
@@ -2096,7 +1852,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Composite Industry Expansion
@@ -2169,7 +1924,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Defense Contracts Expand Production
@@ -2241,7 +1995,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Commercial Shipbuilding Orders Surge
@@ -2313,7 +2066,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Bailout Requested
@@ -2331,11 +2083,11 @@ country_event = {
 		if = {
 			limit = { FROM = { check_variable = { debt_bailout > 0 } } }
 			set_temp_variable = { bailout_cost = FROM.debt_bailout }
-			set_temp_variable = { treasury_change = { value = bailout_cost  multiply = -0.75 } }
+			set_temp_variable = { treasury_change = { value = bailout_cost multiply = -0.75 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = bankruptcy_bailout_influence_TT
 			FROM = {
-				set_temp_variable = { debt_change = { value = debt_bailout  multiply = -1 } }
+				set_temp_variable = { debt_change = { value = debt_bailout multiply = -1 } }
 				modify_debt_effect = yes
 				set_temp_variable = { percent_change = 15 }
 				change_influence_percentage = yes
@@ -2344,9 +2096,7 @@ country_event = {
 				news_event = { id = News_bankruptcy.1 hours = 3 }
 			}
 		}
-		else = {
-			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
-		}
+		else = { custom_effect_tooltip = bankruptcy_bailout_lapsed_TT }
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2376,9 +2126,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 1.05
-				FROM = {
-					is_on_same_continent_as = PREV
-				}
+				FROM = { is_on_same_continent_as = PREV }
 			}
 			modifier = {
 				factor = 1.05
@@ -2485,7 +2233,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 ##Bailout Requested from 2nd biggest influencer###
@@ -2503,11 +2250,11 @@ country_event = {
 		if = {
 			limit = { FROM = { check_variable = { debt_bailout > 0 } } }
 			set_temp_variable = { bailout_cost = FROM.debt_bailout }
-			set_temp_variable = { treasury_change = { value = bailout_cost  multiply = -0.66666 } }
+			set_temp_variable = { treasury_change = { value = bailout_cost multiply = -0.66666 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = bankruptcy_bailout_influence_second_biggest_TT
 			FROM = {
-				set_temp_variable = { debt_change = { value = debt_bailout  multiply = -1 } }
+				set_temp_variable = { debt_change = { value = debt_bailout multiply = -1 } }
 				modify_debt_effect = yes
 				set_temp_variable = { percent_change = 10 }
 				change_influence_percentage = yes
@@ -2517,9 +2264,7 @@ country_event = {
 				news_event = { id = News_bankruptcy.2 hours = 3 }
 			}
 		}
-		else = {
-			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
-		}
+		else = { custom_effect_tooltip = bankruptcy_bailout_lapsed_TT }
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2583,7 +2328,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 ##Bailout Requested from neigbhour###
@@ -2601,11 +2345,11 @@ country_event = {
 		if = {
 			limit = { FROM = { check_variable = { debt_bailout > 0 } } }
 			set_temp_variable = { bailout_cost = FROM.debt_bailout }
-			set_temp_variable = { treasury_change = { value = bailout_cost  multiply = -0.5 } }
+			set_temp_variable = { treasury_change = { value = bailout_cost multiply = -0.5 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = bankruptcy_bailout_influence_neighbour_TT
 			FROM = {
-				set_temp_variable = { debt_change = { value = debt_bailout  multiply = -1 } }
+				set_temp_variable = { debt_change = { value = debt_bailout multiply = -1 } }
 				modify_debt_effect = yes
 				set_temp_variable = { percent_change = 5 }
 				change_influence_percentage = yes
@@ -2615,9 +2359,7 @@ country_event = {
 				news_event = { id = News_bankruptcy.3 hours = 3 }
 			}
 		}
-		else = {
-			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
-		}
+		else = { custom_effect_tooltip = bankruptcy_bailout_lapsed_TT }
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2681,7 +2423,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #We were denied the bailout
@@ -2699,7 +2440,6 @@ country_event = {
 		add_opinion_modifier = { modifier = did_not_support_us target = FROM }
 		clear_variable = debt_bailout
 	}
-
 }
 
 ##Bailout Requested from overlord###
@@ -2717,11 +2457,11 @@ country_event = {
 		if = {
 			limit = { FROM = { check_variable = { debt_bailout > 0 } } }
 			set_temp_variable = { bailout_cost = FROM.debt_bailout }
-			set_temp_variable = { treasury_change = { value = bailout_cost  multiply = -0.5 } }
+			set_temp_variable = { treasury_change = { value = bailout_cost multiply = -0.5 } }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = bankruptcy_bailout_influence_neighbour_TT
 			FROM = {
-				set_temp_variable = { debt_change = { value = debt_bailout  multiply = -1 } }
+				set_temp_variable = { debt_change = { value = debt_bailout multiply = -1 } }
 				modify_debt_effect = yes
 				set_temp_variable = { percent_change = 5 }
 				change_influence_percentage = yes
@@ -2738,9 +2478,7 @@ country_event = {
 				news_event = { id = News_bankruptcy.3 hours = 3 }
 			}
 		}
-		else = {
-			custom_effect_tooltip = bankruptcy_bailout_lapsed_TT
-		}
+		else = { custom_effect_tooltip = bankruptcy_bailout_lapsed_TT }
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -2799,7 +2537,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 ### Financial Collapse ###
@@ -2816,9 +2553,7 @@ country_event = {
 		name = bankruptcy.10.a
 		log = "[GetDateText]: [This.GetName]: bankruptcy.10.a executed"
 		hold_election = ROOT
-		hidden_effect = {
-			set_elections_48_months = yes
-		}
+		hidden_effect = { set_elections_48_months = yes }
 		if = {
 			limit = { is_major = yes }
 			every_country = {
@@ -2835,9 +2570,7 @@ country_event = {
 				news_event = { days = 1 id = News_bankruptcy.4 }
 			}
 		}
-		ai_chance = {
-			base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 
 	#Block new elections
@@ -2849,7 +2582,6 @@ country_event = {
 			base = 5
 		}
 	}
-
 }
 
 #Calls for new election - attempted coup
@@ -2893,9 +2625,7 @@ country_event = {
 		set_temp_variable = { civil_war_chance = 1 }
 		subtract_from_temp_variable = { civil_war_chance = no_civil_war_chance }
 		random_list = {
-			no_civil_war_chance = {
-				custom_effect_tooltip = bankruptcy.11.b_tt
-			}
+			no_civil_war_chance = { custom_effect_tooltip = bankruptcy.11.b_tt }
 			civil_war_chance = {
 				start_civil_war_against_the_strongest_opposition = yes
 				hidden_effect = { news_event = { id = News_bankruptcy.6 hours = 6 } }
@@ -2903,7 +2633,6 @@ country_event = {
 		}
 		ai_chance = { base = 50 }
 	}
-
 }
 #Calls for leadership change - non-democratic
 country_event = {
@@ -2935,9 +2664,7 @@ country_event = {
 				news_event = { days = 1 id = News_bankruptcy.5 }
 			}
 		}
-		ai_chance = {
-			base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 
 	#Block new elections
@@ -2945,11 +2672,8 @@ country_event = {
 		name = bankruptcy.12.b
 		log = "[GetDateText]: [This.GetName]: bankruptcy.12.b executed"
 		country_event = { id = bankruptcy.11 days = 1 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
-
 }
 
 #Country fails to pay their defaulted debt
@@ -2961,7 +2685,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.13.a	#Agree
+		name = bankruptcy.13.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.13.a executed"
 		trigger = {
 			FROM = {
@@ -3114,7 +2838,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # Subject fails to pay on defaulted debt
@@ -3132,13 +2855,8 @@ country_event = {
 		set_temp_variable = { treasury_change = debt_from_subject }
 		modify_treasury_effect = yes
 		clear_variable = debt_from_subject
-		FROM = {
-			add_autonomy_score = {
-				value = -1000
-			}
-		}
+		FROM = { add_autonomy_score = { value = -1000 } }
 	}
-
 }
 
 
@@ -3156,14 +2874,10 @@ country_event = {
 		name = bankruptcy.100.a
 		log = "[GetDateText]: [This.GetName]: bankruptcy.100.a executed"
 		if = {
-			limit = {
-				check_variable = { gdp_per_capita < 5 }
-			}
+			limit = { check_variable = { gdp_per_capita < 5 } }
 			decrease_centralization_2 = yes
 		}
-		else = {
-			decrease_centralization = yes
-		}
+		else = { decrease_centralization = yes }
 		block_bureau_increase = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_industrial_conglomerates_opinion = yes
@@ -3186,7 +2900,6 @@ country_event = {
 		change_oligarchs_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 
 #downsize military
@@ -3198,7 +2911,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.101.a	#Agree
+		name = bankruptcy.101.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.101.a executed"
 		if = {
 			limit = {
@@ -3217,14 +2930,13 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.101.b	#Reject offer
+		name = bankruptcy.101.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.101.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #downsize police
 country_event = {
@@ -3235,7 +2947,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.102.a	#Agree
+		name = bankruptcy.102.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.102.a executed"
 		if = {
 			limit = {
@@ -3254,14 +2966,13 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.102.b	#Reject offer
+		name = bankruptcy.102.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.102.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_intelligence_community_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #cut education spending
 country_event = {
@@ -3272,7 +2983,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.103.a	#Agree
+		name = bankruptcy.103.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.103.a executed"
 		if = {
 			limit = {
@@ -3293,7 +3004,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.103.b	#Reject offer
+		name = bankruptcy.103.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.103.b executed"
 		set_temp_variable = { temp_opinion = 5 }
 		change_farmers_opinion = yes
@@ -3302,7 +3013,6 @@ country_event = {
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #cut health spending
 country_event = {
@@ -3313,7 +3023,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.104.a	#Agree
+		name = bankruptcy.104.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.104.a executed"
 		if = {
 			limit = {
@@ -3333,7 +3043,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.104.b	#Reject offer
+		name = bankruptcy.104.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.104.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
@@ -3341,7 +3051,6 @@ country_event = {
 		change_labour_unions_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #cut social spending
 country_event = {
@@ -3352,7 +3061,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.105.a	#Agree
+		name = bankruptcy.105.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.105.a executed"
 		if = {
 			limit = {
@@ -3372,7 +3081,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.105.b	#Reject offer
+		name = bankruptcy.105.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.105.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
@@ -3380,7 +3089,6 @@ country_event = {
 		change_labour_unions_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #increase resource exports
 country_event = {
@@ -3391,7 +3099,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.106.a	#Agree
+		name = bankruptcy.106.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.106.a executed"
 		if = {
 			limit = {
@@ -3412,7 +3120,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.106.b	#Reject offer
+		name = bankruptcy.106.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.106.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = -5 }
@@ -3421,7 +3129,6 @@ country_event = {
 		change_oligarchs_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 # Corruption
 country_event = {
@@ -3442,12 +3149,11 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.107.b	#Reject offer
+		name = bankruptcy.107.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.107.b executed"
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #land reform
 country_event = {
@@ -3458,7 +3164,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.108.a	#Agree
+		name = bankruptcy.108.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.108.a executed"
 		if = {
 			limit = {
@@ -3507,7 +3213,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.108.b	#Reject offer
+		name = bankruptcy.108.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.108.b executed"
 		set_temp_variable = { temp_opinion = 5 }
 		change_farmers_opinion = yes
@@ -3516,7 +3222,6 @@ country_event = {
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #bankers in government
 country_event = {
@@ -3527,7 +3232,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.109.a	#Agree
+		name = bankruptcy.109.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.109.a executed"
 		if = {
 			limit = {
@@ -3547,14 +3252,13 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.109.b	#Reject offer
+		name = bankruptcy.109.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.109.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_international_bankers_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #confiscate church funds
 country_event = {
@@ -3565,7 +3269,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.110.a	#Agree
+		name = bankruptcy.110.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.110.a executed"
 		set_temp_variable = { temp_opinion = -5 }
 		change_the_clergy_opinion = yes
@@ -3577,7 +3281,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.110.b	#Reject offer
+		name = bankruptcy.110.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.110.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
@@ -3587,7 +3291,6 @@ country_event = {
 		change_the_wahabi_ulema_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #dismantle military factories
 country_event = {
@@ -3598,7 +3301,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.111.a	#Agree
+		name = bankruptcy.111.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.111.a executed"
 		if = { limit = { check_variable = { gdp_per_capita < 5 } }
 			random_owned_state = {
@@ -3632,7 +3335,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.111.b	#Reject offer
+		name = bankruptcy.111.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.111.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
@@ -3640,7 +3343,6 @@ country_event = {
 		change_defense_industry_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #dismantle naval dockyards
 country_event = {
@@ -3651,7 +3353,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.112.a	#Agree
+		name = bankruptcy.112.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.112.a executed"
 		# Dismantles the Dockyards
 		if = { limit = { check_variable = { gdp_per_capita < 5 } }
@@ -3685,14 +3387,13 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.112.b	#Reject offer
+		name = bankruptcy.112.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.112.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_maritime_industry_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #raise taxes
 country_event = {
@@ -3703,7 +3404,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.113.a	#Agree
+		name = bankruptcy.113.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.113.a executed"
 		if = { limit = { check_variable = { gdp_per_capita < 5 } }
 			set_temp_variable = { corp_change = 10 }
@@ -3753,7 +3454,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.113.b	#Reject offer
+		name = bankruptcy.113.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.113.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
@@ -3769,7 +3470,6 @@ country_event = {
 		change_labour_unions_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 #sell international investments
 country_event = {
@@ -3782,7 +3482,7 @@ country_event = {
 	trigger = { check_variable = { int_investments > 0 } }
 
 	option = {
-		name = bankruptcy.114.a	#Agree
+		name = bankruptcy.114.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.114.a executed"
 		if = {
 			limit = {
@@ -3820,14 +3520,13 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.114.b	#Reject offer
+		name = bankruptcy.114.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.114.b executed"
 		imf_debt_relief_rejected_effect = yes
 		set_temp_variable = { temp_opinion = 5 }
 		change_international_bankers_opinion = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 # Dismantle State Owned industry
 country_event = {
@@ -3838,7 +3537,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = bankruptcy.115.a	#Agree
+		name = bankruptcy.115.a #Agree
 		log = "[GetDateText]: [This.GetName]: bankruptcy.115.a executed"
 		if = { limit = { check_variable = { gdp_per_capita < 5 } }
 			random_owned_state = {
@@ -3867,12 +3566,11 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.115.b	#Reject offer
+		name = bankruptcy.115.b #Reject offer
 		log = "[GetDateText]: [This.GetName]: bankruptcy.115.b executed"
 		imf_debt_relief_rejected_effect = yes
 		ai_chance = { base = 10 }
 	}
-
 }
 
 ##Financial collapse stuff
@@ -3906,7 +3604,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.200.a	#Do nothing
+		name = bankruptcy.200.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.200.a executed"
 		set_temp_variable = { party_index = 0 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -3916,7 +3614,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.200.b	#Counter-campaign
+		name = bankruptcy.200.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.200.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 0 }
@@ -3925,7 +3623,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #conservatism makes a speech
 country_event = {
@@ -3957,7 +3654,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.201.a	#Do nothing
+		name = bankruptcy.201.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.201.a executed"
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -3967,7 +3664,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.201.b	#Counter-campaign
+		name = bankruptcy.201.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.201.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 1 }
@@ -3976,7 +3673,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #liberalism makes a speech
 country_event = {
@@ -4008,7 +3704,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.202.a	#Do nothing
+		name = bankruptcy.202.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.202.a executed"
 		set_temp_variable = { party_index = 1 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4018,7 +3714,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.202.b	#Counter-campaign
+		name = bankruptcy.202.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.202.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 2 }
@@ -4027,7 +3723,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #socialism makes a speech
 country_event = {
@@ -4059,7 +3754,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.203.a	#Do nothing
+		name = bankruptcy.203.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.203.a executed"
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4069,7 +3764,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.203.b	#Counter-campaign
+		name = bankruptcy.203.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.203.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 3 }
@@ -4078,7 +3773,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Communist-State makes a speech
 country_event = {
@@ -4110,7 +3804,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.204.a	#Do nothing
+		name = bankruptcy.204.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.204.a executed"
 		set_temp_variable = { party_index = 4 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4120,7 +3814,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.204.b	#Counter-campaign
+		name = bankruptcy.204.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.204.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 4 }
@@ -4129,7 +3823,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #anarchist_communism makes a speech
 country_event = {
@@ -4161,7 +3854,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.205.a	#Do nothing
+		name = bankruptcy.205.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.205.a executed"
 		set_temp_variable = { party_index = 5 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4171,7 +3864,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.205.b	#Counter-campaign
+		name = bankruptcy.205.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.205.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 5 }
@@ -4180,7 +3873,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Conservative makes a speech
 country_event = {
@@ -4212,7 +3904,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.206.a	#Do nothing
+		name = bankruptcy.206.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.206.a executed"
 		set_temp_variable = { party_index = 6 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4222,7 +3914,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.206.b	#Counter-campaign
+		name = bankruptcy.206.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.206.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 6 }
@@ -4231,7 +3923,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Autocracy makes a speech
 country_event = {
@@ -4263,7 +3954,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.207.a	#Do nothing
+		name = bankruptcy.207.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.207.a executed"
 		set_temp_variable = { party_index = 7 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4273,7 +3964,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.207.b	#Counter-campaign
+		name = bankruptcy.207.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.207.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 7 }
@@ -4282,7 +3973,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Mod_Vilayat_e_Faqih makes a speech
 country_event = {
@@ -4338,7 +4028,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.208.a	#Do nothing
+		name = bankruptcy.208.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.208.a executed"
 		set_temp_variable = { party_index = 8 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4348,7 +4038,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.208.b	#Counter-campaign
+		name = bankruptcy.208.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.208.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 8 }
@@ -4357,7 +4047,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Vilayat_e_Faqih makes a speech
 country_event = {
@@ -4413,7 +4102,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.209.a	#Do nothing
+		name = bankruptcy.209.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.209.a executed"
 		set_temp_variable = { party_index = 9 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4423,7 +4112,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.209.b	#Counter-campaign
+		name = bankruptcy.209.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.209.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 9 }
@@ -4432,7 +4121,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Kingdom makes a speech
 country_event = {
@@ -4471,7 +4159,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.210.a	#Do nothing
+		name = bankruptcy.210.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.210.a executed"
 		set_temp_variable = { party_index = 10 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4481,7 +4169,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.210.b	#Counter-campaign
+		name = bankruptcy.210.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.210.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 10 }
@@ -4490,7 +4178,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Caliphate makes a speech
 country_event = {
@@ -4529,7 +4216,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.211.a	#Do nothing
+		name = bankruptcy.211.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.211.a executed"
 		set_temp_variable = { party_index = 11 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4539,7 +4226,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.211.b	#Counter-campaign
+		name = bankruptcy.211.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.211.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 11 }
@@ -4548,7 +4235,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Neutral_Muslim_Brotherhood makes a speech
 country_event = {
@@ -4587,7 +4273,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.212.a	#Do nothing
+		name = bankruptcy.212.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.212.a executed"
 		set_temp_variable = { party_index = 12 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4597,7 +4283,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.212.b	#Counter-campaign
+		name = bankruptcy.212.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.212.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 12 }
@@ -4606,7 +4292,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Neutral_Autocracy makes a speech
 country_event = {
@@ -4638,7 +4323,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.213.a	#Do nothing
+		name = bankruptcy.213.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.213.a executed"
 		set_temp_variable = { party_index = 13 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4648,7 +4333,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.213.b	#Counter-campaign
+		name = bankruptcy.213.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.213.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 13 }
@@ -4657,7 +4342,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Neutral_conservatism makes a speech
 country_event = {
@@ -4689,7 +4373,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.214.a	#Do nothing
+		name = bankruptcy.214.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.214.a executed"
 		set_temp_variable = { party_index = 14 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4699,7 +4383,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.214.b	#Counter-campaign
+		name = bankruptcy.214.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.214.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 14 }
@@ -4708,7 +4392,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #oligarchism makes a speech
 country_event = {
@@ -4740,7 +4423,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.215.a	#Do nothing
+		name = bankruptcy.215.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.215.a executed"
 		set_temp_variable = { party_index = 15 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4750,7 +4433,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.215.b	#Counter-campaign
+		name = bankruptcy.215.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.215.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 15 }
@@ -4759,7 +4442,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Neutral_Libertarian makes a speech
 country_event = {
@@ -4791,7 +4473,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.216.a	#Do nothing
+		name = bankruptcy.216.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.216.a executed"
 		set_temp_variable = { party_index = 16 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4801,7 +4483,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.216.b	#Counter-campaign
+		name = bankruptcy.216.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.216.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 16 }
@@ -4810,7 +4492,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Neutral_green makes a speech
 country_event = {
@@ -4842,7 +4523,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.217.a	#Do nothing
+		name = bankruptcy.217.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.217.a executed"
 		set_temp_variable = { party_index = 17 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4852,7 +4533,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.217.b	#Counter-campaign
+		name = bankruptcy.217.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.217.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 17 }
@@ -4861,7 +4542,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #neutral_Social makes a speech
 country_event = {
@@ -4893,7 +4573,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.218.a	#Do nothing
+		name = bankruptcy.218.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.218.a executed"
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4903,7 +4583,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.218.b	#Counter-campaign
+		name = bankruptcy.218.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.218.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 18 }
@@ -4912,7 +4592,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Neutral_Communism makes a speech
 country_event = {
@@ -4944,7 +4623,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.219.a	#Do nothing
+		name = bankruptcy.219.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.219.a executed"
 		set_temp_variable = { party_index = 19 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -4954,7 +4633,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.219.b	#Counter-campaign
+		name = bankruptcy.219.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.219.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 19 }
@@ -4963,7 +4642,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Nat_Populism makes a speech
 country_event = {
@@ -4995,7 +4673,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.220.a	#Do nothing
+		name = bankruptcy.220.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.220.a executed"
 		set_temp_variable = { party_index = 20 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -5005,7 +4683,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.220.b	#Counter-campaign
+		name = bankruptcy.220.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.220.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 20 }
@@ -5014,7 +4692,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Nat_Fascism makes a speech
 country_event = {
@@ -5046,7 +4723,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.221.a	#Do nothing
+		name = bankruptcy.221.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.221.a executed"
 		set_temp_variable = { party_index = 21 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -5056,7 +4733,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.221.b	#Counter-campaign
+		name = bankruptcy.221.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.221.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 21 }
@@ -5065,7 +4742,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Nat_Autocracy makes a speech
 country_event = {
@@ -5098,7 +4774,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.222.a	#Do nothing
+		name = bankruptcy.222.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.222.a executed"
 		set_temp_variable = { party_index = 22 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -5108,7 +4784,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.222.b	#Counter-campaign
+		name = bankruptcy.222.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.222.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 22 }
@@ -5117,7 +4793,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 #Monarchist makes a speech
 country_event = {
@@ -5150,7 +4825,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.223.a	#Do nothing
+		name = bankruptcy.223.a #Do nothing
 		log = "[GetDateText]: [This.GetName]: bankruptcy.223.a executed"
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
@@ -5160,7 +4835,7 @@ country_event = {
 	}
 
 	option = {
-		name = bankruptcy.223.b	#Counter-campaign
+		name = bankruptcy.223.b #Counter-campaign
 		log = "[GetDateText]: [This.GetName]: bankruptcy.223.b executed"
 		lose_pp_for_15_days = yes
 		set_temp_variable = { party_index = 23 }
@@ -5169,7 +4844,6 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 70 }
 	}
-
 }
 
 ### we got the bailout - biggest influencer
@@ -5181,7 +4855,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = News_bankruptcy.1.a }
-
 }
 
 ### we got the bailout - 2nd biggest influencer
@@ -5193,7 +4866,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = News_bankruptcy.2.a }
-
 }
 ### we got the bailout - neighbour
 news_event = {
@@ -5204,7 +4876,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = News_bankruptcy.3.a }
-
 }
 ###[FROM.GetNameDef] Prepares for New Elections
 news_event = {
@@ -5215,7 +4886,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = News_bankruptcy.4.a }
-
 }
 ###Radical Political Shift in [FROM.GetNameDef]
 news_event = {
@@ -5226,7 +4896,6 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = News_bankruptcy.5.a }
-
 }
 ###Financial Collapse Leads to Conflict in [FROM.GetNameDef]
 news_event = {
@@ -5237,5 +4906,4 @@ news_event = {
 	is_triggered_only = yes
 
 	option = { name = News_bankruptcy.6.a }
-
 }

--- a/events/Egypt.txt
+++ b/events/Egypt.txt
@@ -10,7 +10,6 @@ country_event = {
 	id = egypt_evergreen.2
 	title = egypt_evergreen.2.t
 	desc = egypt_evergreen.2.d
-
 	picture = GFX_treaty
 	is_triggered_only = yes
 
@@ -27,7 +26,6 @@ country_event = {
 	id = egypt_evergreen.3
 	title = egypt_evergreen.3.t
 	desc = egypt_evergreen.3.d
-
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
@@ -43,7 +41,6 @@ country_event = {
 	id = egypt_evergreen.4
 	title = egypt_evergreen.4.t
 	desc = egypt_evergreen.4.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -57,7 +54,6 @@ country_event = {
 	id = egypt_evergreen.1
 	title = egypt_evergreen.1.t
 	desc = egypt_evergreen.1.d
-
 	picture = GFX_generic_tractor_manufacturer
 	is_triggered_only = yes
 
@@ -76,10 +72,8 @@ country_event = {
 		EGY = {
 			country_event = { id = egypt_evergreen.2 days = 1 }
 		}
-
 		ai_chance = {
 			base = 1
-
 			modifier = {
 				THIS = { has_opinion = { target = EGY value > -20 } }
 				add = 10
@@ -90,11 +84,11 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt_evergreen.1.b
 		log = "[GetDateText]: [This.GetName]: egypt_evergreen.1.b executed"
 		EGY = { country_event = { id = egypt_evergreen.3 days = 1 } }
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -104,7 +98,6 @@ country_event = {
 	title = Egypt.1.t
 	desc = Egypt.1.d
 	picture = GFX_egy_flagg
-
 	is_triggered_only = yes
 
 	option = {
@@ -120,7 +113,6 @@ country_event = {
 	title = Egypt.2.t
 	desc = Egypt.2.d
 	picture = GFX_iraq_war3
-
 	is_triggered_only = yes
 
 	option = {
@@ -147,6 +139,7 @@ country_event = {
 		add_stability = 0.05
 		USA = { country_event = Egypt.3 }
 	}
+
 	option = {
 		name = Egypt.2.b
 		log = "[GetDateText]: [This.GetName]: Egypt.2.b executed"
@@ -182,7 +175,6 @@ country_event = {
 	title = Egypt.3.t
 	desc = Egypt.3.d
 	picture = GFX_arab_spring_defection
-
 	is_triggered_only = yes
 
 	option = {
@@ -209,7 +201,6 @@ country_event = {
 	title = Egypt.4.t
 	desc = Egypt.4.d
 	picture = GFX_belarus_send_weapon_to_iraq
-
 	is_triggered_only = yes
 
 	option = {
@@ -258,8 +249,9 @@ country_event = {
 	id = Egypt.5
 	title = Egypt.5.t
 	desc = Egypt.5.d
-	is_triggered_only = yes
 	picture = GFX_paris_convention
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.5.a
 		log = "[GetDateText]: [This.GetName]: Egypt.5.a executed"
@@ -289,6 +281,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = Egypt.5.b
 		log = "[GetDateText]: [This.GetName]: Egypt.5.b executed"
@@ -317,8 +310,9 @@ country_event = {
 	id = Egypt.6
 	title = Egypt.6.t
 	desc = Egypt.6.d
-	is_triggered_only = yes
 	picture = GFX_paris_convention
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.6.a
 		ai_chance = { base = 1 }
@@ -329,8 +323,9 @@ country_event = {
 	id = Egypt.7
 	title = Egypt.7.t
 	desc = Egypt.7.d
-	is_triggered_only = yes
 	picture = GFX_paris_convention
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.7.a
 		log = "[GetDateText]: [This.GetName]: Egypt.7.a executed"
@@ -343,8 +338,9 @@ country_event = {
 	id = Egypt.8
 	title = Egypt.8.t
 	desc = Egypt.8.d
-	is_triggered_only = yes
 	picture = GFX_Hatay
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.8.a
 		log = "[GetDateText]: [This.GetName]: Egypt.8.a executed"
@@ -378,13 +374,10 @@ country_event = {
 				active = no
 			}
 		}
-		SYR = {
-			country_event = Egypt.10
-	 }
-	   EGY = {
-			country_event = Egypt.10
-	 }
+		SYR = { country_event = Egypt.10 }
+	   EGY = { country_event = Egypt.10 }
 	}
+
 	option = {
 		name = Egypt.8.b
 		log = "[GetDateText]: [This.GetName]: Egypt.8.b executed"
@@ -416,12 +409,8 @@ country_event = {
 				target = SYR
 			}
 		}
-	   SYR = {
-			country_event = Egypt.9
-	 }
-	   EGY = {
-			country_event = Egypt.9
-	 }
+	   SYR = { country_event = Egypt.9 }
+	   EGY = { country_event = Egypt.9 }
 	}
 }
 
@@ -429,8 +418,9 @@ country_event = {
 	id = Egypt.9
 	title = Egypt.9.t
 	desc = Egypt.9.d
-	is_triggered_only = yes
 	picture = GFX_Hatay
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.9.a
 		ai_chance = { base = 1 }
@@ -441,8 +431,9 @@ country_event = {
 	id = Egypt.10
 	title = Egypt.10.t
 	desc = Egypt.10.d
-	is_triggered_only = yes
 	picture = GFX_Hatay
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.10.a
 		log = "[GetDateText]: [This.GetName]: Egypt.10.a executed"
@@ -466,8 +457,9 @@ country_event = {
 	id = Egypt.11
 	title = Egypt.11.t
 	desc = Egypt.11.d
-	is_triggered_only = yes
 	picture = GFX_taliban_police_attack
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.11.a
 		log = "[GetDateText]: [This.GetName]: Egypt.11.a executed"
@@ -483,6 +475,7 @@ country_event = {
 		}
 		EGY = { country_event = Egypt.12 }
 	}
+
 	option = {
 		name = Egypt.11.b
 		log = "[GetDateText]: [This.GetName]: Egypt.11.b executed"
@@ -504,14 +497,13 @@ country_event = {
 	id = Egypt.12
 	title = Egypt.12.t
 	desc = Egypt.12.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.12.a
 		log = "[GetDateText]: [This.GetName]: Egypt.12.a executed"
-		PAL = {
-			country_event = Egypt.14
-		}
+		PAL = { country_event = Egypt.14 }
 		ai_chance = { base = 1 }
 	}
 }
@@ -520,8 +512,9 @@ country_event = {
 	id = Egypt.13
 	title = Egypt.13.t
 	desc = Egypt.13.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.13.a
 		log = "[GetDateText]: [This.GetName]: Egypt.13.a executed"
@@ -537,8 +530,9 @@ country_event = {
 	id = Egypt.14
 	title = Egypt.14.t
 	desc = Egypt.14.d
-	is_triggered_only = yes
 	picture = GFX_iran_quds
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.14.a
 		log = "[GetDateText]: [This.GetName]: Egypt.14.a executed"
@@ -556,6 +550,7 @@ country_event = {
 		EGY = { add_state_core = 209 }
 		209 = { transfer_state_to = EGY }
 	}
+
 	option = {
 		name = Egypt.14.b
 		log = "[GetDateText]: [This.GetName]: Egypt.14.b executed"
@@ -592,9 +587,7 @@ country_event = {
 				}
 			}
 		}
-		else = {
-			EGY = { country_event = Egypt.16 }
-		}
+		else = { EGY = { country_event = Egypt.16 } }
 	}
 }
 
@@ -602,8 +595,9 @@ country_event = {
 	id = Egypt.15
 	title = Egypt.15.t
 	desc = Egypt.15.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.15.a
 		log = "[GetDateText]: [This.GetName]: Egypt.15.a executed"
@@ -618,8 +612,9 @@ country_event = {
 	id = Egypt.16
 	title = Egypt.16.t
 	desc = Egypt.16.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.16.a
 		log = "[GetDateText]: [This.GetName]: Egypt.16.a executed"
@@ -643,8 +638,9 @@ country_event = {
 	id = Egypt.17
 	title = Egypt.17.t
 	desc = Egypt.17.d
-	is_triggered_only = yes
 	picture = GFX_retaliatory_strike
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.17.a
 		log = "[GetDateText]: [This.GetName]: Egypt.17.a executed"
@@ -654,6 +650,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = Egypt.17.b
 		log = "[GetDateText]: [This.GetName]: Egypt.17.b executed"
@@ -663,6 +660,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = Egypt.17.c
 		log = "[GetDateText]: [This.GetName]: Egypt.17.c executed"
@@ -678,8 +676,9 @@ country_event = {
 	id = Egypt.18
 	title = Egypt.18.t
 	desc = Egypt.18.d
-	is_triggered_only = yes
 	picture = GFX_boko_haram_insurgency
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.18.a
 		log = "[GetDateText]: [This.GetName]: Egypt.18.a executed"
@@ -695,8 +694,9 @@ country_event = {
 	id = Egypt.19
 	title = Egypt.19.t
 	desc = Egypt.19.d
-	is_triggered_only = yes
 	picture = GFX_report_event_Italy_From_Space
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.19.a
 		log = "[GetDateText]: [This.GetName]: Egypt.19.a executed"
@@ -713,6 +713,7 @@ country_event = {
 		EGY = { country_event = Egypt.20 }
 		hidden_effect = { set_country_flag = didsupp_egy_terror }
 	}
+
 	option = {
 		name = Egypt.19.b
 		log = "[GetDateText]: [This.GetName]: Egypt.19.b executed"
@@ -731,8 +732,9 @@ country_event = {
 	id = Egypt.20
 	title = Egypt.20.t
 	desc = Egypt.20.d
-	is_triggered_only = yes
 	picture = GFX_fbi
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.20.a
 		log = "[GetDateText]: [This.GetName]: Egypt.20.a executed"
@@ -746,8 +748,9 @@ country_event = {
 	id = Egypt.21
 	title = Egypt.21.t
 	desc = Egypt.21.d
-	is_triggered_only = yes
 	picture = GFX_george_w_bush
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.21.a
 		log = "[GetDateText]: [This.GetName]: Egypt.21.a executed"
@@ -772,8 +775,9 @@ country_event = {
 	id = Egypt.22
 	title = Egypt.22.t
 	desc = Egypt.22.d
-	is_triggered_only = yes
 	picture = GFX_report_event_Arrest_5
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.22.a
 		log = "[GetDateText]: [This.GetName]: Egypt.22.a executed"
@@ -791,8 +795,9 @@ country_event = {
 	id = Egypt.23
 	title = Egypt.23.t
 	desc = Egypt.23.d
-	is_triggered_only = yes
 	picture = GFX_turkishmafia
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.23.a
 		log = "[GetDateText]: [This.GetName]: Egypt.23.a executed"
@@ -817,8 +822,9 @@ country_event = {
 	id = Egypt.236
 	title = Egypt.236.t
 	desc = Egypt.236.d
-	is_triggered_only = yes
 	picture = GFX_turkishmafia
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.236.a
 		log = "[GetDateText]: [This.GetName]: Egypt.236.a executed"
@@ -843,8 +849,9 @@ country_event = {
 	id = Egypt.24
 	title = Egypt.24.t
 	desc = Egypt.24.d
-	is_triggered_only = yes
 	picture = GFX_report_event_Arrest_4
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.24.a
 		log = "[GetDateText]: [This.GetName]: Egypt.24.a executed"
@@ -873,8 +880,9 @@ country_event = {
 	id = Egypt.25
 	title = Egypt.25.t
 	desc = Egypt.25.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.25.a
 		log = "[GetDateText]: [This.GetName]: Egypt.25.a executed"
@@ -897,6 +905,7 @@ country_event = {
 		set_temp_variable = { influence_target = EGY }
 		change_influence_percentage = yes
 	}
+
 	option = {
 		name = Egypt.25.b
 		log = "[GetDateText]: [This.GetName]: Egypt.25.b executed"
@@ -918,8 +927,9 @@ country_event = {
 	id = Egypt.26
 	title = Egypt.26.t
 	desc = Egypt.26.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.26.a
 		log = "[GetDateText]: [This.GetName]: Egypt.26.a executed"
@@ -944,8 +954,9 @@ country_event = {
 	id = Egypt.27
 	title = Egypt.27.t
 	desc = Egypt.27.d
-	is_triggered_only = yes
 	picture = GFX_internal_conflict
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.27.a
 		ai_chance = { base = 1 }
@@ -956,8 +967,9 @@ country_event = {
 	id = Egypt.28
 	title = Egypt.28.t
 	desc = Egypt.28.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.28.a
 		log = "[GetDateText]: [This.GetName]: Egypt.28.a executed"
@@ -992,6 +1004,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -4.00 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = Egypt.28.b
 		log = "[GetDateText]: [This.GetName]: Egypt.28.b executed"
@@ -1013,8 +1026,9 @@ country_event = {
 	id = Egypt.29
 	title = Egypt.29.t
 	desc = Egypt.29.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.29.a
 		log = "[GetDateText]: [This.GetName]: Egypt.29.a executed"
@@ -1041,8 +1055,9 @@ country_event = {
 	id = Egypt.30
 	title = Egypt.30.t
 	desc = Egypt.30.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.30.a
 		ai_chance = { base = 1 }
@@ -1053,14 +1068,16 @@ country_event = {
 	id = Egypt.31
 	title = Egypt.31.t
 	desc = Egypt.31.d
-	is_triggered_only = yes
 	picture = GFX_negotiations
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.31.a
 		log = "[GetDateText]: [This.GetName]: Egypt.31.a executed"
 		ai_chance = { base = 1 }
 		EGY = { country_event = Egypt.32 }
 	}
+
 	option = {
 		name = Egypt.31.b
 		log = "[GetDateText]: [This.GetName]: Egypt.31.a executed"
@@ -1073,8 +1090,9 @@ country_event = {
 	id = Egypt.32
 	title = Egypt.32.t
 	desc = Egypt.32.d
-	is_triggered_only = yes
 	picture = GFX_negotiations
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.32.a
 		log = "[GetDateText]: [This.GetName]: Egypt.32.a executed"
@@ -1090,8 +1108,9 @@ country_event = {
 	id = Egypt.33
 	title = Egypt.33.t
 	desc = Egypt.33.d
-	is_triggered_only = yes
 	picture = GFX_negotiations
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.33.a
 		ai_chance = { base = 1 }
@@ -1102,8 +1121,9 @@ country_event = {
 	id = Egypt.34
 	title = Egypt.34.t
 	desc = Egypt.34.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.34.a
 		log = "[GetDateText]: [This.GetName]: Egypt.34.a executed"
@@ -1129,6 +1149,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = Egypt.34.b
 		log = "[GetDateText]: [This.GetName]: Egypt.34.a executed"
@@ -1150,8 +1171,9 @@ country_event = {
 	id = Egypt.35
 	title = Egypt.35.t
 	desc = Egypt.35.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.35.a
 		log = "[GetDateText]: [This.GetName]: Egypt.35.a executed"
@@ -1164,8 +1186,9 @@ country_event = {
 	id = Egypt.36
 	title = Egypt.36.t
 	desc = Egypt.36.d
-	is_triggered_only = yes
 	picture = GFX_mars_colony_20
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.36.a
 		ai_chance = { base = 1 }
@@ -1176,8 +1199,9 @@ country_event = {
 	id = Egypt.375
 	title = Egypt.375.t
 	desc = Egypt.375.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.375.a
 		log = "[GetDateText]: [This.GetName]: Egypt.375.a executed"
@@ -1187,6 +1211,7 @@ country_event = {
 		custom_effect_tooltip = qatar_infl_egy_tt
 		EGY = { country_event = Egypt.38 }
 	}
+
 	option = {
 		name = Egypt.375.b
 		log = "[GetDateText]: [This.GetName]: Egypt.375.b executed"
@@ -1199,8 +1224,9 @@ country_event = {
 	id = Egypt.38
 	title = Egypt.38.t
 	desc = Egypt.38.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.38.a
 		log = "[GetDateText]: [This.GetName]: Egypt.38.a executed"
@@ -1218,8 +1244,9 @@ country_event = {
 	id = Egypt.39
 	title = Egypt.39.t
 	desc = Egypt.39.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.39.a
 		log = "[GetDateText]: [This.GetName]: Egypt.39.a executed"
@@ -1239,8 +1266,9 @@ country_event = {
 	id = Egypt.40
 	title = Egypt.40.t
 	desc = Egypt.40.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.40.a
 		log = "[GetDateText]: [This.GetName]: Egypt.40.a executed"
@@ -1256,6 +1284,7 @@ country_event = {
 			target = ETH
 		}
 	}
+
 	option = {
 		name = Egypt.40.b
 		log = "[GetDateText]: [This.GetName]: Egypt.40.b executed"
@@ -1284,14 +1313,16 @@ country_event = {
 	id = Egypt.41
 	title = Egypt.41.t
 	desc = Egypt.41.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.41.a
 		log = "[GetDateText]: [This.GetName]: Egypt.41.a executed"
 		ai_chance = { base = 1 }
 		EGY = { add_to_faction = ROOT }
 	}
+
 	option = {
 		name = Egypt.41.b
 		log = "[GetDateText]: [This.GetName]: Egypt.41.b executed"
@@ -1311,8 +1342,9 @@ country_event = {
 	id = Egypt.42
 	title = Egypt.42.t
 	desc = Egypt.42.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.42.a
 		log = "[GetDateText]: [This.GetName]: Egypt.42.a executed"
@@ -1333,8 +1365,9 @@ country_event = {
 	id = Egypt.43
 	title = Egypt.43.t
 	desc = Egypt.43.d
-	is_triggered_only = yes
 	picture = GFX_arab_spring_defection
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.43.a
 		log = "[GetDateText]: [This.GetName]: Egypt.43.a executed"
@@ -1351,12 +1384,10 @@ country_event = {
 }
 
 country_event = {
-
 	id = Egypt.44
 	title = Egypt.44.t
 	desc = Egypt.44.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -1366,12 +1397,10 @@ country_event = {
 }
 
 country_event = {
-
 	id = Egypt.45
 	title = Egypt.45.t
 	desc = Egypt.45.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -1382,6 +1411,7 @@ country_event = {
 		change_the_military_opinion = yes
 		ISR = { country_event = Egypt.46 }
 	}
+
 	option = {
 		name = Egypt.45.b
 		log = "[GetDateText]: [This.GetName]: Egypt.45.b executed"
@@ -1391,6 +1421,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_the_military_opinion = yes
 	}
+
 	option = {
 		name = Egypt.45.c
 		log = "[GetDateText]: [This.GetName]: Egypt.45.c executed"
@@ -1412,12 +1443,10 @@ country_event = {
 }
 
 country_event = {
-
 	id = Egypt.46
 	title = Egypt.46.t
 	desc = Egypt.46.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -1444,6 +1473,7 @@ country_event = {
 			change_influence_percentage = yes
 		}
 	}
+
 	option = {
 		name = Egypt.46.b
 		log = "[GetDateText]: [This.GetName]: Egypt.46.b executed"
@@ -1466,12 +1496,10 @@ country_event = {
 }
 
 country_event = {
-
 	id = Egypt.47
 	title = Egypt.47.t
 	desc = Egypt.47.d
 	picture = GFX_united_arab_republic
-
 	is_triggered_only = yes
 
 	option = {
@@ -1490,6 +1518,7 @@ country_event = {
 	desc = Egypt.48.d
 	picture = GFX_message_signing
 	is_triggered_only = yes
+
 	option = {
 		name = Egypt.48.a
 		log = "[GetDateText]: [This.GetName]: Egypt.48.a"
@@ -1500,6 +1529,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		ai_chance = { base = 25 }
 	}
+
 	option = {
 		name = Egypt.48.b
 		log = "[GetDateText]: [This.GetName]: Egypt.48.b"
@@ -1517,7 +1547,6 @@ country_event = {
 	title = Egypt.49.t
 	desc = Egypt.49.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -1533,6 +1562,7 @@ country_event = {
 		set_temp_variable = { percent_change = 2 }
 		change_domestic_influence_percentage = yes
 	}
+
 	option = {
 		name = Egypt.49.b
 		log = "[GetDateText]: [This.GetName]: Egypt.49.b executed"
@@ -1555,7 +1585,6 @@ country_event = {
 	title = Egypt.50.t
 	desc = Egypt.50.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -1578,7 +1607,6 @@ country_event = {
 	title = Egypt.51.t
 	desc = Egypt.51.d
 	picture = GFX_new_intifada
-
 	is_triggered_only = yes
 
 	option = {
@@ -1606,7 +1634,6 @@ country_event = {
 	title = Egypt.52.t
 	desc = Egypt.52.d
 	picture = GFX_lulw
-
 	is_triggered_only = yes
 
 	option = {
@@ -1626,7 +1653,6 @@ country_event = {
 	title = Egypt.53.t
 	desc = Egypt.53.d
 	picture = GFX_handshake_black
-
 	is_triggered_only = yes
 
 	option = {
@@ -1636,6 +1662,7 @@ country_event = {
 		add_stability = 0.05
 		add_political_power = 50
 	}
+
 	option = {
 		name = Egypt.53.b
 		log = "[GetDateText]: [This.GetName]: Egypt.53.b executed"
@@ -1651,10 +1678,8 @@ country_event = {
 	title = egypt.100.t
 	desc = egypt.100.d
 	picture = GFX_evergreen_stuck
-
-	fire_only_once = yes
-
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	trigger = {
 		tag = EGY
@@ -1682,6 +1707,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	#trust in the authorities
 	option = {
 		name = egypt.100.b
@@ -1702,6 +1728,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	#act with cautious
 	option = {
 		name = egypt.100.c
@@ -1749,7 +1776,6 @@ news_event = {
 			limit = { EGY = { has_country_flag = EGY_act_with_cautious } }
 			custom_effect_tooltip = EGY_act_with_cautious_tt
 		}
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -1759,7 +1785,6 @@ country_event = {
 	title = egypt.102.t
 	desc = egypt.102.d
 	picture = GFX_evergreen_tucked
-
 	is_triggered_only = yes
 
 	#
@@ -1773,7 +1798,6 @@ country_event = {
 			clr_country_flag = EGY_trust_authorities
 			clr_country_flag = EGY_act_with_cautious
 			clr_global_flag = SUEZ_CANAL_BLOCKED
-
 			news_event = { id = egypt.103 hours = 16 }
 		}
 		ai_chance = { base = 1 }
@@ -1790,7 +1814,6 @@ news_event = {
 
 	option = {
 		name = egypt.103.a
-
 		ai_chance = { base = 1 }
 	}
 }
@@ -1799,7 +1822,6 @@ country_event = {
 	title = egypt.104.t
 	desc = egypt.104.d
 	picture = GFX_iraq_war3
-
 	is_triggered_only = yes
 
 	#
@@ -1813,6 +1835,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.104.b
 		log = "[GetDateText]: [This.GetName]: egypt.104.b executed"
@@ -1828,7 +1851,6 @@ country_event = {
 	title = egypt_copts.1.t
 	desc = egypt_copts.1.d
 	picture = GFX_taliban_attack_building
-
 	is_triggered_only = yes
 
 	#
@@ -1856,6 +1878,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt_copts.1.b
 		log = "[GetDateText]: [This.GetName]: egypt_copts.1.b executed"
@@ -1884,7 +1907,6 @@ country_event = {
 	title = egypt_copts.2.t
 	desc = egypt_copts.2.d
 	picture = GFX_egyptian_christian_massacre
-
 	is_triggered_only = yes
 
 	#
@@ -1912,6 +1934,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt_copts.2.b
 		log = "[GetDateText]: [This.GetName]: egypt_copts.2.b executed"
@@ -1940,7 +1963,6 @@ country_event = {
 	title = egypt_copts.3.t
 	desc = egypt_copts.3.d
 	picture = GFX_iranian_civ_war_country
-
 	is_triggered_only = yes
 
 	#
@@ -1968,6 +1990,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt_copts.3.b
 		log = "[GetDateText]: [This.GetName]: egypt_copts.3.b executed"
@@ -1996,7 +2019,6 @@ country_event = {
 	title = egypt_copts.4.t
 	desc = egypt_copts.4.d
 	picture = GFX_report_event_crocifisso
-
 	is_triggered_only = yes
 
 	#
@@ -2024,6 +2046,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt_copts.4.b
 		log = "[GetDateText]: [This.GetName]: egypt_copts.4.b executed"
@@ -2052,7 +2075,6 @@ country_event = {
 	title = egypt_copts.5.t
 	desc = egypt_copts.5.d
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	#
@@ -2080,6 +2102,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt_copts.5.b
 		log = "[GetDateText]: [This.GetName]: egypt_copts.5.b executed"
@@ -2108,7 +2131,6 @@ country_event = {
 	title = egypt.105.t
 	desc = egypt.105.d
 	picture = GFX_SYR_tahrir_al_sham
-
 	is_triggered_only = yes
 
 	#
@@ -2123,7 +2145,6 @@ country_event = {
 	title = egypt.106.t
 	desc = egypt.106.d
 	picture = GFX_turkishmafia
-
 	is_triggered_only = yes
 
 	#
@@ -2144,7 +2165,6 @@ country_event = {
 	title = egypt.107.t
 	desc = egypt.107.d
 	picture = GFX_SAU_generic
-
 	is_triggered_only = yes
 
 	#
@@ -2170,6 +2190,7 @@ country_event = {
 		change_influence_percentage = yes
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.107.b
 		log = "[GetDateText]: [This.GetName]: egypt.107.b executed"
@@ -2187,7 +2208,6 @@ country_event = {
 	title = egypt.108.t
 	desc = egypt.108.d
 	picture = GFX_SAU_generic
-
 	is_triggered_only = yes
 
 	#
@@ -2202,7 +2222,6 @@ country_event = {
 	title = egypt.109.t
 	desc = egypt.109.d
 	picture = GFX_boko_haram_insurgency
-
 	is_triggered_only = yes
 
 	#
@@ -2230,7 +2249,6 @@ country_event = {
 	title = egypt.110.t
 	desc = egypt.110.d
 	picture = GFX_boko_haram_insurgency
-
 	is_triggered_only = yes
 
 	#
@@ -2258,7 +2276,6 @@ country_event = {
 	title = egypt.111.t
 	desc = egypt.111.d
 	picture = GFX_EST_VictoryColumng
-
 	is_triggered_only = yes
 
 	#
@@ -2278,8 +2295,9 @@ country_event = {
 	id = Egypt.112
 	title = Egypt.112.t
 	desc = Egypt.112.d
-	is_triggered_only = yes
 	picture = GFX_vladimir_putin
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.112.a
 		log = "[GetDateText]: [This.GetName]: Egypt.112.a executed"
@@ -2296,6 +2314,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = Egypt.112.b
 		log = "[GetDateText]: [This.GetName]: Egypt.112.a executed"
@@ -2308,8 +2327,9 @@ country_event = {
 	id = Egypt.113
 	title = Egypt.113.t
 	desc = Egypt.113.d
-	is_triggered_only = yes
 	picture = GFX_vladimir_putin
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.113.a
 		log = "[GetDateText]: [This.GetName]: Egypt.113.a executed"
@@ -2322,8 +2342,9 @@ country_event = {
 	id = Egypt.114
 	title = Egypt.114.t
 	desc = Egypt.114.d
-	is_triggered_only = yes
 	picture = GFX_vladimir_putin
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.114.a
 		ai_chance = { base = 1 }
@@ -2334,8 +2355,9 @@ country_event = {
 	id = Egypt.115
 	title = Egypt.115.t
 	desc = Egypt.115.d
-	is_triggered_only = yes
 	picture = GFX_harbor
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.115.a
 		log = "[GetDateText]: [This.GetName]: Egypt.115.a executed"
@@ -2361,6 +2383,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = Egypt.115.b
 		log = "[GetDateText]: [This.GetName]: Egypt.115.a executed"
@@ -2382,8 +2405,9 @@ country_event = {
 	id = Egypt.116
 	title = Egypt.116.t
 	desc = Egypt.116.d
-	is_triggered_only = yes
 	picture = GFX_harbor
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.116.a
 		log = "[GetDateText]: [This.GetName]: Egypt.116.a executed"
@@ -2396,8 +2420,9 @@ country_event = {
 	id = Egypt.117
 	title = Egypt.117.t
 	desc = Egypt.117.d
-	is_triggered_only = yes
 	picture = GFX_harbor
+	is_triggered_only = yes
+
 	option = {
 		name = Egypt.117.a
 		ai_chance = { base = 1 }
@@ -2409,7 +2434,6 @@ country_event = {
 	title = egypt.118.t
 	desc = egypt.118.d
 	picture = GFX_american_troops
-
 	is_triggered_only = yes
 
 	#
@@ -2445,6 +2469,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = egypt.118.b
 		log = "[GetDateText]: [This.GetName]: egypt.118.b executed"
@@ -2472,7 +2497,6 @@ country_event = {
 	title = egypt.119.t
 	desc = egypt.119.d
 	picture = GFX_american_troops
-
 	is_triggered_only = yes
 
 	#
@@ -2487,7 +2511,6 @@ country_event = {
 	title = egypt.120.t
 	desc = egypt.120.d
 	picture = GFX_TUR_generic
-
 	is_triggered_only = yes
 
 	#
@@ -2512,6 +2535,7 @@ country_event = {
 		change_influence_percentage = yes
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.120.b
 		log = "[GetDateText]: [This.GetName]: egypt.120.b executed"
@@ -2553,7 +2577,6 @@ country_event = {
 	title = egypt.121.t
 	desc = egypt.121.d
 	picture = GFX_american_troops
-
 	is_triggered_only = yes
 
 	#
@@ -2580,7 +2603,6 @@ country_event = {
 	title = egypt.122.t
 	desc = egypt.122.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	#
@@ -2595,6 +2617,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.122.b
 		log = "[GetDateText]: [This.GetName]: egypt.122.b executed"
@@ -2617,7 +2640,6 @@ country_event = {
 	title = egypt.123.t
 	desc = egypt.123.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -2668,6 +2690,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.123.b
 		log = "[GetDateText]: [This.GetName]: egypt.123.b executed"
@@ -2681,6 +2704,7 @@ country_event = {
 	desc = egypt.124.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.124.a
 		ai_chance = { base = 1 }
@@ -2692,6 +2716,7 @@ country_event = {
 	desc = egypt.125.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.125.a
 		ai_chance = { base = 1 }
@@ -2702,7 +2727,6 @@ country_event = {
 	title = egypt.129.t
 	desc = egypt.129.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -2754,6 +2778,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.129.b
 		log = "[GetDateText]: [This.GetName]: egypt.129.b executed"
@@ -2767,6 +2792,7 @@ country_event = {
 	desc = egypt.130.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.130.a
 		ai_chance = { base = 1 }
@@ -2778,6 +2804,7 @@ country_event = {
 	desc = egypt.131.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.131.a
 		ai_chance = { base = 1 }
@@ -2788,7 +2815,6 @@ country_event = {
 	title = egypt.132.t
 	desc = egypt.132.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -2840,6 +2866,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.132.b
 		log = "[GetDateText]: [This.GetName]: egypt.132.b executed"
@@ -2853,6 +2880,7 @@ country_event = {
 	desc = egypt.133.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.133.a
 		ai_chance = { base = 1 }
@@ -2864,6 +2892,7 @@ country_event = {
 	desc = egypt.134.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.134.a
 		ai_chance = { base = 1 }
@@ -2874,7 +2903,6 @@ country_event = {
 	title = egypt.135.t
 	desc = egypt.135.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -2901,6 +2929,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.135.b
 		log = "[GetDateText]: [This.GetName]: egypt.135.b executed"
@@ -2914,6 +2943,7 @@ country_event = {
 	desc = egypt.136.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.136.a
 		ai_chance = { base = 1 }
@@ -2925,6 +2955,7 @@ country_event = {
 	desc = egypt.137.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.137.a
 		ai_chance = { base = 1 }
@@ -2935,7 +2966,6 @@ country_event = {
 	title = egypt.138.t
 	desc = egypt.138.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -2965,6 +2995,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.138.b
 		log = "[GetDateText]: [This.GetName]: egypt.138.b executed"
@@ -2979,6 +3010,7 @@ country_event = {
 	desc = egypt.139.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.139.a
 		ai_chance = { base = 1 }
@@ -2990,6 +3022,7 @@ country_event = {
 	desc = egypt.140.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.140.a
 		ai_chance = { base = 1 }
@@ -3002,26 +3035,22 @@ country_event = {
 	title = egypt.141.t
 	desc = egypt.141.d
 	picture = GFX_turkeycoup
-
+	is_triggered_only = yes
 	fire_only_once = yes
 
-	is_triggered_only = yes
-
 	option = {
-		name = egypt.141.a	#Side with military peaceful
+		name = egypt.141.a #Side with military peaceful
 		log = "[GetDateText]: [This.GetName]: egypt.141.a executed"
 		if = {
 			limit = { NOT = { has_idea = EGY_guards_of_secularism } }
 			add_ideas = EGY_guards_of_secularism
 		}
-
 		if = {
 			limit = { NOT = { check_variable = { ruling_party = 22 } } }
 			set_temp_variable = { rul_party_temp = 22 }
 			set_temp_variable = { disable_elections = 0 }
 			change_ruling_party_effect = yes
 		}
-
 		create_country_leader = {
 			name = "High Military Command of Egypt"
 			picture = "egypt_junta.dds"
@@ -3035,7 +3064,6 @@ country_event = {
 		}
 		set_cosmetic_tag = EGY_REB_S_nationalist
 		set_variable = { dynamic_flag_variant = 8 }
-
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -3044,8 +3072,9 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
-		name = egypt.141.b	#Side with islam warrrr
+		name = egypt.141.b #Side with islam warrrr
 		log = "[GetDateText]: [This.GetName]: egypt.141.b executed"
 		if = {
 			limit = { has_idea = EGY_guards_of_secularism }
@@ -3073,7 +3102,6 @@ country_event = {
 				change_ruling_party_effect = yes
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -3092,7 +3120,6 @@ country_event = {
 	title = egypt.142.t
 	desc = egypt.142.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	option = {
@@ -3116,6 +3143,7 @@ country_event = {
 		change_influence_percentage = yes
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.142.b
 		log = "[GetDateText]: [This.GetName]: egypt.142.b executed"
@@ -3133,7 +3161,6 @@ country_event = {
 	title = egypt.143.t
 	desc = egypt.143.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3148,7 +3175,6 @@ country_event = {
 	title = egypt.144.t
 	desc = egypt.144.d
 	picture = GFX_arab_spring_defection
-
 	is_triggered_only = yes
 
 	#
@@ -3191,6 +3217,7 @@ country_event = {
 		set_cosmetic_tag = UAR_communism
 		ai_chance = { base = 90 }
 	}
+
 	option = {
 		name = egypt.144.b
 		log = "[GetDateText]: [This.GetName]: egypt.144.b executed"
@@ -3208,10 +3235,10 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = {
 		name = egypt.144.c
 		log = "[GetDateText]: [This.GetName]: egypt.144.b executed"
-
 		set_temp_variable = { percent_change = 5 }
 		change_domestic_influence_percentage = yes
 		ai_chance = { base = 5 }
@@ -3223,7 +3250,6 @@ country_event = {
 	title = egypt.145.t
 	desc = egypt.145.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3233,6 +3259,7 @@ country_event = {
 		ai_chance = { base = 1 }
 		add_ideas = egy_secular_republic
 	}
+
 	option = {
 		name = egypt.145.b
 		log = "[GetDateText]: [This.GetName]: egypt.145.b executed"
@@ -3246,7 +3273,6 @@ country_event = {
 	title = egypt.146.t
 	desc = egypt.146.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3268,6 +3294,7 @@ country_event = {
 			add_to_faction = ROOT
 		}
 	}
+
 	option = {
 		name = egypt.146.b
 		log = "[GetDateText]: [This.GetName]: Egypt.146.b executed"
@@ -3290,7 +3317,6 @@ country_event = {
 	title = egypt.147.t
 	desc = egypt.147.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3307,7 +3333,6 @@ country_event = {
 	title = egypt.148.t
 	desc = egypt.148.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3322,7 +3347,6 @@ country_event = {
 	title = egypt.149.t
 	desc = egypt.149.d
 	picture = GFX_broken_infrastructure
-
 	is_triggered_only = yes
 
 	option = {
@@ -3336,7 +3360,6 @@ country_event = {
 	title = egypt.150.t
 	desc = egypt.150.d
 	picture = GFX_internal_faction_religion
-
 	is_triggered_only = yes
 
 	option = {
@@ -3350,7 +3373,6 @@ country_event = {
 	title = egypt.151.t
 	desc = egypt.151.d
 	picture = GFX_internal_faction_religion
-
 	is_triggered_only = yes
 
 	option = {
@@ -3484,6 +3506,7 @@ country_event = {
 		}
 		ai_chance = { base = 100 }
 	}
+
 	option = {
 		name = egypt.151.b
 		log = "[GetDateText]: [This.GetName]: Egypt.151.a executed"
@@ -3497,7 +3520,6 @@ country_event = {
 	title = egypt.152.t
 	desc = egypt.152.d
 	picture = GFX_internal_faction_religion
-
 	is_triggered_only = yes
 
 	option = {
@@ -3511,7 +3533,6 @@ country_event = {
 	title = egypt.153.t
 	desc = egypt.153.d
 	picture = GFX_internal_faction_religion
-
 	is_triggered_only = yes
 
 	option = {
@@ -3525,7 +3546,6 @@ country_event = {
 	title = egypt_sahar.1.t
 	desc = egypt_sahar.1.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3545,6 +3565,7 @@ country_event = {
 		set_country_flag = sha_egypt_helping
 		EGY = { country_event = egypt_sahar.7 }
 	}
+
 	option = {
 		name = egypt_sahar.1.b
 		log = "[GetDateText]: [This.GetName]: egypt_sahar.1.b executed"
@@ -3558,12 +3579,13 @@ country_event = {
 	title = egypt_sahar.2.t
 	desc = egypt_sahar.2.d
 	picture = GFX_african_union_forces
+	is_triggered_only = yes
+
 	trigger = {
 		tag = MOR
 		has_war_with = SHA
 		surrender_progress > 0.09
 	}
-	is_triggered_only = yes
 
 	#
 	option = {
@@ -3590,7 +3612,6 @@ country_event = {
 	title = egypt_sahar.3.t
 	desc = egypt_sahar.3.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3601,7 +3622,6 @@ country_event = {
 		MOR = { country_event = egypt_sahar.5
 				white_peace = SHA }
 		transfer_state = 373
-
 	}
 
 	option = {
@@ -3618,7 +3638,6 @@ country_event = {
 	title = egypt_sahar.4.t
 	desc = egypt_sahar.4.d
 	picture = GFX_plane_crash
-
 	is_triggered_only = yes
 
 	#
@@ -3635,7 +3654,6 @@ country_event = {
 	title = egypt_sahar.5.t
 	desc = egypt_sahar.5.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	#
@@ -3655,7 +3673,6 @@ country_event = {
 	title = egypt_sahar.6.t
 	desc = egypt_sahar.6.d
 	picture = GFX_african_union_forces
-
 	is_triggered_only = yes
 
 	#
@@ -3670,7 +3687,6 @@ country_event = {
 	title = egypt_sahar.7.t
 	desc = egypt_sahar.7.d
 	picture = GFX_weapons_arms1
-
 	is_triggered_only = yes
 
 	#
@@ -3688,7 +3704,6 @@ country_event = {
 	title = egypt_sahar.8.t
 	desc = egypt_sahar.8.d
 	picture = GFX_treaty_rejected
-
 	is_triggered_only = yes
 
 	#
@@ -3711,7 +3726,6 @@ country_event = {
 	title = egypt.154.t
 	desc = egypt.154.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3763,6 +3777,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.154.b
 		log = "[GetDateText]: [This.GetName]: egypt.154.b executed"
@@ -3777,6 +3792,7 @@ country_event = {
 	desc = egypt.155.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.155.a
 		ai_chance = { base = 1 }
@@ -3788,6 +3804,7 @@ country_event = {
 	desc = egypt.156.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.156.a
 		ai_chance = { base = 1 }
@@ -3798,7 +3815,6 @@ country_event = {
 	title = egypt.157.t
 	desc = egypt.157.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3849,6 +3865,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.157.b
 		log = "[GetDateText]: [This.GetName]: egypt.157.b executed"
@@ -3862,6 +3879,7 @@ country_event = {
 	desc = egypt.158.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.158.a
 		ai_chance = { base = 1 }
@@ -3873,6 +3891,7 @@ country_event = {
 	desc = egypt.159.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.158.a
 		ai_chance = { base = 1 }
@@ -3883,7 +3902,6 @@ country_event = {
 	title = egypt.160.t
 	desc = egypt.160.d
 	picture = GFX_israeli_soldiers_injured
-
 	is_triggered_only = yes
 
 	option = {
@@ -3935,6 +3953,7 @@ country_event = {
 		}
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = egypt.160.b
 		log = "[GetDateText]: [This.GetName]: egypt.160.b executed"
@@ -3949,6 +3968,7 @@ country_event = {
 	desc = egypt.161.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.161.a
 		ai_chance = { base = 1 }
@@ -3960,6 +3980,7 @@ country_event = {
 	desc = egypt.162.d
 	picture = GFX_israeli_soldiers_injured
 	is_triggered_only = yes
+
 	option = {
 		name = egypt.162.a
 		ai_chance = { base = 1 }
@@ -3973,9 +3994,8 @@ country_event = {
 	desc = egypt.163.d
 	picture = GFX_israeli_soldiers_injured # FIXME: Replace with a proper event picture
 	is_triggered_only = yes
-	trigger = {
-		original_tag = EGY
-	}
+
+	trigger = { original_tag = EGY }
 
 	# Worrying...
 	option = {
@@ -3985,7 +4005,6 @@ country_event = {
 		activate_mission = EGY_tribal_conflict_escalation_mission
 		unlock_decision_category_tooltip = EGY_aswan_tribal_clashes_category
 		news_event = egypt_news.5
-
 		hidden_effect = {
 			country_event = { id = egypt.165 days = 2 random_hours = 48 }
 		}
@@ -3999,16 +4018,14 @@ country_event = {
 	desc = egypt.164.d
 	picture = GFX_israeli_soldiers_injured # FIXME: Replace with a proper event picture
 	is_triggered_only = yes
-	trigger = {
-		original_tag = EGY
-	}
+
+	trigger = { original_tag = EGY }
 
 	# The Conflict Resolved
 	option = {
 		name = egypt.164.a
 		log = "[GetDateText]: [This.GetName]: egypt.164.a"
 		set_country_flag = EGY_aswan_tribal_conflict_resolved
-
 		add_stability = 0.03
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -4023,6 +4040,7 @@ country_event = {
 	desc = egypt.165.d
 	picture = GFX_israeli_soldiers_injured # FIXME: Replace with a proper event picture
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = EGY
 		has_active_mission = EGY_tribal_conflict_escalation_mission
@@ -4032,9 +4050,7 @@ country_event = {
 	option = {
 		name = egypt.165.a
 		log = "[GetDateText]: [This.GetName]: egypt.165.a executed"
-		217 = {
-			add_manpower = -26
-		}
+		217 = { add_manpower = -26 }
 	}
 }
 
@@ -4045,6 +4061,7 @@ country_event = {
 	desc = egypt.166.d
 	picture = GFX_israeli_soldiers_injured # FIXME: Replace with a proper event picture
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = EGY
 		has_active_mission = EGY_tribal_conflict_escalation_mission
@@ -4055,12 +4072,10 @@ country_event = {
 		name = egypt.166.a
 		log = "[GetDateText]: [This.GetName]: egypt.166.a"
 		set_country_flag = EGY_aswan_historical_choice
-
 		add_stability = -0.03
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		set_temp_variable = { temp_outlook_increase = -0.03 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4083,7 +4098,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.03 }
 		set_temp_variable = { temp_outlook_increase = 0.03 }
 		change_relative_party_popularity = yes
-
 		hidden_effect = {
 			SUD = {
 				country_event = { id = egypt.168 days = 3 random_hours = 24 }
@@ -4115,18 +4129,15 @@ country_event = {
 	desc = egypt.167.d
 	picture = GFX_israeli_soldiers_injured # FIXME: Replace with a proper event picture
 	is_triggered_only = yes
-	trigger = {
-		original_tag = EGY
-	}
+
+	trigger = { original_tag = EGY }
 
 	# The Conflict Escalated
 	option = {
 		name = egypt.167.a
 		log = "[GetDateText]: [This.GetName]: egypt.167.a"
 		set_country_flag = EGY_aswan_tribal_conflict_escalated
-
 		custom_effect_tooltip = egypt.167.a_tt
-
 		hidden_effect = {
 			create_dynamic_country = {
 				original_tag = EGY
@@ -4140,7 +4151,6 @@ country_event = {
 				transfer_state = 217
 				EGY = { set_state_controller = 217 }
 				set_capital = { state = 217 }
-
 				set_popularities = {
 					neutrality = 100
 				}
@@ -4156,12 +4166,9 @@ country_event = {
 				startup_politics = yes
 				setup_employment_variables = yes
 				ingame_update_setup = yes
-
 				set_variable = { domestic_influence_amount = 100 }
 				sort_influence = yes
-
 				set_variable = { treasury = 5 }
-
 				division_template = {
 					name = "Aswan Rebel Forces"
 					regiments = {
@@ -4234,10 +4241,8 @@ country_event = {
 		name = egypt.168.a
 		log = "[GetDateText]: [This.GetName]: egypt.168.a"
 		set_country_flag = ASW_supported_the_nubian_people
-
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4283,12 +4288,9 @@ country_event = {
 		name = egypt.168.b
 		log = "[GetDateText]: [This.GetName]: egypt.168.b"
 		set_country_flag = ASW_intervention_in_aswan_conflict
-
 		set_temp_variable = { treasury_change = -6 }
 		modify_treasury_effect = yes
-
 		custom_effect_tooltip = ASW_we_will_be_called_to_war_tt
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4332,7 +4334,6 @@ country_event = {
 	# Ignore Their Plight
 	option = {
 		name = egypt.168.c
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -4373,7 +4374,6 @@ country_event = {
 	option = {
 		name = egypt.169.a
 		log = "[GetDateText]: [This.GetName]: egypt.169.a"
-
 		effect_tooltip = {
 			add_to_war = {
 				targeted_alliance = ASW
@@ -4381,20 +4381,14 @@ country_event = {
 				hostility_reason = supporting_the_cause
 			}
 		}
-
 		EGY = { country_event = { id = egypt.170 days = 2 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Back out of the Conflict
 	option = {
 		name = egypt.169.b
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -4410,7 +4404,6 @@ country_event = {
 	option = {
 		name = egypt.170.a
 		log = "[GetDateText]: [This.GetName]: egypt.170.a"
-
 		SUD = {
 			add_to_war = {
 				targeted_alliance = ASW
@@ -4428,9 +4421,8 @@ news_event = {
 	desc = egypt_news.1.d
 	picture = GFX_news_peninsula_shield_intervention
 	is_triggered_only = yes
-	option = {
-		name = egypt_news.1.a
-	}
+
+	option = { name = egypt_news.1.a }
 }
 
 news_event = {
@@ -4439,9 +4431,8 @@ news_event = {
 	desc = egypt_news.2.d
 	picture = GFX_african_union_news
 	is_triggered_only = yes
-	option = {
-		name = egypt_news.2.a
-	}
+
+	option = { name = egypt_news.2.a }
 }
 
 news_event = {
@@ -4450,9 +4441,8 @@ news_event = {
 	desc = egypt_news.3.d
 	picture = GFX_trade_agreement
 	is_triggered_only = yes
-	option = {
-		name = egypt_news.3.a
-	}
+
+	option = { name = egypt_news.3.a }
 }
 
 news_event = {
@@ -4461,9 +4451,8 @@ news_event = {
 	desc = egypt_news.4.d
 	picture = GFX_trade_agreement
 	is_triggered_only = yes
-	option = {
-		name = egypt_news.4.a
-	}
+
+	option = { name = egypt_news.4.a }
 }
 
 news_event = {
@@ -4474,7 +4463,5 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = egypt_news.5.a
-	}
+	option = { name = egypt_news.5.a }
 }

--- a/events/Georgia.txt
+++ b/events/Georgia.txt
@@ -16,9 +16,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg.1000.a
-	}
+	option = { name = georg.1000.a }
 }
 
 country_event = {
@@ -29,9 +27,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg.234.a
-	}
+	option = { name = georg.234.a }
 }
 
 country_event = {
@@ -109,9 +105,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_military.1.a
-	}
+	option = { name = georg_military.1.a }
 }
 
 country_event = {
@@ -122,9 +116,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_militar.1.a
-	}
+	option = { name = georg_militar.1.a }
 }
 
 country_event = {
@@ -135,9 +127,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_militar.2.a
-	}
+	option = { name = georg_militar.2.a }
 }
 
 country_event = {
@@ -164,9 +154,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_chech.2.a
-	}
+	option = { name = georg_chech.2.a }
 
 	option = {
 		name = georg_chech.2.b
@@ -184,9 +172,7 @@ country_event = {
 
 	option = {
 		name = georg_chech.2.c
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 	}
 }
 
@@ -200,9 +186,7 @@ country_event = {
 
 	option = {
 		name = georg_chech.3.a
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 		log = "[GetDateText]: [This.GetName]: georg_chech.3.a executed"
 		add_manpower = 1000
 		add_political_power = 100
@@ -219,16 +203,12 @@ country_event = {
 
 	option = {
 		name = georg_chech.4.a
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 	}
 
 	option = {
 		name = georg_chech.4.b
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: georg_chech.4.b executed"
 		add_opinion_modifier = {
 			modifier = drama
@@ -249,9 +229,7 @@ country_event = {
 
 	option = {
 		name = georg_chech.4.c
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 	}
 }
 
@@ -265,16 +243,12 @@ country_event = {
 
 	option = {
 		name = georg_chech.5.a
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 	}
 
 	option = {
 		name = georg_chech.5.b
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: georg_chech.5.b executed"
 		add_opinion_modifier = {
 			modifier = declaration_of_friendship
@@ -295,9 +269,7 @@ country_event = {
 
 	option = {
 		name = georg_chech.5.c
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 	}
 }
 
@@ -311,16 +283,12 @@ country_event = {
 
 	option = {
 		name = georg_chech.6.a
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 	}
 
 	option = {
 		name = georg_chech.6.b
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: georg_chech.6.b executed"
 		ABK = {
 			diplomatic_relation = {
@@ -329,12 +297,8 @@ country_event = {
 				active = no
 			}
 		}
-		SOV = {
-			add_political_power = 100
-		}
-		GEO = {
-			add_stability = 0.05
-		}
+		SOV = { add_political_power = 100 }
+		GEO = { add_stability = 0.05 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -346,9 +310,7 @@ country_event = {
 
 	option = {
 		name = georg_chech.6.c
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 	}
 }
 
@@ -362,9 +324,7 @@ country_event = {
 
 	option = {
 		name = georg.3.a
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 		log = "[GetDateText]: [This.GetName]: georg.3.a executed"
 		add_opinion_modifier = {
 			target = GEO
@@ -374,9 +334,7 @@ country_event = {
 			target = GEO
 			modifier = diplomatic_support
 		}
-		1033 = {
-			remove_core_of = ARM
-		}
+		1033 = { remove_core_of = ARM }
 		set_temp_variable = { percent_change = 10 }
 		set_temp_variable = { tag_index = ARM }
 		set_temp_variable = { influence_target = GEO }
@@ -390,9 +348,7 @@ country_event = {
 
 	option = {
 		name = georg.3.b
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 		log = "[GetDateText]: [This.GetName]: georg.3.b executed"
 		GEO = { country_event = georg.5 }
 	}
@@ -406,9 +362,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg.4.a
-	}
+	option = { name = georg.4.a }
 }
 
 country_event = {
@@ -419,9 +373,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg.5.a
-	}
+	option = { name = georg.5.a }
 }
 
 country_event = {
@@ -468,9 +420,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_revol.2.a
-	}
+	option = { name = georg_revol.2.a }
 }
 
 country_event = {
@@ -483,9 +433,7 @@ country_event = {
 
 	option = {
 		name = georg_revol.3.a
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 	}
 }
 
@@ -497,9 +445,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_revol.4.a
-	}
+	option = { name = georg_revol.4.a }
 }
 
 country_event = {
@@ -510,9 +456,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_revol.5.a
-	}
+	option = { name = georg_revol.5.a }
 }
 
 country_event = {
@@ -544,9 +488,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = georg_revol.7.a
-	}
+	option = { name = georg_revol.7.a }
 }
 
 country_event = {
@@ -640,9 +582,7 @@ country_event = {
 
 	option = {
 		name = georg_war2008.3.a
-		trigger = {
-			tag = UKR
-		}
+		trigger = { tag = UKR }
 		add_stability = 0.05
 		add_popularity = {
 			ideology = nationalist
@@ -654,9 +594,7 @@ country_event = {
 
 	option = {
 		name = georg_war2008.3.b
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 	}
 }
 
@@ -670,18 +608,14 @@ country_event = {
 
 	option = {
 		name = georg_war2008.4.a
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		add_stability = -0.05
 		log = "[GetDateText]: [This.GetName]: georg_war2008.4.a executed"
 	}
 
 	option = {
 		name = georg_war2008.4.b
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 	}
 }
 
@@ -695,16 +629,12 @@ country_event = {
 
 	option = {
 		name = georg_war2008.5.a
-		trigger = {
-			tag = SOV
-		}
+		trigger = { tag = SOV }
 		log = "[GetDateText]: [This.GetName]: georg_war2008.5.a executed"
 		GEO = {
 			remove_state_core = 706
 			remove_state_core = 705
-			set_rule = {
-				can_join_factions = no
-			}
+			set_rule = { can_join_factions = no }
 			add_opinion_modifier = {
 				modifier = declaration_of_friendship
 				target = SOV
@@ -768,9 +698,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = georg_war2008.6.b
-	}
+	option = { name = georg_war2008.6.b }
 }
 
 country_event = {
@@ -783,9 +711,7 @@ country_event = {
 
 	option = {
 		name = georg_war2008.7.a
-		trigger = {
-			tag = GEO
-		}
+		trigger = { tag = GEO }
 		log = "[GetDateText]: [This.GetName]: georg_war2008.7.a executed"
 		GEO = {
 			annex_country = {
@@ -813,11 +739,7 @@ country_event = {
 			set_country_flag = GEO_lost2008_war
 		}
 		if = {
-			limit = {
-				GEO = {
-					has_war_with = NKO
-				}
-			}
+			limit = { GEO = { has_war_with = NKO } }
 			GEO = {
 				white_peace = NKO
 				set_country_flag = GEO_lost2008_war
@@ -842,11 +764,7 @@ country_event = {
 			set_country_flag = GEO_lost2008_war
 		}
 		if = {
-			limit = {
-				GEO = {
-					has_war_with = NKO
-				}
-			}
+			limit = { GEO = { has_war_with = NKO } }
 			GEO = {
 				white_peace = NKO
 				set_country_flag = GEO_lost2008_war
@@ -862,9 +780,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = georg_war2008.10.b
-	}
+	option = { name = georg_war2008.10.b }
 }
 
 news_event = {
@@ -890,9 +806,7 @@ country_event = {
 		name = georg_war2008.11.a
 		log = "[GetDateText]: [This.GetName]: georg_war2008.11.a executed"
 		ai_chance = { base = 1 }
-		USA = {
-			give_guarantee = GEO
-		}
+		USA = { give_guarantee = GEO }
 	}
 
 	option = {
@@ -947,9 +861,7 @@ country_event = {
 		name = georg.22.a
 		log = "[GetDateText]: [This.GetName]: georg.22.a executed"
 		ai_chance = { base = 1 }
-		GEO = {
-			set_country_flag = GEO_saakash_freed
-		}
+		GEO = { set_country_flag = GEO_saakash_freed }
 	}
 
 	option = {
@@ -1035,9 +947,7 @@ country_event = {
 	option = {
 		name = georg.25.a
 		ai_chance = { base = 1 }
-		GEO = {
-			add_to_faction = ROOT
-		}
+		GEO = { add_to_faction = ROOT }
 		log = "[GetDateText]: [This.GetName]: georg.25.a executed"
 	}
 
@@ -1132,9 +1042,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = geo_misc.4.a
-	}
+	option = { name = geo_misc.4.a }
 }
 country_event = {
 	id = geo_misc.5
@@ -1165,9 +1073,7 @@ country_event = {
 		name = geo_misc.5.b
 		trigger = { tag = SOO }
 		ai_chance = { base = 1 }
-		GEO = {
-			country_event = geo_misc.6
-		}
+		GEO = { country_event = geo_misc.6 }
 		log = "[GetDateText]: [This.GetName]: geo_misc.5.b executed"
 	}
 
@@ -1175,9 +1081,7 @@ country_event = {
 		name = geo_misc.5.c
 		trigger = { tag = ABK }
 		ai_chance = { base = 1 }
-		GEO = {
-			country_event = geo_misc.7
-		}
+		GEO = { country_event = geo_misc.7 }
 		log = "[GetDateText]: [This.GetName]: geo_misc.5.c executed"
 	}
 }
@@ -1190,9 +1094,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = geo_misc.6.a
-	}
+	option = { name = geo_misc.6.a }
 }
 
 country_event = {
@@ -1203,9 +1105,7 @@ country_event = {
 	is_triggered_only = yes
 	fire_only_once = yes
 
-	option = {
-		name = geo_misc.7.a
-	}
+	option = { name = geo_misc.7.a }
 }
 
 country_event = {
@@ -1218,9 +1118,7 @@ country_event = {
 
 	option = {
 		name = geo_misc.8.a
-		GEO = {
-			puppet = ARM
-		}
+		GEO = { puppet = ARM }
 		ai_chance = {
 			base = 1
 			modifier = {

--- a/events/Zombies.txt
+++ b/events/Zombies.txt
@@ -8,6 +8,7 @@ country_event = {
 	desc = zombie.1.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_england }
@@ -56,9 +57,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 3501
-		}
+		ZOM = { set_province_controller = 3501 }
 		15 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -77,15 +76,14 @@ country_event = {
 	desc = zombie.2.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_ireland }
 		has_capitulated = no
 		ZOM = {
 			country_exists = IRE
-			NOT = {
-				country_exists = ENG
-			}
+			NOT = { country_exists = ENG }
 			OR = {
 				ENG = { has_capitulated = yes }
 				IRE = { has_capitulated = no }
@@ -117,9 +115,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 7394
-		}
+		ZOM = { set_province_controller = 7394 }
 		28 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -138,6 +134,7 @@ country_event = {
 	desc = zombie.3.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_usa }
@@ -187,9 +184,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 7394
-		}
+		ZOM = { set_province_controller = 7394 }
 		795 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -208,6 +203,7 @@ country_event = {
 	desc = zombie.4.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_japan }
@@ -246,9 +242,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 11997
-		}
+		ZOM = { set_province_controller = 11997 }
 		610 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -267,6 +261,7 @@ country_event = {
 	desc = zombie.5.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_australia }
@@ -305,9 +300,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 10350
-		}
+		ZOM = { set_province_controller = 10350 }
 		741 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -326,6 +319,7 @@ country_event = {
 	desc = zombie.6.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_new_zealand }
@@ -364,9 +358,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 7783
-		}
+		ZOM = { set_province_controller = 7783 }
 		750 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -385,6 +377,7 @@ country_event = {
 	desc = zombie.7.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_philippines }
@@ -423,9 +416,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 12253
-		}
+		ZOM = { set_province_controller = 12253 }
 		735 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -459,6 +450,7 @@ country_event = {
 	}
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = {
 		OR = {
 			original_tag = RAJ
@@ -473,7 +465,6 @@ country_event = {
 	option = {
 		name = zombie.8.a
 		log = "[GetDateText]: [This.GetName]: zombie.8.a executed"
-
 		if = {
 			limit = { ZOM_coalition_can_form = yes }
 			every_other_country = {
@@ -485,7 +476,6 @@ country_event = {
 					}
 				}
 				display_individual_scopes = yes
-
 				country_event = { id = zombie.9 days = 14 random_days = 7 }
 			}
 		}
@@ -495,13 +485,8 @@ country_event = {
 	option = {
 		name = zombie.8.b
 		log = "[GetDateText]: [This.GetName]: zombie.8.b executed"
-		ZOM = {
-			change_tag_from = RAJ
-		}
-
-		ai_chance = {
-			base = 0
-		}
+		ZOM = { change_tag_from = RAJ }
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -512,9 +497,9 @@ country_event = {
 	desc = zombie.9.d
 	picture = GFX_treaty
 	is_triggered_only = yes
-	trigger = {
-		has_capitulated = no
-	}
+
+	trigger = { has_capitulated = no }
+
 	immediate = {
 		hidden_effect = {
 			if = {
@@ -543,7 +528,6 @@ country_event = {
 		}
 		FROM = {
 			add_to_faction = PREV
-
 			country_event = diplomatic_response.1
 		}
 		ai_chance = {
@@ -572,7 +556,6 @@ country_event = {
 	option = {
 		name = zombie.9.b
 		log = "[GetDateText]: [This.GetName]: zombie.9.b executed"
-
 		FROM = { country_event = diplomatic_response.2 }
 		ai_chance = {
 			base = 1
@@ -604,9 +587,9 @@ country_event = {
 	desc = zombie.10.d
 	picture = GFX_hospital
 	is_triggered_only = yes
-	trigger = {
-		NOT = { has_country_flag = has_had_outbreak_event }
-	}
+
+	trigger = { NOT = { has_country_flag = has_had_outbreak_event } }
+
 	immediate = {
 		set_country_flag = has_had_outbreak_event
 		hidden_effect = {
@@ -675,6 +658,7 @@ country_event = {
 	desc = zombie.15.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_global_flag = ZOM_horde_evolved }
@@ -688,7 +672,6 @@ country_event = {
 		ZOM = {
 			division_template = {
 				name = "Runner Pack"
-
 				regiments = {
 					zombie_runner = { x = 0 y = 0 }
 					zombie_runner = { x = 0 y = 1 }
@@ -705,10 +688,8 @@ country_event = {
 				}
 				priority = 100
 			}
-
 			division_template = {
 				name = "Brute Vanguard"
-
 				regiments = {
 					zombie_brute = { x = 0 y = 0 }
 					zombie_brute = { x = 0 y = 1 }
@@ -748,6 +729,7 @@ country_event = {
 	desc = zombie.12.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_nigeria }
@@ -780,9 +762,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 11358
-		}
+		ZOM = { set_province_controller = 11358 }
 		270 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -801,6 +781,7 @@ country_event = {
 	desc = zombie.13.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_brazil }
@@ -833,9 +814,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 3429
-		}
+		ZOM = { set_province_controller = 3429 }
 		284 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -854,6 +833,7 @@ country_event = {
 	desc = zombie.14.d
 	picture = GFX_hospital
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = ZOM
 		NOT = { has_country_flag = ZOM_invasion_of_turkey }
@@ -886,9 +866,7 @@ country_event = {
 				}
 			}
 		}
-		ZOM = {
-			set_province_controller = 857
-		}
+		ZOM = { set_province_controller = 857 }
 		131 = {
 			create_unit = {
 				division = "name = \"Zombie Horde\" division_template = \"Zombie Horde\" start_experience_factor = 0.3"
@@ -911,18 +889,13 @@ news_event = {
 	# Worrying...
 	option = {
 		name = zombie.11.a
-		trigger = {
-			NOT = { original_tag = ZOM }
-		}
+		trigger = { NOT = { original_tag = ZOM } }
 	}
 
 	# Raaargh
 	option = {
 		name = zombie.11.b
-		trigger = {
-			original_tag = ZOM
-		}
-
+		trigger = { original_tag = ZOM }
 		effect_tooltip = {
 			ZOM = {
 				declare_war_on = {


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,631 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.