### PR TITLE
[GFX] Fix Swedish APC medium texture reference

### DIFF
--- a/interface/mdult_land.gfx
+++ b/interface/mdult_land.gfx
@@ -8759,7 +8759,7 @@ spriteTypes = {
 
 	spriteType = {
 		name = "GFX_SWE_APC_1_medium"
-		texturefile = "gfx/interface/technologies/SWE/LAND/Terrangbil-11-13.dds"
+		texturefile = "gfx/interface/technologies/SWE/LAND/HU3.dds"
 	}
 	spriteType = {
 		name = "GFX_SWE_APC_2_medium"


### PR DESCRIPTION
### Changes

- Updates `GFX_SWE_APC_1_medium` to use the renamed Swedish APC texture.
- Replaces the stale `Terrangbil-11-13.dds` reference with `HU3.dds`.

Refs #3765