### PR TITLE
Restore Singapore volunteer force limits

### DIFF
--- a/common/ideas/Singapore.txt
+++ b/common/ideas/Singapore.txt
@@ -621,7 +621,7 @@ ideas = {
 				political_power_factor = 0.04
 				modifier_army_sub_unit_Special_Forces_defence_factor = 0.04
 				stability_factor = 0.04
-				send_volunteer_factor = 0.04
+				send_volunteer_size = 1
 			}
 		}
 
@@ -632,7 +632,7 @@ ideas = {
 				political_power_factor = 0.08
 				modifier_army_sub_unit_Special_Forces_defence_factor = 0.06
 				stability_factor = 0.08
-				send_volunteer_factor = 0.08
+				send_volunteer_size = 2
 			}
 		}
 
@@ -643,7 +643,7 @@ ideas = {
 				political_power_factor = 0.12
 				modifier_army_sub_unit_Special_Forces_defence_factor = 0.08
 				stability_factor = 0.12
-				send_volunteer_factor = 0.12
+				send_volunteer_size = 3
 			}
 		}
 		SIN_global_diplomacy_4_idea = {
@@ -653,7 +653,7 @@ ideas = {
 				political_power_factor = 0.15
 				modifier_army_sub_unit_Special_Forces_defence_factor = 0.1
 				stability_factor = 0.15
-				send_volunteer_factor = 0.15
+				send_volunteer_size = 4
 			}
 		}
 


### PR DESCRIPTION
Closes #3744

**What**

Restore Singapore's four Global Diplomacy idea tiers to flat volunteer division bonuses of +1 through +4.

**Why**

The current 4–15% factors leave the focus chain unclear and weak for Singapore. A prior targeted correction established flat values, but a later broad cleanup reverted them.

**How**

Replace send_volunteer_factor with send_volunteer_size in each tier. Because each focus swaps to the next idea rather than stacking, the final bonus is +4 divisions.