### PR TITLE
Standardize focus blocks — batch 4/4

### DIFF
--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -2291,9 +2291,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_phase_two_development_fund"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
@@ -2558,9 +2556,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_phase_three_development_funds"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_emigration_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_emigration_crisis }
 			}
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
@@ -2847,9 +2843,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_progressive_taxes_progressive_gains"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_homelessness_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_homelessness_crisis }
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
 			add_to_variable = { fijian_econ_political_power_gain = -0.02 tooltip = political_power_factor_tt }
@@ -3233,9 +3227,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_peace_for_piece"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			add_ideas = fiji_pieces_for_the_peace
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }

--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -4995,9 +4995,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_soldiers_lifestyle_act"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_homelessness_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_homelessness_crisis }
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
 			add_to_variable = { fijian_econ_political_power_gain = 0.03 tooltip = political_power_factor_tt }
@@ -5706,9 +5704,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_redrafting_the_constitution"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
 			add_to_variable = { fijian_econ_political_power_gain = 0.08 tooltip = political_power_factor_tt }
@@ -5963,9 +5959,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_creating_the_research_institute_of_fiji"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_emigration_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_emigration_crisis }
 			}
 			add_ideas = fiji_research_institute_of_fiji
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }

--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -3567,9 +3567,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_building_tall"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_homelessness_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_homelessness_crisis }
 			}
 			add_ideas = fiji_building_tall_within_something_small
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_emigration_crisis }
@@ -4014,9 +4012,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_revitalization_of_foreign_perception"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_emigration_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_emigration_crisis }
 			}
 			add_ideas = fiji_new_foreign_image
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
@@ -4510,9 +4506,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_starting_domestic_arms_companies"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
@@ -4765,9 +4759,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_national_rotc_curriculum"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_emigration_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_emigration_crisis }
 			}
 			add_ideas = fiji_national_rotc_program
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }

--- a/common/national_focus/05_fiji.txt
+++ b/common/national_focus/05_fiji.txt
@@ -6114,9 +6114,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_young_business_leaders_program"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_homelessness_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_homelessness_crisis }
 			}
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }
 			add_to_variable = { fijian_econ_bureaucracy_cost = 0.15 tooltip = bureaucracy_cost_multiplier_modifier_tt }
@@ -7004,9 +7002,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_growing_our_manufacturing_base"
 			if = { limit = { has_dynamic_modifier = { modifier = fijian_ethnic_tensions } }
-				remove_dynamic_modifier = {
-					modifier = fijian_ethnic_tensions
-				}
+				remove_dynamic_modifier = { modifier = fijian_ethnic_tensions }
 			}
 			set_temp_variable = { treasury_change = -7.50 }
 			modify_treasury_effect = yes
@@ -7544,15 +7540,11 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus FIJ_focus_research_paradise_program"
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_emigration_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_emigration_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_emigration_crisis }
 			}
 			if = {
 				limit = { has_dynamic_modifier = { modifier = fijian_homelessness_crisis } }
-				remove_dynamic_modifier = {
-					modifier = fijian_homelessness_crisis
-				}
+				remove_dynamic_modifier = { modifier = fijian_homelessness_crisis }
 			}
 			add_ideas = fiji_research_paradise_program
 			custom_effect_tooltip = { localization_key = modifies_dynamic_modifier_tt MODIFIER = fijian_economic_condition }

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -123,9 +123,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -153,9 +151,7 @@ focus_tree = {
 		available = {
 			has_stability > 0.7
 			has_country_flag = ISR_big_size_knesset
-			NOT = {
-				has_idea = the_military
-			}
+			NOT = { has_idea = the_military }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -195,9 +191,7 @@ focus_tree = {
 							size = 0.2
 						}
 					}
-					50 = {
-						add_stability = -0.1
-					}
+					50 = { add_stability = -0.1 }
 				}
 			}
 			news_event = israel_news.16
