### PR TITLE
Standardize event files — batch 11/14

### DIFF
--- a/events/05_switzerland_events.txt
+++ b/events/05_switzerland_events.txt
@@ -12,9 +12,7 @@ news_event = {
 
 	option = {
 		name = switzerland.2.o1
-		trigger = {
-			original_tag = SWI
-		}
+		trigger = { original_tag = SWI }
 	}
 
 	option = {
@@ -405,9 +403,7 @@ country_event = {
 	option = {
 		name = switzerland.17.a
 		log = "[GetDateText]: [This.GetName]: switzerland.17.a executed"
-		trigger = {
-			NOT = { has_completed_focus = SWI_neutral_foreign_policy }
-		}
+		trigger = { NOT = { has_completed_focus = SWI_neutral_foreign_policy } }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -429,9 +425,7 @@ country_event = {
 	option = {
 		name = switzerland.17.b
 		log = "[GetDateText]: [This.GetName]: switzerland.17.b executed"
-		trigger = {
-			NOT = { has_completed_focus = SWI_opening_up }
-		}
+		trigger = { NOT = { has_completed_focus = SWI_opening_up } }
 		ai_chance = {
 			base = 70
 			modifier = {
@@ -501,9 +495,7 @@ country_event = {
 	option = {
 		name = switzerland.22.a
 		log = "[GetDateText]: [This.GetName]: switzerland.22.a executed"
-		trigger = {
-			NOT = { has_completed_focus = SWI_partner_like_everyone }
-		}
+		trigger = { NOT = { has_completed_focus = SWI_partner_like_everyone } }
 		ai_chance = {
 			base = 60
 			modifier = {
@@ -521,9 +513,7 @@ country_event = {
 	option = {
 		name = switzerland.22.b
 		log = "[GetDateText]: [This.GetName]: switzerland.22.b executed"
-		trigger = {
-			NOT = { has_completed_focus = SWI_expanded_trade }
-		}
+		trigger = { NOT = { has_completed_focus = SWI_expanded_trade } }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -576,9 +566,7 @@ country_event = {
 	option = {
 		name = switzerland.23.b
 		log = "[GetDateText]: [This.GetName]: switzerland.23.b executed"
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 		FROM = {
 			country_event = { id = switzerland.25 hours = 6 }
 		}
@@ -665,9 +653,7 @@ country_event = {
 	option = {
 		name = switzerland.26.b
 		log = "[GetDateText]: [This.GetName]: switzerland.26.b executed"
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 		FROM = { add_state_claim = 947 }
 		add_opinion_modifier = {
 			target = FROM
@@ -687,16 +673,12 @@ news_event = {
 
 	option = {
 		name = switzerland_news.1.o1
-		trigger = {
-			NOT = { original_tag = SWI }
-		}
+		trigger = { NOT = { original_tag = SWI } }
 	}
 
 	option = {
 		name = switzerland_news.1.o3
-		trigger = {
-			original_tag = SWI
-		}
+		trigger = { original_tag = SWI }
 	}
 }
 
@@ -785,9 +767,7 @@ country_event = {
 		name = switzerland.27.b
 		log = "[GetDateText]: [This.GetName]: switzerland.27.b executed"
 		FROM = { country_event = { id = switzerland.31 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -850,9 +830,7 @@ country_event = {
 		name = switzerland.28.b
 		log = "[GetDateText]: [This.GetName]: switzerland.28.b executed"
 		FROM = { country_event = { id = switzerland.31 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -929,9 +907,7 @@ country_event = {
 		name = switzerland.29.b
 		log = "[GetDateText]: [This.GetName]: switzerland.29.b executed"
 		FROM = { country_event = { id = switzerland.31 days = 1 } }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 

--- a/events/Afghanistan.txt
+++ b/events/Afghanistan.txt
@@ -31,9 +31,7 @@ country_event = {
 		random_list = {
 			90 = {
 				retire_character = AFG_ahmed_shah_massoud
-				hidden_effect = {
-					set_leader = yes
-				}
+				hidden_effect = { set_leader = yes }
 				hidden_effect = { news_event = { id = AFG_news.6 hours = 6 } }
 				set_country_flag = AFG_massoud_dead
 			}
@@ -58,7 +56,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #US sets up a government
@@ -135,9 +132,7 @@ country_event = {
 						}
 					}
 				}
-				hidden_effect = {
-					set_leader = yes
-				}
+				hidden_effect = { set_leader = yes }
 			}
 			set_temp_variable = { rul_party_temp = 12 }
 			change_ruling_party_effect = yes
@@ -215,7 +210,6 @@ country_event = {
 			change_relative_party_popularity = yes
 		}
 	}
-
 }
 
 # Contact with Iran
@@ -263,7 +257,6 @@ country_event = {
 			base = 0
 		}
 	}
-
 }
 country_event = {
 	id = AFG_contact_iran.1
@@ -278,7 +271,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = AFG_contact_iran.2
@@ -347,7 +339,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 country_event = {
 	id = AFG_contact_iran.3
@@ -394,7 +385,6 @@ country_event = {
 			base = 0
 		}
 	}
-
 }
 country_event = {
 	id = AFG_contact_iran.4
@@ -424,11 +414,8 @@ country_event = {
 			FROM = { add_to_faction = ROOT }
 			add_ideas = faction_resistance_axis_member
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 country_event = {
 	id = AFG_contact_iran.5
@@ -439,11 +426,8 @@ country_event = {
 
 	option = {
 		name = AFG_contact_iran.5.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 news_event = {
 	id = AFG_contact_iran.6
@@ -454,11 +438,8 @@ news_event = {
 
 	option = {
 		name = AFG_contact_iran.6.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Insurgency
@@ -559,7 +540,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 
 #Raid Successful
@@ -579,11 +559,8 @@ news_event = {
 		army_experience = 5
 		set_temp_variable = { taliban_strength_decrease = 5 }
 		decrease_taliban_strength = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Raid Failure
@@ -601,11 +578,8 @@ news_event = {
 		add_command_power = -5
 		set_temp_variable = { taliban_strength_increase = 1 }
 		increase_taliban_strength = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Airstrike Successful
@@ -623,11 +597,8 @@ news_event = {
 		air_experience = 10
 		set_temp_variable = { taliban_strength_decrease = 10 }
 		decrease_taliban_strength = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Airstrike Failure
@@ -641,20 +612,15 @@ news_event = {
 	option = {
 		log = "[GetDateText]: [This.GetName]: AFG_taliban_insurgency.4.a executed"
 		name = AFG_taliban_insurgency.4.a
-		random_owned_controlled_state = {
-			add_manpower = -10
-		}
+		random_owned_controlled_state = { add_manpower = -10 }
 		add_political_power = -20
 		add_stability = -0.02
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
 		set_temp_variable = { taliban_strength_increase = 5 }
 		increase_taliban_strength = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Aircraft Shot Down
@@ -671,22 +637,14 @@ news_event = {
 		add_command_power = -5
 		add_manpower = -1
 		if = {
-			limit = {
-				has_equipment = {
-					medium_plane_airframe > 0
-				}
-			}
+			limit = { has_equipment = { medium_plane_airframe > 0 } }
 			add_equipment_to_stockpile = {
 				type = medium_plane_airframe
 				amount = -1
 			}
 		}
 		else_if = {
-			limit = {
-				has_equipment = {
-					small_plane_strike_airframe > 0
-				}
-			}
+			limit = { has_equipment = { small_plane_strike_airframe > 0 } }
 			add_equipment_to_stockpile = {
 				type = small_plane_strike_airframe
 				amount = -1
@@ -694,11 +652,8 @@ news_event = {
 		}
 		set_temp_variable = { taliban_strength_increase = 1 }
 		increase_taliban_strength = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Unity Propaganda Successful
@@ -716,11 +671,8 @@ news_event = {
 		add_stability = 0.05
 		set_temp_variable = { taliban_strength_decrease = 10 }
 		decrease_taliban_strength = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Unity Propaganda Failure
@@ -735,11 +687,8 @@ news_event = {
 		name = AFG_taliban_insurgency.7.a
 		log = "[GetDateText]: [This.GetName]: AFG_taliban_insurgency.7.a executed"
 		add_political_power = -10
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Insurgency Eliminated
@@ -753,11 +702,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_insurgency.8.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Hidden Event That Creates Renewed Civil War
@@ -818,7 +764,6 @@ country_event = {
 		}
 		AFG_clear_ci_supporters = yes
 	}
-
 }
 country_event = {
 	id = AFG_taliban_insurgency.10
@@ -838,28 +783,22 @@ country_event = {
 				hours = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
 	id = AFG_taliban_insurgency.11
-	major = yes
 	title = AFG_taliban_insurgency.11.t
 	desc = AFG_taliban_insurgency.11.d
 	picture = GFX_afghan_news_taliban_uprising
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = AFG_taliban_insurgency.11.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Hidden event that removes Taliban insurgency if Taliban come to power in AFG tag
@@ -883,7 +822,6 @@ country_event = {
 		AFG_clear_ci_supporters = yes
 		reset_taliban_strength = yes
 	}
-
 }
 
 #Hidden event that asks countries with military access to take part in the counterinsurgency operations
@@ -913,9 +851,7 @@ country_event = {
 					exists = yes
 					no_jihadist_government = yes
 					has_military_access_to = AFG
-					NOT = {
-						has_country_flag = wot_supporting_afghan_counter_insurgency
-					}
+					NOT = { has_country_flag = wot_supporting_afghan_counter_insurgency }
 				}
 				country_event = {
 					id = AFG_taliban_insurgency.14
@@ -924,7 +860,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Asks if the country has military access wants to take part in the counter-insurgency warfare
@@ -983,9 +918,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: AFG_taliban_insurgency.14.b executed"
 		add_political_power = 15
 		if = {
-			limit = {
-				has_military_access_to = AFG
-			}
+			limit = { has_military_access_to = AFG }
 			diplomatic_relation = {
 				country = AFG
 				relation = military_access
@@ -1034,7 +967,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #The country joins counter-insurgency operations
@@ -1047,11 +979,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_insurgency.15.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #The country pulls out troops
@@ -1064,11 +993,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_insurgency.16.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #ISAF Raid Successful
@@ -1088,11 +1014,8 @@ news_event = {
 			set_temp_variable = { taliban_strength_decrease = 5 }
 			decrease_taliban_strength = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #ISAF Raid Failure
@@ -1116,11 +1039,8 @@ news_event = {
 			set_temp_variable = { taliban_strength_increase = 1 }
 			increase_taliban_strength = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Hidden Event Removes Counter Insurgency Missions If No Military Access
@@ -1145,15 +1065,12 @@ country_event = {
 					exists = yes
 					no_jihadist_government = yes
 					has_country_flag = wot_supporting_afghan_counter_insurgency
-					NOT = {
-						has_military_access_to = AFG
-					}
+					NOT = { has_military_access_to = AFG }
 				}
 				clr_country_flag = wot_supporting_afghan_counter_insurgency
 			}
 		}
 	}
-
 }
 
 #Hidden event that increases Taliban strength
@@ -1450,7 +1367,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #ISAF Drone Strike Successful
@@ -1470,11 +1386,8 @@ news_event = {
 			set_temp_variable = { taliban_strength_decrease = 7 }
 			decrease_taliban_strength = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #ISAF Drone Strike Failure
@@ -1492,23 +1405,16 @@ news_event = {
 		set_temp_variable = { arg_popularity = -0.01 }
 		add_ruling_outlook_popularity = yes
 		if = {
-			limit = {
-				tag = USA
-			}
+			limit = { tag = USA }
 			USA_house_small_opposition = yes
 		}
 		AFG = {
-			random_owned_controlled_state = {
-				add_manpower = -25
-			}
+			random_owned_controlled_state = { add_manpower = -25 }
 			set_temp_variable = { taliban_strength_increase = 3 }
 			increase_taliban_strength = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #ISAF Bombing Successful
@@ -1528,11 +1434,8 @@ news_event = {
 			set_temp_variable = { taliban_strength_decrease = 12 }
 			decrease_taliban_strength = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #ISAF Bombing Failure
@@ -1552,24 +1455,17 @@ news_event = {
 		change_relative_party_popularity = yes
 		air_experience = 5
 		if = {
-			limit = {
-				tag = USA
-			}
+			limit = { tag = USA }
 			USA_congress_small_opposition = yes
 		}
 		AFG = {
-			random_owned_controlled_state = {
-				add_manpower = -85
-			}
+			random_owned_controlled_state = { add_manpower = -85 }
 			add_stability = -0.03
 			set_temp_variable = { taliban_strength_increase = 5 }
 			increase_taliban_strength = yes
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Country Provide Counter-insurgency Equipment
@@ -1587,11 +1483,8 @@ news_event = {
 			target = FROM
 			modifier = helps_our_counter_insurgency
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Attacks Police
@@ -1685,11 +1578,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -1701,11 +1591,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_attack.1.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Attack Bus Kills Foreigners
@@ -1833,7 +1720,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 
 news_event = {
@@ -1848,11 +1734,8 @@ news_event = {
 		name = AFG_taliban_attack.3.a
 		add_manpower = -2
 		add_political_power = -20
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -1864,11 +1747,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_attack.4.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Attack Fuel Tankers
@@ -1887,9 +1767,7 @@ country_event = {
 				value = 10
 				compare = greater_than_or_equals
 			}
-			any_owned_state = {
-				infrastructure > 0
-			}
+			any_owned_state = { infrastructure > 0 }
 			has_country_flag = AFG_active_taliban_insurgency
 		}
 	}
@@ -1900,9 +1778,7 @@ country_event = {
 		add_command_power = -5
 		add_stability = -0.01
 		random_owned_controlled_state = {
-			limit = {
-				infrastructure > 0
-			}
+			limit = { infrastructure > 0 }
 			damage_building = {
 				type = infrastructure
 				damage = 0.25
@@ -1983,11 +1859,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -1999,11 +1872,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_attack.6.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Attacks Afghan Military
@@ -2111,11 +1981,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -2127,11 +1994,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_attack.8.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Attacks Foreign Troops
@@ -2243,11 +2107,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -2265,9 +2126,7 @@ news_event = {
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
 		if = {
-			limit = {
-				tag = USA
-			}
+			limit = { tag = USA }
 			USA_house_small_opposition = yes
 		}
 		add_equipment_to_stockpile = {
@@ -2282,11 +2141,8 @@ news_event = {
 			type = util_vehicle_type
 			amount = -2
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -2324,11 +2180,8 @@ news_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Bombs Buildings
@@ -2363,15 +2216,9 @@ country_event = {
 		add_political_power = -30
 		add_stability = -0.02
 		if = {
-			limit = {
-				any_owned_state = {
-					offices > 0
-				}
-			}
+			limit = { any_owned_state = { offices > 0 } }
 			random_owned_controlled_state = {
-				limit = {
-					offices > 0
-				}
+				limit = { offices > 0 }
 				add_manpower = -35
 				damage_building = {
 					type = offices
@@ -2380,15 +2227,9 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				any_owned_state = {
-					industrial_complex > 0
-				}
-			}
+			limit = { any_owned_state = { industrial_complex > 0 } }
 			random_owned_controlled_state = {
-				limit = {
-					industrial_complex > 0
-				}
+				limit = { industrial_complex > 0 }
 				add_manpower = -35
 				damage_building = {
 					type = industrial_complex
@@ -2489,11 +2330,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -2508,11 +2346,8 @@ news_event = {
 		name = AFG_taliban_attack.13.a
 		add_manpower = -3
 		add_political_power = -20
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -2524,11 +2359,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_attack.14.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Taliban Attacks Airport
@@ -2547,9 +2379,7 @@ country_event = {
 				value = 55
 				compare = greater_than_or_equals
 			}
-			any_owned_state = {
-				air_base > 0
-			}
+			any_owned_state = { air_base > 0 }
 			has_country_flag = AFG_active_taliban_insurgency
 		}
 	}
@@ -2559,9 +2389,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: AFG_taliban_attack.15.a executed"
 		add_stability = -0.05
 		random_owned_controlled_state = {
-			limit = {
-				air_base > 0
-			}
+			limit = { air_base > 0 }
 			add_manpower = -220
 			damage_building = {
 				type = air_base
@@ -2643,11 +2471,8 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -2659,11 +2484,8 @@ news_event = {
 
 	option = {
 		name = AFG_taliban_attack.16.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Asks USA for Guarantee
@@ -2742,7 +2564,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #USA Agrees Guarantee
@@ -2757,11 +2578,8 @@ country_event = {
 		name = AFG_events.9.a
 		log = "[GetDateText]: [This.GetName]: AFG_events.9.a executed"
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #USA Refuses Guarantee
@@ -2778,11 +2596,8 @@ country_event = {
 		add_political_power = -50
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Asks China for Guarantee
@@ -2809,9 +2624,7 @@ country_event = {
 				days = 2
 			}
 		}
-		hidden_effect = {
-			subtract_from_variable = { CHI_chinese_aggression = 1 }
-		}
+		hidden_effect = { subtract_from_variable = { CHI_chinese_aggression = 1 } }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2824,21 +2637,15 @@ country_event = {
 			}
 			modifier = {
 				factor = 2
-				AFG = {
-					has_government = communism
-				}
+				AFG = { has_government = communism }
 			}
 			modifier = {
 				factor = 0
-				AFG = {
-					has_war = yes
-				}
+				AFG = { has_war = yes }
 			}
 			modifier = {
 				factor = 0
-				check_variable = {
-					debt > 10000
-				}
+				check_variable = { debt > 10000 }
 			}
 			modifier = {
 				factor = 2
@@ -2863,9 +2670,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				check_variable = {
-					uighur_threat > 80
-				}
+				check_variable = { uighur_threat > 80 }
 			}
 			modifier = {
 				factor = 2
@@ -2876,7 +2681,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #China Agrees Guarantee
@@ -2891,11 +2695,8 @@ country_event = {
 		name = AFG_events.12.a
 		log = "[GetDateText]: [This.GetName]: AFG_events.12.a executed"
 		add_political_power = 50
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #China Refuses Guarantee
@@ -2912,11 +2713,8 @@ country_event = {
 		add_political_power = -20
 		set_temp_variable = { arg_popularity = -0.02 }
 		add_ruling_outlook_popularity = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Claim Pakistani Pashtunistan
@@ -2931,11 +2729,8 @@ country_event = {
 		name = AFG_events.14.a
 		log = "[GetDateText]: [This.GetName]: AFG_events.14.a executed"
 		add_war_support = 0.01
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Assassination of Burhanuddin Rabbani
@@ -2976,9 +2771,7 @@ country_event = {
 		add_political_power = -10
 		add_stability = -0.01
 		if = {
-			limit = {
-				check_variable = { Neutral_Muslim_Brotherhood_leader = 0 }
-			}
+			limit = { check_variable = { Neutral_Muslim_Brotherhood_leader = 0 } }
 			add_to_variable = { Neutral_Muslim_Brotherhood_leader = 1 }
 		}
 		hidden_effect = {
@@ -2986,7 +2779,6 @@ country_event = {
 		}
 		ai_chance = { base = base }
 	}
-
 }
 
 #Ask UN P5 For Neutrality Recognition
@@ -3051,9 +2843,7 @@ country_event = {
 				factor = 20
 				OR = {
 					has_war = yes
-					AFG = {
-						has_war = yes
-					}
+					AFG = { has_war = yes }
 				}
 			}
 			modifier = {
@@ -3062,19 +2852,11 @@ country_event = {
 			}
 			modifier = {
 				factor = 5
-				AFG = {
-					NOT = {
-						has_idea = intervention_isolation
-					}
-				}
+				AFG = { NOT = { has_idea = intervention_isolation } }
 			}
 			modifier = {
 				factor = 3
-				AFG = {
-					NOT = {
-						has_government = ROOT
-					}
-				}
+				AFG = { NOT = { has_government = ROOT } }
 			}
 			modifier = {
 				factor = 5
@@ -3083,7 +2865,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Agree to Guarantee Afghan Neutrality
@@ -3098,11 +2879,8 @@ country_event = {
 		name = AFG_events.17.a
 		log = "[GetDateText]: [This.GetName]: AFG_events.17.a executed"
 		add_political_power = 20
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Anti-Taliban Uprising
@@ -3127,13 +2905,10 @@ country_event = {
 			set_province_controller = 7916
 			set_province_controller = 8053
 			load_oob = "AFG_uprising_against_taliban"
-			TAL = {
-				remove_ideas = anti_taliban_guerrillas
-			}
+			TAL = { remove_ideas = anti_taliban_guerrillas }
 		}
 		ai_chance = { base = base }
 	}
-
 }
 
 news_event = {
@@ -3152,7 +2927,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.1.a }
-
 }
 
 news_event = {
@@ -3164,7 +2938,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.2.a }
-
 }
 
 news_event = {
@@ -3176,7 +2949,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.3.a }
-
 }
 
 news_event = {
@@ -3188,7 +2960,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.4.a }
-
 }
 
 news_event = {
@@ -3200,7 +2971,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.5.a }
-
 }
 
 news_event = {
@@ -3212,7 +2982,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.6.a }
-
 }
 
 news_event = {
@@ -3224,7 +2993,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.7.a }
-
 }
 
 news_event = {
@@ -3236,7 +3004,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.8.a }
-
 }
 
 news_event = {
@@ -3248,7 +3015,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.9.a }
-
 }
 
 news_event = {
@@ -3260,7 +3026,6 @@ news_event = {
 	major = yes
 
 	option = { name = AFG_news.10.a }
-
 }
 
 #Hijacking of Ariana Airlines Flight 805
@@ -3274,9 +3039,7 @@ news_event = {
 
 	trigger = {
 		tag = TAL
-		TAL = {
-			controls_province = 10737
-		}
+		TAL = { controls_province = 10737 }
 	}
 
 	option = {
@@ -3289,11 +3052,8 @@ news_event = {
 				hours = 1
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 news_event = {
@@ -3306,26 +3066,15 @@ news_event = {
 
 	option = {
 		name = AFG_news.12.a
-		trigger = {
-			NOT = {
-				original_tag = AFG
-			}
-		}
-		ai_chance = {
-			base = 1
-		}
+		trigger = { NOT = { original_tag = AFG } }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = AFG_news.12.b
-		trigger = {
-			tag = AFG
-		}
-		ai_chance = {
-			base = 1
-		}
+		trigger = { tag = AFG }
+		ai_chance = { base = 1 }
 	}
-
 }
 #Iran Returns Afghani Refugees
 news_event = {
@@ -3343,11 +3092,8 @@ news_event = {
 
 	option = {
 		name = AFG_news.13.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #World Food Programme News Event
@@ -3367,11 +3113,8 @@ news_event = {
 
 	option = {
 		name = AFG_news.14.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 #Anti-Taliban Uprising News
 news_event = {
@@ -3384,11 +3127,8 @@ news_event = {
 
 	option = {
 		name = AFG_news.17.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 #Russian Request USA help with Russian airlift to afghanistan
 news_event = {
@@ -3405,31 +3145,20 @@ news_event = {
 			NOT = { original_tag = SOV }
 			NOT = { original_tag = USA }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = AFG_news.18.b
-		trigger = {
-			tag = SOV
-		}
-		ai_chance = {
-			base = 1
-		}
+		trigger = { tag = SOV }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = AFG_news.18.c
-		trigger = {
-			tag = USA
-		}
-		ai_chance = {
-			base = 1
-		}
+		trigger = { tag = USA }
+		ai_chance = { base = 1 }
 	}
-
 }
 #CIA predor drones
 news_event = {
@@ -3442,11 +3171,8 @@ news_event = {
 
 	option = {
 		name = AFG_news.19.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 #EU Speach
 news_event = {
@@ -3459,11 +3185,8 @@ news_event = {
 
 	option = {
 		name = AFG_news.20.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 #Return of Rashid
 news_event = {
@@ -3476,11 +3199,8 @@ news_event = {
 
 	option = {
 		name = AFG_news.21.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 #Investment Offer
 country_event = {
@@ -3496,9 +3216,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -10 }
 		modify_treasury_effect = yes
 		AFG = {
-			random_owned_controlled_state = {
-				AFG_build_infrastructure_or_internet = yes
-			}
+			random_owned_controlled_state = { AFG_build_infrastructure_or_internet = yes }
 			set_temp_variable = { percent_change = 1 }
 			change_influence_percentage = yes
 			country_event = {
@@ -3510,15 +3228,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				AFG = {
-					has_government = ROOT
-				}
+				AFG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				AFG = {
-					has_stability > 0.5
-				}
+				AFG = { has_stability > 0.5 }
 			}
 			modifier = {
 				factor = 2
@@ -3540,9 +3254,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				AFG = {
-					has_stability < 0.2
-				}
+				AFG = { has_stability < 0.2 }
 			}
 		}
 	}
@@ -3572,15 +3284,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				AFG = {
-					has_government = ROOT
-				}
+				AFG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				AFG = {
-					has_stability > 0.6
-				}
+				AFG = { has_stability > 0.6 }
 			}
 			modifier = {
 				factor = 2
@@ -3602,9 +3310,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				AFG = {
-					has_stability < 0.3
-				}
+				AFG = { has_stability < 0.3 }
 			}
 		}
 	}
@@ -3634,15 +3340,11 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				AFG = {
-					has_government = ROOT
-				}
+				AFG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 2
-				AFG = {
-					has_stability > 0.75
-				}
+				AFG = { has_stability > 0.75 }
 			}
 			modifier = {
 				factor = 2
@@ -3664,9 +3366,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0
-				AFG = {
-					has_stability < 0.5
-				}
+				AFG = { has_stability < 0.5 }
 			}
 		}
 	}
@@ -3685,9 +3385,7 @@ country_event = {
 			base = 1
 			modifier = {
 				factor = 2
-				AFG = {
-					has_stability < 0.1
-				}
+				AFG = { has_stability < 0.1 }
 			}
 			modifier = {
 				factor = 2
@@ -3709,13 +3407,10 @@ country_event = {
 			}
 			modifier = {
 				factor = 10
-				AFG = {
-					has_war = yes
-				}
+				AFG = { has_war = yes }
 			}
 		}
 	}
-
 }
 
 #Invest in Infrastructure
@@ -3728,11 +3423,8 @@ country_event = {
 
 	option = {
 		name = AFG_investment.2.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Invest in Factories
@@ -3745,11 +3437,8 @@ country_event = {
 
 	option = {
 		name = AFG_investment.3.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Invest in Offices
@@ -3762,11 +3451,8 @@ country_event = {
 
 	option = {
 		name = AFG_investment.4.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Investment Offer Rejected
@@ -3781,11 +3467,8 @@ country_event = {
 		name = AFG_investment.5.a
 		log = "[GetDateText]: [This.GetName]: AFG_investment.5.a executed"
 		add_political_power = -10
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #South Korean Hostage Crisis
@@ -3801,9 +3484,7 @@ country_event = {
 	option = {
 		name = AFG_hostage_crisis.1.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.1.a executed"
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		random_list = {
 			50 = {
 				AFG = { news_event = { id = AFG_hostage_crisis.2 days = 4 } }
@@ -3817,9 +3498,7 @@ country_event = {
 	option = {
 		name = AFG_hostage_crisis.1.b
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.1.b executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		random_list = {
 			90 = {
 				AFG = { country_event = { id = AFG_hostage_crisis.4 days = 2 } }
@@ -3829,7 +3508,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Rescue attemp succesful
@@ -3843,15 +3521,12 @@ news_event = {
 	option = {
 		name = AFG_hostage_crisis.2.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.2.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_opinion_modifier = {
 			target = KOR
 			modifier = gratitude
 		}
 	}
-
 }
 
 #Rescue attemp failed
@@ -3865,9 +3540,7 @@ news_event = {
 	option = {
 		name = AFG_hostage_crisis.3.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.3.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		add_opinion_modifier = {
 			target = KOR
 			modifier = insult
@@ -3879,7 +3552,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 #Taliban demands prisoners release
@@ -3894,21 +3566,16 @@ country_event = {
 	option = {
 		name = AFG_hostage_crisis.4.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.4.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		AFG = { country_event = { id = AFG_hostage_crisis.6 days = 2 } }
 	}
 
 	option = {
 		name = AFG_hostage_crisis.4.b
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.4.b executed"
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		AFG = { news_event = { id = AFG_hostage_crisis.7 days = 2 } }
 	}
-
 }
 
 #Taliban demands ransom and South Korea withdrawal
@@ -3923,21 +3590,16 @@ country_event = {
 	option = {
 		name = AFG_hostage_crisis.5.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.5.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		KOR = { news_event = { id = AFG_hostage_crisis.8 days = 2 } }
 	}
 
 	option = {
 		name = AFG_hostage_crisis.5.b
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.5.b executed"
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 		KOR = { news_event = { id = AFG_hostage_crisis.9 days = 2 } }
 	}
-
 }
 
 #US refuses to release prisoners
@@ -3952,12 +3614,8 @@ country_event = {
 	option = {
 		name = AFG_hostage_crisis.6.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.6.a executed"
-		ai_chance = {
-			base = 1
-		}
-		AFG = {
-			add_stability = -0.05
-		}
+		ai_chance = { base = 1 }
+		AFG = { add_stability = -0.05 }
 		KOR = {
 			country_event = { id = AFG_hostage_crisis.4 days = 2 }
 			add_popularity = {
@@ -3966,7 +3624,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 #Afghanistan refuses to negocietate
@@ -3981,13 +3638,9 @@ news_event = {
 	option = {
 		name = AFG_hostage_crisis.7.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.7.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		KOR = { country_event = { id = AFG_hostage_crisis.4 days = 2 } }
-		AFG = {
-			add_stability = -0.1
-		}
+		AFG = { add_stability = -0.1 }
 		KOR = {
 			add_popularity = {
 				ideology = democratic
@@ -3995,7 +3648,6 @@ news_event = {
 			}
 		}
 	}
-
 }
 
 #South Korea pays ramson
@@ -4010,9 +3662,7 @@ news_event = {
 	option = {
 		name = AFG_hostage_crisis.8.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.8.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		KOR = {
 			set_temp_variable = { treasury_change = -0.02 }
 			modify_treasury_effect = yes
@@ -4023,7 +3673,6 @@ news_event = {
 			active = no
 		}
 	}
-
 }
 
 #South Korea refuses
@@ -4038,9 +3687,7 @@ news_event = {
 	option = {
 		name = AFG_hostage_crisis.9.a
 		log = "[GetDateText]: [This.GetName]: AFG_hostage_crisis.9.a executed"
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 		KOR = {
 			add_popularity = {
 				ideology = democratic
@@ -4049,7 +3696,6 @@ news_event = {
 			add_political_power = -50
 		}
 	}
-
 }
 #Aloya jirga (No war on terror)
 
@@ -4081,7 +3727,6 @@ country_event = {
 		change_the_ulema_opinion = yes
 		set_drafted_women_effect = yes
 	}
-
 }
 #role of religon
 country_event = {
@@ -4110,7 +3755,6 @@ country_event = {
 		set_temp_variable = { temp_opinion = -5 }
 		change_the_ulema_opinion = yes
 	}
-
 }
 
 #Taloqan Operations hold
@@ -4129,7 +3773,6 @@ country_event = {
 		add_war_support = 0.15
 		custom_effect_tooltip = AFG_taloqan_text2
 	}
-
 }
 #Fall of taloqan
 #A castle called Taloqan has fallen
@@ -4152,7 +3795,6 @@ country_event = {
 			value = 1
 		}
 	}
-
 }
 
 #Hidden Event That Creates Taliban Collpase (pashtun nationalist) stuff
@@ -4166,9 +3808,7 @@ country_event = {
 		original_tag = TAL
 		has_global_flag = GLOBAL_afghan_civil_war_over
 		has_game_rule = { rule = AFG_northern_alliance_uprising option = yes }
-		NOT = {
-			country_exists = AFG
-		}
+		NOT = { country_exists = AFG }
 	}
 
 	immediate = {
@@ -4228,9 +3868,7 @@ country_event = {
 			load_oob = "AFG_uprising_against_taliban"
 			set_cosmetic_tag = AFG_REB
 			set_variable = { dynamic_flag_variant = 6 }
-			TAL = {
-				remove_ideas = anti_taliban_guerrillas
-			}
+			TAL = { remove_ideas = anti_taliban_guerrillas }
 		}
 		TAL = {
 			add_stability = -0.2
@@ -4246,7 +3884,6 @@ country_event = {
 		}
 		AFG_clear_ci_supporters = yes
 	}
-
 }
 country_event = {
 	id = AFG_events.35
@@ -4360,7 +3997,6 @@ country_event = {
 		}
 		AFG = { country_event = AFG_events.41 }
 	}
-
 }
 #CIA Drones
 country_event = {
@@ -4376,9 +4012,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: AFG_events.36.a executed"
 		AFG = {
 			country_event = AFG_events.39
-			effect_tooltip = {
-				add_ideas = AFG_cia_predator_surveillance_drones
-			}
+			effect_tooltip = { add_ideas = AFG_cia_predator_surveillance_drones }
 		}
 		set_temp_variable = { treasury_change = -1 }
 		modify_treasury_effect = yes
@@ -4391,9 +4025,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 20
-				AFG = {
-					has_government = ROOT
-				}
+				AFG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 40
@@ -4427,7 +4059,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 #Indian Support Request More
 country_event = {
@@ -4461,9 +4092,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 20
-				AFG = {
-					has_government = ROOT
-				}
+				AFG = { has_government = ROOT }
 			}
 		}
 	}
@@ -4485,7 +4114,6 @@ country_event = {
 		}
 		AFG = { country_event = AFG_events.41 }
 	}
-
 }
 #Russia Accepts
 country_event = {
@@ -4515,7 +4143,6 @@ country_event = {
 			add_opinion_modifier = { target = AFG modifier = trade_allies }
 		}
 	}
-
 }
 #USA Accepts
 country_event = {
@@ -4533,7 +4160,6 @@ country_event = {
 		ai_chance = { base = 100 }
 		add_ideas = AFG_cia_predator_surveillance_drones
 	}
-
 }
 #India Accepts
 country_event = {
@@ -4554,7 +4180,6 @@ country_event = {
 			add_opinion_modifier = { target = AFG modifier = trade_allies }
 		}
 	}
-
 }
 #Generic reject for war tree
 country_event = {
@@ -4569,7 +4194,6 @@ country_event = {
 		name = AFG_events.41.a
 		ai_chance = { base = 100 }
 	}
-
 }
 #Russia Asked the United states
 country_event = {
@@ -4635,7 +4259,6 @@ country_event = {
 		}
 		AFG = { country_event = AFG_events.41 }
 	}
-
 }
 
 #Ismail Khan escapes from prison in Kandahar.
@@ -4658,7 +4281,6 @@ country_event = {
 		add_war_support = 0.05
 		ai_chance = { base = 100 }
 	}
-
 }
 # Mahmoud Surkha, has defected to the Taliban.
 country_event = {
@@ -4680,7 +4302,6 @@ country_event = {
 		add_war_support = -0.02
 		ai_chance = { base = 100 }
 	}
-
 }
 # Abdullah Jan Wahidi, has defected to the Taliban.
 country_event = {
@@ -4702,7 +4323,6 @@ country_event = {
 		add_war_support = -0.02
 		ai_chance = { base = 100 }
 	}
-
 }
 
 country_event = {
@@ -4712,13 +4332,8 @@ country_event = {
 
 	immediate = {
 		log = "[GetDateText]: [This.GetName]: AFG_events.53 executed"
-		AFG = {
-			random_owned_state = {
-				invest_mic = yes
-			}
-		}
+		AFG = { random_owned_state = { invest_mic = yes } }
 	}
-
 }
 
 
@@ -4746,9 +4361,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 20
-				AFG = {
-					has_government = ROOT
-				}
+				AFG = { has_government = ROOT }
 			}
 			modifier = {
 				factor = 40
@@ -4764,9 +4377,7 @@ country_event = {
 	option = {
 		name = AFG_events.65.b
 		log = "[GetDateText]: [This.GetName]: AFG_events.65.b executed"
-		AFG = {
-			country_event = AFG_events.41
-		}
+		AFG = { country_event = AFG_events.41 }
 		ai_chance = {
 			base = 10
 			modifier = {
@@ -4784,7 +4395,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 #They accept
 country_event = {
@@ -4841,7 +4451,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 #Eastern Front
 
@@ -4861,7 +4470,6 @@ country_event = {
 		newline = yes
 		unlock_decision_tooltip = AFG_atta_installs_leadership
 	}
-
 }
 
 #Send Arms Deal
@@ -4891,9 +4499,7 @@ country_event = {
 				has_opinion = { target = AFG value < 0 }
 			}
 		}
-		AFG = {
-			country_event = AFG_political_events.3
-		}
+		AFG = { country_event = AFG_political_events.3 }
 		effect_tooltip = {
 			AFG = {
 				add_equipment_to_stockpile = {
@@ -4949,11 +4555,8 @@ country_event = {
 				has_opinion = { target = AFG value < 0 }
 			}
 		}
-		AFG = {
-			country_event = AFG_political_events.2
-		}
+		AFG = { country_event = AFG_political_events.2 }
 	}
-
 }
 
 #Rejects Arms Deal
@@ -4964,10 +4567,7 @@ country_event = {
 	picture = GFX_taliban_uprising
 	is_triggered_only = yes
 
-	option = {
-		name = AFG_political_events.2.a
-	}
-
+	option = { name = AFG_political_events.2.a }
 }
 
 #Accept Arms Deal
@@ -5001,7 +4601,6 @@ country_event = {
 		set_temp_variable = { influence_target = AFG }
 		change_influence_percentage = yes
 	}
-
 }
 
 country_event = {
@@ -5078,7 +4677,6 @@ country_event = {
 		change_ruling_party_effect = yes
 		mark_focus_tree_layout_dirty = yes
 	}
-
 }
 
 #Afghanistan wins border war
@@ -5128,9 +4726,7 @@ country_event = {
 		name = AFG_border_wars.1.b
 		trigger = { NOT = { tag = event_target:AFG_ATTACKER } }
 		log = "[GetDateText]: [This.GetName]: AFG_border_wars.1.b executed"
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 		set_temp_variable = { arg_popularity = -0.05 }
 		add_ruling_outlook_popularity = yes
 	}
@@ -5139,25 +4735,20 @@ country_event = {
 		name = AFG_border_wars.1.c
 		trigger = { NOT = { tag = event_target:AFG_ATTACKER } }
 		log = "[GetDateText]: [This.GetName]: AFG_border_wars.1.c executed"
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 		declare_war_on = {
 			target = event_target:AFG_ATTACKER
 			type = annex_everything
 		}
 		random_country_with_original_tag = {
 			original_tag_to_check = PAK
-			limit = {
-				NOT = { tag = event_target:AFG_ATTACKER }
-			}
+			limit = { NOT = { tag = event_target:AFG_ATTACKER } }
 			declare_war_on = {
 				target = event_target:AFG_ATTACKER
 				type = annex_everything
 			}
 		}
 	}
-
 }
 
 #Afghanistan loses border war
@@ -5193,7 +4784,6 @@ country_event = {
 		set_temp_variable = { arg_popularity = -0.05 }
 		add_ruling_outlook_popularity = yes
 	}
-
 }
 
 country_event = {
@@ -5226,11 +4816,8 @@ country_event = {
 				days = 1
 			}
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
-
 }
 
 country_event = {
@@ -5262,7 +4849,6 @@ country_event = {
 			base = 1
 		}
 	}
-
 }
 
 # Taliban Moves To Occupy Tribal Areas
@@ -5276,11 +4862,8 @@ country_event = {
 	# Okay
 	option = {
 		name = AFG_border_wars.5.a
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # Taliban Ignores Us
@@ -5302,11 +4885,8 @@ country_event = {
 			target = TAL
 			type = liberate_wargoal
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # Afghan Victory
@@ -5327,48 +4907,26 @@ country_event = {
 	option = {
 		name = AFG_border_wars.7.a
 		log = "[GetDateText]: [This.GetName]: AFG_border_wars.7.a executed"
-		trigger = {
-			original_tag = AFG
+		trigger = { original_tag = AFG }
+		if = {
+			limit = { has_country_flag = AFG_attacking_1208 }
+			1208 = { transfer_state_to = AFG }
 		}
 		if = {
-			limit = {
-				has_country_flag = AFG_attacking_1208
-			}
-			1208 = {
-				transfer_state_to = AFG
-			}
+			limit = { has_country_flag = AFG_attacking_1154 }
+			1154 = { transfer_state_to = AFG }
 		}
 		if = {
-			limit = {
-				has_country_flag = AFG_attacking_1154
-			}
-			1154 = {
-				transfer_state_to = AFG
-			}
+			limit = { has_country_flag = AFG_attacking_1152 }
+			1152 = { transfer_state_to = AFG }
 		}
 		if = {
-			limit = {
-				has_country_flag = AFG_attacking_1152
-			}
-			1152 = {
-				transfer_state_to = AFG
-			}
+			limit = { has_country_flag = AFG_attacking_415 }
+			415 = { transfer_state_to = AFG }
 		}
 		if = {
-			limit = {
-				has_country_flag = AFG_attacking_415
-			}
-			415 = {
-				transfer_state_to = AFG
-			}
-		}
-		if = {
-			limit = {
-				has_country_flag = AFG_attacking_1207
-			}
-			1207 = {
-				transfer_state_to = AFG
-			}
+			limit = { has_country_flag = AFG_attacking_1207 }
+			1207 = { transfer_state_to = AFG }
 		}
 		clr_country_flag = AFG_attacking_1208
 		clr_country_flag = AFG_attacking_1154
@@ -5377,25 +4935,19 @@ country_event = {
 		clr_country_flag = AFG_attacking_1207
 		clr_country_flag = AFG_doing_border_raid
 		army_experience = 25
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = AFG_border_wars.7.b
 		log = "[GetDateText]: [This.GetName]: AFG_border_wars.7.b executed"
-		trigger = {
-			original_tag = TAL
-		}
+		trigger = { original_tag = TAL }
 		army_experience = -25
 		clr_country_flag = TAL_attacking_1154
 		clr_country_flag = TAL_attacking_1208
 		clr_country_flag = TAL_attacking_415
 		clr_country_flag = AFG_doing_border_raid
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Border war on_win/on_lose ignores the event trigger, so a third-party state controller can receive this
@@ -5405,11 +4957,8 @@ country_event = {
 			NOT = { original_tag = AFG }
 			NOT = { original_tag = TAL }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # Taliban Victory
@@ -5430,49 +4979,31 @@ country_event = {
 	option = {
 		name = AFG_border_wars.8.a
 		log = "[GetDateText]: [This.GetName]: AFG_border_wars.8.a executed"
-		trigger = {
-			original_tag = TAL
-		}
+		trigger = { original_tag = TAL }
 		army_experience = 25
 		if = {
-			limit = {
-				has_country_flag = TAL_attacking_1154
-			}
-			1154 = {
-				transfer_state_to = TAL
-			}
+			limit = { has_country_flag = TAL_attacking_1154 }
+			1154 = { transfer_state_to = TAL }
 		}
 		if = {
-			limit = {
-				has_country_flag = TAL_attacking_1208
-			}
-			1208 = {
-				transfer_state_to = TAL
-			}
+			limit = { has_country_flag = TAL_attacking_1208 }
+			1208 = { transfer_state_to = TAL }
 		}
 		if = {
-			limit = {
-				has_country_flag = TAL_attacking_415
-			}
-			415 = {
-				transfer_state_to = TAL
-			}
+			limit = { has_country_flag = TAL_attacking_415 }
+			415 = { transfer_state_to = TAL }
 		}
 		clr_country_flag = TAL_attacking_1154
 		clr_country_flag = TAL_attacking_1208
 		clr_country_flag = TAL_attacking_415
 		clr_country_flag = AFG_doing_border_raid
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
 		name = AFG_border_wars.8.b
 		log = "[GetDateText]: [This.GetName]: AFG_border_wars.8.b executed"
-		trigger = {
-			original_tag = AFG
-		}
+		trigger = { original_tag = AFG }
 		army_experience = -25
 		clr_country_flag = AFG_attacking_1208
 		clr_country_flag = AFG_attacking_1154
@@ -5480,9 +5011,7 @@ country_event = {
 		clr_country_flag = AFG_attacking_415
 		clr_country_flag = AFG_attacking_1207
 		clr_country_flag = AFG_doing_border_raid
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	# Border war on_win/on_lose ignores the event trigger, so a third-party state controller can receive this
@@ -5492,11 +5021,8 @@ country_event = {
 			NOT = { original_tag = AFG }
 			NOT = { original_tag = TAL }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 # Inconclusive Battle
@@ -5519,9 +5045,6 @@ country_event = {
 		clr_country_flag = TAL_attacking_1208
 		clr_country_flag = TAL_attacking_415
 		clr_country_flag = AFG_doing_border_raid
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }

--- a/events/Indonesia.txt
+++ b/events/Indonesia.txt
@@ -8,6 +8,7 @@ country_event = {
 	desc = indonesia.5.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.5.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.5.a"
@@ -46,6 +47,7 @@ country_event = {
 	desc = indonesia.50.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.50.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.50.a"
@@ -57,13 +59,14 @@ country_event = {
 				modifier = medium_increase
 			}
 		}
-	}
+}
 country_event = {
 	id = indonesia.500
 	title = indonesia.500.t
 	desc = indonesia.500.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.500.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.500.a"
@@ -72,13 +75,14 @@ country_event = {
 				modifier = large_decrease
 			}
 		}
-	}
+}
 country_event = {
 	id = indonesia.6
 	title = indonesia.6.t
 	desc = indonesia.6.d
 	picture = GFX_stock_market
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.6.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.6.a"
@@ -90,18 +94,20 @@ country_event = {
 		set_temp_variable = { treasury_change = -26.45 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = indonesia.6.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.6.b"
 		IND = { country_event = { id = indonesia.600 hours = 6 } }
 		}
-	}
+}
 country_event = {
 	id = indonesia.60
 	title = indonesia.60.t
 	desc = indonesia.60.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.60.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.60.a"
@@ -113,13 +119,14 @@ country_event = {
 				modifier = medium_increase
 			}
 		}
-	}
+}
 country_event = {
 	id = indonesia.600
 	title = indonesia.600.t
 	desc = indonesia.600.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.600.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.600.a"
@@ -128,7 +135,7 @@ country_event = {
 				modifier = large_decrease
 			}
 		}
-	}
+}
 ##Talk with our neighbors events
 country_event = {
 	id = indonesia.7
@@ -136,6 +143,7 @@ country_event = {
 	desc = indonesia.7.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.7.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.7.a"
@@ -149,6 +157,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = indonesia.7.b
 		log = "[GetDateText]: [This.GetName]: indonesia.7.b executed"
@@ -163,6 +172,7 @@ country_event = {
 	desc = indonesia.70.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.70.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.70.a"
@@ -182,6 +192,7 @@ country_event = {
 	desc = indonesia.700.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.700.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.700.a"
@@ -191,9 +202,7 @@ country_event = {
 			modifier = small_increase
 				}
 			}
-		MAY = {
-			remove_state_core = 627
-		}
+		MAY = { remove_state_core = 627 }
 	}
 }
 ##Australia
@@ -203,6 +212,7 @@ country_event = {
 	desc = indonesia.8.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.8.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.8.a"
@@ -219,6 +229,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = indonesia.8.b
 		log = "[GetDateText]: [This.GetName]: indonesia.8.b executed"
@@ -236,6 +247,7 @@ country_event = {
 	desc = indonesia.80.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.80.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.80.a"
@@ -255,6 +267,7 @@ country_event = {
 	desc = indonesia.800.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.800.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.800.a"
@@ -279,9 +292,9 @@ country_event = {
 	desc = indonesia.2.d
 	picture = GFX_politics_protest
 	is_triggered_only = yes
-	trigger = {
-		tag = IND
-	}
+
+	trigger = { tag = IND }
+
 	##East Timor Gains Independence
 	option = {
 		name = indonesia.2.a
@@ -289,7 +302,6 @@ country_event = {
 		hidden_effect = {
 			country_event = { id = indonesia.3 days = 204 }
 		}
-
 		USA = {
 			add_opinion_modifier = { target = IND modifier = large_increase }
 			reverse_add_opinion_modifier = { target = IND modifier = large_increase }
@@ -303,7 +315,6 @@ country_event = {
 			add_opinion_modifier = { target = IND modifier = small_increase }
 			reverse_add_opinion_modifier = { target = IND modifier = small_increase }
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -312,6 +323,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = indonesia.2.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.2.b"
@@ -329,10 +341,7 @@ country_event = {
 				add_opinion_modifier = { target = IND modifier = large_decrease }
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 ##AUSTRALIA FIRES BACK
@@ -340,12 +349,11 @@ country_event = {
 	id = indonesia.9
 	title = indonesia.9.t
 	desc = indonesia.9.d
-	#picture =
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
-	trigger = {
-		tag = AST
-	}
+
+	#picture =
+	trigger = { tag = AST }
 
 	##Start Seperatist or do nothing
 	option = {
@@ -386,11 +394,11 @@ country_event = {
 				amount = -3000
 			}
 		}
-
 		ai_chance = {
 			base = 2
 		}
 	}
+
 	option = {
 		name = indonesia.9.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.9.b"
@@ -400,9 +408,7 @@ country_event = {
 				modifier = large_increase
 			}
 		}
-		ai_chance = {
-		base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #The UN Approves the Constitution
@@ -413,9 +419,8 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	trigger = { tag = IND }
+
 	##East Timor Gains Independence
 	option = {
 		name = indonesia.3.a
@@ -423,9 +428,7 @@ country_event = {
 		hidden_effect = {
 			country_event = { id = indonesia.4 days = 59 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Timor-Leste is free!
@@ -433,17 +436,15 @@ country_event = {
 	id = indonesia.4
 	title = indonesia.4.t
 	desc = indonesia.4.d
-	#picture =
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##East Timor Gains Independence
 	option = {
 		name = indonesia.4.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.4.a"
-
 		TIM = {
 			transfer_state = 734
 			transfer_state = 1226
@@ -488,13 +489,12 @@ country_event = {
 	id = indonesia.41
 	title = indonesia.41.t
 	desc = indonesia.41.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.41.a
@@ -508,9 +508,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -518,12 +516,12 @@ country_event = {
 	id = indonesia.42
 	title = indonesia.42.t
 	desc = indonesia.42.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
-	trigger = {
-		tag = IND
-	}
+
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.42.a
@@ -537,9 +535,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -547,12 +543,11 @@ country_event = {
 	id = indonesia.43
 	title = indonesia.43.t
 	desc = indonesia.43.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
-	trigger = {
-		tag = IND
-	}
+
+	#picture =
+	trigger = { tag = IND }
 
 	##DISASTER
 	option = {
@@ -560,9 +555,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event indonesia.43.a"
 		add_stability = -0.10
 		add_political_power = -300
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -573,9 +566,8 @@ country_event = {
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.44.a
@@ -589,9 +581,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Aceh Revolt
@@ -602,32 +592,27 @@ country_event = {
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.45.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.45.a"
 		add_stability = -0.05
 		add_political_power = -100
-		ai_chance = {
-			base = 1
-			}
+		ai_chance = { base = 1 }
 		}
-	}
+}
 #
 country_event = {
 	id = indonesia.46
 	title = indonesia.46.t
 	desc = indonesia.46.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
 
 	##DISASTER
 	option = {
@@ -642,22 +627,19 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
 	id = indonesia.47
 	title = indonesia.47.t
 	desc = indonesia.47.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.47.a
@@ -671,22 +653,18 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
 	id = indonesia.48
 	title = indonesia.48.t
 	desc = indonesia.48.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
 
 	##DISASTER
 	option = {
@@ -701,9 +679,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -711,13 +687,11 @@ country_event = {
 	id = indonesia.49
 	title = indonesia.49.t
 	desc = indonesia.49.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
 
 	##DISASTER
 	option = {
@@ -725,9 +699,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event indonesia.49.a"
 		add_stability = -0.10
 		add_political_power = -300
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -735,13 +707,12 @@ country_event = {
 	id = indonesia.51
 	title = indonesia.51.t
 	desc = indonesia.51.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.51.a
@@ -755,22 +726,19 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
 	id = indonesia.52
 	title = indonesia.52.t
 	desc = indonesia.52.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.52.a
@@ -784,9 +752,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -794,13 +760,12 @@ country_event = {
 	id = indonesia.53
 	title = indonesia.53.t
 	desc = indonesia.53.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.53.a
@@ -814,9 +779,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
@@ -826,9 +789,8 @@ country_event = {
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.54.a
@@ -842,9 +804,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -852,13 +812,11 @@ country_event = {
 	id = indonesia.56
 	title = indonesia.56.t
 	desc = indonesia.56.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
 
 	##DISASTER
 	option = {
@@ -873,9 +831,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -883,13 +839,12 @@ country_event = {
 	id = indonesia.57
 	title = indonesia.57.t
 	desc = indonesia.57.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.57.a
@@ -903,9 +858,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -913,13 +866,12 @@ country_event = {
 	id = indonesia.58
 	title = indonesia.58.t
 	desc = indonesia.58.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.58.a
@@ -933,9 +885,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -943,13 +893,12 @@ country_event = {
 	id = indonesia.59
 	title = indonesia.59.t
 	desc = indonesia.59.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.59.a
@@ -963,9 +912,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -973,13 +920,12 @@ country_event = {
 	id = indonesia.61
 	title = indonesia.61.t
 	desc = indonesia.61.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.61.a
@@ -993,9 +939,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -1003,13 +947,12 @@ country_event = {
 	id = indonesia.62
 	title = indonesia.62.t
 	desc = indonesia.62.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.62.a
@@ -1023,9 +966,7 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -1033,35 +974,31 @@ country_event = {
 	id = indonesia.63
 	title = indonesia.63.t
 	desc = indonesia.63.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.63.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.63.a"
 		add_stability = -0.10
 		add_political_power = -500
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 country_event = {
 	id = indonesia.64
 	title = indonesia.64.t
 	desc = indonesia.64.d
-	#picture =
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##DISASTER
 	option = {
 		name = indonesia.64.a
@@ -1075,21 +1012,18 @@ country_event = {
 				instant_build = yes
 				}
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #### WARNING FOR DISASTER MECHANIC
 country_event = {
 	id = indonesia.5865
-	picture = GFX_typhoon
 	title = indonesia.5865.t
 	desc = indonesia.5865.d
+	picture = GFX_typhoon
 	is_triggered_only = yes
-	option = {
-		name = indonesia.5865.a
-	}
+
+	option = { name = indonesia.5865.a }
 }
 ####
 
@@ -1101,13 +1035,12 @@ country_event = {
 	id = indonesia.420
 	title = indonesia.420.t
 	desc = indonesia.420.d
-	#picture =
 	picture = GFX_treaty
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##East Timor Gains Independence
 	option = {
 		name = indonesia.420.a
@@ -1121,6 +1054,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = indonesia.420.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.420.b"
@@ -1139,13 +1073,12 @@ country_event = {
 	id = indonesia.55
 	title = indonesia.55.t
 	desc = indonesia.55.d
-	#picture =
 	picture = GFX_generic_education_event_picture
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##Education Question
 	option = {
 		name = indonesia.55.a
@@ -1162,6 +1095,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = indonesia.55.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.55.b"
@@ -1183,6 +1117,7 @@ country_event = {
 	desc = indonesia.77.d
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
 	option = { # Back Muslims
 		name = indonesia.77.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.77.a"
@@ -1195,6 +1130,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # back no one
 		name = indonesia.77.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.77.b"
@@ -1207,6 +1143,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { # back christians
 		name = indonesia.77.c
 		log = "[GetDateText]: [Root.GetName]: event indonesia.77.c"
@@ -1228,20 +1165,17 @@ country_event = {
 	id = indonesia.69
 	title = indonesia.69.t
 	desc = indonesia.69.d
-	#picture =
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
-	trigger = {
-		tag = IND
-	}
+	#picture =
+	trigger = { tag = IND }
+
 	##What to do
 	option = {
 		name = indonesia.69.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.69.a"
-		ai_chance = {
-			base = 1
-			}
+		ai_chance = { base = 1 }
 			add_timed_idea = {
 				idea = IND_scars_kalimantan
 				days = 400
@@ -1254,9 +1188,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -12.5 }
 		modify_treasury_effect = yes
 		add_political_power = -100
-		ai_chance = {
-		base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1264,19 +1196,18 @@ country_event = {
 	id = indonesia.76854
 	title = indonesia.76854.t
 	desc = indonesia.76854.d
-	#picture =
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
+	#picture =
 	#
 	option = {
 		name = indonesia.76854.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.76854.a"
 		IND = { annex_country = { target = ACE transfer_troops = no } }
-		ai_chance = {
-			base = 8
-		}
+		ai_chance = { base = 8 }
 	}
+
 	option = {
 		name = indonesia.76854.b
 		log = "[GetDateText]: [Root.GetName]: event indonesia.76854.b"
@@ -1288,9 +1219,7 @@ country_event = {
 				target = ACE
 			}
 		}
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 }
 #
@@ -1300,12 +1229,13 @@ country_event = {
 	desc = indonesia.923.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.923.a
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.923.a"
 		add_stability = 0.10
 		}
-	}
+}
 #Wahid's impeachment
 country_event = {
 	id = indonesia.27
@@ -1313,9 +1243,9 @@ country_event = {
 	desc = indonesia.27.d
 	picture = GFX_court
 	is_triggered_only = yes
-	trigger = {
-		western_conservatism_are_in_power = yes
-	}
+
+	trigger = { western_conservatism_are_in_power = yes }
+
 	option = {
 		name = indonesia.27.a
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.27.a"
@@ -1323,9 +1253,7 @@ country_event = {
 			add_country_leader_role = {
 			character = IND_tyasno_sudarto
 			promote_leader = yes
-			country_leader = {
-				ideology = conservatism
-			}
+			country_leader = { ideology = conservatism }
 		 }
 	}
 }
@@ -1344,6 +1272,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -22.35 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = indonesia.37.b
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.37.b"
@@ -1360,6 +1289,7 @@ country_event = {
 	desc = indonesia.772.d
 	picture = GFX_court
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.772.a
 		log = "[GetDateText]: [Root.GetName]: country event indonesia.772.a"
@@ -1390,6 +1320,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = {
 		name = indonesia.477.b
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.477.b"
@@ -1407,28 +1338,23 @@ country_event = {
 	id = indonesia.577
 	title = indonesia.577.t
 	desc = {
-		trigger = {
-			has_war_with = ACE
-		}
+		trigger = { has_war_with = ACE }
 		text = indonesia.577.d
 	}
 	desc = {
-		trigger = {
-			NOT = { has_war_with = ACE }
-		}
+		trigger = { NOT = { has_war_with = ACE } }
 		text = indonesia.577.d1
 	}
 	picture = GFX_broken_infrastructure
 	is_triggered_only = yes
+
 	option = {
 		name = indonesia.577.a
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.577.a"
 		mark_focus_tree_layout_dirty = yes
 		if = { limit = { has_war_with = ACE }
 			set_country_flag = ACE1
-			IND = {
-				white_peace = ACE
-			}
+			IND = { white_peace = ACE }
 		}
 	}
 }
@@ -1437,18 +1363,16 @@ country_event = {
 	id = indonesia.988
 	title = indonesia.988.t
 	desc = indonesia.988.d
-	#picture =
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
+	#picture =
 	#
 	option = {
 		name = indonesia.988.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.988.a"
 		complete_national_focus = IND_our_policies
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -1456,18 +1380,16 @@ country_event = {
 	id = indonesia.1000
 	title = indonesia.1000.t
 	desc = indonesia.1000.d
-	#picture =
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
+	#picture =
 	#
 	option = {
 		name = indonesia.1000.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.1000.a"
 		complete_national_focus = IND_fpi
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 # Ambon City Collapse
@@ -1476,10 +1398,10 @@ country_event = {
 	id = indonesia.1001
 	title = indonesia.1001.t
 	desc = indonesia.1001.d
-	#picture =
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
+	#picture =
 	#
 	option = {
 		name = indonesia.1001.a
@@ -1488,9 +1410,7 @@ country_event = {
 			remove_idea = IND_back_christians_b
 			add_idea = IND_back_christians_c
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #Muslims
@@ -1498,10 +1418,10 @@ country_event = {
 	id = indonesia.1002
 	title = indonesia.1002.t
 	desc = indonesia.1002.d
-	#picture =
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
+	#picture =
 	#
 	option = {
 		name = indonesia.1002.a
@@ -1510,9 +1430,7 @@ country_event = {
 			remove_idea = IND_back_muslims_c
 			add_idea = IND_back_muslims_d
 			}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 ##
@@ -1520,17 +1438,15 @@ country_event = {
 	id = indonesia.888
 	title = indonesia.888.t
 	desc = indonesia.888.d
-	#picture =
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
+	#picture =
 	option = {
 		name = indonesia.888.a
 		log = "[GetDateText]: [Root.GetName]: event indonesia.888.a"
 		complete_national_focus = IND_our_policies
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 #
@@ -1555,13 +1471,14 @@ country_event = {
 		set_temp_variable = { treasury_change = -4.35 }
 		modify_treasury_effect = yes
 		}
+
 	option = {
 		name = indonesia.67.b
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.67.b"
 		set_temp_variable = { treasury_change = 7.35 }
 		modify_treasury_effect = yes
 		}
-	}
+}
 ## 2007 National Comittee of Papua New Guinea
 country_event = {
 	id = indonesia.678
@@ -1578,6 +1495,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -8.35 }
 		modify_treasury_effect = yes
 	}
+
 	option = {
 		name = indonesia.678.b
 		log = "[GetDateText]: [Root.GetName]: news event indonesia.678.b"
@@ -1586,4 +1504,4 @@ country_event = {
 			days = 200
 			}
 		}
-	}
+}

--- a/events/Poland.txt
+++ b/events/Poland.txt
@@ -135,11 +135,7 @@ country_event = {
 
 	option = {
 		name = poland.9.a
-		trigger = {
-			NOT = {
-				has_completed_focus = POL_red_dream
-			}
-		}
+		trigger = { NOT = { has_completed_focus = POL_red_dream } }
 		log = "[GetDateText]: [This.GetName]: poland.9.a executed"
 		custom_effect_tooltip = POL_First_elections_1_TT
 		add_political_power = 75
@@ -149,20 +145,14 @@ country_event = {
 
 	option = {
 		name = poland.9.b
-		trigger = {
-			NOT = {
-				has_completed_focus = POL_red_dream
-			}
-		}
+		trigger = { NOT = { has_completed_focus = POL_red_dream } }
 		log = "[GetDateText]: [This.GetName]: poland.9.b executed"
 		custom_effect_tooltip = POL_First_elections_2_TT
 		add_stability = -0.03
 		add_political_power = -50
-
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = -0.10 }
 		change_relative_party_popularity = yes
-
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -174,14 +164,10 @@ country_event = {
 
 	option = {
 		name = poland.9.c
-		trigger = {
-			has_completed_focus = POL_red_dream
-		}
+		trigger = { has_completed_focus = POL_red_dream }
 		log = "[GetDateText]: [This.GetName]: poland.9.c executed"
 		add_political_power = -25
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -326,9 +312,7 @@ country_event = {
 		ai_chance = { base = 90 }
 		POL = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = CZE
 					autonomy_state = autonomy_autonomous_state_colored
@@ -379,9 +363,7 @@ country_event = {
 		ai_chance = { base = 90 }
 		POL = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = SLO
 					autonomy_state = autonomy_autonomous_state_colored
@@ -431,9 +413,7 @@ country_event = {
 		ai_chance = { base = 90 }
 		POL = {
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = HUN
 					autonomy_state = autonomy_autonomous_state_colored
@@ -594,30 +574,14 @@ country_event = {
 		name = poland.26.a
 		log = "[GetDateText]: [This.GetName]: poland.26.a executed"
 		add_political_power = -75
-		POL = {
-			add_political_power = 75
-		}
-		700 = {
-			transfer_state_to = POL
-		}
-		1111 = {
-			transfer_state_to = POL
-		}
-		1247 = {
-			transfer_state_to = POL
-		}
-		701 = {
-			transfer_state_to = POL
-		}
-		1110 = {
-			transfer_state_to = POL
-		}
-		1248 = {
-			transfer_state_to = POL
-		}
-		335 = {
-			transfer_state_to = POL
-		}
+		POL = { add_political_power = 75 }
+		700 = { transfer_state_to = POL }
+		1111 = { transfer_state_to = POL }
+		1247 = { transfer_state_to = POL }
+		701 = { transfer_state_to = POL }
+		1110 = { transfer_state_to = POL }
+		1248 = { transfer_state_to = POL }
+		335 = { transfer_state_to = POL }
 		SOV = {
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = SOV.id }
@@ -796,24 +760,12 @@ country_event = {
 		name = poland.28.a
 		log = "[GetDateText]: [This.GetName]: poland.28.a executed"
 		add_political_power = -75
-		POL = {
-			add_political_power = 75
-		}
-		699 = {
-			transfer_state_to = POL
-		}
-		1250 = {
-			transfer_state_to = POL
-		}
-		695 = {
-			transfer_state_to = POL
-		}
-		333 = {
-			transfer_state_to = POL
-		}
-		335 = {
-			transfer_state_to = POL
-		}
+		POL = { add_political_power = 75 }
+		699 = { transfer_state_to = POL }
+		1250 = { transfer_state_to = POL }
+		695 = { transfer_state_to = POL }
+		333 = { transfer_state_to = POL }
+		335 = { transfer_state_to = POL }
 		SOV = {
 			set_temp_variable = { percent_change = 4 }
 			set_temp_variable = { tag_index = SOV.id }
@@ -991,23 +943,15 @@ country_event = {
 	option = {
 		name = poland.30.a
 		log = "[GetDateText]: [This.GetName]: poland.30.a executed"
-		UKR = {
-			country_event = poland.31
-		}
-		ai_chance = {
-			base = 50
-		}
+		UKR = { country_event = poland.31 }
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = poland.30.b
 		log = "[GetDateText]: [This.GetName]: poland.30.b executed"
-		SOV = {
-			country_event = poland.32
-		}
-		ai_chance = {
-			base = 50
-		}
+		SOV = { country_event = poland.32 }
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -1023,9 +967,7 @@ country_event = {
 		name = poland.31.a
 		log = "[GetDateText]: [This.GetName]: poland.31.a executed"
 		add_political_power = -75
-		POL = {
-			puppet = UKR
-		}
+		POL = { puppet = UKR }
 		news_event = poland_news.18
 		ai_chance = {
 			base = 50
@@ -1172,26 +1114,16 @@ country_event = {
 	option = {
 		name = poland.32.a
 		log = "[GetDateText]: [This.GetName]: poland.32.a executed"
-		POL = {
-			country_event = poland.34
-		}
-		UKR = {
-			country_event = poland.35
-		}
-		ai_chance = {
-			base = 50
-		}
+		POL = { country_event = poland.34 }
+		UKR = { country_event = poland.35 }
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = poland.32.b
 		log = "[GetDateText]: [This.GetName]: poland.32.b executed"
-		POL = {
-			country_event = poland.36
-		}
-		ai_chance = {
-			base = 50
-		}
+		POL = { country_event = poland.36 }
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -1221,9 +1153,7 @@ country_event = {
 			value = -0.15
 			tooltip_side = POL_korwin_win_bop_left_side
 		}
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 
 	option = {
@@ -1239,9 +1169,7 @@ country_event = {
 			value = -0.15
 			tooltip_side = POL_korwin_win_bop_left_side
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1258,9 +1186,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.34.a executed"
 		add_political_power = 100
 		add_war_support = 0.05
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -1277,54 +1203,22 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.35.a executed"
 		add_political_power = -75
 		hidden_effect = {
-			698 = {
-				transfer_state_to = POL
-			}
-			1091 = {
-				transfer_state_to = POL
-			}
-			1090 = {
-				transfer_state_to = POL
-			}
-			1086 = {
-				transfer_state_to = POL
-			}
-			697 = {
-				transfer_state_to = POL
-			}
-			1089 = {
-				transfer_state_to = POL
-			}
-			1087 = {
-				transfer_state_to = POL
-			}
-			1088 = {
-				transfer_state_to = SOV
-			}
-			696 = {
-				transfer_state_to = SOV
-			}
-			1076 = {
-				transfer_state_to = SOV
-			}
-			1075 = {
-				transfer_state_to = SOV
-			}
-			693 = {
-				transfer_state_to = SOV
-			}
-			1030 = {
-				transfer_state_to = SOV
-			}
-			694 = {
-				transfer_state_to = SOV
-			}
-			1085 = {
-				transfer_state_to = SOV
-			}
-			669 = {
-				transfer_state_to = SOV
-			}
+			698 = { transfer_state_to = POL }
+			1091 = { transfer_state_to = POL }
+			1090 = { transfer_state_to = POL }
+			1086 = { transfer_state_to = POL }
+			697 = { transfer_state_to = POL }
+			1089 = { transfer_state_to = POL }
+			1087 = { transfer_state_to = POL }
+			1088 = { transfer_state_to = SOV }
+			696 = { transfer_state_to = SOV }
+			1076 = { transfer_state_to = SOV }
+			1075 = { transfer_state_to = SOV }
+			693 = { transfer_state_to = SOV }
+			1030 = { transfer_state_to = SOV }
+			694 = { transfer_state_to = SOV }
+			1085 = { transfer_state_to = SOV }
+			669 = { transfer_state_to = SOV }
 		}
 		news_event = poland_news.19
 		ai_chance = {
@@ -1482,12 +1376,8 @@ country_event = {
 		name = poland.36.a
 		log = "[GetDateText]: [This.GetName]: poland.36.a executed"
 		add_political_power = -50
-		UKR = {
-			country_event = poland.31
-		}
-		ai_chance = {
-			base = 99
-		}
+		UKR = { country_event = poland.31 }
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -1506,18 +1396,14 @@ country_event = {
 			target = UKR
 			type = annex_everything
 		}
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.37.b
 		log = "[GetDateText]: [This.GetName]: poland.37.b executed"
 		add_political_power = -100
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -1531,27 +1417,17 @@ country_event = {
 	option = {
 		name = poland.38.a
 		log = "[GetDateText]: [This.GetName]: poland.38.a executed"
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 		add_political_power = 150
 		add_war_support = 0.25
 		add_stability = 0.2
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.38.b
 		log = "[GetDateText]: [This.GetName]: poland.38.b executed"
-		trigger = {
-			NOT = {
-				original_tag = UKR
-			}
-		}
+		trigger = { NOT = { original_tag = UKR } }
 		add_political_power = -200
 		add_war_support = -0.3
 		add_stability = -0.15
@@ -1570,12 +1446,8 @@ country_event = {
 			tag = UKR
 			message = POL_ukraine_peace_TT
 		}
-		UKR = {
-			country_event = poland.38
-		}
-		ai_chance = {
-			base = 1
-		}
+		UKR = { country_event = poland.38 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -1634,37 +1506,25 @@ country_event = {
 		controls_state = 700
 		controls_state = 1111
 		controls_state = 1247
-		NOT = {
-			has_completed_focus = POL_access_to_the_black_sea
-		}
+		NOT = { has_completed_focus = POL_access_to_the_black_sea }
 		nationalist_monarchists_are_in_power = yes
-		UKR = {
-			is_in_faction = no
-		}
+		UKR = { is_in_faction = no }
 	}
 
 	option = {
 		name = poland.39.a
 		log = "[GetDateText]: [This.GetName]: poland.39.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_political_power = 50
 		add_stability = 0.05
-		UKR = {
-			country_event = poland.40
-		}
-		ai_chance = {
-			base = 99
-		}
+		UKR = { country_event = poland.40 }
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.39.b
 		log = "[GetDateText]: [This.GetName]: poland.39.b executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_war_support = -0.05
 		every_neighbor_country = {
 			limit = {
@@ -1684,20 +1544,12 @@ country_event = {
 		}
 		unlock_national_focus = POL_access_to_the_black_sea
 		if = {
-			limit = {
-				NOT = {
-					has_completed_focus = POL_path_of_terror
-				}
-			}
+			limit = { NOT = { has_completed_focus = POL_path_of_terror } }
 			complete_national_focus = POL_path_of_terror
 		}
 		unlock_national_focus = POL_end_of_the_ukrainian_regime
-		UKR = {
-			country_event = poland.41
-		}
-		ai_chance = {
-			base = 1
-		}
+		UKR = { country_event = poland.41 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1712,9 +1564,7 @@ country_event = {
 	option = {
 		name = poland.40.a
 		log = "[GetDateText]: [This.GetName]: poland.40.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_political_power = 50
 		add_stability = 0.05
 		white_peace = {
@@ -1728,26 +1578,18 @@ country_event = {
 		1110 = { transfer_state_to = POL }
 		1248 = { transfer_state_to = POL }
 		335 = { transfer_state_to = POL }
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
 		name = poland.40.b
 		log = "[GetDateText]: [This.GetName]: poland.40.b executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_political_power = 50
 		add_stability = -0.1
 		add_war_support = 0.1
-		POL = {
-			country_event = poland.42
-		}
-		ai_chance = {
-			base = 20
-		}
+		POL = { country_event = poland.42 }
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -1761,14 +1603,10 @@ country_event = {
 	option = {
 		name = poland.41.a
 		log = "[GetDateText]: [This.GetName]: poland.41.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_stability = -0.05
 		add_war_support = 0.1
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -1782,24 +1620,16 @@ country_event = {
 	option = {
 		name = poland.42.a
 		log = "[GetDateText]: [This.GetName]: poland.42.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_stability = -0.05
 		add_war_support = 0.05
 		unlock_national_focus = POL_access_to_the_black_sea
 		if = {
-			limit = {
-				NOT = {
-					has_completed_focus = POL_path_of_terror
-				}
-			}
+			limit = { NOT = { has_completed_focus = POL_path_of_terror } }
 			complete_national_focus = POL_path_of_terror
 		}
 		unlock_national_focus = POL_end_of_the_ukrainian_regime
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -1818,37 +1648,25 @@ country_event = {
 		controls_state = 695
 		controls_state = 333
 		has_completed_focus = POL_access_to_the_black_sea
-		NOT = {
-			has_completed_focus = POL_end_of_the_ukrainian_regime
-		}
+		NOT = { has_completed_focus = POL_end_of_the_ukrainian_regime }
 		nationalist_monarchists_are_in_power = yes
-		UKR = {
-			is_in_faction = no
-		}
+		UKR = { is_in_faction = no }
 	}
 
 	option = {
 		name = poland.43.a
 		log = "[GetDateText]: [This.GetName]: poland.43.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_political_power = 50
 		add_stability = 0.05
-		UKR = {
-			country_event = poland.44
-		}
-		ai_chance = {
-			base = 99
-		}
+		UKR = { country_event = poland.44 }
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.43.b
 		log = "[GetDateText]: [This.GetName]: poland.43.b executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_war_support = -0.05
 		every_neighbor_country = {
 			limit = {
@@ -1867,20 +1685,12 @@ country_event = {
 			tooltip_side = POL_korwin_win_bop_left_side
 		}
 		if = {
-			limit = {
-				NOT = {
-					has_completed_focus = POL_path_of_terror
-				}
-			}
+			limit = { NOT = { has_completed_focus = POL_path_of_terror } }
 			complete_national_focus = POL_path_of_terror
 		}
 		unlock_national_focus = POL_end_of_the_ukrainian_regime
-		UKR = {
-			country_event = poland.46
-		}
-		ai_chance = {
-			base = 1
-		}
+		UKR = { country_event = poland.46 }
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1895,50 +1705,30 @@ country_event = {
 	option = {
 		name = poland.44.a
 		log = "[GetDateText]: [This.GetName]: poland.44.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_political_power = 50
 		add_stability = 0.05
 		white_peace = {
 			tag = POL
 			message = POL_ukraine_peace2_TT
 		}
-		699 = {
-			transfer_state_to = POL
-		}
-		1250 = {
-			transfer_state_to = POL
-		}
-		695 = {
-			transfer_state_to = POL
-		}
-		333 = {
-			transfer_state_to = POL
-		}
-		335 = {
-			transfer_state_to = POL
-		}
-		ai_chance = {
-			base = 80
-		}
+		699 = { transfer_state_to = POL }
+		1250 = { transfer_state_to = POL }
+		695 = { transfer_state_to = POL }
+		333 = { transfer_state_to = POL }
+		335 = { transfer_state_to = POL }
+		ai_chance = { base = 80 }
 	}
 
 	option = {
 		name = poland.44.b
 		log = "[GetDateText]: [This.GetName]: poland.44.b executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_political_power = 50
 		add_stability = -0.1
 		add_war_support = 0.1
-		POL = {
-			country_event = poland.45
-		}
-		ai_chance = {
-			base = 20
-		}
+		POL = { country_event = poland.45 }
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -1952,23 +1742,15 @@ country_event = {
 	option = {
 		name = poland.45.a
 		log = "[GetDateText]: [This.GetName]: poland.45.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_stability = -0.05
 		add_war_support = 0.05
 		if = {
-			limit = {
-				NOT = {
-					has_completed_focus = POL_path_of_terror
-				}
-			}
+			limit = { NOT = { has_completed_focus = POL_path_of_terror } }
 			complete_national_focus = POL_path_of_terror
 		}
 		unlock_national_focus = POL_end_of_the_ukrainian_regime
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -1982,14 +1764,10 @@ country_event = {
 	option = {
 		name = poland.46.a
 		log = "[GetDateText]: [This.GetName]: poland.46.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_stability = -0.05
 		add_war_support = 0.1
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -2003,31 +1781,23 @@ country_event = {
 	option = {
 		name = poland.47.a
 		log = "[GetDateText]: [This.GetName]: poland.47.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		set_temp_variable = { percent_change = -4 }
 		set_temp_variable = { tag_index = SOV.id }
 		set_temp_variable = { influence_target = UKR.id }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.47.b
 		log = "[GetDateText]: [This.GetName]: poland.47.b executed"
-		trigger = {
-			original_tag = SOV
-		}
+		trigger = { original_tag = SOV }
 		add_opinion_modifier = {
 			target = POL
 			modifier = POL_destroys_our_influence
 		}
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -2041,16 +1811,10 @@ country_event = {
 	option = {
 		name = poland.48.a
 		log = "[GetDateText]: [This.GetName]: poland.48.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_political_power = 100
-		hidden_effect = {
-			set_country_flag = POL_ukraine_cooperation
-		}
-		POL = {
-			country_event = poland.50
-		}
+		hidden_effect = { set_country_flag = POL_ukraine_cooperation }
+		POL = { country_event = poland.50 }
 		ai_chance = {
 			base = 99
 			modifier = {
@@ -2081,16 +1845,12 @@ country_event = {
 			modifier = {
 				POL = {
 					has_completed_focus = POL_political_manipulation
-					NOT = {
-						has_completed_focus = POL_territorial_propaganda
-					}
+					NOT = { has_completed_focus = POL_territorial_propaganda }
 				}
 				factor = 40
 			}
 			modifier = {
-				POL = {
-					has_completed_focus = POL_territorial_propaganda
-				}
+				POL = { has_completed_focus = POL_territorial_propaganda }
 				factor = 20
 			}
 		}
@@ -2099,12 +1859,8 @@ country_event = {
 	option = {
 		name = poland.48.b
 		log = "[GetDateText]: [This.GetName]: poland.48.b executed"
-		trigger = {
-			original_tag = UKR
-		}
-		POL = {
-			country_event = poland.49
-		}
+		trigger = { original_tag = UKR }
+		POL = { country_event = poland.49 }
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -2135,16 +1891,12 @@ country_event = {
 			modifier = {
 				POL = {
 					has_completed_focus = POL_political_manipulation
-					NOT = {
-						has_completed_focus = POL_territorial_propaganda
-					}
+					NOT = { has_completed_focus = POL_territorial_propaganda }
 				}
 				factor = 60
 			}
 			modifier = {
-				POL = {
-					has_completed_focus = POL_territorial_propaganda
-				}
+				POL = { has_completed_focus = POL_territorial_propaganda }
 				factor = 80
 			}
 		}
@@ -2162,13 +1914,9 @@ country_event = {
 	option = {
 		name = poland.49.a
 		log = "[GetDateText]: [This.GetName]: poland.49.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_political_power = -50
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -2183,13 +1931,9 @@ country_event = {
 	option = {
 		name = poland.50.a
 		log = "[GetDateText]: [This.GetName]: poland.50.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_political_power = 50
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -2387,9 +2131,7 @@ country_event = {
 		name = poland.52.b
 		log = "[GetDateText]: [This.GetName]: poland.52.b executed"
 		add_political_power = 50
-		POL = {
-			country_event = poland.53
-		}
+		POL = { country_event = poland.53 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2442,17 +2184,13 @@ country_event = {
 	option = {
 		name = poland.53.a
 		log = "[GetDateText]: [This.GetName]: poland.53.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_political_power = -50
 		add_opinion_modifier = {
 			target = UKR
 			modifier = POL_ukraine_rejected_alliance
 		}
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -2532,9 +2270,7 @@ country_event = {
 		name = poland.54.b
 		log = "[GetDateText]: [This.GetName]: poland.54.b executed"
 		add_political_power = 50
-		POL = {
-			country_event = poland.53
-		}
+		POL = { country_event = poland.53 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2587,33 +2323,23 @@ country_event = {
 	option = {
 		name = poland.55.a
 		log = "[GetDateText]: [This.GetName]: poland.55.a executed"
-		trigger = {
-			original_tag = UKR
-		}
+		trigger = { original_tag = UKR }
 		add_political_power = 50
 		USA = { add_to_faction = UKR }
 		add_ideas = NATO_member
 		if = {
-			limit = {
-				has_idea = CSTO_member
-			}
+			limit = { has_idea = CSTO_member }
 			remove_ideas = CSTO_member
 		}
 		news_event = poland_news.22
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = poland.55.b
 		log = "[GetDateText]: [This.GetName]: poland.55.b executed"
-		trigger = {
-			original_tag = UKR
-		}
-		hidden_effect = {
-			set_country_flag = POL_ukraine_rej
-		}
+		trigger = { original_tag = UKR }
+		hidden_effect = { set_country_flag = POL_ukraine_rej }
 		add_political_power = -150
 		add_stability = -0.05
 		for_each_scope_loop = {
@@ -2625,9 +2351,7 @@ country_event = {
 			}
 		}
 		news_event = poland_news.23
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -2699,9 +2423,7 @@ country_event = {
 		name = poland.56.b
 		log = "[GetDateText]: [This.GetName]: poland.56.b executed"
 		add_political_power = 100
-		POL = {
-			country_event = poland.57
-		}
+		POL = { country_event = poland.57 }
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -2759,9 +2481,7 @@ country_event = {
 		name = poland.57.a
 		log = "[GetDateText]: [This.GetName]: poland.57.a executed"
 		add_political_power = -150
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -2776,9 +2496,7 @@ country_event = {
 	option = {
 		name = poland.58.a
 		log = "[GetDateText]: [This.GetName]: poland.58.a executed"
-		642 = {
-			transfer_state_to = POL
-		}
+		642 = { transfer_state_to = POL }
 		set_temp_variable = { treasury_change = 60 }
 		modify_treasury_effect = yes
 		POL = {
@@ -2786,21 +2504,15 @@ country_event = {
 			modify_treasury_effect = yes
 		}
 		news_event = poland_news.26
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 
 	option = {
 		name = poland.58.b
 		log = "[GetDateText]: [This.GetName]: poland.58.b executed"
 		add_political_power = 100
-		POL = {
-			country_event = poland.59
-		}
-		ai_chance = {
-			base = 30
-		}
+		POL = { country_event = poland.59 }
+		ai_chance = { base = 30 }
 	}
 }
 
@@ -2816,9 +2528,7 @@ country_event = {
 		name = poland.59.a
 		log = "[GetDateText]: [This.GetName]: poland.59.a executed"
 		add_political_power = -50
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 }
 
@@ -2833,9 +2543,7 @@ country_event = {
 	option = {
 		name = poland.60.a
 		log = "[GetDateText]: [This.GetName]: poland.60.a executed"
-		642 = {
-			transfer_state_to = POL
-		}
+		642 = { transfer_state_to = POL }
 		white_peace = {
 			tag = SOV
 			message = POL_russia_peace_TT
@@ -2843,9 +2551,7 @@ country_event = {
 		add_war_support = 0.1
 		add_political_power = 50
 		news_event = poland_news.27
-		ai_chance = {
-			base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 
 	option = {
@@ -2853,9 +2559,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.60.b executed"
 		add_stability = -0.1
 		news_event = poland_news.28
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2878,11 +2582,7 @@ country_event = {
 		ai_chance = {
 			base = 50
 			modifier = {
-				POL = {
-					NOT = {
-						is_in_faction = yes
-					}
-				}
+				POL = { NOT = { is_in_faction = yes } }
 				factor = 90
 			}
 			modifier = {
@@ -2927,17 +2627,11 @@ country_event = {
 		name = poland.61.b
 		log = "[GetDateText]: [This.GetName]: poland.61.b executed"
 		add_political_power = 50
-		POL = {
-			country_event = poland.63
-		}
+		POL = { country_event = poland.63 }
 		ai_chance = {
 			base = 50
 			modifier = {
-				POL = {
-					NOT = {
-						is_in_faction = yes
-					}
-				}
+				POL = { NOT = { is_in_faction = yes } }
 				factor = 10
 			}
 			modifier = {
@@ -2998,9 +2692,7 @@ country_event = {
 				modifier = POL_poland_starts_cooperation_with_russia
 			}
 		}
-		ai_chance = {
-			base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 }
 
@@ -3016,9 +2708,7 @@ country_event = {
 		name = poland.63.a
 		log = "[GetDateText]: [This.GetName]: poland.63.a executed"
 		add_political_power = -50
-		ai_chance = {
-			base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 }
 
@@ -3055,38 +2745,24 @@ country_event = {
 		SOV = { add_to_faction = POL }
 		add_political_power = 150
 		add_threat = 5
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
 		name = poland.64.b
 		log = "[GetDateText]: [This.GetName]: poland.64.b executed"
-		trigger = {
-			669 = {
-				is_controlled_by = POL
-			}
-		}
+		trigger = { 669 = { is_controlled_by = POL } }
 		add_political_power = 150
-		POL = {
-			country_event = poland.65
-		}
-		ai_chance = {
-			base = 40
-		}
+		POL = { country_event = poland.65 }
+		ai_chance = { base = 40 }
 	}
 
 	option = {
 		name = poland.64.c
 		log = "[GetDateText]: [This.GetName]: poland.64.c executed"
-		POL = {
-			country_event = poland.66
-		}
+		POL = { country_event = poland.66 }
 		add_political_power = -150
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -3105,21 +2781,15 @@ country_event = {
 		SOV = { add_to_faction = POL }
 		add_political_power = 150
 		add_threat = 5
-		669 = {
-			transfer_state_to = SOV
-		}
-		ai_chance = {
-			base = 99
-		}
+		669 = { transfer_state_to = SOV }
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.65.b
 		log = "[GetDateText]: [This.GetName]: poland.65.b executed"
 		add_political_power = -200
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -3133,9 +2803,7 @@ country_event = {
 
 	option = {
 		name = poland.66.a
-		ai_chance = {
-			base = 99
-		}
+		ai_chance = { base = 99 }
 	}
 }
 
@@ -3165,9 +2833,7 @@ country_event = {
 				modifier = POL_poland_plays_aggressive
 			}
 		}
-		hidden_effect = {
-			set_country_flag = POL_choose_aggressive_way
-		}
+		hidden_effect = { set_country_flag = POL_choose_aggressive_way }
 	}
 
 	option = {
@@ -3189,9 +2855,7 @@ country_event = {
 				modifier = POL_poland_goes_rational_way
 			}
 		}
-		hidden_effect = {
-			set_country_flag = POL_choose_democratic_way
-		}
+		hidden_effect = { set_country_flag = POL_choose_democratic_way }
 	}
 }
 
@@ -3205,9 +2869,7 @@ country_event = {
 	option = {
 		name = poland.71.a
 		log = "[GetDateText]: [This.GetName]: poland.71.a executed"
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 		add_stability = -0.05
 		add_political_power = 50
 		if = {
@@ -3219,9 +2881,7 @@ country_event = {
 	option = {
 		name = poland.71.b
 		log = "[GetDateText]: [This.GetName]: poland.71.b executed"
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 		add_political_power = 150
 		reverse_add_opinion_modifier = {
 			target = POL
@@ -3965,9 +3625,7 @@ country_event = {
 	option = {
 		name = poland.105.a
 		log = "[GetDateText]: [This.GetName]: poland.105.a executed"
-		var:POL.POL_faction_invite = {
-			country_event = poland.106
-		}
+		var:POL.POL_faction_invite = { country_event = poland.106 }
 		clear_variable = POL.faction_invite
 		ai_chance = { base = 90 }
 	}
@@ -3975,9 +3633,7 @@ country_event = {
 	option = {
 		name = poland.105.b
 		log = "[GetDateText]: [This.GetName]: poland.105.b executed"
-		var:POL.POL_faction_invite = {
-			country_event = poland.107
-		}
+		var:POL.POL_faction_invite = { country_event = poland.107 }
 		clear_variable = POL.faction_invite
 		ai_chance = { base = 10 }
 	}
@@ -3994,9 +3650,7 @@ country_event = {
 		name = poland.106.a
 		log = "[GetDateText]: [This.GetName]: poland.106.a executed"
 		if = {
-			limit = {
-				has_idea = NATO_member
-			}
+			limit = { has_idea = NATO_member }
 			NATO_leave = yes
 		}
 		set_politics = {
@@ -4009,9 +3663,7 @@ country_event = {
 			POL_gui_dirty_update = yes
 		}
 		add_ideas = REP_member
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -4022,9 +3674,7 @@ country_event = {
 			ideology = communism
 			popularity = -0.45
 		}
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 
@@ -4039,9 +3689,7 @@ country_event = {
 		name = poland.107.a
 		log = "[GetDateText]: [This.GetName]: poland.107.a executed"
 		if = {
-			limit = {
-				has_idea = NATO_member
-			}
+			limit = { has_idea = NATO_member }
 			NATO_leave = yes
 		}
 		set_politics = {
@@ -4053,9 +3701,7 @@ country_event = {
 			add_to_faction = ROOT
 			add_faction_initiative = 1
 			if = {
-				limit = {
-					has_global_flag = GAME_RULE_allow_colored_puppets
-				}
+				limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 				set_autonomy = {
 					target = ROOT
 					autonomy_state = autonomy_satellite_state_colored
@@ -4073,9 +3719,7 @@ country_event = {
 			}
 			POL_gui_dirty_update = yes
 		}
-		ai_chance = {
-			base = 95
-		}
+		ai_chance = { base = 95 }
 	}
 
 	option = {
@@ -4086,9 +3730,7 @@ country_event = {
 			ideology = communism
 			popularity = -0.30
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -4103,9 +3745,7 @@ country_event = {
 		name = poland.114.a
 		log = "[GetDateText]: [This.GetName]: poland.114.a executed"
 		if = {
-			limit = {
-				original_tag = LIT
-			}
+			limit = { original_tag = LIT }
 			build_railway = {
 				level = 1
 				build_only_on_allied = no
@@ -4114,14 +3754,10 @@ country_event = {
 				start_province = 6281
 				target_province = 9374
 			}
-			POL = {
-				set_country_flag = POL_lithuania_railway_built
-			}
+			POL = { set_country_flag = POL_lithuania_railway_built }
 		}
 		if = {
-			limit = {
-				original_tag = LAT
-			}
+			limit = { original_tag = LAT }
 			build_railway = {
 				level = 1
 				build_only_on_allied = no
@@ -4130,14 +3766,10 @@ country_event = {
 				start_province = 265
 				target_province = 9317
 			}
-			POL = {
-				set_country_flag = POL_latvian_railway_built
-			}
+			POL = { set_country_flag = POL_latvian_railway_built }
 		}
 		if = {
-			limit = {
-				original_tag = EST
-			}
+			limit = { original_tag = EST }
 			build_railway = {
 				level = 1
 				build_only_on_allied = no
@@ -4146,9 +3778,7 @@ country_event = {
 				start_province = 265
 				target_province = 9317
 			}
-			POL = {
-				set_country_flag = POL_estonian_railway_built
-			}
+			POL = { set_country_flag = POL_estonian_railway_built }
 		}
 		POL = {
 			set_temp_variable = { treasury_change = -0.12 }
@@ -4171,9 +3801,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.114.b executed"
 		ai_chance = { base = 10 }
 		add_political_power = 50
-		POL = {
-			country_event = poland.118
-		}
+		POL = { country_event = poland.118 }
 	}
 }
 
@@ -4236,9 +3864,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.06 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4271,9 +3897,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.06 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4300,9 +3924,7 @@ country_event = {
 			set_temp_variable = { temp_outlook_increase = 0.06 }
 			change_relative_party_popularity = yes
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4322,9 +3944,7 @@ country_event = {
 		add_manpower = -1
 		add_stability = -0.05
 		set_country_flag = POL_first_assassination
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4343,9 +3963,7 @@ country_event = {
 		add_manpower = -1
 		add_stability = -0.05
 		set_country_flag = POL_second_assassination
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4361,16 +3979,12 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.150.a executed"
 		set_country_flag = { flag = POL_economy_event_happened days = 90 value = 1 }
 		sre_economy_situation_change_to_workers = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = poland.150.b
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4386,16 +4000,12 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.151.a executed"
 		set_country_flag = { flag = POL_economy_event_happened days = 30 value = 1 }
 		sre_economy_situation_change_to_administration = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = poland.151.b
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4411,16 +4021,12 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.152.a executed"
 		set_country_flag = { flag = POL_economy_event_happened days = 30 value = 1 }
 		sre_economy_situation_change_to_companies = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
 		name = poland.152.b
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4436,9 +4042,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.153.a executed"
 		add_political_power = -50
 		add_stability = -0.05
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4454,9 +4058,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.154.a executed"
 		add_political_power = -75
 		add_stability = -0.07
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4480,9 +4082,7 @@ country_event = {
 			ideology = communism
 			popularity = -0.05
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4504,12 +4104,8 @@ country_event = {
 			remove_idea = POL_second_red_revolution1_idea
 			add_idea = POL_second_red_revolution2_idea
 		}
-		POL = {
-			country_event = poland.157
-		}
-		ai_chance = {
-			base = 100
-		}
+		POL = { country_event = poland.157 }
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4531,9 +4127,7 @@ country_event = {
 			remove_idea = POL_second_red_revolution1_idea
 			add_idea = POL_second_red_revolution3_idea
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4555,17 +4149,11 @@ country_event = {
 			add_idea = POL_second_red_revolution4_idea
 		}
 		if = {
-			limit = {
-				has_idea = POL_second_red_revolution1_idea
-			}
+			limit = { has_idea = POL_second_red_revolution1_idea }
 			remove_ideas = POL_second_red_revolution1_idea
 		}
-		POL = {
-			country_event = poland.159
-		}
-		ai_chance = {
-			base = 100
-		}
+		POL = { country_event = poland.159 }
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4588,14 +4176,10 @@ country_event = {
 			add_idea = POL_second_red_revolution5_idea
 		}
 		if = {
-			limit = {
-				has_idea = POL_second_red_revolution1_idea
-			}
+			limit = { has_idea = POL_second_red_revolution1_idea }
 			remove_ideas = POL_second_red_revolution1_idea
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 
 	option = {
@@ -4608,9 +4192,7 @@ country_event = {
 			remove_idea = POL_second_red_revolution3_idea
 			add_idea = POL_second_red_revolution6_idea
 		}
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4627,15 +4209,9 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.160.a executed"
 		add_command_power = -20
 		add_stability = -0.15
-		628 = {
-			transfer_state_to = POL
-		}
-		POL = {
-			country_event = poland.161
-		}
-		ai_chance = {
-			base = 100
-		}
+		628 = { transfer_state_to = POL }
+		POL = { country_event = poland.161 }
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4653,9 +4229,7 @@ country_event = {
 		add_political_power = 150
 		add_command_power = 50
 		add_stability = 0.15
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4669,190 +4243,134 @@ country_event = {
 	option = {
 		name = poland.162.a
 		log = "[GetDateText]: [This.GetName]: poland.162.a executed"
-		trigger = {
-			original_tag = GER
-		}
+		trigger = { original_tag = GER }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	option = {
 		name = poland.162.aa
-		trigger = {
-			original_tag = GER
-		}
-		ai_chance = {
-			base = 25
-		}
+		trigger = { original_tag = GER }
+		ai_chance = { base = 25 }
 	}
 
 	option = {
 		name = poland.162.b
 		log = "[GetDateText]: [This.GetName]: poland.162.b executed"
-		trigger = {
-			original_tag = ITA
-		}
+		trigger = { original_tag = ITA }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = poland.162.bb
-		trigger = {
-			original_tag = ITA
-		}
-		ai_chance = {
-			base = 50
-		}
+		trigger = { original_tag = ITA }
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = poland.162.c
 		log = "[GetDateText]: [This.GetName]: poland.162.c executed"
-		trigger = {
-			original_tag = CZE
-		}
+		trigger = { original_tag = CZE }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
 		name = poland.162.cc
-		trigger = {
-			original_tag = CZE
-		}
-		ai_chance = {
-			base = 10
-		}
+		trigger = { original_tag = CZE }
+		ai_chance = { base = 10 }
 	}
 
 	option = {
 		name = poland.162.dd
 		log = "[GetDateText]: [This.GetName]: poland.162.dd executed"
-		trigger = {
-			original_tag = SLO
-		}
+		trigger = { original_tag = SLO }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
 		name = poland.162.ddd
-		trigger = {
-			original_tag = SLO
-		}
-		ai_chance = {
-			base = 20
-		}
+		trigger = { original_tag = SLO }
+		ai_chance = { base = 20 }
 	}
 
 	option = {
 		name = poland.162.e
 		log = "[GetDateText]: [This.GetName]: poland.162.e executed"
-		trigger = {
-			original_tag = FRA
-		}
+		trigger = { original_tag = FRA }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = poland.162.ee
-		trigger = {
-			original_tag = FRA
-		}
-		ai_chance = {
-			base = 50
-		}
+		trigger = { original_tag = FRA }
+		ai_chance = { base = 50 }
 	}
 
 	option = {
 		name = poland.162.f
 		log = "[GetDateText]: [This.GetName]: poland.162.f executed"
-		trigger = {
-			original_tag = ENG
-		}
+		trigger = { original_tag = ENG }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
 		name = poland.162.ff
-		trigger = {
-			original_tag = ENG
-		}
-		ai_chance = {
-			base = 70
-		}
+		trigger = { original_tag = ENG }
+		ai_chance = { base = 70 }
 	}
 
 	option = {
 		name = poland.162.g
 		log = "[GetDateText]: [This.GetName]: poland.162.g executed"
-		trigger = {
-			original_tag = USA
-		}
+		trigger = { original_tag = USA }
 		add_political_power = 100
 		send_equipment = {
 			equipment = infantry_weapons_4
 			amount = 300
 			target = POL
 		}
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 
 	option = {
 		name = poland.162.gg
-		trigger = {
-			original_tag = USA
-		}
-		ai_chance = {
-			base = 30
-		}
+		trigger = { original_tag = USA }
+		ai_chance = { base = 30 }
 	}
 }
 
@@ -4874,9 +4392,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.6 }
 		set_temp_variable = { temp_outlook_increase = 0.6 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 
@@ -4892,20 +4408,14 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: poland.164.a executed"
 		add_political_power = 50
 		add_to_variable = { POL.euro_accept = 1 }
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 
 	option = {
 		name = poland.164.b
 		log = "[GetDateText]: [This.GetName]: poland.164.b executed"
-		POL = {
-			country_event = poland.165
-		}
-		ai_chance = {
-			base = 10
-		}
+		POL = { country_event = poland.165 }
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -4920,9 +4430,7 @@ country_event = {
 		name = poland.165.a
 		log = "[GetDateText]: [This.GetName]: poland.165.a executed"
 		add_political_power = -50
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 }
 
@@ -4939,9 +4447,7 @@ country_event = {
 		name = poland.166.a
 		log = "[GetDateText]: [This.GetName]: poland.166.a executed"
 		joining_the_euro = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 }
 
@@ -4956,19 +4462,13 @@ country_event = {
 	option = {
 		name = poland.167.a
 		log = "[GetDateText]: [This.GetName]: poland.167.a executed"
-		POL = {
-			set_country_flag = POL_usa_accepted_flag
-		}
-		ai_chance = {
-			base = 99
-		}
+		POL = { set_country_flag = POL_usa_accepted_flag }
+		ai_chance = { base = 99 }
 	}
 
 	option = {
 		name = poland.167.b
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -5202,11 +4702,7 @@ news_event = {
 
 	option = {
 		name = poland_news.4.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5226,11 +4722,7 @@ news_event = {
 
 	option = {
 		name = poland_news.5.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5363,11 +4855,7 @@ news_event = {
 
 	option = {
 		name = poland_news.10.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5386,11 +4874,7 @@ news_event = {
 
 	option = {
 		name = poland_news.11.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5409,11 +4893,7 @@ news_event = {
 
 	option = {
 		name = poland_news.12.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5432,11 +4912,7 @@ news_event = {
 
 	option = {
 		name = poland_news.13.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5455,11 +4931,7 @@ news_event = {
 
 	option = {
 		name = poland_news.14.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5942,11 +5414,7 @@ news_event = {
 
 	option = {
 		name = poland_news.29.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5965,11 +5433,7 @@ news_event = {
 
 	option = {
 		name = poland_news.30.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -5988,11 +5452,7 @@ news_event = {
 
 	option = {
 		name = poland_news.31.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -6011,11 +5471,7 @@ news_event = {
 
 	option = {
 		name = poland_news.32.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -6034,11 +5490,7 @@ news_event = {
 
 	option = {
 		name = poland_news.33.a
-		trigger = {
-			NOT = {
-				original_tag = POL
-			}
-		}
+		trigger = { NOT = { original_tag = POL } }
 	}
 
 	option = {
@@ -6058,9 +5510,7 @@ news_event = {
 	option = {
 		name = poland_news.34.a
 		trigger = {
-			NOT = {
-				original_tag = POL
-			}
+			NOT = { original_tag = POL }
 			OR = {
 				capital_scope = { is_on_continent = europe }
 				capital_scope = { is_on_continent = middle_east }
@@ -6085,9 +5535,7 @@ news_event = {
 	option = {
 		name = poland_news.35.a
 		trigger = {
-			NOT = {
-				original_tag = POL
-			}
+			NOT = { original_tag = POL }
 			OR = {
 				capital_scope = { is_on_continent = europe }
 				capital_scope = { is_on_continent = middle_east }
@@ -6113,18 +5561,14 @@ country_event = {
 	option = {
 		name = poland_border_conflict.2.a
 		log = "[GetDateText]: [This.GetName]: poland_border_conflict.2.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		642 = { transfer_state_to = POL }
 	}
 
 	option = {
 		name = poland_border_conflict.2.b
 		log = "[GetDateText]: [This.GetName]: poland_border_conflict.2.b executed"
-		trigger = {
-			original_tag = SOV
-		}
+		trigger = { original_tag = SOV }
 		add_political_power = -100
 	}
 }
@@ -6139,9 +5583,7 @@ country_event = {
 	option = {
 		name = poland_border_conflict.3.a
 		log = "[GetDateText]: [This.GetName]: poland_border_conflict.3.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		POL = {
 			add_war_support = -0.1
 			add_political_power = -150
@@ -6153,9 +5595,7 @@ country_event = {
 	option = {
 		name = poland_border_conflict.3.b
 		log = "[GetDateText]: [This.GetName]: poland_border_conflict.3.b executed"
-		trigger = {
-			original_tag = SOV
-		}
+		trigger = { original_tag = SOV }
 		SOV = {
 			add_war_support = 0.1
 			add_political_power = 150
@@ -6175,9 +5615,7 @@ country_event = {
 	option = {
 		name = poland_border_conflict.4.a
 		log = "[GetDateText]: [This.GetName]: poland_border_conflict.4.a executed"
-		trigger = {
-			original_tag = POL
-		}
+		trigger = { original_tag = POL }
 		add_war_support = -0.05
 		add_stability = -0.05
 		add_political_power = -50
@@ -6187,9 +5625,7 @@ country_event = {
 	option = {
 		name = poland_border_conflict.4.b
 		log = "[GetDateText]: [This.GetName]: poland_border_conflict.4.b executed"
-		trigger = {
-			original_tag = SOV
-		}
+		trigger = { original_tag = SOV }
 		add_war_support = -0.04
 		add_stability = -0.02
 		add_political_power = -20
@@ -6493,9 +5929,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		POL_industrial_sovereignty_outcome_settled = no
-	}
+	trigger = { POL_industrial_sovereignty_outcome_settled = no }
 
 	option = {
 		name = poland.305.a

--- a/events/comoros.txt
+++ b/events/comoros.txt
@@ -7,9 +7,8 @@ country_event = {
 	desc = comoros.1.d
 	picture = GFX_arab_spring_defection
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	option = {
 		name = comoros.1.a
@@ -76,7 +75,6 @@ country_event = {
 			}
 		}
 	}
-
 }
 
 # The 2001 Constitutional Referendum
@@ -86,25 +84,21 @@ country_event = {
 	desc = comoros.4.d
 	picture = GFX_ivory_coast_protest_supressed
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
+
 	immediate = {
 		set_country_flag = COM_constitutional_referendum_active
-		hidden_effect = {
-			activate_mission = COM_the_constitutional_referendum_mission
-		}
+		hidden_effect = { activate_mission = COM_the_constitutional_referendum_mission }
 	}
 
 	# Support the Pro-Federalist Movement
 	option = {
 		name = comoros.4.a
 		log = "[GetDateText]: [This.GetName]: comoros.4.a executed"
-
 		custom_effect_tooltip = COM_federalist_supported_tt
 		set_variable = { COM_federalist_constitutional_support = 0.55 }
 		set_variable = { COM_anti_federalist_constitutional_support = 0.45 }
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -123,11 +117,9 @@ country_event = {
 	option = {
 		name = comoros.4.b
 		log = "[GetDateText]: [This.GetName]: comoros.4.b executed"
-
 		custom_effect_tooltip = COM_constitutionalists_supported_tt
 		set_variable = { COM_federalist_constitutional_support = 0.45 }
 		set_variable = { COM_anti_federalist_constitutional_support = 0.55 }
-
 		ai_chance = {
 			base = 50
 			modifier = {
@@ -153,6 +145,7 @@ country_event = {
 	desc = comoros.5.d
 	picture = GFX_ivory_coast_protest_supressed
 	is_triggered_only = yes
+
 	trigger = {
 		OR = {
 			original_tag = FRA
@@ -178,18 +171,14 @@ country_event = {
 	desc = comoros.6.d
 	picture = GFX_ETH_ELF
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	option = {
 		name = comoros.6.a
 		log = "[GetDateText]: [This.GetName]: comoros.6.a executed"
-
 		add_opinion_modifier = { target = COM modifier = drama }
-		COM = {
-			add_war_support = 0.10
-		}
+		COM = { add_war_support = 0.10 }
 	}
 }
 
@@ -200,6 +189,7 @@ country_event = {
 	desc = comoros.7.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	trigger = {
 		OR = {
 			original_tag = FRA
@@ -226,7 +216,6 @@ country_event = {
 		set_temp_variable = { tag_index = THIS }
 		set_temp_variable = { influence_target = COM }
 		change_influence_percentage = yes
-
 		set_temp_variable = { treasury_change = -5 }
 		modify_treasury_effect = yes
 		COM = {
@@ -242,7 +231,6 @@ country_event = {
 			}
 			country_event = diplomatic_response.1
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -259,11 +247,7 @@ country_event = {
 			}
 			modifier = {
 				add = 5
-				any_enemy_country = {
-					capital_scope = {
-						is_on_continent = africa
-					}
-				}
+				any_enemy_country = { capital_scope = { is_on_continent = africa } }
 			}
 			modifier = {
 				add = 10
@@ -278,7 +262,6 @@ country_event = {
 		name = comoros.7.b
 		log = "[GetDateText]: [This.GetName]: comoros.7.b"
 		country_event = diplomatic_response.2
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -303,31 +286,18 @@ country_event = {
 	desc = comoros.8.d
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	option = {
 		name = comoros.8.a
 		log = "[GetDateText]: [This.GetName]: comoros.8.a executed"
-		SEN = {
-			country_event = comoros.9
-		}
-		SUD = {
-			country_event = comoros.9
-		}
-		TNZ = {
-			country_event = comoros.9
-		}
-		FRA = {
-			country_event = comoros.9
-		}
-		USA = {
-			country_event = comoros.9
-		}
-		LBA = {
-			country_event = comoros.9
-		}
+		SEN = { country_event = comoros.9 }
+		SUD = { country_event = comoros.9 }
+		TNZ = { country_event = comoros.9 }
+		FRA = { country_event = comoros.9 }
+		USA = { country_event = comoros.9 }
+		LBA = { country_event = comoros.9 }
 		country_event = { id = comoros.10 days = 20 }
 	}
 }
@@ -352,9 +322,7 @@ country_event = {
 			add_manpower = 100
 			country_event = diplomatic_response.1
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -362,11 +330,8 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: comoros.9.b executed"
 		add_opinion_modifier = { modifier = drama target = COM }
 		reverse_add_opinion_modifier = { modifier = drama target = COM }
-
 		COM = { country_event = diplomatic_response.2 }
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -376,9 +341,8 @@ country_event = {
 	title = comoros.10.t
 	desc = comoros.10.d
 	picture = GFX_puntland_police_force_ev
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = comoros.10.a
@@ -436,13 +400,8 @@ country_event = {
 		name = comoros.12.a
 		log = "[GetDateText]: [This.GetName]: comoros.12.a executed"
 		940 = { transfer_state_to = COM }
-
-		COM = {
-			country_event = diplomatic_response.1
-		}
-		ai_chance = {
-			base = 1
-		}
+		COM = { country_event = diplomatic_response.1 }
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -459,12 +418,9 @@ country_event = {
 				}
 				expire = 365
 			}
-
 			country_event = diplomatic_response.2
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -475,9 +431,8 @@ country_event = {
 	desc = comoros.13.d
 	picture = GFX_african_union # TODO: Replace with a proper event
 	is_triggered_only = yes
-	trigger = {
-		original_tag = FRA
-	}
+
+	trigger = { original_tag = FRA }
 
 	option = {
 		name = comoros.13.a
@@ -492,7 +447,6 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -505,11 +459,7 @@ country_event = {
 	option = {
 		name = comoros.13.b
 		log = "[GetDateText]: [This.GetName]: comoros.13.b executed"
-
-		COM = {
-			country_event = comoros.14
-		}
-
+		COM = { country_event = comoros.14 }
 		ai_chance = {
 			base = 25
 			modifier = {
@@ -527,14 +477,12 @@ country_event = {
 	desc = comoros.14.d
 	picture = GFX_african_union
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	option = {
 		name = comoros.14.a
 		log = "[GetDateText]: [This.GetName]: comoros.14.a executed"
-
 		FRA = {
 			set_autonomy = {
 				target = COM
@@ -554,13 +502,10 @@ country_event = {
 	desc = comoros.15.d
 	picture = GFX_burkina_coast_protests
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
 
-	option = {
-		name = comoros.15.a
-	}
+	trigger = { original_tag = COM }
+
+	option = { name = comoros.15.a }
 }
 
 # Comoros Seeks Investments
@@ -568,9 +513,10 @@ country_event = {
 	id = comoros.16
 	title = comoros.16.t
 	desc = comoros.16.d
+	picture = GFX_CAN_cptpp_trade_agreement
 	is_triggered_only = yes
 	fire_only_once = yes
-	picture = GFX_CAN_cptpp_trade_agreement
+
 	option = {
 		name = comoros.16.a
 		log = "[GetDateText]: [This.GetName]: comoros.16.a executed"
@@ -583,7 +529,6 @@ country_event = {
 			add_offsite_building = { type = industrial_complex level = 1 }
 			country_event = { id = comoros.17 days = 1 }
 		}
-
 		ai_chance = { base = 1 }
 	}
 
@@ -600,7 +545,6 @@ country_event = {
 			modify_debt_effect = yes
 			country_event = { id = comoros.18 days = 1 }
 		}
-
 		ai_chance = { base = 1 }
 	}
 
@@ -620,13 +564,10 @@ country_event = {
 	title = comoros.17.t
 	desc = comoros.17.d
 	picture = GFX_CAN_cptpp_trade_agreement
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = comoros.17.a
-	}
+	option = { name = comoros.17.a }
 }
 
 # [FROM.GetName] Agreed to the Debt Refactor
@@ -635,13 +576,10 @@ country_event = {
 	title = comoros.18.t
 	desc = comoros.18.d
 	picture = GFX_CAN_cptpp_trade_agreement
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = comoros.18.a
-	}
+	option = { name = comoros.18.a }
 }
 
 # [FROM.GetName] Declined the Deals
@@ -650,13 +588,10 @@ country_event = {
 	title = comoros.19.t
 	desc = comoros.19.d
 	picture = GFX_CAN_cptpp_trade_agreement
-
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = comoros.19.a
-	}
+	option = { name = comoros.19.a }
 }
 
 # Foiled Coup Plot
@@ -664,9 +599,10 @@ country_event = {
 	id = comoros.20
 	title = comoros.20.t
 	desc = comoros.20.d
-	#picture
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+
+	#picture
 	trigger = {
 		original_tag = COM
 		has_country_leader = {
@@ -691,9 +627,8 @@ country_event = {
 	desc = comoros.21.d
 	picture = GFX_volcano
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# Launch Emergency Response
 	option = {
@@ -717,9 +652,8 @@ country_event = {
 	desc = comoros.22.d
 	picture = GFX_volcano
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# Not again...
 	option = {
@@ -743,9 +677,8 @@ country_event = {
 	desc = comoros.23.d
 	picture = GFX_passenger_plane
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# Mourn the Victims
 	option = {
@@ -763,9 +696,8 @@ country_event = {
 	desc = comoros.24.d
 	picture = GFX_typhoon
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	option = {
 		name = comoros.24.a
@@ -783,9 +715,10 @@ country_event = {
 	id = comoros.25
 	title = comoros.25.t
 	desc = comoros.25.d
-	#picture
 	picture = GFX_court
 	is_triggered_only = yes
+
+	#picture
 	trigger = {
 		original_tag = COM
 		NOT = { has_idea = police_05 }
@@ -812,9 +745,10 @@ country_event = {
 	id = comoros.26
 	title = comoros.26.t
 	desc = comoros.26.d
-	#picture
 	picture = GFX_political_deal
 	is_triggered_only = yes
+
+	#picture
 	trigger = {
 		original_tag = COM
 		has_country_leader = { name = "Azali Assoumani" ruling_only = yes }
@@ -844,15 +778,13 @@ country_event = {
 	desc = comoros.27.d
 	picture = GFX_report_event_Protest_ITA_1 # TODO: Add a new picture for this
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# Worrying...
 	option = {
 		name = comoros.27.a
 		log = "[GetDateText]: [This.GetName]: comoros.27.a executed"
-
 		hidden_effect = {
 			random_list = {
 				75 = { country_event = { id = comoros.28 random_days = 30 } }
@@ -865,7 +797,6 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -879,7 +810,6 @@ country_event = {
 	option = {
 		name = comoros.27.b
 		log = "[GetDateText]: [This.GetName]: comoros.27.b executed"
-
 		hidden_effect = {
 			random_list = {
 				50 = { country_event = { id = comoros.28 random_days = 30 } }
@@ -899,7 +829,6 @@ country_event = {
 	option = {
 		name = comoros.27.c
 		log = "[GetDateText]: [This.GetName]: comoros.27.c executed"
-
 		hidden_effect = {
 			random_list = {
 				25 = { country_event = { id = comoros.29 random_days = 30 } }
@@ -923,9 +852,8 @@ country_event = {
 	desc = comoros.28.d
 	picture = GFX_report_event_Protest_ITA_1 # TODO: Add a new picture for this
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# A Warrior King!
 	option = {
@@ -935,7 +863,6 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.15 }
 		set_temp_variable = { temp_outlook_increase = 0.15 }
 		change_relative_party_popularity = yes
-
 		if = {
 			limit = { is_ai = yes }
 			set_temp_variable = { disable_elections = 1 }
@@ -951,14 +878,11 @@ country_event = {
 				mercenary_leader
 			}
 		}
-
 		add_stability = -0.15
-
 		add_timed_idea = {
 			idea = COM_unstable_government_idea
 			days = 730
 		}
-
 		set_country_flag = COM_robert_denard_seized_power
 	}
 }
@@ -970,14 +894,11 @@ country_event = {
 	desc = comoros.29.d
 	picture = GFX_report_event_Protest_ITA_1 # TODO: Add a new picture for this
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# Finally good riddance!
-	option = {
-		name = comoros.29.a
-	}
+	option = { name = comoros.29.a }
 }
 
 # Robert Denard Fails to Coup the Government
@@ -987,14 +908,11 @@ country_event = {
 	desc = comoros.30.d
 	picture = GFX_report_event_Protest_ITA_1 # TODO: Add a new picture for this
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# A Major Setback
-	option = {
-		name = comoros.30.a
-	}
+	option = { name = comoros.30.a }
 }
 
 # The Constitutional Referendum Results
@@ -1004,9 +922,8 @@ country_event = {
 	desc = comoros.31.d
 	picture = GFX_report_event_Protest_ITA_1 # TODO: Add a new picture for this
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	trigger = { original_tag = COM }
 
 	# The Results Are In
 	option = {
@@ -1015,9 +932,7 @@ country_event = {
 		if = { limit = { check_variable = { COM_federalist_constitutional_support > COM_anti_federalist_constitutional_support } }
 			set_country_flag = COM_pro_federalist
 		}
-		else = {
-			set_country_flag = COM_anti_federalist
-		}
+		else = { set_country_flag = COM_anti_federalist }
 	}
 }
 
@@ -1026,12 +941,11 @@ country_event = {
 	id = comoros.32
 	title = comoros.32.t
 	desc = comoros.32.d
-	# picture FIXME: add a event picture here
 	picture = GFX_political_deal
 	is_triggered_only = yes
-	trigger = {
-		original_tag = COM
-	}
+
+	# picture FIXME: add a event picture here
+	trigger = { original_tag = COM }
 
 	# X to Pay Respects
 	option = {
@@ -1046,18 +960,16 @@ country_event = {
 	id = comoros.33
 	title = comoros.33.t
 	desc = comoros.33.d
-	# picture FIXME: add a event picture here
 	picture = GFX_treaty
 	is_triggered_only = yes
-	trigger = {
-		owns_state = 253
-	}
+
+	# picture FIXME: add a event picture here
+	trigger = { owns_state = 253 }
 
 	# Accept the Deal
 	option = {
 		name = comoros.33.a
 		log = "[GetDateText]: [This.GetName]: comoros.33.a"
-
 		253 = { transfer_state_to = COM }
 		set_country_flag = { flag = COM_the_zanzibar_agreement_payee value = 1 days = 730 }
 		set_temp_variable = { additional_income_change = 0.25 }
@@ -1069,7 +981,6 @@ country_event = {
 			custom_effect_tooltip = additional_expense_rate_percent_tt
 			set_country_flag = { flag = COM_the_zanzibar_agreement_pay value = 1 days = 730 }
 		}
-
 		ai_chance = {
 			base = 1
 			modifier = {
@@ -1082,9 +993,6 @@ country_event = {
 	# Reject the Deal
 	option = {
 		name = comoros.33.b
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,603 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.