### PR TITLE
Fix France ignoring the historical path on default settings (#3886)

### DIFF
--- a/common/ai_strategy_plans/FRA_strategy_plans.txt
+++ b/common/ai_strategy_plans/FRA_strategy_plans.txt
@@ -4,7 +4,7 @@ FRA_HISTORICAL_plan = {
 	desc = "Gaullist continuity, EU leadership and the Francosphere, with the presidency passing to its historical holders"
 
 	enable = {
-		has_global_flag = FRA_HISTORICAL_FOCUS_PATH
+		FRA_ai_historical_path = yes
 	}
 
 	abort = {
@@ -236,7 +236,7 @@ FRA_WESTERN_LR_plan = {
 
 	enable = {
 		has_completed_focus = FRA_LR
-		NOT = { has_global_flag = FRA_HISTORICAL_FOCUS_PATH }
+		FRA_ai_historical_path = no
 	}
 
 	abort = {

--- a/events/France.txt
+++ b/events/France.txt
@@ -14055,14 +14055,20 @@ country_event = { #chirac weakened who shall compete
 			base = 3
 			modifier = {
 				factor = 30
-				has_global_flag = FRA_COMMUNE_FOCUS_PATH
+				OR = {
+					FRA_ai_commune_path = yes
+					has_global_flag = FRA_SOCIALIST_FOCUS_PATH
+					has_global_flag = FRA_GREEN_FOCUS_PATH
+					has_global_flag = FRA_FRANCE_UNBOWED_FOCUS_PATH
+				}
 			}
 			modifier = {
 				factor = 0
 				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
+					FRA_ai_historical_path = yes
+					FRA_ai_nationalist_path = yes
+					has_global_flag = FRA_GAULLIST_FOCUS_PATH
+					has_global_flag = FRA_LIBERAL_FOCUS_PATH
 				}
 			}
 		}
@@ -14091,20 +14097,22 @@ country_event = { #chirac weakened who shall compete
 		ai_chance = {
 			base = 3
 			modifier = {
-				is_historical_focus_on = yes
-				add = 5
-			}
-			modifier = {
 				factor = 30
 				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
+					FRA_ai_historical_path = yes
+					FRA_ai_nationalist_path = yes
+					has_global_flag = FRA_GAULLIST_FOCUS_PATH
+					has_global_flag = FRA_LIBERAL_FOCUS_PATH
 				}
 			}
 			modifier = {
 				factor = 0
-				has_global_flag = FRA_COMMUNE_FOCUS_PATH
+				OR = {
+					FRA_ai_commune_path = yes
+					has_global_flag = FRA_SOCIALIST_FOCUS_PATH
+					has_global_flag = FRA_GREEN_FOCUS_PATH
+					has_global_flag = FRA_FRANCE_UNBOWED_FOCUS_PATH
+				}
 			}
 		}
 	}
@@ -14128,8 +14136,18 @@ country_event = { #yes
 		ai_chance = {
 			base = 3
 			modifier = {
+				factor = 30
+				OR = {
+					has_global_flag = FRA_SOCIALIST_FOCUS_PATH
+					has_global_flag = FRA_FRANCE_UNBOWED_FOCUS_PATH
+				}
+			}
+			modifier = {
 				factor = 0
-				has_global_flag = FRA_COMMUNE_FOCUS_PATH
+				OR = {
+					FRA_ai_commune_path = yes
+					has_global_flag = FRA_GREEN_FOCUS_PATH
+				}
 			}
 		}
 	}
@@ -14145,7 +14163,15 @@ country_event = { #yes
 			base = 3
 			modifier = {
 				factor = 30
-				has_global_flag = FRA_COMMUNE_FOCUS_PATH
+				FRA_ai_commune_path = yes
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					has_global_flag = FRA_SOCIALIST_FOCUS_PATH
+					has_global_flag = FRA_GREEN_FOCUS_PATH
+					has_global_flag = FRA_FRANCE_UNBOWED_FOCUS_PATH
+				}
 			}
 		}
 	}
@@ -14160,8 +14186,16 @@ country_event = { #yes
 		ai_chance = {
 			base = 3
 			modifier = {
+				factor = 30
+				has_global_flag = FRA_GREEN_FOCUS_PATH
+			}
+			modifier = {
 				factor = 0
-				has_global_flag = FRA_COMMUNE_FOCUS_PATH
+				OR = {
+					FRA_ai_commune_path = yes
+					has_global_flag = FRA_SOCIALIST_FOCUS_PATH
+					has_global_flag = FRA_FRANCE_UNBOWED_FOCUS_PATH
+				}
 			}
 		}
 	}
@@ -14308,11 +14342,15 @@ country_event = { #neither right nor left
 		ai_chance = {
 			base = 3
 			modifier = {
+				factor = 30
+				has_global_flag = FRA_LIBERAL_FOCUS_PATH
+			}
+			modifier = {
 				factor = 0
 				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
+					FRA_ai_historical_path = yes
+					FRA_ai_nationalist_path = yes
+					has_global_flag = FRA_GAULLIST_FOCUS_PATH
 				}
 			}
 		}
@@ -14328,16 +14366,16 @@ country_event = { #neither right nor left
 		ai_chance = {
 			base = 3
 			modifier = {
-				is_historical_focus_on = yes
-				add = 5
-			}
-			modifier = {
 				factor = 30
 				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
+					FRA_ai_historical_path = yes
+					FRA_ai_nationalist_path = yes
+					has_global_flag = FRA_GAULLIST_FOCUS_PATH
 				}
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = FRA_LIBERAL_FOCUS_PATH
 			}
 		}
 	}
