### PR TITLE
Standardize event files — batch 12/14

### DIFF
--- a/events/05_netherlands.txt
+++ b/events/05_netherlands.txt
@@ -101,9 +101,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 country_event = {
@@ -191,9 +189,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 country_event = {
@@ -212,9 +208,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.04 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -226,9 +220,7 @@ country_event = {
 		change_farmers_opinion = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -323,9 +315,7 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -2.50 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 }
 country_event = {
@@ -386,9 +376,7 @@ country_event = {
 		}
 		set_temp_variable = { treasury_change = -5.63 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 90
-		}
+		ai_chance = { base = 90 }
 	}
 }
 country_event = {
@@ -407,9 +395,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.04 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -421,9 +407,7 @@ country_event = {
 		change_farmers_opinion = yes
 		set_temp_variable = { temp_opinion = -5 }
 		change_labour_unions_opinion = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -501,9 +485,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 country_event = {
@@ -524,9 +506,7 @@ country_event = {
 			multiply_temp_variable = { treasury_change = -0.05 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -540,9 +520,7 @@ country_event = {
 			set_temp_variable = { temp_opinion = -5 }
 			change_industrial_conglomerates_opinion = yes
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 
@@ -600,9 +578,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.06 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 country_event = {
@@ -621,9 +597,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 
 	option = {
@@ -637,9 +611,7 @@ country_event = {
 			set_temp_variable = { temp_opinion = -5 }
 			change_industrial_conglomerates_opinion = yes
 		}
-		ai_chance = {
-			base = 80
-		}
+		ai_chance = { base = 80 }
 	}
 }
 country_event = {
@@ -749,9 +721,7 @@ country_event = {
 	picture = GFX_hol_asml_building_abroad_cancelled_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_economy.023.a
-	}
+	option = { name = HOL_economy.023.a }
 }
 country_event = {
 	id = HOL_economy.024 #Delta-Rhine Corridor to Germany
@@ -1157,9 +1127,7 @@ country_event = {
 		set_temp_variable = { int_investment_change = gdp_per_capita }
 		multiply_temp_variable = { int_investment_change = 0.05 }
 		modify_international_investment_effect = yes
-		ai_chance = {
-			base = 100
-		}
+		ai_chance = { base = 100 }
 	}
 }
 country_event = {
@@ -1169,9 +1137,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.007.a
-	}
+	option = { name = HOL_military.007.a }
 }
 
 
@@ -1253,9 +1219,7 @@ country_event = {
 	picture = GFX_hol_qra_benelux_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.010.a
-	}
+	option = { name = HOL_military.010.a }
 }
 country_event = {
 	id = HOL_military.011 #QRA Treaty rejected by Belgium to Netherlands
@@ -1264,9 +1228,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.011.a
-	}
+	option = { name = HOL_military.011.a }
 }
 country_event = {
 	id = HOL_military.012 #QRA Treaty accepted by Luxembourg & Belgium to Netherlands
@@ -1290,9 +1252,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.013.a
-	}
+	option = { name = HOL_military.013.a }
 }
 country_event = {
 	id = HOL_military.014 #QRA Treaty Established to HOL, BEL and LUX
@@ -1389,9 +1349,7 @@ country_event = {
 	picture = GFX_hol_BENECC_benelux_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.017.a
-	}
+	option = { name = HOL_military.017.a }
 }
 country_event = {
 	id = HOL_military.018 #Belgium Rejecting BENECC to Netherlands
@@ -1400,9 +1358,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.018.a
-	}
+	option = { name = HOL_military.018.a }
 }
 country_event = {
 	id = HOL_military.019 #Luxembourg Accepts BENECC to Netherlands
@@ -1426,9 +1382,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.020.a
-	}
+	option = { name = HOL_military.020.a }
 }
 country_event = {
 	id = HOL_military.021 #BENECC Established to HOL, BEL and LUX
@@ -1523,9 +1477,7 @@ country_event = {
 	picture = GFX_hol_BANC_benelux_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.024.a
-	}
+	option = { name = HOL_military.024.a }
 }
 country_event = {
 	id = HOL_military.025 #Benelux Air Navigation Comittee Rejected  by Belgium to Netherlands
@@ -1534,9 +1486,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.025.a
-	}
+	option = { name = HOL_military.025.a }
 }
 country_event = {
 	id = HOL_military.026 #Benelux Air Navigation Comittee accepted by Luxembourg & Belgium to Netherlands
@@ -1560,9 +1510,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_bad_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.027.a
-	}
+	option = { name = HOL_military.027.a }
 }
 country_event = {
 	id = HOL_military.028 #Benelux Air Navigation Comittee Established to HOL, BEL and LUX
@@ -1597,9 +1545,7 @@ country_event = {
 		}
 		BEL = { country_event = { id = HOL_military.030 days = 1 } }
 		set_country_flag = HOL_accepts_mrtt
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
@@ -1633,9 +1579,7 @@ country_event = {
 		}
 		set_country_flag = BEL_accepts_mrtt
 		LUX = { country_event = { id = HOL_military.031 days = 1 } }
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
@@ -1673,9 +1617,7 @@ country_event = {
 			HOL = { country_event = { id = HOL_military.032 days = 1 } }
 			BEL = { country_event = { id = HOL_military.032 days = 1 } }
 		}
-		ai_chance = {
-			base = 65
-		}
+		ai_chance = { base = 65 }
 	}
 
 	option = {
@@ -2155,9 +2097,7 @@ country_event = {
 		ai_chance = {
 			base = 25
 			modifier = {
-				any_owned_state = {
-					is_claimed_by = HOL
-				}
+				any_owned_state = { is_claimed_by = HOL }
 				add = 50
 			}
 			modifier = {
@@ -2245,9 +2185,7 @@ country_event = {
 		ai_chance = {
 			base = 25
 			modifier = {
-				any_owned_state = {
-					is_claimed_by = HOL
-				}
+				any_owned_state = { is_claimed_by = HOL }
 				add = 50
 			}
 			modifier = {
@@ -2335,9 +2273,7 @@ country_event = {
 		ai_chance = {
 			base = 25
 			modifier = {
-				any_owned_state = {
-					is_claimed_by = HOL
-				}
+				any_owned_state = { is_claimed_by = HOL }
 				add = 50
 			}
 			modifier = {
@@ -2417,9 +2353,7 @@ country_event = {
 
 	option = {
 		name = HOL_military.064.b
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -2433,9 +2367,7 @@ country_event = {
 		name = HOL_military.065.a
 		log = "[GetDateText]: [This.GetName]: HOL_military.065.a executed"
 		if = {
-			limit = {
-				is_special_project_completed = sp:sp_stealth_destroyer
-			}
+			limit = { is_special_project_completed = sp:sp_stealth_destroyer }
 			add_tech_bonus = {
 				name = HOL_military.065.t
 				bonus = 0.15
@@ -2444,9 +2376,7 @@ country_event = {
 			}
 		}
 		else_if = {
-			limit = {
-				NOT = { is_special_project_completed = sp:sp_stealth_destroyer }
-			}
+			limit = { NOT = { is_special_project_completed = sp:sp_stealth_destroyer } }
 			add_breakthrough_points = {
 				specialization = specialization_naval
 				value = 1
@@ -2862,9 +2792,7 @@ country_event = {
 	is_triggered_only = yes
 
 	trigger = {
-		HOL = {
-			has_tech = frigate_hull_4
-		}
+		HOL = { has_tech = frigate_hull_4 }
 		BEL = {
 			exists = yes
 			NOT = { has_war_with = HOL }
@@ -2931,18 +2859,14 @@ country_event = {
 		multiply_temp_variable = { treasury_change = -0.10 }
 		modify_treasury_effect = yes
 		HOL = { country_event = { id = HOL_military.078 days = 1 } }
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 
 	option = {
 		name = HOL_military.077.b
 		log = "[GetDateText]: [This.GetName]: HOL_military.077.b executed"
 		HOL = { country_event = { id = HOL_military.079 days = 1 } }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -2980,9 +2904,7 @@ country_event = {
 	picture = GFX_hol_asw_fregat_ship_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.079.a
-	}
+	option = { name = HOL_military.079.a }
 }
 country_event = {
 	id = HOL_military.083
@@ -3054,9 +2976,7 @@ country_event = {
 				HOL = { country_event = HOL_military.087 }
 			}
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
@@ -3064,9 +2984,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_military.084.b executed"
 		HOL = { country_event = HOL_military.085 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 
@@ -3345,9 +3263,7 @@ country_event = {
 				modifier = HOL_Caribbean_Naval_Opinion
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -3355,9 +3271,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_military.104.b executed"
 		HOL = { country_event = HOL_military.106 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -3378,9 +3292,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = HOL_military.105.a
-	}
+	option = { name = HOL_military.105.a }
 }
 country_event = {
 	id = HOL_military.106
@@ -3389,9 +3301,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.106.a
-	}
+	option = { name = HOL_military.106.a }
 }
 country_event = {
 	id = HOL_military.107
@@ -3403,9 +3313,7 @@ country_event = {
 	option = {
 		name = HOL_military.107.a
 		log = "[GetDateText]: [Root.GetName]: HOL_military.107.a executed"
-		mio:FRA_eurocopter_manufacturer = {
-			add_mio_funds = 1000
-		}
+		mio:FRA_eurocopter_manufacturer = { add_mio_funds = 1000 }
 	}
 }
 country_event = {
@@ -3418,9 +3326,7 @@ country_event = {
 	option = {
 		name = HOL_military.108.a
 		log = "[GetDateText]: [Root.GetName]: HOL_military.108.a executed"
-		mio:SPR_airbus_helicopters_tank_manufacturer = {
-			add_mio_funds = 1000
-		}
+		mio:SPR_airbus_helicopters_tank_manufacturer = { add_mio_funds = 1000 }
 	}
 }
 country_event = {
@@ -3433,9 +3339,7 @@ country_event = {
 	option = {
 		name = HOL_military.109.a
 		log = "[GetDateText]: [Root.GetName]: HOL_military.109.a executed"
-		mio:ENG_bae_systems_manufacturer = {
-			add_mio_funds = 1000
-		}
+		mio:ENG_bae_systems_manufacturer = { add_mio_funds = 1000 }
 	}
 }
 country_event = {
@@ -3448,9 +3352,7 @@ country_event = {
 	option = {
 		name = HOL_military.110.a
 		log = "[GetDateText]: [Root.GetName]: HOL_military.110.a executed"
-		mio:ITA_alenia_aeronautica = {
-			add_mio_funds = 1000
-		}
+		mio:ITA_alenia_aeronautica = { add_mio_funds = 1000 }
 	}
 }
 country_event = {
@@ -3463,9 +3365,7 @@ country_event = {
 	option = {
 		name = HOL_military.111.a
 		log = "[GetDateText]: [Root.GetName]: HOL_military.111.a executed"
-		mio:SWE_saab_ab_manufacturer = {
-			add_mio_funds = 1000
-		}
+		mio:SWE_saab_ab_manufacturer = { add_mio_funds = 1000 }
 	}
 }
 country_event = {
@@ -3478,9 +3378,7 @@ country_event = {
 	option = {
 		name = HOL_military.112.a
 		log = "[GetDateText]: [Root.GetName]: HOL_military.112.a executed"
-		mio:SWE_bae_systems_bofors_manufacturer = {
-			add_mio_funds = 1000
-		}
+		mio:SWE_bae_systems_bofors_manufacturer = { add_mio_funds = 1000 }
 	}
 }
 country_event = {
@@ -3505,9 +3403,7 @@ country_event = {
 
 	trigger = { USA = { has_country_flag = USA_f35_designed } }
 
-	option = {
-		name = HOL_military.114.a
-	}
+	option = { name = HOL_military.114.a }
 }
 country_event = {
 	id = HOL_military.115
@@ -3516,9 +3412,7 @@ country_event = {
 	picture = GFX_F35C_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_military.115.a
-	}
+	option = { name = HOL_military.115.a }
 }
 
 
@@ -3821,9 +3715,7 @@ country_event = {
 				random_days = 7
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -3838,9 +3730,7 @@ country_event = {
 				random_days = 7
 			}
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 
@@ -3926,9 +3816,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.14.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.14.a executed"
-		annex_country = {
-			target = LUX
-		}
+		annex_country = { target = LUX }
 	}
 }
 
@@ -4017,9 +3905,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.17.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.17.a executed"
-		annex_country = {
-			target = IRE
-		}
+		annex_country = { target = IRE }
 	}
 }
 
@@ -4108,9 +3994,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.20.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.20.a executed"
-		annex_country = {
-			target = ENG
-		}
+		annex_country = { target = ENG }
 	}
 }
 
@@ -4199,9 +4083,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.23.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.23.a executed"
-		annex_country = {
-			target = SCO
-		}
+		annex_country = { target = SCO }
 	}
 }
 
@@ -4262,9 +4144,7 @@ country_event = {
 		name = HOL_monarchy.25.b
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.25.b executed"
 		HOL = { country_event = HOL_monarchy.27 }
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 country_event = {
@@ -4277,9 +4157,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.26.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.26.a executed"
-		puppet = {
-			target = LUX
-		}
+		puppet = { target = LUX }
 		hidden_effect = {
 			set_autonomy = {
 				target = LUX
@@ -4287,9 +4165,7 @@ country_event = {
 				end_wars = yes
 				end_civil_wars = yes
 			}
-			LUX = {
-				add_ideas = HOL_dutch_realpolitik_idea
-			}
+			LUX = { add_ideas = HOL_dutch_realpolitik_idea }
 		}
 	}
 }
@@ -4300,9 +4176,7 @@ country_event = {
 	picture = GFX_lux_luxembourg_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_monarchy.27.a
-	}
+	option = { name = HOL_monarchy.27.a }
 }
 country_event = {
 	id = HOL_monarchy.28
@@ -4342,9 +4216,7 @@ country_event = {
 		name = HOL_monarchy.28.b
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.28.b executed"
 		HOL = { country_event = HOL_monarchy.30 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4358,9 +4230,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.29.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.29.a executed"
-		puppet = {
-			target = IRE
-		}
+		puppet = { target = IRE }
 		hidden_effect = {
 			set_autonomy = {
 				target = IRE
@@ -4368,9 +4238,7 @@ country_event = {
 				end_wars = yes
 				end_civil_wars = yes
 			}
-			IRE = {
-				add_ideas = HOL_dutch_realpolitik_idea
-			}
+			IRE = { add_ideas = HOL_dutch_realpolitik_idea }
 		}
 	}
 }
@@ -4382,9 +4250,7 @@ country_event = {
 	picture = GFX_IRE_ireland_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_monarchy.30.a
-	}
+	option = { name = HOL_monarchy.30.a }
 }
 country_event = {
 	id = HOL_monarchy.31
@@ -4424,9 +4290,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.31.b executed"
 		HOL = { country_event = HOL_monarchy.33 }
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 
@@ -4440,9 +4304,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.32.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.32.a executed"
-		puppet = {
-			target = ENG
-		}
+		puppet = { target = ENG }
 		hidden_effect = {
 			set_autonomy = {
 				target = ENG
@@ -4450,9 +4312,7 @@ country_event = {
 				end_wars = yes
 				end_civil_wars = yes
 			}
-			ENG = {
-				add_ideas = HOL_dutch_realpolitik_idea
-			}
+			ENG = { add_ideas = HOL_dutch_realpolitik_idea }
 		}
 	}
 }
@@ -4464,9 +4324,7 @@ country_event = {
 	picture = GFX_british_flag_two
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_monarchy.33.a
-	}
+	option = { name = HOL_monarchy.33.a }
 }
 country_event = {
 	id = HOL_monarchy.34
@@ -4506,9 +4364,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.34.b executed"
 		HOL = { country_event = HOL_monarchy.36 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -4522,9 +4378,7 @@ country_event = {
 	option = {
 		name = HOL_monarchy.35.a
 		log = "[GetDateText]: [This.GetName]: HOL_monarchy.35.a executed"
-		puppet = {
-			target = SCO
-		}
+		puppet = { target = SCO }
 		hidden_effect = {
 			set_autonomy = {
 				target = SCO
@@ -4532,9 +4386,7 @@ country_event = {
 				end_wars = yes
 				end_civil_wars = yes
 			}
-			SCO = {
-				add_ideas = HOL_dutch_realpolitik_idea
-			}
+			SCO = { add_ideas = HOL_dutch_realpolitik_idea }
 		}
 	}
 }
@@ -4545,9 +4397,7 @@ country_event = {
 	picture = GFX_SCO_scotland_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_monarchy.36.a
-	}
+	option = { name = HOL_monarchy.36.a }
 }
 country_event = {
 	id = HOL_monarchy.37
@@ -4592,9 +4442,7 @@ country_event = {
 	picture = GFX_HOL_event_dutch_american_flag
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_monarchy.39.a
-	}
+	option = { name = HOL_monarchy.39.a }
 }
 country_event = {
 	id = HOL_monarchy.40
@@ -4832,9 +4680,7 @@ country_event = {
 			complete_national_focus = HOL_rita_verdonk
 			set_country_flag = VVD_Leader_Verdonk
 		}
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -4894,9 +4740,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_small_medium_business_owners_opinion = yes
 		complete_national_focus = HOL_maxime_verhagen
-		hidden_effect = {
-			set_country_flag = CDA_Leader_Verhagen
-		}
+		hidden_effect = { set_country_flag = CDA_Leader_Verhagen }
 		ai_chance = {
 			base = 50
 			modifier = { factor = 0 HOL_ai_historical_path = yes }
@@ -4911,9 +4755,7 @@ country_event = {
 		set_temp_variable = { temp_opinion = 5 }
 		change_maritime_industry_opinion = yes
 		complete_national_focus = HOL_buma
-		hidden_effect = {
-			set_country_flag = CDA_Leader_Buma
-		}
+		hidden_effect = { set_country_flag = CDA_Leader_Buma }
 		ai_chance = {
 			base = 50
 			modifier = { factor = 4 HOL_ai_historical_path = yes }
@@ -5101,9 +4943,7 @@ country_event = {
 		set_temp_variable = { treasury_change = gdp_per_capita }
 		multiply_temp_variable = { treasury_change = -0.05 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -5195,9 +5035,7 @@ country_event = {
 			idea = HOL_social_innovation_idea
 			days = 365
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 
 	option = {
@@ -5209,9 +5047,7 @@ country_event = {
 			uses = 2
 			category = CAT_Civilian
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -5233,12 +5069,8 @@ country_event = {
 		country_event = HOL_politics.15
 		hidden_effect = {
 			random_list = {
-				50 = {
-					set_country_flag = netherlands_gets_275
-				}
-				50 = {
-					set_country_flag = netherlands_gets_279
-				}
+				50 = { set_country_flag = netherlands_gets_275 }
+				50 = { set_country_flag = netherlands_gets_279 }
 			}
 		}
 	}
@@ -5247,10 +5079,7 @@ country_event = {
 		name = HOL_politics.14.b
 		log = "[GetDateText]: [This.GetName]: HOL_politics.14.b executed"
 		ai_chance = { base = 25 }
-		start_civil_war = {
-			ideology = nationalist
-			states = { 275 274 279 281 }
-		}
+		start_civil_war = { ideology = nationalist states = { 275 274 279 281 } }
 	}
 }
 country_event = {
@@ -5299,9 +5128,7 @@ country_event = {
 		set_variable = { var = dutch_influence value = 0 }
 	}
 
-	option = {
-		name = HOL_politics.16.a
-	}
+	option = { name = HOL_politics.16.a }
 }
 country_event = {
 	id = HOL_politics.17
@@ -5320,9 +5147,7 @@ country_event = {
 		set_variable = { var = dutch_influence value = 0 }
 	}
 
-	option = {
-		name = HOL_politics.17.a
-	}
+	option = { name = HOL_politics.17.a }
 }
 country_event = {
 	id = HOL_politics.18
@@ -5341,9 +5166,7 @@ country_event = {
 		set_variable = { var = dutch_influence value = 0 }
 	}
 
-	option = {
-		name = HOL_politics.18.a
-	}
+	option = { name = HOL_politics.18.a }
 }
 country_event = {
 	id = HOL_politics.19
@@ -5362,9 +5185,7 @@ country_event = {
 		set_variable = { var = dutch_influence value = 0 }
 	}
 
-	option = {
-		name = HOL_politics.19.a
-	}
+	option = { name = HOL_politics.19.a }
 }
 country_event = {
 	id = HOL_politics.20
@@ -5383,9 +5204,7 @@ country_event = {
 		set_variable = { var = dutch_influence value = 0 }
 	}
 
-	option = {
-		name = HOL_politics.20.a
-	}
+	option = { name = HOL_politics.20.a }
 }
 country_event = {
 	id = HOL_politics.21
@@ -5398,24 +5217,16 @@ country_event = {
 		name = HOL_politics.21.a
 		custom_effect_tooltip = TT_IF_WE_ACCEPT
 		log = "[GetDateText]: [This.GetName]: HOL_politics.21.a executed"
-		ai_chance = {
-			base = 70
-		}
-		50 = {
-			set_state_owner_to = HOL
-		}
+		ai_chance = { base = 70 }
+		50 = { set_state_owner_to = HOL }
 	}
 
 	option = {
 		name = HOL_politics.21.b
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_politics.21.b executed"
-		ai_chance = {
-			base = 30
-		}
-		declare_war_on = {
-			target = HOL
-		}
+		ai_chance = { base = 30 }
+		declare_war_on = { target = HOL }
 	}
 }
 country_event = {
@@ -5447,9 +5258,7 @@ country_event = {
 		name = HOL_politics.22.b
 		log = "[GetDateText]: [This.GetName]: HOL_politics.22.b executed"
 		HOL = { country_event = HOL_politics.24 }
-		ai_chance = {
-			base = 40
-		}
+		ai_chance = { base = 40 }
 	}
 }
 country_event = {
@@ -5463,9 +5272,7 @@ country_event = {
 		name = HOL_politics.23.a
 		log = "[GetDateText]: [This.GetName]: HOL_politics.23.a executed"
 		custom_effect_tooltip = BEL_referendum_mission_tooltip
-		hidden_effect = {
-			set_country_flag = HOL_belgium_pressured_annexation
-		}
+		hidden_effect = { set_country_flag = HOL_belgium_pressured_annexation }
 		ai_chance = {
 			base = 40
 			modifier = {
@@ -5584,9 +5391,7 @@ country_event = {
 	picture = GFX_bel_belgium_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_politics.25.a
-	}
+	option = { name = HOL_politics.25.a }
 }
 country_event = {
 	id = HOL_politics.26
@@ -5615,9 +5420,7 @@ country_event = {
 			transfer_state_to = GER
 			add_core_of = GER
 		}
-		transfer_navy = {
-			target = HOL
-		}
+		transfer_navy = { target = HOL }
 		HOL = { country_event = HOL_politics.28 }
 		FRA = { country_event = HOL_politics.28 }
 		GER = { country_event = HOL_politics.28 }
@@ -5648,9 +5451,7 @@ country_event = {
 	picture = GFX_bel_dismantled_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_politics.28.a
-	}
+	option = { name = HOL_politics.28.a }
 }
 country_event = {
 	id = HOL_politics.29
@@ -5710,9 +5511,7 @@ country_event = {
 			target = HOL
 			modifier = HOL_dutch_latin_trade_efforts
 		}
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 
 	option = {
@@ -5720,9 +5519,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_politics.30.b executed"
 		HOL = { country_event = HOL_politics.32 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 
@@ -5802,9 +5599,7 @@ country_event = {
 			target = HOL
 			modifier = HOL_dutch_latin_trade_efforts
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
@@ -5812,9 +5607,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_politics.33.b executed"
 		HOL = { country_event = HOL_politics.35 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -5907,9 +5700,7 @@ country_event = {
 			modifier = HOL_dutch_latin_trade_efforts
 		}
 		HOL = { set_country_flag = HOL_MEX_accepted_deal }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 
 	option = {
@@ -5917,9 +5708,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_politics.36.b executed"
 		HOL = { country_event = HOL_politics.38 }
-		ai_chance = {
-			base = 20
-		}
+		ai_chance = { base = 20 }
 	}
 }
 country_event = {
@@ -5934,9 +5723,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: HOL_politics.37.a executed"
 		if = {
 			limit = { has_dlc = "Arms Against Tyranny" }
-			mio:HOL_Damen_naval_equipment_organisation = {
-				add_mio_size = 1
-				}
+			mio:HOL_Damen_naval_equipment_organisation = { add_mio_size = 1 }
 		}
 		else = {
 			random_owned_state = {
@@ -6019,9 +5806,7 @@ country_event = {
 			country_event = HOL_politics.40
 			set_country_flag = HOL_COL_accepted_deal
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
@@ -6031,9 +5816,7 @@ country_event = {
 		HOL = { country_event = HOL_politics.41 }
 		set_temp_variable = { temp_opinion = -5 }
 		change_maritime_industry_opinion = yes
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 
@@ -6121,9 +5904,7 @@ country_event = {
 			country_event = HOL_politics.43
 			set_country_flag = HOL_PAR_accepted_deal
 		}
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 
 	option = {
@@ -6131,9 +5912,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_politics.42.b executed"
 		HOL = { country_event = HOL_politics.44 }
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 }
 country_event = {
@@ -6217,12 +5996,8 @@ country_event = {
 			target = HOL
 			modifier = HOL_dutch_latin_trade_efforts
 		}
-		HOL = {
-			country_event = HOL_politics.46
-		}
-		ai_chance = {
-			base = 25
-		}
+		HOL = { country_event = HOL_politics.46 }
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -6230,9 +6005,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_politics.45.b executed"
 		HOL = { country_event = HOL_politics.47 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 country_event = {
@@ -6329,9 +6102,7 @@ country_event = {
 		name = HOL_politics.48.b
 		log = "[GetDateText]: [This.GetName]: HOL_politics.48.b executed"
 		add_political_power = -100
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 country_event = {
@@ -6386,22 +6157,14 @@ country_event = {
 				random_list = {
 					50 = {
 						random_owned_controlled_state = {
-							limit = {
-								can_construct_building = land_facility
-							}
-							construct_building_in_random_province = {
-								land_facility = 1
-							}
+							limit = { can_construct_building = land_facility }
+							construct_building_in_random_province = { land_facility = 1 }
 						}
 					}
 					50 = {
 						random_owned_controlled_state = {
-							limit = {
-								can_construct_building = naval_facility
-							}
-							construct_building_in_random_province = {
-								naval_facility = 1
-							}
+							limit = { can_construct_building = naval_facility }
+							construct_building_in_random_province = { naval_facility = 1 }
 						}
 					}
 				}
@@ -6482,9 +6245,7 @@ country_event = {
 			set_temp_variable = { treasury_change = -50 }
 			modify_treasury_effect = yes
 		}
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 
 	option = {
@@ -6511,9 +6272,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_politics.50.a
-	}
+	option = { name = HOL_politics.50.a }
 }
 country_event = {
 	id = HOL_politics.51
@@ -6530,18 +6289,14 @@ country_event = {
 		set_temp_variable = { sender_nation = HOL }
 		set_improved_trade_agreement = yes
 		HOL = { country_event = HOL_politics.52 }
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 
 	option = {
 		name = HOL_politics.51.b
 		log = "[GetDateText]: [This.GetName]: HOL_politics.51.b executed"
 		HOL = { country_event = HOL_politics.53 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 country_event = {
@@ -6564,9 +6319,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_politics.53.a
-	}
+	option = { name = HOL_politics.53.a }
 }
 country_event = {
 	id = HOL_politics.54
@@ -6627,18 +6380,14 @@ country_event = {
 			country_event = HOL_politics.55
 			set_country_flag = HOL_suriname_accepted_infrastructure
 		}
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 
 	option = {
 		name = HOL_politics.54.b
 		log = "[GetDateText]: [This.GetName]: HOL_politics.54.b executed"
 		HOL = { country_event = HOL_politics.56 }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 country_event = {
@@ -6662,9 +6411,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_politics.56.a
-	}
+	option = { name = HOL_politics.56.a }
 }
 country_event = {
 	id = HOL_politics.57
@@ -6823,9 +6570,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66 }
 			complete_national_focus = {
 				focus = HOL_d66
 				use_side_message = yes
@@ -6835,9 +6580,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_democratic_institutions
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_democratic_institutions }
 			complete_national_focus = {
 				focus = HOL_d66_democratic_institutions
 				use_side_message = yes
@@ -6847,9 +6590,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_direct_democracy
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_direct_democracy }
 			complete_national_focus = {
 				focus = HOL_d66_direct_democracy
 				use_side_message = yes
@@ -6859,9 +6600,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_rule_of_law
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_rule_of_law }
 			complete_national_focus = {
 				focus = HOL_d66_rule_of_law
 				use_side_message = yes
@@ -6871,9 +6610,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_climate_action_plan
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_climate_action_plan }
 			complete_national_focus = {
 				focus = HOL_d66_climate_action_plan
 				use_side_message = yes
@@ -6883,9 +6620,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_green_energy
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_green_energy }
 			complete_national_focus = {
 				focus = HOL_d66_green_energy
 				use_side_message = yes
@@ -6895,9 +6630,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_european_initiative
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_european_initiative }
 			complete_national_focus = {
 				focus = HOL_d66_european_initiative
 				use_side_message = yes
@@ -6907,9 +6640,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_social_progress
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_social_progress }
 			complete_national_focus = {
 				focus = HOL_d66_social_progress
 				use_side_message = yes
@@ -6919,9 +6650,7 @@ country_event = {
 			country_event = { id = HOL_politics.57 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_d66_education_investments
-			}
+			limit = { has_shine_effect_on_focus = HOL_d66_education_investments }
 			complete_national_focus = {
 				focus = HOL_d66_education_investments
 				use_side_message = yes
@@ -7072,9 +6801,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp }
 			complete_national_focus = {
 				focus = HOL_sgp
 				use_side_message = yes
@@ -7084,9 +6811,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_protect_sunday_rest
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_protect_sunday_rest }
 			complete_national_focus = {
 				focus = HOL_sgp_protect_sunday_rest
 				use_side_message = yes
@@ -7096,9 +6821,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_religious_education_policy
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_religious_education_policy }
 			complete_national_focus = {
 				focus = HOL_sgp_religious_education_policy
 				use_side_message = yes
@@ -7108,9 +6831,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_support_large_families
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_support_large_families }
 			complete_national_focus = {
 				focus = HOL_sgp_support_large_families
 				use_side_message = yes
@@ -7120,9 +6841,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_support_christian_unions
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_support_christian_unions }
 			complete_national_focus = {
 				focus = HOL_sgp_support_christian_unions
 				use_side_message = yes
@@ -7132,9 +6851,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_secure_rural_communities
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_secure_rural_communities }
 			complete_national_focus = {
 				focus = HOL_sgp_secure_rural_communities
 				use_side_message = yes
@@ -7144,9 +6861,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_strengthen_defense
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_strengthen_defense }
 			complete_national_focus = {
 				focus = HOL_sgp_strengthen_defense
 				use_side_message = yes
@@ -7156,9 +6871,7 @@ country_event = {
 			country_event = { id = HOL_politics.59 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_sgp_resist_secularism
-			}
+			limit = { has_shine_effect_on_focus = HOL_sgp_resist_secularism }
 			complete_national_focus = {
 				focus = HOL_sgp_resist_secularism
 				use_side_message = yes
@@ -7329,9 +7042,7 @@ country_event = {
 
 	immediate = {
 		if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl }
 			complete_national_focus = {
 				focus = HOL_gl
 				use_side_message = yes
@@ -7341,9 +7052,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_affordable_housing_program
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_affordable_housing_program }
 			complete_national_focus = {
 				focus = HOL_gl_affordable_housing_program
 				use_side_message = yes
@@ -7353,9 +7062,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_biodiversity_protection
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_biodiversity_protection }
 			complete_national_focus = {
 				focus = HOL_gl_biodiversity_protection
 				use_side_message = yes
@@ -7365,9 +7072,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_digital_innovation
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_digital_innovation }
 			complete_national_focus = {
 				focus = HOL_gl_digital_innovation
 				use_side_message = yes
@@ -7377,9 +7082,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_international_solidarity
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_international_solidarity }
 			complete_national_focus = {
 				focus = HOL_gl_international_solidarity
 				use_side_message = yes
@@ -7389,9 +7092,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_fair_trade_policy
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_fair_trade_policy }
 			complete_national_focus = {
 				focus = HOL_gl_fair_trade_policy
 				use_side_message = yes
@@ -7401,9 +7102,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_diversify_workforce
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_diversify_workforce }
 			complete_national_focus = {
 				focus = HOL_gl_diversify_workforce
 				use_side_message = yes
@@ -7413,9 +7112,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_transparent_governance
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_transparent_governance }
 			complete_national_focus = {
 				focus = HOL_gl_transparent_governance
 				use_side_message = yes
@@ -7425,9 +7122,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_youth_empowerment
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_youth_empowerment }
 			complete_national_focus = {
 				focus = HOL_gl_youth_empowerment
 				use_side_message = yes
@@ -7437,9 +7132,7 @@ country_event = {
 			country_event = { id = HOL_politics.61 days = 180 random_days = 36 }
 		}
 		else_if = {
-			limit = {
-				has_shine_effect_on_focus = HOL_gl_energy_independence
-			}
+			limit = { has_shine_effect_on_focus = HOL_gl_energy_independence }
 			complete_national_focus = {
 				focus = HOL_gl_energy_independence
 				use_side_message = yes
@@ -7858,8 +7551,8 @@ country_event = {
 }
 country_event = {
 	id = HOL_politics.86
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
 
 	trigger = {
 		is_ai = yes
@@ -7897,15 +7590,12 @@ country_event = {
 			set_temp_variable = { col_one = 2 }
 			set_temp_variable = { col_two = 20 }
 		}
-
 		if = {
 			limit = { NOT = { check_variable = { ruling_party = rul_party_temp } } }
 			change_ruling_party_effect = yes
 			set_elections_48_months = yes
 		}
-		else = {
-			set_leader = yes
-		}
+		else = { set_leader = yes }
 	}
 }
 
@@ -8120,15 +7810,9 @@ country_event = {
 			modifier = {
 				452 = {
 					OR = {
-						has_dynamic_modifier = {
-							modifier = HOL_gujurat_port_patrol1
-						}
-						has_dynamic_modifier = {
-							modifier = HOL_gujurat_port_patrol3
-						}
-						has_dynamic_modifier = {
-							modifier = HOL_gujurat_port_patrol4
-						}
+						has_dynamic_modifier = { modifier = HOL_gujurat_port_patrol1 }
+						has_dynamic_modifier = { modifier = HOL_gujurat_port_patrol3 }
+						has_dynamic_modifier = { modifier = HOL_gujurat_port_patrol4 }
 					}
 				}
 				add = 5
@@ -8136,15 +7820,9 @@ country_event = {
 			modifier = {
 				436 = {
 					OR = {
-						has_dynamic_modifier = {
-							modifier = HOL_gujurat_port_patrol1
-						}
-						has_dynamic_modifier = {
-							modifier = HOL_gujurat_port_patrol3
-						}
-						has_dynamic_modifier = {
-							modifier = HOL_gujurat_port_patrol4
-						}
+						has_dynamic_modifier = { modifier = HOL_gujurat_port_patrol1 }
+						has_dynamic_modifier = { modifier = HOL_gujurat_port_patrol3 }
+						has_dynamic_modifier = { modifier = HOL_gujurat_port_patrol4 }
 					}
 				}
 				add = 5
@@ -8159,15 +7837,8 @@ country_event = {
 	option = {
 		name = HOL_voc.1.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.1.b executed"
-		HOL = {
-			declare_war_on = {
-				target = RAJ
-				generator = { 436 452 465 462 987 471 464 467 }
-			}
-		}
-		ai_chance = {
-			base = 45
-		}
+		HOL = { declare_war_on = { target = RAJ generator = { 436 452 465 462 987 471 464 467 } } }
+		ai_chance = { base = 45 }
 	}
 }
 country_event = {
@@ -8336,9 +8007,7 @@ country_event = {
 	picture = GFX_us_flag
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.7.a
-	}
+	option = { name = HOL_voc.7.a }
 }
 country_event = {
 	id = HOL_voc.8
@@ -8347,9 +8016,7 @@ country_event = {
 	picture = GFX_usn_seven_fleet
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.8.a
-	}
+	option = { name = HOL_voc.8.a }
 }
 country_event = {
 	id = HOL_voc.9
@@ -8395,9 +8062,7 @@ country_event = {
 		ai_chance = {
 			base = 30
 			modifier = {
-				TAI = {
-					is_guaranteed_by = USA
-				}
+				TAI = { is_guaranteed_by = USA }
 				add = 50
 			}
 			modifier = {
@@ -8412,9 +8077,7 @@ country_event = {
 		name = HOL_voc.9.c
 		log = "[GetDateText]: [This.GetName]: HOL_voc.9.c executed"
 		HOL = { country_event = HOL_voc.15 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -8452,9 +8115,7 @@ country_event = {
 		name = HOL_voc.11.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.11.a executed"
 		TAI = { country_event = HOL_voc.12 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 
 	option = {
@@ -8542,10 +8203,7 @@ country_event = {
 	option = {
 		name = HOL_voc.13.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.13.b executed"
-		declare_war_on = {
-			target = TAI
-			generator = { 1157 599 }
-		}
+		declare_war_on = { target = TAI generator = { 1157 599 } }
 		set_country_flag = HOL_voc_tai_done
 	}
 }
@@ -8656,9 +8314,7 @@ country_event = {
 				add = 20
 			}
 			modifier = {
-				check_variable = {
-					HOL.gdp_from_agriculture > SRI.gdp_from_agriculture
-				}
+				check_variable = { HOL.gdp_from_agriculture > SRI.gdp_from_agriculture }
 				add = 45
 			}
 		}
@@ -8669,9 +8325,7 @@ country_event = {
 		name = HOL_voc.17.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.17.b executed"
 		HOL = { country_event = HOL_voc.19 }
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 }
 country_event = {
@@ -8695,9 +8349,7 @@ country_event = {
 	picture = GFX_sri_srilanka_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.19.a
-	}
+	option = { name = HOL_voc.19.a }
 }
 country_event = {
 	id = HOL_voc.20
@@ -8835,9 +8487,7 @@ country_event = {
 		set_temp_variable = { tag_index = HOL }
 		set_temp_variable = { influence_target = SRI }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 }
 country_event = {
@@ -8917,13 +8567,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_ACCEPT
 		log = "[GetDateText]: [This.GetName]: HOL_voc.26.a executed"
 		HOL = { country_event = HOL_voc.28 }
-		effect_tooltip = {
-			HOL = {
-				annex_country = {
-					target = SRI
-				}
-			}
-		}
+		effect_tooltip = { HOL = { annex_country = { target = SRI } } }
 		ai_chance = {
 			base = 30
 			modifier = {
@@ -8949,9 +8593,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_voc.26.b executed"
 		HOL = { country_event = HOL_voc.27 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -8981,9 +8623,7 @@ country_event = {
 	option = {
 		name = HOL_voc.28.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.28.a executed"
-		annex_country = {
-			target = SRI
-		}
+		annex_country = { target = SRI }
 		set_country_flag = HOL_voc_sri_done
 	}
 }
@@ -8994,9 +8634,7 @@ country_event = {
 	picture = GFX_hol_dutch_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.29.a
-	}
+	option = { name = HOL_voc.29.a }
 }
 country_event = {
 	id = HOL_voc.30
@@ -9032,9 +8670,7 @@ country_event = {
 					level = 1
 					instant_build = yes
 				}
-				add_dynamic_modifier = {
-					modifier = HOL_cape_port_investment
-				}
+				add_dynamic_modifier = { modifier = HOL_cape_port_investment }
 			}
 		}
 		HOL = { country_event = HOL_voc.31 }
@@ -9066,9 +8702,7 @@ country_event = {
 		name = HOL_voc.30.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.30.b executed"
 		HOL = { country_event = HOL_voc.32 }
-		ai_chance = {
-			base = 35
-		}
+		ai_chance = { base = 35 }
 	}
 }
 country_event = {
@@ -9078,9 +8712,7 @@ country_event = {
 	picture = GFX_SAF_generic
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.31.a
-	}
+	option = { name = HOL_voc.31.a }
 }
 country_event = {
 	id = HOL_voc.32
@@ -9089,9 +8721,7 @@ country_event = {
 	picture = GFX_SAF_generic
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.32.a
-	}
+	option = { name = HOL_voc.32.a }
 }
 country_event = {
 	id = HOL_voc.33
@@ -9130,9 +8760,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [This.GetName]: HOL_voc.33.b executed"
 		HOL = { country_event = HOL_voc.34 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -9145,10 +8773,7 @@ country_event = {
 	option = {
 		name = HOL_voc.34.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.34.a executed"
-		declare_war_on = {
-			target = SAF
-			generator = { 281 278 280 }
-		}
+		declare_war_on = { target = SAF generator = { 281 278 280 } }
 		set_country_flag = HOL_saf_voc_done
 	}
 }
@@ -9182,17 +8807,11 @@ country_event = {
 			target = IND
 			type = annex_everything
 		}
-		hidden_effect = {
-			set_country_flag = HOL_dutch_indies_conquest
-		}
+		hidden_effect = { set_country_flag = HOL_dutch_indies_conquest }
 	}
 
 	option = {
-		trigger = {
-			NOT = {
-				has_country_flag = HOL_delayed_indonesian_operation
-			}
-		}
+		trigger = { NOT = { has_country_flag = HOL_delayed_indonesian_operation } }
 		name = HOL_voc.36.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.36.b executed"
 		add_war_support = -0.10
@@ -9202,9 +8821,7 @@ country_event = {
 			idea = HOL_voc_penalty_operation_extension
 			days = 365
 		}
-		hidden_effect = {
-			set_country_flag = HOL_delayed_indonesian_operation
-		}
+		hidden_effect = { set_country_flag = HOL_delayed_indonesian_operation }
 	}
 }
 country_event = {
@@ -9235,9 +8852,7 @@ country_event = {
 				add = 10
 			}
 			modifier = {
-				HOL = {
-					has_idea = Major_Non_NATO_Ally
-				}
+				HOL = { has_idea = Major_Non_NATO_Ally }
 				add = 30
 			}
 		}
@@ -9247,9 +8862,7 @@ country_event = {
 		name = HOL_voc.39.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.39.b executed"
 		HOL = { country_event = HOL_voc.41 }
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -9259,9 +8872,7 @@ country_event = {
 	picture = GFX_AST_generic
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.40.a
-	}
+	option = { name = HOL_voc.40.a }
 }
 country_event = {
 	id = HOL_voc.41
@@ -9270,9 +8881,7 @@ country_event = {
 	picture = GFX_AST_generic
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.41.a
-	}
+	option = { name = HOL_voc.41.a }
 }
 country_event = {
 	id = HOL_voc.42
@@ -9289,13 +8898,9 @@ country_event = {
 	option = {
 		name = HOL_voc.42.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.42.a executed"
-		trigger = {
-			has_completed_focus = HOL_reclaim_batavia
-		}
+		trigger = { has_completed_focus = HOL_reclaim_batavia }
 		random_list = {
-			HOL_java_detection_chance = {
-				HOL = { country_event = HOL_voc.43 }
-			}
+			HOL_java_detection_chance = { HOL = { country_event = HOL_voc.43 } }
 			50 = { HOL = { country_event = HOL_voc.44 } }
 		}
 	}
@@ -9303,13 +8908,9 @@ country_event = {
 	option = {
 		name = HOL_voc.42.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.42.b executed"
-		trigger = {
-			has_completed_focus = HOL_reclaim_outer_islands
-		}
+		trigger = { has_completed_focus = HOL_reclaim_outer_islands }
 		random_list = {
-			HOL_islands_detection = {
-				HOL = { country_event = HOL_voc.43 }
-			}
+			HOL_islands_detection = { HOL = { country_event = HOL_voc.43 } }
 			50 = { HOL = { country_event = HOL_voc.44 } }
 		}
 	}
@@ -9342,9 +8943,7 @@ country_event = {
 	picture = GFX_special_forces
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.44.a
-	}
+	option = { name = HOL_voc.44.a }
 }
 country_event = {
 	id = HOL_voc.45
@@ -9381,9 +8980,7 @@ country_event = {
 				add = 10
 			}
 		}
-		hidden_effect = {
-			set_country_flag = HOL_australian_military_compensation
-		}
+		hidden_effect = { set_country_flag = HOL_australian_military_compensation }
 	}
 
 	option = {
@@ -9391,9 +8988,7 @@ country_event = {
 		name = HOL_voc.45.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.45.b executed"
 		HOL = { country_event = HOL_voc.46 }
-		hidden_effect = {
-			set_country_flag = HOL_australian_industrial_compensation
-		}
+		hidden_effect = { set_country_flag = HOL_australian_industrial_compensation }
 		ai_chance = {
 			base = 20
 			modifier = {
@@ -9456,9 +9051,7 @@ country_event = {
 	picture = GFX_AST_generic
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.47.a
-	}
+	option = { name = HOL_voc.47.a }
 }
 country_event = {
 	id = HOL_voc.51
@@ -9514,9 +9107,7 @@ country_event = {
 	option = {
 		name = HOL_voc.52.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.52.a executed"
-		annex_country = {
-			target = MAY
-		}
+		annex_country = { target = MAY }
 	}
 }
 country_event = {
@@ -9529,11 +9120,7 @@ country_event = {
 	option = {
 		name = HOL_voc.53.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.53.a executed"
-		MAY = {
-			every_owned_state = {
-				add_claim_by = HOL
-			}
-		}
+		MAY = { every_owned_state = { add_claim_by = HOL } }
 	}
 }
 country_event = {
@@ -9590,9 +9177,7 @@ country_event = {
 	option = {
 		name = HOL_voc.55.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.55.a executed"
-		annex_country = {
-			target = SIN
-		}
+		annex_country = { target = SIN }
 	}
 }
 country_event = {
@@ -9605,11 +9190,7 @@ country_event = {
 	option = {
 		name = HOL_voc.56.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.56.a executed"
-		SIN = {
-			every_owned_state = {
-				add_claim_by = HOL
-			}
-		}
+		SIN = { every_owned_state = { add_claim_by = HOL } }
 	}
 }
 country_event = {
@@ -9666,9 +9247,7 @@ country_event = {
 	option = {
 		name = HOL_voc.58.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.58.a executed"
-		annex_country = {
-			target = BRU
-		}
+		annex_country = { target = BRU }
 	}
 }
 country_event = {
@@ -9681,11 +9260,7 @@ country_event = {
 	option = {
 		name = HOL_voc.59.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.59.a executed"
-		BRU = {
-			every_owned_state = {
-				add_claim_by = HOL
-			}
-		}
+		BRU = { every_owned_state = { add_claim_by = HOL } }
 	}
 }
 country_event = {
@@ -9746,9 +9321,7 @@ country_event = {
 		}
 	}
 
-	option = {
-		name = HOL_voc.62.b
-	}
+	option = { name = HOL_voc.62.b }
 }
 country_event = {
 	id = HOL_voc.63
@@ -9765,9 +9338,7 @@ country_event = {
 			enemy = HOL
 			hostility_reason = anti_dutch_coalition
 		}
-		ai_chance = {
-			base = 75
-		}
+		ai_chance = { base = 75 }
 	}
 
 	option = {
@@ -9775,9 +9346,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: HOL_voc.63.b executed"
 		remove_ideas = HOL_country_prepare_for_the_dutch2
 		FROM = { add_opinion_modifier = { target = ROOT modifier = HOL_refused_call_for_defence } }
-		ai_chance = {
-			base = 0
-		}
+		ai_chance = { base = 0 }
 	}
 }
 country_event = {
@@ -10015,9 +9584,7 @@ country_event = {
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_voc.73.a
-	}
+	option = { name = HOL_voc.73.a }
 }
 country_event = {
 	id = HOL_voc.74
@@ -10030,9 +9597,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_ACCEPT
 		name = HOL_voc.74.a
 		log = "[GetDateText]: [This.GetName]: HOL_voc.74.a executed"
-		trigger = {
-			tag = TAI
-		}
+		trigger = { tag = TAI }
 		add_ideas = HOL_voc_semiconductor_control_TAI
 	}
 
@@ -10040,9 +9605,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		name = HOL_voc.74.b
 		log = "[GetDateText]: [This.GetName]: HOL_voc.74.b executed"
-		trigger = {
-			tag = HOL
-		}
+		trigger = { tag = HOL }
 		add_ideas = HOL_voc_semiconductor_control_HOL
 	}
 }
@@ -10121,9 +9684,7 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: HOL_wic.01.b executed"
 		complete_national_focus = HOL_wic_war_preparations
 		every_other_country = {
-			limit = {
-				HOL_is_wic_country = yes
-			}
+			limit = { HOL_is_wic_country = yes }
 			ROOT = {
 				add_opinion_modifier = {
 					target = HOL
@@ -10349,9 +9910,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10399,9 +9958,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10479,9 +10036,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10559,9 +10114,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10645,9 +10198,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10727,9 +10278,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10807,9 +10356,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10889,9 +10436,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10904,9 +10449,7 @@ country_event = {
 	option = {
 		name = HOL_wic.27.a
 		log = "[GetDateText]: [This.GetName]: HOL_wic.27.a executed"
-		annex_country = {
-			target = SUR
-		}
+		annex_country = { target = SUR }
 	}
 }
 country_event = {
@@ -10972,9 +10515,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -10987,9 +10528,7 @@ country_event = {
 	option = {
 		name = HOL_wic.30.a
 		log = "[GetDateText]: [This.GetName]: HOL_wic.30.a executed"
-		annex_country = {
-			target = GUY
-		}
+		annex_country = { target = GUY }
 	}
 }
 country_event = {
@@ -11056,9 +10595,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -11138,9 +10675,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 2
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 country_event = {
@@ -11224,9 +10759,7 @@ country_event = {
 			idea = HOL_prepare_dutch_invasion
 			months = 3
 		}
-		ai_chance = {
-			base = 50
-		}
+		ai_chance = { base = 50 }
 	}
 }
 country_event = {
@@ -11316,17 +10849,9 @@ country_event = {
 	option = {
 		name = HOL_nvu.6.a
 		log = "[GetDateText]: [This.GetName]: HOL_nvu.6.a executed"
-		50 = {
-			transfer_state_to = HOL
-		}
-		51 = {
-			transfer_state_to = HOL
-		}
-		BEL = {
-			transfer_navy = {
-				target = HOL
-			}
-		}
+		50 = { transfer_state_to = HOL }
+		51 = { transfer_state_to = HOL }
+		BEL = { transfer_navy = { target = HOL } }
 	}
 }
 country_event = {
@@ -11367,9 +10892,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: HOL_nvu.8.a executed"
 		HOL = { country_event = { id = HOL_nvu.9 days = 1 } }
 		add_stability = -0.05
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 
 	option = {
@@ -11377,9 +10900,7 @@ country_event = {
 		custom_effect_tooltip = TT_IF_WE_DECLINE
 		log = "[GetDateText]: [Root.GetName]: HOL_nvu.8.b executed"
 		HOL = { country_event = { id = HOL_nvu.10 days = 1 } }
-		ai_chance = {
-			base = 25
-		}
+		ai_chance = { base = 25 }
 	}
 }
 country_event = {
@@ -11634,9 +11155,7 @@ country_event = {
 	picture = GFX_HOL_event_dutch_austrian_flag
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_nvu.19.a
-	}
+	option = { name = HOL_nvu.19.a }
 }
 country_event = {
 	id = HOL_nvu.20
@@ -11983,9 +11502,7 @@ country_event = {
 		add_ideas = HOL_willem_alexander
 		if = {
 			limit = { has_country_leader = { name = "Beatrix der Nederlanden" ruling_only = yes } }
-			hidden_effect = {
-				kill_country_leader = yes
-			}
+			hidden_effect = { kill_country_leader = yes }
 			create_country_leader = {
 				name = "Willem-Alexander der Nederlanden"
 				picture = "willem_alexander.dds"
@@ -12045,9 +11562,7 @@ country_event = {
 		add_ideas = HOL_amalia
 		if = {
 			limit = { has_country_leader = { name = "Willem-Alexander der Nederlanden" ruling_only = yes } }
-			hidden_effect = {
-				kill_country_leader = yes
-			}
+			hidden_effect = { kill_country_leader = yes }
 			create_country_leader = {
 				name = "Catharina-Amalia der Nederlanden"
 				picture = "hol_amalia.dds"
@@ -12189,9 +11704,7 @@ country_event = {
 	}
 
 	option = {
-		trigger = {
-			has_idea = NATO_member
-		}
+		trigger = { has_idea = NATO_member }
 		name = HOL_common_event.6.e
 		log = "[GetDateText]: [This.GetName]: HOL_common_event.6.e executed"
 		add_war_support = 15
@@ -12202,9 +11715,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		set_temp_variable = { temp_outlook_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 15
-		}
+		ai_chance = { base = 15 }
 	}
 }
 country_event = {
@@ -12440,11 +11951,7 @@ country_event = {
 	option = {
 		name = HOL_common_event.15.a
 		log = "[GetDateText]: [This.GetName]: HOL_common_event.15.a executed"
-		47 = {
-			add_dynamic_modifier = {
-				modifier = HOL_limburg_water_management
-			}
-		}
+		47 = { add_dynamic_modifier = { modifier = HOL_limburg_water_management } }
 		large_expenditure = yes
 	}
 
@@ -12927,9 +12434,7 @@ country_event = {
 	picture = GFX_hol_french_dutch_flag_event_picture
 	is_triggered_only = yes
 
-	option = {
-		name = HOL_politics.85.a
-	}
+	option = { name = HOL_politics.85.a }
 }
 
 # ASML Corporate History
@@ -12941,8 +12446,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = HOL_asml_event_01_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_01_resolved }
+
 	option = {
 		name = HOL_asml_events.1.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.1.a executed"
@@ -12950,6 +12458,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2000_euv_commitment = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.1.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.1.b executed"
@@ -12966,8 +12475,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_01_resolved NOT = { has_country_flag = HOL_asml_event_02_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_02_resolved }
+
 	option = {
 		name = HOL_asml_events.2.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.2.a executed"
@@ -12975,6 +12487,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2001_program_consolidation = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.2.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.2.b executed"
@@ -12991,8 +12504,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_02_resolved NOT = { has_country_flag = HOL_asml_event_03_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_03_resolved }
+
 	option = {
 		name = HOL_asml_events.3.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.3.a executed"
@@ -13000,6 +12516,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2006_alpha_tools = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.3.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.3.b executed"
@@ -13016,8 +12533,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_03_resolved NOT = { has_country_flag = HOL_asml_event_04_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_04_resolved }
+
 	option = {
 		name = HOL_asml_events.4.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.4.a executed"
@@ -13025,6 +12545,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2007_brion = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.4.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.4.b executed"
@@ -13041,8 +12562,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_04_resolved NOT = { has_country_flag = HOL_asml_event_05_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_05_resolved }
+
 	option = {
 		name = HOL_asml_events.5.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.5.a executed"
@@ -13050,6 +12574,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2008_yieldstar = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.5.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.5.b executed"
@@ -13066,8 +12591,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_05_resolved NOT = { has_country_flag = HOL_asml_event_06_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_06_resolved }
+
 	option = {
 		name = HOL_asml_events.6.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.6.a executed"
@@ -13075,6 +12603,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2010_nxe_delivery = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.6.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.6.b executed"
@@ -13091,8 +12620,11 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_06_resolved NOT = { has_country_flag = HOL_asml_event_07_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_07_resolved }
+
 	option = {
 		name = HOL_asml_events.7.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.7.a executed"
@@ -13109,6 +12641,7 @@ country_event = {
 		}
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.7.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.7.b executed"
@@ -13125,8 +12658,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_07_resolved NOT = { has_country_flag = HOL_asml_event_08_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_08_resolved }
+
 	option = {
 		name = HOL_asml_events.8.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.8.a executed"
@@ -13134,6 +12670,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2013_cymer = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.8.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.8.b executed"
@@ -13150,8 +12687,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_08_resolved NOT = { has_country_flag = HOL_asml_event_09_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_09_resolved }
+
 	option = {
 		name = HOL_asml_events.9.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.9.a executed"
@@ -13159,6 +12699,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2016_nxe_3400 = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.9.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.9.b executed"
@@ -13175,8 +12716,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_09_resolved NOT = { has_country_flag = HOL_asml_event_10_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_10_resolved }
+
 	option = {
 		name = HOL_asml_events.10.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.10.a executed"
@@ -13184,6 +12728,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2019_commercial_euv = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.10.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.10.b executed"
@@ -13200,8 +12745,11 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_10_resolved NOT = { has_country_flag = HOL_asml_event_11_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_11_resolved }
+
 	option = {
 		name = HOL_asml_events.11.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.11.a executed"
@@ -13209,6 +12757,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2020_service_scale = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.11.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.11.b executed"
@@ -13225,8 +12774,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_11_resolved NOT = { has_country_flag = HOL_asml_event_12_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_12_resolved }
+
 	option = {
 		name = HOL_asml_events.12.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.12.a executed"
@@ -13234,6 +12786,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2023_high_na_delivery = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.12.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.12.b executed"
@@ -13250,8 +12803,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_12_resolved NOT = { has_country_flag = HOL_asml_event_13_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_13_resolved }
+
 	option = {
 		name = HOL_asml_events.13.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.13.a executed"
@@ -13259,6 +12815,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2024_imec_lab = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.13.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.13.b executed"
@@ -13275,8 +12832,11 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_13_resolved NOT = { has_country_flag = HOL_asml_event_14_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes set_country_flag = HOL_asml_event_14_resolved }
+
 	option = {
 		name = HOL_asml_events.14.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.14.a executed"
@@ -13284,6 +12844,7 @@ country_event = {
 		hidden_effect = { HOL_asml_record_2024_export_controls = yes }
 		ai_chance = { base = 70 modifier = { factor = 4 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = HOL_asml_events.14.b
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.14.b executed"
@@ -13300,8 +12861,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = HOL NOT = { has_country_flag = collapsed_nation } has_country_flag = HOL_asml_event_14_resolved NOT = { has_country_flag = HOL_asml_terminal_resolved } }
+
 	immediate = { HOL_asml_initialize_state = yes }
+
 	option = {
 		name = HOL_asml_events.15.a
 		log = "[GetDateText]: [Root.GetName]: HOL_asml_events.15.a executed"

--- a/events/Denmark.txt
+++ b/events/Denmark.txt
@@ -11,10 +11,7 @@ country_event = {
 
 	option = {
 		name = denmark.2.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -27,10 +24,7 @@ country_event = {
 
 	option = {
 		name = denmark.3.a
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -40,8 +34,8 @@ country_event = {
 	title = denmark.4.t
 	desc = denmark.4.d
 	picture = GFX_fighter_jet
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	##Accept Send Request
 	option = {
@@ -68,9 +62,9 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = { base = 1 }
 	}
+
 	option = {
 		name = denmark.4.o2
 		trigger = { is_in_faction_with = SOV }
@@ -95,7 +89,6 @@ country_event = {
 				}
 			}
 		}
-
 		ai_chance = { base = 1 }
 	}
 
@@ -105,7 +98,6 @@ country_event = {
 		log = "[GetDateText]: [This.GetName]: denmark.4.o3 executed"
 		add_political_power = 50
 		add_war_support = -0.03
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -136,14 +128,13 @@ country_event = {
 		text = denmark.4001.d2
 	}
 	picture = GFX_fighter_jet
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.4001.o1
 		log = "[GetDateText]: [This.GetName]: denmark.4001.o1 executed"
 		DEN = { country_event = { id = denmark.4002 days = 1 } }
-
 		ai_chance = { base = 1 }
 	}
 
@@ -151,7 +142,6 @@ country_event = {
 		name = denmark.4001.o2
 		log = "[GetDateText]: [This.GetName]: denmark.4001.o2 executed"
 		DEN = { country_event = { id = denmark.4003 days = 1 } }
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -180,8 +170,8 @@ country_event = {
 		text = denmark.4002.d2
 	}
 	picture = GFX_fighter_jet
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.4002.o1
@@ -246,12 +236,10 @@ country_event = {
 		text = denmark.4003.d2
 	}
 	picture = GFX_fighter_jet
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
-	option = {
-		name = denmark.4003.o1
-	}
+	option = { name = denmark.4003.o1 }
 }
 
 # Reactionary Focus
@@ -264,10 +252,7 @@ country_event = {
 
 	option = {
 		name = denmark.6.o1
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -281,10 +266,7 @@ country_event = {
 
 	option = {
 		name = denmark.7.o1
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -298,24 +280,17 @@ country_event = {
 
 	option = {
 		name = denmark.8.a
-
-		ai_chance = {
-			base = 0.3
-		}
+		ai_chance = { base = 0.3 }
 	}
+
 	option = {
 		name = denmark.8.b
-
-		ai_chance = {
-			base = 0.3
-		}
+		ai_chance = { base = 0.3 }
 	}
+
 	option = {
 		name = denmark.8.c
-
-		ai_chance = {
-			base = 0.3
-		}
+		ai_chance = { base = 0.3 }
 	}
 }
 
@@ -335,10 +310,7 @@ country_event = {
 		set_temp_variable = { temp_outlook_increase = 0.10 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -352,10 +324,7 @@ country_event = {
 
 	option = {
 		name = denmark.11.o1
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -365,8 +334,8 @@ country_event = {
 	title = denmark.18.t
 	desc = denmark.18.d
 	picture = GFX_ace_promoted
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.18.a
@@ -394,10 +363,7 @@ country_event = {
 				logistics_skill = 2
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -423,10 +389,7 @@ country_event = {
 				military_career
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -439,7 +402,7 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = denmark.19.a		#England accepts purchase
+		name = denmark.19.a #England accepts purchase
 		log = "[GetDateText]: [This.GetName]: denmark.19.a executed"
 		if = {
 			limit = {
@@ -459,15 +422,13 @@ country_event = {
 				modify_treasury_effect = yes
 			}
 		}
-
 		ai_chance = {
 			base = 10
 		}
 	}
 
 	option = {
-		name = denmark.19.b		#That's gonna be a no from me dog
-
+		name = denmark.19.b #That's gonna be a no from me dog
 		ai_chance = {
 			base = 90
 		}
@@ -483,11 +444,10 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = denmark.21.a		#The Kalmar Union upgraded
+		name = denmark.21.a #The Kalmar Union upgraded
 		log = "[GetDateText]: [This.GetName]: denmark.21.a executed"
 		trigger = { is_subject = no }
 		DEN = { add_to_faction = PREV }
-
 		ai_chance = {
 			base = 90
 			modifier = {
@@ -502,9 +462,8 @@ country_event = {
 	}
 
 	option = {
-		name = denmark.21.b		#That's gonna be a no from me dog
+		name = denmark.21.b #That's gonna be a no from me dog
 		trigger = { is_subject = no }
-
 		ai_chance = {
 			base = 10
 		}
@@ -513,7 +472,6 @@ country_event = {
 	option = {
 		name = denmark.21.c # Not for us to decide
 		trigger = { is_subject = yes }
-
 		ai_chance = {
 			base = 10
 		}
@@ -536,10 +494,7 @@ country_event = {
 		add_popularity = { ideology = neutrality popularity = -0.05 }
 		add_manpower = 10000
 		recalculate_party = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -554,10 +509,7 @@ country_event = {
 
 	option = {
 		name = denmark.17.o1
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -610,7 +562,6 @@ country_event = {
 			}
 			DEN = { puppet = ROOT }
 		}
-
 		ai_chance = {
 			base = 0
 			modifier = {
@@ -619,9 +570,9 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #No
 		name = denmark.39.b
-
 		ai_chance = {
 			base = 95
 			modifier = {
@@ -640,42 +591,30 @@ news_event = {
 	desc = denmark_news.1.d
 	picture = GFX_news_press_conference
 	is_triggered_only = yes
-	fire_only_once = yes
 	major = yes
-	trigger = {
-		DEN = { has_completed_focus = DEN_abolish_monarchy }
-	}
+	fire_only_once = yes
+
+	trigger = { DEN = { has_completed_focus = DEN_abolish_monarchy } }
 
 	option = {
 		name = denmark_news.1.o1
-		trigger = {
-			check_variable = { ruling_party = 23 }
-		}
-
-		ai_chance = {
-			base = 0.3
-		}
+		trigger = { check_variable = { ruling_party = 23 } }
+		ai_chance = { base = 0.3 }
 	}
+
 	option = {
 		name = denmark_news.1.o2
-		trigger = {
-			tag = DEN
-		}
-
-		ai_chance = {
-			base = 0.3
-		}
+		trigger = { tag = DEN }
+		ai_chance = { base = 0.3 }
 	}
+
 	option = {
 		name = denmark_news.1.o3
 		trigger = {
 			NOT = { check_variable = { ruling_party = 23 } }
 			NOT = { tag = DEN }
 		}
-
-		ai_chance = {
-			base = 0.3
-		}
+		ai_chance = { base = 0.3 }
 	}
 }
 
@@ -686,20 +625,15 @@ country_event = {
 	desc = denmark.1.d
 	picture = GFX_olsen
 	is_triggered_only = yes
-	trigger = {
-		original_tag = DEN
-	}
+
+	trigger = { original_tag = DEN }
 
 	option = {
 		name = denmark.1.a
 		log = "[GetDateText]: [This.GetName]: denmark.1.a executed"
 		add_political_power = 50
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
-
 }
 
 #Øresundsbroen
@@ -708,8 +642,8 @@ country_event = {
 	title = denmark.22.t
 	desc = denmark.22.d
 	picture = GFX_Oresundsbron
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.22.a
@@ -717,10 +651,7 @@ country_event = {
 		add_political_power = 25
 		add_opinion_modifier = { target = SWE modifier = small_increase }
 		reverse_add_opinion_modifier = { target = SWE modifier = small_increase }
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -730,8 +661,8 @@ country_event = {
 	title = denmark.23.t
 	desc = denmark.23.d
 	picture = GFX_blizzard
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.23.a
@@ -745,10 +676,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -758,18 +686,15 @@ country_event = {
 	title = denmark.24.t
 	desc = denmark.24.d
 	picture = GFX_politics_demands
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.24.a
 		log = "[GetDateText]: [This.GetName]: denmark.24.a executed"
 		add_opinion_modifier = { target = CAN modifier = small_decrease }
 		reverse_add_opinion_modifier = { target = CAN modifier = small_decrease }
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -779,8 +704,8 @@ country_event = {
 	title = denmark.25.t
 	desc = denmark.25.d
 	picture = GFX_politics_speak
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.25.a
@@ -790,10 +715,7 @@ country_event = {
 		reverse_add_opinion_modifier = { target = UAE modifier = large_decrease }
 		reverse_add_opinion_modifier = { target = OMA modifier = large_decrease }
 		reverse_add_opinion_modifier = { target = YEM modifier = large_decrease }
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -803,8 +725,8 @@ news_event = {
 	title = denmark.26.t
 	desc = denmark.26.d
 	picture = GFX_news_event_war
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.26.a
@@ -812,10 +734,7 @@ news_event = {
 		add_manpower = 470
 		reverse_add_opinion_modifier = { target = USA modifier = small_decrease }
 		reverse_add_opinion_modifier = { target = IRQ modifier = small_increase }
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -825,17 +744,14 @@ country_event = {
 	title = denmark.27.t
 	desc = denmark.27.d
 	picture = GFX_politics_eye
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.27.a
 		log = "[GetDateText]: [This.GetName]: denmark.27.a executed"
 		add_stability = -0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -845,8 +761,8 @@ country_event = {
 	title = denmark.28.t
 	desc = denmark.28.d
 	picture = GFX_blizzard
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.28.a
@@ -867,10 +783,7 @@ country_event = {
 				instant_build = yes
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -880,8 +793,8 @@ country_event = {
 	title = denmark.29.t
 	desc = denmark.29.d
 	picture = GFX_political_deal
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.29.a
@@ -889,10 +802,7 @@ country_event = {
 		add_stability = 0.02
 		set_temp_variable = { treasury_change = 1 }
 		modify_treasury_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -902,17 +812,14 @@ country_event = {
 	title = denmark.30.t
 	desc = denmark.30.d
 	picture = GFX_politics_surveillence
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.30.a
 		log = "[GetDateText]: [This.GetName]: denmark.30.a executed"
 		add_stability = -0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -922,18 +829,15 @@ country_event = {
 	title = denmark.31.t
 	desc = denmark.31.d
 	picture = GFX_politics_surveillence
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.31.a
 		log = "[GetDateText]: [This.GetName]: denmark.31.a executed"
 		add_stability = 0.01
 		add_political_power = 25
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -943,17 +847,14 @@ country_event = {
 	title = denmark.32.t
 	desc = denmark.32.d
 	picture = GFX_declined_offer_no
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.32.a
 		log = "[GetDateText]: [This.GetName]: denmark.32.a executed"
 		add_political_power = -25
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -963,18 +864,15 @@ country_event = {
 	title = denmark.33.t
 	desc = denmark.33.d
 	picture = GFX_politics_talks
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.33.a
 		log = "[GetDateText]: [This.GetName]: denmark.33.a executed"
 		add_stability = 0.02
 		add_political_power = 25
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -984,18 +882,15 @@ country_event = {
 	title = denmark.34.t
 	desc = denmark.34.d
 	picture = GFX_politics_demands
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.34.a
 		log = "[GetDateText]: [This.GetName]: denmark.34.a executed"
 		add_stability = -0.01
 		add_political_power = -10
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1005,17 +900,14 @@ country_event = {
 	title = denmark.35.t
 	desc = denmark.35.d
 	picture = GFX_politics_salafism
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.35.a
 		log = "[GetDateText]: [This.GetName]: denmark.35.a executed"
 		add_stability = -0.02
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1025,8 +917,8 @@ country_event = {
 	title = denmark.36.t
 	desc = denmark.36.d
 	picture = GFX_trade_agreement
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.36.a
@@ -1034,10 +926,7 @@ country_event = {
 		add_stability = -0.03
 		set_temp_variable = { treasury_change = 1 }
 		modify_treasury_effect = yes
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1047,17 +936,14 @@ country_event = {
 	title = denmark.37.t
 	desc = denmark.37.d
 	picture = GFX_declined_offer_no
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.37.a
 		log = "[GetDateText]: [This.GetName]: denmark.37.a executed"
 		add_stability = 0.02
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1067,17 +953,14 @@ country_event = {
 	title = denmark.38.t
 	desc = denmark.38.d
 	picture = GFX_declined_offer_no
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.38.a
 		log = "[GetDateText]: [This.GetName]: denmark.38.a executed"
 		add_stability = 0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1087,17 +970,14 @@ country_event = {
 	title = denmark.43.t
 	desc = denmark.43.d
 	picture = GFX_typhoon
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.43.a
 		log = "[GetDateText]: [This.GetName]: denmark.43.a executed"
 		add_stability = -0.01
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1107,27 +987,21 @@ country_event = {
 	title = denmark.44.t
 	desc = denmark.44.d
 	picture = GFX_court
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.44.a
 		log = "[GetDateText]: [This.GetName]: denmark.44.a executed"
 		set_temp_variable = { treasury_change = -5.00 }
 		modify_treasury_effect = yes
-
 		GRN = {
 			set_temp_variable = { treasury_change = 3.00 }
 			modify_treasury_effect = yes
 		}
-
 		1161 = { add_extra_state_shared_building_slots = 1 }
 		1162 = { add_extra_state_shared_building_slots = 1 }
-
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1137,13 +1011,12 @@ country_event = {
 	title = denmark.45.t
 	desc = denmark.45.d
 	picture = GFX_court
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.45.a
 		log = "[GetDateText]: [This.GetName]: denmark.45.a executed"
-
 		set_autonomy = {
 			target = FAO
 			autonomy_state = autonomy_danish_crown_holding
@@ -1160,19 +1033,13 @@ country_event = {
 			set_variable = { DEN_colonial_holding_modifier_4 = 0.10 }
 			set_variable = { DEN_colonial_holding_modifier_5 = 0.10 }
 			set_variable = { DEN_colonial_holding_modifier_6 = 0.10 }
-			add_dynamic_modifier = {
-				modifier = DEN_colonial_holding_modifier
-			}
-
+			add_dynamic_modifier = { modifier = DEN_colonial_holding_modifier }
 		}
 		DEN = {
 			set_variable = { DEN_colonial_holding_modifier_1 = 0.10 }
 			set_variable = { DEN_colonial_holding_modifier_2 = 0.05 }
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1182,8 +1049,8 @@ country_event = {
 	title = denmark.46.t
 	desc = denmark.46.d
 	picture = GFX_typhoon
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	# Results
 	option = {
@@ -1236,10 +1103,7 @@ country_event = {
 				}
 			}
 		}
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1249,8 +1113,8 @@ country_event = {
 	title = denmark.47.t
 	desc = denmark.47.d
 	picture = GFX_typhoon
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	#accept resulst
 	option = {
@@ -1261,11 +1125,9 @@ country_event = {
 		set_temp_variable = { modify_europeanism = 0.05 }
 		set_temp_variable = { modify_europeanism_target = DEN }
 		europeanism_change = yes
-
-		ai_chance = {
-			base = 0.5
-		}
+		ai_chance = { base = 0.5 }
 	}
+
 	#don´t accept
 	option = {
 		name = denmark.47.b
@@ -1278,10 +1140,7 @@ country_event = {
 		set_temp_variable = { modify_europeanism = -0.05 }
 		set_temp_variable = { modify_europeanism_target = DEN }
 		europeanism_change = yes
-
-		ai_chance = {
-			base = 0.5
-		}
+		ai_chance = { base = 0.5 }
 	}
 }
 
@@ -1291,8 +1150,8 @@ country_event = {
 	title = denmark.48.t
 	desc = denmark.48.d
 	picture = GFX_typhoon
-	fire_only_once = yes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	#accept resulst
 	option = {
@@ -1303,11 +1162,9 @@ country_event = {
 		remove_ideas = DEN_euro_question_idea
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 0.5
-		}
+		ai_chance = { base = 0.5 }
 	}
+
 	#don´t accept
 	option = {
 		name = denmark.48.b
@@ -1321,10 +1178,7 @@ country_event = {
 		set_temp_variable = { modify_europeanism_target = DEN }
 		europeanism_change = yes
 		set_country_flag = DEN_accept
-
-		ai_chance = {
-			base = 0.5
-		}
+		ai_chance = { base = 0.5 }
 	}
 }
 
@@ -1333,9 +1187,9 @@ country_event = {
 	id = denmark.100
 	title = denmark.100.t
 	desc = denmark.100.d
-	fire_only_once = yes
 	picture = GFX_politics_cut_taxes
 	is_triggered_only = yes
+	fire_only_once = yes
 
 	option = {
 		name = denmark.100.a
@@ -1344,10 +1198,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.02 }
 		set_temp_variable = { temp_outlook_increase = 0.02 }
 		change_relative_party_popularity = yes
-
-		ai_chance = {
-			base = 0.5
-		}
+		ai_chance = { base = 0.5 }
 	}
 
 	option = {
@@ -1355,10 +1206,7 @@ country_event = {
 		log = "[GetDateText]: [THIS.GetName]: denmark.100.b executed"
 		add_political_power = 100
 		increase_centralization = yes
-
-		ai_chance = {
-			base = 0.5
-		}
+		ai_chance = { base = 0.5 }
 	}
 }
 
@@ -1385,6 +1233,20 @@ country_event = {
 		trigger = { check_variable = { DEN_agrar_event_tier = 14 } }
 		text = denmark_agrar_event.14.t
 	}
+	title = {
+		trigger = {
+			NOT = {
+				OR = {
+					check_variable = { DEN_agrar_event_tier = 10 }
+					check_variable = { DEN_agrar_event_tier = 11 }
+					check_variable = { DEN_agrar_event_tier = 12 }
+					check_variable = { DEN_agrar_event_tier = 13 }
+					check_variable = { DEN_agrar_event_tier = 14 }
+				}
+			}
+		}
+		text = denmark_agrar_event.10.other_t
+	}
 	desc = {
 		trigger = { check_variable = { DEN_agrar_event_tier = 10 } }
 		text = denmark_agrar_event.10.d
@@ -1404,20 +1266,6 @@ country_event = {
 	desc = {
 		trigger = { check_variable = { DEN_agrar_event_tier = 14 } }
 		text = denmark_agrar_event.14.d
-	}
-	title = {
-		trigger = {
-			NOT = {
-				OR = {
-					check_variable = { DEN_agrar_event_tier = 10 }
-					check_variable = { DEN_agrar_event_tier = 11 }
-					check_variable = { DEN_agrar_event_tier = 12 }
-					check_variable = { DEN_agrar_event_tier = 13 }
-					check_variable = { DEN_agrar_event_tier = 14 }
-				}
-			}
-		}
-		text = denmark_agrar_event.10.other_t
 	}
 	desc = {
 		trigger = {
@@ -1495,10 +1343,7 @@ country_event = {
 		recalculate_party = yes
 		clear_variable = DEN_agrar_event_tier
 		clr_country_flag = DEN_agrar_event_pending
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1524,6 +1369,20 @@ country_event = {
 		trigger = { check_variable = { DEN_agrar_event_tier_II = 19 } }
 		text = denmark_agrar_event.19.t
 	}
+	title = {
+		trigger = {
+			NOT = {
+				OR = {
+					check_variable = { DEN_agrar_event_tier_II = 15 }
+					check_variable = { DEN_agrar_event_tier_II = 16 }
+					check_variable = { DEN_agrar_event_tier_II = 17 }
+					check_variable = { DEN_agrar_event_tier_II = 18 }
+					check_variable = { DEN_agrar_event_tier_II = 19 }
+				}
+			}
+		}
+		text = denmark_agrar_event.15.other_t
+	}
 	desc = {
 		trigger = { check_variable = { DEN_agrar_event_tier_II = 15 } }
 		text = denmark_agrar_event.15.d
@@ -1543,20 +1402,6 @@ country_event = {
 	desc = {
 		trigger = { check_variable = { DEN_agrar_event_tier_II = 19 } }
 		text = denmark_agrar_event.19.d
-	}
-	title = {
-		trigger = {
-			NOT = {
-				OR = {
-					check_variable = { DEN_agrar_event_tier_II = 15 }
-					check_variable = { DEN_agrar_event_tier_II = 16 }
-					check_variable = { DEN_agrar_event_tier_II = 17 }
-					check_variable = { DEN_agrar_event_tier_II = 18 }
-					check_variable = { DEN_agrar_event_tier_II = 19 }
-				}
-			}
-		}
-		text = denmark_agrar_event.15.other_t
 	}
 	desc = {
 		trigger = {
@@ -1630,10 +1475,7 @@ country_event = {
 		recalculate_party = yes
 		clear_variable = DEN_agrar_event_tier_II
 		clr_country_flag = DEN_agrar_event_pending_II
-
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -1900,9 +1742,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		DEN_novo_outcome_settled = no
-	}
+	trigger = { DEN_novo_outcome_settled = no }
 
 	option = {
 		name = denmark.315.a

--- a/events/Korea.txt
+++ b/events/Korea.txt
@@ -18,7 +18,6 @@ news_event = {
 #Peace Talks in Beijing
 country_event = {
 	id = korea.5
-
 	title = korea.5.t
 	desc = {
 		trigger = { original_tag = KOR }
@@ -29,7 +28,6 @@ country_event = {
 		text = korea.5.d_NKO
 	}
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -208,7 +206,6 @@ news_event = {
 	title = korea.8.t
 	desc = korea.8.d
 	picture = GFX_news_election_rally
-
 	is_triggered_only = yes
 
 	option = {
@@ -222,7 +219,6 @@ country_event = {
 	title = korea.9.t
 	desc = korea.9.d
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	# We will join their struggle!
@@ -239,9 +235,7 @@ country_event = {
 		}
 		hidden_effect = {
 			every_other_country = {
-				limit = {
-					has_guaranteed = NKO
-				}
+				limit = { has_guaranteed = NKO }
 				diplomatic_relation = {
 					country = NKO
 					relation = guarantee
@@ -260,9 +254,7 @@ country_event = {
 		}
 		hidden_effect = {
 			every_other_country = {
-				limit = {
-					has_country_flag = guaranteed_NKO
-				}
+				limit = { has_country_flag = guaranteed_NKO }
 				clr_country_flag = guaranteed_NKO
 				diplomatic_relation = {
 					country = NKO
@@ -271,9 +263,7 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -289,12 +279,10 @@ country_event = {
 	title = korea.10.t
 	desc = korea.10.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
 		name = korea.10.a #We will stand by our allies!
-
 		ai_chance = {
 			base = 1
 		}
@@ -322,7 +310,6 @@ country_event = {
 	title = korea.11.t #Korean Arms Companies Offer Products
 	desc = korea.11.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -336,10 +323,8 @@ country_event = {
 		}
 		if = {
 			limit = { has_dlc = "No Step Back" }
-
 			if = {
 				limit = { has_tech = mbt_tech_2 }
-
 				add_equipment_to_stockpile = {
 					type = medium_tank_chassis_2
 					amount = 45
@@ -409,7 +394,6 @@ country_event = {
 				producer = KOR
 			}
 		}
-
 		set_temp_variable = { percent_change = 2 }
 		set_temp_variable = { tag_index = KOR.id }
 		change_influence_percentage = yes
@@ -508,7 +492,6 @@ country_event = {
 	title = korea.12.t #[FROM.GetNameDef] Agrees to Arms Deal!
 	desc = korea.12.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -625,6 +608,7 @@ country_event = {
 	desc = korea.16.d
 	picture = GFX_afghanistan_war
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = KOR
 		is_subject = no
@@ -645,12 +629,10 @@ country_event = {
 			enemy = NKO
 			hostility_reason = asked_to_join
 		}
-
 		if = {
 			limit = { NOT = { has_idea = Major_Non_NATO_Ally } }
 			NATO_major_non_nato_ally_join = yes
 		}
-
 		if = {
 			limit = {
 				USA = {
@@ -659,7 +641,6 @@ country_event = {
 					}
 				}
 			}
-
 		USA = {
 			add_to_war = {
 				targeted_alliance = KOR
@@ -677,6 +658,7 @@ country_event = {
 	desc = korea.17.d
 	picture = GFX_afghanistan_war
 	is_triggered_only = yes
+
 	trigger = {
 		original_tag = KOR
 		KOR = { is_in_faction_with = USA }
@@ -696,11 +678,9 @@ country_event = {
 #National Assembly Elections Loom as Parties Begin Campaigning
 country_event = {
 	id = korea.18
-
 	title = korea.18.t
 	desc = korea.18.d
 	picture = GFX_politics_speak
-
 	is_triggered_only = yes
 
 	option = {
@@ -718,11 +698,11 @@ country_event = {
 #hidden event checking for elections
 country_event = {
 	id = korea.19
-	hidden = yes
 	is_triggered_only = yes
-	trigger = {
-		has_elections = yes
-	}
+	hidden = yes
+
+	trigger = { has_elections = yes }
+
 	immediate = {
 		#The elections are coming!
 		country_event = { days = 1 id = korea.18 }
@@ -732,8 +712,9 @@ country_event = {
 #hidden event checking result
 country_event = {
 	id = korea.20
-	hidden = yes
 	is_triggered_only = yes
+	hidden = yes
+
 	immediate = {
 		log = "[GetDateText]: [This.GetName]: korea.20 executed"
 		random_list = {
@@ -801,16 +782,11 @@ country_event = {
 #The results are in!
 country_event = {
 	id = korea.21
-
 	title = korea.21.t
-
 	desc = {
 		text = korea.21.d_no
-		trigger = {
-			has_country_flag = KOR_no_victory
-		}
+		trigger = { has_country_flag = KOR_no_victory }
 	}
-
 	desc = {
 		text = korea.21.d_con_loss
 		trigger = {
@@ -818,7 +794,6 @@ country_event = {
 			KOR_has_conservative_government = yes
 		}
 	}
-
 	desc = {
 		text = korea.21.d_lib_loss
 		trigger = {
@@ -826,7 +801,6 @@ country_event = {
 			KOR_has_liberal_government = yes
 		}
 	}
-
 	desc = {
 		text = korea.21.d_con_win
 		trigger = {
@@ -834,7 +808,6 @@ country_event = {
 			KOR_has_conservative_government = yes
 		}
 	}
-
 	desc = {
 		text = korea.21.d_lib_win
 		trigger = {
@@ -842,9 +815,7 @@ country_event = {
 			KOR_has_liberal_government = yes
 		}
 	}
-
 	picture = GFX_politics_speak
-
 	is_triggered_only = yes
 
 	option = {
@@ -900,6 +871,7 @@ country_event = {
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = {
 		OR = {
 			original_tag = KOR
@@ -912,9 +884,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				original_tag = NKO
-			}
+			limit = { original_tag = NKO }
 			owns_state = 604
 			owns_state = 605
 			owns_state = 606
@@ -922,9 +892,7 @@ country_event = {
 			owns_state = 608
 		}
 		else_if = {
-			limit = {
-				original_tag = KOR
-			}
+			limit = { original_tag = KOR }
 			owns_state = 601
 			owns_state = 602
 			owns_state = 603
@@ -959,9 +927,7 @@ country_event = {
 	id = korea.23
 	title = korea.23.t
 	desc = korea.23.d
-
 	picture = GFX_KOR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -1104,8 +1070,8 @@ news_event = {
 	title = korea.24.t
 	desc = korea.24.d
 	picture = GFX_trade_agreement
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = korea.24.a #A bright future lies before the peninsula!
@@ -1166,19 +1132,13 @@ country_event = {
 	title = korea.26.t
 	desc = {
 		text = korea.26.d
-		trigger = {
-			KOR = { has_country_flag = KOR_proposed_south_reunification }
-		}
+		trigger = { KOR = { has_country_flag = KOR_proposed_south_reunification } }
 	}
 	desc = {
 		text = korea.26.d1
-		trigger = {
-			KOR = { has_country_flag = KOR_proposed_unity_reunification }
-		}
+		trigger = { KOR = { has_country_flag = KOR_proposed_unity_reunification } }
 	}
-
 	picture = GFX_KOR_generic
-
 	is_triggered_only = yes
 
 	trigger = {
@@ -1324,7 +1284,6 @@ country_event = {
 	title = korea.27.t
 	desc = korea.27.d
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -1358,7 +1317,6 @@ country_event = {
 	title = korea.28.t
 	desc = korea.28.d
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -1372,16 +1330,16 @@ news_event = {
 	title = korea.29.t
 	desc = korea.29.d
 	picture = GFX_political_deal
+	is_triggered_only = yes
 
 	trigger = { tag = KOR }
-
-	is_triggered_only = yes
 
 	option = {
 		name = korea.29.a #Of course we will. We respect these soldiers.
 		log = "[GetDateText]: [This.GetName]: korea.29.a executed"
 		set_country_flag = KOR_agreed_to_return_cpv_remains
 	}
+
 	option = {
 		name = korea.29.b #They are the enemies of the invasion of our land! We can't accept it!
 		log = "[GetDateText]: [This.GetName]: korea.29.b executed"
@@ -1395,14 +1353,11 @@ news_event = {
 	title = korea.30.t
 	desc = korea.30.d
 	picture = GFX_chinese_soldiers_back_home2
+	is_triggered_only = yes
 
 	trigger = { tag = KOR }
 
-	is_triggered_only = yes
-
-	option = {
-		name = korea.30.a
-	}
+	option = { name = korea.30.a }
 }
 
 #The Seventh Collection
@@ -1411,6 +1366,7 @@ news_event = {
 	title = korea.31.t
 	desc = korea.31.d
 	picture = GFX_chinese_soldiers_back_home1
+	is_triggered_only = yes
 
 	trigger = {
 		OR = {
@@ -1419,11 +1375,7 @@ news_event = {
 		}
 	}
 
-	is_triggered_only = yes
-
-	option = {
-		name = korea.31.a
-	}
+	option = { name = korea.31.a }
 }
 
 #Our Response to the North's Overture
@@ -1431,16 +1383,13 @@ country_event = {
 	id = korea.33
 	title = korea.33.t
 	desc = korea.33.d
-
 	picture = GFX_politics_negotiations
-
 	is_triggered_only = yes
 
 	option = {
 		name = korea.23.a #We will agree to a treaty
 		log = "[GetDateText]: [This.GetName]: korea.33.a executed"
 		news_event = { days = 1 id = korea.24 }
-
 		ai_chance = {
 			base = 700
 			modifier = {
@@ -1529,9 +1478,7 @@ country_event = {
 	title = korea.34.t
 	desc = {
 		text = korea.34.d
-		trigger = {
-			NKO = { has_country_flag = NKO_proposed_north_reunification }
-		}
+		trigger = { NKO = { has_country_flag = NKO_proposed_north_reunification } }
 	}
 	picture = GFX_politics_negotiations
 	is_triggered_only = yes
@@ -1670,7 +1617,6 @@ country_event = {
 	title = korea.35.t
 	desc = korea.35.d
 	picture = GFX_KOR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -1706,7 +1652,6 @@ country_event = {
 	title = korea.36.t
 	desc = korea.36.d
 	picture = GFX_KOR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -1718,9 +1663,7 @@ country_event = {
 	id = korea.38
 	title = korea.38.t
 	desc = korea.38.d
-
 	picture = GFX_american_troops
-
 	is_triggered_only = yes
 
 	option = {
@@ -1744,18 +1687,14 @@ country_event = {
 				}
 			}
 		}
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 		log = "[GetDateText]: [This.GetName]: korea.38.a executed"
 	}
 
 	option = {
 		name = korea.38.b
 		if = {
-			limit = {
-				country_exists = KOR
-			}
+			limit = { country_exists = KOR }
 			diplomatic_relation = {
 				country = KOR
 				relation = guarantee
@@ -1763,9 +1702,7 @@ country_event = {
 			}
 		}
 		if = {
-			limit = {
-				country_exists = NKO
-			}
+			limit = { country_exists = NKO }
 			diplomatic_relation = {
 				country = NKO
 				relation = guarantee
@@ -1810,9 +1747,7 @@ country_event = {
 	option = {
 		name = korea.39.a
 		log = "[GetDateText]: [This.GetName]: korea.39.a executed"
-		NKO = {
-			country_event = korea.40
-		}
+		NKO = { country_event = korea.40 }
 	}
 }
 
@@ -1827,9 +1762,7 @@ country_event = {
 		name = korea.40.a
 		log = "[GetDateText]: [This.GetName]: korea.40.a executed"
 		if = {
-			limit = {
-				has_global_flag = GAME_RULE_allow_colored_puppets
-			}
+			limit = { has_global_flag = GAME_RULE_allow_colored_puppets }
 			set_autonomy = {
 				target = FROM
 				autonomy_state = autonomy_autonomous_state_colored
@@ -1891,39 +1824,27 @@ country_event = {
 			}
 			modifier = {
 				factor = 1
-				KOR = {
-					check_variable = { SFR < 50 }
-				}
+				KOR = { check_variable = { SFR < 50 } }
 			}
 			modifier = {
 				add = 2
-				KOR = {
-					check_variable = { SFR > 50 }
-				}
+				KOR = { check_variable = { SFR > 50 } }
 			}
 			modifier = {
 				add = 2
-				KOR = {
-					check_variable = { SFR > 60 }
-				}
+				KOR = { check_variable = { SFR > 60 } }
 			}
 			modifier = {
 				add = 2
-				KOR = {
-					check_variable = { SFR > 70 }
-				}
+				KOR = { check_variable = { SFR > 70 } }
 			}
 			modifier = {
 				add = 2
-				KOR = {
-					check_variable = { SFR > 80 }
-				}
+				KOR = { check_variable = { SFR > 80 } }
 			}
 			modifier = {
 				add = 2
-				KOR = {
-					check_variable = { SFR > 90 }
-				}
+				KOR = { check_variable = { SFR > 90 } }
 			}
 			modifier = {
 				add = 2
@@ -1991,7 +1912,6 @@ country_event = {
 	title = korea.42.t
 	desc = korea.42.d
 	picture = GFX_KOR_generic
-
 	is_triggered_only = yes
 
 	option = {
@@ -2044,12 +1964,9 @@ country_event = {
 	title = korea.43.t
 	desc = korea.43.d
 	picture = GFX_KOR_generic
-
 	is_triggered_only = yes
 
-	option = {
-		name = korea.43.a
-	}
+	option = { name = korea.43.a }
 }
 
 country_event = {
@@ -2057,7 +1974,6 @@ country_event = {
 	title = korea.60.t
 	desc = korea.60.d
 	picture = GFX_grain_silo_investments
-
 	is_triggered_only = yes
 
 	option = { #Gives IDEA for India and Investment for KOR
@@ -2086,6 +2002,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives factories and resource but no idea
 		name = korea.60.b
 		log = "[GetDateText]: [This.GetName]: korea.60.b executed"
@@ -2111,6 +2028,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives one factory and smalles amount of resources to india
 		name = korea.60.c
 		log = "[GetDateText]: [This.GetName]: korea.60.c executed"
@@ -2143,7 +2061,6 @@ country_event = {
 	title = korea.61.t
 	desc = korea.61.d
 	picture = GFX_grain_silo_investments
-
 	is_triggered_only = yes
 
 	option = { #Gives IDEA for mexico and Investment for KOR
@@ -2175,6 +2092,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives factories and resource but no idea
 		name = korea.61.b
 		log = "[GetDateText]: [This.GetName]: korea.61.b executed"
@@ -2199,6 +2117,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives one factory and smalles amount of resources to mexico
 		name = korea.61.c
 		log = "[GetDateText]: [This.GetName]: korea.61.c executed"
@@ -2231,7 +2150,6 @@ country_event = {
 	title = korea.62.t
 	desc = korea.62.d
 	picture = GFX_grain_silo_investments
-
 	is_triggered_only = yes
 
 	option = { #Gives IDEA for vietnam and Investment for KOR
@@ -2263,6 +2181,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives factories and resource but no idea
 		name = korea.62.b
 		log = "[GetDateText]: [This.GetName]: korea.62.b executed"
@@ -2287,6 +2206,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives one factory and smalles amount of resources to vietnam
 		name = korea.62.c
 		log = "[GetDateText]: [This.GetName]: korea.62.c executed"
@@ -2319,7 +2239,6 @@ country_event = {
 	title = korea.63.t
 	desc = korea.63.d
 	picture = GFX_grain_silo_investments
-
 	is_triggered_only = yes
 
 	option = { #Gives IDEA for argentina and Investment for KOR
@@ -2345,6 +2264,7 @@ country_event = {
 			add_opinion_modifier = { target = ARG modifier = mutual_trade_agreement }
 		}
 	}
+
 	option = { #gives factories and resource but no idea
 		name = korea.63.b
 		log = "[GetDateText]: [This.GetName]: korea.63.b executed"
@@ -2369,6 +2289,7 @@ country_event = {
 			}
 		}
 	}
+
 	option = { #gives one factory and smalles amount of resources to argentina
 		name = korea.63.c
 		log = "[GetDateText]: [This.GetName]: korea.63.c executed"
@@ -2446,7 +2367,6 @@ country_event = {
 	title = korea.51.t
 	desc = korea.51.d
 	picture = GFX_grain_silo_investments
-
 	is_triggered_only = yes
 
 	option = { #Agriculture in  pyongyang
@@ -2469,6 +2389,7 @@ country_event = {
 		}
 		modify_treasury_effect = yes
 	}
+
 	option = { #Agriculture in Hwanghae
 		name = korea.51.b
 		log = "[GetDateText]: [This.GetName]: NKO_farms.1.b executed"
@@ -2488,8 +2409,8 @@ country_event = {
 			set_temp_variable = { treasury_change = -3.75 }
 		}
 		modify_treasury_effect = yes
-
 	}
+
 	option = { #Agriculture in Chagang
 		name = korea.51.c
 		log = "[GetDateText]: [This.GetName]: NKO_farms.1.c executed"
@@ -2509,8 +2430,8 @@ country_event = {
 			set_temp_variable = { treasury_change = -3.75 }
 		}
 		modify_treasury_effect = yes
-
 	}
+
 	option = { #Agriculture in hamgyong
 	name = korea.51.e
 	log = "[GetDateText]: [This.GetName]: NKO_farms.1.e executed"
@@ -2530,7 +2451,6 @@ country_event = {
 		set_temp_variable = { treasury_change = -3.75 }
 	}
 	modify_treasury_effect = yes
-
 	}
 }
 
@@ -2539,7 +2459,6 @@ country_event = {
 	title = korea.52.t
 	desc = korea.52.d
 	picture = GFX_generic_train_event
-
 	is_triggered_only = yes
 
 	option = { #Supply the Korean Side
@@ -2606,7 +2525,7 @@ country_event = {
 }
 
 country_event = {
-	id = korea.135  #Operation Succeeded hack
+	id = korea.135 #Operation Succeeded hack
 	title = korea.135.t
 	desc = korea.135.d
 	picture = GFX_computer
@@ -2620,7 +2539,7 @@ country_event = {
 }
 
 country_event = {
-	id = korea.136  #Hacking
+	id = korea.136 #Hacking
 	title = korea.136.t
 	desc = korea.136.d
 	picture = GFX_economy_crisis
@@ -2639,7 +2558,7 @@ country_event = {
 }
 
 country_event = {
-	id = korea.137   #drugs
+	id = korea.137 #drugs
 	title = korea.137.t
 	desc = korea.137.d
 	picture = GFX_bar
@@ -2652,6 +2571,7 @@ country_event = {
 			modify_treasury_effect = yes
 			add_stability = 0.01
 	}
+
 	option = {
 		name = korea.137.b #Unexpected
 		log = "[GetDateText]: [This.GetName]: korea.137.b executed"
@@ -2661,7 +2581,7 @@ country_event = {
 }
 
 country_event = {
-	id = korea.138  #Operation Succeeded drugs
+	id = korea.138 #Operation Succeeded drugs
 	title = korea.138.t
 	desc = korea.138.d
 	picture = GFX_computer
@@ -2675,7 +2595,7 @@ country_event = {
 }
 
 country_event = {
-	id = korea.139  #Money Printing operation
+	id = korea.139 #Money Printing operation
 	title = korea.139.t
 	desc = korea.139.d
 	picture = GFX_invetsments_in_eastern_europe
@@ -2697,8 +2617,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_nand_system_lsi } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.1.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.1.a executed"
@@ -2706,6 +2629,7 @@ country_event = {
 		hidden_effect = { KOR_samsung_record_nand_leadership = yes }
 		ai_chance = { base = 80 }
 	}
+
 	option = {
 		name = KOR_samsung_events.1.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.1.b executed"
@@ -2722,8 +2646,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_s1_investment } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.2.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.2.a executed"
@@ -2731,6 +2658,7 @@ country_event = {
 		hidden_effect = { KOR_samsung_record_s1_investment = yes }
 		ai_chance = { base = 75 }
 	}
+
 	option = {
 		name = KOR_samsung_events.2.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.2.b executed"
@@ -2747,8 +2675,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_2008_governance_reform } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.3.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.3.a executed"
@@ -2756,6 +2687,7 @@ country_event = {
 		hidden_effect = { KOR_samsung_record_governance_reform = yes }
 		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = KOR_samsung_events.3.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.3.b executed"
@@ -2772,8 +2704,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_galaxy_launch } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.4.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.4.a executed"
@@ -2781,6 +2716,7 @@ country_event = {
 		hidden_effect = { set_country_flag = KOR_samsung_galaxy_ecosystem_strategy KOR_samsung_record_galaxy_launch = yes }
 		ai_chance = { base = 55 }
 	}
+
 	option = {
 		name = KOR_samsung_events.4.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.4.b executed"
@@ -2797,8 +2733,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { OR = { has_country_flag = KOR_samsung_asml_coinvestment has_country_flag = KOR_samsung_asml_coinvestment_declined } } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.5.a
 		trigger = {
@@ -2819,6 +2758,7 @@ country_event = {
 			modifier = { factor = 0 has_war_with = HOL }
 		}
 	}
+
 	option = {
 		name = KOR_samsung_events.5.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.5.b executed"
@@ -2842,8 +2782,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_vnand_mass_production } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.6.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.6.a executed"
@@ -2860,8 +2803,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_techwin_transferred } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.7.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.7.a executed"
@@ -2878,8 +2824,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_note7_quality_reform } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.8.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.8.a executed"
@@ -2887,6 +2836,7 @@ country_event = {
 		hidden_effect = { KOR_samsung_record_note7_reform = yes }
 		ai_chance = { base = 75 }
 	}
+
 	option = {
 		name = KOR_samsung_events.8.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.8.b executed"
@@ -2903,8 +2853,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_dedicated_foundry } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.9.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.9.a executed"
@@ -2912,6 +2865,7 @@ country_event = {
 		hidden_effect = { set_country_flag = KOR_samsung_merchant_foundry_strategy KOR_samsung_record_foundry_organization = yes }
 		ai_chance = { base = 60 }
 	}
+
 	option = {
 		name = KOR_samsung_events.9.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.9.b executed"
@@ -2928,8 +2882,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_7lpp_euv } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.10.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.10.a executed"
@@ -2946,8 +2903,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_fold_relaunched } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.11.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.11.a executed"
@@ -2964,8 +2924,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_v1_euv_line } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.12.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.12.a executed"
@@ -2982,8 +2945,11 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_taylor_investment } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.13.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.13.a executed"
@@ -2991,6 +2957,7 @@ country_event = {
 		hidden_effect = { KOR_samsung_record_taylor_investment = yes }
 		ai_chance = { base = 70 }
 	}
+
 	option = {
 		name = KOR_samsung_events.13.b
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.13.b executed"
@@ -3007,8 +2974,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_3nm_gaa } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.14.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.14.a executed"
@@ -3025,8 +2995,11 @@ country_event = {
 	picture = GFX_computer
 	is_triggered_only = yes
 	fire_only_once = yes
+
 	trigger = { has_game_rule = { rule = rule_corporate_history option = full } original_tag = KOR NOT = { has_country_flag = collapsed_nation } NOT = { has_country_flag = KOR_samsung_capstone_resolved } }
+
 	immediate = { KOR_samsung_initialize_state = yes }
+
 	option = {
 		name = KOR_samsung_events.15.a
 		log = "[GetDateText]: [Root.GetName]: KOR_samsung_events.15.a executed"

--- a/events/PMC.txt
+++ b/events/PMC.txt
@@ -4,13 +4,10 @@ country_event = {
 	id = pmc_events.1
 	title = pmc_events.1.t
 	desc = pmc_events.1.d
-
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
-	option = {
-		name = pmc_events.1.a
-	}
+	option = { name = pmc_events.1.a }
 }
 country_event = {
 	id = pmc_events.2
@@ -23,13 +20,7 @@ country_event = {
 		name = pmc_events.2.a
 		log = "[GetDateText]: [This.GetName]: pmc_events.2.a executed"
 		if = {
-			limit = {
-				NOT = {
-					FROM = {
-						original_tag = ROOT
-					}
-				}
-			}
+			limit = { NOT = { FROM = { original_tag = ROOT } } }
 			set_temp_variable = { treasury_change = 5.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1.5 }
@@ -49,13 +40,7 @@ country_event = {
 		name = pmc_events.3.a
 		log = "[GetDateText]: [This.GetName]: pmc_events.3.a executed"
 		if = {
-			limit = {
-				NOT = {
-					FROM = {
-						original_tag = ROOT
-					}
-				}
-			}
+			limit = { NOT = { FROM = { original_tag = ROOT } } }
 			set_temp_variable = { treasury_change = 2.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1.5 }
@@ -75,13 +60,7 @@ country_event = {
 		name = pmc_events.4.a
 		log = "[GetDateText]: [This.GetName]: pmc_events.4.a executed"
 		if = {
-			limit = {
-				NOT = {
-					FROM = {
-						original_tag = ROOT
-					}
-				}
-			}
+			limit = { NOT = { FROM = { original_tag = ROOT } } }
 			set_temp_variable = { treasury_change = 3.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1.5 }
@@ -101,13 +80,7 @@ country_event = {
 		name = pmc_events.5.a
 		log = "[GetDateText]: [This.GetName]: pmc_events.5.a executed"
 		if = {
-			limit = {
-				NOT = {
-					FROM = {
-						original_tag = ROOT
-					}
-				}
-			}
+			limit = { NOT = { FROM = { original_tag = ROOT } } }
 			set_temp_variable = { treasury_change = 4 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1.5 }
@@ -127,13 +100,7 @@ country_event = {
 		name = pmc_events.6.a
 		log = "[GetDateText]: [This.GetName]: pmc_events.6.a executed"
 		if = {
-			limit = {
-				NOT = {
-					FROM = {
-						original_tag = ROOT
-					}
-				}
-			}
+			limit = { NOT = { FROM = { original_tag = ROOT } } }
 			set_temp_variable = { treasury_change = 1.5 }
 			modify_treasury_effect = yes
 			set_temp_variable = { percent_change = 1.5 }
@@ -151,6 +118,7 @@ news_event = {
 	picture = GFX_trade_agreement # TODO: Need a better event picture here
 	is_triggered_only = yes
 	major = yes
+
 	trigger = {
 		NOT = { USA = { has_country_flag = collapsed_nation } }
 		NOT = { has_global_flag = constellis_pmc_formed }

--- a/events/Thailand.txt
+++ b/events/Thailand.txt
@@ -10,9 +10,7 @@ country_event = {
 	picture = GFX_election_rally
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	# A - Back Thai Rak Thai (Pheu Thai, neutrality, idx 18)
 	option = {
@@ -64,9 +62,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.2.a
@@ -87,9 +83,7 @@ country_event = {
 	picture = GFX_mexican_drug_war
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	# A - Hard line (extrajudicial campaign). Historical default, always available.
 	option = {
@@ -136,9 +130,7 @@ country_event = {
 			USA = { add_opinion_modifier = { target = SIA modifier = small_increase } }
 			ENG = { add_opinion_modifier = { target = SIA modifier = small_increase } }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -167,9 +159,7 @@ country_event = {
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.4.a
@@ -202,9 +192,7 @@ country_event = {
 		hidden_effect = {
 			news_event = { id = thailand_news.1 days = 1 }
 		}
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 
 	option = {
@@ -241,9 +229,7 @@ country_event = {
 	picture = GFX_court
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.5.a
@@ -256,9 +242,7 @@ country_event = {
 		set_temp_variable = { coup_delta = -10 }
 		SIA_coup_set_risk = yes
 		country_event = { id = thailand.20 days = 3 }
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 	}
 
 	option = {
@@ -269,9 +253,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		recalculate_party = yes
 		add_political_power = 50
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -282,9 +264,7 @@ country_event = {
 	picture = GFX_turkeycoup
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.6.a
@@ -368,9 +348,7 @@ country_event = {
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.9.a
@@ -403,9 +381,7 @@ country_event = {
 	picture = GFX_politics_talks
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.10.a
@@ -451,9 +427,7 @@ country_event = {
 	picture = GFX_court
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.11.a
@@ -480,9 +454,7 @@ country_event = {
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.12.a
@@ -518,9 +490,7 @@ country_event = {
 	option = {
 		name = thailand.12.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.12.b"
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 		add_stability = 0.02
 		add_political_power = -75
 		set_temp_variable = { party_index = 3 }
@@ -539,9 +509,7 @@ country_event = {
 	picture = GFX_country_monarchy_abolished
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.13.a
@@ -567,9 +535,7 @@ country_event = {
 	option = {
 		name = thailand.13.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.13.b"
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 		add_political_power = 50
 		add_stability = 0.02
 	}
@@ -637,9 +603,7 @@ country_event = {
 			}
 			news_event = { id = thailand_news.4 days = 1 }
 		}
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = {
@@ -670,9 +634,7 @@ country_event = {
 			}
 			news_event = { id = thailand_news.4 days = 1 }
 		}
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 	}
 
 	option = {
@@ -707,9 +669,7 @@ country_event = {
 			}
 			news_event = { id = thailand_news.4 days = 1 }
 		}
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -720,9 +680,7 @@ country_event = {
 	picture = GFX_monarch_event
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.15.a
@@ -793,9 +751,7 @@ country_event = {
 	picture = GFX_politics_speak
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.16.a
@@ -816,9 +772,7 @@ country_event = {
 	picture = GFX_monarchist_rally
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.17.a
@@ -839,9 +793,7 @@ country_event = {
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.18.a
@@ -906,7 +858,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.20.a		# Re-register clean, under new management
+		name = thailand.20.a # Re-register clean, under new management
 		log = "[GetDateText]: [Root.GetName]: event thailand.20.a"
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.04 }
@@ -921,7 +873,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.20.b		# The banned executives keep running it from outside
+		name = thailand.20.b # The banned executives keep running it from outside
 		log = "[GetDateText]: [Root.GetName]: event thailand.20.b"
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.08 }
@@ -961,7 +913,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.21.a		# Let the defectors go and hand the Democrats the chamber
+		name = thailand.21.a # Let the defectors go and hand the Democrats the chamber
 		log = "[GetDateText]: [Root.GetName]: event thailand.21.a"
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = -0.05 }
@@ -987,7 +939,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.21.b		# Buy the defectors back and hold the coalition
+		name = thailand.21.b # Buy the defectors back and hold the coalition
 		log = "[GetDateText]: [Root.GetName]: event thailand.21.b"
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.03 }
@@ -1008,9 +960,7 @@ country_event = {
 	picture = GFX_banking_crisis
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.50.a
@@ -1018,9 +968,7 @@ country_event = {
 		set_temp_variable = { treasury_change = 8 }
 		modify_treasury_effect = yes
 		add_stability = -0.03
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1029,9 +977,7 @@ country_event = {
 		add_stability = 0.02
 		set_temp_variable = { treasury_change = -4 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1042,9 +988,7 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.51.a
@@ -1063,9 +1007,7 @@ country_event = {
 	picture = GFX_sinking_ship
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.52.a
@@ -1133,9 +1075,7 @@ country_event = {
 				country_event = { id = thailand.220 days = 365 }
 			}
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -1146,9 +1086,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.53.a
@@ -1217,9 +1155,7 @@ country_event = {
 			set_temp_variable = { coup_delta = 15 }
 			SIA_coup_set_risk = yes
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -1239,9 +1175,7 @@ country_event = {
 	option = {
 		name = thailand.54.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.54.a"
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 		set_temp_variable = { treasury_change = -4 }
 		modify_treasury_effect = yes
 		set_party_index_to_ruling_party = yes
@@ -1252,9 +1186,7 @@ country_event = {
 	option = {
 		name = thailand.54.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.54.b"
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 		set_party_index_to_ruling_party = yes
 		set_temp_variable = { party_popularity_increase = -0.03 }
 		change_relative_party_popularity = yes
@@ -1270,9 +1202,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.55.a
@@ -1302,9 +1232,7 @@ country_event = {
 		add_political_power = -50
 		custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = SIA_economy_modifier }
 		add_to_variable = { SIA_econ_consumer_goods_factor = -0.01 tooltip = consumer_goods_factor_tt }
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 }
 
@@ -1315,9 +1243,7 @@ country_event = {
 	picture = GFX_southeast_asian_tiger
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.56.a
@@ -1352,9 +1278,7 @@ country_event = {
 	picture = GFX_submarine
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.57.a
@@ -1379,16 +1303,12 @@ country_event = {
 	picture = GFX_court
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.58.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.58.a"
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 		set_temp_variable = { treasury_change = -4 }
 		modify_treasury_effect = yes
 		set_country_flag = SIA_suvarnabhumi_on_time
@@ -1400,9 +1320,7 @@ country_event = {
 	option = {
 		name = thailand.58.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.58.b"
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 		add_stability = -0.01
 		add_political_power = -25
 		set_temp_variable = { treasury_change = 4 }
@@ -1421,9 +1339,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.59.a
@@ -1459,9 +1375,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.60.a
@@ -1491,9 +1405,7 @@ country_event = {
 	picture = GFX_united_states_dollar
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.61.a
@@ -1518,36 +1430,28 @@ country_event = {
 	picture = GFX_negotiations
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.62.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.62.a"
 		set_temp_variable = { int_investment_change = 10 }
 		modify_international_investment_effect = yes
-		506 = {
-			two_state_infrastructure = yes
-		}
+		506 = { two_state_infrastructure = yes }
 		set_temp_variable = { percent_change = 5 }
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = SIA }
 		change_influence_percentage = yes
 		add_opinion_modifier = { target = CHI modifier = medium_increase }
 		add_timed_idea = { idea = SIA_bri_debt days = 1825 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
 		name = thailand.62.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.62.b"
 		add_opinion_modifier = { target = CHI modifier = small_decrease }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1558,9 +1462,7 @@ country_event = {
 	picture = GFX_court
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.63.a
@@ -1570,9 +1472,7 @@ country_event = {
 		set_temp_variable = { coup_delta = -10 }
 		SIA_coup_set_risk = yes
 		add_stability = 0.03
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = {
@@ -1585,9 +1485,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		set_temp_variable = { treasury_change = 6 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 }
 
@@ -1609,9 +1507,7 @@ country_event = {
 		set_temp_variable = { treasury_change = -8 }
 		modify_treasury_effect = yes
 		add_stability = 0.02
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -1625,9 +1521,7 @@ country_event = {
 		change_relative_party_popularity = yes
 		set_temp_variable = { treasury_change = 5 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -1638,9 +1532,7 @@ country_event = {
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.65.a
@@ -1670,9 +1562,7 @@ country_event = {
 	picture = GFX_submarine
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.66.a
@@ -1706,16 +1596,12 @@ country_event = {
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.67.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.67.a"
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 		add_stability = 0.03
 		add_political_power = 50
 		navy_experience = 25
@@ -1726,9 +1612,7 @@ country_event = {
 	option = {
 		name = thailand.67.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.67.b"
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 		navy_experience = 25
 	}
 }
@@ -1740,9 +1624,7 @@ country_event = {
 	picture = GFX_soldiers_drug_dealing
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.68.a
@@ -1780,9 +1662,7 @@ country_event = {
 	picture = GFX_alawite_officers_event
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.69.a
@@ -1824,9 +1704,7 @@ country_event = {
 	picture = GFX_malian_coup
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.70.a
@@ -1934,11 +1812,7 @@ country_event = {
 		NOT = { has_idea = SIA_consolidated_democracy_idea }
 	}
 
-	immediate = {
-		hidden_effect = {
-			set_country_flag = SIA_2020_protests_done
-		}
-	}
+	immediate = { hidden_effect = { set_country_flag = SIA_2020_protests_done } }
 
 	option = {
 		name = thailand.71.a
@@ -1964,9 +1838,7 @@ country_event = {
 		set_temp_variable = { party_index = 3 }
 		set_temp_variable = { party_popularity_increase = 0.12 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 
 	option = {
@@ -1975,9 +1847,7 @@ country_event = {
 		hidden_effect = {
 			country_event = { id = thailand.208 days = 120 }
 		}
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -1988,9 +1858,7 @@ country_event = {
 	picture = GFX_politics_demands
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.100.a
@@ -2011,9 +1879,7 @@ country_event = {
 	picture = GFX_politics_speak
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.101.a
@@ -2034,9 +1900,7 @@ country_event = {
 	picture = GFX_politics_talks
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.102.a
@@ -2070,16 +1934,12 @@ country_event = {
 	picture = GFX_message_signing
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.103.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.103.a"
-		ai_chance = {
-			base = 6
-		}
+		ai_chance = { base = 6 }
 		512 = { add_claim_by = SIA }
 		513 = { add_claim_by = SIA }
 		hidden_effect = {
@@ -2091,9 +1951,7 @@ country_event = {
 	option = {
 		name = thailand.103.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.103.b"
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 		512 = { add_claim_by = SIA }
 		513 = { add_claim_by = SIA }
 		set_temp_variable = { wargoal_on = CBD }
@@ -2121,9 +1979,7 @@ country_event = {
 	picture = GFX_politics_negotiations
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.104.a
@@ -2157,9 +2013,7 @@ country_event = {
 	picture = GFX_weapons_arms1
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.105.a
@@ -2188,9 +2042,7 @@ country_event = {
 	picture = GFX_treaty
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.106.a
@@ -2208,9 +2060,7 @@ country_event = {
 	picture = GFX_message_signing
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.107.a
@@ -2232,9 +2082,7 @@ country_event = {
 	picture = GFX_political_deal
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.108.a
@@ -2252,9 +2100,7 @@ country_event = {
 	picture = GFX_politics_talks
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.109.a
@@ -2372,9 +2218,7 @@ country_event = {
 	picture = GFX_event_pmcs
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.152.a
@@ -2423,9 +2267,7 @@ country_event = {
 	picture = GFX_treaty
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.154.a
@@ -2532,6 +2374,7 @@ country_event = {
 		complete_national_focus = SIA_iron_fist_doctrine
 		ai_chance = { base = 1 modifier = { factor = 5 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = thailand.350.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.350.b"
@@ -2539,6 +2382,7 @@ country_event = {
 		complete_national_focus = SIA_royal_development_projects
 		ai_chance = { base = 1 modifier = { factor = 5 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = thailand.350.c
 		log = "[GetDateText]: [Root.GetName]: event thailand.350.c"
@@ -2549,6 +2393,7 @@ country_event = {
 		complete_national_focus = SIA_peace_dialogue_initiative
 		ai_chance = { base = 1 modifier = { factor = 5 is_historical_focus_on = yes } }
 	}
+
 	# D - We have no clear policy (default, trackless).
 	option = {
 		name = thailand.350.e
@@ -2579,9 +2424,7 @@ country_event = {
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.356.a
@@ -2607,9 +2450,7 @@ country_event = {
 	picture = GFX_special_forces
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.357.a
@@ -2629,9 +2470,7 @@ country_event = {
 	picture = GFX_buddh_rally
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.358.a
@@ -2649,9 +2488,7 @@ country_event = {
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.359.a
@@ -2662,6 +2499,7 @@ country_event = {
 		add_political_power = 30
 		ai_chance = { base = 3 modifier = { factor = 2 is_historical_focus_on = yes } }
 	}
+
 	option = {
 		name = thailand.359.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.359.b"
@@ -2681,9 +2519,7 @@ country_event = {
 	picture = GFX_paris_convention
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.360.a
@@ -2703,9 +2539,7 @@ country_event = {
 	picture = GFX_drug_dealers_trial
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.361.a
@@ -2725,14 +2559,10 @@ country_event = {
 	picture = GFX_soldiers_drug_dealing
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	# .362 has two fire paths (Golden Triangle completion and thailand.3 Option C).
-	immediate = {
-		set_country_flag = SIA_362_fired
-	}
+	immediate = { set_country_flag = SIA_362_fired }
 
 	option = {
 		name = thailand.362.a
@@ -2764,9 +2594,7 @@ country_event = {
 		add_stability = 0.04
 		set_temp_variable = { treasury_change = 3 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 1
-		}
+		ai_chance = { base = 1 }
 	}
 }
 
@@ -2778,9 +2606,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.1.a
-	}
+	option = { name = thailand_news.1.a }
 }
 
 news_event = {
@@ -2791,9 +2617,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.2.a
-	}
+	option = { name = thailand_news.2.a }
 }
 
 news_event = {
@@ -2804,9 +2628,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.3.a
-	}
+	option = { name = thailand_news.3.a }
 }
 
 news_event = {
@@ -2817,9 +2639,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.4.a
-	}
+	option = { name = thailand_news.4.a }
 }
 
 news_event = {
@@ -2830,9 +2650,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.5.a
-	}
+	option = { name = thailand_news.5.a }
 }
 
 country_event = {
@@ -2842,9 +2660,7 @@ country_event = {
 	picture = GFX_message_signing
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.200.a
@@ -2863,18 +2679,14 @@ country_event = {
 	picture = GFX_southeast_asian_tiger
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.201.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.201.a"
 		set_temp_variable = { temp_productivity_change = 5 }
 		509 = { state_flat_productivity_change_effect = yes }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -2882,9 +2694,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event thailand.201.b"
 		set_temp_variable = { treasury_change = 6 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2895,18 +2705,14 @@ country_event = {
 	picture = GFX_report_event_Sicily_Farms
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.202.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.202.a"
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -2914,9 +2720,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event thailand.202.b"
 		add_stability = 0.05
 		add_resource = { type = rubber amount = 4 state = 509 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -2927,9 +2731,7 @@ country_event = {
 	picture = GFX_american_troops
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.203.a
@@ -2957,9 +2759,7 @@ country_event = {
 			limit = { country_exists = USA }
 			add_opinion_modifier = { target = USA modifier = small_decrease }
 		}
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 }
 
@@ -2973,9 +2773,7 @@ country_event = {
 	picture = GFX_politics_talks
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.205.a
@@ -3011,9 +2809,7 @@ country_event = {
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.207.a
@@ -3030,18 +2826,14 @@ country_event = {
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.208.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.208.a"
 		add_stability = 0.02
 		add_political_power = 50
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -3052,9 +2844,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		change_relative_party_popularity = yes
 		add_war_support = 0.02
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3066,9 +2856,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.6.a
-	}
+	option = { name = thailand_news.6.a }
 }
 
 news_event = {
@@ -3079,9 +2867,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.7.a
-	}
+	option = { name = thailand_news.7.a }
 }
 
 news_event = {
@@ -3092,9 +2878,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.8.a
-	}
+	option = { name = thailand_news.8.a }
 }
 
 # Youth Wave - future forward flavor (SIA_future_forward)
@@ -3105,9 +2889,7 @@ country_event = {
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.209.a
@@ -3142,9 +2924,7 @@ country_event = {
 	picture = GFX_ecu_junta
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.210.a
@@ -3172,9 +2952,7 @@ country_event = {
 	picture = GFX_pol_election_event
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.211.a
@@ -3208,9 +2986,7 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.212.a
@@ -3243,41 +3019,31 @@ country_event = {
 	picture = GFX_country_monarchy_abolished
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.213.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.213.a"
-		trigger = {
-			has_stability > 0.50
-		}
+		trigger = { has_stability > 0.50 }
 		add_ideas = SIA_thai_republic
 		add_stability = 0.05
 		add_political_power = 100
 		set_temp_variable = { rul_party_temp = 3 }
 		set_temp_variable = { disable_elections = 0 }
 		change_ruling_party_effect = yes
-		ai_chance = {
-			base = 8
-		}
+		ai_chance = { base = 8 }
 	}
 
 	option = {
 		name = thailand.213.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.213.b"
-		trigger = {
-			has_war_support > 0.50
-		}
+		trigger = { has_war_support > 0.50 }
 		add_stability = -0.08
 		add_war_support = 0.05
 		set_temp_variable = { party_index = 23 }
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 2
-		}
+		ai_chance = { base = 2 }
 	}
 
 	option = {
@@ -3286,9 +3052,7 @@ country_event = {
 		add_stability = -0.04
 		add_political_power = -50
 		army_experience = 15
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3300,9 +3064,7 @@ country_event = {
 	picture = GFX_american_troops
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.214.a
@@ -3320,9 +3082,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.9.a
-	}
+	option = { name = thailand_news.9.a }
 }
 
 # The Spring Holds - consolidated_democracy.
@@ -3334,9 +3094,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.10.a
-	}
+	option = { name = thailand_news.10.a }
 }
 
 # Thai Wave Sweeps Asia - creative_economy.
@@ -3348,9 +3106,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.11.a
-	}
+	option = { name = thailand_news.11.a }
 }
 
 # Gateway of Asia Declared - gateway_of_asia.
@@ -3362,9 +3118,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.13.a
-	}
+	option = { name = thailand_news.13.a }
 }
 
 # The Bamboo Curtain Falls - SIA_bamboo_curtain capstone ( communist path)
@@ -3376,9 +3130,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.14.a
-	}
+	option = { name = thailand_news.14.a }
 }
 
 # The Countryside Surrounds the City - SIA_protracted_peoples_war ( fork 1)
@@ -3390,9 +3142,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.31.a
-	}
+	option = { name = thailand_news.31.a }
 }
 
 # The Road from Beijing - SIA_the_beijing_road ( fork 4a)
@@ -3404,9 +3154,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.32.a
-	}
+	option = { name = thailand_news.32.a }
 }
 
 # A Federation of the Three Rivers - SIA_indochina_federation ( fork 4b)
@@ -3418,9 +3166,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.33.a
-	}
+	option = { name = thailand_news.33.a }
 }
 
 # Taking Stock of the Kingdom - mandate choice event
@@ -3431,18 +3177,14 @@ country_event = {
 	picture = GFX_politics_talks
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.215.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.215.a"
 		add_political_power = 100
 		add_timed_idea = { idea = SIA_mandate_recovery days = 730 }
-		ai_chance = {
-			base = 4
-		}
+		ai_chance = { base = 4 }
 	}
 
 	option = {
@@ -3461,9 +3203,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event thailand.215.c"
 		add_political_power = 100
 		add_timed_idea = { idea = SIA_mandate_outreach days = 730 }
-		ai_chance = {
-			base = 3
-		}
+		ai_chance = { base = 3 }
 	}
 }
 
@@ -3476,9 +3216,7 @@ country_event = {
 	picture = GFX_sov_oligarchs_coup
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.216.a
@@ -3552,9 +3290,7 @@ country_event = {
 	picture = GFX_american_troops
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.217.a
@@ -3571,9 +3307,7 @@ country_event = {
 		set_temp_variable = { tag_index = CHI }
 		set_temp_variable = { influence_target = SIA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -3589,9 +3323,7 @@ country_event = {
 		set_temp_variable = { influence_target = SIA }
 		change_influence_percentage = yes
 		add_political_power = -50
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3602,9 +3334,7 @@ country_event = {
 	picture = GFX_handshake_black
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.218.a
@@ -3621,9 +3351,7 @@ country_event = {
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = SIA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -3638,9 +3366,7 @@ country_event = {
 		set_temp_variable = { tag_index = USA }
 		set_temp_variable = { influence_target = SIA }
 		change_influence_percentage = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3652,9 +3378,7 @@ country_event = {
 	picture = GFX_politics_speak
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.219.a
@@ -3672,9 +3396,7 @@ country_event = {
 		}
 		add_to_variable = { SIA_reform_radicalization = 15 }
 		add_political_power = 25
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 
 	option = {
@@ -3688,9 +3410,7 @@ country_event = {
 			USA = { add_opinion_modifier = { target = SIA modifier = large_decrease } }
 		}
 		add_to_variable = { SIA_reform_radicalization = 25 }
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }
 
@@ -3702,9 +3422,7 @@ country_event = {
 	picture = GFX_southeast_asian_tiger
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.220.a
@@ -3728,9 +3446,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.221.a
@@ -3749,9 +3465,7 @@ country_event = {
 	picture = GFX_banking_crisis
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.222.a
@@ -3772,13 +3486,9 @@ country_event = {
 	option = {
 		name = thailand.222.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.222.b"
-		trigger = {
-			NOT = { has_country_flag = SIA_debt_free_credibility_active }
-		}
+		trigger = { NOT = { has_country_flag = SIA_debt_free_credibility_active } }
 		add_timed_idea = { idea = SIA_gfc_headwinds days = 730 }
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3790,18 +3500,14 @@ country_event = {
 	picture = GFX_monarchist_sentiment
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.223.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.223.a"
 		add_stability = 0.03
 		add_political_power = 25
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3813,9 +3519,7 @@ country_event = {
 	picture = GFX_drug_dealers_trial
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.224.a
@@ -3827,9 +3531,7 @@ country_event = {
 			limit = { has_idea = SIA_rice_pledge }
 			remove_ideas = SIA_rice_pledge
 		}
-		ai_chance = {
-			base = 60
-		}
+		ai_chance = { base = 60 }
 	}
 
 	option = {
@@ -3844,9 +3546,7 @@ country_event = {
 		}
 		set_temp_variable = { coup_delta = 15 }
 		SIA_coup_set_risk = yes
-		ai_chance = {
-			base = 40
-		}
+		ai_chance = { base = 40 }
 	}
 }
 
@@ -3858,18 +3558,14 @@ country_event = {
 	picture = GFX_ukraine_roads
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.225.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.225.a"
 		add_political_power = 25
 		add_stability = 0.02
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3881,9 +3577,7 @@ country_event = {
 	picture = GFX_monarch_event
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.226.a
@@ -3894,9 +3588,7 @@ country_event = {
 		}
 		add_ideas = SIA_kings_moral_authority_2
 		add_stability = 0.02
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3908,18 +3600,14 @@ country_event = {
 	picture = GFX_monarchist_rally
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.227.a
 		log = "[GetDateText]: [Root.GetName]: event thailand.227.a"
 		add_stability = -0.02
 		add_political_power = 50
-		ai_chance = {
-			base = 70
-		}
+		ai_chance = { base = 70 }
 	}
 
 	option = {
@@ -3927,9 +3615,7 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event thailand.227.b"
 		add_political_power = -50
 		army_experience = 25
-		ai_chance = {
-			base = 30
-		}
+		ai_chance = { base = 30 }
 	}
 }
 
@@ -3952,9 +3638,7 @@ country_event = {
 		set_temp_variable = { treasury_change = 4 }
 		modify_treasury_effect = yes
 		add_stability = 0.02
-		ai_chance = {
-			base = 10
-		}
+		ai_chance = { base = 10 }
 	}
 }
 
@@ -3970,9 +3654,7 @@ country_event = {
 	picture = GFX_politics_protest
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	# The strike momentum reached 100 — the government blinks. Fired from the weekly on_action the
 	# moment SIA_strike_momentum tops out. Peaceful road to power.
@@ -4003,9 +3685,7 @@ country_event = {
 	picture = GFX_turkeycoup
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.259.a
@@ -4043,9 +3723,7 @@ country_event = {
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.251.a
@@ -4076,9 +3754,7 @@ country_event = {
 	picture = GFX_country_monarchy_abolished
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.252.a
@@ -4100,9 +3776,7 @@ country_event = {
 	picture = GFX_proposition_of_the_monarch
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.253.a
@@ -4154,7 +3828,6 @@ country_event = {
 	title = thailand.260.t
 	desc = thailand.260.d
 	picture = GFX_politics_protest
-
 	is_triggered_only = yes
 
 	# Armed a week earlier by on_weekly_SIA; the government can still defuse the tide, be couped
@@ -4211,7 +3884,6 @@ country_event = {
 	title = thailand.270.t
 	desc = thailand.270.d
 	picture = GFX_political_deal
-
 	is_triggered_only = yes
 
 	trigger = {
@@ -4219,9 +3891,7 @@ country_event = {
 		NOT = { has_country_flag = SIA_path_communist }
 	}
 
-	immediate = {
-		SIA_found_bhumjaithai = yes
-	}
+	immediate = { SIA_found_bhumjaithai = yes }
 
 	option = {
 		name = thailand.270.a
@@ -4247,7 +3917,6 @@ country_event = {
 	title = thailand.271.t
 	desc = thailand.271.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -4264,7 +3933,6 @@ country_event = {
 	title = thailand.272.t
 	desc = thailand.272.d
 	picture = GFX_mexican_drug_war
-
 	is_triggered_only = yes
 
 	option = {
@@ -4293,7 +3961,6 @@ country_event = {
 	title = thailand.273.t
 	desc = thailand.273.d
 	picture = GFX_message_signing
-
 	is_triggered_only = yes
 
 	option = {
@@ -4328,7 +3995,6 @@ country_event = {
 	title = thailand.280.t
 	desc = thailand.280.d
 	picture = GFX_weapons_arms1
-
 	is_triggered_only = yes
 
 	option = {
@@ -4350,7 +4016,6 @@ country_event = {
 	title = thailand.281.t
 	desc = thailand.281.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
 	option = {
@@ -4367,10 +4032,9 @@ news_event = {
 	id = thailand_news.15
 	title = thailand_news.15.t
 	desc = thailand_news.15.d
-
-	major = yes
 	picture = GFX_political_deal
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.15.a
@@ -4384,9 +4048,8 @@ news_event = {
 	title = thailand_news.16.t
 	desc = thailand_news.16.d
 	picture = GFX_news_generic_soldiers
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.16.a
@@ -4402,7 +4065,6 @@ country_event = {
 	title = thailand.310.t
 	desc = thailand.310.d
 	picture = GFX_southeast_asian_tiger
-
 	is_triggered_only = yes
 
 	option = {
@@ -4419,7 +4081,6 @@ country_event = {
 	title = thailand.311.t
 	desc = thailand.311.d
 	picture = GFX_negotiations
-
 	is_triggered_only = yes
 
 	option = {
@@ -4446,7 +4107,6 @@ country_event = {
 	title = thailand.312.t
 	desc = thailand.312.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -4496,7 +4156,6 @@ country_event = {
 	title = thailand.313.t
 	desc = thailand.313.d
 	picture = GFX_stock_market
-
 	is_triggered_only = yes
 
 	option = {
@@ -4531,7 +4190,6 @@ country_event = {
 	title = thailand.314.t
 	desc = thailand.314.d
 	picture = GFX_american_troops
-
 	is_triggered_only = yes
 
 	option = {
@@ -4561,12 +4219,9 @@ country_event = {
 	title = thailand.315.t
 	desc = thailand.315.d
 	picture = GFX_special_forces
-
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.315.a
@@ -4604,7 +4259,6 @@ country_event = {
 	title = thailand.316.t
 	desc = thailand.316.d
 	picture = GFX_weapons_arms1
-
 	is_triggered_only = yes
 
 	option = {
@@ -4635,12 +4289,9 @@ country_event = {
 	title = thailand.317.t
 	desc = thailand.317.d
 	picture = GFX_event_pmcs
-
 	is_triggered_only = yes
 
-	trigger = {
-		has_country_flag = SIA_border_war_escalated
-	}
+	trigger = { has_country_flag = SIA_border_war_escalated }
 
 	option = {
 		name = thailand.317.a
@@ -4670,7 +4321,6 @@ country_event = {
 	title = thailand.318.t
 	desc = thailand.318.d
 	picture = GFX_Military_Reform
-
 	is_triggered_only = yes
 
 	option = {
@@ -4705,7 +4355,6 @@ country_event = {
 	title = thailand.319.t
 	desc = thailand.319.d
 	picture = GFX_declined_offer_no
-
 	is_triggered_only = yes
 
 	option = {
@@ -4751,7 +4400,6 @@ country_event = {
 	title = thailand.320.t
 	desc = thailand.320.d
 	picture = GFX_court
-
 	is_triggered_only = yes
 
 	trigger = {
@@ -4759,9 +4407,7 @@ country_event = {
 		NOT = { has_country_flag = SIA_path_communist }
 	}
 
-	immediate = {
-		SIA_found_bhumjaithai = yes
-	}
+	immediate = { SIA_found_bhumjaithai = yes }
 
 	option = {
 		name = thailand.320.a
@@ -4790,7 +4436,6 @@ country_event = {
 	title = thailand.321.t
 	desc = thailand.321.d
 	picture = GFX_politics_talks
-
 	is_triggered_only = yes
 
 	option = {
@@ -4807,7 +4452,6 @@ country_event = {
 	title = thailand.322.t
 	desc = thailand.322.d
 	picture = GFX_election_rally
-
 	is_triggered_only = yes
 
 	option = {
@@ -4846,10 +4490,9 @@ news_event = {
 	id = thailand_news.17
 	title = thailand_news.17.t
 	desc = thailand_news.17.d
-
-	major = yes
 	picture = GFX_nuclear_power_plant
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.17.a
@@ -4863,9 +4506,8 @@ news_event = {
 	title = thailand_news.18.t
 	desc = thailand_news.18.d
 	picture = GFX_news_press_conference
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.18.a
@@ -4878,10 +4520,9 @@ news_event = {
 	id = thailand_news.19
 	title = thailand_news.19.t
 	desc = thailand_news.19.d
-
-	major = yes
 	picture = GFX_election_day
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.19.a
@@ -4896,12 +4537,9 @@ country_event = {
 	title = thailand.330.t
 	desc = thailand.330.d
 	picture = GFX_Military_Reform
-
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = { # nudge toward N1 (professional)
 		name = thailand.330.a
@@ -4909,6 +4547,7 @@ country_event = {
 		army_experience = 25
 		ai_chance = { base = 1 modifier = { factor = 5 is_historical_focus_on = yes } }
 	}
+
 	option = { # nudge toward N2 (prestige)
 		name = thailand.330.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.330.b"
@@ -4924,12 +4563,9 @@ country_event = {
 	title = thailand.334.t
 	desc = thailand.334.d
 	picture = GFX_submarine
-
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.334.a
@@ -4943,10 +4579,9 @@ news_event = {
 	id = thailand_news.26
 	title = thailand_news.26.t
 	desc = thailand_news.26.d
-
-	major = yes
 	picture = GFX_political_deal
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.26.a
@@ -4960,9 +4595,8 @@ news_event = {
 	title = thailand_news.27.t
 	desc = thailand_news.27.d
 	picture = GFX_trade_agreement
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.27.a
@@ -4976,9 +4610,8 @@ news_event = {
 	title = thailand_news.28.t
 	desc = thailand_news.28.d
 	picture = GFX_news_generic_soldiers
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.28.a
@@ -4991,10 +4624,9 @@ news_event = {
 	id = thailand_news.24
 	title = thailand_news.24.t
 	desc = thailand_news.24.d
-
-	major = yes
 	picture = GFX_treaty
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.24.a
@@ -5007,10 +4639,9 @@ news_event = {
 	id = thailand_news.25
 	title = thailand_news.25.t
 	desc = thailand_news.25.d
-
-	major = yes
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.25.a
@@ -5025,9 +4656,8 @@ news_event = {
 	title = thailand_news.23.t
 	desc = thailand_news.23.d
 	picture = GFX_news_press_conference
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.23.a
@@ -5047,9 +4677,7 @@ country_event = {
 	picture = GFX_politics_negotiations
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = { # a - Chinese / BRI financing (cheap, debt trap)
 		name = thailand.380.a
@@ -5114,9 +4742,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.381.a
@@ -5132,9 +4758,7 @@ country_event = {
 	picture = GFX_southeast_asian_tiger
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.382.a
@@ -5153,9 +4777,7 @@ country_event = {
 	picture = GFX_stock_market
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = { # a - pour money in (no progress lost)
 		name = thailand.383.a
@@ -5189,9 +4811,7 @@ country_event = {
 	picture = GFX_submarine
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.384.a
@@ -5213,9 +4833,7 @@ country_event = {
 	picture = GFX_news_generic_soldiers
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = { # a - reinforce security
 		name = thailand.385.a
@@ -5305,9 +4923,7 @@ country_event = {
 	picture = GFX_united_states_dollar
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.388.a
@@ -5328,9 +4944,7 @@ country_event = {
 	picture = GFX_message_signing
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = { # a - reassure both
 		name = thailand.389.a
@@ -5371,9 +4985,7 @@ country_event = {
 	picture = GFX_southeast_asian_tiger
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.390.a
@@ -5401,9 +5013,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = { # a - militarize (fortress canal)
 		name = thailand.391.a
@@ -5430,9 +5040,7 @@ news_event = {
 	is_triggered_only = yes
 	major = yes
 
-	option = {
-		name = thailand_news.20.a
-	}
+	option = { name = thailand_news.20.a }
 }
 
 # STORY 2.6 - ASEAN CROSSROADS The peace/hegemony choice is the mutually exclusive focus pair
@@ -5445,6 +5053,7 @@ country_event = {
 	desc = thailand.393.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5474,6 +5083,7 @@ country_event = {
 	desc = thailand.394.d
 	picture = GFX_treaty_rejected
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5501,6 +5111,7 @@ country_event = {
 	desc = thailand.395.d
 	picture = GFX_handshake_black
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5574,9 +5185,7 @@ country_event = {
 	picture = GFX_politics_talks
 	is_triggered_only = yes
 
-	option = {
-		name = thailand.426.a
-	}
+	option = { name = thailand.426.a }
 }
 
 # thailand.433 - Bamboo bends east: Bangkok requests a Chinese guarantee. Fired at CHI from
@@ -5596,9 +5205,9 @@ country_event = {
 		FROM = { add_opinion_modifier = { target = ROOT modifier = medium_increase } }
 		ai_chance = {
 			base = 20
-			modifier = { factor = 3  has_opinion = { target = FROM value > 30 } }
-			modifier = { factor = 0.2  has_opinion = { target = FROM value < 0 } }
-			modifier = { factor = 0.4  has_war = yes }
+			modifier = { factor = 3 has_opinion = { target = FROM value > 30 } }
+			modifier = { factor = 0.2 has_opinion = { target = FROM value < 0 } }
+			modifier = { factor = 0.4 has_war = yes }
 		}
 	}
 
@@ -5608,7 +5217,7 @@ country_event = {
 		FROM = { add_opinion_modifier = { target = ROOT modifier = small_decrease } }
 		ai_chance = {
 			base = 30
-			modifier = { factor = 0.3  has_opinion = { target = FROM value > 50 } }
+			modifier = { factor = 0.3 has_opinion = { target = FROM value > 50 } }
 		}
 	}
 }
@@ -5624,6 +5233,7 @@ country_event = {
 	desc = thailand.410.d
 	picture = GFX_politics_demands
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5657,6 +5267,7 @@ country_event = {
 	desc = thailand.411.d
 	picture = GFX_politics_speak
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5683,6 +5294,7 @@ country_event = {
 	desc = thailand.412.d
 	picture = GFX_negotiations
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5702,6 +5314,7 @@ country_event = {
 	desc = thailand.413.d
 	picture = GFX_declined_offer_no
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5737,6 +5350,7 @@ country_event = {
 	desc = thailand.414.d
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5761,6 +5375,7 @@ country_event = {
 	desc = thailand.415.d
 	picture = GFX_treaty
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5784,6 +5399,7 @@ country_event = {
 	desc = thailand.416.d
 	picture = GFX_politics_autocracy
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -5814,6 +5430,7 @@ country_event = {
 	desc = thailand.417.d
 	picture = GFX_generic_factory
 	is_triggered_only = yes
+
 	trigger = { original_tag = SIA }
 
 	option = {
@@ -6051,7 +5668,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.74.a		# Lean on the court - the verdict is bought
+		name = thailand.74.a # Lean on the court - the verdict is bought
 		log = "[GetDateText]: [Root.GetName]: event thailand.74.a"
 		set_temp_variable = { coup_delta = 12 }
 		SIA_coup_set_risk = yes
@@ -6061,8 +5678,9 @@ country_event = {
 		recalculate_party = yes
 		ai_chance = { base = 7 }
 	}
+
 	option = {
-		name = thailand.74.b		# Submit to the process
+		name = thailand.74.b # Submit to the process
 		log = "[GetDateText]: [Root.GetName]: event thailand.74.b"
 		set_temp_variable = { coup_delta = 3 }
 		SIA_coup_set_risk = yes
@@ -6086,7 +5704,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.75.a		# Back the generals - no inquiry
+		name = thailand.75.a # Back the generals - no inquiry
 		log = "[GetDateText]: [Root.GetName]: event thailand.75.a"
 		set_temp_variable = { coup_delta = 8 }
 		SIA_coup_set_risk = yes
@@ -6098,8 +5716,9 @@ country_event = {
 		}
 		ai_chance = { base = 5 }
 	}
+
 	option = {
-		name = thailand.75.b		# Order an inquiry - discipline the army
+		name = thailand.75.b # Order an inquiry - discipline the army
 		log = "[GetDateText]: [Root.GetName]: event thailand.75.b"
 		set_temp_variable = { coup_delta = 14 }
 		SIA_coup_set_risk = yes
@@ -6123,7 +5742,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.76.a		# Bury the audit, bank the kickback
+		name = thailand.76.a # Bury the audit, bank the kickback
 		log = "[GetDateText]: [Root.GetName]: event thailand.76.a"
 		set_temp_variable = { coup_delta = 10 }
 		SIA_coup_set_risk = yes
@@ -6131,8 +5750,9 @@ country_event = {
 		modify_treasury_effect = yes
 		ai_chance = { base = 6 }
 	}
+
 	option = {
-		name = thailand.76.b		# Cancel the contract
+		name = thailand.76.b # Cancel the contract
 		log = "[GetDateText]: [Root.GetName]: event thailand.76.b"
 		set_temp_variable = { coup_delta = 2 }
 		SIA_coup_set_risk = yes
@@ -6158,7 +5778,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.77.a		# Silence the critics
+		name = thailand.77.a # Silence the critics
 		log = "[GetDateText]: [Root.GetName]: event thailand.77.a"
 		set_temp_variable = { coup_delta = 11 }
 		SIA_coup_set_risk = yes
@@ -6169,8 +5789,9 @@ country_event = {
 		recalculate_party = yes
 		ai_chance = { base = 6 }
 	}
+
 	option = {
-		name = thailand.77.b		# Let the press run
+		name = thailand.77.b # Let the press run
 		log = "[GetDateText]: [Root.GetName]: event thailand.77.b"
 		set_temp_variable = { coup_delta = 4 }
 		SIA_coup_set_risk = yes
@@ -6197,15 +5818,16 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.78.a		# Govern unchecked
+		name = thailand.78.a # Govern unchecked
 		log = "[GetDateText]: [Root.GetName]: event thailand.78.a"
 		set_temp_variable = { coup_delta = 10 }
 		SIA_coup_set_risk = yes
 		add_political_power = 75
 		ai_chance = { base = 6 }
 	}
+
 	option = {
-		name = thailand.78.b		# Court the opposition - share the table
+		name = thailand.78.b # Court the opposition - share the table
 		log = "[GetDateText]: [Root.GetName]: event thailand.78.b"
 		set_temp_variable = { coup_delta = 3 }
 		SIA_coup_set_risk = yes
@@ -6229,7 +5851,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.73.a		# Pocket the billions
+		name = thailand.73.a # Pocket the billions
 		log = "[GetDateText]: [Root.GetName]: event thailand.73.a"
 		set_temp_variable = { coup_delta = 18 }
 		SIA_coup_set_risk = yes
@@ -6242,8 +5864,9 @@ country_event = {
 		recalculate_party = yes
 		ai_chance = { base = 7 }
 	}
+
 	option = {
-		name = thailand.73.b		# Pay the tax, defuse the scandal
+		name = thailand.73.b # Pay the tax, defuse the scandal
 		log = "[GetDateText]: [Root.GetName]: event thailand.73.b"
 		set_temp_variable = { coup_delta = 6 }
 		SIA_coup_set_risk = yes
@@ -6313,15 +5936,16 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
-		name = thailand.423.a		# Accept the verdict - step aside
+		name = thailand.423.a # Accept the verdict - step aside
 		log = "[GetDateText]: [Root.GetName]: event thailand.423.a"
 		put_the_largest_opposition_party_in_power = yes
 		add_stability = 0.03
 		add_political_power = -50
 		ai_chance = { base = 5 }
 	}
+
 	option = {
-		name = thailand.423.b		# Defy the court
+		name = thailand.423.b # Defy the court
 		log = "[GetDateText]: [Root.GetName]: event thailand.423.b"
 		add_stability = -0.05
 		set_temp_variable = { coup_delta = 15 }
@@ -6357,7 +5981,6 @@ country_event = {
 	title = thailand.430.t
 	desc = thailand.430.d
 	picture = GFX_weapons_arms1
-
 	is_triggered_only = yes
 
 	trigger = {
@@ -6366,7 +5989,7 @@ country_event = {
 	}
 
 	option = {
-		name = thailand.430.a		# Strategic retaliation only - a minimal second-strike deterrent
+		name = thailand.430.a # Strategic retaliation only - a minimal second-strike deterrent
 		log = "[GetDateText]: [Root.GetName]: event thailand.430.a"
 		if = {
 			limit = { has_idea = no_use_case }
@@ -6379,8 +6002,9 @@ country_event = {
 		add_war_support = 0.03
 		ai_chance = { base = 70 }
 	}
+
 	option = {
-		name = thailand.430.b		# Tactical and strategic retaliation
+		name = thailand.430.b # Tactical and strategic retaliation
 		log = "[GetDateText]: [Root.GetName]: event thailand.430.b"
 		if = {
 			limit = { has_idea = no_use_case }
@@ -6392,8 +6016,9 @@ country_event = {
 		add_war_support = 0.05
 		ai_chance = { base = 25 }
 	}
+
 	option = {
-		name = thailand.430.c		# Declared first-use posture
+		name = thailand.430.c # Declared first-use posture
 		log = "[GetDateText]: [Root.GetName]: event thailand.430.c"
 		if = {
 			limit = { has_idea = no_use_case }
@@ -6416,9 +6041,8 @@ news_event = {
 	title = thailand_news.30.t
 	desc = thailand_news.30.d
 	picture = GFX_news_press_conference
-
-	major = yes
 	is_triggered_only = yes
+	major = yes
 
 	option = {
 		name = thailand_news.30.a
@@ -6431,7 +6055,6 @@ country_event = {
 	title = thailand.432.t
 	desc = thailand.432.d
 	picture = GFX_generic_factory
-
 	is_triggered_only = yes
 
 	option = {
@@ -6443,6 +6066,7 @@ country_event = {
 		complete_national_focus = SIA_ignite_thailand
 		ai_chance = { base = 10 }
 	}
+
 	option = {
 		name = thailand.432.b
 		log = "[GetDateText]: [Root.GetName]: event thailand.432.b"
@@ -6515,9 +6139,7 @@ country_event = {
 		set_temp_variable = { party_popularity_increase = 0.10 }
 		change_relative_party_popularity = yes
 		recalculate_party = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6542,9 +6164,7 @@ country_event = {
 	picture = GFX_generic_factory
 	is_triggered_only = yes
 
-	trigger = {
-		original_tag = SIA
-	}
+	trigger = { original_tag = SIA }
 
 	option = {
 		name = thailand.436.a
@@ -6553,9 +6173,7 @@ country_event = {
 		set_temp_variable = { party_index = 18 }
 		set_temp_variable = { party_popularity_increase = 0.05 }
 		change_relative_party_popularity = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 
 	option = {
@@ -6563,8 +6181,6 @@ country_event = {
 		log = "[GetDateText]: [Root.GetName]: event thailand.436.b"
 		set_temp_variable = { treasury_change = 10 }
 		modify_treasury_effect = yes
-		ai_chance = {
-			base = 5
-		}
+		ai_chance = { base = 5 }
 	}
 }


### PR DESCRIPTION
Split from #3800.

Standardizes 5 event files while keeping focus, MIO, localisation, and unrelated tooling changes out of scope. China remains excluded. This branch starts from current `main` and preserves the reviewed event-picture corrections already merged through #3798.

Size: 5 files, 2,609 changed lines (additions + deletions).

Merge event batch 01/14 first so this batch’s repeat check uses the corrected standardizer.

The source content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved execution logging. No runtime or in-game visual verification was performed.