### PR TITLE
Standardize focus blocks — batch 1/4

### DIFF
--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -2291,9 +2291,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_phase_two_development_fund"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
@@ -2558,9 +2556,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_phase_three_development_funds"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_emigration_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_emigration_crisis }
 			}
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
@@ -2847,9 +2843,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_progressive_taxes_progressive_gains"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_homelessness_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_homelessness_crisis }
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
 			add_to_variable = { fijian_econ_political_power_gain = -0.02 tooltip = political_power_factor_tt }
@@ -3233,9 +3227,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_peace_for_piece"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			add_ideas = fiji_pieces_for_the_peace
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -123,9 +123,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -153,9 +151,7 @@ focus_tree = {
 		available = {
 			has_stability > 0.7
 			has_country_flag = ISR_big_size_knesset
-			NOT = {
-				has_idea = the_military
-			}
+			NOT = { has_idea = the_military }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -195,9 +191,7 @@ focus_tree = {
 							size = 0.2
 						}
 					}
-					50 = {
-						add_stability = -0.1
-					}
+					50 = { add_stability = -0.1 }
 				}
 			}
 			news_event = israel_news.16
@@ -307,9 +301,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SAF
-			NOT = {
-				has_war_with = SAF
-			}
+			NOT = { has_war_with = SAF }
 			SAF = {
 				has_opinion = {
 					target = ISR
@@ -327,9 +319,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_south_africa executed"
-			SAF = {
-				country_event = israel_economy.27
-			}
+			SAF = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -343,15 +333,9 @@ focus_tree = {
 				custom_effect_tooltip = isrg_inv_foc_tt
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SAF
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SAF }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = SAF
@@ -420,11 +404,7 @@ focus_tree = {
 				}
 			}
 			random_owned_controlled_state = {
-				limit = {
-					ROOT = {
-						has_full_control_of_state = PREV
-					}
-				}
+				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = {
 					652
 				}
@@ -796,9 +776,7 @@ focus_tree = {
 
 		available = {
 			country_exists = LBA
-			NOT = {
-				has_war_with = LBA
-			}
+			NOT = { has_war_with = LBA }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -818,15 +796,9 @@ focus_tree = {
 				target = LBA
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = LBA
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = LBA }
 			change_influence_percentage = yes
 		}
 
@@ -854,12 +826,8 @@ focus_tree = {
 
 		available = {
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
-			NOT = {
-				has_completed_focus = ISR_farright_china
-			}
+			NOT = { has_war_with = CHI }
+			NOT = { has_completed_focus = ISR_farright_china }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -951,9 +919,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -1006,16 +972,12 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_raam_party executed"
 			add_political_power = 100
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
 			set_temp_variable = { party_index = 12 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 			add_days_mission_timeout = {
 				mission = ISR_isr_arab_coalition_ticker_mission
@@ -1053,12 +1015,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shura_council executed"
 			country_event = israel.148
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1100,18 +1058,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_bedouin_interests executed"
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
-			206 = {
-				one_state_industrial_complex = yes
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
+			206 = { one_state_industrial_complex = yes }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1159,17 +1109,13 @@ focus_tree = {
 		available = {
 			neutrality_neutral_muslim_brotherhood_are_in_coalition = yes
 			has_idea = ISR_support_of_settlements2
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_recognize_illegal_outposts executed"
 			custom_effect_tooltip = isr_tension_decrease_5_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 5 }
 			add_stability = -0.03
 			add_to_variable = {
 				var = arab_completed
@@ -1210,12 +1156,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_family_values executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_ideas = ISR_family_values
 			PAL = {
@@ -1262,13 +1204,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_legalize_polygamy executed"
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
 			add_ideas = ISR_legalized_plygamy
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1312,17 +1250,13 @@ focus_tree = {
 			add_political_power = 100
 			add_stability = -0.04
 			every_country = {
-				limit = {
-					has_idea = sunni
-				}
+				limit = { has_idea = sunni }
 				add_opinion_modifier = {
 					modifier = political_outreach
 					target = ISR
 				}
 			}
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1368,15 +1302,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_meretz executed"
 			add_political_power = 100
-			set_temp_variable = {
-				party_index = 18
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1488,9 +1416,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_affirmative_action executed"
 			custom_effect_tooltip = isr_tension_decrease_10_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 10
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 10 }
 			PAL = {
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 1
@@ -1501,19 +1427,11 @@ focus_tree = {
 					}
 				}
 			}
-			set_temp_variable = {
-				percent_change = 6
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PAL
-			}
+			set_temp_variable = { percent_change = 6 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PAL }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				treasury_change = -4.5
-			}
+			set_temp_variable = { treasury_change = -4.5 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1555,16 +1473,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_meretz_green executed"
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_renewable_energy_focused
-					}
-				}
+				limit = { NOT = { has_idea = ISR_renewable_energy_focused } }
 				add_ideas = ISR_renewable_energy_focused
 			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1606,13 +1518,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ideological_feminism executed"
 			add_stability = 0.03
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1654,17 +1562,11 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_fight_gender_discrimination executed"
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_gender_equality
-					}
-				}
+				limit = { NOT = { has_idea = ISR_gender_equality } }
 				add_ideas = ISR_gender_equality
 			}
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1848,9 +1750,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -1897,9 +1797,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_agricultural_protection_act executed"
 			add_ideas = ISR_agricultural_protection
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -1964,9 +1862,7 @@ focus_tree = {
 					add_idea = ISR_farmer_union
 				}
 			}
-			else = {
-				add_ideas = ISR_farmer_union_1
-			}
+			else = { add_ideas = ISR_farmer_union_1 }
 			one_random_agriculture_district = yes
 			add_to_variable = {
 				var = labour_completed
@@ -2013,9 +1909,7 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			NOT = {
-				has_idea = labour_unions
-			}
+			NOT = { has_idea = labour_unions }
 		}
 
 		bypass = { has_idea = labour_unions }
@@ -2140,13 +2034,9 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sponsored_products executed"
 			set_temp_variable = { temp_productivity_change = 25 }
 			flat_productivity_change_effect = yes
-			set_temp_variable = {
-				treasury_change = -3.5
-			}
+			set_temp_variable = { treasury_change = -3.5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			change_labour_unions_opinion = yes
 		}
@@ -2177,9 +2067,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_youth_movements executed"
 			country_event = israel_labour.0
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
@@ -2212,9 +2100,7 @@ focus_tree = {
 				remove_idea = ISR_price_protection_act
 				add_idea = ISR_competition_directory_i
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			change_small_medium_business_owners_opinion = yes
 		}
@@ -2261,9 +2147,7 @@ focus_tree = {
 				}
 			}
 			ghost_incr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 		}
 
 		ai_will_do = {
@@ -2351,9 +2235,7 @@ focus_tree = {
 					spy
 				}
 			}
-			set_temp_variable = {
-				party_popularity_increase = 0.02
-			}
+			set_temp_variable = { party_popularity_increase = 0.02 }
 		}
 
 		ai_will_do = {
@@ -2539,9 +2421,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_computing_tech
 			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = labour_completed
@@ -2740,9 +2620,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_smaller_classes executed"
 			add_ideas = ISR_smaller_classes_th
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = labour_completed
@@ -2893,9 +2771,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_social_protests executed"
 			country_event = israel_labour.1
 			custom_effect_tooltip = shellyyech_tt
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
@@ -3086,13 +2962,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_regulate_finance executed"
 			add_ideas = ISR_regulated_finances
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -3158,22 +3030,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_raise_tax_on_wealthy executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			set_temp_variable = { corp_change = 10 }
 			modify_corporate_tax_rate_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -3239,9 +3103,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_public_transport executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -3294,9 +3156,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -3328,9 +3188,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_where_is_the_money executed"
 			add_ideas = ISR_yesh_pey_atid_taxx
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -3366,9 +3224,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_taxx
 				add_idea = ISR_yesh_pey_atid_yeshiva
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -3404,9 +3260,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_taxx
 				add_idea = ISR_yesh_pey_atid_settlements
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_military_opinion = yes
 		}
 
@@ -3446,9 +3300,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_disabled_people executed"
 			add_ideas = ISR_yesh_pey_atid_elder_scrolls
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -3488,16 +3340,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_holocaust_survivors executed"
 			add_ideas = ISR_yesh_pey_atid_localhost
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3542,9 +3388,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ministry_of_social_development"
 			add_ideas = ISR_yesh_pey_atid_ministry
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3629,9 +3473,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_idea1
 				add_idea = ISR_yesh_pey_atid_idea2
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3674,9 +3516,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_idea2
 				add_idea = ISR_yesh_pey_atid_idea3
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3756,18 +3596,10 @@ focus_tree = {
 			add_stability = -0.05
 			set_temp_variable = { temp_opinion = 10 }
 			change_landowners_opinion = yes
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -3802,9 +3634,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_zero_vat"
 			add_ideas = ISR_yesh_pey_atid_marxx
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -3847,11 +3677,7 @@ focus_tree = {
 					array = global.EU_member
 					tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
 					if = {
-						limit = {
-							NOT = {
-								has_war_with = ISR
-							}
-						}
+						limit = { NOT = { has_war_with = ISR } }
 						add_opinion_modifier = {
 							target = ROOT
 							modifier = diplomatic_support
@@ -3927,9 +3753,7 @@ focus_tree = {
 				idea = ISR_yesh_pey_atid_debils
 				days = 380
 			}
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -3964,9 +3788,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_eighteen_ministers executed"
 			add_ideas = ISR_yesh_pey_atid_idea
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -4007,9 +3829,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_idea
 				add_idea = ISR_yesh_pey_atid_idea1
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4150,20 +3970,12 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_accept_kotel_protocols executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4210,9 +4022,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = 15 }
 			modify_treasury_effect = yes
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4257,9 +4067,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_redraft_conscription_law executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4354,9 +4162,7 @@ focus_tree = {
 					add_idea = farmers
 				}
 			}
-			set_temp_variable = {
-				temp_opinion = 25
-			}
+			set_temp_variable = { temp_opinion = 25 }
 			change_farmers_opinion = yes
 		}
 
@@ -4447,9 +4253,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_public_transport_shabbat executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4556,9 +4360,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -4602,9 +4404,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -4680,12 +4480,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_above_all executed"
 			add_ideas = ISR_israel_above_all
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_popularity = {
 				ideology = nationalist
@@ -4724,9 +4520,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_general_politics executed"
 			add_war_support = 0.05
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
 		}
 
@@ -4762,9 +4556,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_increase_army_pay executed"
 			increase_military_spending = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4799,9 +4591,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_increase_pensions executed"
 			increase_social_spending = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4845,9 +4635,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4882,13 +4670,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_social_cabinet executed"
 			increase_economic_growth = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -4927,9 +4711,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shasha_biton executed"
 			increase_education_budget = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4967,9 +4749,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -5005,9 +4785,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_regulate_ottoman_agencies executed"
 			add_ideas = ISR_ottoman_agencies
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -5048,9 +4826,7 @@ focus_tree = {
 			add_stability = -0.03
 			decrease_centralization = yes
 			decrease_corruption = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -5197,12 +4973,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_limit_terms executed"
 			add_political_power = 50
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			set_temp_variable = { threshold_change = 0.05 }
 			modify_election_threshold = yes
@@ -5248,9 +5020,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_empower_regional_governments executed"
 			add_ideas = ISR_emp_reg_govs
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -5295,9 +5065,7 @@ focus_tree = {
 			add_stability = 0.05
 			set_temp_variable = { temp_productivity_change = 50 }
 			flat_productivity_change_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -5339,9 +5107,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_days_mission_timeout = {
 				mission = ISR_isr_liberman_coalition_ticker_mission
@@ -5414,12 +5180,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_soviet_voters executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_opinion_modifier = {
 				target = SOV
@@ -5468,15 +5230,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_russian_tv executed"
 			add_ideas = ISR_russian_tv_channels
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = SOV
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = SOV }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -5553,17 +5309,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_five_mems executed"
-			set_temp_variable = {
-				treasury_change = -6
-			}
+			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -5607,9 +5357,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_citizenship_law executed"
 			custom_effect_tooltip = isr_tension_increase_5_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 5 }
 			add_stability = 0.05
 			reverse_add_opinion_modifier = {
 				modifier = drama
@@ -5661,9 +5409,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_empower_city_rabbis executed"
 			add_political_power = 100
 			ghost_incr = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -5717,15 +5463,9 @@ focus_tree = {
 						has_idea = eastern_church_eth
 					}
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = THIS
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = THIS }
 				change_influence_percentage = yes
 			}
 			add_to_variable = {
@@ -5827,9 +5567,7 @@ focus_tree = {
 				}
 				complete_national_focus = ISR_religous_status_quo_revisit
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -6002,12 +5740,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_kaminitz_law executed"
 			add_ideas = ISR_kaminitz
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 3
-			}
-			set_temp_variable = {
-				treasury_change = -1
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 3 }
+			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = jewish_completed
@@ -6142,14 +5876,10 @@ focus_tree = {
 			country_event = israel_home.1
 			add_ideas = ISR_nation_state
 			custom_effect_tooltip = ISR_arab_bad_TT
-			hidden_effect = {
-				add_to_variable = { ISR_palestine_situation_additional = 5 }
-			}
+			hidden_effect = { add_to_variable = { ISR_palestine_situation_additional = 5 } }
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6189,9 +5919,7 @@ focus_tree = {
 
 		completion_reward = { log = "[GetDateText]: [This.GetName]: focus ISR_bennet_rule executed" }
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6221,9 +5949,7 @@ focus_tree = {
 			add_ideas = ISR_raegan_legacy
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6250,9 +5976,7 @@ focus_tree = {
 			decrease_centralization = yes
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6286,14 +6010,10 @@ focus_tree = {
 					add_idea = industrial_conglomerates
 				}
 			}
-			else = {
-				add_ideas = ISR_limit_labor
-			}
+			else = { add_ideas = ISR_limit_labor }
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6332,9 +6052,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6361,19 +6079,13 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tax_reductions executed"
-			set_temp_variable = {
-				corp_change = -5
-			}
+			set_temp_variable = { corp_change = -5 }
 			modify_corporate_tax_rate_effect = yes
-			set_temp_variable = {
-				temp_opinion = 6
-			}
+			set_temp_variable = { temp_opinion = 6 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6403,9 +6115,7 @@ focus_tree = {
 			decrease_corruption = yes
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6440,9 +6150,7 @@ focus_tree = {
 
 		completion_reward = { log = "[GetDateText]: [This.GetName]: focus ISR_shaked_rule executed" }
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6472,9 +6180,7 @@ focus_tree = {
 			add_ideas = ISR_bull_moose
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6513,9 +6219,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6548,9 +6252,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6580,9 +6282,7 @@ focus_tree = {
 			add_ideas = ISR_women_serving
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6615,9 +6315,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6660,9 +6358,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -6774,9 +6470,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = { value = gdp_from_agriculture multiply = -0.3 } }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -6787,9 +6481,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -6932,15 +6624,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_protect_terrorists executed"
 			add_war_support = 0.02
-			set_temp_variable = {
-				party_index = 20
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.03
-			}
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
+			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
 			ghost_incr = yes
 			for_each_scope_loop = {
@@ -6978,9 +6664,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -6991,9 +6675,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7042,13 +6724,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_protect_ideological_core executed"
-			ISR = {
-				country_event = israel_nationalist.4
-			}
+			ISR = { country_event = israel_nationalist.4 }
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7059,9 +6737,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7110,30 +6786,16 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_denounce_mafdal executed"
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				party_index = 0
-			}
-			set_temp_variable = {
-				party_popularity_increase = -0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = -0.05
-			}
+			set_temp_variable = { party_index = 0 }
+			set_temp_variable = { party_popularity_increase = -0.05 }
+			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7144,9 +6806,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7197,9 +6857,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_late_marriage executed"
 			add_ideas = ISR_promote_early_marriage
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7210,9 +6868,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7259,9 +6915,7 @@ focus_tree = {
 				nationalist_fascist_are_in_coalition = yes
 			}
 			country_exists = PAL
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
@@ -7275,21 +6929,13 @@ focus_tree = {
 						NOT = { is_owned_by = ISR }
 					}
 				}
-				208 = {
-					set_occupation_law = foreign_civilian_oversight
-				}
+				208 = { set_occupation_law = foreign_civilian_oversight }
 			}
-			PAL = {
-				add_ideas = ISR_palestine_civilian_adm
-			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			PAL = { add_ideas = ISR_palestine_civilian_adm }
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7300,9 +6946,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7399,9 +7043,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tal_law executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 			add_manpower = -1000
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
@@ -7437,13 +7079,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reject_liba executed"
 			add_ideas = ISR_freedom_of_teaching_1
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = jud_completed
@@ -7476,18 +7114,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_obstruct_mamlakhti executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					has_idea = ISR_freedom_of_teaching_1
-				}
+				limit = { has_idea = ISR_freedom_of_teaching_1 }
 				swap_ideas = {
 					remove_idea = ISR_freedom_of_teaching_1
 					add_idea = ISR_freedom_of_teaching_2
@@ -7525,13 +7157,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shopkeepers_law executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = jud_completed
@@ -7564,13 +7192,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_saturday_construction executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_ideas = ISR_only_pikuach_nefesh
 			add_to_variable = {
@@ -7607,13 +7231,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_new_conscription_law executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 			add_manpower = -5000
 			add_stability = -0.03
@@ -7649,16 +7269,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_anti_reformism executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			if = {
-				limit = {
-					USA = {
-						has_government = democratic
-					}
-				}
+				limit = { USA = { has_government = democratic } }
 				USA = {
 					add_opinion_modifier = {
 						target = ISR
@@ -7737,13 +7351,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_segregated_prayers executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_stability = -0.03
 			add_to_variable = {
@@ -7778,13 +7388,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_anti_lgbt_propaganda executed"
 			add_ideas = ISR_family_values
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_stability = -0.05
 			add_to_variable = {
@@ -7827,9 +7433,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			add_days_mission_timeout = {
 				mission = ISR_isr_shas_coalition_ticker_mission
@@ -7878,9 +7482,7 @@ focus_tree = {
 				mission = ISR_isr_shas_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 7
-			}
+			set_temp_variable = { temp_opinion = 7 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -7925,9 +7527,7 @@ focus_tree = {
 				mission = ISR_isr_shas_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 7
-			}
+			set_temp_variable = { temp_opinion = 7 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -7963,9 +7563,7 @@ focus_tree = {
 			random_list = {
 				50 = {
 					custom_effect_tooltip = isr_tension_decrease_5_TT
-					subtract_from_variable = {
-						ISR_palestine_situation_additional = 5
-					}
+					subtract_from_variable = { ISR_palestine_situation_additional = 5 }
 					set_temp_variable = { party_index = 12 }
 					set_temp_variable = { party_popularity_increase = 0.02 }
 					set_temp_variable = { temp_outlook_increase = 0.02 }
@@ -7977,9 +7575,7 @@ focus_tree = {
 				}
 				50 = {
 					custom_effect_tooltip = isr_tension_increase_5_TT
-					add_to_variable = {
-						ISR_palestine_situation_additional = 5
-					}
+					add_to_variable = { ISR_palestine_situation_additional = 5 }
 					set_temp_variable = { party_index = 23 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -8073,20 +7669,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_adinas_donations executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.04
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.04
-			}
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			set_temp_variable = { temp_outlook_increase = 0.04 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8136,9 +7724,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 6
-			}
+			set_temp_variable = { temp_opinion = 6 }
 			change_the_military_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8181,13 +7767,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_food_checks executed"
 			add_ideas = ISR_food_for_poor
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8228,16 +7810,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_crown_to_its_former_glory executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
+			set_temp_variable = { percent_change = 3 }
 			change_domestic_influence_percentage = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8280,9 +7856,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_yemenite_affair executed"
 			add_stability = -0.04
 			ghost_decr = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8324,13 +7898,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sephardic_cultural_heritage executed"
 			ghost_decr = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				treasury_change = -2.5
-			}
+			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8452,9 +8022,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -8495,9 +8063,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			country_event = israel_likud.63
 			country_event = { id = israel_likud.64 days = 30 }
@@ -8532,9 +8098,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_mofaz executed"
 			custom_effect_tooltip = national_unity_camp_tt
-			hidden_effect = {
-				set_country_flag = mofaz_rules
-			}
+			hidden_effect = { set_country_flag = mofaz_rules }
 		}
 
 		ai_will_do = { base = 3 }
@@ -8607,12 +8171,8 @@ focus_tree = {
 					ideology = democratic
 					popularity = 0.05
 				}
-				set_temp_variable = {
-					party_index = 1
-				}
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
+				set_temp_variable = { party_index = 1 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
 			else = {
@@ -8620,12 +8180,8 @@ focus_tree = {
 					ideology = neutrality
 					popularity = 0.05
 				}
-				set_temp_variable = {
-					party_index = 14
-				}
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
+				set_temp_variable = { party_index = 14 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
 			add_political_power = 150
@@ -8682,9 +8238,7 @@ focus_tree = {
 					ruling_only = yes
 				}
 			}
-			NOT = {
-				neutrality_neutral_autocracy_in_power_or_coalition = yes
-			}
+			NOT = { neutrality_neutral_autocracy_in_power_or_coalition = yes }
 			emerging_conservative_in_power_or_coalition = no
 		}
 
@@ -8707,13 +8261,9 @@ focus_tree = {
 				mission = ISR_isr_shas_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -8866,9 +8416,7 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 			SOV = {
 				has_opinion = {
 					target = ISR
@@ -8879,9 +8427,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_russia executed"
-			SOV = {
-				country_event = israel_likud.29
-			}
+			SOV = { country_event = israel_likud.29 }
 		}
 
 		ai_will_do = {
@@ -8911,9 +8457,7 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -8924,9 +8468,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_republicans executed"
-			USA = {
-				country_event = israel_likud.28
-			}
+			USA = { country_event = israel_likud.28 }
 		}
 
 		ai_will_do = {
@@ -8963,16 +8505,12 @@ focus_tree = {
 				}
 			}
 			country_exists = BRA
-			NOT = {
-				has_war_with = BRA
-			}
+			NOT = { has_war_with = BRA }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_brazil executed"
-			BRA = {
-				country_event = israel_likud.31
-			}
+			BRA = { country_event = israel_likud.31 }
 		}
 
 		ai_will_do = {
@@ -9009,16 +8547,12 @@ focus_tree = {
 				}
 			}
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_trump executed"
-			USA = {
-				country_event = israel_likud.33
-			}
+			USA = { country_event = israel_likud.33 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9050,9 +8584,7 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = HUN
-			NOT = {
-				has_war_with = HUN
-			}
+			NOT = { has_war_with = HUN }
 			HUN = {
 				neutrality_neutral_conservatism_are_in_power = yes
 				has_opinion = {
@@ -9064,9 +8596,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_support_hungary executed"
-			HUN = {
-				country_event = israel_likud.38
-			}
+			HUN = { country_event = israel_likud.38 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9098,19 +8628,13 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = POL
-			NOT = {
-				has_war_with = POL
-			}
-			POL = {
-				western_conservatism_are_in_power = yes
-			}
+			NOT = { has_war_with = POL }
+			POL = { western_conservatism_are_in_power = yes }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_matter_of_poland executed"
-			POL = {
-				country_event = israel_likud.41
-			}
+			POL = { country_event = israel_likud.41 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9283,9 +8807,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_request_immuity executed"
 			custom_effect_tooltip = ISR_request_immunity_TT
-			hidden_effect = {
-				country_event = israel_likud.5
-			}
+			hidden_effect = { country_event = israel_likud.5 }
 		}
 
 		ai_will_do = {
@@ -9353,9 +8875,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_national_camp executed"
 			custom_effect_tooltip = ISR_national_camp_TT
-			hidden_effect = {
-				set_country_flag = ISR_national_camp
-			}
+			hidden_effect = { set_country_flag = ISR_national_camp }
 			country_event = israel_likud.4
 		}
 
@@ -9393,9 +8913,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_judicial_reform_full executed"
 			custom_effect_tooltip = ISR_judicial_reform_TT
-			hidden_effect = {
-				country_event = israel_likud.16
-			}
+			hidden_effect = { country_event = israel_likud.16 }
 		}
 
 		ai_will_do = {
@@ -9426,12 +8944,8 @@ focus_tree = {
 				name = "Benjamin Netanyahu"
 				ruling_only = yes
 			}
-			custom_trigger_tooltip = {
-				tooltip = ISR_judicial_pres_TT
-			}
-			hidden_trigger = {
-				has_country_flag = ISR_judicial
-			}
+			custom_trigger_tooltip = { tooltip = ISR_judicial_pres_TT }
+			hidden_trigger = { has_country_flag = ISR_judicial }
 		}
 
 		completion_reward = {
@@ -9470,20 +8984,14 @@ focus_tree = {
 				name = "Benjamin Netanyahu"
 				ruling_only = yes
 			}
-			custom_trigger_tooltip = {
-				tooltip = ISR_judicial_pres_TT
-			}
-			hidden_trigger = {
-				has_country_flag = ISR_partners
-			}
+			custom_trigger_tooltip = { tooltip = ISR_judicial_pres_TT }
+			hidden_trigger = { has_country_flag = ISR_partners }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_rein_in_partners executed"
 			custom_effect_tooltip = ISR_national_camp_disband_TT
-			hidden_effect = {
-				clr_country_flag = ISR_national_camp
-			}
+			hidden_effect = { clr_country_flag = ISR_national_camp }
 			swap_ideas = {
 				remove_idea = harari_compromise
 				add_idea = basic_law_making_isr
@@ -9692,9 +9200,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cyprus_marriage executed"
-			CYP = {
-				country_event = israel_likud.44
-			}
+			CYP = { country_event = israel_likud.44 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9767,9 +9273,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_association_agreement_eu executed"
-			GER = {
-				country_event = israel_likud.47
-			}
+			GER = { country_event = israel_likud.47 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9829,9 +9333,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_association_agreement_usa executed"
-			USA = {
-				country_event = israel_likud.50
-			}
+			USA = { country_event = israel_likud.50 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9896,15 +9398,11 @@ focus_tree = {
 			custom_effect_tooltip = prev_foc_dec_efe_tt
 			if = {
 				limit = { has_country_flag = ISR_usa_assosiation }
-				USA = {
-					country_event = israel_likud.57
-				}
+				USA = { country_event = israel_likud.57 }
 			}
 			else_if = {
 				limit = { has_country_flag = ISR_eu_assosiation }
-				GER = {
-					country_event = israel_likud.53
-				}
+				GER = { country_event = israel_likud.53 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -10024,12 +9522,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_legalize_cannabis executed"
 			add_ideas = ISR_legalize_cannabis
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 		}
 
@@ -10089,25 +9583,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_supertanker executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				party_index = 1
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
 			change_relative_party_popularity = yes
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -10379,13 +9861,9 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = {
-					treasury_change = -5.5
-				}
+				set_temp_variable = { treasury_change = -5.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					temp_opinion = 2
-				}
+				set_temp_variable = { temp_opinion = 2 }
 				change_small_medium_business_owners_opinion = yes
 			}
 			else_if = {
@@ -10398,17 +9876,11 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = {
-					treasury_change = -3
-				}
+				set_temp_variable = { treasury_change = -3 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 1
-				}
+				set_temp_variable = { percent_change = 1 }
 				change_domestic_influence_percentage = yes
-				set_temp_variable = {
-					temp_opinion = -2
-				}
+				set_temp_variable = { temp_opinion = -2 }
 				change_small_medium_business_owners_opinion = yes
 			}
 			else_if = {
@@ -10421,23 +9893,13 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = {
-					treasury_change = -3
-				}
+				set_temp_variable = { treasury_change = -3 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ENG
-				}
-				set_temp_variable = {
-					influence_target = ISR
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ENG }
+				set_temp_variable = { influence_target = ISR }
 				change_influence_percentage = yes
-				set_temp_variable = {
-					temp_opinion = 2
-				}
+				set_temp_variable = { temp_opinion = 2 }
 				change_small_medium_business_owners_opinion = yes
 			}
 		}
@@ -10562,9 +10024,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_privatize_elal executed"
 			if = {
-				limit = {
-					has_idea = ISR_kachlon_priv
-				}
+				limit = { has_idea = ISR_kachlon_priv }
 				swap_ideas = {
 					remove_idea = ISR_kachlon_priv
 					add_idea = ISR_elal_kachlon_priv
@@ -10643,9 +10103,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_open_skies executed"
 			add_ideas = ISR_open_skies
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -10891,9 +10349,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_kachlon_program executed"
 			if = {
-				limit = {
-					has_idea = ISR_elal_priv
-				}
+				limit = { has_idea = ISR_elal_priv }
 				swap_ideas = {
 					remove_idea = ISR_elal_priv
 					add_idea = ISR_elal_kachlon_priv
@@ -10971,9 +10427,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_harish executed"
-			204 = {
-				two_state_office_construction = yes
-			}
+			204 = { two_state_office_construction = yes }
 		}
 
 		ai_will_do = {
@@ -11040,12 +10494,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tama_38 executed"
 			add_ideas = ISR_tama
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -1
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 		}
 
@@ -11087,9 +10537,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_pension_reform executed"
 			add_ideas = ISR_lower_pension
-			set_temp_variable = {
-				party_popularity_increase = -0.04
-			}
+			set_temp_variable = { party_popularity_increase = -0.04 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = likud_completed
@@ -11142,13 +10590,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_lower_income_tax executed"
-			set_temp_variable = {
-				pop_change = -5
-			}
+			set_temp_variable = { pop_change = -5 }
 			modify_population_tax_rate_effect = yes
-			set_temp_variable = {
-				corp_change = -5
-			}
+			set_temp_variable = { corp_change = -5 }
 			modify_corporate_tax_rate_effect = yes
 			add_to_variable = {
 				var = likud_completed
@@ -11158,9 +10602,7 @@ focus_tree = {
 				mission = ISR_isr_likud_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 3
-			}
+			set_temp_variable = { temp_opinion = 3 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -11214,9 +10656,7 @@ focus_tree = {
 				mission = ISR_isr_likud_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -11262,9 +10702,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reform_bituach_leumi executed"
 			add_ideas = ISR_no_insurance
-			set_temp_variable = {
-				party_popularity_increase = -0.04
-			}
+			set_temp_variable = { party_popularity_increase = -0.04 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = likud_completed
@@ -11396,9 +10834,7 @@ focus_tree = {
 				mission = ISR_isr_jud_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -11652,22 +11088,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_engagement_reform executed"
 			add_war_support = 0.05
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_ben_gvir_easy_trigger_1
-					}
-				}
+				limit = { NOT = { has_idea = ISR_ben_gvir_easy_trigger_1 } }
 				add_ideas = ISR_ben_gvir_easy_trigger_1
 			}
 			else_if = {
-				limit = {
-					has_idea = ISR_ben_gvir_easy_trigger_1
-				}
+				limit = { has_idea = ISR_ben_gvir_easy_trigger_1 }
 				swap_ideas = {
 					remove_idea = ISR_ben_gvir_easy_trigger_1
 					add_idea = ISR_ben_gvir_easy_trigger_2
@@ -11723,22 +11151,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_immunity_to_soldiers executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_ben_gvir_easy_trigger_1
-					}
-				}
+				limit = { NOT = { has_idea = ISR_ben_gvir_easy_trigger_1 } }
 				add_ideas = ISR_ben_gvir_easy_trigger_1
 			}
 			else_if = {
-				limit = {
-					has_idea = ISR_ben_gvir_easy_trigger_1
-				}
+				limit = { has_idea = ISR_ben_gvir_easy_trigger_1 }
 				swap_ideas = {
 					remove_idea = ISR_ben_gvir_easy_trigger_1
 					add_idea = ISR_ben_gvir_easy_trigger_2
@@ -11880,14 +11300,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_hebrew_justice executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			ISR_decrease_peoples_army = yes
 		}
@@ -11918,13 +11334,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_basic_law_torah executed"
 			add_stability = -0.02
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			ISR_decrease_peoples_army = yes
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
@@ -11956,23 +11368,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_hebraic_studies executed"
 			ISR_increase_kahanism = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
+			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.02
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.02
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.02 }
+			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -12010,33 +11412,23 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ban_women_from_military executed"
 			add_stability = -0.05
 			ISR_decrease_peoples_army = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			if = {
-				limit = {
-					has_idea = alice_miller_v_ministry_of_defence
-				}
+				limit = { has_idea = alice_miller_v_ministry_of_defence }
 				remove_ideas = alice_miller_v_ministry_of_defence
 			}
 			if = {
-				limit = {
-					has_idea = volunteer_women
-				}
+				limit = { has_idea = volunteer_women }
 				swap_ideas = {
 					remove_idea = volunteer_women
 					add_idea = no_women_in_military
 				}
 			}
 			if = {
-				limit = {
-					has_idea = drafted_women
-				}
+				limit = { has_idea = drafted_women }
 				swap_ideas = {
 					remove_idea = drafted_women
 					add_idea = no_women_in_military
@@ -12069,20 +11461,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_outlaw_lgbt executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			add_ideas = ISR_family_values
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = -0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = -0.03
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = -0.03 }
+			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_manpower = -5000
 			add_stability = -0.05
 		}
@@ -12110,34 +11494,20 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRPOLIT FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				has_completed_focus = ISR_accept_kotel_protocols
-			}
+			NOT = { has_completed_focus = ISR_accept_kotel_protocols }
 			nationalist_fascist_are_in_power = yes
-			207 = {
-				is_controlled_by = ISR
-			}
+			207 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_third_temple executed"
 			add_stability = 0.03
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.03
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
+			set_temp_variable = { temp_outlook_increase = 0.03 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			every_country = {
 				limit = {
@@ -12221,15 +11591,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ben_gvir_eretz_israel executed"
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.03
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
+			set_temp_variable = { temp_outlook_increase = 0.03 }
 			swap_ideas = {
 				remove_idea = small_medium_business_owners
 				add_idea = farmers
@@ -12282,13 +11646,9 @@ focus_tree = {
 				target = JOR
 				expire = 365
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 			every_country = {
 				limit = {
@@ -12300,9 +11660,7 @@ focus_tree = {
 						neutrality_neutral_green_are_in_power = yes
 						neutrality_neutral_social_are_in_power = yes
 					}
-					NOT = {
-						tag = JOR
-					}
+					NOT = { tag = JOR }
 				}
 				add_opinion_modifier = {
 					target = ISR
@@ -12491,9 +11849,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 150000
-			}
+			has_army_manpower = { size > 150000 }
 			OR = {
 				country_exists = IRQ
 				country_exists = ISI
@@ -12573,9 +11929,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 250000
-			}
+			has_army_manpower = { size > 250000 }
 			CHI = {
 				exists = yes
 				has_government = communism
@@ -12623,9 +11977,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 150000
-			}
+			has_army_manpower = { size > 150000 }
 			country_exists = SAU
 		}
 
@@ -12669,9 +12021,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 250000
-			}
+			has_army_manpower = { size > 250000 }
 			USA = {
 				exists = yes
 				has_government = democratic
@@ -12822,18 +12172,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_learn_from_october_events executed"
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
 			random_owned_controlled_state = {
 				if = {
@@ -12980,18 +12324,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_rely_on_gideonites executed"
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
+			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13074,9 +12412,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_police_racism executed"
 			add_stability = 0.05
 			increase_policing_budget = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_popularity = {
 				ideology = nationalist
@@ -13116,14 +12452,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reform_the_fire_fighting_force executed"
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13165,14 +12497,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_show_more_presence executed"
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13216,9 +12544,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shabac_intervention_yes executed"
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13250,9 +12576,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -13263,9 +12587,7 @@ focus_tree = {
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = USA
-				}
+				NOT = { country_exists = USA }
 				has_war_with = USA
 				USA = {
 					has_opinion = {
@@ -13278,9 +12600,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_gather_all_the_equipment executed"
-			USA = {
-				country_event = israel_economy.1
-			}
+			USA = { country_event = israel_economy.1 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
@@ -13289,9 +12609,7 @@ focus_tree = {
 						amount = 6000
 						producer = ROOT
 					}
-					set_temp_variable = {
-						treasury_change = -4
-					}
+					set_temp_variable = { treasury_change = -4 }
 					modify_treasury_effect = yes
 				}
 			}
@@ -13327,14 +12645,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_storm_tuba_zangariya executed"
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13369,9 +12683,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_speak_to_malal executed"
-			set_temp_variable = {
-				percent_change = 3
-			}
+			set_temp_variable = { percent_change = 3 }
 			change_domestic_influence_percentage = yes
 			unlock_decision_category_tooltip = israel_arab_boycott_category
 		}
@@ -13395,29 +12707,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_middle_east_peace executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SAU
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SAU }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = UAE
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = UAE }
 			change_influence_percentage = yes
 		}
 
@@ -13440,13 +12738,9 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = {
@@ -13461,25 +12755,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_neighbors executed"
 			add_stability = 0.03
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = JOR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = JOR }
 			change_influence_percentage = yes
 		}
 
@@ -13502,19 +12784,13 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 		}
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = EGY
-				}
-				EGY = {
-					has_completed_focus = EGY_isr_peace_support
-				}
+				NOT = { country_exists = EGY }
+				EGY = { has_completed_focus = EGY_isr_peace_support }
 			}
 		}
 
@@ -13530,22 +12806,12 @@ focus_tree = {
 				modifier = peace_talks
 				target = EGY
 			}
-			set_temp_variable = {
-				percent_change = 4
-			}
-			set_temp_variable = {
-				tag_index = EGY
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 4 }
+			set_temp_variable = { tag_index = EGY }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				party_popularity_increase = -0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = -0.05
-			}
+			set_temp_variable = { party_popularity_increase = -0.05 }
+			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
 		}
 
@@ -13568,9 +12834,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13585,15 +12849,9 @@ focus_tree = {
 				idea = ISR_sinai_investig
 				days = 150
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13616,9 +12874,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13629,9 +12885,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sinai_tourism executed"
-			EGY = {
-				country_event = israel_economy.27
-			}
+			EGY = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -13653,15 +12907,9 @@ focus_tree = {
 				target = EGY
 				modifier = major_improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13684,9 +12932,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13705,15 +12951,9 @@ focus_tree = {
 				target = EGY
 				modifier = major_improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13736,9 +12976,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13749,14 +12987,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_azam_azam executed"
-			EGY = {
-				country_event = israel_economy.122
-			}
+			EGY = { country_event = israel_economy.122 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
+				set_temp_variable = { party_popularity_increase = 0.05 }
 				change_relative_party_popularity = yes
 				add_opinion_modifier = {
 					modifier = diplomatic_proximity
@@ -13788,9 +13022,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13801,9 +13033,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_taba_conference executed"
-			EGY = {
-				country_event = israel_economy.119
-			}
+			EGY = { country_event = israel_economy.119 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				diplomatic_relation = {
@@ -13823,34 +13053,20 @@ focus_tree = {
 						remove_ideas = pol_isr_boycotte
 					}
 					if = {
-						limit = {
-							has_idea = full_isr_boycotte
-						}
+						limit = { has_idea = full_isr_boycotte }
 						swap_ideas = {
 							remove_idea = full_isr_boycotte
 							add_idea = econ_isr_boycotte
 						}
 					}
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = EGY
-				}
-				set_temp_variable = {
-					influence_target = ISR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = EGY }
+				set_temp_variable = { influence_target = ISR }
 				change_influence_percentage = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 			}
 		}
 
@@ -13873,9 +13089,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13886,9 +13100,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_assam_ibrahims_mission executed"
-			EGY = {
-				country_event = md4.4
-			}
+			EGY = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -13908,15 +13120,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13939,30 +13145,22 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
 					value > 4
 				}
 			}
-			213 = {
-				is_demilitarized_zone = yes
-			}
+			213 = { is_demilitarized_zone = yes }
 		}
 
 		bypass = { NOT = { 213 = { is_demilitarized_zone = yes } } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sisi_barak_call executed"
-			EGY = {
-				country_event = israel_economy.173
-			}
-			213 = {
-				set_demilitarized_zone = no
-			}
+			EGY = { country_event = israel_economy.173 }
+			213 = { set_demilitarized_zone = no }
 			effect_tooltip = {
 				add_opinion_modifier = {
 					target = EGY
@@ -13973,15 +13171,9 @@ focus_tree = {
 					modifier = diplomatic_support
 				}
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -14004,9 +13196,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -14021,20 +13211,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_isis_sinai executed"
-			EGY = {
-				country_event = israel_economy.174
-			}
+			EGY = { country_event = israel_economy.174 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					percent_change = 4
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 4 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 				change_influence_percentage = yes
 				EGY = {
 					add_timed_idea = {
@@ -14063,9 +13245,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				OR = {
 					neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -14084,15 +13264,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_arab_spring executed"
-			set_temp_variable = {
-				percent_change = -3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = -3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 			EGY = {
 				add_stability = -0.05
@@ -14121,9 +13295,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			OR = {
 				has_idea = intervention_global_interventionism
 				has_government = nationalist
@@ -14210,9 +13382,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				OR = {
 					neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -14223,15 +13393,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_watch_their_moves executed"
-			set_temp_variable = {
-				percent_change = -3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = -3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 			EGY = {
 				add_stability = -0.02
@@ -14265,9 +13429,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				OR = {
 					neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -14280,9 +13442,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_migrants executed"
 			206 = {
 				if = {
-					limit = {
-						is_controlled_by = ISR
-					}
+					limit = { is_controlled_by = ISR }
 					custom_effect_tooltip = ISR_fortress_egy_pal_border_TT
 					hidden_effect = {
 						add_building_construction = {
@@ -14331,9 +13491,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -14344,15 +13502,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_arish_ashkelon executed"
-			EGY = {
-				country_event = israel_economy.53
-			}
+			EGY = { country_event = israel_economy.53 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = egy_petr_tt
-				set_temp_variable = {
-					treasury_change = -4
-				}
+				set_temp_variable = { treasury_change = -4 }
 				modify_treasury_effect = yes
 				random_owned_state = {
 					add_extra_state_shared_building_slots = 1
@@ -14388,9 +13542,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -14405,24 +13557,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_invite_egypt_to_gas_project executed"
-			EGY = {
-				country_event = israel_economy.215
-			}
+			EGY = { country_event = israel_economy.215 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = 6
-				}
+				set_temp_variable = { treasury_change = 6 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 				change_influence_percentage = yes
 			}
 		}
@@ -14446,28 +13588,18 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_jordan executed"
-			set_temp_variable = {
-				temp_opinion = 2
-			}
+			set_temp_variable = { temp_opinion = 2 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = JOR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = JOR }
 			change_influence_percentage = yes
 		}
 
@@ -14490,9 +13622,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -14505,21 +13635,13 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_expand_on_jordan_treaty executed"
-			JOR = {
-				country_event = israel_economy.179
-			}
+			JOR = { country_event = israel_economy.179 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_ideas = ISR_jor_isr_treaty
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -14543,31 +13665,21 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_preserve_the_dead_sea executed"
-			JOR = {
-				country_event = israel_economy.182
-			}
+			JOR = { country_event = israel_economy.182 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = 100
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
-				set_temp_variable = {
-					temp_outlook_increase = 0.05
-				}
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				change_relative_party_popularity = yes
-				set_temp_variable = {
-					treasury_change = -2
-				}
+				set_temp_variable = { treasury_change = -2 }
 				modify_treasury_effect = yes
 			}
 		}

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -432,9 +432,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_disarm_the_militias"
 			if = {
-				limit = {
-					has_template = "Christian Militias"
-				}
+				limit = { has_template = "Christian Militias" }
 				hidden_effect = {
 					delete_unit_template_and_units = { division_template = "Christian Militias" }
 					add_manpower = 2000
@@ -536,20 +534,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_tolerance"
 			if = {
-				limit = {
-					has_completed_focus = NIG_continue_sharia_law
-				}
+				limit = { has_completed_focus = NIG_continue_sharia_law }
 				add_stability = 0.025
 			}
 			else_if = {
-				limit = {
-					has_completed_focus = NIG_end_sharia_law
-				}
+				limit = { has_completed_focus = NIG_end_sharia_law }
 				add_political_power = 150
 			}
-			else = {
-				custom_effect_tooltip = NIG_tolerance_toolie_TT
-			}
+			else = { custom_effect_tooltip = NIG_tolerance_toolie_TT }
 		}
 
 		ai_will_do = {
@@ -1390,9 +1382,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			every_other_country = {
-				limit = {
-					salafist_caliphate_are_in_power = yes
-				}
+				limit = { salafist_caliphate_are_in_power = yes }
 				if = {
 					limit = { NIG = { has_tech = infantry_weapons_4 } }
 					add_equipment_to_stockpile = {
@@ -2226,14 +2216,8 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_balanced_budgets"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			random_owned_state = {
-				prioritize = { 337 334 }
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_state = {
-				prioritize = { 336 332 }
-				add_extra_state_shared_building_slots = 1
-			}
+			random_owned_state = { prioritize = { 337 334 } add_extra_state_shared_building_slots = 1 }
+			random_owned_state = { prioritize = { 336 332 } add_extra_state_shared_building_slots = 1 }
 		}
 
 		ai_will_do = {

--- a/common/national_focus/05_sahrawi.txt
+++ b/common/national_focus/05_sahrawi.txt
@@ -96,11 +96,7 @@ shared_focus = {
 				L_Inf_Bat = { x = 1 y = 0 }
 			}
 		}
-		SHA = {
-			SHA_lahbib_ayoub = {
-				set_nationality = SHA
-			}
-		}
+		SHA = { SHA_lahbib_ayoub = { set_nationality = SHA } }
 		SHA_lahbib_ayoub = {
 			set_nationality = SHA
 			add_corps_commander_role = {

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -108,9 +108,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			change_relative_party_popularity = yes
-			set_politics = {
-				ruling_party = neutrality
-			}
+			set_politics = { ruling_party = neutrality }
 			recalculate_party = yes
 		}
 
@@ -338,9 +336,7 @@ focus_tree = {
 				remove_ideas = iranian_quds_force
 				add_ideas = small_medium_business_owners
 			}
-			else = {
-				add_ideas = small_medium_business_owners
-			}
+			else = { add_ideas = small_medium_business_owners }
 		}
 
 		ai_will_do = {
@@ -474,9 +470,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			change_relative_party_popularity = yes
-			set_politics = {
-				ruling_party = communism
-			}
+			set_politics = { ruling_party = communism }
 			recalculate_party = yes
 			set_variable = { Autocracy_leader = 1 }
 			custom_effect_tooltip = available_military_high_command
@@ -799,9 +793,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			change_relative_party_popularity = yes
-			set_politics = {
-				ruling_party = nationalist
-			}
+			set_politics = { ruling_party = nationalist }
 			recalculate_party = yes
 		}
 
@@ -855,9 +847,7 @@ focus_tree = {
 				remove_ideas = iranian_quds_force
 				add_ideas = the_military
 			}
-			else = {
-				add_ideas = the_military
-			}
+			else = { add_ideas = the_military }
 		}
 
 		ai_will_do = { base = 1 }
@@ -882,9 +872,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_resestablish_defence_companies"
 			custom_effect_tooltip = TT_ACTIVATE_DEFENCE_COMPANIES
-			hidden_effect = {
-				load_oob = "SYR_defence_companies"
-			}
+			hidden_effect = { load_oob = "SYR_defence_companies" }
 		}
 
 		ai_will_do = { base = 1 }
@@ -918,9 +906,7 @@ focus_tree = {
 				remove_ideas = oligarchs
 				add_ideas = fossil_fuel_industry
 			}
-			else = {
-				add_ideas = fossil_fuel_industry
-			}
+			else = { add_ideas = fossil_fuel_industry }
 		}
 
 		ai_will_do = { base = 1 }
@@ -1024,9 +1010,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_western
-				}
+				limit = { has_country_flag = Rifaat_western }
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 0 }
@@ -1045,9 +1029,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_emerging
-				}
+				limit = { has_country_flag = Rifaat_emerging }
 				set_temp_variable = { rul_party_temp = 6 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 6 }
@@ -1066,9 +1048,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_nonaligned
-				}
+				limit = { has_country_flag = Rifaat_nonaligned }
 				set_temp_variable = { rul_party_temp = 15 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 15 }
@@ -1087,9 +1067,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_salafist
-				}
+				limit = { has_country_flag = Rifaat_salafist }
 				set_temp_variable = { rul_party_temp = 10 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 10 }
@@ -1108,9 +1086,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_nationalist
-				}
+				limit = { has_country_flag = Rifaat_nationalist }
 				set_temp_variable = { rul_party_temp = 21 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 21 }
@@ -1381,9 +1357,7 @@ focus_tree = {
 				change_relative_party_popularity = yes
 			}
 			if = { limit = { NOT = { has_idea = idea_syrian_kurds_without_citizenships } }
-				hidden_effect = {
-					country_event = SyriaFocus.99
-				}
+				hidden_effect = { country_event = SyriaFocus.99 }
 			}
 		}
 
@@ -3253,9 +3227,7 @@ focus_tree = {
 			syrian_corrcost_civ = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3263,9 +3235,7 @@ focus_tree = {
 				}
 			}
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3273,9 +3243,7 @@ focus_tree = {
 				}
 			}
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3283,9 +3251,7 @@ focus_tree = {
 				}
 			}
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3682,9 +3648,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3711,9 +3675,7 @@ focus_tree = {
 						}
 						set_country_flag = SYR_AI_annex_LEB
 					}
-					25 = {
-						set_country_flag = SYR_AI_free_LEB
-					}
+					25 = { set_country_flag = SYR_AI_free_LEB }
 				}
 			}
 		}
@@ -3746,9 +3708,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_EXPENDITURE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3811,9 +3771,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3829,9 +3787,7 @@ focus_tree = {
 			}
 			LEB = {
 				random_owned_state = {
-					limit = {
-						industrial_complex > 0
-					}
+					limit = { industrial_complex > 0 }
 					remove_building = {
 						type = industrial_complex
 						level = 1
@@ -3878,9 +3834,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INSURGENCY FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3888,9 +3842,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_commit_more_troops"
 			LEB = { add_autonomy_score = { value = -150 } }
 			custom_effect_tooltip = TT_SYR_COMMIT_MORE_TROOPS
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_manpower_effect = -0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_manpower_effect = -0.05 } }
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
@@ -3928,9 +3880,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INSURGENCY FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3938,9 +3888,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_reduce_presence"
 			LEB = { add_autonomy_score = { value = 150 } }
 			custom_effect_tooltip = TT_SYR_REDUCE_TROOPS
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_manpower_effect = 0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_manpower_effect = 0.05 } }
 			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 		}
@@ -3974,9 +3922,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3984,9 +3930,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_replace_ghazi_kanaan"
 			LEB = { add_autonomy_score = { value = -150 } }
 			custom_effect_tooltip = TT_REPLACE_INTELLIGENCE
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_stability_effect = -0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_stability_effect = -0.05 } }
 			set_temp_variable = { temp_opinion = 5 }
 			change_intelligence_community_opinion = yes
 		}
@@ -4020,9 +3964,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION FOCUS_FILTER_STABILITY }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4030,9 +3972,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_recall_intelligence"
 			LEB = { add_autonomy_score = { value = 150 } }
 			custom_effect_tooltip = TT_RECALL_INTELLIGENCE
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_stability_effect = 0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_stability_effect = 0.05 } }
 			set_temp_variable = { temp_opinion = -5 }
 			change_intelligence_community_opinion = yes
 		}
@@ -4070,9 +4010,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4100,9 +4038,7 @@ focus_tree = {
 				LEB = { add_popularity = { ideology = fascism popularity = 0.10 } }
 			}
 			custom_effect_tooltip = TT_REDUCE_POLITICAL_LIBERTIES
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_political_power_effect = -0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_political_power_effect = -0.05 } }
 		}
 
 		ai_will_do = {
@@ -4138,9 +4074,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4168,9 +4102,7 @@ focus_tree = {
 				LEB = { add_popularity = { ideology = fascism popularity = -0.10 } }
 			}
 			custom_effect_tooltip = TT_INCREASE_POLITICAL_LIBERTIES
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_political_power_effect = 0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_political_power_effect = 0.05 } }
 		}
 
 		ai_will_do = {
@@ -4206,9 +4138,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 

--- a/common/national_focus/05_usa.txt
+++ b/common/national_focus/05_usa.txt
@@ -387,17 +387,13 @@ focus_tree = {
 
 		available = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2000_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2000_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -931,17 +927,13 @@ focus_tree = {
 
 		available = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2000_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2000_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -1405,17 +1397,13 @@ focus_tree = {
 
 		available = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2004_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2004_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -1793,17 +1781,13 @@ focus_tree = {
 
 		available = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2004_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2004_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -2348,17 +2332,13 @@ focus_tree = {
 
 		available = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2008_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2008_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -2793,17 +2773,13 @@ focus_tree = {
 
 		available = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2008_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2008_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -3279,17 +3255,13 @@ focus_tree = {
 
 		available = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2012_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2012_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -3791,17 +3763,13 @@ focus_tree = {
 
 		available = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2012_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2012_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -4308,17 +4276,13 @@ focus_tree = {
 
 		available = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_republican_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_republican_victory }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_republican_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_republican_victory }
 			western_liberals_are_in_power = yes
 		}
 
@@ -4589,17 +4553,13 @@ focus_tree = {
 
 		available = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_democrat_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_democrat_victory }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_democrat_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_democrat_victory }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -8092,9 +8052,7 @@ focus_tree = {
 					NOT = { has_trait = skilled_staffer }
 				}
 				random_select_amount = 6
-				add_trait = {
-					trait = skilled_staffer
-				}
+				add_trait = { trait = skilled_staffer }
 			}
 		}
 
@@ -8700,9 +8658,7 @@ focus_tree = {
 				add_political_power = 50
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 40 }
@@ -8851,9 +8807,7 @@ focus_tree = {
 				army_experience = 10
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 40 }
@@ -9296,9 +9250,7 @@ focus_tree = {
 				army_experience = 15
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9339,9 +9291,7 @@ focus_tree = {
 				add_political_power = 50
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9447,9 +9397,7 @@ focus_tree = {
 				add_political_power = 50
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9484,9 +9432,7 @@ focus_tree = {
 				army_experience = 15
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9869,9 +9815,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -9984,9 +9928,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10024,9 +9966,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10140,9 +10080,7 @@ focus_tree = {
 				add_political_power = 100
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10176,9 +10114,7 @@ focus_tree = {
 				add_political_power = 100
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10213,9 +10149,7 @@ focus_tree = {
 				add_political_power = 100
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10885,9 +10819,7 @@ focus_tree = {
 				}
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				FSA = { add_ideas = USA_fsa_the_damascus_legion }
-			}
+			effect_tooltip = { FSA = { add_ideas = USA_fsa_the_damascus_legion } }
 		}
 
 		ai_will_do = { base = 1 }
@@ -15476,9 +15408,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_establishment_of_the_space_force"
 			add_ideas = space_force
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 50


### PR DESCRIPTION
Split from #3800.

Standardizes complete focus blocks across the six affected focus files. Event, MIO, localisation, and tooling changes stay out of this PR’s diff.

Size: 6 files, 2,094 changed lines (additions + deletions).

This PR is stacked on #3817 so the requested PKK-strength correction is preserved while Syria is standardized. Merge order: #3817 → #3818 → #3820 → #3821 → #3822.

Israel’s full-file standardization exceeds 7,000 changed lines, so the focus work is split at balanced, complete focus-block boundaries. The files are intentionally only partially standardized until #3822; do not run the whole-file standardizer before then.

The source content set passed the standardizer repeat check after all four focus batches. Structural comparison preserved gameplay statements and execution order apart from approved logging. No runtime or in-game visual verification was performed.