@@ -14372,9 +14410,10 @@ country_event = { #eurosceptic have a chance
 			modifier = {
 				factor = 0
 				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
+					FRA_ai_historical_path = yes
+					FRA_ai_nationalist_path = yes
+					has_global_flag = FRA_GAULLIST_FOCUS_PATH
+					has_global_flag = FRA_LIBERAL_FOCUS_PATH
 				}
 			}
 		}
@@ -14391,15 +14430,11 @@ country_event = { #eurosceptic have a chance
 		ai_chance = {
 			base = 3
 			modifier = {
-				is_historical_focus_on = yes
-				add = 5
-			}
-			modifier = {
 				factor = 30
 				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
+					FRA_ai_historical_path = yes
+					FRA_ai_nationalist_path = yes
+					has_global_flag = FRA_GAULLIST_FOCUS_PATH
 				}
 			}
 		}
@@ -14434,11 +14469,11 @@ country_event = { #national rally win right
 			base = 3
 			modifier = {
 				factor = 30
-				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
-				}
+				FRA_ai_nationalist_path = yes
+			}
+			modifier = {
+				factor = 0
+				FRA_ai_not_nationalist_path = yes
 			}
 		}
 	}
@@ -14463,16 +14498,12 @@ country_event = { #national rally win right
 		ai_chance = {
 			base = 4
 			modifier = {
-				is_historical_focus_on = yes
-				add = 5
+				factor = 30
+				FRA_ai_not_nationalist_path = yes
 			}
 			modifier = {
 				factor = 0
-				OR = {
-					has_global_flag = FRA_NATIONAL_RALLY_FOCUS_PATH
-					has_global_flag = FRA_KINGDOM_FOCUS_PATH
-					has_global_flag = FRA_EMPIRE_FOCUS_PATH
-				}
+				FRA_ai_nationalist_path = yes
 			}
 		}
 	}