@@ -307,9 +301,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SAF
-			NOT = {
-				has_war_with = SAF
-			}
+			NOT = { has_war_with = SAF }
 			SAF = {
 				has_opinion = {
 					target = ISR
@@ -327,9 +319,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_south_africa executed"
-			SAF = {
-				country_event = israel_economy.27
-			}
+			SAF = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -343,15 +333,9 @@ focus_tree = {
 				custom_effect_tooltip = isrg_inv_foc_tt
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SAF
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SAF }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = SAF
@@ -420,11 +404,7 @@ focus_tree = {
 				}
 			}
 			random_owned_controlled_state = {
-				limit = {
-					ROOT = {
-						has_full_control_of_state = PREV
-					}
-				}
+				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = {
 					652
 				}
@@ -796,9 +776,7 @@ focus_tree = {
 
 		available = {
 			country_exists = LBA
-			NOT = {
-				has_war_with = LBA
-			}
+			NOT = { has_war_with = LBA }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -818,15 +796,9 @@ focus_tree = {
 				target = LBA
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = LBA
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = LBA }
 			change_influence_percentage = yes
 		}
 
@@ -854,12 +826,8 @@ focus_tree = {
 
 		available = {
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
-			NOT = {
-				has_completed_focus = ISR_farright_china
-			}
+			NOT = { has_war_with = CHI }
+			NOT = { has_completed_focus = ISR_farright_china }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -951,9 +919,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			OR = {
 				emerging_anarchist_communism_are_in_power = yes
 				emerging_communist_state_are_in_power = yes
@@ -1006,16 +972,12 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_raam_party executed"
 			add_political_power = 100
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
 			set_temp_variable = { party_index = 12 }
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 			add_days_mission_timeout = {
 				mission = ISR_isr_arab_coalition_ticker_mission
@@ -1053,12 +1015,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shura_council executed"
 			country_event = israel.148
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1100,18 +1058,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_bedouin_interests executed"
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
-			206 = {
-				one_state_industrial_complex = yes
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
+			206 = { one_state_industrial_complex = yes }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1159,17 +1109,13 @@ focus_tree = {
 		available = {
 			neutrality_neutral_muslim_brotherhood_are_in_coalition = yes
 			has_idea = ISR_support_of_settlements2
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_recognize_illegal_outposts executed"
 			custom_effect_tooltip = isr_tension_decrease_5_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 5 }
 			add_stability = -0.03
 			add_to_variable = {
 				var = arab_completed
@@ -1210,12 +1156,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_family_values executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_ideas = ISR_family_values
 			PAL = {
@@ -1262,13 +1204,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_legalize_polygamy executed"
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
 			add_ideas = ISR_legalized_plygamy
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1312,17 +1250,13 @@ focus_tree = {
 			add_political_power = 100
 			add_stability = -0.04
 			every_country = {
-				limit = {
-					has_idea = sunni
-				}
+				limit = { has_idea = sunni }
 				add_opinion_modifier = {
 					modifier = political_outreach
 					target = ISR
 				}
 			}
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = arab_completed
@@ -1368,15 +1302,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_meretz executed"
 			add_political_power = 100
-			set_temp_variable = {
-				party_index = 18
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_index = 18 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1488,9 +1416,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_affirmative_action executed"
 			custom_effect_tooltip = isr_tension_decrease_10_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 10
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 10 }
 			PAL = {
 				random_owned_controlled_state = {
 					add_extra_state_shared_building_slots = 1
@@ -1501,19 +1427,11 @@ focus_tree = {
 					}
 				}
 			}
-			set_temp_variable = {
-				percent_change = 6
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PAL
-			}
+			set_temp_variable = { percent_change = 6 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PAL }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				treasury_change = -4.5
-			}
+			set_temp_variable = { treasury_change = -4.5 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1555,16 +1473,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_meretz_green executed"
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_renewable_energy_focused
-					}
-				}
+				limit = { NOT = { has_idea = ISR_renewable_energy_focused } }
 				add_ideas = ISR_renewable_energy_focused
 			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1606,13 +1518,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ideological_feminism executed"
 			add_stability = 0.03
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1654,17 +1562,11 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_fight_gender_discrimination executed"
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_gender_equality
-					}
-				}
+				limit = { NOT = { has_idea = ISR_gender_equality } }
 				add_ideas = ISR_gender_equality
 			}
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = meretz_completed
@@ -1848,9 +1750,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -1897,9 +1797,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_agricultural_protection_act executed"
 			add_ideas = ISR_agricultural_protection
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -1964,9 +1862,7 @@ focus_tree = {
 					add_idea = ISR_farmer_union
 				}
 			}
-			else = {
-				add_ideas = ISR_farmer_union_1
-			}
+			else = { add_ideas = ISR_farmer_union_1 }
 			one_random_agriculture_district = yes
 			add_to_variable = {
 				var = labour_completed
@@ -2013,9 +1909,7 @@ focus_tree = {
 
 		available = {
 			western_social_democrats_are_in_power = yes
-			NOT = {
-				has_idea = labour_unions
-			}
+			NOT = { has_idea = labour_unions }
 		}
 
 		bypass = { has_idea = labour_unions }
@@ -2140,13 +2034,9 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sponsored_products executed"
 			set_temp_variable = { temp_productivity_change = 25 }
 			flat_productivity_change_effect = yes
-			set_temp_variable = {
-				treasury_change = -3.5
-			}
+			set_temp_variable = { treasury_change = -3.5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			change_labour_unions_opinion = yes
 		}
@@ -2177,9 +2067,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_youth_movements executed"
 			country_event = israel_labour.0
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
@@ -2212,9 +2100,7 @@ focus_tree = {
 				remove_idea = ISR_price_protection_act
 				add_idea = ISR_competition_directory_i
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			change_small_medium_business_owners_opinion = yes
 		}
@@ -2261,9 +2147,7 @@ focus_tree = {
 				}
 			}
 			ghost_incr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 		}
 
 		ai_will_do = {
@@ -2351,9 +2235,7 @@ focus_tree = {
 					spy
 				}
 			}
-			set_temp_variable = {
-				party_popularity_increase = 0.02
-			}
+			set_temp_variable = { party_popularity_increase = 0.02 }
 		}
 
 		ai_will_do = {
@@ -2539,9 +2421,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_computing_tech
 			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = labour_completed
@@ -2740,9 +2620,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_smaller_classes executed"
 			add_ideas = ISR_smaller_classes_th
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = labour_completed
@@ -2893,9 +2771,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_social_protests executed"
 			country_event = israel_labour.1
 			custom_effect_tooltip = shellyyech_tt
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
@@ -3086,13 +2962,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_regulate_finance executed"
 			add_ideas = ISR_regulated_finances
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -3158,22 +3030,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_raise_tax_on_wealthy executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			set_temp_variable = { corp_change = 10 }
 			modify_corporate_tax_rate_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -3239,9 +3103,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_public_transport executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = labour_completed
@@ -3294,9 +3156,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -3328,9 +3188,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_where_is_the_money executed"
 			add_ideas = ISR_yesh_pey_atid_taxx
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -3366,9 +3224,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_taxx
 				add_idea = ISR_yesh_pey_atid_yeshiva
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -3404,9 +3260,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_taxx
 				add_idea = ISR_yesh_pey_atid_settlements
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_military_opinion = yes
 		}
 
@@ -3446,9 +3300,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_disabled_people executed"
 			add_ideas = ISR_yesh_pey_atid_elder_scrolls
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -3488,16 +3340,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_holocaust_survivors executed"
 			add_ideas = ISR_yesh_pey_atid_localhost
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3542,9 +3388,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ministry_of_social_development"
 			add_ideas = ISR_yesh_pey_atid_ministry
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3629,9 +3473,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_idea1
 				add_idea = ISR_yesh_pey_atid_idea2
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3674,9 +3516,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_idea2
 				add_idea = ISR_yesh_pey_atid_idea3
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -3756,18 +3596,10 @@ focus_tree = {
 			add_stability = -0.05
 			set_temp_variable = { temp_opinion = 10 }
 			change_landowners_opinion = yes
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -3802,9 +3634,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_zero_vat"
 			add_ideas = ISR_yesh_pey_atid_marxx
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -3847,11 +3677,7 @@ focus_tree = {
 					array = global.EU_member
 					tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
 					if = {
-						limit = {
-							NOT = {
-								has_war_with = ISR
-							}
-						}
+						limit = { NOT = { has_war_with = ISR } }
 						add_opinion_modifier = {
 							target = ROOT
 							modifier = diplomatic_support
@@ -3927,9 +3753,7 @@ focus_tree = {
 				idea = ISR_yesh_pey_atid_debils
 				days = 380
 			}
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -3964,9 +3788,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_eighteen_ministers executed"
 			add_ideas = ISR_yesh_pey_atid_idea
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -4007,9 +3829,7 @@ focus_tree = {
 				remove_idea = ISR_yesh_pey_atid_idea
 				add_idea = ISR_yesh_pey_atid_idea1
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4150,20 +3970,12 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_accept_kotel_protocols executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_labour_unions_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4210,9 +4022,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = 15 }
 			modify_treasury_effect = yes
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4257,9 +4067,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_redraft_conscription_law executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4354,9 +4162,7 @@ focus_tree = {
 					add_idea = farmers
 				}
 			}
-			set_temp_variable = {
-				temp_opinion = 25
-			}
+			set_temp_variable = { temp_opinion = 25 }
 			change_farmers_opinion = yes
 		}
 
@@ -4447,9 +4253,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_public_transport_shabbat executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4556,9 +4360,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -4602,9 +4404,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -4680,12 +4480,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_above_all executed"
 			add_ideas = ISR_israel_above_all
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_popularity = {
 				ideology = nationalist
@@ -4724,9 +4520,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_general_politics executed"
 			add_war_support = 0.05
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
 		}
 
@@ -4762,9 +4556,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_increase_army_pay executed"
 			increase_military_spending = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4799,9 +4591,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_increase_pensions executed"
 			increase_social_spending = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4845,9 +4635,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -4882,13 +4670,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_social_cabinet executed"
 			increase_economic_growth = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -4927,9 +4711,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shasha_biton executed"
 			increase_education_budget = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -4967,9 +4749,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = -0.05 }
 			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -5005,9 +4785,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_regulate_ottoman_agencies executed"
 			add_ideas = ISR_ottoman_agencies
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -5048,9 +4826,7 @@ focus_tree = {
 			add_stability = -0.03
 			decrease_centralization = yes
 			decrease_corruption = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -5197,12 +4973,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_limit_terms executed"
 			add_political_power = 50
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			set_temp_variable = { threshold_change = 0.05 }
 			modify_election_threshold = yes
@@ -5248,9 +5020,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_empower_regional_governments executed"
 			add_ideas = ISR_emp_reg_govs
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -5295,9 +5065,7 @@ focus_tree = {
 			add_stability = 0.05
 			set_temp_variable = { temp_productivity_change = 50 }
 			flat_productivity_change_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -5339,9 +5107,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.03 }
 			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_days_mission_timeout = {
 				mission = ISR_isr_liberman_coalition_ticker_mission
@@ -5414,12 +5180,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_soviet_voters executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_opinion_modifier = {
 				target = SOV
@@ -5468,15 +5230,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_russian_tv executed"
 			add_ideas = ISR_russian_tv_channels
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = SOV
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = SOV }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -5553,17 +5309,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_five_mems executed"
-			set_temp_variable = {
-				treasury_change = -6
-			}
+			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -5607,9 +5357,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_citizenship_law executed"
 			custom_effect_tooltip = isr_tension_increase_5_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 5 }
 			add_stability = 0.05
 			reverse_add_opinion_modifier = {
 				modifier = drama
@@ -5661,9 +5409,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_empower_city_rabbis executed"
 			add_political_power = 100
 			ghost_incr = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -5717,15 +5463,9 @@ focus_tree = {
 						has_idea = eastern_church_eth
 					}
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = THIS
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = THIS }
 				change_influence_percentage = yes
 			}
 			add_to_variable = {
@@ -5827,9 +5567,7 @@ focus_tree = {
 				}
 				complete_national_focus = ISR_religous_status_quo_revisit
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = liberam_completed
@@ -6002,12 +5740,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_kaminitz_law executed"
 			add_ideas = ISR_kaminitz
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 3
-			}
-			set_temp_variable = {
-				treasury_change = -1
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 3 }
+			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = jewish_completed
@@ -6142,14 +5876,10 @@ focus_tree = {
 			country_event = israel_home.1
 			add_ideas = ISR_nation_state
 			custom_effect_tooltip = ISR_arab_bad_TT
-			hidden_effect = {
-				add_to_variable = { ISR_palestine_situation_additional = 5 }
-			}
+			hidden_effect = { add_to_variable = { ISR_palestine_situation_additional = 5 } }
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6189,9 +5919,7 @@ focus_tree = {
 
 		completion_reward = { log = "[GetDateText]: [This.GetName]: focus ISR_bennet_rule executed" }
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6221,9 +5949,7 @@ focus_tree = {
 			add_ideas = ISR_raegan_legacy
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6250,9 +5976,7 @@ focus_tree = {
 			decrease_centralization = yes
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6286,14 +6010,10 @@ focus_tree = {
 					add_idea = industrial_conglomerates
 				}
 			}
-			else = {
-				add_ideas = ISR_limit_labor
-			}
+			else = { add_ideas = ISR_limit_labor }
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6332,9 +6052,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6361,19 +6079,13 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tax_reductions executed"
-			set_temp_variable = {
-				corp_change = -5
-			}
+			set_temp_variable = { corp_change = -5 }
 			modify_corporate_tax_rate_effect = yes
-			set_temp_variable = {
-				temp_opinion = 6
-			}
+			set_temp_variable = { temp_opinion = 6 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6403,9 +6115,7 @@ focus_tree = {
 			decrease_corruption = yes
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6440,9 +6150,7 @@ focus_tree = {
 
 		completion_reward = { log = "[GetDateText]: [This.GetName]: focus ISR_shaked_rule executed" }
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6472,9 +6180,7 @@ focus_tree = {
 			add_ideas = ISR_bull_moose
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6513,9 +6219,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6548,9 +6252,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6580,9 +6282,7 @@ focus_tree = {
 			add_ideas = ISR_women_serving
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6615,9 +6315,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 3
-		}
+		ai_will_do = { base = 3 }
 	}
 
 	focus = {
@@ -6660,9 +6358,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.02 }
 			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -6774,9 +6470,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = { value = gdp_from_agriculture multiply = -0.3 } }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -6787,9 +6481,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -6932,15 +6624,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_protect_terrorists executed"
 			add_war_support = 0.02
-			set_temp_variable = {
-				party_index = 20
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.03
-			}
+			set_temp_variable = { party_index = 20 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
+			set_temp_variable = { temp_outlook_increase = 0.03 }
 			change_relative_party_popularity = yes
 			ghost_incr = yes
 			for_each_scope_loop = {
@@ -6978,9 +6664,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -6991,9 +6675,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7042,13 +6724,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_protect_ideological_core executed"
-			ISR = {
-				country_event = israel_nationalist.4
-			}
+			ISR = { country_event = israel_nationalist.4 }
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7059,9 +6737,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7110,30 +6786,16 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_denounce_mafdal executed"
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				party_index = 0
-			}
-			set_temp_variable = {
-				party_popularity_increase = -0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = -0.05
-			}
+			set_temp_variable = { party_index = 0 }
+			set_temp_variable = { party_popularity_increase = -0.05 }
+			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7144,9 +6806,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7197,9 +6857,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_late_marriage executed"
 			add_ideas = ISR_promote_early_marriage
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7210,9 +6868,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7259,9 +6915,7 @@ focus_tree = {
 				nationalist_fascist_are_in_coalition = yes
 			}
 			country_exists = PAL
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
@@ -7275,21 +6929,13 @@ focus_tree = {
 						NOT = { is_owned_by = ISR }
 					}
 				}
-				208 = {
-					set_occupation_law = foreign_civilian_oversight
-				}
+				208 = { set_occupation_law = foreign_civilian_oversight }
 			}
-			PAL = {
-				add_ideas = ISR_palestine_civilian_adm
-			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			PAL = { add_ideas = ISR_palestine_civilian_adm }
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					nationalist_right_wing_populists_are_in_power_or_coalition = yes
-				}
+				limit = { nationalist_right_wing_populists_are_in_power_or_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_nz_coalition_ticker_mission
 					days = 45
@@ -7300,9 +6946,7 @@ focus_tree = {
 				}
 			}
 			else_if = {
-				limit = {
-					nationalist_fascist_are_in_coalition = yes
-				}
+				limit = { nationalist_fascist_are_in_coalition = yes }
 				add_days_mission_timeout = {
 					mission = ISR_isr_givir_coalition_ticker_mission
 					days = 45
@@ -7399,9 +7043,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tal_law executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 			add_manpower = -1000
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
@@ -7437,13 +7079,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reject_liba executed"
 			add_ideas = ISR_freedom_of_teaching_1
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = jud_completed
@@ -7476,18 +7114,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_obstruct_mamlakhti executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					has_idea = ISR_freedom_of_teaching_1
-				}
+				limit = { has_idea = ISR_freedom_of_teaching_1 }
 				swap_ideas = {
 					remove_idea = ISR_freedom_of_teaching_1
 					add_idea = ISR_freedom_of_teaching_2
@@ -7525,13 +7157,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shopkeepers_law executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = jud_completed
@@ -7564,13 +7192,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_saturday_construction executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_ideas = ISR_only_pikuach_nefesh
 			add_to_variable = {
@@ -7607,13 +7231,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_new_conscription_law executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 			add_manpower = -5000
 			add_stability = -0.03
@@ -7649,16 +7269,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_anti_reformism executed"
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			if = {
-				limit = {
-					USA = {
-						has_government = democratic
-					}
-				}
+				limit = { USA = { has_government = democratic } }
 				USA = {
 					add_opinion_modifier = {
 						target = ISR
@@ -7737,13 +7351,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_segregated_prayers executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_stability = -0.03
 			add_to_variable = {
@@ -7778,13 +7388,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_anti_lgbt_propaganda executed"
 			add_ideas = ISR_family_values
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_stability = -0.05
 			add_to_variable = {
@@ -7827,9 +7433,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			add_days_mission_timeout = {
 				mission = ISR_isr_shas_coalition_ticker_mission
@@ -7878,9 +7482,7 @@ focus_tree = {
 				mission = ISR_isr_shas_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 7
-			}
+			set_temp_variable = { temp_opinion = 7 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -7925,9 +7527,7 @@ focus_tree = {
 				mission = ISR_isr_shas_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 7
-			}
+			set_temp_variable = { temp_opinion = 7 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -7963,9 +7563,7 @@ focus_tree = {
 			random_list = {
 				50 = {
 					custom_effect_tooltip = isr_tension_decrease_5_TT
-					subtract_from_variable = {
-						ISR_palestine_situation_additional = 5
-					}
+					subtract_from_variable = { ISR_palestine_situation_additional = 5 }
 					set_temp_variable = { party_index = 12 }
 					set_temp_variable = { party_popularity_increase = 0.02 }
 					set_temp_variable = { temp_outlook_increase = 0.02 }
@@ -7977,9 +7575,7 @@ focus_tree = {
 				}
 				50 = {
 					custom_effect_tooltip = isr_tension_increase_5_TT
-					add_to_variable = {
-						ISR_palestine_situation_additional = 5
-					}
+					add_to_variable = { ISR_palestine_situation_additional = 5 }
 					set_temp_variable = { party_index = 23 }
 					set_temp_variable = { party_popularity_increase = 0.05 }
 					set_temp_variable = { temp_outlook_increase = 0.05 }
@@ -8073,20 +7669,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_adinas_donations executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.04
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.04
-			}
+			set_temp_variable = { party_popularity_increase = 0.04 }
+			set_temp_variable = { temp_outlook_increase = 0.04 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8136,9 +7724,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 6
-			}
+			set_temp_variable = { temp_opinion = 6 }
 			change_the_military_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8181,13 +7767,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_food_checks executed"
 			add_ideas = ISR_food_for_poor
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8228,16 +7810,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_crown_to_its_former_glory executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
+			set_temp_variable = { percent_change = 3 }
 			change_domestic_influence_percentage = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8280,9 +7856,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_yemenite_affair executed"
 			add_stability = -0.04
 			ghost_decr = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8324,13 +7898,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sephardic_cultural_heritage executed"
 			ghost_decr = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				treasury_change = -2.5
-			}
+			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 			add_to_variable = {
 				var = shas_completed
@@ -8452,9 +8022,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -8495,9 +8063,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = 0.05 }
 			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			country_event = israel_likud.63
 			country_event = { id = israel_likud.64 days = 30 }
@@ -8532,9 +8098,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_mofaz executed"
 			custom_effect_tooltip = national_unity_camp_tt
-			hidden_effect = {
-				set_country_flag = mofaz_rules
-			}
+			hidden_effect = { set_country_flag = mofaz_rules }
 		}
 
 		ai_will_do = { base = 3 }
@@ -8607,12 +8171,8 @@ focus_tree = {
 					ideology = democratic
 					popularity = 0.05
 				}
-				set_temp_variable = {
-					party_index = 1
-				}
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
+				set_temp_variable = { party_index = 1 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
 			else = {
@@ -8620,12 +8180,8 @@ focus_tree = {
 					ideology = neutrality
 					popularity = 0.05
 				}
-				set_temp_variable = {
-					party_index = 14
-				}
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
+				set_temp_variable = { party_index = 14 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
 			add_political_power = 150
@@ -8682,9 +8238,7 @@ focus_tree = {
 					ruling_only = yes
 				}
 			}
-			NOT = {
-				neutrality_neutral_autocracy_in_power_or_coalition = yes
-			}
+			NOT = { neutrality_neutral_autocracy_in_power_or_coalition = yes }
 			emerging_conservative_in_power_or_coalition = no
 		}
 
@@ -8707,13 +8261,9 @@ focus_tree = {
 				mission = ISR_isr_shas_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -8866,9 +8416,7 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 			SOV = {
 				has_opinion = {
 					target = ISR
@@ -8879,9 +8427,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_russia executed"
-			SOV = {
-				country_event = israel_likud.29
-			}
+			SOV = { country_event = israel_likud.29 }
 		}
 
 		ai_will_do = {
@@ -8911,9 +8457,7 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -8924,9 +8468,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_republicans executed"
-			USA = {
-				country_event = israel_likud.28
-			}
+			USA = { country_event = israel_likud.28 }
 		}
 
 		ai_will_do = {
@@ -8963,16 +8505,12 @@ focus_tree = {
 				}
 			}
 			country_exists = BRA
-			NOT = {
-				has_war_with = BRA
-			}
+			NOT = { has_war_with = BRA }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_brazil executed"
-			BRA = {
-				country_event = israel_likud.31
-			}
+			BRA = { country_event = israel_likud.31 }
 		}
 
 		ai_will_do = {
@@ -9009,16 +8547,12 @@ focus_tree = {
 				}
 			}
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_befriend_trump executed"
-			USA = {
-				country_event = israel_likud.33
-			}
+			USA = { country_event = israel_likud.33 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9050,9 +8584,7 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = HUN
-			NOT = {
-				has_war_with = HUN
-			}
+			NOT = { has_war_with = HUN }
 			HUN = {
 				neutrality_neutral_conservatism_are_in_power = yes
 				has_opinion = {
@@ -9064,9 +8596,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_support_hungary executed"
-			HUN = {
-				country_event = israel_likud.38
-			}
+			HUN = { country_event = israel_likud.38 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9098,19 +8628,13 @@ focus_tree = {
 				ruling_only = yes
 			}
 			country_exists = POL
-			NOT = {
-				has_war_with = POL
-			}
-			POL = {
-				western_conservatism_are_in_power = yes
-			}
+			NOT = { has_war_with = POL }
+			POL = { western_conservatism_are_in_power = yes }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_matter_of_poland executed"
-			POL = {
-				country_event = israel_likud.41
-			}
+			POL = { country_event = israel_likud.41 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9283,9 +8807,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_request_immuity executed"
 			custom_effect_tooltip = ISR_request_immunity_TT
-			hidden_effect = {
-				country_event = israel_likud.5
-			}
+			hidden_effect = { country_event = israel_likud.5 }
 		}
 
 		ai_will_do = {
@@ -9353,9 +8875,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_national_camp executed"
 			custom_effect_tooltip = ISR_national_camp_TT
-			hidden_effect = {
-				set_country_flag = ISR_national_camp
-			}
+			hidden_effect = { set_country_flag = ISR_national_camp }
 			country_event = israel_likud.4
 		}
 
@@ -9393,9 +8913,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_judicial_reform_full executed"
 			custom_effect_tooltip = ISR_judicial_reform_TT
-			hidden_effect = {
-				country_event = israel_likud.16
-			}
+			hidden_effect = { country_event = israel_likud.16 }
 		}
 
 		ai_will_do = {
@@ -9426,12 +8944,8 @@ focus_tree = {
 				name = "Benjamin Netanyahu"
 				ruling_only = yes
 			}
-			custom_trigger_tooltip = {
-				tooltip = ISR_judicial_pres_TT
-			}
-			hidden_trigger = {
-				has_country_flag = ISR_judicial
-			}
+			custom_trigger_tooltip = { tooltip = ISR_judicial_pres_TT }
+			hidden_trigger = { has_country_flag = ISR_judicial }
 		}
 
 		completion_reward = {
@@ -9470,20 +8984,14 @@ focus_tree = {
 				name = "Benjamin Netanyahu"
 				ruling_only = yes
 			}
-			custom_trigger_tooltip = {
-				tooltip = ISR_judicial_pres_TT
-			}
-			hidden_trigger = {
-				has_country_flag = ISR_partners
-			}
+			custom_trigger_tooltip = { tooltip = ISR_judicial_pres_TT }
+			hidden_trigger = { has_country_flag = ISR_partners }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_rein_in_partners executed"
 			custom_effect_tooltip = ISR_national_camp_disband_TT
-			hidden_effect = {
-				clr_country_flag = ISR_national_camp
-			}
+			hidden_effect = { clr_country_flag = ISR_national_camp }
 			swap_ideas = {
 				remove_idea = harari_compromise
 				add_idea = basic_law_making_isr
@@ -9692,9 +9200,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cyprus_marriage executed"
-			CYP = {
-				country_event = israel_likud.44
-			}
+			CYP = { country_event = israel_likud.44 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9767,9 +9273,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_association_agreement_eu executed"
-			GER = {
-				country_event = israel_likud.47
-			}
+			GER = { country_event = israel_likud.47 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9829,9 +9333,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_association_agreement_usa executed"
-			USA = {
-				country_event = israel_likud.50
-			}
+			USA = { country_event = israel_likud.50 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -9896,15 +9398,11 @@ focus_tree = {
 			custom_effect_tooltip = prev_foc_dec_efe_tt
 			if = {
 				limit = { has_country_flag = ISR_usa_assosiation }
-				USA = {
-					country_event = israel_likud.57
-				}
+				USA = { country_event = israel_likud.57 }
 			}
 			else_if = {
 				limit = { has_country_flag = ISR_eu_assosiation }
-				GER = {
-					country_event = israel_likud.53
-				}
+				GER = { country_event = israel_likud.53 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -10024,12 +9522,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_legalize_cannabis executed"
 			add_ideas = ISR_legalize_cannabis
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 		}
 
@@ -10089,25 +9583,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_supertanker executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				party_index = 1
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
+			set_temp_variable = { party_index = 1 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
 			change_relative_party_popularity = yes
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -10379,13 +9861,9 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = {
-					treasury_change = -5.5
-				}
+				set_temp_variable = { treasury_change = -5.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					temp_opinion = 2
-				}
+				set_temp_variable = { temp_opinion = 2 }
 				change_small_medium_business_owners_opinion = yes
 			}
 			else_if = {
@@ -10398,17 +9876,11 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = {
-					treasury_change = -3
-				}
+				set_temp_variable = { treasury_change = -3 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 1
-				}
+				set_temp_variable = { percent_change = 1 }
 				change_domestic_influence_percentage = yes
-				set_temp_variable = {
-					temp_opinion = -2
-				}
+				set_temp_variable = { temp_opinion = -2 }
 				change_small_medium_business_owners_opinion = yes
 			}
 			else_if = {
@@ -10421,23 +9893,13 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
-				set_temp_variable = {
-					treasury_change = -3
-				}
+				set_temp_variable = { treasury_change = -3 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ENG
-				}
-				set_temp_variable = {
-					influence_target = ISR
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ENG }
+				set_temp_variable = { influence_target = ISR }
 				change_influence_percentage = yes
-				set_temp_variable = {
-					temp_opinion = 2
-				}
+				set_temp_variable = { temp_opinion = 2 }
 				change_small_medium_business_owners_opinion = yes
 			}
 		}
@@ -10562,9 +10024,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_privatize_elal executed"
 			if = {
-				limit = {
-					has_idea = ISR_kachlon_priv
-				}
+				limit = { has_idea = ISR_kachlon_priv }
 				swap_ideas = {
 					remove_idea = ISR_kachlon_priv
 					add_idea = ISR_elal_kachlon_priv
@@ -10643,9 +10103,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_open_skies executed"
 			add_ideas = ISR_open_skies
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -10891,9 +10349,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_kachlon_program executed"
 			if = {
-				limit = {
-					has_idea = ISR_elal_priv
-				}
+				limit = { has_idea = ISR_elal_priv }
 				swap_ideas = {
 					remove_idea = ISR_elal_priv
 					add_idea = ISR_elal_kachlon_priv
@@ -10971,9 +10427,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_harish executed"
-			204 = {
-				two_state_office_construction = yes
-			}
+			204 = { two_state_office_construction = yes }
 		}
 
 		ai_will_do = {
@@ -11040,12 +10494,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tama_38 executed"
 			add_ideas = ISR_tama
-			random_owned_controlled_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -1
-			}
+			random_owned_controlled_state = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -1 }
 			modify_treasury_effect = yes
 		}
 
@@ -11087,9 +10537,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_pension_reform executed"
 			add_ideas = ISR_lower_pension
-			set_temp_variable = {
-				party_popularity_increase = -0.04
-			}
+			set_temp_variable = { party_popularity_increase = -0.04 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = likud_completed
@@ -11142,13 +10590,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_lower_income_tax executed"
-			set_temp_variable = {
-				pop_change = -5
-			}
+			set_temp_variable = { pop_change = -5 }
 			modify_population_tax_rate_effect = yes
-			set_temp_variable = {
-				corp_change = -5
-			}
+			set_temp_variable = { corp_change = -5 }
 			modify_corporate_tax_rate_effect = yes
 			add_to_variable = {
 				var = likud_completed
@@ -11158,9 +10602,7 @@ focus_tree = {
 				mission = ISR_isr_likud_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 3
-			}
+			set_temp_variable = { temp_opinion = 3 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -11214,9 +10656,7 @@ focus_tree = {
 				mission = ISR_isr_likud_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -11262,9 +10702,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reform_bituach_leumi executed"
 			add_ideas = ISR_no_insurance
-			set_temp_variable = {
-				party_popularity_increase = -0.04
-			}
+			set_temp_variable = { party_popularity_increase = -0.04 }
 			change_relative_party_popularity = yes
 			add_to_variable = {
 				var = likud_completed
@@ -11396,9 +10834,7 @@ focus_tree = {
 				mission = ISR_isr_jud_coalition_ticker_mission
 				days = 45
 			}
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -11652,22 +11088,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_engagement_reform executed"
 			add_war_support = 0.05
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_ben_gvir_easy_trigger_1
-					}
-				}
+				limit = { NOT = { has_idea = ISR_ben_gvir_easy_trigger_1 } }
 				add_ideas = ISR_ben_gvir_easy_trigger_1
 			}
 			else_if = {
-				limit = {
-					has_idea = ISR_ben_gvir_easy_trigger_1
-				}
+				limit = { has_idea = ISR_ben_gvir_easy_trigger_1 }
 				swap_ideas = {
 					remove_idea = ISR_ben_gvir_easy_trigger_1
 					add_idea = ISR_ben_gvir_easy_trigger_2
@@ -11723,22 +11151,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_immunity_to_soldiers executed"
 			add_stability = 0.05
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			if = {
-				limit = {
-					NOT = {
-						has_idea = ISR_ben_gvir_easy_trigger_1
-					}
-				}
+				limit = { NOT = { has_idea = ISR_ben_gvir_easy_trigger_1 } }
 				add_ideas = ISR_ben_gvir_easy_trigger_1
 			}
 			else_if = {
-				limit = {
-					has_idea = ISR_ben_gvir_easy_trigger_1
-				}
+				limit = { has_idea = ISR_ben_gvir_easy_trigger_1 }
 				swap_ideas = {
 					remove_idea = ISR_ben_gvir_easy_trigger_1
 					add_idea = ISR_ben_gvir_easy_trigger_2
@@ -11880,14 +11300,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_hebrew_justice executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 			ISR_decrease_peoples_army = yes
 		}
@@ -11918,13 +11334,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_basic_law_torah executed"
 			add_stability = -0.02
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			ISR_decrease_peoples_army = yes
 			ISR_decrease_unintegrated_ultraorthodox_community = yes
@@ -11956,23 +11368,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_hebraic_studies executed"
 			ISR_increase_kahanism = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
+			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.02
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.02
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.02 }
+			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -12010,33 +11412,23 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ban_women_from_military executed"
 			add_stability = -0.05
 			ISR_decrease_peoples_army = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			if = {
-				limit = {
-					has_idea = alice_miller_v_ministry_of_defence
-				}
+				limit = { has_idea = alice_miller_v_ministry_of_defence }
 				remove_ideas = alice_miller_v_ministry_of_defence
 			}
 			if = {
-				limit = {
-					has_idea = volunteer_women
-				}
+				limit = { has_idea = volunteer_women }
 				swap_ideas = {
 					remove_idea = volunteer_women
 					add_idea = no_women_in_military
 				}
 			}
 			if = {
-				limit = {
-					has_idea = drafted_women
-				}
+				limit = { has_idea = drafted_women }
 				swap_ideas = {
 					remove_idea = drafted_women
 					add_idea = no_women_in_military
@@ -12069,20 +11461,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_outlaw_lgbt executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
 			add_ideas = ISR_family_values
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = -0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = -0.03
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = -0.03 }
+			set_temp_variable = { temp_outlook_increase = -0.03 }
 			add_manpower = -5000
 			add_stability = -0.05
 		}
@@ -12110,34 +11494,20 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRPOLIT FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				has_completed_focus = ISR_accept_kotel_protocols
-			}
+			NOT = { has_completed_focus = ISR_accept_kotel_protocols }
 			nationalist_fascist_are_in_power = yes
-			207 = {
-				is_controlled_by = ISR
-			}
+			207 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_third_temple executed"
 			add_stability = 0.03
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.03
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
+			set_temp_variable = { temp_outlook_increase = 0.03 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			every_country = {
 				limit = {
@@ -12221,15 +11591,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ben_gvir_eretz_israel executed"
-			set_temp_variable = {
-				party_index = 21
-			}
-			set_temp_variable = {
-				party_popularity_increase = 0.03
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.03
-			}
+			set_temp_variable = { party_index = 21 }
+			set_temp_variable = { party_popularity_increase = 0.03 }
+			set_temp_variable = { temp_outlook_increase = 0.03 }
 			swap_ideas = {
 				remove_idea = small_medium_business_owners
 				add_idea = farmers
@@ -12282,13 +11646,9 @@ focus_tree = {
 				target = JOR
 				expire = 365
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_farmers_opinion = yes
 			every_country = {
 				limit = {
@@ -12300,9 +11660,7 @@ focus_tree = {
 						neutrality_neutral_green_are_in_power = yes
 						neutrality_neutral_social_are_in_power = yes
 					}
-					NOT = {
-						tag = JOR
-					}
+					NOT = { tag = JOR }
 				}
 				add_opinion_modifier = {
 					target = ISR
@@ -12491,9 +11849,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 150000
-			}
+			has_army_manpower = { size > 150000 }
 			OR = {
 				country_exists = IRQ
 				country_exists = ISI
@@ -12573,9 +11929,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 250000
-			}
+			has_army_manpower = { size > 250000 }
 			CHI = {
 				exists = yes
 				has_government = communism
@@ -12623,9 +11977,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 150000
-			}
+			has_army_manpower = { size > 150000 }
 			country_exists = SAU
 		}
 
@@ -12669,9 +12021,7 @@ focus_tree = {
 
 		available = {
 			nationalist_fascist_are_in_power = yes
-			has_army_manpower = {
-				size > 250000
-			}
+			has_army_manpower = { size > 250000 }
 			USA = {
 				exists = yes
 				has_government = democratic
@@ -12822,18 +12172,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_learn_from_october_events executed"
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
 			random_owned_controlled_state = {
 				if = {
@@ -12980,18 +12324,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_rely_on_gideonites executed"
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
+			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13074,9 +12412,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_police_racism executed"
 			add_stability = 0.05
 			increase_policing_budget = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_popularity = {
 				ideology = nationalist
@@ -13116,14 +12452,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reform_the_fire_fighting_force executed"
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13165,14 +12497,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_show_more_presence executed"
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13216,9 +12544,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shabac_intervention_yes executed"
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13250,9 +12576,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -13263,9 +12587,7 @@ focus_tree = {
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = USA
-				}
+				NOT = { country_exists = USA }
 				has_war_with = USA
 				USA = {
 					has_opinion = {
@@ -13278,9 +12600,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_gather_all_the_equipment executed"
-			USA = {
-				country_event = israel_economy.1
-			}
+			USA = { country_event = israel_economy.1 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
@@ -13289,9 +12609,7 @@ focus_tree = {
 						amount = 6000
 						producer = ROOT
 					}
-					set_temp_variable = {
-						treasury_change = -4
-					}
+					set_temp_variable = { treasury_change = -4 }
 					modify_treasury_effect = yes
 				}
 			}
@@ -13327,14 +12645,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_storm_tuba_zangariya executed"
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			arab_mafia_decr = yes
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
 			change_relative_party_popularity = yes
 			random_owned_controlled_state = {
 				if = {
@@ -13369,9 +12683,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_speak_to_malal executed"
-			set_temp_variable = {
-				percent_change = 3
-			}
+			set_temp_variable = { percent_change = 3 }
 			change_domestic_influence_percentage = yes
 			unlock_decision_category_tooltip = israel_arab_boycott_category
 		}
@@ -13395,29 +12707,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_middle_east_peace executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SAU
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SAU }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = UAE
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = UAE }
 			change_influence_percentage = yes
 		}
 
@@ -13440,13 +12738,9 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = {
@@ -13461,25 +12755,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_neighbors executed"
 			add_stability = 0.03
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = JOR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = JOR }
 			change_influence_percentage = yes
 		}
 
@@ -13502,19 +12784,13 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 		}
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = EGY
-				}
-				EGY = {
-					has_completed_focus = EGY_isr_peace_support
-				}
+				NOT = { country_exists = EGY }
+				EGY = { has_completed_focus = EGY_isr_peace_support }
 			}
 		}
 
@@ -13530,22 +12806,12 @@ focus_tree = {
 				modifier = peace_talks
 				target = EGY
 			}
-			set_temp_variable = {
-				percent_change = 4
-			}
-			set_temp_variable = {
-				tag_index = EGY
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 4 }
+			set_temp_variable = { tag_index = EGY }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				party_popularity_increase = -0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = -0.05
-			}
+			set_temp_variable = { party_popularity_increase = -0.05 }
+			set_temp_variable = { temp_outlook_increase = -0.05 }
 			change_relative_party_popularity = yes
 		}
 
@@ -13568,9 +12834,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13585,15 +12849,9 @@ focus_tree = {
 				idea = ISR_sinai_investig
 				days = 150
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13616,9 +12874,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13629,9 +12885,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sinai_tourism executed"
-			EGY = {
-				country_event = israel_economy.27
-			}
+			EGY = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -13653,15 +12907,9 @@ focus_tree = {
 				target = EGY
 				modifier = major_improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13684,9 +12932,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13705,15 +12951,9 @@ focus_tree = {
 				target = EGY
 				modifier = major_improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13736,9 +12976,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13749,14 +12987,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_azam_azam executed"
-			EGY = {
-				country_event = israel_economy.122
-			}
+			EGY = { country_event = israel_economy.122 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
+				set_temp_variable = { party_popularity_increase = 0.05 }
 				change_relative_party_popularity = yes
 				add_opinion_modifier = {
 					modifier = diplomatic_proximity
@@ -13788,9 +13022,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13801,9 +13033,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_taba_conference executed"
-			EGY = {
-				country_event = israel_economy.119
-			}
+			EGY = { country_event = israel_economy.119 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				diplomatic_relation = {
@@ -13823,34 +13053,20 @@ focus_tree = {
 						remove_ideas = pol_isr_boycotte
 					}
 					if = {
-						limit = {
-							has_idea = full_isr_boycotte
-						}
+						limit = { has_idea = full_isr_boycotte }
 						swap_ideas = {
 							remove_idea = full_isr_boycotte
 							add_idea = econ_isr_boycotte
 						}
 					}
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = EGY
-				}
-				set_temp_variable = {
-					influence_target = ISR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = EGY }
+				set_temp_variable = { influence_target = ISR }
 				change_influence_percentage = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 			}
 		}
 
@@ -13873,9 +13089,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -13886,9 +13100,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_assam_ibrahims_mission executed"
-			EGY = {
-				country_event = md4.4
-			}
+			EGY = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -13908,15 +13120,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -13939,30 +13145,22 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
 					value > 4
 				}
 			}
-			213 = {
-				is_demilitarized_zone = yes
-			}
+			213 = { is_demilitarized_zone = yes }
 		}
 
 		bypass = { NOT = { 213 = { is_demilitarized_zone = yes } } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sisi_barak_call executed"
-			EGY = {
-				country_event = israel_economy.173
-			}
-			213 = {
-				set_demilitarized_zone = no
-			}
+			EGY = { country_event = israel_economy.173 }
+			213 = { set_demilitarized_zone = no }
 			effect_tooltip = {
 				add_opinion_modifier = {
 					target = EGY
@@ -13973,15 +13171,9 @@ focus_tree = {
 					modifier = diplomatic_support
 				}
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 		}
 
@@ -14004,9 +13196,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -14021,20 +13211,12 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_isis_sinai executed"
-			EGY = {
-				country_event = israel_economy.174
-			}
+			EGY = { country_event = israel_economy.174 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					percent_change = 4
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 4 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 				change_influence_percentage = yes
 				EGY = {
 					add_timed_idea = {
@@ -14063,9 +13245,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				OR = {
 					neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -14084,15 +13264,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_arab_spring executed"
-			set_temp_variable = {
-				percent_change = -3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = -3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 			EGY = {
 				add_stability = -0.05
@@ -14121,9 +13295,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			OR = {
 				has_idea = intervention_global_interventionism
 				has_government = nationalist
@@ -14210,9 +13382,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				OR = {
 					neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -14223,15 +13393,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_watch_their_moves executed"
-			set_temp_variable = {
-				percent_change = -3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = EGY
-			}
+			set_temp_variable = { percent_change = -3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = EGY }
 			change_influence_percentage = yes
 			EGY = {
 				add_stability = -0.02
@@ -14265,9 +13429,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				OR = {
 					neutrality_neutral_muslim_brotherhood_are_in_power = yes
@@ -14280,9 +13442,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_migrants executed"
 			206 = {
 				if = {
-					limit = {
-						is_controlled_by = ISR
-					}
+					limit = { is_controlled_by = ISR }
 					custom_effect_tooltip = ISR_fortress_egy_pal_border_TT
 					hidden_effect = {
 						add_building_construction = {
@@ -14331,9 +13491,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -14344,15 +13502,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_arish_ashkelon executed"
-			EGY = {
-				country_event = israel_economy.53
-			}
+			EGY = { country_event = israel_economy.53 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = egy_petr_tt
-				set_temp_variable = {
-					treasury_change = -4
-				}
+				set_temp_variable = { treasury_change = -4 }
 				modify_treasury_effect = yes
 				random_owned_state = {
 					add_extra_state_shared_building_slots = 1
@@ -14388,9 +13542,7 @@ focus_tree = {
 
 		available = {
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -14405,24 +13557,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_invite_egypt_to_gas_project executed"
-			EGY = {
-				country_event = israel_economy.215
-			}
+			EGY = { country_event = israel_economy.215 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = 6
-				}
+				set_temp_variable = { treasury_change = 6 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 				change_influence_percentage = yes
 			}
 		}
@@ -14446,28 +13588,18 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deal_with_jordan executed"
-			set_temp_variable = {
-				temp_opinion = 2
-			}
+			set_temp_variable = { temp_opinion = 2 }
 			change_the_priesthood_opinion = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = JOR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = JOR }
 			change_influence_percentage = yes
 		}
 
@@ -14490,9 +13622,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -14505,21 +13635,13 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_expand_on_jordan_treaty executed"
-			JOR = {
-				country_event = israel_economy.179
-			}
+			JOR = { country_event = israel_economy.179 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_ideas = ISR_jor_isr_treaty
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -14543,31 +13665,21 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_preserve_the_dead_sea executed"
-			JOR = {
-				country_event = israel_economy.182
-			}
+			JOR = { country_event = israel_economy.182 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = 100
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
-				set_temp_variable = {
-					temp_outlook_increase = 0.05
-				}
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				change_relative_party_popularity = yes
-				set_temp_variable = {
-					treasury_change = -2
-				}
+				set_temp_variable = { treasury_change = -2 }
 				modify_treasury_effect = yes
 			}
 		}

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -18370,23 +18370,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_support_iranian_protesters executed"
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			PER = {
-				country_event = israel_economy.84
-			}
+			PER = { country_event = israel_economy.84 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				PER = {
 					add_stability = -0.05
-					set_temp_variable = {
-						party_popularity_increase = -0.05
-					}
-					set_temp_variable = {
-						temp_outlook_increase = -0.05
-					}
+					set_temp_variable = { party_popularity_increase = -0.05 }
+					set_temp_variable = { temp_outlook_increase = -0.05 }
 					change_relative_party_popularity = yes
 				}
 			}
@@ -18441,9 +18433,7 @@ focus_tree = {
 					influence_higher_25 = yes
 					custom_trigger_tooltip = {
 						tooltip = ISR_top_influencer_per_tt
-						check_variable = {
-							influence_array^0 = ISR
-						}
+						check_variable = { influence_array^0 = ISR }
 					}
 				}
 			}
@@ -18525,9 +18515,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_operation_olympic_games executed"
-			USA = {
-				country_event = israel_economy.218
-			}
+			USA = { country_event = israel_economy.218 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = chanc_of_succ_hack_incr
 		}
@@ -18566,9 +18554,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deniable_drone_strikes executed"
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 			add_ideas = ISR_drone_better_operations
 		}
@@ -18609,9 +18595,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_assassinate_soleimani executed"
-			USA = {
-				country_event = israel_economy.91
-			}
+			USA = { country_event = israel_economy.91 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = chanc_of_succ_incr
 		}
@@ -18666,9 +18650,7 @@ focus_tree = {
 					influence_higher_10 = yes
 					custom_trigger_tooltip = {
 						tooltip = ISR_top_influencer_per_tt
-						check_variable = {
-							influence_array^0 = ISR
-						}
+						check_variable = { influence_array^0 = ISR }
 					}
 				}
 			}
@@ -18723,9 +18705,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_strike_alone executed"
 			add_stability = -0.05
 			add_war_support = 0.05
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 			set_temp_variable = { wargoal_on = PER }
 			add_threat_from_wargoal_effect = yes
@@ -18787,9 +18767,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_strike_with_america executed"
-			USA = {
-				country_event = israel_economy.85
-			}
+			USA = { country_event = israel_economy.85 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				news_event = israel_news.12
@@ -18855,17 +18833,13 @@ focus_tree = {
 					value > 24
 				}
 			}
-			NOT = {
-				has_completed_focus = ISR_steal_the_nuclear_archive
-			}
+			NOT = { has_completed_focus = ISR_steal_the_nuclear_archive }
 			country_exists = PER
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_accept_diplomacy executed"
-			PER = {
-				country_event = israel_economy.88
-			}
+			PER = { country_event = israel_economy.88 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				news_event = israel_news.13
@@ -18875,22 +18849,12 @@ focus_tree = {
 						relation = non_aggression_pact
 						active = yes
 					}
-					set_temp_variable = {
-						percent_change = 5
-					}
-					set_temp_variable = {
-						tag_index = PER
-					}
-					set_temp_variable = {
-						influence_target = ISR
-					}
+					set_temp_variable = { percent_change = 5 }
+					set_temp_variable = { tag_index = PER }
+					set_temp_variable = { influence_target = ISR }
 					change_influence_percentage = yes
-					set_temp_variable = {
-						receiver_nation = PER.id
-					}
-					set_temp_variable = {
-						sender_nation = ISR.id
-					}
+					set_temp_variable = { receiver_nation = PER.id }
+					set_temp_variable = { sender_nation = ISR.id }
 					set_improved_trade_agreement = yes
 				}
 			}
@@ -18927,9 +18891,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -18941,28 +18903,18 @@ focus_tree = {
 			add_war_support = -0.05
 			add_stability = 0.02
 			news_event = israel_news.7
-			PER = {
-				country_event = israel_economy.94
-			}
+			PER = { country_event = israel_economy.94 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				PER = {
-					give_military_access = ISR
-				}
+				PER = { give_military_access = ISR }
 				add_equipment_to_stockpile = {
 					type = infantry_weapons_5
 					amount = -6000
 					producer = ISR
 				}
-				set_temp_variable = {
-					percent_change = 6
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 6 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = PER
@@ -18997,9 +18949,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19009,9 +18959,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cyrus_accords_sign"
-			PER = {
-				country_event = israel_economy.97
-			}
+			PER = { country_event = israel_economy.97 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				give_guarantee = PER
@@ -19020,15 +18968,9 @@ focus_tree = {
 					relation = non_aggression_pact
 					active = yes
 				}
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 		}
@@ -19052,9 +18994,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19068,9 +19008,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_iran_singapore_model"
-			PER = {
-				country_event = md4.4
-			}
+			PER = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -19090,15 +19028,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 
@@ -19121,9 +19053,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19137,14 +19067,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_flower_ii_project"
-			PER = {
-				country_event = israel_economy.107
-			}
+			PER = { country_event = israel_economy.107 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -5
-				}
+				set_temp_variable = { treasury_change = -5 }
 				modify_treasury_effect = yes
 				add_tech_bonus = {
 					name = ISR_flower_ii_project
@@ -19158,15 +19084,9 @@ focus_tree = {
 					uses = 1
 					category = Cat_ICBM
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 		}
@@ -19203,25 +19123,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_parash_partner"
-			PER = {
-				country_event = israel_economy.110
-			}
+			PER = { country_event = israel_economy.110 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -5
-				}
+				set_temp_variable = { treasury_change = -5 }
 				modify_treasury_effect = yes
 				add_ideas = ISR_isr_iran_int
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 		}
@@ -19248,9 +19158,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19260,25 +19168,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_military_liason_office"
-			PER = {
-				country_event = israel_economy.113
-			}
+			PER = { country_event = israel_economy.113 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -5
-				}
+				set_temp_variable = { treasury_change = -5 }
 				modify_treasury_effect = yes
 				add_ideas = ISR_isr_iran_int_2
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 		}
@@ -19302,9 +19200,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				influence_higher_25 = yes
 				emerging_moderate_shiite_are_in_power = no
@@ -19315,24 +19211,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_treaty_of_susa"
-			PER = {
-				country_event = israel_economy.116
-			}
+			PER = { country_event = israel_economy.116 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = 5
-				}
+				set_temp_variable = { treasury_change = 5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 6
-				}
-				set_temp_variable = {
-					tag_index = PER
-				}
-				set_temp_variable = {
-					influence_target = ISR
-				}
+				set_temp_variable = { percent_change = 6 }
+				set_temp_variable = { tag_index = PER }
+				set_temp_variable = { influence_target = ISR }
 				change_influence_percentage = yes
 			}
 		}
@@ -19356,9 +19242,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19471,9 +19355,7 @@ focus_tree = {
 		available = {
 			country_exists = TAL
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19483,9 +19365,7 @@ focus_tree = {
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = TAL
-				}
+				NOT = { country_exists = TAL }
 				has_war_with = TAL
 			}
 		}
@@ -19530,17 +19410,13 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = PAK
-			PAK = {
-				influence_higher_30 = yes
-			}
+			PAK = { influence_higher_30 = yes }
 			network_strength = {
 				target = PAK
 				value > 70
 			}
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19550,18 +19426,14 @@ focus_tree = {
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = PAK
-				}
+				NOT = { country_exists = PAK }
 				has_war_with = PAK
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_operation_silk_road"
-			set_temp_variable = {
-				treasury_change = -25
-			}
+			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = RAJ_REV_PAK_TT
 			hidden_effect = {
@@ -19587,9 +19459,7 @@ focus_tree = {
 						ideology = democratic
 						popularity = 0.35
 					}
-					add_to_variable = {
-						party_pop_array^0 = 0.5
-					}
+					add_to_variable = { party_pop_array^0 = 0.5 }
 					recalculate_party = yes
 					start_civil_war = {
 						ideology = nationalist
@@ -19648,35 +19518,23 @@ focus_tree = {
 			if = {
 				limit = {
 					country_exists = TUR
-					NOT = {
-						has_war_with = TUR
-					}
+					NOT = { has_war_with = TUR }
 				}
-				TUR = {
-					country_event = md4.1
-				}
+				TUR = { country_event = md4.1 }
 			}
 			if = {
 				limit = {
 					country_exists = RAJ
-					NOT = {
-						has_war_with = RAJ
-					}
+					NOT = { has_war_with = RAJ }
 				}
-				RAJ = {
-					country_event = md4.1
-				}
+				RAJ = { country_event = md4.1 }
 			}
 			if = {
 				limit = {
 					country_exists = ETH
-					NOT = {
-						has_war_with = ETH
-					}
+					NOT = { has_war_with = ETH }
 				}
-				ETH = {
-					country_event = md4.1
-				}
+				ETH = { country_event = md4.1 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = ISR_trade_agr_seks
@@ -19714,9 +19572,7 @@ focus_tree = {
 				}
 			}
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19735,9 +19591,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_royal_road_iraq"
-			set_temp_variable = {
-				treasury_change = -25
-			}
+			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = ISR_REV_IRQ_TT
 			hidden_effect = {
@@ -19763,9 +19617,7 @@ focus_tree = {
 						ideology = democratic
 						popularity = 0.35
 					}
-					add_to_variable = {
-						party_pop_array^0 = 0.5
-					}
+					add_to_variable = { party_pop_array^0 = 0.5 }
 					recalculate_party = yes
 					start_civil_war = {
 						ideology = communism
@@ -19815,13 +19667,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cento_iran"
-			PER = {
-				country_event = israel_economy.125
-			}
+			PER = { country_event = israel_economy.125 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = faction_cento_alliance
-			}
+			effect_tooltip = { add_ideas = faction_cento_alliance }
 		}
 
 		ai_will_do = { base = 3 }
@@ -19848,9 +19696,7 @@ focus_tree = {
 		available = {
 			is_subject = no
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19870,28 +19716,18 @@ focus_tree = {
 			if = {
 				limit = {
 					country_exists = TUR
-					NOT = {
-						has_war_with = TUR
-					}
+					NOT = { has_war_with = TUR }
 				}
-				TUR = {
-					country_event = generic.5
-				}
+				TUR = { country_event = generic.5 }
 			}
 			if = {
 				limit = {
 					country_exists = ETH
-					NOT = {
-						has_war_with = ETH
-					}
+					NOT = { has_war_with = ETH }
 				}
-				ETH = {
-					country_event = generic.5
-				}
+				ETH = { country_event = generic.5 }
 			}
-			PER = {
-				country_event = generic.5
-			}
+			PER = { country_event = generic.5 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -19921,9 +19757,7 @@ focus_tree = {
 		available = {
 			country_exists = SAU
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19976,9 +19810,7 @@ focus_tree = {
 				}
 			}
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -19997,9 +19829,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_royal_road_syria"
-			set_temp_variable = {
-				treasury_change = -25
-			}
+			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = ISR_REV_SYR_TT
 			hidden_effect = {
@@ -20025,9 +19855,7 @@ focus_tree = {
 						ideology = democratic
 						popularity = 0.35
 					}
-					add_to_variable = {
-						party_pop_array^0 = 0.5
-					}
+					add_to_variable = { party_pop_array^0 = 0.5 }
 					recalculate_party = yes
 					start_civil_war = {
 						ideology = communism
@@ -20062,9 +19890,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20086,12 +19912,8 @@ focus_tree = {
 				target = PER
 				modifier = major_improve_trade
 			}
-			set_temp_variable = {
-				receiver_nation = ISR.id
-			}
-			set_temp_variable = {
-				sender_nation = PER.id
-			}
+			set_temp_variable = { receiver_nation = ISR.id }
+			set_temp_variable = { sender_nation = PER.id }
 			set_improved_trade_agreement = yes
 		}
 
@@ -20114,9 +19936,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20126,15 +19946,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_transasiatic_oil"
-			PER = {
-				country_event = israel_economy.53
-			}
+			PER = { country_event = israel_economy.53 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = egy_petr_tt
-				set_temp_variable = {
-					treasury_change = -4
-				}
+				set_temp_variable = { treasury_change = -4 }
 				modify_treasury_effect = yes
 				random_owned_state = {
 					add_extra_state_shared_building_slots = 1
@@ -20170,9 +19986,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20186,25 +20000,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_eilat_ashkelon_route"
-			PER = {
-				country_event = israel_economy.103
-			}
+			PER = { country_event = israel_economy.103 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -20
-				}
+				set_temp_variable = { treasury_change = -20 }
 				modify_treasury_effect = yes
 				add_ideas = ISR_isr_iran_oil
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 		}
@@ -20228,9 +20032,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20240,9 +20042,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_invest_iran"
-			PER = {
-				country_event = israel_economy.27
-			}
+			PER = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -20256,15 +20056,9 @@ focus_tree = {
 				custom_effect_tooltip = isrg_inv_foc_tt
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 
@@ -20287,9 +20081,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20299,24 +20091,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_water_and_life"
-			PER = {
-				country_event = israel_economy.100
-			}
+			PER = { country_event = israel_economy.100 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = 4
-				}
+				set_temp_variable = { treasury_change = 4 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 		}
@@ -20343,9 +20125,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20355,29 +20135,17 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_propaganda_in_iran"
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			PER = {
 				add_stability = 0.02
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
-				set_temp_variable = {
-					temp_outlook_increase = 0.05
-				}
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 
@@ -20401,9 +20169,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PER
-			NOT = {
-				has_war_with = PER
-			}
+			NOT = { has_war_with = PER }
 			PER = {
 				emerging_moderate_shiite_are_in_power = no
 				emerging_hardline_shiite_are_in_power = no
@@ -20413,18 +20179,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_fallow_deer_diplomacy"
-			PER = {
-				country_event = israel_economy.106
-			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			PER = { country_event = israel_economy.106 }
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 
@@ -20447,29 +20205,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_usa_china_balance"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = USA
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = USA }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = CHI
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = CHI }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 		}
 
@@ -20495,9 +20239,7 @@ focus_tree = {
 
 		available = {
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 		}
 
 		completion_reward = {
@@ -20510,15 +20252,9 @@ focus_tree = {
 				target = RAJ
 				modifier = supports_us
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = RAJ
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = RAJ }
 			change_influence_percentage = yes
 		}
 
@@ -20541,9 +20277,7 @@ focus_tree = {
 
 		available = {
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -20557,13 +20291,9 @@ focus_tree = {
 			country_event = israel.1
 			add_political_power = 150
 			add_stability = 0.05
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -20592,9 +20322,7 @@ focus_tree = {
 
 		available = {
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -20605,32 +20333,20 @@ focus_tree = {
 				is_ai = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
-					has_equipment = {
-						small_plane_suicide_airframe_2 > 49
-					}
+					has_equipment = { small_plane_suicide_airframe_2 > 49 }
 				}
-				else = {
-					has_equipment = {
-						Air_UAV1 > 49
-					}
-				}
+				else = { has_equipment = { Air_UAV1 > 49 } }
 			}
-			has_equipment = {
-				cnc_equipment_4 > 249
-			}
+			has_equipment = { cnc_equipment_4 > 249 }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_arm_exports_to_india executed"
-			RAJ = {
-				country_event = israel_economy.19
-			}
+			RAJ = { country_event = israel_economy.19 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
-					set_temp_variable = {
-						treasury_change = 10
-					}
+					set_temp_variable = { treasury_change = 10 }
 					modify_treasury_effect = yes
 					if = {
 						limit = { has_dlc = "By Blood Alone" }
@@ -20652,15 +20368,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = RAJ
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = RAJ }
 			change_influence_percentage = yes
 		}
 
@@ -20686,9 +20396,7 @@ focus_tree = {
 
 		available = {
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -20706,20 +20414,12 @@ focus_tree = {
 					province = 1065
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -2.2
-			}
+			set_temp_variable = { treasury_change = -2.2 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = infl_lease_tt
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = RAJ
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = RAJ }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 		}
 
@@ -20742,9 +20442,7 @@ focus_tree = {
 
 		available = {
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -20755,9 +20453,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_joint_space_program executed"
-			RAJ = {
-				country_event = israel_economy.24
-			}
+			RAJ = { country_event = israel_economy.24 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_tech_bonus = {
@@ -20766,9 +20462,7 @@ focus_tree = {
 					uses = 2
 					category = Cat_missile
 				}
-				set_temp_variable = {
-					treasury_change = -15
-				}
+				set_temp_variable = { treasury_change = -15 }
 				modify_treasury_effect = yes
 			}
 		}
@@ -20792,9 +20486,7 @@ focus_tree = {
 
 		available = {
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -20805,9 +20497,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_make_in_india executed"
-			RAJ = {
-				country_event = israel_economy.22
-			}
+			RAJ = { country_event = israel_economy.22 }
 			country_event = israel_economy.22
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -20817,22 +20507,12 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = RAJ
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = RAJ }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				receiver_nation = RAJ.id
-			}
-			set_temp_variable = {
-				sender_nation = ISR.id
-			}
+			set_temp_variable = { receiver_nation = RAJ.id }
+			set_temp_variable = { sender_nation = ISR.id }
 			set_improved_trade_agreement = yes
 		}
 
@@ -20856,9 +20536,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -20884,25 +20562,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_salinization_support_india executed"
-			RAJ = {
-				country_event = israel_economy.23
-			}
+			RAJ = { country_event = israel_economy.23 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
-					set_temp_variable = {
-						treasury_change = 2
-					}
+					set_temp_variable = { treasury_change = 2 }
 					modify_treasury_effect = yes
-					set_temp_variable = {
-						percent_change = 5
-					}
-					set_temp_variable = {
-						tag_index = ISR
-					}
-					set_temp_variable = {
-						influence_target = RAJ
-					}
+					set_temp_variable = { percent_change = 5 }
+					set_temp_variable = { tag_index = ISR }
+					set_temp_variable = { influence_target = RAJ }
 					change_influence_percentage = yes
 				}
 				RAJ = {
@@ -20937,9 +20605,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 			SOV = {
 				has_opinion = {
 					target = ISR
@@ -20950,14 +20616,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_balance_favor_russia executed"
-			SOV = {
-				country_event = israel_economy.35
-			}
+			SOV = { country_event = israel_economy.35 }
 			custom_effect_tooltip = grain_rus_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_grain_bought
-			}
+			effect_tooltip = { add_ideas = ISR_grain_bought }
 		}
 
 		ai_will_do = {
@@ -20983,16 +20645,12 @@ focus_tree = {
 
 		available = {
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_russian_military_coordination executed"
-			SOV = {
-				country_event = md4.4
-			}
+			SOV = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -21012,15 +20670,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SOV
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SOV }
 			change_influence_percentage = yes
 		}
 
@@ -21047,9 +20699,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 			SOV = {
 				has_opinion = {
 					target = ISR
@@ -21070,15 +20720,9 @@ focus_tree = {
 				target = SOV
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SOV
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SOV }
 			change_influence_percentage = yes
 		}
 
@@ -21105,16 +20749,12 @@ focus_tree = {
 
 		available = {
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cede_sergeys_courtyard executed"
-			SOV = {
-				country_event = israel_economy.38
-			}
+			SOV = { country_event = israel_economy.38 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = serg_court_tt
 		}
@@ -21142,20 +20782,14 @@ focus_tree = {
 
 		available = {
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_part_of_the_russian_world executed"
-			SOV = {
-				country_event = israel_economy.41
-			}
+			SOV = { country_event = israel_economy.41 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_idea_eacu_cooperation
-			}
+			effect_tooltip = { add_ideas = ISR_idea_eacu_cooperation }
 			for_each_scope_loop = {
 				array = global.CSTO_member
 				tooltip = TT_ALL_CSTO_MEMBER_NATIONS_GAIN
@@ -21193,9 +20827,7 @@ focus_tree = {
 
 		available = {
 			country_exists = UKR
-			NOT = {
-				has_war_with = UKR
-			}
+			NOT = { has_war_with = UKR }
 			UKR = {
 				has_opinion = {
 					target = ISR
@@ -21206,14 +20838,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_balance_favor_ukraine executed"
-			UKR = {
-				country_event = israel_economy.35
-			}
+			UKR = { country_event = israel_economy.35 }
 			custom_effect_tooltip = grain_ukr_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_grain_bought
-			}
+			effect_tooltip = { add_ideas = ISR_grain_bought }
 		}
 
 		ai_will_do = {
@@ -21243,20 +20871,14 @@ focus_tree = {
 
 		available = {
 			country_exists = UKR
-			NOT = {
-				has_war_with = UKR
-			}
+			NOT = { has_war_with = UKR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ukrainian_foreign_workers executed"
-			UKR = {
-				country_event = israel_economy.44
-			}
+			UKR = { country_event = israel_economy.44 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_idea_two_ukr_work
-			}
+			effect_tooltip = { add_ideas = ISR_idea_two_ukr_work }
 		}
 
 		ai_will_do = {
@@ -21282,9 +20904,7 @@ focus_tree = {
 
 		available = {
 			country_exists = UKR
-			NOT = {
-				has_war_with = UKR
-			}
+			NOT = { has_war_with = UKR }
 		}
 
 		completion_reward = {
@@ -21299,15 +20919,9 @@ focus_tree = {
 				target = UKR
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = UKR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = UKR }
 			change_influence_percentage = yes
 		}
 
@@ -21334,16 +20948,12 @@ focus_tree = {
 
 		available = {
 			country_exists = UKR
-			NOT = {
-				has_war_with = UKR
-			}
+			NOT = { has_war_with = UKR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_red_color_systems executed"
-			UKR = {
-				country_event = israel_economy.47
-			}
+			UKR = { country_event = israel_economy.47 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = ukr_acc_redcol
 		}
@@ -21371,16 +20981,12 @@ focus_tree = {
 
 		available = {
 			country_exists = UKR
-			NOT = {
-				has_war_with = UKR
-			}
+			NOT = { has_war_with = UKR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_deliver_kipot_barzel_to_ukraine executed"
-			UKR = {
-				country_event = israel_economy.50
-			}
+			UKR = { country_event = israel_economy.50 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = ukr_acc_irdo
 		}
@@ -21412,21 +21018,13 @@ focus_tree = {
 		available = {
 			OR = {
 				country_exists = KAZ
-				NOT = {
-					has_war_with = KAZ
-				}
+				NOT = { has_war_with = KAZ }
 				country_exists = KYR
-				NOT = {
-					has_war_with = KYR
-				}
+				NOT = { has_war_with = KYR }
 				country_exists = UZB
-				NOT = {
-					has_war_with = UZB
-				}
+				NOT = { has_war_with = UZB }
 				country_exists = TAJ
-				NOT = {
-					has_war_with = TAJ
-				}
+				NOT = { has_war_with = TAJ }
 			}
 		}
 
@@ -21440,15 +21038,9 @@ focus_tree = {
 				target = KAZ
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = KAZ
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = KAZ }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = KYR
@@ -21458,15 +21050,9 @@ focus_tree = {
 				target = KYR
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = KYR
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = KYR }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = UZB
@@ -21476,15 +21062,9 @@ focus_tree = {
 				target = UZB
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = UZB
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = UZB }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = TAJ
@@ -21494,15 +21074,9 @@ focus_tree = {
 				target = TAJ
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = TAJ
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = TAJ }
 			change_influence_percentage = yes
 		}
 
@@ -21526,29 +21100,17 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
-			NOT = {
-				has_completed_focus = ISR_farright_america
-			}
+			NOT = { has_war_with = USA }
+			NOT = { has_completed_focus = ISR_farright_america }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_balance_favor_america"
 			daneils_promis_decr = yes
-			USA = {
-				country_event = israel_economy.8
-			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = USA
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			USA = { country_event = israel_economy.8 }
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = USA }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = USA
@@ -21558,12 +21120,8 @@ focus_tree = {
 				target = USA
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				receiver_nation = USA.id
-			}
-			set_temp_variable = {
-				sender_nation = ISR.id
-			}
+			set_temp_variable = { receiver_nation = USA.id }
+			set_temp_variable = { sender_nation = ISR.id }
 			set_improved_trade_agreement = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -21595,9 +21153,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -21610,23 +21166,13 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_joint_development_zone"
 			daneils_promis_decr = yes
 			country_event = israel_economy.11
-			USA = {
-				country_event = israel_economy.11
-			}
+			USA = { country_event = israel_economy.11 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_us_dev_zon
-			}
+			effect_tooltip = { add_ideas = ISR_us_dev_zon }
 			newline = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = USA
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = USA }
 			change_influence_percentage = yes
 		}
 
@@ -21653,9 +21199,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -21667,23 +21211,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visa_free_request"
 			daneils_promis_decr = yes
-			USA = {
-				country_event = israel_economy.12
-			}
+			USA = { country_event = israel_economy.12 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_us_visa_free
-			}
+			effect_tooltip = { add_ideas = ISR_us_visa_free }
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = USA
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = USA }
 			change_influence_percentage = yes
 		}
 
@@ -21710,9 +21244,7 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -21736,9 +21268,7 @@ focus_tree = {
 					amount = 6000
 					producer = USA
 				}
-				set_temp_variable = {
-					treasury_change = -4
-				}
+				set_temp_variable = { treasury_change = -4 }
 				modify_treasury_effect = yes
 			}
 			newline = yes
@@ -21791,9 +21321,7 @@ focus_tree = {
 					}
 				}
 			}
-			else = {
-				add_political_power = 150
-			}
+			else = { add_political_power = 150 }
 		}
 
 		ai_will_do = { base = 3 }
@@ -21815,9 +21343,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus ISR_join_oecd executed"
-			set_temp_variable = {
-				percent_change = -3
-			}
+			set_temp_variable = { percent_change = -3 }
 			change_domestic_influence_percentage = yes
 			country_event = israel_economy.34
 			custom_effect_tooltip = oecd_supp_tt
@@ -21858,9 +21384,7 @@ focus_tree = {
 
 		available = {
 			country_exists = GER
-			NOT = {
-				has_war_with = GER
-			}
+			NOT = { has_war_with = GER }
 			GER = {
 				has_opinion = {
 					target = ISR
@@ -21871,9 +21395,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus ISR_germany_relations executed"
-			GER = {
-				country_event = israel_economy.16
-			}
+			GER = { country_event = israel_economy.16 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_tech_bonus = {
@@ -21882,19 +21404,11 @@ focus_tree = {
 					uses = 2
 					category = Cat_GENES
 				}
-				set_temp_variable = {
-					treasury_change = -2.5
-				}
+				set_temp_variable = { treasury_change = -2.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = GER
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = GER }
 				change_influence_percentage = yes
 			}
 			newline = yes
@@ -21906,15 +21420,9 @@ focus_tree = {
 				target = GER
 				modifier = supports_us
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GER
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GER }
 			change_influence_percentage = yes
 		}
 
@@ -21940,9 +21448,7 @@ focus_tree = {
 
 		available = {
 			country_exists = KOS
-			NOT = {
-				has_war_with = KOS
-			}
+			NOT = { has_war_with = KOS }
 		}
 
 		completion_reward = {
@@ -21957,9 +21463,7 @@ focus_tree = {
 				modifier = supports_us
 			}
 			every_country = {
-				limit = {
-					has_idea = sunni
-				}
+				limit = { has_idea = sunni }
 				add_opinion_modifier = {
 					modifier = political_outreach
 					target = ISR
@@ -21969,15 +21473,9 @@ focus_tree = {
 					target = ISR
 				}
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = KOS
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = KOS }
 			change_influence_percentage = yes
 		}
 
@@ -22000,9 +21498,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JAP
-			NOT = {
-				has_war_with = JAP
-			}
+			NOT = { has_war_with = JAP }
 			JAP = {
 				has_opinion = {
 					target = ISR
@@ -22013,9 +21509,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visit_japan executed"
-			JAP = {
-				country_event = israel_economy.27
-			}
+			JAP = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -22029,15 +21523,9 @@ focus_tree = {
 				custom_effect_tooltip = isrg_inv_foc_tt
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = JAP
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = JAP }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = JAP
@@ -22068,9 +21556,7 @@ focus_tree = {
 
 		available = {
 			country_exists = KOR
-			NOT = {
-				has_war_with = KOR
-			}
+			NOT = { has_war_with = KOR }
 			KOR = {
 				has_opinion = {
 					target = ISR
@@ -22081,9 +21567,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visit_south_korea executed"
-			KOR = {
-				country_event = israel_economy.27
-			}
+			KOR = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -22105,15 +21589,9 @@ focus_tree = {
 				target = KOR
 				modifier = supports_us
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = KOR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = KOR }
 			change_influence_percentage = yes
 		}
 
@@ -22136,9 +21614,7 @@ focus_tree = {
 
 		available = {
 			country_exists = VIE
-			NOT = {
-				has_war_with = VIE
-			}
+			NOT = { has_war_with = VIE }
 			VIE = {
 				has_opinion = {
 					target = ISR
@@ -22149,24 +21625,16 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visit_vietnam executed"
-			VIE = {
-				country_event = israel_economy.30
-			}
+			VIE = { country_event = israel_economy.30 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_timed_idea = {
 					idea = ISR_vie_isr_coop
 					days = 365
 				}
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = VIE
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = VIE }
 				change_influence_percentage = yes
 			}
 		}
@@ -22190,16 +21658,12 @@ focus_tree = {
 
 		available = {
 			country_exists = SIN
-			NOT = {
-				has_war_with = SIN
-			}
+			NOT = { has_war_with = SIN }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_approach_singapore executed"
-			SIN = {
-				country_event = md4.4
-			}
+			SIN = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -22219,15 +21683,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SIN
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SIN }
 			change_influence_percentage = yes
 		}
 
@@ -22249,20 +21707,14 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY }
 
 		available = {
-			ISR = {
-				has_completed_focus = ISR_join_oecd
-			}
+			ISR = { has_completed_focus = ISR_join_oecd }
 			country_exists = IND
-			NOT = {
-				has_war_with = IND
-			}
+			NOT = { has_war_with = IND }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_negotiate_with_indonesia executed"
-			IND = {
-				country_event = israel_economy.27
-			}
+			IND = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -22284,15 +21736,9 @@ focus_tree = {
 				target = IND
 				modifier = major_improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = IND
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = IND }
 			change_influence_percentage = yes
 		}
 
@@ -22315,9 +21761,7 @@ focus_tree = {
 
 		available = {
 			country_exists = BRM
-			NOT = {
-				has_war_with = BRM
-			}
+			NOT = { has_war_with = BRM }
 		}
 
 		completion_reward = {
@@ -22325,27 +21769,17 @@ focus_tree = {
 			country_event = israel_economy.33
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					receiver_nation = ISR.id
-				}
-				set_temp_variable = {
-					sender_nation = BRM.id
-				}
+				set_temp_variable = { receiver_nation = ISR.id }
+				set_temp_variable = { sender_nation = BRM.id }
 				set_improved_trade_agreement = yes
 				add_political_power = 50
 				add_opinion_modifier = {
 					target = BRM
 					modifier = supports_us
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = BRM
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = BRM }
 				change_influence_percentage = yes
 			}
 		}
@@ -22370,29 +21804,17 @@ focus_tree = {
 
 		available = {
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
-			NOT = {
-				has_completed_focus = ISR_farright_china
-			}
+			NOT = { has_war_with = CHI }
+			NOT = { has_completed_focus = ISR_farright_china }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_balance_favor_china"
 			daneils_promis_decr = yes
-			CHI = {
-				country_event = israel_economy.8
-			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = CHI
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			CHI = { country_event = israel_economy.8 }
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = CHI }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = CHI
@@ -22402,12 +21824,8 @@ focus_tree = {
 				target = CHI
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				receiver_nation = CHI.id
-			}
-			set_temp_variable = {
-				sender_nation = ISR.id
-			}
+			set_temp_variable = { receiver_nation = CHI.id }
+			set_temp_variable = { sender_nation = ISR.id }
 			set_improved_trade_agreement = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -22435,9 +21853,7 @@ focus_tree = {
 
 		available = {
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
+			NOT = { has_war_with = CHI }
 			CHI = {
 				has_opinion = {
 					target = ISR
@@ -22448,34 +21864,22 @@ focus_tree = {
 				is_ai = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
-					has_equipment = {
-						small_plane_suicide_airframe_2 > 49
-					}
+					has_equipment = { small_plane_suicide_airframe_2 > 49 }
 				}
-				else = {
-					has_equipment = {
-						Air_UAV1 > 49
-					}
-				}
+				else = { has_equipment = { Air_UAV1 > 49 } }
 			}
-			has_equipment = {
-				cnc_equipment_4 > 249
-			}
+			has_equipment = { cnc_equipment_4 > 249 }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_china_arm_shipments"
 			daneils_promis_decr = yes
 			custom_effect_tooltip = ISR_chi_dr_TT
-			CHI = {
-				country_event = israel_economy.4
-			}
+			CHI = { country_event = israel_economy.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
-					set_temp_variable = {
-						treasury_change = 10
-					}
+					set_temp_variable = { treasury_change = 10 }
 					modify_treasury_effect = yes
 					if = {
 						limit = { has_dlc = "By Blood Alone" }
@@ -22497,15 +21901,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = CHI
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = CHI }
 			change_influence_percentage = yes
 		}
 
@@ -22532,9 +21930,7 @@ focus_tree = {
 
 		available = {
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
+			NOT = { has_war_with = CHI }
 			CHI = {
 				has_opinion = {
 					target = ISR
@@ -22547,23 +21943,13 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_israel_china_innovation_conference"
 			daneils_promis_decr = yes
 			country_event = israel_economy.7
-			CHI = {
-				country_event = israel_economy.7
-			}
+			CHI = { country_event = israel_economy.7 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				add_ideas = ISR_chi_isr_forum
-			}
+			effect_tooltip = { add_ideas = ISR_chi_isr_forum }
 			newline = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = CHI
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = CHI }
 			change_influence_percentage = yes
 		}
 
@@ -22591,9 +21977,7 @@ focus_tree = {
 
 		available = {
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
+			NOT = { has_war_with = CHI }
 			CHI = {
 				has_opinion = {
 					target = ISR
@@ -22619,20 +22003,12 @@ focus_tree = {
 					province = 1065
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5.5
-			}
+			set_temp_variable = { treasury_change = -5.5 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = infl_lease_tt
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = CHI
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = CHI }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 		}
 
@@ -22661,9 +22037,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_speak_to_cabinet executed"
 			add_political_power = 50
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -22692,9 +22066,7 @@ focus_tree = {
 				mission = south_lebanon_occupation_ticker_mission
 				days = 20
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
+			set_temp_variable = { percent_change = 3 }
 			change_domestic_influence_percentage = yes
 		}
 
@@ -22731,16 +22103,12 @@ focus_tree = {
 			add_stability = -0.04
 			add_war_support = 0.05
 			add_manpower = 6000
-			LEB = {
-				add_manpower = -6000
-			}
+			LEB = { add_manpower = -6000 }
 			add_popularity = {
 				ideology = nationalist
 				popularity = 0.03
 			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
@@ -22778,18 +22146,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_south_lebanon_repatriation_act executed"
 			add_stability = 0.05
-			FRA = {
-				country_event = israel_mechanic.27
-			}
-			set_temp_variable = {
-				percent_change = -5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = FRA
-			}
+			FRA = { country_event = israel_mechanic.27 }
+			set_temp_variable = { percent_change = -5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = FRA }
 			change_influence_percentage = yes
 		}
 
@@ -22828,20 +22188,14 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_herzog_declaration executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			add_days_mission_timeout = {
 				mission = south_lebanon_occupation_ticker_mission
 				days = 20
 			}
-			set_temp_variable = {
-				party_popularity_increase = 0.02
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.02
-			}
+			set_temp_variable = { party_popularity_increase = 0.02 }
+			set_temp_variable = { temp_outlook_increase = 0.02 }
 			change_relative_party_popularity = yes
 		}
 
@@ -23003,9 +22357,7 @@ focus_tree = {
 						set_country_flag = shar_not_conv
 						custom_effect_tooltip = sharnotconv_tt
 					}
-					10 = {
-						custom_effect_tooltip = sharconv_tt
-					}
+					10 = { custom_effect_tooltip = sharconv_tt }
 				}
 			}
 			custom_effect_tooltip = resthirdday_tt
@@ -23015,9 +22367,7 @@ focus_tree = {
 						set_country_flag = shar_not_conv
 						custom_effect_tooltip = sharnotconv_tt
 					}
-					1 = {
-						custom_effect_tooltip = sharconv_tt
-					}
+					1 = { custom_effect_tooltip = sharconv_tt }
 				}
 			}
 		}
@@ -23083,9 +22433,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_respond_with_caution executed"
 			country_event = israel.31
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -23119,9 +22467,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 		}
 
 		completion_reward = {
@@ -23148,34 +22494,22 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_meet_with_the_committee executed"
 			random_list = {
-				20 = {
-					decrease_corruption = yes
-				}
-				20 = {
-					decrease_policing_budget = yes
-				}
+				20 = { decrease_corruption = yes }
+				20 = { decrease_policing_budget = yes }
 				20 = {
 					reverse_add_opinion_modifier = {
 						modifier = drama
 						target = PAL
 					}
-					set_temp_variable = {
-						party_index = 12
-					}
-					set_temp_variable = {
-						party_popularity_increase = -0.05
-					}
-					set_temp_variable = {
-						temp_outlook_increase = -0.05
-					}
+					set_temp_variable = { party_index = 12 }
+					set_temp_variable = { party_popularity_increase = -0.05 }
+					set_temp_variable = { temp_outlook_increase = -0.05 }
 					change_relative_party_popularity = yes
 				}
 				20 = {
@@ -23183,28 +22517,16 @@ focus_tree = {
 						modifier = political_outreach
 						target = PAL
 					}
-					set_temp_variable = {
-						party_index = 12
-					}
-					set_temp_variable = {
-						party_popularity_increase = 0.05
-					}
-					set_temp_variable = {
-						temp_outlook_increase = 0.05
-					}
+					set_temp_variable = { party_index = 12 }
+					set_temp_variable = { party_popularity_increase = 0.05 }
+					set_temp_variable = { temp_outlook_increase = 0.05 }
 					change_relative_party_popularity = yes
 				}
 				20 = {
-					set_temp_variable = {
-						treasury_change = 4
-					}
+					set_temp_variable = { treasury_change = 4 }
 					modify_treasury_effect = yes
-					set_temp_variable = {
-						party_popularity_increase = -0.05
-					}
-					set_temp_variable = {
-						temp_outlook_increase = -0.05
-					}
+					set_temp_variable = { party_popularity_increase = -0.05 }
+					set_temp_variable = { temp_outlook_increase = -0.05 }
 					change_relative_party_popularity = yes
 				}
 			}
@@ -23229,9 +22551,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 		}
 
 		completion_reward = {
@@ -23282,9 +22602,7 @@ focus_tree = {
 			add_political_power = 100
 			add_war_support = -0.05
 			country_event = israel.41
-			HEZ = {
-				country_event = israel.41
-			}
+			HEZ = { country_event = israel.41 }
 		}
 
 		ai_will_do = {
@@ -23368,22 +22686,14 @@ focus_tree = {
 
 		available = {
 			country_exists = SYR
-			NOT = {
-				has_war_with = SYR
-			}
-			587 = {
-				is_controlled_by = ISR
-			}
+			NOT = { has_war_with = SYR }
+			587 = { is_controlled_by = ISR }
 		}
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = SYR
-				}
-				SYR = {
-					has_completed_focus = SYR_renounce_claims_on_golan
-				}
+				NOT = { country_exists = SYR }
+				SYR = { has_completed_focus = SYR_renounce_claims_on_golan }
 			}
 		}
 
@@ -23420,18 +22730,10 @@ focus_tree = {
 		available = {
 			OR = {
 				date > 2008.1.1
-				SYR = {
-					has_completed_focus = SYR_fund_hezbollah
-				}
+				SYR = { has_completed_focus = SYR_fund_hezbollah }
 			}
-			NOT = {
-				has_idea = security_belt
-			}
-			NOT = {
-				LEB = {
-					owns_state = 201
-				}
-			}
+			NOT = { has_idea = security_belt }
+			NOT = { LEB = { owns_state = 201 } }
 			HEZ = {
 				OR = {
 					emerging_hardline_shiite_are_in_power = yes
@@ -23445,15 +22747,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reconsider_lebanese_policy executed"
-			set_temp_variable = {
-				percent_change = 4
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = LEB
-			}
+			set_temp_variable = { percent_change = 4 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = LEB }
 			change_influence_percentage = yes
 		}
 
@@ -23497,20 +22793,12 @@ focus_tree = {
 			country_event = israel.50
 			news_event = israel_news.10
 			custom_effect_tooltip = syrhez_tt
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			hidden_effect = {
-				HEZ = {
-					country_event = israel.50
-				}
-				SYR = {
-					country_event = israel.50
-				}
-				PER = {
-					country_event = israel.50
-				}
+				HEZ = { country_event = israel.50 }
+				SYR = { country_event = israel.50 }
+				PER = { country_event = israel.50 }
 			}
 		}
 
@@ -23552,17 +22840,13 @@ focus_tree = {
 					target = HEZ
 					value > 50
 				}
-				HEZ = {
-					influence_higher_5 = yes
-				}
+				HEZ = { influence_higher_5 = yes }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prepare_radwan executed"
-			HEZ = {
-				country_event = israel.53
-			}
+			HEZ = { country_event = israel.53 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				HEZ = {
@@ -23595,12 +22879,8 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRPALSTUFF FOCUS_FILTER_INSURGENCY FOCUS_FILTER_EXPENDITURE }
 
 		available = {
-			587 = {
-				is_controlled_by = ISR
-			}
-			205 = {
-				is_controlled_by = ISR
-			}
+			587 = { is_controlled_by = ISR }
+			205 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -23621,9 +22901,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -23666,12 +22944,8 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_northern_shield executed"
-			HEZ = {
-				country_event = israel.52
-			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			HEZ = { country_event = israel.52 }
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
@@ -23761,12 +23035,8 @@ focus_tree = {
 			if = {
 				limit = {
 					OR = {
-						LEB = {
-							has_government = nationalist
-						}
-						LEB = {
-							has_government = democratic
-						}
+						LEB = { has_government = nationalist }
+						LEB = { has_government = democratic }
 					}
 				}
 				add_opinion_modifier = {
@@ -23777,9 +23047,7 @@ focus_tree = {
 					target = LEB
 					modifier = diplomatic_support
 				}
-				LEB = {
-					country_event = md4.4
-				}
+				LEB = { country_event = md4.4 }
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
 					add_political_power = -100
@@ -23799,15 +23067,9 @@ focus_tree = {
 					}
 				}
 				newline = yes
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = LEB
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = LEB }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -23823,15 +23085,9 @@ focus_tree = {
 						ideology = nationalist
 						popularity = 0.1
 					}
-					set_temp_variable = {
-						percent_change = 5
-					}
-					set_temp_variable = {
-						tag_index = ISR
-					}
-					set_temp_variable = {
-						influence_target = LEB
-					}
+					set_temp_variable = { percent_change = 5 }
+					set_temp_variable = { tag_index = ISR }
+					set_temp_variable = { influence_target = LEB }
 					change_influence_percentage = yes
 				}
 			}
@@ -23884,23 +23140,15 @@ focus_tree = {
 					target = HEZ
 					value > 5
 				}
-				HEZ = {
-					influence_higher_5 = yes
-				}
+				HEZ = { influence_higher_5 = yes }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_operation_pager executed"
 			country_event = israel.147
-			hidden_effect = {
-				HEZ = {
-					country_event = israel.147
-				}
-			}
-			set_temp_variable = {
-				treasury_change = -10
-			}
+			hidden_effect = { HEZ = { country_event = israel.147 } }
+			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 		}
 
@@ -23956,12 +23204,8 @@ focus_tree = {
 				if = {
 					limit = {
 						OR = {
-							LEB = {
-								has_government = nationalist
-							}
-							LEB = {
-								has_government = democratic
-							}
+							LEB = { has_government = nationalist }
+							LEB = { has_government = democratic }
 						}
 					}
 					declare_war_on = {
@@ -23995,9 +23239,7 @@ focus_tree = {
 							ideology = nationalist
 							popularity = 0.35
 						}
-						add_to_variable = {
-							party_pop_array^0 = 0.5
-						}
+						add_to_variable = { party_pop_array^0 = 0.5 }
 						recalculate_party = yes
 						start_civil_war = {
 							ideology = communism
@@ -24045,17 +23287,11 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reject_the_equation executed"
 			country_event = israel.51
 			custom_effect_tooltip = istspechez_tt
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			hidden_effect = {
-				HEZ = {
-					country_event = israel.51
-				}
-				PER = {
-					country_event = israel.51
-				}
+				HEZ = { country_event = israel.51 }
+				PER = { country_event = israel.51 }
 			}
 		}
 
@@ -24126,13 +23362,9 @@ focus_tree = {
 				idea = ISR_tzamams
 				days = 150
 			}
-			set_temp_variable = {
-				temp_opinion = 2
-			}
+			set_temp_variable = { temp_opinion = 2 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				temp_opinion = 2
-			}
+			set_temp_variable = { temp_opinion = 2 }
 			change_the_military_opinion = yes
 		}
 
@@ -24161,9 +23393,7 @@ focus_tree = {
 				idea = ISR_shabac_dominance
 				days = 150
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -24192,9 +23422,7 @@ focus_tree = {
 				idea = ISR_8200_dominance
 				days = 150
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -24266,15 +23494,9 @@ focus_tree = {
 			clr_country_flag = ISR_catch_boat
 			custom_effect_tooltip = operation_noahs_TT
 			hidden_effect = {
-				ISR = {
-					country_event = israel.78
-				}
-				PER = {
-					country_event = israel.80
-				}
-				PAL = {
-					country_event = israel.81
-				}
+				ISR = { country_event = israel.78 }
+				PER = { country_event = israel.80 }
+				PAL = { country_event = israel.81 }
 			}
 		}
 
@@ -24303,9 +23525,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_refuse_nohal executed"
 			custom_effect_tooltip = isr_tension_decrease_10_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 10
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 10 }
 			add_timed_idea = {
 				idea = ISR_peaceful_approach
 				days = 150
@@ -24347,9 +23567,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_nohal_shakhen executed"
 			custom_effect_tooltip = isr_tension_increase_7_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 7
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 7 }
 			add_timed_idea = {
 				idea = ISR_neighbor_procedure
 				days = 150
@@ -24475,24 +23693,16 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRPALSTUFF FOCUS_FILTER_INSURGENCY }
 
 		available = {
-			204 = {
-				is_controlled_by = ISR
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
-			207 = {
-				is_controlled_by = ISR
-			}
+			204 = { is_controlled_by = ISR }
+			206 = { is_controlled_by = ISR }
+			207 = { is_controlled_by = ISR }
 			country_exists = PAL
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_construct_the_wall_settlements executed"
 			custom_effect_tooltip = isr_tension_increase_10_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 10
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 10 }
 			add_stability = 0.05
 			add_war_support = 0.1
 			add_ideas = west_bank_barrier_with_settlements
@@ -24540,9 +23750,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			hidden_effect = {
-				country_event = israel.115
-			}
+			hidden_effect = { country_event = israel.115 }
 		}
 
 		ai_will_do = {
@@ -24572,24 +23780,16 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRPALSTUFF FOCUS_FILTER_INSURGENCY }
 
 		available = {
-			204 = {
-				is_controlled_by = ISR
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
-			207 = {
-				is_controlled_by = ISR
-			}
+			204 = { is_controlled_by = ISR }
+			206 = { is_controlled_by = ISR }
+			207 = { is_controlled_by = ISR }
 			country_exists = PAL
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_construct_the_wall_no_settlements executed"
 			custom_effect_tooltip = isr_tension_increase_5_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 5 }
 			add_political_power = 120
 			add_stability = -0.05
 			add_war_support = -0.05
@@ -24638,9 +23838,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			hidden_effect = {
-				country_event = israel.115
-			}
+			hidden_effect = { country_event = israel.115 }
 		}
 
 		ai_will_do = {
@@ -24674,15 +23872,9 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRPALSTUFF FOCUS_FILTER_INSURGENCY FOCUS_FILTER_EXPENDITURE }
 
 		available = {
-			204 = {
-				is_controlled_by = ISR
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
-			207 = {
-				is_controlled_by = ISR
-			}
+			204 = { is_controlled_by = ISR }
+			206 = { is_controlled_by = ISR }
+			207 = { is_controlled_by = ISR }
 			country_exists = PAL
 		}
 
@@ -24691,9 +23883,7 @@ focus_tree = {
 			add_stability = -0.05
 			add_war_support = -0.05
 			custom_effect_tooltip = isr_tension_decrease_10_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 10
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 10 }
 			add_offsite_building = {
 				type = industrial_complex
 				level = 1
@@ -24725,13 +23915,9 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -16.5
-			}
+			set_temp_variable = { treasury_change = -16.5 }
 			modify_treasury_effect = yes
-			hidden_effect = {
-				country_event = israel.115
-			}
+			hidden_effect = { country_event = israel.115 }
 		}
 
 		ai_will_do = {
@@ -24770,11 +23956,7 @@ focus_tree = {
 					ruling_only = yes
 				}
 			}
-			209 = {
-				has_dynamic_modifier = {
-					modifier = israeli_settlements
-				}
-			}
+			209 = { has_dynamic_modifier = { modifier = israeli_settlements } }
 		}
 
 		completion_reward = {
@@ -24862,9 +24044,7 @@ focus_tree = {
 				HAM = {
 					NOT = { has_government = democratic }
 					neutrality_neutral_social_in_power_or_coalition = no
-					208 = {
-						is_controlled_by = HAM
-					}
+					208 = { is_controlled_by = HAM }
 				}
 			}
 		}
@@ -24912,9 +24092,7 @@ focus_tree = {
 				NOT = { country_exists = HAM }
 				has_government = nationalist
 			}
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
@@ -24954,18 +24132,14 @@ focus_tree = {
 		available = {
 			has_war_support < 0.25
 			has_idea = ISR_support_of_settlements2
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_focus_on_the_clusters executed"
 			unlock_decision_tooltip = ISR_jabel_mukaber_judge
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
 			reverse_add_opinion_modifier = {
 				target = PAL
 				modifier = stage_peaceful
@@ -24974,15 +24148,9 @@ focus_tree = {
 				target = USA
 				modifier = stage_peaceful
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PAL
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PAL }
 			change_influence_percentage = yes
 		}
 
@@ -25006,27 +24174,17 @@ focus_tree = {
 		available = {
 			has_war_support < 0.25
 			has_idea = ISR_support_of_settlements2
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ariel_industrial_zone executed"
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
-			204 = {
-				add_extra_state_shared_building_slots = 2
-			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
+			204 = { add_extra_state_shared_building_slots = 2 }
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -25050,17 +24208,13 @@ focus_tree = {
 		available = {
 			has_war_support < 0.25
 			has_idea = ISR_support_of_settlements2
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_expand_gush_etzion executed"
 			custom_effect_tooltip = isr_tension_decrease_2_TT
-			subtract_from_variable = {
-				ISR_palestine_situation_additional = 2
-			}
+			subtract_from_variable = { ISR_palestine_situation_additional = 2 }
 			206 = {
 				add_building_construction = {
 					type = infrastructure
@@ -25075,13 +24229,9 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -25111,29 +24261,17 @@ focus_tree = {
 		available = {
 			has_war_support < 0.25
 			has_idea = ISR_support_of_settlements2
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_edumim_tourist_mall_center executed"
-			207 = {
-				one_state_industrial_complex = yes
-			}
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PAL
-			}
+			207 = { one_state_industrial_complex = yes }
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PAL }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -25173,9 +24311,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_samarian_wine executed"
 			add_ideas = samarian_wine
 			one_random_industrial_complex = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -25211,17 +24347,13 @@ focus_tree = {
 			has_war_support > 0.25
 			has_idea = ISR_support_of_settlements2
 			western_socialism_are_in_power_or_coalition = no
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_the_enclave_settlements executed"
 			custom_effect_tooltip = isr_tension_increase_7_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 7
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 7 }
 			swap_ideas = {
 				remove_idea = ISR_support_of_settlements2
 				add_idea = focus_on_exclaves_0
@@ -25264,17 +24396,13 @@ focus_tree = {
 			has_war_support > 0.25
 			has_idea = focus_on_exclaves_0
 			western_socialism_are_in_power_or_coalition = no
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_settlement_amona executed"
 			custom_effect_tooltip = isr_tension_increase_5_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 5 }
 			country_event = israel.144
 			custom_effect_tooltip = amona_tt
 		}
@@ -25304,17 +24432,13 @@ focus_tree = {
 			has_war_support > 0.25
 			has_idea = focus_on_exclaves_0
 			western_socialism_are_in_power_or_coalition = no
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_settlement_evyatar executed"
 			custom_effect_tooltip = isr_tension_increase_5_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 5 }
 			country_event = israel.145
 			custom_effect_tooltip = eviatar_tt
 		}
@@ -25344,9 +24468,7 @@ focus_tree = {
 			has_war_support > 0.25
 			has_idea = focus_on_exclaves_0
 			western_socialism_are_in_power_or_coalition = no
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 		}
 
 		completion_reward = {
@@ -25381,12 +24503,8 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
-			PAL = {
-				has_war_support < 0.25
-			}
+			NOT = { has_war_with = PAL }
+			PAL = { has_war_support < 0.25 }
 		}
 
 		completion_reward = {

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -24547,9 +24547,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_daniel_lions_cage executed"
 			add_war_support = 0.05
 			custom_effect_tooltip = isr_tension_increase_10_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 10
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 10 }
 			effect_tooltip = {
 				swap_ideas = {
 					add_idea = daniel_lions_cage_1
@@ -24616,9 +24614,7 @@ focus_tree = {
 					modifier = betrayed_oslo
 				}
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 		}
 
@@ -24690,17 +24686,13 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_strangle_jenin executed"
 			custom_effect_tooltip = isr_tension_increase_5_TT
-			add_to_variable = {
-				ISR_palestine_situation_additional = 5
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 5 }
 			effect_tooltip = {
 				swap_ideas = {
 					add_idea = operation_shover_galim_2
@@ -24735,9 +24727,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 			divisions_in_state = {
 				type = infantry
 				size > 1
@@ -24781,9 +24771,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 		}
 
 		completion_reward = {
@@ -24802,15 +24790,9 @@ focus_tree = {
 					days = 365
 				}
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PAL
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PAL }
 			change_influence_percentage = yes
 		}
 
@@ -24835,9 +24817,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 			NOT = {
 				OR = {
 					has_country_leader = {
@@ -24853,9 +24833,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_restore_palestinian_authority executed"
-			PAL = {
-				country_event = israel.122
-			}
+			PAL = { country_event = israel.122 }
 			custom_effect_tooltip = theymayrej_pal_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -24883,9 +24861,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 			has_completed_focus = ISR_focus_on_the_clusters
 		}
 
@@ -24896,9 +24872,7 @@ focus_tree = {
 				amount = -1000
 				producer = ISR
 			}
-			PAL = {
-				country_event = israel.125
-			}
+			PAL = { country_event = israel.125 }
 			swap_ideas = {
 				add_idea = oslo_accords_4
 				remove_idea = oslo_accords_3
@@ -24928,9 +24902,7 @@ focus_tree = {
 
 		available = {
 			country_exists = PAL
-			NOT = {
-				has_war_with = PAL
-			}
+			NOT = { has_war_with = PAL }
 			has_completed_focus = ISR_focus_on_the_clusters
 		}
 
@@ -24969,9 +24941,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -25010,9 +24980,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_country_flag = hudna_notaccept }
 				NOT = { has_government = democratic }
@@ -25022,9 +24990,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_propose_hudna executed"
-			HAM = {
-				country_event = israel.126
-			}
+			HAM = { country_event = israel.126 }
 			custom_effect_tooltip = hudna_whatdo_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -25057,12 +25023,8 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
-			HAM = {
-				NOT = { has_country_flag = hudna_notaccept }
-			}
+			NOT = { has_war_with = HAM }
+			HAM = { NOT = { has_country_flag = hudna_notaccept } }
 		}
 
 		completion_reward = {
@@ -25076,15 +25038,9 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -3.5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = HAM
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = HAM }
 			change_influence_percentage = yes
 		}
 
@@ -25115,12 +25071,8 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
-			HAM = {
-				NOT = { has_country_flag = hudna_notaccept }
-			}
+			NOT = { has_war_with = HAM }
+			HAM = { NOT = { has_country_flag = hudna_notaccept } }
 		}
 
 		completion_reward = {
@@ -25137,15 +25089,9 @@ focus_tree = {
 			}
 			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = HAM
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = HAM }
 			change_influence_percentage = yes
 		}
 
@@ -25183,20 +25129,14 @@ focus_tree = {
 					has_war_with = USA
 				}
 			}
-			HAM = {
-				NOT = { has_country_flag = hudna_notaccept }
-			}
+			HAM = { NOT = { has_country_flag = hudna_notaccept } }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_gazan_casinos executed"
-			USA = {
-				country_event = israel.135
-			}
+			USA = { country_event = israel.135 }
 			custom_effect_tooltip = gazan_casino_tt
-			effect_tooltip = {
-				209 = { add_dynamic_modifier = { modifier = gaza_casinos } }
-			}
+			effect_tooltip = { 209 = { add_dynamic_modifier = { modifier = gaza_casinos } } }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -25223,9 +25163,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_country_flag = hudna_notaccept }
 				influence_higher_10 = yes
@@ -25241,15 +25179,9 @@ focus_tree = {
 					days = 365
 				}
 			}
-			set_temp_variable = {
-				percent_change = -10
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = HAM
-			}
+			set_temp_variable = { percent_change = -10 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = HAM }
 			change_influence_percentage = yes
 		}
 
@@ -25285,9 +25217,7 @@ focus_tree = {
 					has_war_with = SAU
 				}
 			}
-			HAM = {
-				NOT = { has_country_flag = hudna_notaccept }
-			}
+			HAM = { NOT = { has_country_flag = hudna_notaccept } }
 			SAU = {
 				has_opinion = {
 					target = ISR
@@ -25298,9 +25228,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_saudi_donations executed"
-			SAU = {
-				country_event = israel.138
-			}
+			SAU = { country_event = israel.138 }
 			HAM = {
 				add_popularity = {
 					ideology = fascism
@@ -25342,9 +25270,7 @@ focus_tree = {
 					has_war_with = UAE
 				}
 			}
-			HAM = {
-				NOT = { has_country_flag = hudna_notaccept }
-			}
+			HAM = { NOT = { has_country_flag = hudna_notaccept } }
 			UAE = {
 				has_opinion = {
 					target = ISR
@@ -25355,9 +25281,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_emirati_donations executed"
-			UAE = {
-				country_event = israel.138
-			}
+			UAE = { country_event = israel.138 }
 			HAM = {
 				add_popularity = {
 					ideology = democratic
@@ -25391,9 +25315,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				has_idea = PAL_closing_gates_all_open
 				NOT = { has_government = democratic }
@@ -25411,9 +25333,7 @@ focus_tree = {
 				limit = { has_dlc = "By Blood Alone" }
 				send_embargo = HAM
 			}
-			HAM = {
-				country_event = israel.129
-			}
+			HAM = { country_event = israel.129 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				swap_ideas = {
@@ -25446,9 +25366,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -25461,15 +25379,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_limit_fishing_rights executed"
-			HAM = {
-				country_event = israel.133
-			}
+			HAM = { country_event = israel.133 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				custom_effect_tooltip = willincr_bloc_tt
-				HAM = {
-					HAM_increase_blockade = yes
-				}
+				HAM = { HAM_increase_blockade = yes }
 			}
 		}
 
@@ -25511,9 +25425,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_egypt_joint_blockade executed"
-			EGY = {
-				country_event = israel.130
-			}
+			EGY = { country_event = israel.130 }
 			custom_effect_tooltip = egyopi_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -25560,9 +25472,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ships_not_pass executed"
-			TUR = {
-				country_event = TUR_flavor_event.8
-			}
+			TUR = { country_event = TUR_flavor_event.8 }
 			custom_effect_tooltip = tur_mrmr_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -25590,9 +25500,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -25605,15 +25513,9 @@ focus_tree = {
 				idea = ISR_gazan_workers
 				days = 1000
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = HAM
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = HAM }
 			change_influence_percentage = yes
 			HAM = {
 				add_timed_idea = {
@@ -25648,9 +25550,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -25672,9 +25572,7 @@ focus_tree = {
 					}
 				}
 				AND = {
-					HAM = {
-						has_government = fascism
-					}
+					HAM = { has_government = fascism }
 					SAU = {
 						has_completed_focus = GCC_support_hamas
 						has_opinion = {
@@ -25684,9 +25582,7 @@ focus_tree = {
 					}
 				}
 				AND = {
-					HAM = {
-						has_government = communism
-					}
+					HAM = { has_government = communism }
 					SYR = {
 						has_completed_focus = SYR_meet_hamas
 						has_opinion = {
@@ -25737,9 +25633,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -25769,22 +25663,14 @@ focus_tree = {
 					target = QAT
 					modifier = recent_actions_negative
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = QAT
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = QAT }
 				change_influence_percentage = yes
 			}
 			if = {
 				limit = {
-					HAM = {
-						has_government = fascism
-					}
+					HAM = { has_government = fascism }
 					SAU = {
 						has_completed_focus = GCC_support_hamas
 						has_opinion = {
@@ -25797,22 +25683,14 @@ focus_tree = {
 					target = SAU
 					modifier = recent_actions_negative
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = SAU
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = SAU }
 				change_influence_percentage = yes
 			}
 			if = {
 				limit = {
-					HAM = {
-						has_government = communism
-					}
+					HAM = { has_government = communism }
 					SYR = {
 						has_completed_focus = SYR_meet_hamas
 						has_opinion = {
@@ -25825,15 +25703,9 @@ focus_tree = {
 					target = SYR
 					modifier = recent_actions_negative
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = SYR
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = SYR }
 				change_influence_percentage = yes
 			}
 		}
@@ -25864,9 +25736,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -25902,9 +25772,7 @@ focus_tree = {
 			}
 			if = {
 				limit = {
-					HAM = {
-						has_government = fascism
-					}
+					HAM = { has_government = fascism }
 					SAU = {
 						has_completed_focus = GCC_support_hamas
 						has_opinion = {
@@ -25923,9 +25791,7 @@ focus_tree = {
 			}
 			if = {
 				limit = {
-					HAM = {
-						has_government = communism
-					}
+					HAM = { has_government = communism }
 					SYR = {
 						has_completed_focus = SYR_meet_hamas
 						has_opinion = {
@@ -25974,9 +25840,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 		}
 
 		completion_reward = {
@@ -26010,9 +25874,7 @@ focus_tree = {
 
 		available = {
 			country_exists = HAM
-			NOT = {
-				has_war_with = HAM
-			}
+			NOT = { has_war_with = HAM }
 			HAM = {
 				NOT = { has_government = democratic }
 				neutrality_neutral_social_in_power_or_coalition = no
@@ -26050,13 +25912,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_speak_to_staff"
 			add_war_support = 0.05
-			add_to_variable = {
-				party_pop_array^21 = 0.055
-			}
+			add_to_variable = { party_pop_array^21 = 0.055 }
 			recalculate_party = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -26152,15 +26010,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_miller_case"
 			remove_ideas = alice_miller_v_ministry_of_defence
-			206 = {
-				add_extra_state_shared_building_slots = 1
-			}
-			205 = {
-				add_extra_state_shared_building_slots = 1
-			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			206 = { add_extra_state_shared_building_slots = 1 }
+			205 = { add_extra_state_shared_building_slots = 1 }
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
@@ -26191,16 +26043,12 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			205 = {
-				is_controlled_by = ISR
-			}
+			205 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_prioritize_ramat_david"
-			205 = {
-				two_state_air_base = yes
-			}
+			205 = { two_state_air_base = yes }
 			two_anti_air = yes
 		}
 
@@ -26231,16 +26079,12 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			206 = {
-				is_controlled_by = ISR
-			}
+			206 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_prioritize_nevatim"
-			206 = {
-				two_state_air_base = yes
-			}
+			206 = { two_state_air_base = yes }
 			two_anti_air = yes
 		}
 
@@ -26302,9 +26146,7 @@ focus_tree = {
 					technology = Strike_fighter4
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -15
-			}
+			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 		}
 
@@ -26367,9 +26209,7 @@ focus_tree = {
 					technology = MR_Fighter4
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -15
-			}
+			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 		}
 
@@ -26402,13 +26242,9 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			USA = {
-				has_tech = MR_Fighter4
-			}
+			USA = { has_tech = MR_Fighter4 }
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			OR = {
 				has_completed_focus = ISR_villa_in_the_jungle
 				has_completed_focus = ISR_war_between_the_wars
@@ -26417,9 +26253,7 @@ focus_tree = {
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = USA
-				}
+				NOT = { country_exists = USA }
 				has_war_with = USA
 			}
 		}
@@ -26483,16 +26317,12 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = GER
-			NOT = {
-				has_war_with = GER
-			}
+			NOT = { has_war_with = GER }
 		}
 
 		bypass = {
 			OR = {
-				NOT = {
-					country_exists = GER
-				}
+				NOT = { country_exists = GER }
 				has_war_with = GER
 			}
 		}
@@ -26590,9 +26420,7 @@ focus_tree = {
 				bonus = 0.3
 				category = CAT_air_eqp
 			}
-			set_temp_variable = {
-				treasury_change = 5
-			}
+			set_temp_variable = { treasury_change = 5 }
 			modify_treasury_effect = yes
 		}
 
@@ -26637,9 +26465,7 @@ focus_tree = {
 					producer = FRA
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -26684,9 +26510,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_trans_heli
 			}
-			set_temp_variable = {
-				treasury_change = -14
-			}
+			set_temp_variable = { treasury_change = -14 }
 			modify_treasury_effect = yes
 		}
 
@@ -26728,9 +26552,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_trans_heli
 			}
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -26764,9 +26586,7 @@ focus_tree = {
 				limit = { has_dlc = "No Step Back" }
 				has_tech = nsb_attack_helicopter_tech_4
 			}
-			else = {
-				has_tech = attack_helicopter_4
-			}
+			else = { has_tech = attack_helicopter_4 }
 		}
 
 		completion_reward = {
@@ -26872,67 +26692,39 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_operation_orchard"
 			custom_effect_tooltip = syr_ope_aa_tt
 			if = {
-				limit = {
-					SYR = {
-						all_controlled_state = {
-							anti_air_building > 5
-						}
-					}
-				}
+				limit = { SYR = { all_controlled_state = { anti_air_building > 5 } } }
 				random_list = {
 					40 = {
 						country_event = israel.54
 						hidden_effect = {
-							SYR = {
-								country_event = israel.54
-							}
-							PER = {
-								country_event = israel.54
-							}
+							SYR = { country_event = israel.54 }
+							PER = { country_event = israel.54 }
 						}
 					}
 					60 = {
 						country_event = israel.55
 						hidden_effect = {
-							SYR = {
-								country_event = israel.55
-							}
-							PER = {
-								country_event = israel.55
-							}
+							SYR = { country_event = israel.55 }
+							PER = { country_event = israel.55 }
 						}
 					}
 				}
 			}
 			if = {
-				limit = {
-					SYR = {
-						all_controlled_state = {
-							anti_air_building < 5
-						}
-					}
-				}
+				limit = { SYR = { all_controlled_state = { anti_air_building < 5 } } }
 				random_list = {
 					70 = {
 						country_event = israel.54
 						hidden_effect = {
-							SYR = {
-								country_event = israel.54
-							}
-							PER = {
-								country_event = israel.54
-							}
+							SYR = { country_event = israel.54 }
+							PER = { country_event = israel.54 }
 						}
 					}
 					30 = {
 						country_event = israel.55
 						hidden_effect = {
-							SYR = {
-								country_event = israel.55
-							}
-							PER = {
-								country_event = israel.55
-							}
+							SYR = { country_event = israel.55 }
+							PER = { country_event = israel.55 }
 						}
 					}
 				}
@@ -26980,9 +26772,7 @@ focus_tree = {
 				has_completed_focus = ISR_steal_the_nuclear_archive
 				has_completed_focus = ISR_deniable_drone_strikes
 			}
-			PER = {
-				has_completed_focus = PER_ir_forty
-			}
+			PER = { has_completed_focus = PER_ir_forty }
 			country_exists = PER
 		}
 
@@ -26990,45 +26780,17 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prevent_iranian_nukes executed"
 			custom_effect_tooltip = per_ope_aa_tt
 			if = {
-				limit = {
-					PER = {
-						all_controlled_state = {
-							anti_air_building > 5
-						}
-					}
-				}
+				limit = { PER = { all_controlled_state = { anti_air_building > 5 } } }
 				random_list = {
-					40 = {
-						PER = {
-							country_event = israel.60
-						}
-					}
-					60 = {
-						PER = {
-							country_event = israel.61
-						}
-					}
+					40 = { PER = { country_event = israel.60 } }
+					60 = { PER = { country_event = israel.61 } }
 				}
 			}
 			if = {
-				limit = {
-					PER = {
-						all_controlled_state = {
-							anti_air_building < 5
-						}
-					}
-				}
+				limit = { PER = { all_controlled_state = { anti_air_building < 5 } } }
 				random_list = {
-					70 = {
-						PER = {
-							country_event = israel.60
-						}
-					}
-					30 = {
-						PER = {
-							country_event = israel.61
-						}
-					}
+					70 = { PER = { country_event = israel.60 } }
+					30 = { PER = { country_event = israel.61 } }
 				}
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -27089,45 +26851,17 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prevent_iraqi_nukes executed"
 			custom_effect_tooltip = irq_ope_aa_tt
 			if = {
-				limit = {
-					IRQ = {
-						all_controlled_state = {
-							anti_air_building > 5
-						}
-					}
-				}
+				limit = { IRQ = { all_controlled_state = { anti_air_building > 5 } } }
 				random_list = {
-					40 = {
-						IRQ = {
-							country_event = israel.60
-						}
-					}
-					60 = {
-						IRQ = {
-							country_event = israel.61
-						}
-					}
+					40 = { IRQ = { country_event = israel.60 } }
+					60 = { IRQ = { country_event = israel.61 } }
 				}
 			}
 			if = {
-				limit = {
-					IRQ = {
-						all_controlled_state = {
-							anti_air_building < 5
-						}
-					}
-				}
+				limit = { IRQ = { all_controlled_state = { anti_air_building < 5 } } }
 				random_list = {
-					70 = {
-						IRQ = {
-							country_event = israel.60
-						}
-					}
-					30 = {
-						IRQ = {
-							country_event = israel.61
-						}
-					}
+					70 = { IRQ = { country_event = israel.60 } }
+					30 = { IRQ = { country_event = israel.61 } }
 				}
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -27187,45 +26921,17 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prevent_libyan_nukes executed"
 			custom_effect_tooltip = lba_ope_aa_tt
 			if = {
-				limit = {
-					LBA = {
-						all_controlled_state = {
-							anti_air_building > 5
-						}
-					}
-				}
+				limit = { LBA = { all_controlled_state = { anti_air_building > 5 } } }
 				random_list = {
-					40 = {
-						LBA = {
-							country_event = israel.60
-						}
-					}
-					60 = {
-						LBA = {
-							country_event = israel.61
-						}
-					}
+					40 = { LBA = { country_event = israel.60 } }
+					60 = { LBA = { country_event = israel.61 } }
 				}
 			}
 			if = {
-				limit = {
-					LBA = {
-						all_controlled_state = {
-							anti_air_building < 5
-						}
-					}
-				}
+				limit = { LBA = { all_controlled_state = { anti_air_building < 5 } } }
 				random_list = {
-					70 = {
-						LBA = {
-							country_event = israel.60
-						}
-					}
-					30 = {
-						LBA = {
-							country_event = israel.61
-						}
-					}
+					70 = { LBA = { country_event = israel.60 } }
+					30 = { LBA = { country_event = israel.61 } }
 				}
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -27259,9 +26965,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_dimona executed"
 			add_stability = 0.02
 			add_threat = 5
-			set_temp_variable = {
-				percent_change = 3
-			}
+			set_temp_variable = { percent_change = 3 }
 			change_domestic_influence_percentage = yes
 		}
 
@@ -27301,21 +27005,15 @@ focus_tree = {
 			news_event = israel_news.14
 			increase_economic_growth = yes
 			if = {
-				limit = {
-					is_middle_eastern_nation = yes
-				}
+				limit = { is_middle_eastern_nation = yes }
 				add_opinion_modifier = {
 					target = ISR
 					modifier = tensions_eased
 				}
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 		}
 
@@ -27364,9 +27062,7 @@ focus_tree = {
 			}
 			if = {
 				limit = { NOT = { has_tech = reactor3 } }
-				set_technology = {
-					reactor3 = 1
-				}
+				set_technology = { reactor3 = 1 }
 			}
 			else = {
 				add_tech_bonus = {
@@ -27376,13 +27072,9 @@ focus_tree = {
 					category = CAT_nuclear
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -18
-			}
+			set_temp_variable = { treasury_change = -18 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
 		}
 
@@ -27457,9 +27149,7 @@ focus_tree = {
 				remove_idea = ISR_air_profs_idea
 				add_idea = ISR_air_profs_idea2
 			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
@@ -27496,9 +27186,7 @@ focus_tree = {
 				remove_idea = ISR_air_profs_idea2
 				add_idea = ISR_air_profs_idea3
 			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -27532,9 +27220,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_shuffle_squadrons"
 			ghost_decr = yes
 			add_stability = -0.03
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_military_opinion = yes
 		}
 
@@ -27628,9 +27314,7 @@ focus_tree = {
 				remove_idea = ISR_air_reservists_idea
 				add_idea = ISR_air_reservists_idea2
 			}
-			add_to_variable = {
-				party_pop_array^21 = 0.055
-			}
+			add_to_variable = { party_pop_array^21 = 0.055 }
 			recalculate_party = yes
 		}
 
@@ -27659,13 +27343,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_brothers_in_arms_air"
 			ghost_incr = yes
-			add_to_variable = {
-				party_pop_array^21 = 0.055
-			}
+			add_to_variable = { party_pop_array^21 = 0.055 }
 			recalculate_party = yes
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_the_military_opinion = yes
 		}
 
@@ -27697,9 +27377,7 @@ focus_tree = {
 				remove_idea = ISR_air_reservists_idea2
 				add_idea = ISR_air_reservists_idea3
 			}
-			add_to_variable = {
-				party_pop_array^21 = 0.055
-			}
+			add_to_variable = { party_pop_array^21 = 0.055 }
 			recalculate_party = yes
 		}
 
@@ -27779,9 +27457,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus ISR_villa_in_the_jungle"
-			SYR = {
-				country_event = israel.56
-			}
+			SYR = { country_event = israel.56 }
 			custom_effect_tooltip = syr_manip_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -27814,9 +27490,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_icbm
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -27915,9 +27589,7 @@ focus_tree = {
 				remove_idea = kirya_glilot_tensions
 				add_idea = kirya_ontop
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -27954,9 +27626,7 @@ focus_tree = {
 				remove_idea = kirya_glilot_tensions
 				add_idea = gilot_ontop
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -27993,9 +27663,7 @@ focus_tree = {
 				remove_idea = kirya_glilot_tensions
 				add_idea = kirya_gilot_middle
 			}
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 		}
 
@@ -28060,9 +27728,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_missile
 			}
-			set_temp_variable = {
-				treasury_change = -6
-			}
+			set_temp_variable = { treasury_change = -6 }
 			modify_treasury_effect = yes
 		}
 
@@ -28100,9 +27766,7 @@ focus_tree = {
 				uses = 3
 				category = CAT_OLV
 			}
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -28141,9 +27805,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_missile
 			}
-			set_temp_variable = {
-				treasury_change = -4
-			}
+			set_temp_variable = { treasury_change = -4 }
 			modify_treasury_effect = yes
 		}
 
@@ -28252,9 +27914,7 @@ focus_tree = {
 				uses = 3
 				category = CAT_l_drone
 			}
-			set_temp_variable = {
-				treasury_change = -20
-			}
+			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
 
@@ -28284,16 +27944,12 @@ focus_tree = {
 
 		available = {
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ilan_ramon executed"
-			USA = {
-				country_event = israel.16
-			}
+			USA = { country_event = israel.16 }
 			custom_effect_tooltip = isr_usa_flight_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -28323,9 +27979,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_spaceil executed"
 			add_ideas = Private_Sector_Space_Program
-			set_temp_variable = {
-				treasury_change = -15
-			}
+			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 		}
 
@@ -28364,9 +28018,7 @@ focus_tree = {
 					add_idea = Private_Sector_Space_Program1
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -20
-			}
+			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
 
@@ -28404,9 +28056,7 @@ focus_tree = {
 				uses = 2
 				category = cat_satellite
 			}
-			set_temp_variable = {
-				treasury_change = -10
-			}
+			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 		}
 
@@ -28447,9 +28097,7 @@ focus_tree = {
 				uses = 2
 				category = cat_space
 			}
-			set_temp_variable = {
-				treasury_change = -15
-			}
+			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 		}
 
@@ -28482,9 +28130,7 @@ focus_tree = {
 				idea = ISR_economic_startup
 				days = 1500
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -28543,19 +28189,13 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			207 = {
-				is_controlled_by = ISR
-			}
+			207 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tel_aviv_priority executed"
-			207 = {
-				two_state_office_construction = yes
-			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			207 = { two_state_office_construction = yes }
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -28601,9 +28241,7 @@ focus_tree = {
 				start_state = 207
 				target_state = 204
 			}
-			set_temp_variable = {
-				treasury_change = -2.6
-			}
+			set_temp_variable = { treasury_change = -2.6 }
 			modify_treasury_effect = yes
 			204 = {
 				if = { limit = { has_dynamic_modifier = { modifier = ISR_infrastruc_problems } } remove_dynamic_modifier = { modifier = ISR_infrastruc_problems } }
@@ -28611,19 +28249,11 @@ focus_tree = {
 			207 = {
 				if = { limit = { has_dynamic_modifier = { modifier = ISR_infrastruc_problems } } remove_dynamic_modifier = { modifier = ISR_infrastruc_problems } }
 			}
-			set_temp_variable = {
-				percent_change = 2.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PAL
-			}
+			set_temp_variable = { percent_change = 2.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PAL }
 			change_influence_percentage = yes
-			add_to_variable = {
-				ISR_palestine_situation_additional = 7
-			}
+			add_to_variable = { ISR_palestine_situation_additional = 7 }
 		}
 
 		ai_will_do = {
@@ -28651,25 +28281,15 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			207 = {
-				is_controlled_by = ISR
-			}
+			207 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_jerusalem_light_rail executed"
-			207 = {
-				add_dynamic_modifier = {
-					modifier = ISR_jerus_lightrail_mod
-				}
-			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			207 = { add_dynamic_modifier = { modifier = ISR_jerus_lightrail_mod } }
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -28698,25 +28318,15 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			204 = {
-				is_controlled_by = ISR
-			}
+			204 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tel_aviv_metro executed"
-			204 = {
-				add_dynamic_modifier = {
-					modifier = ISR_tel_aviv_metro_mod
-				}
-			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			204 = { add_dynamic_modifier = { modifier = ISR_tel_aviv_metro_mod } }
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -28751,9 +28361,7 @@ focus_tree = {
 				idea = ISR_begin_projects
 				days = 1095
 			}
-			set_temp_variable = {
-				treasury_change = -3.75
-			}
+			set_temp_variable = { treasury_change = -3.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -28776,12 +28384,8 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects2
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
+			NOT = { has_idea = ISR_begin_projects2 }
+			206 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -28797,9 +28401,7 @@ focus_tree = {
 				start_state = 206
 				target_state = 206
 			}
-			set_temp_variable = {
-				treasury_change = -2.6
-			}
+			set_temp_variable = { treasury_change = -2.6 }
 			modify_treasury_effect = yes
 			206 = {
 				if = { limit = { has_dynamic_modifier = { modifier = ISR_infrastruc_problems } } remove_dynamic_modifier = { modifier = ISR_infrastruc_problems } }
@@ -28831,19 +28433,13 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects2
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
+			NOT = { has_idea = ISR_begin_projects2 }
+			206 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_coastal_southern_road executed"
-			206 = {
-				two_state_infrastructure = yes
-			}
+			206 = { two_state_infrastructure = yes }
 		}
 
 		ai_will_do = {
@@ -28871,19 +28467,11 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects2
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
-			213 = {
-				is_controlled_by = EGY
-			}
+			NOT = { has_idea = ISR_begin_projects2 }
+			206 = { is_controlled_by = ISR }
+			213 = { is_controlled_by = EGY }
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 			EGY = {
 				has_opinion = {
 					target = ISR
@@ -28894,9 +28482,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_egypt_train_offer executed"
-			EGY = {
-				country_event = israel_economy.193
-			}
+			EGY = { country_event = israel_economy.193 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				build_railway = {
@@ -28910,19 +28496,11 @@ focus_tree = {
 					start_state = 206
 					target_state = 213
 				}
-				set_temp_variable = {
-					treasury_change = -1.5
-				}
+				set_temp_variable = { treasury_change = -1.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 				change_influence_percentage = yes
 			}
 		}
@@ -28947,15 +28525,9 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects2
-			}
-			204 = {
-				is_controlled_by = ISR
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
+			NOT = { has_idea = ISR_begin_projects2 }
+			204 = { is_controlled_by = ISR }
+			206 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -28972,9 +28544,7 @@ focus_tree = {
 				start_state = 204
 				target_state = 206
 			}
-			set_temp_variable = {
-				treasury_change = -3
-			}
+			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 		}
 
@@ -29009,9 +28579,7 @@ focus_tree = {
 				idea = ISR_begin_projects2
 				days = 1095
 			}
-			set_temp_variable = {
-				treasury_change = -3.75
-			}
+			set_temp_variable = { treasury_change = -3.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -29034,15 +28602,9 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects
-			}
-			587 = {
-				is_controlled_by = ISR
-			}
-			205 = {
-				is_controlled_by = ISR
-			}
+			NOT = { has_idea = ISR_begin_projects }
+			587 = { is_controlled_by = ISR }
+			205 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -29065,9 +28627,7 @@ focus_tree = {
 				start_state = 205
 				target_state = 587
 			}
-			set_temp_variable = {
-				treasury_change = -3.5
-			}
+			set_temp_variable = { treasury_change = -3.5 }
 			modify_treasury_effect = yes
 			205 = {
 				if = { limit = { has_dynamic_modifier = { modifier = ISR_infrastruc_problems } } remove_dynamic_modifier = { modifier = ISR_infrastruc_problems } }
@@ -29102,9 +28662,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects
-			}
+			NOT = { has_idea = ISR_begin_projects }
 		}
 
 		completion_reward = {
@@ -29116,9 +28674,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_construction_tech
 			}
-			set_temp_variable = {
-				treasury_change = -2.5
-			}
+			set_temp_variable = { treasury_change = -2.5 }
 			modify_treasury_effect = yes
 		}
 
@@ -29148,19 +28704,11 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects
-			}
-			206 = {
-				is_controlled_by = ISR
-			}
-			210 = {
-				is_controlled_by = JOR
-			}
+			NOT = { has_idea = ISR_begin_projects }
+			206 = { is_controlled_by = ISR }
+			210 = { is_controlled_by = JOR }
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -29171,9 +28719,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_jordan_israel_rail executed"
-			JOR = {
-				country_event = israel_economy.196
-			}
+			JOR = { country_event = israel_economy.196 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				build_railway = {
@@ -29187,19 +28733,11 @@ focus_tree = {
 					start_state = 206
 					target_state = 210
 				}
-				set_temp_variable = {
-					treasury_change = -1.5
-				}
+				set_temp_variable = { treasury_change = -1.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -29227,9 +28765,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -29237,9 +28773,7 @@ focus_tree = {
 				}
 			}
 			country_exists = UAE
-			NOT = {
-				has_war_with = UAE
-			}
+			NOT = { has_war_with = UAE }
 			UAE = {
 				has_opinion = {
 					target = ISR
@@ -29247,9 +28781,7 @@ focus_tree = {
 				}
 			}
 			country_exists = RAJ
-			NOT = {
-				has_war_with = RAJ
-			}
+			NOT = { has_war_with = RAJ }
 			RAJ = {
 				has_opinion = {
 					target = ISR
@@ -29271,15 +28803,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_middle_eastern_quad executed"
 			add_ideas = ISR_quad_idea
-			USA = {
-				country_event = israel_economy.202
-			}
-			UAE = {
-				country_event = israel_economy.202
-			}
-			RAJ = {
-				country_event = israel_economy.202
-			}
+			USA = { country_event = israel_economy.202 }
+			UAE = { country_event = israel_economy.202 }
+			RAJ = { country_event = israel_economy.202 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = three_perc_inf
@@ -29307,19 +28833,11 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_begin_projects
-			}
-			210 = {
-				is_controlled_by = JOR
-			}
-			933 = {
-				is_controlled_by = SAU
-			}
+			NOT = { has_idea = ISR_begin_projects }
+			210 = { is_controlled_by = JOR }
+			933 = { is_controlled_by = SAU }
 			country_exists = SAU
-			NOT = {
-				has_war_with = SAU
-			}
+			NOT = { has_war_with = SAU }
 			SAU = {
 				has_opinion = {
 					target = ISR
@@ -29330,9 +28848,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_israel_gulf_highway executed"
-			SAU = {
-				country_event = israel_economy.199
-			}
+			SAU = { country_event = israel_economy.199 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				build_railway = {
@@ -29345,9 +28861,7 @@ focus_tree = {
 					start_state = 210
 					target_state = 933
 				}
-				set_temp_variable = {
-					treasury_change = -1.5
-				}
+				set_temp_variable = { treasury_change = -1.5 }
 				modify_treasury_effect = yes
 			}
 		}
@@ -29381,12 +28895,8 @@ focus_tree = {
 				tooltip = TT_ALL_EU_MEMBER_NATIONS_GAIN
 				if = {
 					limit = {
-						NOT = {
-							has_war_with = ISR
-						}
-						NOT = {
-							has_war_with = RAJ
-						}
+						NOT = { has_war_with = ISR }
+						NOT = { has_war_with = RAJ }
 					}
 					add_opinion_modifier = {
 						target = ISR
@@ -29396,15 +28906,11 @@ focus_tree = {
 						target = RAJ
 						modifier = improve_trade
 					}
-					set_temp_variable = {
-						modify_europeanism = 0.03
-					}
+					set_temp_variable = { modify_europeanism = 0.03 }
 					EU_europeanism_change = yes
 				}
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 		}
 
@@ -29429,9 +28935,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_lighthouse executed"
-			set_temp_variable = {
-				treasury_change = -10
-			}
+			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = ISR_lighthouse
@@ -29482,9 +28986,7 @@ focus_tree = {
 				idea = ISR_increased_taxation
 				days = 365
 			}
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -29514,9 +29016,7 @@ focus_tree = {
 				idea = ISR_yotzma_idea
 				days = 365
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -29548,9 +29048,7 @@ focus_tree = {
 			}
 			set_temp_variable = { temp_productivity_change = 50 }
 			flat_productivity_change_effect = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 			ghost_incr = yes
 		}
@@ -29596,9 +29094,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_3d
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -29621,17 +29117,13 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = ISR_cutzpah_thing
-			}
+			NOT = { has_idea = ISR_cutzpah_thing }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_silicon_wadi executed"
 			add_ideas = ISR_silicon_wadi_idea
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -29654,21 +29146,15 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			587 = {
-				is_controlled_by = ISR
-			}
+			587 = { is_controlled_by = ISR }
 			has_stability > 0.5
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_hightech_fortress executed"
 			ghost_decr = yes
-			587 = {
-				two_state_office_construction = yes
-			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			587 = { two_state_office_construction = yes }
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -29701,21 +29187,15 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			206 = {
-				is_controlled_by = ISR
-			}
+			206 = { is_controlled_by = ISR }
 			has_stability > 0.5
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ben_gurion_university executed"
 			ghost_decr = yes
-			206 = {
-				two_state_office_construction = yes
-			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			206 = { two_state_office_construction = yes }
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -29765,9 +29245,7 @@ focus_tree = {
 				ahead_reduction = 2
 				category = CAT_ai
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			set_temp_variable = { treasury_change = -50 }
 			modify_treasury_effect = yes
@@ -29801,9 +29279,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_shine_like_a_diamond executed"
 			one_random_industrial_complex = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -29837,9 +29313,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 			SOV = {
 				has_opinion = {
 					target = ISR
@@ -29850,9 +29324,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_russia_diamonds executed"
-			SOV = {
-				country_event = israel_economy.207
-			}
+			SOV = { country_event = israel_economy.207 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
@@ -29888,9 +29360,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = CAN
-			NOT = {
-				has_war_with = CAN
-			}
+			NOT = { has_war_with = CAN }
 			CAN = {
 				has_opinion = {
 					target = ISR
@@ -29901,9 +29371,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_canada_diamonds executed"
-			CAN = {
-				country_event = israel_economy.207
-			}
+			CAN = { country_event = israel_economy.207 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
@@ -29939,9 +29407,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = BOT
-			NOT = {
-				has_war_with = BOT
-			}
+			NOT = { has_war_with = BOT }
 			BOT = {
 				has_opinion = {
 					target = ISR
@@ -29952,9 +29418,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_botswana_diamonds executed"
-			BOT = {
-				country_event = israel_economy.207
-			}
+			BOT = { country_event = israel_economy.207 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				ISR = {
@@ -29997,17 +29461,11 @@ focus_tree = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			OR = {
 				country_exists = DRC
-				NOT = {
-					has_war_with = DRC
-				}
+				NOT = { has_war_with = DRC }
 				country_exists = RCD
-				NOT = {
-					has_war_with = RCD
-				}
+				NOT = { has_war_with = RCD }
 				country_exists = MLC
-				NOT = {
-					has_war_with = MLC
-				}
+				NOT = { has_war_with = MLC }
 			}
 		}
 
@@ -30018,35 +29476,23 @@ focus_tree = {
 			if = {
 				limit = {
 					country_exists = DRC
-					NOT = {
-						has_war_with = DRC
-					}
+					NOT = { has_war_with = DRC }
 				}
-				DRC = {
-					country_event = israel_economy.207
-				}
+				DRC = { country_event = israel_economy.207 }
 			}
 			if = {
 				limit = {
 					country_exists = RCD
-					NOT = {
-						has_war_with = RCD
-					}
+					NOT = { has_war_with = RCD }
 				}
-				RCD = {
-					country_event = israel_economy.207
-				}
+				RCD = { country_event = israel_economy.207 }
 			}
 			if = {
 				limit = {
 					country_exists = MLC
-					NOT = {
-						has_war_with = MLC
-					}
+					NOT = { has_war_with = MLC }
 				}
-				MLC = {
-					country_event = israel_economy.207
-				}
+				MLC = { country_event = israel_economy.207 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -30090,9 +29536,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_kimberley_process executed"
-			set_temp_variable = {
-				treasury_change = 10
-			}
+			set_temp_variable = { treasury_change = 10 }
 			modify_treasury_effect = yes
 			decrease_corruption = yes
 		}
@@ -30125,9 +29569,7 @@ focus_tree = {
 			every_country = {
 				limit = {
 					has_country_flag = asian_nation_flag
-					NOT = {
-						has_war_with = ISR
-					}
+					NOT = { has_war_with = ISR }
 				}
 				add_opinion_modifier = {
 					target = ROOT
@@ -30137,15 +29579,9 @@ focus_tree = {
 					target = ROOT
 					modifier = improve_trade
 				}
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = THIS
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = THIS }
 				change_influence_percentage = yes
 			}
 		}
@@ -30216,9 +29652,7 @@ focus_tree = {
 				remove_idea = ISR_israeli_diamond_stuff
 				add_idea = ISR_israeli_diamond_stuff2
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -30246,9 +29680,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_transition_to_manufacturing executed"
-			set_temp_variable = {
-				treasury_change = -10
-			}
+			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 			add_tech_bonus = {
 				name = ISR_transition_to_manufacturing
@@ -30293,9 +29725,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_diamond_district executed"
 			two_random_industrial_complex = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -30350,9 +29780,7 @@ focus_tree = {
 					province = 1015
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
 
@@ -30381,9 +29809,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			204 = {
-				is_controlled_by = ISR
-			}
+			204 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -30394,9 +29820,7 @@ focus_tree = {
 					amount = 19
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -17.82
-			}
+			set_temp_variable = { treasury_change = -17.82 }
 			modify_treasury_effect = yes
 		}
 
@@ -30425,9 +29849,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			205 = {
-				is_controlled_by = ISR
-			}
+			205 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -30438,9 +29860,7 @@ focus_tree = {
 					amount = 10
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -9.38
-			}
+			set_temp_variable = { treasury_change = -9.38 }
 			modify_treasury_effect = yes
 		}
 
@@ -30469,9 +29889,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			206 = {
-				is_controlled_by = ISR
-			}
+			206 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
@@ -30482,9 +29900,7 @@ focus_tree = {
 					amount = 8
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -7.504
-			}
+			set_temp_variable = { treasury_change = -7.504 }
 			modify_treasury_effect = yes
 		}
 
@@ -30530,13 +29946,9 @@ focus_tree = {
 				idea = ISR_compromised_gas_deal
 				days = 1095
 			}
-			set_temp_variable = {
-				treasury_change = -5.5
-			}
+			set_temp_variable = { treasury_change = -5.5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = 2
-			}
+			set_temp_variable = { temp_opinion = 2 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -30578,17 +29990,11 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -12
-			}
+			set_temp_variable = { treasury_change = -12 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				percent_change = 2
-			}
+			set_temp_variable = { percent_change = 2 }
 			change_domestic_influence_percentage = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -30621,9 +30027,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = ENG
-			NOT = {
-				has_war_with = ENG
-			}
+			NOT = { has_war_with = ENG }
 			ENG = {
 				has_opinion = {
 					target = ISR
@@ -30643,23 +30047,13 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ENG
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ENG }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -30702,16 +30096,12 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = TUR
-			NOT = {
-				has_war_with = TUR
-			}
+			NOT = { has_war_with = TUR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prefer_turkey executed"
-			TUR = {
-				country_event = md4.1
-			}
+			TUR = { country_event = md4.1 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = ISR_trade_agr_seks
 			add_opinion_modifier = {
@@ -30722,15 +30112,9 @@ focus_tree = {
 				target = TUR
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = TUR
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = TUR }
 			change_influence_percentage = yes
 		}
 
@@ -30763,16 +30147,12 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = GRE
-			NOT = {
-				has_war_with = GRE
-			}
+			NOT = { has_war_with = GRE }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prefer_greece executed"
-			GRE = {
-				country_event = md4.1
-			}
+			GRE = { country_event = md4.1 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = ISR_trade_agr_seks
 			add_opinion_modifier = {
@@ -30783,15 +30163,9 @@ focus_tree = {
 				target = GRE
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GRE
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GRE }
 			change_influence_percentage = yes
 		}
 
@@ -30814,9 +30188,7 @@ focus_tree = {
 
 		available = {
 			country_exists = GRE
-			NOT = {
-				has_war_with = GRE
-			}
+			NOT = { has_war_with = GRE }
 			GRE = {
 				has_opinion = {
 					target = ISR
@@ -30827,9 +30199,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_blue_flag executed"
-			GRE = {
-				country_event = md4.4
-			}
+			GRE = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -30849,15 +30219,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GRE
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GRE }
 			change_influence_percentage = yes
 		}
 
@@ -30882,9 +30246,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = GRE
-			NOT = {
-				has_war_with = GRE
-			}
+			NOT = { has_war_with = GRE }
 			GRE = {
 				has_opinion = {
 					target = ISR
@@ -30904,19 +30266,11 @@ focus_tree = {
 				target = TUR
 				modifier = ideological_enemy
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GRE
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GRE }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -30941,9 +30295,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = GRE
-			NOT = {
-				has_war_with = GRE
-			}
+			NOT = { has_war_with = GRE }
 			GRE = {
 				has_opinion = {
 					target = ISR
@@ -30956,22 +30308,12 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_east_med_pipeline executed"
 			add_ideas = ISR_pipeline_2
 			news_event = israel_news.6
-			GRE = {
-				country_event = israel_economy.214
-			}
-			set_temp_variable = {
-				percent_change = 2.5
-			}
-			set_temp_variable = {
-				tag_index = GRE
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			GRE = { country_event = israel_economy.214 }
+			set_temp_variable = { percent_change = 2.5 }
+			set_temp_variable = { tag_index = GRE }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				treasury_change = -11
-			}
+			set_temp_variable = { treasury_change = -11 }
 			modify_treasury_effect = yes
 		}
 
@@ -31007,13 +30349,9 @@ focus_tree = {
 					value > 24
 				}
 			}
-			NOT = {
-				has_war_with = TUR
-			}
+			NOT = { has_war_with = TUR }
 			country_exists = NCY
-			NOT = {
-				has_war_with = NCY
-			}
+			NOT = { has_war_with = NCY }
 		}
 
 		completion_reward = {
@@ -31027,19 +30365,11 @@ focus_tree = {
 				target = GRE
 				modifier = ideological_enemy
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = TUR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = TUR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
 
@@ -31068,9 +30398,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = TUR
-			NOT = {
-				has_war_with = TUR
-			}
+			NOT = { has_war_with = TUR }
 			TUR = {
 				has_opinion = {
 					target = ISR
@@ -31081,9 +30409,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_support_blue_homeland executed"
-			TUR = {
-				country_event = md4.4
-			}
+			TUR = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -31103,15 +30429,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = TUR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = TUR }
 			change_influence_percentage = yes
 		}
 
@@ -31140,9 +30460,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = TUR
-			NOT = {
-				has_war_with = TUR
-			}
+			NOT = { has_war_with = TUR }
 			TUR = {
 				has_opinion = {
 					target = ISR
@@ -31154,22 +30472,12 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_israel_turkey_pipeline executed"
 			add_ideas = ISR_pipeline_1
-			TUR = {
-				country_event = israel_economy.213
-			}
-			set_temp_variable = {
-				percent_change = 2.5
-			}
-			set_temp_variable = {
-				tag_index = TUR
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			TUR = { country_event = israel_economy.213 }
+			set_temp_variable = { percent_change = 2.5 }
+			set_temp_variable = { tag_index = TUR }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				treasury_change = -11
-			}
+			set_temp_variable = { treasury_change = -11 }
 			modify_treasury_effect = yes
 		}
 
@@ -31204,16 +30512,12 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = HEZ
-			205 = {
-				is_controlled_by = ISR
-			}
+			205 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_karish executed"
-			HEZ = {
-				country_event = israel_economy.210
-			}
+			HEZ = { country_event = israel_economy.210 }
 			custom_effect_tooltip = hezwileit_tt
 			205 = {
 				add_resource = {
@@ -31221,9 +30525,7 @@ focus_tree = {
 					amount = 9
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -8.4
-			}
+			set_temp_variable = { treasury_change = -8.4 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -31253,9 +30555,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			any_owned_state = {
-				is_coastal = yes
-			}
+			any_owned_state = { is_coastal = yes }
 		}
 
 		completion_reward = {
@@ -31267,9 +30567,7 @@ focus_tree = {
 				uses = 3
 				category = CAT_naval_all
 			}
-			set_temp_variable = {
-				treasury_change = -6.5
-			}
+			set_temp_variable = { treasury_change = -6.5 }
 			modify_treasury_effect = yes
 		}
 
@@ -31299,21 +30597,15 @@ focus_tree = {
 
 		available = {
 			OR = {
-				205 = {
-					is_controlled_by = ISR
-				}
-				any_owned_state = {
-					is_coastal = yes
-				}
+				205 = { is_controlled_by = ISR }
+				any_owned_state = { is_coastal = yes }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ships_saar executed"
 			navy_experience = 15
-			205 = {
-				one_state_dockyard = yes
-			}
+			205 = { one_state_dockyard = yes }
 		}
 
 		ai_will_do = {
@@ -31346,21 +30638,15 @@ focus_tree = {
 
 		available = {
 			OR = {
-				204 = {
-					is_controlled_by = ISR
-				}
-				any_owned_state = {
-					is_coastal = yes
-				}
+				204 = { is_controlled_by = ISR }
+				any_owned_state = { is_coastal = yes }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_ships_bat_yam executed"
 			navy_experience = 15
-			204 = {
-				one_state_dockyard = yes
-			}
+			204 = { one_state_dockyard = yes }
 		}
 
 		ai_will_do = {
@@ -31393,9 +30679,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			any_owned_state = {
-				is_coastal = yes
-			}
+			any_owned_state = { is_coastal = yes }
 		}
 
 		completion_reward = {
@@ -31406,9 +30690,7 @@ focus_tree = {
 				bonus = 0.3
 				category = CAT_corvette
 			}
-			set_temp_variable = {
-				treasury_change = -3.5
-			}
+			set_temp_variable = { treasury_change = -3.5 }
 			modify_treasury_effect = yes
 		}
 
@@ -31439,12 +30721,8 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = GER
-			NOT = {
-				has_war_with = GER
-			}
-			any_owned_state = {
-				is_coastal = yes
-			}
+			NOT = { has_war_with = GER }
+			any_owned_state = { is_coastal = yes }
 		}
 
 		bypass = { NOT = { country_exists = GER } }
@@ -31452,18 +30730,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_thyssenkrupp_deal executed"
 			custom_effect_tooltip = ISR_ger_fleet_tt
-			GER = {
-				country_event = israel.13
-			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = GER
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			GER = { country_event = israel.13 }
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = GER }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = GER
@@ -31498,9 +30768,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			any_owned_state = {
-				is_coastal = yes
-			}
+			any_owned_state = { is_coastal = yes }
 		}
 
 		completion_reward = {
@@ -31517,9 +30785,7 @@ focus_tree = {
 				bonus = 0.5
 				category = CAT_sub
 			}
-			set_temp_variable = {
-				treasury_change = -4.5
-			}
+			set_temp_variable = { treasury_change = -4.5 }
 			modify_treasury_effect = yes
 		}
 
@@ -31549,9 +30815,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			any_owned_state = {
-				is_coastal = yes
-			}
+			any_owned_state = { is_coastal = yes }
 		}
 
 		completion_reward = {
@@ -31563,9 +30827,7 @@ focus_tree = {
 				category = CAT_surface_ship
 				category = CAT_sub
 			}
-			set_temp_variable = {
-				treasury_change = -9
-			}
+			set_temp_variable = { treasury_change = -9 }
 			modify_treasury_effect = yes
 			two_random_dockyards = yes
 		}
@@ -31603,12 +30865,8 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = GER
-			NOT = {
-				has_war_with = GER
-			}
-			any_owned_state = {
-				is_coastal = yes
-			}
+			NOT = { has_war_with = GER }
+			any_owned_state = { is_coastal = yes }
 		}
 
 		bypass = { NOT = { country_exists = GER } }
@@ -31616,13 +30874,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_bibi_submarine_deal executed"
 			add_political_power = 100
-			GER = {
-				country_event = israel_navy.13
-			}
+			GER = { country_event = israel_navy.13 }
 			custom_effect_tooltip = ISR_ger_fleet_again_tt
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -31652,12 +30906,8 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			OR = {
-				204 = {
-					is_controlled_by = ISR
-				}
-				any_owned_state = {
-					is_coastal = yes
-				}
+				204 = { is_controlled_by = ISR }
+				any_owned_state = { is_coastal = yes }
 			}
 		}
 
@@ -31676,13 +30926,9 @@ focus_tree = {
 				uses = 2
 				category = CAT_green_water_navy
 			}
-			set_temp_variable = {
-				treasury_change = -7.5
-			}
+			set_temp_variable = { treasury_change = -7.5 }
 			modify_treasury_effect = yes
-			set_temp_variable = {
-				temp_opinion = -5
-			}
+			set_temp_variable = { temp_opinion = -5 }
 			change_small_medium_business_owners_opinion = yes
 		}
 
@@ -31715,20 +30961,14 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			NOT = {
-				has_idea = kirya_glilot_tensions
-			}
-			any_owned_state = {
-				is_coastal = yes
-			}
+			NOT = { has_idea = kirya_glilot_tensions }
+			any_owned_state = { is_coastal = yes }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_madan executed"
 			add_ideas = madan_idea
-			set_temp_variable = {
-				treasury_change = -9
-			}
+			set_temp_variable = { treasury_change = -9 }
 			modify_treasury_effect = yes
 		}
 
@@ -31786,12 +31026,8 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_support_our_pmcs executed"
 			add_command_power = 10
 			add_ideas = ISR_pmc_first_idea
-			set_rule = {
-				can_send_volunteers = yes
-			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_rule = { can_send_volunteers = yes }
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -31828,13 +31064,9 @@ focus_tree = {
 				remove_idea = ISR_pmc_first_idea
 				add_idea = ISR_pmc_sec_idea
 			}
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -31871,13 +31103,9 @@ focus_tree = {
 				remove_idea = ISR_pmc_first_idea
 				add_idea = ISR_pmc_three_idea
 			}
-			set_temp_variable = {
-				temp_opinion = 10
-			}
+			set_temp_variable = { temp_opinion = 10 }
 			change_small_medium_business_owners_opinion = yes
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -31910,21 +31138,15 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_women_corps executed"
 			if = {
-				limit = {
-					has_idea = no_women_in_military
-				}
+				limit = { has_idea = no_women_in_military }
 				set_volunteer_women_effect = yes
 			}
 			if = {
-				limit = {
-					has_idea = volunteer_women
-				}
+				limit = { has_idea = volunteer_women }
 				set_drafted_women_effect = yes
 			}
 			if = {
-				limit = {
-					has_idea = drafted_women
-				}
+				limit = { has_idea = drafted_women }
 				add_war_support = 0.15
 			}
 		}
@@ -31957,12 +31179,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_yohalam executed"
 			add_stability = 0.02
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 		}
 
@@ -32047,11 +31265,7 @@ focus_tree = {
 				}
 			}
 			random_owned_controlled_state = {
-				limit = {
-					ROOT = {
-						has_full_control_of_state = PREV
-					}
-				}
+				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = {
 					652
 				}
@@ -32060,9 +31274,7 @@ focus_tree = {
 					owner = ISR
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -32127,11 +31339,7 @@ focus_tree = {
 				}
 			}
 			random_owned_controlled_state = {
-				limit = {
-					ROOT = {
-						has_full_control_of_state = PREV
-					}
-				}
+				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = {
 					652
 				}
@@ -32140,9 +31348,7 @@ focus_tree = {
 					owner = ISR
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -32178,12 +31384,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_army_builds_society executed"
 			add_war_support = 0.05
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			increase_military_spending = yes
 		}
@@ -32210,22 +31412,14 @@ focus_tree = {
 
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
-			206 = {
-				is_controlled_by = ISR
-			}
-			205 = {
-				is_controlled_by = ISR
-			}
+			206 = { is_controlled_by = ISR }
+			205 = { is_controlled_by = ISR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_gsharim executed"
-			206 = {
-				add_extra_state_shared_building_slots = 1
-			}
-			205 = {
-				add_extra_state_shared_building_slots = 1
-			}
+			206 = { add_extra_state_shared_building_slots = 1 }
+			205 = { add_extra_state_shared_building_slots = 1 }
 		}
 
 		ai_will_do = {
@@ -32279,17 +31473,11 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			country_exists = FRA
-			NOT = {
-				has_war_with = FRA
-			}
+			NOT = { has_war_with = FRA }
 			country_exists = CHI
-			NOT = {
-				has_war_with = CHI
-			}
+			NOT = { has_war_with = CHI }
 		}
 
 		bypass = {
@@ -32305,15 +31493,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_fill_our_stocks executed"
 			custom_effect_tooltip = ISR_chi_ar_TT
-			USA = {
-				country_event = israel_economy.1
-			}
-			FRA = {
-				country_event = israel_economy.1
-			}
-			CHI = {
-				country_event = israel_economy.1
-			}
+			USA = { country_event = israel_economy.1 }
+			FRA = { country_event = israel_economy.1 }
+			CHI = { country_event = israel_economy.1 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
 
@@ -32351,9 +31533,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_mbt
 			}
-			set_temp_variable = {
-				treasury_change = -20
-			}
+			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
 
@@ -32408,9 +31588,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -17.5
-			}
+			set_temp_variable = { treasury_change = -17.5 }
 			modify_treasury_effect = yes
 		}
 
@@ -32463,9 +31641,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -12.5
-			}
+			set_temp_variable = { treasury_change = -12.5 }
 			modify_treasury_effect = yes
 		}
 
@@ -32511,9 +31687,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_inf_wep
 			}
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 		}
 
@@ -32546,17 +31720,11 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_civillian_exports executed"
-			hidden_effect = {
-				add_ideas = civ_guns_exports
-			}
+			hidden_effect = { add_ideas = civ_guns_exports }
 			custom_effect_tooltip = add_income_two_tt
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
-			set_temp_variable = {
-				temp_opinion = -10
-			}
+			set_temp_variable = { temp_opinion = -10 }
 			change_the_military_opinion = yes
 		}
 
@@ -32584,9 +31752,7 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			country_exists = SOV
-			NOT = {
-				has_war_with = SOV
-			}
+			NOT = { has_war_with = SOV }
 			SOV = {
 				has_opinion = {
 					target = ISR
@@ -32611,15 +31777,9 @@ focus_tree = {
 					uses = 1
 					category = CAT_inf_wep
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = SOV
-				}
-				set_temp_variable = {
-					influence_target = ISR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = SOV }
+				set_temp_variable = { influence_target = ISR }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = SOV
@@ -32675,9 +31835,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -15
-			}
+			set_temp_variable = { treasury_change = -15 }
 			modify_treasury_effect = yes
 		}
 
@@ -32733,9 +31891,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -30
-			}
+			set_temp_variable = { treasury_change = -30 }
 			modify_treasury_effect = yes
 		}
 
@@ -32776,9 +31932,7 @@ focus_tree = {
 				add_idea = ISR_modernization_of_armored_forces_2_idea
 			}
 			if = {
-				limit = {
-					has_dlc = "No Step Back"
-				}
+				limit = { has_dlc = "No Step Back" }
 				add_tech_bonus = {
 					name = ISR_eitan
 					bonus = 0.2
@@ -32794,9 +31948,7 @@ focus_tree = {
 					category = CAT_apc
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -20
-			}
+			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
 
@@ -32834,9 +31986,7 @@ focus_tree = {
 				uses = 1
 				category = CAT_sp_arty
 			}
-			set_temp_variable = {
-				treasury_change = -10
-			}
+			set_temp_variable = { treasury_change = -10 }
 			modify_treasury_effect = yes
 		}
 
@@ -32879,9 +32029,7 @@ focus_tree = {
 				uses = 2
 				category = CAT_mbt
 			}
-			set_temp_variable = {
-				treasury_change = -20
-			}
+			set_temp_variable = { treasury_change = -20 }
 			modify_treasury_effect = yes
 		}
 
@@ -33015,14 +32163,10 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			has_war = no
-			has_army_manpower = {
-				size > 120000
-			}
+			has_army_manpower = { size > 120000 }
 			command_power > 50
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			USA = {
 				has_opinion = {
 					target = ISR
@@ -33042,13 +32186,9 @@ focus_tree = {
 				uses = 1
 				cost_reduction = 0.25
 			}
-			USA = {
-				country_event = israel.5
-			}
+			USA = { country_event = israel.5 }
 			add_command_power = -50
-			set_temp_variable = {
-				treasury_change = -2.75
-			}
+			set_temp_variable = { treasury_change = -2.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33089,26 +32229,20 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_flash_formations executed"
 			custom_effect_tooltip = will_appear_after_dec_tt
 			if = {
-				limit = {
-					has_idea = ISR_gideon_plan_idea
-				}
+				limit = { has_idea = ISR_gideon_plan_idea }
 				swap_ideas = {
 					remove_idea = ISR_gideon_plan_idea
 					add_idea = ISR_gideon_plan_idea_usa_1
 				}
 			}
 			if = {
-				limit = {
-					has_idea = ISR_tenufa_project_idea
-				}
+				limit = { has_idea = ISR_tenufa_project_idea }
 				swap_ideas = {
 					remove_idea = ISR_tenufa_project_idea
 					add_idea = ISR_tenufa_project_idea_usa_1
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5.75
-			}
+			set_temp_variable = { treasury_change = -5.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33149,26 +32283,20 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_lightning_campaign executed"
 			custom_effect_tooltip = will_appear_after_dec_tt
 			if = {
-				limit = {
-					has_idea = ISR_gideon_plan_idea_usa_1
-				}
+				limit = { has_idea = ISR_gideon_plan_idea_usa_1 }
 				swap_ideas = {
 					remove_idea = ISR_gideon_plan_idea_usa_1
 					add_idea = ISR_gideon_plan_idea_usa_2
 				}
 			}
 			if = {
-				limit = {
-					has_idea = ISR_tenufa_project_idea_usa_1
-				}
+				limit = { has_idea = ISR_tenufa_project_idea_usa_1 }
 				swap_ideas = {
 					remove_idea = ISR_tenufa_project_idea_usa_1
 					add_idea = ISR_tenufa_project_idea_usa_2
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -6.75
-			}
+			set_temp_variable = { treasury_change = -6.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33210,9 +32338,7 @@ focus_tree = {
 				add_idea = ISR_sayaret_matkal_drills_2
 			}
 			add_command_power = -50
-			set_temp_variable = {
-				treasury_change = -3.75
-			}
+			set_temp_variable = { treasury_change = -3.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33272,11 +32398,7 @@ focus_tree = {
 				priority = 2
 			}
 			random_owned_controlled_state = {
-				limit = {
-					ROOT = {
-						has_full_control_of_state = PREV
-					}
-				}
+				limit = { ROOT = { has_full_control_of_state = PREV } }
 				prioritize = {
 					46
 				}
@@ -33290,9 +32412,7 @@ focus_tree = {
 				add_idea = ISR_sayaret_matkal_drills_3
 			}
 			add_command_power = -60
-			set_temp_variable = {
-				treasury_change = -7.75
-			}
+			set_temp_variable = { treasury_change = -7.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33340,9 +32460,7 @@ focus_tree = {
 				uses = 1
 				cost_reduction = 0.3
 			}
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 
@@ -33377,23 +32495,17 @@ focus_tree = {
 		available = {
 			NOT = { has_active_mission = bankruptcy_incoming_collapse }
 			has_war = no
-			has_army_manpower = {
-				size > 120000
-			}
+			has_army_manpower = { size > 120000 }
 			command_power > 50
 			country_exists = CYP
-			NOT = {
-				has_war_with = CYP
-			}
+			NOT = { has_war_with = CYP }
 			CYP = {
 				has_opinion = {
 					target = ISR
 					value > 19
 				}
 			}
-			NOT = {
-				has_completed_focus = ISR_prefer_turkey
-			}
+			NOT = { has_completed_focus = ISR_prefer_turkey }
 		}
 
 		completion_reward = {
@@ -33406,13 +32518,9 @@ focus_tree = {
 				uses = 1
 				cost_reduction = 0.25
 			}
-			CYP = {
-				country_event = israel.6
-			}
+			CYP = { country_event = israel.6 }
 			add_command_power = -50
-			set_temp_variable = {
-				treasury_change = -2.75
-			}
+			set_temp_variable = { treasury_change = -2.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33453,26 +32561,20 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_operating_to_victory executed"
 			custom_effect_tooltip = will_appear_after_dec_tt
 			if = {
-				limit = {
-					has_idea = ISR_gideon_plan_idea
-				}
+				limit = { has_idea = ISR_gideon_plan_idea }
 				swap_ideas = {
 					remove_idea = ISR_gideon_plan_idea
 					add_idea = ISR_gideon_plan_idea_cyprus_1
 				}
 			}
 			if = {
-				limit = {
-					has_idea = ISR_tenufa_project_idea
-				}
+				limit = { has_idea = ISR_tenufa_project_idea }
 				swap_ideas = {
 					remove_idea = ISR_tenufa_project_idea
 					add_idea = ISR_tenufa_project_idea_cyprus_1
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5.75
-			}
+			set_temp_variable = { treasury_change = -5.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33513,26 +32615,20 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prepare_maneuvers executed"
 			custom_effect_tooltip = will_appear_after_dec_tt
 			if = {
-				limit = {
-					has_idea = ISR_gideon_plan_idea_cyprus_1
-				}
+				limit = { has_idea = ISR_gideon_plan_idea_cyprus_1 }
 				swap_ideas = {
 					remove_idea = ISR_gideon_plan_idea_cyprus_1
 					add_idea = ISR_gideon_plan_idea_cyprus_2
 				}
 			}
 			if = {
-				limit = {
-					has_idea = ISR_tenufa_project_idea_cyprus_1
-				}
+				limit = { has_idea = ISR_tenufa_project_idea_cyprus_1 }
 				swap_ideas = {
 					remove_idea = ISR_tenufa_project_idea_cyprus_1
 					add_idea = ISR_tenufa_project_idea_cyprus_2
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -6.75
-			}
+			set_temp_variable = { treasury_change = -6.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33571,9 +32667,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_prioritize_golani executed"
 			587 = {
 				if = {
-					limit = {
-						is_controlled_by = ISR
-					}
+					limit = { is_controlled_by = ISR }
 					custom_effect_tooltip = golan_fort_tt
 					hidden_effect = {
 						add_building_construction = {
@@ -33590,9 +32684,7 @@ focus_tree = {
 				add_idea = ISR_paphos_drills_2
 			}
 			add_command_power = -50
-			set_temp_variable = {
-				treasury_change = -5.75
-			}
+			set_temp_variable = { treasury_change = -5.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33634,9 +32726,7 @@ focus_tree = {
 				add_idea = ISR_paphos_drills_3
 			}
 			add_command_power = -60
-			set_temp_variable = {
-				treasury_change = -7.75
-			}
+			set_temp_variable = { treasury_change = -7.75 }
 			modify_treasury_effect = yes
 		}
 
@@ -33686,9 +32776,7 @@ focus_tree = {
 				uses = 1
 				cost_reduction = 0.3
 			}
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 		}
 

--- a/common/national_focus/05_israel.txt
+++ b/common/national_focus/05_israel.txt
@@ -13703,9 +13703,7 @@ focus_tree = {
 
 		available = {
 			country_exists = IRQ
-			IRQ = {
-				nationalist_fascist_are_in_power = yes
-			}
+			IRQ = { nationalist_fascist_are_in_power = yes }
 		}
 
 		bypass = { NOT = { IRQ = { nationalist_fascist_are_in_power = yes } } }
@@ -13713,9 +13711,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_iraq_war executed"
 			if = {
-				limit = {
-					country_exists = JOR
-				}
+				limit = { country_exists = JOR }
 				JOR = {
 					add_opinion_modifier = {
 						modifier = threat_to_our_independence
@@ -13725,15 +13721,9 @@ focus_tree = {
 						modifier = threat_to_our_independence
 						target = IRQ
 					}
-					set_temp_variable = {
-						percent_change = -5
-					}
-					set_temp_variable = {
-						tag_index = IRQ
-					}
-					set_temp_variable = {
-						influence_target = JOR
-					}
+					set_temp_variable = { percent_change = -5 }
+					set_temp_variable = { tag_index = IRQ }
+					set_temp_variable = { influence_target = JOR }
 					change_influence_percentage = yes
 				}
 			}
@@ -13745,15 +13735,9 @@ focus_tree = {
 				modifier = threat_to_our_independence
 				target = IRQ
 			}
-			set_temp_variable = {
-				percent_change = -5
-			}
-			set_temp_variable = {
-				tag_index = IRQ
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = -5 }
+			set_temp_variable = { tag_index = IRQ }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 		}
 
@@ -13779,9 +13763,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -13794,13 +13776,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_intelligence_sharing_jordan executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
-			JOR = {
-				country_event = israel_economy.137
-			}
+			JOR = { country_event = israel_economy.137 }
 			custom_effect_tooltip = wewillspendtwenty_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -13829,37 +13807,23 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_jordan_river_agreement executed"
-			JOR = {
-				country_event = israel_economy.185
-			}
+			JOR = { country_event = israel_economy.185 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = 10
-				}
+				set_temp_variable = { treasury_change = 10 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
-				JOR = {
-					add_ideas = ISR_jor_water_share
-				}
+				JOR = { add_ideas = ISR_jor_water_share }
 			}
 		}
 
@@ -13893,9 +13857,7 @@ focus_tree = {
 				add_hydroelectric_energy_production_effect = yes
 			}
 			if = {
-				limit = {
-					country_exists = JOR
-				}
+				limit = { country_exists = JOR }
 				add_opinion_modifier = {
 					modifier = diplomatic_insults
 					target = JOR
@@ -13904,15 +13866,9 @@ focus_tree = {
 					modifier = diplomatic_insults
 					target = JOR
 				}
-				set_temp_variable = {
-					percent_change = -2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = -2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -13936,9 +13892,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
@@ -13959,20 +13913,12 @@ focus_tree = {
 					province = 1015
 				}
 			}
-			set_temp_variable = {
-				treasury_change = -5.5
-			}
+			set_temp_variable = { treasury_change = -5.5 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = infl_lease_tt
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = JOR
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = JOR }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
 		}
 
@@ -14007,9 +13953,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -14022,9 +13966,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_jordan_defensive executed"
-			JOR = {
-				country_event = md4.4
-			}
+			JOR = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -14068,9 +14010,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -14078,9 +14018,7 @@ focus_tree = {
 				}
 			}
 			country_exists = UAE
-			NOT = {
-				has_war_with = UAE
-			}
+			NOT = { has_war_with = UAE }
 			UAE = {
 				has_opinion = {
 					target = ISR
@@ -14100,46 +14038,20 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_green_blue_deal executed"
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
-			random_owned_state = {
-				add_dynamic_modifier = {
-					modifier = ISR_solar_farms
-				}
-			}
-			random_owned_state = {
-				add_dynamic_modifier = {
-					modifier = ISR_solar_farms
-				}
-			}
-			random_owned_state = {
-				add_dynamic_modifier = {
-					modifier = ISR_solar_farms
-				}
-			}
-			JOR = {
-				country_event = israel_economy.188
-			}
-			UAE = {
-				country_event = israel_economy.188
-			}
+			random_owned_state = { add_dynamic_modifier = { modifier = ISR_solar_farms } }
+			random_owned_state = { add_dynamic_modifier = { modifier = ISR_solar_farms } }
+			random_owned_state = { add_dynamic_modifier = { modifier = ISR_solar_farms } }
+			JOR = { country_event = israel_economy.188 }
+			UAE = { country_event = israel_economy.188 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = 6
-				}
+				set_temp_variable = { treasury_change = 6 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -14171,9 +14083,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			JOR = {
 				has_opinion = {
 					target = ISR
@@ -14190,12 +14100,8 @@ focus_tree = {
 				give_military_access = JOR
 				give_guarantee = JOR
 			}
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 		}
 
@@ -14229,23 +14135,15 @@ focus_tree = {
 		available = {
 			OR = {
 				country_exists = ISI
-				IRQ = {
-					has_government = fascism
-				}
-				SYR = {
-					has_government = fascism
-				}
+				IRQ = { has_government = fascism }
+				SYR = { has_government = fascism }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_war_with_isis executed"
-			set_temp_variable = {
-				party_popularity_increase = 0.05
-			}
-			set_temp_variable = {
-				temp_outlook_increase = 0.05
-			}
+			set_temp_variable = { party_popularity_increase = 0.05 }
+			set_temp_variable = { temp_outlook_increase = 0.05 }
 			change_relative_party_popularity = yes
 			add_stability = -0.05
 			add_war_support = 0.05
@@ -14256,11 +14154,7 @@ focus_tree = {
 				type = puppet_wargoal_focus
 			}
 			if = {
-				limit = {
-					SYR = {
-						has_government = fascism
-					}
-				}
+				limit = { SYR = { has_government = fascism } }
 				set_temp_variable = { wargoal_on = SYR }
 				add_threat_from_wargoal_effect = yes
 				create_wargoal = {
@@ -14269,11 +14163,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					IRQ = {
-						has_government = fascism
-					}
-				}
+				limit = { IRQ = { has_government = fascism } }
 				set_temp_variable = { wargoal_on = IRQ }
 				add_threat_from_wargoal_effect = yes
 				create_wargoal = {
@@ -14310,9 +14200,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			OR = {
 				has_idea = intervention_global_interventionism
 				has_government = nationalist
@@ -14328,9 +14216,7 @@ focus_tree = {
 				idea = ISR_jor_attack_idea
 				days = 150
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 		}
 
@@ -14353,12 +14239,8 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
-			JOR = {
-				influence_higher_20 = yes
-			}
+			NOT = { has_war_with = JOR }
+			JOR = { influence_higher_20 = yes }
 			OR = {
 				has_idea = intervention_global_interventionism
 				has_government = nationalist
@@ -14369,14 +14251,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_jordan_military_bases executed"
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			country_event = israel_economy.192
-			JOR = {
-				country_event = israel_economy.192
-			}
+			JOR = { country_event = israel_economy.192 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				JOR = {
@@ -14385,15 +14263,9 @@ focus_tree = {
 						days = 150
 					}
 				}
-				set_temp_variable = {
-					percent_change = 6
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				set_temp_variable = { percent_change = 6 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -14423,9 +14295,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			OR = {
 				has_idea = intervention_global_interventionism
 				has_government = nationalist
@@ -14437,23 +14307,13 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_manipulate_royal_family executed"
 			country_event = israel_economy.191
-			JOR = {
-				country_event = israel_economy.191
-			}
+			JOR = { country_event = israel_economy.191 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
-				JOR = {
-					add_stability = -0.1
-				}
-				set_temp_variable = {
-					percent_change = 6
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = JOR
-				}
+				JOR = { add_stability = -0.1 }
+				set_temp_variable = { percent_change = 6 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = JOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -14478,21 +14338,15 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
-			JOR = {
-				influence_higher_40 = yes
-			}
+			NOT = { has_war_with = JOR }
+			JOR = { influence_higher_40 = yes }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_puppet_jordan executed"
-			set_temp_variable = {
-				treasury_change = -25
-			}
+			set_temp_variable = { treasury_change = -25 }
 			modify_treasury_effect = yes
 			custom_effect_tooltip = ISR_REV_JOR_TT
 			hidden_effect = {
@@ -14518,9 +14372,7 @@ focus_tree = {
 						ideology = nationalist
 						popularity = 0.35
 					}
-					add_to_variable = {
-						party_pop_array^0 = 0.5
-					}
+					add_to_variable = { party_pop_array^0 = 0.5 }
 					recalculate_party = yes
 					start_civil_war = {
 						ideology = democratic
@@ -14555,9 +14407,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
@@ -14566,9 +14416,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_temple_mount_issue executed"
 			add_political_power = 50
 			add_stability = -0.02
-			set_temp_variable = {
-				temp_opinion = 2
-			}
+			set_temp_variable = { temp_opinion = 2 }
 			change_the_priesthood_opinion = yes
 		}
 
@@ -14592,9 +14440,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
@@ -14603,9 +14449,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_status_quo_temple_mount executed"
 			add_stability = 0.05
 			every_country = {
-				limit = {
-					has_idea = sunni
-				}
+				limit = { has_idea = sunni }
 				add_opinion_modifier = {
 					modifier = political_outreach
 					target = ISR
@@ -14641,9 +14485,7 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
@@ -14658,22 +14500,12 @@ focus_tree = {
 				target = JOR
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = JOR
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = JOR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				receiver_nation = ISR.id
-			}
-			set_temp_variable = {
-				sender_nation = JOR.id
-			}
+			set_temp_variable = { receiver_nation = ISR.id }
+			set_temp_variable = { sender_nation = JOR.id }
 			set_improved_trade_agreement = yes
 		}
 
@@ -14701,22 +14533,16 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			country_exists = SAU
-			NOT = {
-				has_war_with = SAU
-			}
+			NOT = { has_war_with = SAU }
 			SAU = {
 				has_opinion = {
 					target = ISR
 					value > 24
 				}
 			}
-			207 = {
-				is_controlled_by = ISR
-			}
+			207 = { is_controlled_by = ISR }
 		}
 
 		bypass = {
@@ -14730,43 +14556,21 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_temple_mount_saudi executed"
-			JOR = {
-				country_event = israel_economy.178
-			}
+			JOR = { country_event = israel_economy.178 }
 			207 = {
 				if = { limit = { has_dynamic_modifier = { modifier = jordanian_waqf_authprity } } remove_dynamic_modifier = { modifier = jordanian_waqf_authprity } }
 			}
-			set_temp_variable = {
-				percent_change = -5
-			}
-			set_temp_variable = {
-				tag_index = JOR
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			set_temp_variable = { percent_change = -5 }
+			set_temp_variable = { tag_index = JOR }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			SAU = {
-				country_event = israel_economy.178
-			}
-			207 = {
-				add_dynamic_modifier = {
-					modifier = saudi_waqf_authprity
-				}
-			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = SAU
-			}
-			set_temp_variable = {
-				influence_target = ISR
-			}
+			SAU = { country_event = israel_economy.178 }
+			207 = { add_dynamic_modifier = { modifier = saudi_waqf_authprity } }
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = SAU }
+			set_temp_variable = { influence_target = ISR }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				treasury_change = 5
-			}
+			set_temp_variable = { treasury_change = 5 }
 			modify_treasury_effect = yes
 		}
 
@@ -14794,25 +14598,19 @@ focus_tree = {
 
 		available = {
 			country_exists = JOR
-			NOT = {
-				has_war_with = JOR
-			}
+			NOT = { has_war_with = JOR }
 			OR = {
 				has_war_support > 0.5
 				has_government = nationalist
 			}
-			207 = {
-				is_controlled_by = ISR
-			}
+			207 = { is_controlled_by = ISR }
 		}
 
 		bypass = { NOT = { country_exists = JOR } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_amend_status_quo executed"
-			set_temp_variable = {
-				percent_change = 15
-			}
+			set_temp_variable = { percent_change = 15 }
 			change_domestic_influence_percentage = yes
 			207 = {
 				if = { limit = { has_dynamic_modifier = { modifier = jordanian_waqf_authprity } } remove_dynamic_modifier = { modifier = jordanian_waqf_authprity } }
@@ -14826,9 +14624,7 @@ focus_tree = {
 				}
 			}
 			every_country = {
-				limit = {
-					has_idea = sunni
-				}
+				limit = { has_idea = sunni }
 				add_opinion_modifier = {
 					modifier = note_of_protest
 					target = ISR
@@ -14910,15 +14706,9 @@ focus_tree = {
 					country_exists = SAU
 					NOT = { has_war_with = SAU }
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = SAU
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = SAU }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -14926,15 +14716,9 @@ focus_tree = {
 					country_exists = QAT
 					NOT = { has_war_with = QAT }
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = QAT
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = QAT }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -14942,15 +14726,9 @@ focus_tree = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = BHR
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = BHR }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -14958,15 +14736,9 @@ focus_tree = {
 					country_exists = OMA
 					NOT = { has_war_with = OMA }
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = OMA
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = OMA }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -14974,15 +14746,9 @@ focus_tree = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = UAE
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = UAE }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -14990,15 +14756,9 @@ focus_tree = {
 					country_exists = YEM
 					NOT = { has_war_with = YEM }
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = YEM
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = YEM }
 				change_influence_percentage = yes
 			}
 		}
@@ -15022,9 +14782,7 @@ focus_tree = {
 
 		available = {
 			country_exists = MOR
-			NOT = {
-				has_war_with = MOR
-			}
+			NOT = { has_war_with = MOR }
 		}
 
 		completion_reward = {
@@ -15037,15 +14795,9 @@ focus_tree = {
 				target = MOR
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = MOR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = MOR }
 			change_influence_percentage = yes
 		}
 
@@ -15068,16 +14820,12 @@ focus_tree = {
 
 		available = {
 			country_exists = MOR
-			NOT = {
-				has_war_with = MOR
-			}
+			NOT = { has_war_with = MOR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cultural_ties executed"
-			MOR = {
-				country_event = md4.1
-			}
+			MOR = { country_event = md4.1 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				MOR = {
@@ -15094,23 +14842,13 @@ focus_tree = {
 					target = MOR
 					modifier = free_trade_agreement
 				}
-				set_temp_variable = {
-					receiver_nation = ISR.id
-				}
-				set_temp_variable = {
-					sender_nation = MOR.id
-				}
+				set_temp_variable = { receiver_nation = ISR.id }
+				set_temp_variable = { sender_nation = MOR.id }
 				set_improved_trade_agreement = yes
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = MOR
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = MOR }
 			change_influence_percentage = yes
 		}
 
@@ -15133,32 +14871,20 @@ focus_tree = {
 
 		available = {
 			country_exists = MOR
-			NOT = {
-				has_war_with = MOR
-			}
+			NOT = { has_war_with = MOR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visa_indirect_travel executed"
-			MOR = {
-				country_event = israel_economy.147
-			}
+			MOR = { country_event = israel_economy.147 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_ideas = ISR_visa_free_moroc
 				custom_effect_tooltip = decreses_boyc_tt
-				MOR = {
-					add_ideas = ISR_visa_free_moroc
-				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = MOR
-				}
+				MOR = { add_ideas = ISR_visa_free_moroc }
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = MOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -15183,18 +14909,14 @@ focus_tree = {
 		available = {
 			country_exists = MOR
 			country_exists = SHA
-			NOT = {
-				has_war_with = MOR
-			}
+			NOT = { has_war_with = MOR }
 		}
 
 		bypass = { NOT = { country_exists = SHA } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_denounce_polisario_iran executed"
-			MOR = {
-				country_event = israel_economy.56
-			}
+			MOR = { country_event = israel_economy.56 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_equipment_to_stockpile = {
@@ -15202,9 +14924,7 @@ focus_tree = {
 					amount = -6000
 					producer = ROOT
 				}
-				set_temp_variable = {
-					treasury_change = 4
-				}
+				set_temp_variable = { treasury_change = 4 }
 				modify_treasury_effect = yes
 			}
 			add_opinion_modifier = {
@@ -15217,9 +14937,7 @@ focus_tree = {
 			}
 		}
 
-		ai_will_do = {
-			base = 1
-		}
+		ai_will_do = { base = 1 }
 	}
 
 	focus = {
@@ -15238,20 +14956,14 @@ focus_tree = {
 
 		available = {
 			country_exists = MOR
-			NOT = {
-				has_war_with = MOR
-			}
+			NOT = { has_war_with = MOR }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_restore_security_links executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
-			MOR = {
-				country_event = israel_economy.137
-			}
+			MOR = { country_event = israel_economy.137 }
 			custom_effect_tooltip = wewillspendtwenty_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -15280,37 +14992,23 @@ focus_tree = {
 
 		available = {
 			country_exists = MOR
-			NOT = {
-				has_war_with = MOR
-			}
+			NOT = { has_war_with = MOR }
 			country_exists = USA
-			NOT = {
-				has_war_with = USA
-			}
+			NOT = { has_war_with = USA }
 			country_exists = SHA
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_usa_mor_isr_deal executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
-			USA = {
-				country_event = israel_economy.150
-			}
+			USA = { country_event = israel_economy.150 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = 100
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = MOR
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = MOR }
 				change_influence_percentage = yes
 			}
 		}
@@ -15334,18 +15032,14 @@ focus_tree = {
 
 		available = {
 			country_exists = ETH
-			NOT = {
-				has_war_with = ETH
-			}
+			NOT = { has_war_with = ETH }
 		}
 
 		bypass = { NOT = { country_exists = ETH } }
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_return_to_africa executed"
-			ETH = {
-				country_event = israel_economy.162
-			}
+			ETH = { country_event = israel_economy.162 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_ideas = israel_observer_african_union
@@ -15364,15 +15058,9 @@ focus_tree = {
 						}
 					}
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = ETH
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = ETH }
 				change_influence_percentage = yes
 			}
 		}
@@ -15398,13 +15086,9 @@ focus_tree = {
 
 		available = {
 			country_exists = ETH
-			NOT = {
-				has_war_with = ETH
-			}
+			NOT = { has_war_with = ETH }
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 		}
 
 		bypass = { NOT = { country_exists = ETH } }
@@ -15412,12 +15096,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_mediate_nile_egypt executed"
 			country_event = israel_economy.169
-			ETH = {
-				country_event = israel_economy.169
-			}
-			EGY = {
-				country_event = israel_economy.169
-			}
+			ETH = { country_event = israel_economy.169 }
+			EGY = { country_event = israel_economy.169 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				add_opinion_modifier = {
@@ -15436,15 +15116,9 @@ focus_tree = {
 					target = ETH
 					modifier = major_breach_of_trust
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = EGY
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = EGY }
 				change_influence_percentage = yes
 			}
 		}
@@ -15469,13 +15143,9 @@ focus_tree = {
 
 		available = {
 			country_exists = ETH
-			NOT = {
-				has_war_with = ETH
-			}
+			NOT = { has_war_with = ETH }
 			country_exists = EGY
-			NOT = {
-				has_war_with = EGY
-			}
+			NOT = { has_war_with = EGY }
 		}
 
 		bypass = { NOT = { country_exists = EGY } }
@@ -15483,12 +15153,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_mediate_nile_ethiopia executed"
 			country_event = israel_economy.168
-			ETH = {
-				country_event = israel_economy.168
-			}
-			EGY = {
-				country_event = israel_economy.168
-			}
+			ETH = { country_event = israel_economy.168 }
+			EGY = { country_event = israel_economy.168 }
 			custom_effect_tooltip = they_will_get_tt
 			effect_tooltip = {
 				add_opinion_modifier = {
@@ -15507,15 +15173,9 @@ focus_tree = {
 					target = EGY
 					modifier = major_breach_of_trust
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = ETH
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = ETH }
 				change_influence_percentage = yes
 			}
 		}
@@ -15542,32 +15202,20 @@ focus_tree = {
 
 		available = {
 			country_exists = ETH
-			NOT = {
-				has_war_with = ETH
-			}
+			NOT = { has_war_with = ETH }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_bring_back_falashmura executed"
-			ETH = {
-				country_event = israel_economy.170
-			}
+			ETH = { country_event = israel_economy.170 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -5
-				}
+				set_temp_variable = { treasury_change = -5 }
 				modify_treasury_effect = yes
 				add_ideas = ISR_eth_jews_migr_isr
-				set_temp_variable = {
-					percent_change = -4
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = ETH
-				}
+				set_temp_variable = { percent_change = -4 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = ETH }
 				change_influence_percentage = yes
 			}
 		}
@@ -15591,9 +15239,7 @@ focus_tree = {
 
 		available = {
 			country_exists = ERI
-			NOT = {
-				has_war_with = ERI
-			}
+			NOT = { has_war_with = ERI }
 			ERI = {
 				has_opinion = {
 					target = ISR
@@ -15606,9 +15252,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_eritrean_bases executed"
-			ERI = {
-				country_event = md4.4
-			}
+			ERI = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -15628,15 +15272,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = ERI
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = ERI }
 			change_influence_percentage = yes
 		}
 
@@ -15694,15 +15332,9 @@ focus_tree = {
 					target = UGA
 					modifier = diplomatic_support
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = UGA
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = UGA }
 				change_influence_percentage = yes
 			}
 			if = {
@@ -15718,15 +15350,9 @@ focus_tree = {
 					target = SUD
 					modifier = trade_mission
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = SUD
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = SUD }
 				change_influence_percentage = yes
 			}
 		}
@@ -15792,15 +15418,9 @@ focus_tree = {
 					country_exists = RWA
 					NOT = { has_war_with = RWA }
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = RWA
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = RWA }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = RWA
@@ -15816,15 +15436,9 @@ focus_tree = {
 					country_exists = UGA
 					NOT = { has_war_with = UGA }
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = UGA
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = UGA }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = UGA
@@ -15840,15 +15454,9 @@ focus_tree = {
 					country_exists = BUR
 					NOT = { has_war_with = BUR }
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = BUR
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = BUR }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = BUR
@@ -15864,15 +15472,9 @@ focus_tree = {
 					country_exists = KEN
 					NOT = { has_war_with = KEN }
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = KEN
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = KEN }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = KEN
@@ -15888,15 +15490,9 @@ focus_tree = {
 					country_exists = TNZ
 					NOT = { has_war_with = TNZ }
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = TNZ
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = TNZ }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = TNZ
@@ -15928,9 +15524,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SUD
-			NOT = {
-				has_war_with = SUD
-			}
+			NOT = { has_war_with = SUD }
 			SUD = {
 				has_opinion = {
 					target = ISR
@@ -15951,19 +15545,13 @@ focus_tree = {
 				target = SUD
 				modifier = diplomatic_support
 			}
-			SUD = {
-				country_event = israel_economy.165
-			}
+			SUD = { country_event = israel_economy.165 }
 			newline = yes
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -7.5
-				}
+				set_temp_variable = { treasury_change = -7.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					int_investment_change = 7.5
-				}
+				set_temp_variable = { int_investment_change = 7.5 }
 				modify_international_investment_effect = yes
 				SUD = {
 					random_owned_controlled_state = {
@@ -16001,9 +15589,7 @@ focus_tree = {
 
 		available = {
 			country_exists = CHA
-			NOT = {
-				has_war_with = CHA
-			}
+			NOT = { has_war_with = CHA }
 			CHA = {
 				has_opinion = {
 					target = ISR
@@ -16024,20 +15610,12 @@ focus_tree = {
 				target = CHA
 				modifier = diplomatic_support
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = CHA
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = CHA }
 			change_influence_percentage = yes
 			newline = yes
-			CHA = {
-				country_event = israel_economy.56
-			}
+			CHA = { country_event = israel_economy.56 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_equipment_to_stockpile = {
@@ -16045,9 +15623,7 @@ focus_tree = {
 					amount = -6000
 					producer = ROOT
 				}
-				set_temp_variable = {
-					treasury_change = 4
-				}
+				set_temp_variable = { treasury_change = 4 }
 				modify_treasury_effect = yes
 			}
 		}
@@ -16100,13 +15676,9 @@ focus_tree = {
 					custom_effect_tooltip = TT_IF_THEY_ACCEPT
 					effect_tooltip = {
 						ISR = {
-							set_temp_variable = {
-								treasury_change = -7.5
-							}
+							set_temp_variable = { treasury_change = -7.5 }
 							modify_treasury_effect = yes
-							set_temp_variable = {
-								int_investment_change = 7.5
-							}
+							set_temp_variable = { int_investment_change = 7.5 }
 							modify_international_investment_effect = yes
 						}
 						random_owned_controlled_state = {
@@ -16117,15 +15689,9 @@ focus_tree = {
 								instant_build = yes
 							}
 						}
-						set_temp_variable = {
-							percent_change = 5
-						}
-						set_temp_variable = {
-							tag_index = ISR
-						}
-						set_temp_variable = {
-							influence_target = THIS
-						}
+						set_temp_variable = { percent_change = 5 }
+						set_temp_variable = { tag_index = ISR }
+						set_temp_variable = { influence_target = THIS }
 						change_influence_percentage = yes
 						custom_effect_tooltip = decreses_boyc_tt
 					}
@@ -16152,9 +15718,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SAU
-			NOT = {
-				has_war_with = SAU
-			}
+			NOT = { has_war_with = SAU }
 			SAU = {
 				has_opinion = {
 					target = ISR
@@ -16167,9 +15731,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_enemy_of_my_enemy executed"
-			SAU = {
-				country_event = israel_economy.128
-			}
+			SAU = { country_event = israel_economy.128 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_opinion_modifier = {
@@ -16180,15 +15742,9 @@ focus_tree = {
 					target = SAU
 					modifier = has_expressed_loyalty
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = SAU
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = SAU }
 				change_influence_percentage = yes
 				diplomatic_relation = {
 					country = SAU
@@ -16224,9 +15780,7 @@ focus_tree = {
 
 		available = {
 			country_exists = OMA
-			NOT = {
-				has_war_with = OMA
-			}
+			NOT = { has_war_with = OMA }
 			OMA = {
 				has_opinion = {
 					target = ISR
@@ -16239,14 +15793,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visit_oman executed"
-			OMA = {
-				country_event = israel_economy.134
-			}
+			OMA = { country_event = israel_economy.134 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				OMA = {
-					give_military_access = ISR
-				}
+				OMA = { give_military_access = ISR }
 				add_opinion_modifier = {
 					target = OMA
 					modifier = diplomatic_support
@@ -16255,15 +15805,9 @@ focus_tree = {
 					target = OMA
 					modifier = diplomatic_support
 				}
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = OMA
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = OMA }
 				change_influence_percentage = yes
 			}
 		}
@@ -16320,33 +15864,25 @@ focus_tree = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = israel_economy.131
-				}
+				UAE = { country_event = israel_economy.131 }
 			}
 			if = {
 				limit = {
 					country_exists = QAT
 					NOT = { has_war_with = QAT }
 				}
-				QAT = {
-					country_event = israel_economy.131
-				}
+				QAT = { country_event = israel_economy.131 }
 			}
 			if = {
 				limit = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = israel_economy.131
-				}
+				BHR = { country_event = israel_economy.131 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				set_temp_variable = {
-					treasury_change = -2
-				}
+				set_temp_variable = { treasury_change = -2 }
 				modify_treasury_effect = yes
 				custom_effect_tooltip = easten_andinf_tt
 			}
@@ -16409,54 +15945,42 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_covert_ties executed"
-			set_temp_variable = {
-				temp_opinion = 5
-			}
+			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 			if = {
 				limit = {
 					country_exists = SAU
 					NOT = { has_war_with = SAU }
 				}
-				SAU = {
-					country_event = israel_economy.137
-				}
+				SAU = { country_event = israel_economy.137 }
 			}
 			if = {
 				limit = {
 					country_exists = OMA
 					NOT = { has_war_with = OMA }
 				}
-				OMA = {
-					country_event = israel_economy.137
-				}
+				OMA = { country_event = israel_economy.137 }
 			}
 			if = {
 				limit = {
 					country_exists = YEM
 					NOT = { has_war_with = YEM }
 				}
-				YEM = {
-					country_event = israel_economy.137
-				}
+				YEM = { country_event = israel_economy.137 }
 			}
 			if = {
 				limit = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = israel_economy.137
-				}
+				BHR = { country_event = israel_economy.137 }
 			}
 			if = {
 				limit = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = israel_economy.137
-				}
+				UAE = { country_event = israel_economy.137 }
 			}
 			custom_effect_tooltip = wewillspendtwenty_tt
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
@@ -16486,9 +16010,7 @@ focus_tree = {
 
 		available = {
 			country_exists = YEM
-			NOT = {
-				has_war_with = YEM
-			}
+			NOT = { has_war_with = YEM }
 			YEM = {
 				has_opinion = {
 					target = ISR
@@ -16506,9 +16028,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_yemen_intervene executed"
-			YEM = {
-				country_event = israel_economy.56
-			}
+			YEM = { country_event = israel_economy.56 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_equipment_to_stockpile = {
@@ -16516,9 +16036,7 @@ focus_tree = {
 					amount = -6000
 					producer = ROOT
 				}
-				set_temp_variable = {
-					treasury_change = 4
-				}
+				set_temp_variable = { treasury_change = 4 }
 				modify_treasury_effect = yes
 			}
 		}
@@ -16544,9 +16062,7 @@ focus_tree = {
 		available = {
 			country_exists = YEM
 			country_exists = HOU
-			NOT = {
-				has_war_with = YEM
-			}
+			NOT = { has_war_with = YEM }
 			YEM = {
 				has_opinion = {
 					target = ISR
@@ -16572,15 +16088,9 @@ focus_tree = {
 				target = YEM
 				modifier = ideological_alliance
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = YEM
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = YEM }
 			change_influence_percentage = yes
 			set_temp_variable = { wargoal_on = HOU }
 			set_temp_variable = { wargoal_type = 1 }
@@ -16653,9 +16163,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY }
 
 		available = {
-			PAL = {
-				is_subject_of = ISR
-			}
+			PAL = { is_subject_of = ISR }
 			OR = {
 				AND = {
 					country_exists = SAU
@@ -16687,45 +16195,35 @@ focus_tree = {
 					country_exists = SAU
 					NOT = { has_war_with = SAU }
 				}
-				SAU = {
-					country_event = israel_economy.143
-				}
+				SAU = { country_event = israel_economy.143 }
 			}
 			if = {
 				limit = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = israel_economy.143
-				}
+				UAE = { country_event = israel_economy.143 }
 			}
 			if = {
 				limit = {
 					country_exists = QAT
 					NOT = { has_war_with = QAT }
 				}
-				QAT = {
-					country_event = israel_economy.143
-				}
+				QAT = { country_event = israel_economy.143 }
 			}
 			if = {
 				limit = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = israel_economy.143
-				}
+				BHR = { country_event = israel_economy.143 }
 			}
 			if = {
 				limit = {
 					country_exists = OMA
 					NOT = { has_war_with = OMA }
 				}
-				OMA = {
-					country_event = israel_economy.143
-				}
+				OMA = { country_event = israel_economy.143 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
@@ -16806,36 +16304,28 @@ focus_tree = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = israel_economy.153
-				}
+				BHR = { country_event = israel_economy.153 }
 			}
 			if = {
 				limit = {
 					country_exists = MOR
 					NOT = { has_war_with = MOR }
 				}
-				MOR = {
-					country_event = israel_economy.153
-				}
+				MOR = { country_event = israel_economy.153 }
 			}
 			if = {
 				limit = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = israel_economy.153
-				}
+				UAE = { country_event = israel_economy.153 }
 			}
 			if = {
 				limit = {
 					country_exists = SUD
 					NOT = { has_war_with = SUD }
 				}
-				SUD = {
-					country_event = israel_economy.153
-				}
+				SUD = { country_event = israel_economy.153 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = norm_rel_infl_tt
@@ -16861,9 +16351,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SAU
-			NOT = {
-				has_war_with = SAU
-			}
+			NOT = { has_war_with = SAU }
 			SAU = {
 				has_opinion = {
 					target = ISR
@@ -16876,9 +16364,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_visit_saudi executed"
-			SAU = {
-				country_event = md4.4
-			}
+			SAU = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -16898,15 +16384,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = SAU
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = SAU }
 			change_influence_percentage = yes
 		}
 
@@ -16930,9 +16410,7 @@ focus_tree = {
 
 		available = {
 			country_exists = SAU
-			NOT = {
-				has_war_with = SAU
-			}
+			NOT = { has_war_with = SAU }
 			SAU = {
 				has_opinion = {
 					target = ISR
@@ -16943,9 +16421,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_treaty_saudi executed"
-			SAU = {
-				country_event = israel_economy.159
-			}
+			SAU = { country_event = israel_economy.159 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = decreses_boyc_tt
@@ -16959,15 +16435,9 @@ focus_tree = {
 					relation = military_access
 					active = yes
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = SAU
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = SAU }
 				change_influence_percentage = yes
 			}
 		}
@@ -17021,40 +16491,30 @@ focus_tree = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = israel_economy.156
-				}
+				BHR = { country_event = israel_economy.156 }
 			}
 			if = {
 				limit = {
 					country_exists = MOR
 					NOT = { has_war_with = MOR }
 				}
-				MOR = {
-					country_event = israel_economy.156
-				}
+				MOR = { country_event = israel_economy.156 }
 			}
 			if = {
 				limit = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = israel_economy.156
-				}
+				UAE = { country_event = israel_economy.156 }
 			}
 			if = {
 				limit = {
 					country_exists = EGY
 					NOT = { has_war_with = EGY }
 				}
-				EGY = {
-					country_event = israel_economy.156
-				}
+				EGY = { country_event = israel_economy.156 }
 			}
-			USA = {
-				country_event = israel_economy.156
-			}
+			USA = { country_event = israel_economy.156 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = neg_for_tt
 			news_event = israel_news.9
@@ -17130,36 +16590,28 @@ focus_tree = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = israel_economy.159
-				}
+				BHR = { country_event = israel_economy.159 }
 			}
 			if = {
 				limit = {
 					country_exists = MOR
 					NOT = { has_war_with = MOR }
 				}
-				MOR = {
-					country_event = israel_economy.159
-				}
+				MOR = { country_event = israel_economy.159 }
 			}
 			if = {
 				limit = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = israel_economy.159
-				}
+				UAE = { country_event = israel_economy.159 }
 			}
 			if = {
 				limit = {
 					country_exists = EGY
 					NOT = { has_war_with = EGY }
 				}
-				EGY = {
-					country_event = israel_economy.159
-				}
+				EGY = { country_event = israel_economy.159 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = full_mil_tt
@@ -17257,45 +16709,35 @@ focus_tree = {
 					country_exists = BHR
 					NOT = { has_war_with = BHR }
 				}
-				BHR = {
-					country_event = generic.5
-				}
+				BHR = { country_event = generic.5 }
 			}
 			if = {
 				limit = {
 					country_exists = MOR
 					NOT = { has_war_with = MOR }
 				}
-				MOR = {
-					country_event = generic.5
-				}
+				MOR = { country_event = generic.5 }
 			}
 			if = {
 				limit = {
 					country_exists = UAE
 					NOT = { has_war_with = UAE }
 				}
-				UAE = {
-					country_event = generic.5
-				}
+				UAE = { country_event = generic.5 }
 			}
 			if = {
 				limit = {
 					country_exists = EGY
 					NOT = { has_war_with = EGY }
 				}
-				EGY = {
-					country_event = generic.5
-				}
+				EGY = { country_event = generic.5 }
 			}
 			if = {
 				limit = {
 					country_exists = SAU
 					NOT = { has_war_with = SAU }
 				}
-				SAU = {
-					country_event = generic.5
-				}
+				SAU = { country_event = generic.5 }
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 		}
@@ -17319,9 +16761,7 @@ focus_tree = {
 
 		available = {
 			country_exists = UAE
-			NOT = {
-				has_war_with = UAE
-			}
+			NOT = { has_war_with = UAE }
 			UAE = {
 				has_opinion = {
 					target = ISR
@@ -17334,9 +16774,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_exhibitions_dubai executed"
-			UAE = {
-				country_event = israel_economy.140
-			}
+			UAE = { country_event = israel_economy.140 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				UAE = {
@@ -17351,9 +16789,7 @@ focus_tree = {
 						remove_ideas = pol_isr_boycotte
 					}
 					if = {
-						limit = {
-							has_idea = full_isr_boycotte
-						}
+						limit = { has_idea = full_isr_boycotte }
 						swap_ideas = {
 							remove_idea = full_isr_boycotte
 							add_idea = econ_isr_boycotte
@@ -17368,12 +16804,8 @@ focus_tree = {
 					target = UAE
 					modifier = major_improve_trade
 				}
-				set_temp_variable = {
-					receiver_nation = ISR.id
-				}
-				set_temp_variable = {
-					sender_nation = UAE.id
-				}
+				set_temp_variable = { receiver_nation = ISR.id }
+				set_temp_variable = { sender_nation = UAE.id }
 				set_improved_trade_agreement = yes
 			}
 		}
@@ -17397,9 +16829,7 @@ focus_tree = {
 
 		available = {
 			country_exists = UAE
-			NOT = {
-				has_war_with = UAE
-			}
+			NOT = { has_war_with = UAE }
 			UAE = {
 				has_opinion = {
 					target = ISR
@@ -17412,9 +16842,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_uae_invest executed"
-			UAE = {
-				country_event = israel_economy.27
-			}
+			UAE = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -17436,15 +16864,9 @@ focus_tree = {
 				target = UAE
 				modifier = supports_us
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = UAE
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = UAE }
 			change_influence_percentage = yes
 		}
 
@@ -17467,12 +16889,8 @@ focus_tree = {
 
 		available = {
 			country_exists = KUR
-			NOT = {
-				has_war_with = KUR
-			}
-			NOT = {
-				has_war_with = IKR
-			}
+			NOT = { has_war_with = KUR }
+			NOT = { has_war_with = IKR }
 			PER = {
 				OR = {
 					emerging_hardline_shiite_are_in_power = yes
@@ -17483,34 +16901,20 @@ focus_tree = {
 				is_ai = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
-					has_equipment = {
-						small_plane_suicide_airframe_2 > 49
-					}
+					has_equipment = { small_plane_suicide_airframe_2 > 49 }
 				}
-				else = {
-					has_equipment = {
-						Air_UAV1 > 49
-					}
-				}
+				else = { has_equipment = { Air_UAV1 > 49 } }
 			}
-			has_equipment = {
-				infantry_weapons_5 > 5999
-			}
+			has_equipment = { infantry_weapons_5 > 5999 }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_plan_bet executed"
-			KUR = {
-				country_event = israel_economy.78
-			}
+			KUR = { country_event = israel_economy.78 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				KUR = {
-					give_military_access = ISR
-				}
-				set_temp_variable = {
-					treasury_change = 14
-				}
+				KUR = { give_military_access = ISR }
+				set_temp_variable = { treasury_change = 14 }
 				modify_treasury_effect = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
@@ -17530,15 +16934,9 @@ focus_tree = {
 					amount = -6000
 					producer = ISR
 				}
-				set_temp_variable = {
-					percent_change = 6
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = KUR
-				}
+				set_temp_variable = { percent_change = 6 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = KUR }
 				change_influence_percentage = yes
 				add_opinion_modifier = {
 					target = KUR
@@ -17579,9 +16977,7 @@ focus_tree = {
 			add_war_support = 0.05
 			add_stability = -0.02
 			add_ideas = ISR_iran_def_idea
-			set_temp_variable = {
-				percent_change = 5
-			}
+			set_temp_variable = { percent_change = 5 }
 			change_domestic_influence_percentage = yes
 			add_opinion_modifier = {
 				target = PER
@@ -17620,22 +17016,16 @@ focus_tree = {
 
 		available = {
 			country_exists = AZE
-			NOT = {
-				has_war_with = AZE
-			}
+			NOT = { has_war_with = AZE }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_bct_pipleine_azerbaijan executed"
-			AZE = {
-				country_event = israel_economy.53
-			}
+			AZE = { country_event = israel_economy.53 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = egy_petr_tt
-				set_temp_variable = {
-					treasury_change = -4
-				}
+				set_temp_variable = { treasury_change = -4 }
 				modify_treasury_effect = yes
 				random_owned_state = {
 					add_extra_state_shared_building_slots = 1
@@ -17683,19 +17073,13 @@ focus_tree = {
 
 		available = {
 			country_exists = AZE
-			NOT = {
-				has_war_with = AZE
-			}
-			has_equipment = {
-				infantry_weapons_5 > 5999
-			}
+			NOT = { has_war_with = AZE }
+			has_equipment = { infantry_weapons_5 > 5999 }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_tavor_arm_shipments executed"
-			AZE = {
-				country_event = israel_economy.56
-			}
+			AZE = { country_event = israel_economy.56 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_equipment_to_stockpile = {
@@ -17703,9 +17087,7 @@ focus_tree = {
 					amount = -6000
 					producer = ROOT
 				}
-				set_temp_variable = {
-					treasury_change = 4
-				}
+				set_temp_variable = { treasury_change = 4 }
 				modify_treasury_effect = yes
 			}
 		}
@@ -17733,35 +17115,23 @@ focus_tree = {
 
 		available = {
 			country_exists = AZE
-			NOT = {
-				has_war_with = AZE
-			}
+			NOT = { has_war_with = AZE }
 			OR = {
 				is_ai = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
-					has_equipment = {
-						small_plane_suicide_airframe_2 > 49
-					}
+					has_equipment = { small_plane_suicide_airframe_2 > 49 }
 				}
-				else = {
-					has_equipment = {
-						Air_UAV1 > 49
-					}
-				}
+				else = { has_equipment = { Air_UAV1 > 49 } }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_uvda_airlift executed"
-			AZE = {
-				country_event = israel_economy.59
-			}
+			AZE = { country_event = israel_economy.59 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				AZE = {
-					give_military_access = ISR
-				}
+				AZE = { give_military_access = ISR }
 				ISR = {
 					if = {
 						limit = { has_dlc = "By Blood Alone" }
@@ -17776,9 +17146,7 @@ focus_tree = {
 							amount = -50
 						}
 					}
-					set_temp_variable = {
-						treasury_change = 4
-					}
+					set_temp_variable = { treasury_change = 4 }
 					modify_treasury_effect = yes
 				}
 			}
@@ -17809,13 +17177,9 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY }
 
 		available = {
-			NOT = {
-				has_idea = kirya_glilot_tensions
-			}
+			NOT = { has_idea = kirya_glilot_tensions }
 			country_exists = AZE
-			NOT = {
-				has_war_with = AZE
-			}
+			NOT = { has_war_with = AZE }
 			AZE = {
 				has_opinion = {
 					target = ISR
@@ -17826,14 +17190,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_mossads_door executed"
-			AZE = {
-				country_event = israel_economy.62
-			}
+			AZE = { country_event = israel_economy.62 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = aze_int_gain
-			effect_tooltip = {
-				add_ideas = israeli_intelligenc_idea
-			}
+			effect_tooltip = { add_ideas = israeli_intelligenc_idea }
 		}
 
 		ai_will_do = {
@@ -17859,9 +17219,7 @@ focus_tree = {
 
 		available = {
 			country_exists = AZE
-			NOT = {
-				has_war_with = AZE
-			}
+			NOT = { has_war_with = AZE }
 			AZE = {
 				has_opinion = {
 					target = ISR
@@ -17872,25 +17230,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_sitalchay_airbase_lease executed"
-			AZE = {
-				country_event = israel_economy.65
-			}
+			AZE = { country_event = israel_economy.65 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = we_will_att_per2
-				set_temp_variable = {
-					treasury_change = 2.5
-				}
+				set_temp_variable = { treasury_change = 2.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = AZE
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = AZE }
 				change_influence_percentage = yes
 			}
 		}
@@ -17918,9 +17266,7 @@ focus_tree = {
 
 		available = {
 			country_exists = AZE
-			NOT = {
-				has_war_with = AZE
-			}
+			NOT = { has_war_with = AZE }
 			AZE = {
 				has_opinion = {
 					target = ISR
@@ -17937,15 +17283,9 @@ focus_tree = {
 				idea = ISR_karabakh_victory
 				days = 365
 			}
-			set_temp_variable = {
-				percent_change = 5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = AZE
-			}
+			set_temp_variable = { percent_change = 5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = AZE }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = ARM
@@ -17984,22 +17324,16 @@ focus_tree = {
 
 		available = {
 			country_exists = ARM
-			NOT = {
-				has_war_with = ARM
-			}
+			NOT = { has_war_with = ARM }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_reconsider_caucasus_position executed"
-			ARM = {
-				country_event = israel_economy.68
-			}
+			ARM = { country_event = israel_economy.68 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = egy_petr_tt
-				set_temp_variable = {
-					treasury_change = -3.25
-				}
+				set_temp_variable = { treasury_change = -3.25 }
 				modify_treasury_effect = yes
 				random_owned_state = {
 					add_extra_state_shared_building_slots = 1
@@ -18051,26 +17385,16 @@ focus_tree = {
 
 		available = {
 			country_exists = ARM
-			NOT = {
-				has_war_with = ARM
-			}
+			NOT = { has_war_with = ARM }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_recognize_arm_genocide executed"
-			ARM = {
-				country_event = israel_economy.71
-			}
+			ARM = { country_event = israel_economy.71 }
 			add_stability = 0.05
-			set_temp_variable = {
-				percent_change = 6
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = ARM
-			}
+			set_temp_variable = { percent_change = 6 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = ARM }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = ARM
@@ -18109,9 +17433,7 @@ focus_tree = {
 
 		available = {
 			country_exists = ARM
-			NOT = {
-				has_war_with = ARM
-			}
+			NOT = { has_war_with = ARM }
 			ARM = {
 				has_opinion = {
 					target = ISR
@@ -18122,25 +17444,15 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_syunik_air_base"
-			ARM = {
-				country_event = israel_economy.65
-			}
+			ARM = { country_event = israel_economy.65 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				custom_effect_tooltip = we_will_att_per2
-				set_temp_variable = {
-					treasury_change = 2.5
-				}
+				set_temp_variable = { treasury_change = 2.5 }
 				modify_treasury_effect = yes
-				set_temp_variable = {
-					percent_change = 5
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = ARM
-				}
+				set_temp_variable = { percent_change = 5 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = ARM }
 				change_influence_percentage = yes
 			}
 		}
@@ -18170,13 +17482,9 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY }
 
 		available = {
-			NOT = {
-				has_idea = kirya_glilot_tensions
-			}
+			NOT = { has_idea = kirya_glilot_tensions }
 			country_exists = ARM
-			NOT = {
-				has_war_with = ARM
-			}
+			NOT = { has_war_with = ARM }
 			ARM = {
 				has_opinion = {
 					target = ISR
@@ -18187,14 +17495,10 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_armenia_mossad_door"
-			ARM = {
-				country_event = israel_economy.62
-			}
+			ARM = { country_event = israel_economy.62 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			custom_effect_tooltip = aze_int_gain
-			effect_tooltip = {
-				add_ideas = israeli_intelligenc_idea
-			}
+			effect_tooltip = { add_ideas = israeli_intelligenc_idea }
 		}
 
 		ai_will_do = {
@@ -18220,35 +17524,23 @@ focus_tree = {
 
 		available = {
 			country_exists = ARM
-			NOT = {
-				has_war_with = ARM
-			}
+			NOT = { has_war_with = ARM }
 			OR = {
 				is_ai = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
-					has_equipment = {
-						small_plane_suicide_airframe_2 > 49
-					}
+					has_equipment = { small_plane_suicide_airframe_2 > 49 }
 				}
-				else = {
-					has_equipment = {
-						Air_UAV1 > 49
-					}
-				}
+				else = { has_equipment = { Air_UAV1 > 49 } }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_airlift_support_armenia executed"
-			ARM = {
-				country_event = israel_economy.59
-			}
+			ARM = { country_event = israel_economy.59 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				ARM = {
-					give_military_access = ISR
-				}
+				ARM = { give_military_access = ISR }
 				ISR = {
 					if = {
 						limit = { has_dlc = "By Blood Alone" }
@@ -18263,9 +17555,7 @@ focus_tree = {
 							amount = -50
 						}
 					}
-					set_temp_variable = {
-						treasury_change = 4
-					}
+					set_temp_variable = { treasury_change = 4 }
 					modify_treasury_effect = yes
 				}
 			}
@@ -18294,9 +17584,7 @@ focus_tree = {
 
 		available = {
 			country_exists = ARM
-			NOT = {
-				has_war_with = ARM
-			}
+			NOT = { has_war_with = ARM }
 			ARM = {
 				has_opinion = {
 					target = ISR
@@ -18307,36 +17595,18 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_recognize_artsakh"
-			ARM = {
-				country_event = israel_economy.72
-			}
+			ARM = { country_event = israel_economy.72 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
-				NKR = {
-					give_military_access = ISR
-				}
-				ISR = {
-					give_guarantee = NKR
-				}
-				set_temp_variable = {
-					percent_change = 6
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = NKR
-				}
+				NKR = { give_military_access = ISR }
+				ISR = { give_guarantee = NKR }
+				set_temp_variable = { percent_change = 6 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = NKR }
 				change_influence_percentage = yes
-				set_temp_variable = {
-					percent_change = 4
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = ARM
-				}
+				set_temp_variable = { percent_change = 4 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = ARM }
 				change_influence_percentage = yes
 			}
 			NKR = {
@@ -18389,31 +17659,21 @@ focus_tree = {
 
 		available = {
 			country_exists = GEO
-			NOT = {
-				has_war_with = GEO
-			}
+			NOT = { has_war_with = GEO }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_approach_georgia"
-			GEO = {
-				country_event = israel_economy.75
-			}
+			GEO = { country_event = israel_economy.75 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_opinion_modifier = {
 					target = GEO
 					modifier = diplomatic_support
 				}
-				set_temp_variable = {
-					percent_change = 2
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = GEO
-				}
+				set_temp_variable = { percent_change = 2 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = GEO }
 				change_influence_percentage = yes
 			}
 		}
@@ -18437,9 +17697,7 @@ focus_tree = {
 
 		available = {
 			country_exists = GEO
-			NOT = {
-				has_war_with = GEO
-			}
+			NOT = { has_war_with = GEO }
 			GEO = {
 				has_opinion = {
 					target = ISR
@@ -18450,9 +17708,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_mil_cyb_geo"
-			GEO = {
-				country_event = md4.4
-			}
+			GEO = { country_event = md4.4 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				add_political_power = -100
@@ -18472,15 +17728,9 @@ focus_tree = {
 				}
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GEO
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GEO }
 			change_influence_percentage = yes
 		}
 
@@ -18503,9 +17753,7 @@ focus_tree = {
 
 		available = {
 			country_exists = GEO
-			NOT = {
-				has_war_with = GEO
-			}
+			NOT = { has_war_with = GEO }
 			GEO = {
 				has_opinion = {
 					target = ISR
@@ -18516,9 +17764,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_free_trade_geo"
-			GEO = {
-				country_event = israel_economy.27
-			}
+			GEO = { country_event = israel_economy.27 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
 			effect_tooltip = {
 				random_owned_state = {
@@ -18532,22 +17778,12 @@ focus_tree = {
 				custom_effect_tooltip = isrg_inv_foc_tt
 			}
 			newline = yes
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GEO
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GEO }
 			change_influence_percentage = yes
-			set_temp_variable = {
-				receiver_nation = ISR.id
-			}
-			set_temp_variable = {
-				sender_nation = GEO.id
-			}
+			set_temp_variable = { receiver_nation = ISR.id }
+			set_temp_variable = { sender_nation = GEO.id }
 			set_improved_trade_agreement = yes
 		}
 
@@ -18575,17 +17811,11 @@ focus_tree = {
 		available = {
 			OR = {
 				country_exists = ARM
-				NOT = {
-					has_war_with = ARM
-				}
+				NOT = { has_war_with = ARM }
 				country_exists = AZE
-				NOT = {
-					has_war_with = AZE
-				}
+				NOT = { has_war_with = AZE }
 				country_exists = GEO
-				NOT = {
-					has_war_with = GEO
-				}
+				NOT = { has_war_with = GEO }
 			}
 		}
 
@@ -18599,15 +17829,9 @@ focus_tree = {
 				target = ARM
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = ARM
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = ARM }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = AZE
@@ -18617,15 +17841,9 @@ focus_tree = {
 				target = AZE
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = AZE
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = AZE }
 			change_influence_percentage = yes
 			add_opinion_modifier = {
 				target = GEO
@@ -18635,15 +17853,9 @@ focus_tree = {
 				target = GEO
 				modifier = improve_trade
 			}
-			set_temp_variable = {
-				percent_change = 1.5
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = GEO
-			}
+			set_temp_variable = { percent_change = 1.5 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = GEO }
 			change_influence_percentage = yes
 		}
 
@@ -18678,9 +17890,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY FOCUS_FILTER_EXPENDITURE }
 
 		available = {
-			NOT = {
-				has_idea = kirya_glilot_tensions
-			}
+			NOT = { has_idea = kirya_glilot_tensions }
 			PER = {
 				OR = {
 					emerging_hardline_shiite_are_in_power = yes
@@ -18693,14 +17903,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_iran_command executed"
 			custom_effect_tooltip = eff_of_foc
-			set_temp_variable = {
-				treasury_change = -5
-			}
+			set_temp_variable = { treasury_change = -5 }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					has_idea = israeli_intelligenc_idea
-				}
+				limit = { has_idea = israeli_intelligenc_idea }
 				swap_ideas = {
 					remove_idea = israeli_intelligenc_idea
 					add_idea = israeli_intelligenc2_idea
@@ -18708,9 +17914,7 @@ focus_tree = {
 				custom_effect_tooltip = add_spendmos_three_tt
 			}
 			if = {
-				limit = {
-					has_idea = israeli_intelligenc2_idea
-				}
+				limit = { has_idea = israeli_intelligenc2_idea }
 				swap_ideas = {
 					remove_idea = israeli_intelligenc2_idea
 					add_idea = israeli_intelligenc3_idea
@@ -18770,30 +17974,18 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_iran_international executed"
-			set_temp_variable = {
-				treasury_change = -2
-			}
+			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 			news_event = israel_news.11
 			PER = {
 				add_stability = -0.02
-				set_temp_variable = {
-					party_popularity_increase = -0.05
-				}
-				set_temp_variable = {
-					temp_outlook_increase = -0.05
-				}
+				set_temp_variable = { party_popularity_increase = -0.05 }
+				set_temp_variable = { temp_outlook_increase = -0.05 }
 				change_relative_party_popularity = yes
 			}
-			set_temp_variable = {
-				percent_change = 3
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			set_temp_variable = { percent_change = 3 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 
@@ -18815,9 +18007,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY FOCUS_FILTER_EXPENDITURE }
 
 		available = {
-			NOT = {
-				has_idea = kirya_glilot_tensions
-			}
+			NOT = { has_idea = kirya_glilot_tensions }
 			PER = {
 				OR = {
 					emerging_hardline_shiite_are_in_power = yes
@@ -18830,14 +18020,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cyber_defence_unit executed"
 			custom_effect_tooltip = eff_of_foc
-			set_temp_variable = {
-				treasury_change = -7
-			}
+			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 			if = {
-				limit = {
-					has_idea = israeli_intelligenc_idea
-				}
+				limit = { has_idea = israeli_intelligenc_idea }
 				swap_ideas = {
 					remove_idea = israeli_intelligenc_idea
 					add_idea = israeli_intelligenc2_idea
@@ -18845,9 +18031,7 @@ focus_tree = {
 				custom_effect_tooltip = add_spendmos_three_tt
 			}
 			if = {
-				limit = {
-					has_idea = israeli_intelligenc2_idea
-				}
+				limit = { has_idea = israeli_intelligenc2_idea }
 				swap_ideas = {
 					remove_idea = israeli_intelligenc2_idea
 					add_idea = israeli_intelligenc3_idea
@@ -18870,18 +18054,14 @@ focus_tree = {
 			if = {
 				limit = {
 					has_dlc = "La Resistance"
-					NOT = {
-						has_done_agency_upgrade = upgrade_army_department
-					}
+					NOT = { has_done_agency_upgrade = upgrade_army_department }
 				}
 				upgrade_intelligence_agency = upgrade_form_department
 			}
 			if = {
 				limit = {
 					has_dlc = "La Resistance"
-					NOT = {
-						has_done_agency_upgrade = upgrade_computer_servers
-					}
+					NOT = { has_done_agency_upgrade = upgrade_computer_servers }
 				}
 				upgrade_intelligence_agency = upgrade_computer_servers
 			}
@@ -18927,9 +18107,7 @@ focus_tree = {
 					influence_higher_10 = yes
 					custom_trigger_tooltip = {
 						tooltip = ISR_top_influencer_per_tt
-						check_variable = {
-							influence_array^0 = ISR
-						}
+						check_variable = { influence_array^0 = ISR }
 					}
 				}
 			}
@@ -18938,13 +18116,9 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_cyber_attack_iran executed"
 			country_event = israel_economy.83
-			PER = {
-				country_event = israel_economy.83
-			}
+			PER = { country_event = israel_economy.83 }
 			if = {
-				limit = {
-					has_dlc = "La Resistance"
-				}
+				limit = { has_dlc = "La Resistance" }
 				add_intel = {
 					target = PER
 					army_intel = 15
@@ -18980,12 +18154,8 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ISRFOREIGNPOL FOCUS_FILTER_FOREIGN_POLICY }
 
 		available = {
-			NOT = {
-				has_war_with = KUR
-			}
-			NOT = {
-				has_war_with = IKR
-			}
+			NOT = { has_war_with = KUR }
+			NOT = { has_war_with = IKR }
 			PER = {
 				OR = {
 					emerging_hardline_shiite_are_in_power = yes
@@ -18997,39 +18167,23 @@ focus_tree = {
 				is_ai = yes
 				if = {
 					limit = { has_dlc = "By Blood Alone" }
-					has_equipment = {
-						small_plane_suicide_airframe_2 > 49
-					}
+					has_equipment = { small_plane_suicide_airframe_2 > 49 }
 				}
-				else = {
-					has_equipment = {
-						Air_UAV1 > 49
-					}
-				}
+				else = { has_equipment = { Air_UAV1 > 49 } }
 			}
-			has_equipment = {
-				infantry_weapons_5 > 5999
-			}
+			has_equipment = { infantry_weapons_5 > 5999 }
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_supply_the_pjaks executed"
 			custom_effect_tooltip = eff_of_foc
 			if = {
-				limit = {
-					country_exists = IKR
-				}
-				IKR = {
-					country_event = israel_economy.78
-				}
+				limit = { country_exists = IKR }
+				IKR = { country_event = israel_economy.78 }
 				custom_effect_tooltip = TT_IF_THEY_ACCEPT
 				effect_tooltip = {
-					IKR = {
-						give_military_access = ISR
-					}
-					set_temp_variable = {
-						treasury_change = 14
-					}
+					IKR = { give_military_access = ISR }
+					set_temp_variable = { treasury_change = 14 }
 					modify_treasury_effect = yes
 					if = {
 						limit = { has_dlc = "By Blood Alone" }
@@ -19049,15 +18203,9 @@ focus_tree = {
 						amount = -6000
 						producer = ISR
 					}
-					set_temp_variable = {
-						percent_change = 6
-					}
-					set_temp_variable = {
-						tag_index = ISR
-					}
-					set_temp_variable = {
-						influence_target = IKR
-					}
+					set_temp_variable = { percent_change = 6 }
+					set_temp_variable = { tag_index = ISR }
+					set_temp_variable = { influence_target = IKR }
 					change_influence_percentage = yes
 					add_opinion_modifier = {
 						target = IKR
@@ -19066,11 +18214,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					NOT = {
-						country_exists = IKR
-					}
-				}
+				limit = { NOT = { country_exists = IKR } }
 				add_equipment_to_stockpile = {
 					type = infantry_weapons_2
 					amount = -1000
@@ -19087,26 +18231,14 @@ focus_tree = {
 							}
 						}
 					}
-					set_temp_variable = {
-						percent_change = 2
-					}
-					set_temp_variable = {
-						tag_index = KUR
-					}
-					set_temp_variable = {
-						influence_target = PER
-					}
+					set_temp_variable = { percent_change = 2 }
+					set_temp_variable = { tag_index = KUR }
+					set_temp_variable = { influence_target = PER }
 					change_influence_percentage = yes
 				}
-				set_temp_variable = {
-					percent_change = 3
-				}
-				set_temp_variable = {
-					tag_index = ISR
-				}
-				set_temp_variable = {
-					influence_target = PER
-				}
+				set_temp_variable = { percent_change = 3 }
+				set_temp_variable = { tag_index = ISR }
+				set_temp_variable = { influence_target = PER }
 				change_influence_percentage = yes
 			}
 			add_opinion_modifier = {
@@ -19151,26 +18283,14 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_invite_rajavi executed"
 			country_event = israel_economy.82
 			PER = {
-				set_temp_variable = {
-					party_index = 5
-				}
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
-				set_temp_variable = {
-					temp_outlook_increase = 0.05
-				}
+				set_temp_variable = { party_index = 5 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 
@@ -19206,26 +18326,14 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus ISR_invite_pahlavi executed"
 			country_event = israel_economy.81
 			PER = {
-				set_temp_variable = {
-					party_index = 23
-				}
-				set_temp_variable = {
-					party_popularity_increase = 0.05
-				}
-				set_temp_variable = {
-					temp_outlook_increase = 0.05
-				}
+				set_temp_variable = { party_index = 23 }
+				set_temp_variable = { party_popularity_increase = 0.05 }
+				set_temp_variable = { temp_outlook_increase = 0.05 }
 				change_relative_party_popularity = yes
 			}
-			set_temp_variable = {
-				percent_change = 2
-			}
-			set_temp_variable = {
-				tag_index = ISR
-			}
-			set_temp_variable = {
-				influence_target = PER
-			}
+			set_temp_variable = { percent_change = 2 }
+			set_temp_variable = { tag_index = ISR }
+			set_temp_variable = { influence_target = PER }
 			change_influence_percentage = yes
 		}
 

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -432,9 +432,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_disarm_the_militias"
 			if = {
-				limit = {
-					has_template = "Christian Militias"
-				}
+				limit = { has_template = "Christian Militias" }
 				hidden_effect = {
 					delete_unit_template_and_units = { division_template = "Christian Militias" }
 					add_manpower = 2000
@@ -536,20 +534,14 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_tolerance"
 			if = {
-				limit = {
-					has_completed_focus = NIG_continue_sharia_law
-				}
+				limit = { has_completed_focus = NIG_continue_sharia_law }
 				add_stability = 0.025
 			}
 			else_if = {
-				limit = {
-					has_completed_focus = NIG_end_sharia_law
-				}
+				limit = { has_completed_focus = NIG_end_sharia_law }
 				add_political_power = 150
 			}
-			else = {
-				custom_effect_tooltip = NIG_tolerance_toolie_TT
-			}
+			else = { custom_effect_tooltip = NIG_tolerance_toolie_TT }
 		}
 
 		ai_will_do = {
@@ -1390,9 +1382,7 @@ focus_tree = {
 			set_temp_variable = { treasury_change = -3 }
 			modify_treasury_effect = yes
 			every_other_country = {
-				limit = {
-					salafist_caliphate_are_in_power = yes
-				}
+				limit = { salafist_caliphate_are_in_power = yes }
 				if = {
 					limit = { NIG = { has_tech = infantry_weapons_4 } }
 					add_equipment_to_stockpile = {
@@ -2226,14 +2216,8 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: Focus NIG_balanced_budgets"
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
-			random_owned_state = {
-				prioritize = { 337 334 }
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_state = {
-				prioritize = { 336 332 }
-				add_extra_state_shared_building_slots = 1
-			}
+			random_owned_state = { prioritize = { 337 334 } add_extra_state_shared_building_slots = 1 }
+			random_owned_state = { prioritize = { 336 332 } add_extra_state_shared_building_slots = 1 }
 		}
 
 		ai_will_do = {

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -4114,9 +4114,7 @@ focus_tree = {
 					modify_international_investment_effect = yes
 				}
 				random_owned_controlled_state = {
-					limit = {
-						infrastructure < 5
-					}
+					limit = { infrastructure < 5 }
 					add_building_construction = {
 						type = infrastructure
 						level = 1
@@ -4247,9 +4245,7 @@ focus_tree = {
 			change_industrial_conglomerates_opinion = yes
 			change_international_bankers_opinion = yes
 			if = {
-				limit = {
-					has_idea = NIG_reckless_growth_idea
-				}
+				limit = { has_idea = NIG_reckless_growth_idea }
 				modify_timed_idea = {
 					idea = NIG_reckless_growth_idea
 					days = 180
@@ -4661,9 +4657,7 @@ focus_tree = {
 					modify_international_investment_effect = yes
 				}
 				random_owned_controlled_state = {
-					limit = {
-						infrastructure < 5
-					}
+					limit = { infrastructure < 5 }
 					add_building_construction = {
 						type = infrastructure
 						level = 1
@@ -4730,9 +4724,7 @@ focus_tree = {
 			base = 1
 			modifier = {
 				add = 10
-				any_owned_state = {
-					infrastructure < 3
-				}
+				any_owned_state = { infrastructure < 3 }
 			}
 			modifier = {
 				factor = 0
@@ -4846,9 +4838,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_idea = NIG_reckless_growth_idea
-				}
+				limit = { has_idea = NIG_reckless_growth_idea }
 				modify_timed_idea = {
 					idea = NIG_reckless_growth_idea
 					days = 180
@@ -5129,9 +5119,7 @@ focus_tree = {
 			set_temp_variable = { temp_opinion = 5 }
 			change_small_medium_business_owners_opinion = yes
 			if = {
-				limit = {
-					has_idea = NIG_reckless_growth_idea
-				}
+				limit = { has_idea = NIG_reckless_growth_idea }
 				modify_timed_idea = {
 					idea = NIG_reckless_growth_idea
 					days = 180

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -2517,9 +2517,7 @@ focus_tree = {
 					set_temp_variable = { treasury_change = 1 }
 					modify_treasury_effect = yes
 					random_owned_controlled_state = {
-						limit = {
-							infrastructure < 5
-						}
+						limit = { infrastructure < 5 }
 						add_building_construction = {
 							type = infrastructure
 							level = 1
@@ -3369,12 +3367,8 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NIG_industrial_regulations"
 			add_stability = 0.025
-			random_owned_state = {
-				add_extra_state_shared_building_slots = 1
-			}
-			random_owned_state = {
-				add_extra_state_shared_building_slots = 1
-			}
+			random_owned_state = { add_extra_state_shared_building_slots = 1 }
+			random_owned_state = { add_extra_state_shared_building_slots = 1 }
 			set_temp_variable = { treasury_change = -2 }
 			modify_treasury_effect = yes
 		}
@@ -3693,9 +3687,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NIG_nigerian_industry"
-			every_owned_state = {
-				add_extra_state_shared_building_slots = 1
-			}
+			every_owned_state = { add_extra_state_shared_building_slots = 1 }
 			set_temp_variable = { treasury_change = -7 }
 			modify_treasury_effect = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -3757,9 +3749,7 @@ focus_tree = {
 					modify_international_investment_effect = yes
 				}
 				random_owned_controlled_state = {
-					limit = {
-						infrastructure < 5
-					}
+					limit = { infrastructure < 5 }
 					add_building_construction = {
 						type = infrastructure
 						level = 1
@@ -4009,9 +3999,7 @@ focus_tree = {
 			}
 			hidden_effect = {
 				if = {
-					limit = {
-						check_variable = { oligarchs_opinion > 49 }
-					}
+					limit = { check_variable = { oligarchs_opinion > 49 } }
 					random_owned_controlled_state = {
 						limit = { free_shared_building_slots = yes }
 						add_extra_state_shared_building_slots = 1

--- a/common/national_focus/05_nigeria.txt
+++ b/common/national_focus/05_nigeria.txt
@@ -5310,9 +5310,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_idea = NIG_reckless_growth_idea
-				}
+				limit = { has_idea = NIG_reckless_growth_idea }
 				modify_timed_idea = {
 					idea = NIG_reckless_growth_idea
 					days = 180
@@ -5436,9 +5434,7 @@ focus_tree = {
 				add_ideas = rifle_production_bonus
 			}
 			else_if = {
-				limit = {
-					has_idea = rifle_production_bonus
-				}
+				limit = { has_idea = rifle_production_bonus }
 				swap_ideas = {
 					remove_idea = rifle_production_bonus
 					add_idea = rifle_production_bonus2
@@ -5947,9 +5943,7 @@ focus_tree = {
 						has_completed_focus = NIG_contract_boko_haram
 					}
 				}
-				hidden_effect = {
-					load_oob = "NIG_establish_ng"
-				}
+				hidden_effect = { load_oob = "NIG_establish_ng" }
 				set_temp_variable = { treasury_change = -1.5 }
 				modify_treasury_effect = yes
 				custom_effect_tooltip = NIG_establish_ng_two_TT
@@ -6193,9 +6187,7 @@ focus_tree = {
 			log = "[GetDateText]: [This.GetName]: focus NIG_western_military_assistance"
 			if = {
 				limit = {
-					NIG = {
-						NOT = { has_war_with = USA }
-					}
+					NIG = { NOT = { has_war_with = USA } }
 					USA = { has_idea = NATO_member }
 					NOT = { has_global_flag = GAME_RULE_nato_disabled }
 				}
@@ -6221,9 +6213,7 @@ focus_tree = {
 			}
 			else = {
 				every_country = {
-					limit = {
-						has_government = democratic
-					}
+					limit = { has_government = democratic }
 					add_opinion_modifier = { target = NIG modifier = political_outreach }
 					reverse_add_opinion_modifier = { target = NIG modifier = political_outreach }
 				}
@@ -6270,9 +6260,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [This.GetName]: focus NIG_eastern_doctrines"
 			if = {
-				limit = {
-					NOT = { has_war_with = CHI }
-				}
+				limit = { NOT = { has_war_with = CHI } }
 				CHI = {
 					add_opinion_modifier = { target = NIG modifier = has_expressed_loyalty }
 					reverse_add_opinion_modifier = { target = NIG modifier = has_expressed_loyalty }
@@ -6283,9 +6271,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					NOT = { has_war_with = SOV }
-				}
+				limit = { NOT = { has_war_with = SOV } }
 				SOV = {
 					add_opinion_modifier = { target = NIG modifier = has_expressed_loyalty }
 					reverse_add_opinion_modifier = { target = NIG modifier = has_expressed_loyalty }

--- a/common/national_focus/05_sahrawi.txt
+++ b/common/national_focus/05_sahrawi.txt
@@ -342,12 +342,8 @@ shared_focus = {
 		custom_effect_tooltip = SHA_effect_from_evemt_TT
 		effect_tooltip = {
 			MAU = {
-				SHA_saleh_ould_hanenna = {
-					set_nationality = SHA
-				}
-				SHA_moulaye_ould_boukhreiss = {
-					set_nationality = SHA
-				}
+				SHA_saleh_ould_hanenna = { set_nationality = SHA }
+				SHA_moulaye_ould_boukhreiss = { set_nationality = SHA }
 			}
 			SHA_saleh_ould_hanenna = {
 				set_nationality = SHA
@@ -400,9 +396,7 @@ shared_focus = {
 		base = 0
 		modifier = {
 			factor = 10
-			has_army_manpower = {
-				size > 1000
-			}
+			has_army_manpower = { size > 1000 }
 		}
 		modifier = {
 			factor = 10

--- a/common/national_focus/05_sahrawi.txt
+++ b/common/national_focus/05_sahrawi.txt
@@ -611,13 +611,7 @@ shared_focus = {
 		add_state_core = 1179
 		add_state_claim = 378
 		if = {
-			limit = {
-				SHA = {
-					NOT = {
-						has_full_control_of_state = 1179
-					}
-				}
-			}
+			limit = { SHA = { NOT = { has_full_control_of_state = 1179 } } }
 			1179 = {
 				OWNER = {
 					SHA = {

--- a/common/national_focus/05_sahrawi.txt
+++ b/common/national_focus/05_sahrawi.txt
@@ -211,9 +211,7 @@ shared_focus = {
 		NOT = {
 			OR = {
 				has_war_with = MAU
-				any_allied_country = {
-					has_war_with = MAU
-				}
+				any_allied_country = { has_war_with = MAU }
 			}
 		}
 		if = {
@@ -230,9 +228,7 @@ shared_focus = {
 				is_subject_of = MAU
 				is_subject = yes
 				has_country_flag = trade_agreement@ROOT
-				MAU = {
-					has_country_flag = trade_agreement@PREV
-				}
+				MAU = { has_country_flag = trade_agreement@PREV }
 			}
 		}
 	}

--- a/common/national_focus/05_sahrawi.txt
+++ b/common/national_focus/05_sahrawi.txt
@@ -96,11 +96,7 @@ shared_focus = {
 				L_Inf_Bat = { x = 1 y = 0 }
 			}
 		}
-		SHA = {
-			SHA_lahbib_ayoub = {
-				set_nationality = SHA
-			}
-		}
+		SHA = { SHA_lahbib_ayoub = { set_nationality = SHA } }
 		SHA_lahbib_ayoub = {
 			set_nationality = SHA
 			add_corps_commander_role = {

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -8504,9 +8504,7 @@ focus_tree = {
 				limit = { NOT = { has_variable = SYR_amount_of_loans } }
 				set_variable = { SYR_amount_of_loans = 1 }
 			}
-			else = {
-				add_to_variable = { SYR_amount_of_loans = 1 }
-			}
+			else = { add_to_variable = { SYR_amount_of_loans = 1 } }
 		}
 
 		ai_will_do = {
@@ -8556,9 +8554,7 @@ focus_tree = {
 				limit = { NOT = { has_variable = SYR_amount_of_loans } }
 				set_variable = { SYR_amount_of_loans = 1 }
 			}
-			else = {
-				add_to_variable = { SYR_amount_of_loans = 1 }
-			}
+			else = { add_to_variable = { SYR_amount_of_loans = 1 } }
 		}
 
 		ai_will_do = {
@@ -8611,9 +8607,7 @@ focus_tree = {
 				limit = { NOT = { has_variable = SYR_amount_of_loans } }
 				set_variable = { SYR_amount_of_loans = 1 }
 			}
-			else = {
-				add_to_variable = { SYR_amount_of_loans = 1 }
-			}
+			else = { add_to_variable = { SYR_amount_of_loans = 1 } }
 		}
 
 		ai_will_do = {
@@ -8668,9 +8662,7 @@ focus_tree = {
 				limit = { NOT = { has_variable = SYR_amount_of_loans } }
 				set_variable = { SYR_amount_of_loans = 1 }
 			}
-			else = {
-				add_to_variable = { SYR_amount_of_loans = 1 }
-			}
+			else = { add_to_variable = { SYR_amount_of_loans = 1 } }
 		}
 
 		ai_will_do = {
@@ -8723,9 +8715,7 @@ focus_tree = {
 				limit = { NOT = { has_variable = SYR_amount_of_loans } }
 				set_variable = { SYR_amount_of_loans = 1 }
 			}
-			else = {
-				add_to_variable = { SYR_amount_of_loans = 1 }
-			}
+			else = { add_to_variable = { SYR_amount_of_loans = 1 } }
 		}
 
 		ai_will_do = {
@@ -8778,9 +8768,7 @@ focus_tree = {
 				limit = { NOT = { has_variable = SYR_amount_of_loans } }
 				set_variable = { SYR_amount_of_loans = 1 }
 			}
-			else = {
-				add_to_variable = { SYR_amount_of_loans = 1 }
-			}
+			else = { add_to_variable = { SYR_amount_of_loans = 1 } }
 		}
 
 		ai_will_do = {
@@ -9843,9 +9831,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_lebanese_chaos"
 		LEB = {
-			every_core_state = {
-				add_claim_by = ROOT
-			}
+			every_core_state = { add_claim_by = ROOT }
 			country_event = { id = SyriaFocus.50 days = 1 }
 		}
 	}
@@ -9938,9 +9924,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -9999,21 +9983,15 @@ shared_focus = {
 		}
 		random_list = {
 			1 = {
-				modifier = {
-					factor = success_chance
-				}
+				modifier = { factor = success_chance }
 				JOR = { country_event = SyriaFocus.55 }
 			}
 			1 = {
-				modifier = {
-					factor = civil_war_chance
-				}
+				modifier = { factor = civil_war_chance }
 				JOR = { country_event = SyriaFocus.57 }
 			}
 			1 = {
-				modifier = {
-					factor = remaining_chance
-				}
+				modifier = { factor = remaining_chance }
 				JOR = { country_event = SyriaFocus.58 }
 			}
 		}
@@ -10034,9 +10012,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -10139,21 +10115,15 @@ shared_focus = {
 			}
 		}
 		if = {
-			limit = {
-				country_exists = ISR
-			}
+			limit = { country_exists = ISR }
 			ISR = { country_event = { id = SyriaFocus.59 hours = 6 } }
 		}
 		if = {
-			limit = {
-				country_exists = PAL
-			}
+			limit = { country_exists = PAL }
 			PAL = { country_event = { id = SyriaFocus.59 hours = 6 } }
 		}
 		if = {
-			limit = {
-				country_exists = HAM
-			}
+			limit = { country_exists = HAM }
 			HAM = { country_event = { id = SyriaFocus.59 hours = 6 } }
 		}
 	}
@@ -10194,9 +10164,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_zionist_threat"
 		if = {
-			limit = {
-				NOT = { has_completed_focus = SYR_arm_palestinians_to_fight }
-			}
+			limit = { NOT = { has_completed_focus = SYR_arm_palestinians_to_fight } }
 			every_state = {
 				limit = {
 					OR = {
@@ -10216,9 +10184,7 @@ shared_focus = {
 			}
 		}
 		if = {
-			limit = {
-				has_completed_focus = SYR_arm_palestinians_to_fight
-			}
+			limit = { has_completed_focus = SYR_arm_palestinians_to_fight }
 			ISR = { country_event = { id = SyriaFocus.60 hours = 6 } }
 		}
 	}
@@ -10227,9 +10193,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -10278,9 +10242,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_befriend_sudan"
 		SUD = { country_event = { id = SyriaFocus.63 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_to_faction = SUD
-		}
+		effect_tooltip = { add_to_faction = SUD }
 		custom_effect_tooltip = TT_SYR_ALIGN_SUDAN
 	}
 
@@ -10320,9 +10282,7 @@ shared_focus = {
 		}
 		NOT = { owns_state = 213 }
 		EGY = { owns_state = 213 }
-		NOT = {
-			has_global_flag = SUEZ_CANAL_BLOCKED
-		}
+		NOT = { has_global_flag = SUEZ_CANAL_BLOCKED }
 	}
 
 	completion_reward = {
@@ -10339,9 +10299,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -10376,18 +10334,10 @@ shared_focus = {
 
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_iraq_divisions"
-		IRQ = {
-			every_owned_state = {
-				add_claim_by = ROOT
-			}
-		}
+		IRQ = { every_owned_state = { add_claim_by = ROOT } }
 		if = {
 			limit = { country_exists = KUR }
-			KUR = {
-				every_owned_state = {
-					add_claim_by = ROOT
-				}
-			}
+			KUR = { every_owned_state = { add_claim_by = ROOT } }
 		}
 		if = {
 			limit = { IRQ = { has_idea = sunni } }
@@ -10507,9 +10457,7 @@ shared_focus = {
 			}
 		}
 		if = {
-			limit = {
-				IRQ = { has_civil_war = yes }
-			}
+			limit = { IRQ = { has_civil_war = yes } }
 			every_country_with_original_tag = {
 				original_tag_to_check = IRQ
 				ROOT = {
@@ -10542,9 +10490,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -10588,18 +10534,14 @@ shared_focus = {
 		}
 		KUW = { country_event = { id = md4.14 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			puppet = KUW
-		}
+		effect_tooltip = { puppet = KUW }
 	}
 
 	ai_will_do = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -10653,9 +10595,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -10686,9 +10626,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_concessions_to_kurds"
 		KUR = { country_event = { id = SyriaFocus.66 days = 3 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			puppet = KUR
-		}
+		effect_tooltip = { puppet = KUR }
 		custom_effect_tooltip = TT_SYR_CONCESSIONS_TO_KURDS
 		effect_tooltip = {
 			if = {
@@ -10745,9 +10683,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_kurds_in_turkey"
 		custom_effect_tooltip = TT_NEW_OOB_SYRIA
-		hidden_effect = {
-			load_oob = SYR_PKK_units
-		}
+		hidden_effect = { load_oob = SYR_PKK_units }
 	}
 
 	ai_will_do = { base = 1 }
@@ -10784,9 +10720,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_kurds_in_iran"
 		custom_effect_tooltip = TT_NEW_OOB_SYRIA
-		hidden_effect = {
-			load_oob = SYR_PDKI_units
-		}
+		hidden_effect = { load_oob = SYR_PDKI_units }
 	}
 
 	ai_will_do = { base = 1 }
@@ -10833,9 +10767,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_align_azerbaijan"
 		AZE = { country_event = { id = SyriaFocus.72 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_to_faction = AZE
-		}
+		effect_tooltip = { add_to_faction = AZE }
 		custom_effect_tooltip = TT_SYR_ALIGN_AZERBAIJAN
 	}
 

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -108,9 +108,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			change_relative_party_popularity = yes
-			set_politics = {
-				ruling_party = neutrality
-			}
+			set_politics = { ruling_party = neutrality }
 			recalculate_party = yes
 		}
 
@@ -338,9 +336,7 @@ focus_tree = {
 				remove_ideas = iranian_quds_force
 				add_ideas = small_medium_business_owners
 			}
-			else = {
-				add_ideas = small_medium_business_owners
-			}
+			else = { add_ideas = small_medium_business_owners }
 		}
 
 		ai_will_do = {
@@ -474,9 +470,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			change_relative_party_popularity = yes
-			set_politics = {
-				ruling_party = communism
-			}
+			set_politics = { ruling_party = communism }
 			recalculate_party = yes
 			set_variable = { Autocracy_leader = 1 }
 			custom_effect_tooltip = available_military_high_command
@@ -799,9 +793,7 @@ focus_tree = {
 			set_temp_variable = { party_popularity_increase = leader_popularity }
 			set_temp_variable = { temp_outlook_increase = leader_popularity }
 			change_relative_party_popularity = yes
-			set_politics = {
-				ruling_party = nationalist
-			}
+			set_politics = { ruling_party = nationalist }
 			recalculate_party = yes
 		}
 
@@ -855,9 +847,7 @@ focus_tree = {
 				remove_ideas = iranian_quds_force
 				add_ideas = the_military
 			}
-			else = {
-				add_ideas = the_military
-			}
+			else = { add_ideas = the_military }
 		}
 
 		ai_will_do = { base = 1 }
@@ -882,9 +872,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_resestablish_defence_companies"
 			custom_effect_tooltip = TT_ACTIVATE_DEFENCE_COMPANIES
-			hidden_effect = {
-				load_oob = "SYR_defence_companies"
-			}
+			hidden_effect = { load_oob = "SYR_defence_companies" }
 		}
 
 		ai_will_do = { base = 1 }
@@ -918,9 +906,7 @@ focus_tree = {
 				remove_ideas = oligarchs
 				add_ideas = fossil_fuel_industry
 			}
-			else = {
-				add_ideas = fossil_fuel_industry
-			}
+			else = { add_ideas = fossil_fuel_industry }
 		}
 
 		ai_will_do = { base = 1 }
@@ -1024,9 +1010,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_western
-				}
+				limit = { has_country_flag = Rifaat_western }
 				set_temp_variable = { rul_party_temp = 0 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 0 }
@@ -1045,9 +1029,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_emerging
-				}
+				limit = { has_country_flag = Rifaat_emerging }
 				set_temp_variable = { rul_party_temp = 6 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 6 }
@@ -1066,9 +1048,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_nonaligned
-				}
+				limit = { has_country_flag = Rifaat_nonaligned }
 				set_temp_variable = { rul_party_temp = 15 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 15 }
@@ -1087,9 +1067,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_salafist
-				}
+				limit = { has_country_flag = Rifaat_salafist }
 				set_temp_variable = { rul_party_temp = 10 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 10 }
@@ -1108,9 +1086,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					has_country_flag = Rifaat_nationalist
-				}
+				limit = { has_country_flag = Rifaat_nationalist }
 				set_temp_variable = { rul_party_temp = 21 }
 				change_ruling_party_effect = yes
 				set_temp_variable = { party_index = 21 }
@@ -1381,9 +1357,7 @@ focus_tree = {
 				change_relative_party_popularity = yes
 			}
 			if = { limit = { NOT = { has_idea = idea_syrian_kurds_without_citizenships } }
-				hidden_effect = {
-					country_event = SyriaFocus.99
-				}
+				hidden_effect = { country_event = SyriaFocus.99 }
 			}
 		}
 
@@ -3253,9 +3227,7 @@ focus_tree = {
 			syrian_corrcost_civ = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3263,9 +3235,7 @@ focus_tree = {
 				}
 			}
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3273,9 +3243,7 @@ focus_tree = {
 				}
 			}
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3283,9 +3251,7 @@ focus_tree = {
 				}
 			}
 			random_owned_state = {
-				limit = {
-					infrastructure < 5
-				}
+				limit = { infrastructure < 5 }
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -3682,9 +3648,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3711,9 +3675,7 @@ focus_tree = {
 						}
 						set_country_flag = SYR_AI_annex_LEB
 					}
-					25 = {
-						set_country_flag = SYR_AI_free_LEB
-					}
+					25 = { set_country_flag = SYR_AI_free_LEB }
 				}
 			}
 		}
@@ -3746,9 +3708,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_EXPENDITURE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3811,9 +3771,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3829,9 +3787,7 @@ focus_tree = {
 			}
 			LEB = {
 				random_owned_state = {
-					limit = {
-						industrial_complex > 0
-					}
+					limit = { industrial_complex > 0 }
 					remove_building = {
 						type = industrial_complex
 						level = 1
@@ -3878,9 +3834,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INSURGENCY FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3888,9 +3842,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_commit_more_troops"
 			LEB = { add_autonomy_score = { value = -150 } }
 			custom_effect_tooltip = TT_SYR_COMMIT_MORE_TROOPS
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_manpower_effect = -0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_manpower_effect = -0.05 } }
 			set_temp_variable = { temp_opinion = 5 }
 			change_the_military_opinion = yes
 		}
@@ -3928,9 +3880,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INSURGENCY FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3938,9 +3888,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_reduce_presence"
 			LEB = { add_autonomy_score = { value = 150 } }
 			custom_effect_tooltip = TT_SYR_REDUCE_TROOPS
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_manpower_effect = 0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_manpower_effect = 0.05 } }
 			set_temp_variable = { temp_opinion = -5 }
 			change_the_military_opinion = yes
 		}
@@ -3974,9 +3922,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -3984,9 +3930,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_replace_ghazi_kanaan"
 			LEB = { add_autonomy_score = { value = -150 } }
 			custom_effect_tooltip = TT_REPLACE_INTELLIGENCE
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_stability_effect = -0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_stability_effect = -0.05 } }
 			set_temp_variable = { temp_opinion = 5 }
 			change_intelligence_community_opinion = yes
 		}
@@ -4020,9 +3964,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION FOCUS_FILTER_STABILITY }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4030,9 +3972,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_recall_intelligence"
 			LEB = { add_autonomy_score = { value = 150 } }
 			custom_effect_tooltip = TT_RECALL_INTELLIGENCE
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_stability_effect = 0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_stability_effect = 0.05 } }
 			set_temp_variable = { temp_opinion = -5 }
 			change_intelligence_community_opinion = yes
 		}
@@ -4070,9 +4010,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4100,9 +4038,7 @@ focus_tree = {
 				LEB = { add_popularity = { ideology = fascism popularity = 0.10 } }
 			}
 			custom_effect_tooltip = TT_REDUCE_POLITICAL_LIBERTIES
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_political_power_effect = -0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_political_power_effect = -0.05 } }
 		}
 
 		ai_will_do = {
@@ -4138,9 +4074,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4168,9 +4102,7 @@ focus_tree = {
 				LEB = { add_popularity = { ideology = fascism popularity = -0.10 } }
 			}
 			custom_effect_tooltip = TT_INCREASE_POLITICAL_LIBERTIES
-			hidden_effect = {
-				add_to_variable = { occupation_of_lebanon_political_power_effect = 0.05 }
-			}
+			hidden_effect = { add_to_variable = { occupation_of_lebanon_political_power_effect = 0.05 } }
 		}
 
 		ai_will_do = {
@@ -4206,9 +4138,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_FOREIGN_POLICY FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -4217,9 +4217,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INTERNAL_FACTION }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 		}
 
@@ -4280,9 +4278,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 			OR = {
 				AND = {
@@ -4291,19 +4287,13 @@ focus_tree = {
 					has_completed_focus = SYR_reduced_political_liberty
 					has_completed_focus = SYR_assassinate_lebanese_prime_minister
 				}
-				LEB = {
-					has_autonomy_state = autonomy_autonomous_state
-				}
+				LEB = { has_autonomy_state = autonomy_autonomous_state }
 			}
 		}
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_integrate_lebanon"
-			LEB = {
-				every_core_state = {
-					add_core_of = ROOT
-				}
-			}
+			LEB = { every_core_state = { add_core_of = ROOT } }
 			annex_country = { target = LEB }
 			hidden_effect = { news_event = { id = SyriaFocusNews.17 hours = 6 } }
 		}
@@ -4312,9 +4302,7 @@ focus_tree = {
 			base = 1
 			modifier = {
 				add = 25
-				LEB = {
-					has_autonomy_state = autonomy_autonomous_state
-				}
+				LEB = { has_autonomy_state = autonomy_autonomous_state }
 			}
 			modifier = {
 				add = 15
@@ -4347,9 +4335,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INFLUENCE }
 
 		available = {
-			NOT = {
-				has_global_flag = GLOBAL_syrian_civil_war_over
-			}
+			NOT = { has_global_flag = GLOBAL_syrian_civil_war_over }
 			LEB = { is_subject_of = ROOT }
 			OR = {
 				AND = {
@@ -4650,9 +4636,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_bawabet_dimashq"
 			set_temp_variable = { arg_popularity = 0.05 }
 			add_ruling_outlook_popularity = yes
-			186 = {
-				one_state_office_construction = yes
-			}
+			186 = { one_state_office_construction = yes }
 		}
 
 		ai_will_do = {
@@ -4886,9 +4870,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_dynamic_modifier = {
-					modifier = SYR_automotive_giants_modifier
-				}
+				add_dynamic_modifier = { modifier = SYR_automotive_giants_modifier }
 			}
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = GER.id }
@@ -4944,9 +4926,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_dynamic_modifier = {
-					modifier = SYR_SIAMCO_modifier
-				}
+				add_dynamic_modifier = { modifier = SYR_SIAMCO_modifier }
 			}
 			set_temp_variable = { percent_change = 3 }
 			set_temp_variable = { tag_index = PER.id }
@@ -5119,9 +5099,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_dynamic_modifier = {
-					modifier = SYR_production_invigoration_modifier
-				}
+				add_dynamic_modifier = { modifier = SYR_production_invigoration_modifier }
 			}
 			syrian_corrcost_civ = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
@@ -5212,9 +5190,7 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_dynamic_modifier = {
-					modifier = SYR_pharmaceutical_capital_modifier
-				}
+				add_dynamic_modifier = { modifier = SYR_pharmaceutical_capital_modifier }
 			}
 			syrian_corrcost_civ = yes
 			custom_effect_tooltip = TT_SYR_CORRUPTION_COSTS
@@ -5340,15 +5316,9 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_road_to_palmyra"
-			188 = {
-				one_state_infrastructure = yes
-			}
-			186 = {
-				one_state_infrastructure = yes
-			}
-			561 = {
-				one_state_infrastructure = yes
-			}
+			188 = { one_state_infrastructure = yes }
+			186 = { one_state_infrastructure = yes }
+			561 = { one_state_infrastructure = yes }
 		}
 
 		ai_will_do = {
@@ -5461,11 +5431,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_expand_the_sector"
-			189 = {
-				add_dynamic_modifier = {
-					modifier = SYR_latakian_service_expansion
-				}
-			}
+			189 = { add_dynamic_modifier = { modifier = SYR_latakian_service_expansion } }
 		}
 
 		ai_will_do = {
@@ -5522,9 +5488,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_expand_powerstations_in_homs"
-			188 = {
-				two_state_fossil_fuel_powerplant = yes
-			}
+			188 = { two_state_fossil_fuel_powerplant = yes }
 		}
 
 		ai_will_do = {
@@ -5639,15 +5603,9 @@ focus_tree = {
 					level = 1
 					instant_build = yes
 				}
-				add_dynamic_modifier = {
-					modifier = SYR_aleppan_agricultural_investors_modifier
-				}
+				add_dynamic_modifier = { modifier = SYR_aleppan_agricultural_investors_modifier }
 			}
-			566 = {
-				add_dynamic_modifier = {
-					modifier = SYR_aleppan_agricultural_investors_modifier
-				}
-			}
+			566 = { add_dynamic_modifier = { modifier = SYR_aleppan_agricultural_investors_modifier } }
 			set_temp_variable = { temp_opinion = -10 }
 			change_oligarchs_opinion = yes
 			set_temp_variable = { temp_opinion = 10 }
@@ -5834,9 +5792,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_invest_in_wdrvm"
-			188 = {
-				one_state_renewable_energy_infra = yes
-			}
+			188 = { one_state_renewable_energy_infra = yes }
 			set_temp_variable = { temp_opinion = -5 }
 			change_oligarchs_opinion = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -5880,9 +5836,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_set_up_puppet_ren_company"
-			188 = {
-				one_state_renewable_energy_infra = yes
-			}
+			188 = { one_state_renewable_energy_infra = yes }
 			set_temp_variable = { temp_opinion = 5 }
 			change_oligarchs_opinion = yes
 			set_temp_variable = { temp_opinion = -5 }
@@ -5920,9 +5874,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_encourage_domestic_solar_companies"
-			188 = {
-				two_state_renewable_energy_infra = yes
-			}
+			188 = { two_state_renewable_energy_infra = yes }
 			set_temp_variable = { temp_opinion = -5 }
 			change_oligarchs_opinion = yes
 			set_temp_variable = { temp_opinion = 5 }
@@ -5958,9 +5910,7 @@ focus_tree = {
 
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_monopolize_solar_power"
-			188 = {
-				one_state_renewable_energy_infra = yes
-			}
+			188 = { one_state_renewable_energy_infra = yes }
 			set_temp_variable = { temp_opinion = 5 }
 			change_oligarchs_opinion = yes
 			set_temp_variable = { temp_opinion = -5 }
@@ -7328,9 +7278,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_russian_tool"
 			SOV = { country_event = SyriaFocus.16 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				SOV = { give_guarantee = ROOT }
-			}
+			effect_tooltip = { SOV = { give_guarantee = ROOT } }
 		}
 
 		ai_will_do = {
@@ -7377,9 +7325,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_iranian_puppet"
 			PER = { country_event = SyriaFocus.16 }
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				PER = { give_guarantee = ROOT }
-			}
+			effect_tooltip = { PER = { give_guarantee = ROOT } }
 		}
 
 		ai_will_do = {
@@ -8237,13 +8183,7 @@ focus_tree = {
 						enemy = HEZ
 					}
 				}
-				else = {
-					HEZ = {
-						every_controlled_state = {
-							add_claim_by = ROOT
-						}
-					}
-				}
+				else = { HEZ = { every_controlled_state = { add_claim_by = ROOT } } }
 			}
 		}
 
@@ -8251,9 +8191,7 @@ focus_tree = {
 			base = 1
 			modifier = {
 				factor = 0
-				any_neighbor_country = {
-					has_war_with = ROOT
-				}
+				any_neighbor_country = { has_war_with = ROOT }
 			}
 		}
 	}
@@ -8405,9 +8343,7 @@ focus_tree = {
 				has_country_flag = SYR_Post_War_Tree_Finished
 			}
 			country_exists = LEB
-			LEB = {
-				communism > 0.20
-			}
+			LEB = { communism > 0.20 }
 		}
 
 		bypass = {
@@ -8420,16 +8356,10 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus SYR_lebanese_coup"
 			if = {
-				limit = {
-					LEB = { communism < 0.3 }
-				}
+				limit = { LEB = { communism < 0.3 } }
 				random_list = {
-					40 = {
-						country_event = SyriaFocus.33
-					}
-					60 = {
-						country_event = SyriaFocus.34
-					}
+					40 = { country_event = SyriaFocus.33 }
+					60 = { country_event = SyriaFocus.34 }
 				}
 			}
 			if = {
@@ -8440,12 +8370,8 @@ focus_tree = {
 					}
 				}
 				random_list = {
-					60 = {
-						country_event = SyriaFocus.33
-					}
-					40 = {
-						country_event = SyriaFocus.34
-					}
+					60 = { country_event = SyriaFocus.33 }
+					40 = { country_event = SyriaFocus.34 }
 				}
 			}
 			if = {
@@ -8456,18 +8382,12 @@ focus_tree = {
 					}
 				}
 				random_list = {
-					80 = {
-						country_event = SyriaFocus.33
-					}
-					20 = {
-						country_event = SyriaFocus.34
-					}
+					80 = { country_event = SyriaFocus.33 }
+					20 = { country_event = SyriaFocus.34 }
 				}
 			}
 			if = {
-				limit = {
-					LEB = { communism > 0.5 }
-				}
+				limit = { LEB = { communism > 0.5 } }
 				country_event = SyriaFocus.33
 			}
 		}

--- a/common/national_focus/05_syria.txt
+++ b/common/national_focus/05_syria.txt
@@ -10876,9 +10876,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_alawite_militias"
 		custom_effect_tooltip = TT_NEW_OOB_SYRIA
-		hidden_effect = {
-			load_oob = SYR_alawite_units
-		}
+		hidden_effect = { load_oob = SYR_alawite_units }
 	}
 
 	ai_will_do = { base = 1 }
@@ -10926,9 +10924,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_align_armenia"
 		ARM = { country_event = { id = SyriaFocus.73 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_to_faction = ARM
-		}
+		effect_tooltip = { add_to_faction = ARM }
 		custom_effect_tooltip = TT_SYR_ALIGN_ARMENIA
 	}
 
@@ -10977,9 +10973,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_align_greece"
 		GRE = { country_event = { id = SyriaFocus.74 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_to_faction = GRE
-		}
+		effect_tooltip = { add_to_faction = GRE }
 		custom_effect_tooltip = TT_SYR_ALIGN_GREECE
 	}
 
@@ -11036,9 +11030,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -11109,9 +11101,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_align_cyprus"
 		CYP = { country_event = { id = md4.14 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			puppet = CYP
-		}
+		effect_tooltip = { puppet = CYP }
 		set_temp_variable = { wargoal_on = NCY }
 		set_temp_variable = { wargoal_type = 2 }
 		add_threat_from_wargoal_effect = yes
@@ -11125,9 +11115,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -11164,9 +11152,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_align_northern_cyprus"
 		NCY = { country_event = { id = md4.14 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			puppet = NCY
-		}
+		effect_tooltip = { puppet = NCY }
 		set_temp_variable = { wargoal_on = CYP }
 		set_temp_variable = { wargoal_type = 2 }
 		add_threat_from_wargoal_effect = yes
@@ -11180,9 +11166,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -11234,9 +11218,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -11284,9 +11266,7 @@ shared_focus = {
 		base = 1
 		modifier = {
 			factor = 0
-			any_neighbor_country = {
-				has_war_with = ROOT
-			}
+			any_neighbor_country = { has_war_with = ROOT }
 		}
 	}
 }
@@ -11406,9 +11386,7 @@ shared_focus = {
 				remove_idea = alawite_high_command
 			}
 		}
-		else = {
-			add_ideas = syrian_peoples_army
-		}
+		else = { add_ideas = syrian_peoples_army }
 		set_temp_variable = { temp_opinion = -5 }
 		change_the_military_opinion = yes
 	}
@@ -11457,9 +11435,7 @@ shared_focus = {
 					remove_idea = military_power_vacuum
 				}
 			}
-			else = {
-				add_ideas = alawite_high_command_strengthened
-			}
+			else = { add_ideas = alawite_high_command_strengthened }
 		}
 	}
 
@@ -12451,9 +12427,7 @@ shared_focus = {
 			limit = { has_dlc = "La Resistance" }
 			add_ideas = syrian_electronic_army_LAR
 		}
-		else = {
-			add_ideas = syrian_electronic_army
-		}
+		else = { add_ideas = syrian_electronic_army }
 	}
 
 	ai_will_do = { base = 1 }
@@ -12615,9 +12589,7 @@ shared_focus = {
 
 	available = {
 		NOT = { has_country_flag = Relinquished_Golan }
-		NOT = {
-			has_country_flag = syracc_negot
-		}
+		NOT = { has_country_flag = syracc_negot }
 	}
 
 	bypass = { owns_state = 587 }
@@ -12660,11 +12632,7 @@ shared_focus = {
 		remove_state_core = 587
 		remove_state_claim = 587
 		if = {
-			limit = {
-				587 = {
-					is_controlled_by = SYR
-				}
-			}
+			limit = { 587 = { is_controlled_by = SYR } }
 			587 = { transfer_state_to = ISR }
 		}
 		set_country_flag = Relinquished_Golan
@@ -12703,9 +12671,7 @@ shared_focus = {
 			NOT = { has_government = democratic }
 			neutrality_neutral_social_in_power_or_coalition = no
 		}
-		NOT = {
-			has_country_flag = syracc_negot
-		}
+		NOT = { has_country_flag = syracc_negot }
 		OR = {
 			country_exists = HAM
 			country_exists = PAL
@@ -12744,9 +12710,7 @@ shared_focus = {
 					remove_state_claim = 209
 					add_state_core = 209
 				}
-				PAL = {
-					add_state_core = 209
-				}
+				PAL = { add_state_core = 209 }
 			}
 			ISR = { country_event = { id = SyriaFocus.76 hours = 6 } }
 			PAL = { country_event = { id = SyriaFocus.76 hours = 6 } }
@@ -12793,9 +12757,7 @@ shared_focus = {
 			NOT = { has_government = democratic }
 			neutrality_neutral_social_in_power_or_coalition = no
 		}
-		NOT = {
-			has_country_flag = syracc_negot
-		}
+		NOT = { has_country_flag = syracc_negot }
 		country_exists = HAM
 		HAM = { is_subject = no }
 	}
@@ -12844,9 +12806,7 @@ shared_focus = {
 				change_influence_percentage = yes
 			}
 		}
-		else = {
-			add_political_power = 100
-		}
+		else = { add_political_power = 100 }
 	}
 
 	ai_will_do = { base = 1 }
@@ -12867,9 +12827,7 @@ shared_focus = {
 	search_filters = { FOCUS_FILTER_DIPLOMACY }
 
 	available = {
-		NOT = {
-			has_country_flag = syracc_negot
-		}
+		NOT = { has_country_flag = syracc_negot }
 		NOT = { has_war_with = PAL }
 		is_subject = no
 	}
@@ -13177,9 +13135,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_invite_jordan"
 		JOR = { country_event = { id = SyriaFocus.79 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_to_faction = JOR
-		}
+		effect_tooltip = { add_to_faction = JOR }
 		custom_effect_tooltip = TT_SYR_ALIGN_JORDAN
 	}
 
@@ -13215,9 +13171,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_invite_egypt"
 		EGY = { country_event = { id = SyriaFocus.79 hours = 6 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_to_faction = EGY
-		}
+		effect_tooltip = { add_to_faction = EGY }
 		custom_effect_tooltip = TT_SYR_ALIGN_EGYPT
 	}
 
@@ -13366,9 +13320,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_join_peninsula_shield"
 		SAU = { country_event = { id = SyriaFocus.80 days = 3 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			SAU = { add_to_faction = ROOT }
-		}
+		effect_tooltip = { SAU = { add_to_faction = ROOT } }
 		custom_effect_tooltip = TT_SYR_ALIGN_SAUDI_ARABIA
 	}
 
@@ -13681,9 +13633,7 @@ shared_focus = {
 	available = {
 		is_in_faction = no
 		emerging_autocracy_are_in_power = yes
-		EGY = {
-			emerging_autocracy_are_in_power = yes
-		}
+		EGY = { emerging_autocracy_are_in_power = yes }
 	}
 
 	bypass = { EGY = { is_subject_of = ROOT } }
@@ -13697,9 +13647,7 @@ shared_focus = {
 			country_event = { id = md4.14 days = 2 }
 		}
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			puppet = EGY
-		}
+		effect_tooltip = { puppet = EGY }
 		hidden_effect = { news_event = { id = SyriaFocusNews.21 hours = 6 } }
 	}
 
@@ -13988,11 +13936,7 @@ shared_focus = {
 	available = { NOT = { has_country_flag = Relinquished_Hatay } }
 
 	bypass = {
-		158 = {
-			OWNER = {
-				is_subject_of = SYR
-			}
-		}
+		158 = { OWNER = { is_subject_of = SYR } }
 		owns_state = 158
 	}
 
@@ -14023,9 +13967,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_provide_intelligence_to_pkk"
 		custom_effect_tooltip = TT_SYR_INTELLIGENCE_TO_PKK
-		TUR = {
-			add_to_variable = { TUR_PKK_strength = 10 }
-		}
+		TUR = { add_to_variable = { TUR_PKK_strength = 10 } }
 	}
 
 	ai_will_do = {
@@ -14267,9 +14209,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_close_pkk_border"
 		custom_effect_tooltip = TT_SYR_CLOSE_PKK_BORDER
-		TUR = {
-			add_to_variable = { TUR_PKK_strength = -10 }
-		}
+		TUR = { add_to_variable = { TUR_PKK_strength = -10 } }
 		add_opinion_modifier = {
 			modifier = supports_us
 			target = TUR
@@ -14341,9 +14281,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_turkish_delights"
 		custom_effect_tooltip = TT_SYR_CLOSE_PKK_BORDER
-		TUR = {
-			add_to_variable = { TUR_PKK_strength = -10 }
-		}
+		TUR = { add_to_variable = { TUR_PKK_strength = -10 } }
 		add_opinion_modifier = {
 			modifier = free_trade_agreement
 			target = TUR
@@ -14574,9 +14512,7 @@ shared_focus = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_russian_military_cooperation"
 		SOV = { country_event = { id = CSTO.1 days = 1 } }
 		custom_effect_tooltip = TT_IF_THEY_ACCEPT
-		effect_tooltip = {
-			add_ideas = CSTO_member
-		}
+		effect_tooltip = { add_ideas = CSTO_member }
 		custom_effect_tooltip = TT_SYR_ALIGN_RUSSIA
 	}
 
@@ -15007,11 +14943,7 @@ shared_focus = {
 	search_filters = { FOCUS_FILTER_DIPLOMACY }
 
 	available = {
-		NOT = {
-			any_enemy_country = {
-				has_idea = NATO_member
-			}
-		}
+		NOT = { any_enemy_country = { has_idea = NATO_member } }
 		has_government = democratic
 	}
 
@@ -15255,9 +15187,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_safehaven_for_islamists"
 		if = {
-			limit = {
-				NOT = { has_idea = global_salafist_recruitment }
-			}
+			limit = { NOT = { has_idea = global_salafist_recruitment } }
 			add_ideas = global_salafist_recruitment
 		}
 		set_temp_variable = { party_index = 11 }
@@ -15288,9 +15218,7 @@ shared_focus = {
 	completion_reward = {
 		log = "[GetDateText]: [Root.GetName]: Focus SYR_ally_alqaeda"
 		if = {
-			limit = {
-				NOT = { has_idea = al_qaeda_network }
-			}
+			limit = { NOT = { has_idea = al_qaeda_network } }
 			add_ideas = al_qaeda_network
 		}
 	}

--- a/common/national_focus/05_usa.txt
+++ b/common/national_focus/05_usa.txt
@@ -40223,9 +40223,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_cradle"
 			if = {
-				limit = {
-					country_exists = YEM
-				}
+				limit = { country_exists = YEM }
 				set_temp_variable = { wargoal_on = YEM }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40235,9 +40233,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = OMA
-				}
+				limit = { country_exists = OMA }
 				set_temp_variable = { wargoal_on = OMA }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40247,9 +40243,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = UAE
-				}
+				limit = { country_exists = UAE }
 				set_temp_variable = { wargoal_on = UAE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40259,9 +40253,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SAU
-				}
+				limit = { country_exists = SAU }
 				set_temp_variable = { wargoal_on = SAU }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40271,9 +40263,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = QAT
-				}
+				limit = { country_exists = QAT }
 				set_temp_variable = { wargoal_on = QAT }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40283,9 +40273,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = KUW
-				}
+				limit = { country_exists = KUW }
 				set_temp_variable = { wargoal_on = KUW }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40295,9 +40283,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = IRQ
-				}
+				limit = { country_exists = IRQ }
 				set_temp_variable = { wargoal_on = IRQ }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40307,9 +40293,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = JOR
-				}
+				limit = { country_exists = JOR }
 				set_temp_variable = { wargoal_on = JOR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40319,9 +40303,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = ISR
-				}
+				limit = { country_exists = ISR }
 				set_temp_variable = { wargoal_on = ISR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40331,9 +40313,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = PAL
-				}
+				limit = { country_exists = PAL }
 				set_temp_variable = { wargoal_on = PAL }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40343,9 +40323,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = HEZ
-				}
+				limit = { country_exists = HEZ }
 				set_temp_variable = { wargoal_on = HEZ }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40355,9 +40333,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = LEB
-				}
+				limit = { country_exists = LEB }
 				set_temp_variable = { wargoal_on = LEB }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40367,9 +40343,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SYR
-				}
+				limit = { country_exists = SYR }
 				set_temp_variable = { wargoal_on = SYR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40379,9 +40353,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = KUR
-				}
+				limit = { country_exists = KUR }
 				set_temp_variable = { wargoal_on = KUR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40391,9 +40363,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = TUR
-				}
+				limit = { country_exists = TUR }
 				set_temp_variable = { wargoal_on = TUR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40486,9 +40456,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_sarajevo"
 			if = {
-				limit = {
-					country_exists = CRO
-				}
+				limit = { country_exists = CRO }
 				set_temp_variable = { wargoal_on = CRO }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40498,9 +40466,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = BOS
-				}
+				limit = { country_exists = BOS }
 				set_temp_variable = { wargoal_on = BOS }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40510,9 +40476,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SER
-				}
+				limit = { country_exists = SER }
 				set_temp_variable = { wargoal_on = SER }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40522,9 +40486,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = KOS
-				}
+				limit = { country_exists = KOS }
 				set_temp_variable = { wargoal_on = KOS }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40534,9 +40496,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = MNT
-				}
+				limit = { country_exists = MNT }
 				set_temp_variable = { wargoal_on = MNT }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40546,9 +40506,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = ROM
-				}
+				limit = { country_exists = ROM }
 				set_temp_variable = { wargoal_on = ROM }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40558,9 +40516,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = BUL
-				}
+				limit = { country_exists = BUL }
 				set_temp_variable = { wargoal_on = BUL }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40570,9 +40526,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = FYR
-				}
+				limit = { country_exists = FYR }
 				set_temp_variable = { wargoal_on = FYR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40582,9 +40536,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = ALB
-				}
+				limit = { country_exists = ALB }
 				set_temp_variable = { wargoal_on = ALB }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40594,9 +40546,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = GRE
-				}
+				limit = { country_exists = GRE }
 				set_temp_variable = { wargoal_on = GRE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40642,9 +40592,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_caging_the_bear"
 			if = {
-				limit = {
-					country_exists = SOV
-				}
+				limit = { country_exists = SOV }
 				set_temp_variable = { wargoal_on = SOV }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40709,9 +40657,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_himalayas"
 			if = {
-				limit = {
-					country_exists = RAJ
-				}
+				limit = { country_exists = RAJ }
 				set_temp_variable = { wargoal_on = RAJ }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40721,9 +40667,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = PAK
-				}
+				limit = { country_exists = PAK }
 				set_temp_variable = { wargoal_on = PAK }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40733,9 +40677,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = BAN
-				}
+				limit = { country_exists = BAN }
 				set_temp_variable = { wargoal_on = BAN }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40745,9 +40687,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = BHU
-				}
+				limit = { country_exists = BHU }
 				set_temp_variable = { wargoal_on = BHU }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40757,9 +40697,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = NEP
-				}
+				limit = { country_exists = NEP }
 				set_temp_variable = { wargoal_on = NEP }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40824,9 +40762,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_great_leap_forward"
 			if = {
-				limit = {
-					country_exists = CHI
-				}
+				limit = { country_exists = CHI }
 				set_temp_variable = { wargoal_on = CHI }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40836,9 +40772,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = MON
-				}
+				limit = { country_exists = MON }
 				set_temp_variable = { wargoal_on = MON }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40848,9 +40782,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = NKO
-				}
+				limit = { country_exists = NKO }
 				set_temp_variable = { wargoal_on = NKO }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40860,9 +40792,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = KOR
-				}
+				limit = { country_exists = KOR }
 				set_temp_variable = { wargoal_on = KOR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40872,9 +40802,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = TAI
-				}
+				limit = { country_exists = TAI }
 				set_temp_variable = { wargoal_on = TAI }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -42437,9 +42365,7 @@ focus_tree = {
 				MODIFIER = USA_dynamic_modifier_us_army
 			}
 			add_to_variable = { us_army_coordination = -0.12 tooltip = coordination_bonus_tt }
-			hidden_effect = {
-				set_cosmetic_tag = USA_free_american_territories
-			}
+			hidden_effect = { set_cosmetic_tag = USA_free_american_territories }
 		}
 
 		ai_will_do = { base = 1 }

--- a/common/national_focus/05_usa.txt
+++ b/common/national_focus/05_usa.txt
@@ -15480,9 +15480,7 @@ focus_tree = {
 				add_idea = space_force2
 			}
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 100
@@ -15541,9 +15539,7 @@ focus_tree = {
 			}
 			add_ideas = space_marines
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 150
@@ -15604,9 +15600,7 @@ focus_tree = {
 				add_idea = continued_space_efforts3
 			}
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 50
@@ -15666,9 +15660,7 @@ focus_tree = {
 				add_idea = continued_space_efforts4
 			}
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 100
@@ -15726,9 +15718,7 @@ focus_tree = {
 				add_idea = continued_space_efforts5
 			}
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 150
@@ -15838,9 +15828,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = 0.06 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems }
 		}
 
 		ai_will_do = {
@@ -15895,9 +15883,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = 0.08 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_two_a
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_two_a }
 		}
 
 		ai_will_do = {
@@ -15952,9 +15938,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = 0.10 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_three_a
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_three_a }
 		}
 
 		ai_will_do = { base = 10 }
@@ -16000,9 +15984,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = 0.12 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_four_a
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_four_a }
 		}
 
 		ai_will_do = { base = 10 }
@@ -16066,9 +16048,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = -0.06 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems }
 		}
 
 		ai_will_do = {
@@ -16124,9 +16104,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = -0.08 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_two_b
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_two_b }
 		}
 
 		ai_will_do = { base = 10 }
@@ -16177,9 +16155,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = -0.10 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_three_b
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_three_b }
 		}
 
 		ai_will_do = { base = 10 }
@@ -16229,9 +16205,7 @@ focus_tree = {
 				MODIFIER = USA_american_tax_code
 			}
 			add_to_variable = { tax_code_interest_rate = -0.12 tooltip = interest_rate_multiplier_modifier_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_four_b
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_four_b }
 		}
 
 		ai_will_do = { base = 10 }
@@ -16287,9 +16261,7 @@ focus_tree = {
 				MODIFIER = us_economic_policies
 			}
 			add_to_variable = { econ_consumer_goods = -0.01 tooltip = consumer_goods_factor_tt }
-			hidden_effect = {
-				remove_ideas = us_mass_media_problems_five_b
-			}
+			hidden_effect = { remove_ideas = us_mass_media_problems_five_b }
 		}
 
 		ai_will_do = { base = 10 }
@@ -16319,9 +16291,7 @@ focus_tree = {
 					add_idea = us_war_on_drugs_two
 				}
 			}
-			else = {
-				add_ideas = us_war_on_drugs_two
-			}
+			else = { add_ideas = us_war_on_drugs_two }
 		}
 
 		ai_will_do = {
@@ -17234,15 +17204,11 @@ focus_tree = {
 				AND = {
 					custom_trigger_tooltip = {
 						tooltip = USA_not_have_republicans_in_charge_TT
-						NOT = {
-							western_conservatism_are_in_power = yes
-						}
+						NOT = { western_conservatism_are_in_power = yes }
 					}
 					custom_trigger_tooltip = {
 						tooltip = USA_not_have_democrats_in_charge_TT
-						NOT = {
-							western_liberals_are_in_power = yes
-						}
+						NOT = { western_liberals_are_in_power = yes }
 					}
 					has_completed_focus = USA_focus_domestic_over_foreign
 				}
@@ -32768,9 +32734,7 @@ focus_tree = {
 			add_to_variable = { genstaff_conscription = -0.01 tooltip = conscription_tt }
 			add_to_variable = { genstaff_recruitable_population = 0.10 tooltip = conscription_factor_tt }
 			custom_effect_tooltip = USA_cosmetic_tag_military_junta_completed_desc
-			hidden_effect = {
-				set_cosmetic_tag = USA_cosmetic_tag_military_junta_completed
-			}
+			hidden_effect = { set_cosmetic_tag = USA_cosmetic_tag_military_junta_completed }
 		}
 
 		ai_will_do = { base = 1 }
@@ -34748,9 +34712,7 @@ focus_tree = {
 			}
 			add_to_variable = { domestic_political_power_gain = 0.04 tooltip = political_power_factor_tt }
 			add_to_variable = { domestic_foreign_influence_defense = 0.02 tooltip = foreign_influence_defense_modifier_tt }
-			hidden_effect = {
-				set_cosmetic_tag = USA_cosmetic_tag_monarchist
-			}
+			hidden_effect = { set_cosmetic_tag = USA_cosmetic_tag_monarchist }
 		}
 
 		ai_will_do = { base = 1 }
@@ -36167,9 +36129,7 @@ focus_tree = {
 			add_to_variable = { genstaff_daily_army_xp = 0.04 tooltip = experience_gain_army_tt }
 			add_to_variable = { genstaff_daily_navy_xp = 0.02 tooltip = experience_gain_navy_tt }
 			add_to_variable = { genstaff_daily_air_xp = 0.02 tooltip = experience_gain_air_tt }
-			hidden_effect = {
-				set_cosmetic_tag = USA_cosmetic_tag_red_junta
-			}
+			hidden_effect = { set_cosmetic_tag = USA_cosmetic_tag_red_junta }
 		}
 
 		ai_will_do = { base = 1 }
@@ -38933,9 +38893,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_the_eagle_descends_onto_the_continent"
 			if = {
-				limit = {
-					country_exists = SIE
-				}
+				limit = { country_exists = SIE }
 				set_temp_variable = { wargoal_on = SIE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -38945,9 +38903,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = AFR
-				}
+				limit = { country_exists = AFR }
 				set_temp_variable = { wargoal_on = AFR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39073,9 +39029,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_the_northern_cleanup"
 			if = {
-				limit = {
-					country_exists = SHA
-				}
+				limit = { country_exists = SHA }
 				set_temp_variable = { wargoal_on = SHA }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39085,9 +39039,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SSU
-				}
+				limit = { country_exists = SSU }
 				set_temp_variable = { wargoal_on = SSU }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39097,9 +39049,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = DAR
-				}
+				limit = { country_exists = DAR }
 				set_temp_variable = { wargoal_on = DAR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39211,9 +39161,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_congo_cabal"
 			if = {
-				limit = {
-					country_exists = DRC
-				}
+				limit = { country_exists = DRC }
 				set_temp_variable = { wargoal_on = DRC }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39223,9 +39171,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = RCD
-				}
+				limit = { country_exists = RCD }
 				set_temp_variable = { wargoal_on = RCD }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39235,9 +39181,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = MLC
-				}
+				limit = { country_exists = MLC }
 				set_temp_variable = { wargoal_on = MLC }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39347,9 +39291,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_geographic_horn"
 			if = {
-				limit = {
-					country_exists = SML
-				}
+				limit = { country_exists = SML }
 				set_temp_variable = { wargoal_on = SML }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39359,9 +39301,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = PUN
-				}
+				limit = { country_exists = PUN }
 				set_temp_variable = { wargoal_on = PUN }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39371,9 +39311,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SOM
-				}
+				limit = { country_exists = SOM }
 				set_temp_variable = { wargoal_on = SOM }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39383,9 +39321,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SNA
-				}
+				limit = { country_exists = SNA }
 				set_temp_variable = { wargoal_on = SNA }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39395,9 +39331,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SOM
-				}
+				limit = { country_exists = SOM }
 				set_temp_variable = { wargoal_on = SWS }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39407,9 +39341,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SOM
-				}
+				limit = { country_exists = SOM }
 				set_temp_variable = { wargoal_on = JUB }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes

--- a/common/national_focus/05_usa.txt
+++ b/common/national_focus/05_usa.txt
@@ -387,17 +387,13 @@ focus_tree = {
 
 		available = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2000_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2000_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -931,17 +927,13 @@ focus_tree = {
 
 		available = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2000_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2001.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2000_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2000_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -1405,17 +1397,13 @@ focus_tree = {
 
 		available = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2004_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2004_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -1793,17 +1781,13 @@ focus_tree = {
 
 		available = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2004_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2005.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2004_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2004_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -2348,17 +2332,13 @@ focus_tree = {
 
 		available = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2008_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2008_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -2793,17 +2773,13 @@ focus_tree = {
 
 		available = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2008_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2009.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2008_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2008_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -3279,17 +3255,13 @@ focus_tree = {
 
 		available = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2012_republicans }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_republicans
-			}
+			NOT = { has_completed_focus = USA_focus_2012_republicans }
 			western_liberals_are_in_power = yes
 		}
 
@@ -3791,17 +3763,13 @@ focus_tree = {
 
 		available = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2012_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2013.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2012_democrats
-			}
+			NOT = { has_completed_focus = USA_focus_2012_democrats }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -4308,17 +4276,13 @@ focus_tree = {
 
 		available = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_republican_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_republican_victory }
 			western_liberals_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_republican_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_republican_victory }
 			western_liberals_are_in_power = yes
 		}
 
@@ -4589,17 +4553,13 @@ focus_tree = {
 
 		available = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_democrat_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_democrat_victory }
 			western_conservatism_are_in_power = yes
 		}
 
 		bypass = {
 			date > 2017.1.20
-			NOT = {
-				has_completed_focus = USA_focus_2016_democrat_victory
-			}
+			NOT = { has_completed_focus = USA_focus_2016_democrat_victory }
 			western_conservatism_are_in_power = yes
 		}
 
@@ -8092,9 +8052,7 @@ focus_tree = {
 					NOT = { has_trait = skilled_staffer }
 				}
 				random_select_amount = 6
-				add_trait = {
-					trait = skilled_staffer
-				}
+				add_trait = { trait = skilled_staffer }
 			}
 		}
 
@@ -8700,9 +8658,7 @@ focus_tree = {
 				add_political_power = 50
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 40 }
@@ -8851,9 +8807,7 @@ focus_tree = {
 				army_experience = 10
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 40 }
@@ -9296,9 +9250,7 @@ focus_tree = {
 				army_experience = 15
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9339,9 +9291,7 @@ focus_tree = {
 				add_political_power = 50
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9447,9 +9397,7 @@ focus_tree = {
 				add_political_power = 50
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9484,9 +9432,7 @@ focus_tree = {
 				army_experience = 15
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 30 }
@@ -9869,9 +9815,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -9984,9 +9928,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10024,9 +9966,7 @@ focus_tree = {
 				modify_treasury_effect = yes
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10140,9 +10080,7 @@ focus_tree = {
 				add_political_power = 100
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10176,9 +10114,7 @@ focus_tree = {
 				add_political_power = 100
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10213,9 +10149,7 @@ focus_tree = {
 				add_political_power = 100
 			}
 			custom_effect_tooltip = TT_IF_THEY_REJECT
-			effect_tooltip = {
-				add_political_power = -50
-			}
+			effect_tooltip = { add_political_power = -50 }
 		}
 
 		ai_will_do = { base = 1 }
@@ -10885,9 +10819,7 @@ focus_tree = {
 				}
 			}
 			custom_effect_tooltip = TT_IF_THEY_ACCEPT
-			effect_tooltip = {
-				FSA = { add_ideas = USA_fsa_the_damascus_legion }
-			}
+			effect_tooltip = { FSA = { add_ideas = USA_fsa_the_damascus_legion } }
 		}
 
 		ai_will_do = { base = 1 }
@@ -15476,9 +15408,7 @@ focus_tree = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_establishment_of_the_space_force"
 			add_ideas = space_force
 			if = {
-				limit = {
-					NOT = { has_country_flag = finance_private_space_ventures }
-				}
+				limit = { NOT = { has_country_flag = finance_private_space_ventures } }
 				if = {
 					limit = { has_country_flag = finance_nasa }
 					add_political_power = 50

--- a/common/national_focus/05_usa.txt
+++ b/common/national_focus/05_usa.txt
@@ -39417,9 +39417,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_capetown"
 			if = {
-				limit = {
-					country_exists = UNI
-				}
+				limit = { country_exists = UNI }
 				set_temp_variable = { wargoal_on = UNI }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39429,9 +39427,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = AGL
-				}
+				limit = { country_exists = AGL }
 				set_temp_variable = { wargoal_on = AGL }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39549,9 +39545,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_old_world"
 			if = {
-				limit = {
-					country_exists = CAN
-				}
+				limit = { country_exists = CAN }
 				set_temp_variable = { wargoal_on = CAN }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39561,9 +39555,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = ENG
-				}
+				limit = { country_exists = ENG }
 				set_temp_variable = { wargoal_on = ENG }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39573,9 +39565,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = IRE
-				}
+				limit = { country_exists = IRE }
 				set_temp_variable = { wargoal_on = IRE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39640,9 +39630,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_norse"
 			if = {
-				limit = {
-					country_exists = ICE
-				}
+				limit = { country_exists = ICE }
 				set_temp_variable = { wargoal_on = ICE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39652,9 +39640,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = DEN
-				}
+				limit = { country_exists = DEN }
 				set_temp_variable = { wargoal_on = DEN }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39664,9 +39650,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = NRY
-				}
+				limit = { country_exists = NRY }
 				set_temp_variable = { wargoal_on = NRY }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39676,9 +39660,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SWE
-				}
+				limit = { country_exists = SWE }
 				set_temp_variable = { wargoal_on = SWE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39688,9 +39670,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = FIN
-				}
+				limit = { country_exists = FIN }
 				set_temp_variable = { wargoal_on = FIN }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39760,9 +39740,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_west_has_fallen"
 			if = {
-				limit = {
-					country_exists = POR
-				}
+				limit = { country_exists = POR }
 				set_temp_variable = { wargoal_on = POR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39772,9 +39750,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SPR
-				}
+				limit = { country_exists = SPR }
 				set_temp_variable = { wargoal_on = SPR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39784,9 +39760,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = FRA
-				}
+				limit = { country_exists = FRA }
 				set_temp_variable = { wargoal_on = FRA }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39796,9 +39770,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = LUX
-				}
+				limit = { country_exists = LUX }
 				set_temp_variable = { wargoal_on = LUX }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39808,9 +39780,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = BEL
-				}
+				limit = { country_exists = BEL }
 				set_temp_variable = { wargoal_on = BEL }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39820,9 +39790,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = HOL
-				}
+				limit = { country_exists = HOL }
 				set_temp_variable = { wargoal_on = HOL }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39897,9 +39865,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_black_sea"
 			if = {
-				limit = {
-					country_exists = EST
-				}
+				limit = { country_exists = EST }
 				set_temp_variable = { wargoal_on = EST }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39909,9 +39875,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = LAT
-				}
+				limit = { country_exists = LAT }
 				set_temp_variable = { wargoal_on = LAT }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39921,9 +39885,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = LIT
-				}
+				limit = { country_exists = LIT }
 				set_temp_variable = { wargoal_on = LIT }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39933,9 +39895,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = BLR
-				}
+				limit = { country_exists = BLR }
 				set_temp_variable = { wargoal_on = BLR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39945,9 +39905,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = UKR
-				}
+				limit = { country_exists = UKR }
 				set_temp_variable = { wargoal_on = UKR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39957,9 +39915,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = PMR
-				}
+				limit = { country_exists = PMR }
 				set_temp_variable = { wargoal_on = PMR }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -39969,9 +39925,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = MLV
-				}
+				limit = { country_exists = MLV }
 				set_temp_variable = { wargoal_on = MLV }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40061,9 +40015,7 @@ focus_tree = {
 		completion_reward = {
 			log = "[GetDateText]: [Root.GetName]: Focus USA_american_trotskist_operation_vistula"
 			if = {
-				limit = {
-					country_exists = GER
-				}
+				limit = { country_exists = GER }
 				set_temp_variable = { wargoal_on = GER }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40073,9 +40025,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SWI
-				}
+				limit = { country_exists = SWI }
 				set_temp_variable = { wargoal_on = SWI }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40085,9 +40035,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = ITA
-				}
+				limit = { country_exists = ITA }
 				set_temp_variable = { wargoal_on = ITA }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40097,9 +40045,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = HLS
-				}
+				limit = { country_exists = HLS }
 				set_temp_variable = { wargoal_on = HLS }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40109,9 +40055,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SLV
-				}
+				limit = { country_exists = SLV }
 				set_temp_variable = { wargoal_on = SLV }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40121,9 +40065,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = AUS
-				}
+				limit = { country_exists = AUS }
 				set_temp_variable = { wargoal_on = AUS }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40133,9 +40075,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = CZE
-				}
+				limit = { country_exists = CZE }
 				set_temp_variable = { wargoal_on = CZE }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40145,9 +40085,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = POL
-				}
+				limit = { country_exists = POL }
 				set_temp_variable = { wargoal_on = POL }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40157,9 +40095,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = HUN
-				}
+				limit = { country_exists = HUN }
 				set_temp_variable = { wargoal_on = HUN }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes
@@ -40169,9 +40105,7 @@ focus_tree = {
 				}
 			}
 			if = {
-				limit = {
-					country_exists = SLO
-				}
+				limit = { country_exists = SLO }
 				set_temp_variable = { wargoal_on = SLO }
 				set_temp_variable = { wargoal_type = 2 }
 				add_threat_from_wargoal_effect = yes


### PR DESCRIPTION
Split from #3800.

Standardizes the final complete block range across the six affected focus files. Event, MIO, localisation, and tooling changes stay out of this PR’s diff.

Size: 6 files, 2,096 changed lines (additions + deletions).

This focus stack inherits the requested PKK-strength correction from #3817. Merge order: #3817 → #3818 → #3820 → #3821 → #3822.

This final batch completes Israel and the other five focus files; after it lands, the six files match the fully standardized source apart from the requested PKK variable correction.

The completed content set passed the standardizer repeat check. Structural comparison preserved gameplay statements and execution order apart from approved logging. No runtime or in-game visual verification was performed.