### PR TITLE
[LOC] Standardize ADS subideology localisation

### DIFF
--- a/localisation/english/MD_politics_view_parties_l_english.yml
+++ b/localisation/english/MD_politics_view_parties_l_english.yml
@@ -4164,7 +4164,7 @@
  ENG.Monarchist_desc: "(Royal Absolutism) - House of Windsor (English: House of Windsor, HOW)\n\nThe House of Windsor as a governing faction represents a monarchy that no longer contents itself with ceremonial influence. It claims the Crown is the ultimate anchor of national unity and therefore must hold decisive authority over ministers, security policy, and the direction of the realm. Under this settlement, legitimacy flows from dynasty and continuity rather than party competition.\n\nIts doctrine favors centralized statecraft, disciplined public order, and strategic use of royal institutions to steer the economy and society. Supporters call it stability and national purpose, opponents call it a return to rule by decree."
 
  ADS.Nat_Autocracy: "£ads_nationalist_military_junta  (ADF) - Albionis Defense Forces"
- ADS.Nat_Autocracy_desc: "(Nationalistic Paramilitary Company) - Formed in response to growing threats to British sovereignty, Albionis Defense Forces core objective is to create a security belt that'll ensure the stability of the state, and the safety of [ENG.GetLeader]."
+ ADS.Nat_Autocracy_desc: "(Nationalistic Paramilitary Company) - Albinois Defense Forces (English: Albinois Defense Forces, ADF)\n\n Formed in response to growing threats to British sovereignty, Albionis Defense Forces core objective is to create a security belt that'll ensure the stability of the state, and the safety of [ENG.GetLeader]."
 
 
  ### USA ###


### PR DESCRIPTION
### Changes

- Standardizes the ADS NAT_Autocracy Description to the new subideology localization format.
- Adds the party name, English native name, ADF acronym, and required '\n\n' separator.
- Preserves the existing description text.

Refs #3703