@@ -15435,7 +15466,7 @@ country_event = {
 	trigger = {
 		original_tag = FRA
 		is_ai = yes
-		has_global_flag = FRA_HISTORICAL_FOCUS_PATH
+		FRA_ai_historical_path = yes
 		OR = {
 			has_idea = FRA_5th_republic
 			has_idea = FRA_sixth_republic_idea
@@ -15473,7 +15504,7 @@ country_event = {
 	trigger = {
 		original_tag = FRA
 		is_ai = yes
-		has_global_flag = FRA_HISTORICAL_FOCUS_PATH
+		FRA_ai_historical_path = yes
 		OR = {
 			has_idea = FRA_5th_republic
 			has_idea = FRA_sixth_republic_idea
@@ -15510,7 +15541,7 @@ country_event = {
 	trigger = {
 		original_tag = FRA
 		is_ai = yes
-		has_global_flag = FRA_HISTORICAL_FOCUS_PATH
+		FRA_ai_historical_path = yes
 		OR = {
 			has_idea = FRA_5th_republic
 			has_idea = FRA_sixth_republic_idea
@@ -15548,7 +15579,7 @@ country_event = {
 	trigger = {
 		original_tag = FRA
 		is_ai = yes
-		has_global_flag = FRA_HISTORICAL_FOCUS_PATH
+		FRA_ai_historical_path = yes
 		OR = {
 			has_idea = FRA_5th_republic
 			has_idea = FRA_sixth_republic_idea


### PR DESCRIPTION
Closes #3886

France was supposed to follow history on historical AI, but on default settings it almost never did — the reporter got Jean-Marie Le Pen as president in 2002.

The `FRA_ai_behavior` game rule defaults to `NO_PATH`, so **no `FRA_*_FOCUS_PATH` global flag is ever set** in a normal game. Three systems still tested that raw flag (or a weak `is_historical_focus_on add = 5`) instead of the `FRA_ai_*_path` scripted triggers the focus tree already uses everywhere:

- The scripted 2002 presidential chain (`france_md.503 → .990 → .991 → .510`) leaked ~27% at every node, and the decisive runoff option `france_md.510.a` ("Le Pen wins") had **no historical modifier at all** — a flat 25% against `base = 4 + 5`. Net: the historical result (Chirac's *front républicain* win, `france_md.513`) fired only ~29% of the time and Le Pen took the Élysée in ~10% of historical games.
- `france_md.550/551/552/553` — the historical presidencies (Sarkozy 2007, Hollande 2012, Macron 2017/2022) — gated on `has_global_flag = FRA_HISTORICAL_FOCUS_PATH`, so on default settings **none of them ever fired**.
- `FRA_HISTORICAL_plan` gated on the same raw flag, so AI France never picked its historical focus plan.

#### Bug Fixes

- Rewrote the 2002 election chain's `ai_chance` blocks (`france_md.503`, `.986`, `.990`, `.991`, `.510`) onto the `FRA_ai_*_path` scripted triggers, using the `factor = 30` / `factor = 0` idiom already used throughout `05_france.txt`. Each configured `FRA_ai_behavior` path now gets a deterministic 2002 result: HISTORICAL and GAULLIST → Chirac barrage; LIBERAL → Bayrou; NATIONAL_RALLY / KINGDOM / EMPIRE → Le Pen; SOCIALIST and FRANCE_UNBOWED → Jospin; COMMUNE → PCF; GREEN → the Greens. No path maps to the RPF, so `991.a` is zeroed for every configured path.
- Switched the four historical-presidency event triggers to `FRA_ai_historical_path = yes`, so Sarkozy, Hollande and Macron actually take office on a default historical game.
- Switched `FRA_HISTORICAL_plan`'s `enable` (and `FRA_WESTERN_LR_plan`'s matching exclusion) to `FRA_ai_historical_path = yes`, so AI France picks the historical plan on default settings.

`FRA_ai_historical_path` is a strict superset of the raw flag, and `FRA_ai_not_nationalist_path` is false under `NO_PATH` + non-historical, so explicitly-set paths behave exactly as before and a non-historical game with no rule set keeps today's random spread.

#### Testing

- `pre-commit run --files events/France.txt common/ai_strategy_plans/FRA_strategy_plans.txt` — all hooks pass.
- Every scripted trigger referenced (`FRA_ai_historical_path`, `FRA_ai_nationalist_path`, `FRA_ai_not_nationalist_path`, `FRA_ai_commune_path`) verified to exist in `common/scripted_triggers/99_FRA_scripted_triggers.txt`; every `FRA_*_FOCUS_PATH` flag verified against its setter in `common/on_actions/999_game_rules_on_actions.txt`.
- Not yet play-tested in game. Suggested check: default rules + historical AI, observe France — `hoi4.log` should show `france_md.503.b`, `.990.b`, `.991.b`, `.510.b` and `france_md.513.a executed`, never `france_md.512.a executed`, followed by `france_md.550.a` (2007), `.551.a` (2012), `.552.a` (2017), `.553.a` (2022). Re-run with `FRA_ai_behavior = NATIONAL_RALLY` and confirm `france_md.512.a` fires instead.

#### Out of scope

- The generic `MD4_election` / `AI_setup_government` system — popularity-driven by design and shared by every country; it only ratifies the popularities the 2002 chain writes.
- France's `FRA_political_balance` drift values in `history/countries/FRA - France.txt` — balance, not a bug.
- The `RANDOM_PATH` weights, and changing the `FRA_ai_behavior` default away from `NO_PATH`.
