### PR TITLE
Add validation timing reports and fix parser cache invalidation

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -42,6 +42,61 @@ python3 tools/run.py publish_workshop release --full      # pass args through
 python3 tools/run.py gfx_entry_generator                  # works on any platform
 ```
 
+### Validation timing baselines
+
+Save the Actions data without timing instrumentation:
+
+```bash
+gh run view RUN_ID --attempt ATTEMPT --json databaseId,attempt,headSha,displayTitle,status,conclusion,createdAt,startedAt,updatedAt,jobs > timing-RUN_ID-ATTEMPT.json
+```
+
+Add a `metadata` object to each export. Its required fields are `workload`,
+`runner`, `tool`, `python`, `dependencies`, `cache` (`cold` or `warm`),
+`worker_budget`, and `baseSha`. For example, this is user-supplied metadata,
+not independently verified by the report:
+
+```json
+{
+  "metadata": {
+    "workload": "tools-tests",
+    "runner": "ubuntu-24.04",
+    "tool": "6bf489e",
+    "python": "3.14.0",
+    "dependencies": { "pytest": "9.1.0", "ruff": "0.15.17" },
+    "cache": "cold",
+    "worker_budget": 4,
+    "baseSha": "4bce0fe"
+  }
+}
+```
+
+Run the same workload at least three times for cold-cache and three times for
+warm-cache samples, keeping those fields identical within each set. Missing
+memory or cache-hit counters are unknown, not zero. Fewer than three matching
+samples is not an accepted baseline and does not support a speed claim. Then
+run:
+
+```bash
+python3 tools/run.py validation_timing_report timing-*.json
+```
+
+The report lists each real Actions job and step, overall run span, and summed
+job time. It ignores synthetic Checks API jobs that have no `steps`, excludes
+incomplete or unsuccessful runs from summaries, and keeps revisions, cache
+modes, and job/step outcomes separate. Existing section timers and CI artifact
+logs are the timing mechanism. Do not instrument subprocess elapsed time with
+parent wait timestamps. `databaseId` plus positive integer `attempt` identifies
+an export, so duplicate files are ignored while distinct reruns are retained.
+Run history alone is not a controlled baseline and does not establish a
+performance gain. No workflow scheduling, worker count, checkout scope, or cache
+portability changes are part of this report.
+
+Observed run `34426341721` is illustrative only: head
+`3a6f37f9c5677f0276fc1ff8f57802b294b5362a`, base
+`4bce0fe79f9dd293a40a7200c99c63e5a58bb111`, Linux job 422s, worktree 131s,
+coverage 95s, integration 64s, prepare 119s, core batch 283s, targeted-a 143s,
+and targeted-b 115s. It is not a comparable baseline for this worktree.
+
 ## Directory Structure
 
 ```
@@ -190,6 +245,7 @@ Metrics, reference analysis, and review tools.
 | **calculate_days.py**               | Calculates days from January 1st for the HOI4 date system                                                                                                       |
 | **estimate_gdp.py**                 | Estimates starting GDP for country tags using MD's building formulas                                                                                            |
 | **event_load.py**                   | Reports how many events the yearly pulse schedules for one country and when, flagging years where several land in the same window                               |
+| **validation_timing_report.py**     | Summarizes saved GitHub Actions validation job and step timings, grouped by compatible revision and environment                                                 |
 | **find_idea_references.py**         | Finds which ideas from a file are referenced elsewhere in the codebase                                                                                          |
 | **find_scripted_loc_references.py** | Checks whether scripted localisation names are actually referenced                                                                                              |
 | **pre_place_power_plants.py**       | Bakes fossil_powerplant + composite_plant counts into `history/states/` to skip startup loops. Re-run after edits to the energy formula or country/state setup. |

--- a/tools/analysis/validation_timing_report.py
+++ b/tools/analysis/validation_timing_report.py
@@ -1,0 +1,480 @@
+"""Summarize saved GitHub Actions validation-run timings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+_REQUIRED_FIELDS = (
+    "databaseId",
+    "attempt",
+    "headSha",
+    "displayTitle",
+    "status",
+    "conclusion",
+    "createdAt",
+    "startedAt",
+    "updatedAt",
+    "jobs",
+)
+_REQUIRED_METADATA = (
+    "workload",
+    "runner",
+    "tool",
+    "python",
+    "dependencies",
+    "cache",
+    "worker_budget",
+    "baseSha",
+)
+_UNKNOWN_VALUES = {"unknown", "n/a", "na", "none", "null"}
+
+
+class TimingReportError(ValueError):
+    """Raised when an Actions export cannot be interpreted."""
+
+
+@dataclass(frozen=True)
+class StepTiming:
+    name: str
+    status: Optional[str]
+    conclusion: Optional[str]
+    duration_seconds: Optional[float]
+
+
+@dataclass(frozen=True)
+class JobTiming:
+    database_id: Optional[str]
+    name: str
+    status: Optional[str]
+    conclusion: Optional[str]
+    duration_seconds: Optional[float]
+    steps: Tuple[StepTiming, ...]
+
+
+@dataclass(frozen=True)
+class TimingSample:
+    database_id: str
+    attempt: int
+    head_sha: str
+    status: str
+    conclusion: Optional[str]
+    overall_seconds: Optional[float]
+    jobs: Tuple[JobTiming, ...]
+    metadata: Mapping[str, Any]
+    metadata_error: Optional[str]
+
+    @property
+    def summed_job_seconds(self) -> Optional[float]:
+        durations = [job.duration_seconds for job in self.jobs]
+        if not durations or any(value is None for value in durations):
+            return None
+        return sum(value for value in durations if value is not None)
+
+    @property
+    def eligible_for_summary(self) -> bool:
+        if (
+            self.status.lower() != "completed"
+            or self.conclusion != "success"
+            or self.metadata_error is not None
+            or self.overall_seconds is None
+            or self.summed_job_seconds is None
+        ):
+            return False
+        return all(_job_is_complete(job) for job in self.jobs)
+
+    @property
+    def compatibility_key(self) -> Optional[str]:
+        if self.metadata_error is not None:
+            return None
+        metadata = {field: self.metadata[field] for field in _REQUIRED_METADATA}
+        job_signatures = [_job_signature(job) for job in self.jobs]
+        job_signatures.sort(
+            key=lambda signature: json.dumps(
+                signature, sort_keys=True, separators=(",", ":")
+            )
+        )
+        workload = {
+            "headSha": self.head_sha,
+            "metadata": metadata,
+            "jobs": job_signatures,
+        }
+        return json.dumps(workload, sort_keys=True, separators=(",", ":"))
+
+    @property
+    def cache_label(self) -> str:
+        return str(self.metadata["cache"])
+
+
+def _require_string(value: Any, field: str, path: Path) -> str:
+    if not isinstance(value, str) or not value:
+        raise TimingReportError(f"{path}: field '{field}' must be a non-empty string")
+    return value
+
+
+def _require_attempt(value: Any, path: Path) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise TimingReportError(f"{path}: field 'attempt' must be a positive integer")
+    return value
+
+
+def _parse_timestamp(value: Any, field: str, path: Path) -> Optional[datetime]:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise TimingReportError(
+            f"{path}: field '{field}' must be an ISO timestamp or null"
+        )
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TimingReportError(
+            f"{path}: field '{field}' is not an ISO timestamp"
+        ) from exc
+    if timestamp.tzinfo is None:
+        raise TimingReportError(f"{path}: field '{field}' must include a timezone")
+    return timestamp
+
+
+def _duration(
+    start: Optional[datetime], end: Optional[datetime], label: str, path: Path
+) -> Optional[float]:
+    if start is None or end is None:
+        return None
+    seconds = (end - start).total_seconds()
+    if seconds < 0:
+        raise TimingReportError(f"{path}: {label} ends before it starts")
+    return seconds
+
+
+def _optional_status(value: Any, field: str, path: Path) -> Optional[str]:
+    if value is None:
+        return None
+    return _require_string(value, field, path)
+
+
+def _is_skipped(step: StepTiming) -> bool:
+    return step.status == "skipped" or step.conclusion == "skipped"
+
+
+def _parse_step(raw: Any, index: int, path: Path) -> StepTiming:
+    if not isinstance(raw, dict):
+        raise TimingReportError(f"{path}: job step {index} must be an object")
+    name = _require_string(raw.get("name"), f"jobs[].steps[{index}].name", path)
+    status = _optional_status(raw.get("status"), f"jobs[].steps[{index}].status", path)
+    conclusion = _optional_status(
+        raw.get("conclusion"), f"jobs[].steps[{index}].conclusion", path
+    )
+    started = _parse_timestamp(
+        raw.get("startedAt"), f"jobs[].steps[{index}].startedAt", path
+    )
+    completed = _parse_timestamp(
+        raw.get("completedAt"), f"jobs[].steps[{index}].completedAt", path
+    )
+    duration = (
+        None
+        if status == "skipped" or conclusion == "skipped"
+        else _duration(started, completed, f"step '{name}'", path)
+    )
+    return StepTiming(name, status, conclusion, duration)
+
+
+def _parse_job(raw: Any, index: int, path: Path) -> Optional[JobTiming]:
+    if not isinstance(raw, dict):
+        raise TimingReportError(f"{path}: jobs[{index}] must be an object")
+    if "steps" not in raw or raw["steps"] == []:
+        return None
+    steps = raw["steps"]
+    if not isinstance(steps, list):
+        raise TimingReportError(f"{path}: jobs[{index}].steps must be an array")
+    name = _require_string(raw.get("name"), f"jobs[{index}].name", path)
+    database_id = raw.get("databaseId")
+    if database_id is not None and isinstance(database_id, (dict, list, bool)):
+        raise TimingReportError(
+            f"{path}: jobs[{index}].databaseId must be scalar or null"
+        )
+    status = _optional_status(raw.get("status"), f"jobs[{index}].status", path)
+    conclusion = _optional_status(
+        raw.get("conclusion"), f"jobs[{index}].conclusion", path
+    )
+    started = _parse_timestamp(raw.get("startedAt"), f"jobs[{index}].startedAt", path)
+    completed = _parse_timestamp(
+        raw.get("completedAt"), f"jobs[{index}].completedAt", path
+    )
+    duration = _duration(started, completed, f"job '{name}'", path)
+    parsed_steps = tuple(
+        _parse_step(step, step_index, path) for step_index, step in enumerate(steps)
+    )
+    return JobTiming(
+        None if database_id is None else str(database_id),
+        name,
+        status,
+        conclusion,
+        duration,
+        parsed_steps,
+    )
+
+
+def _meaningful_string(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and value.strip().lower() not in _UNKNOWN_VALUES
+    )
+
+
+def _nonempty_representation(value: Any) -> bool:
+    if isinstance(value, str):
+        return _meaningful_string(value)
+    if isinstance(value, (dict, list)):
+        return bool(value)
+    return False
+
+
+def _metadata(
+    payload: Mapping[str, Any], path: Path
+) -> Tuple[Mapping[str, Any], Optional[str]]:
+    value = payload.get("metadata", {})
+    if value is None:
+        value = {}
+    if not isinstance(value, dict):
+        raise TimingReportError(f"{path}: field 'metadata' must be an object")
+    metadata = dict(value)
+    invalid = []
+    for field in ("workload", "runner", "tool", "python", "baseSha"):
+        if not _meaningful_string(metadata.get(field)):
+            invalid.append(field)
+    if not _nonempty_representation(metadata.get("dependencies")):
+        invalid.append("dependencies")
+    worker_budget = metadata.get("worker_budget")
+    if (
+        isinstance(worker_budget, bool)
+        or not isinstance(worker_budget, int)
+        or worker_budget <= 0
+    ):
+        invalid.append("worker_budget")
+    if metadata.get("cache") not in ("cold", "warm"):
+        invalid.append("cache")
+    if invalid:
+        return metadata, "unusable metadata: " + ", ".join(invalid)
+    return metadata, None
+
+
+def parse_export(payload: Any, path: Path) -> TimingSample:
+    """Parse one ``gh run view --json`` export."""
+    if not isinstance(payload, dict):
+        raise TimingReportError(f"{path}: top-level JSON value must be an object")
+    missing = [field for field in _REQUIRED_FIELDS if field not in payload]
+    if missing:
+        raise TimingReportError(
+            f"{path}: missing required field(s): {', '.join(missing)}"
+        )
+    database_id = payload["databaseId"]
+    if isinstance(database_id, (dict, list, bool)) or database_id in (None, ""):
+        raise TimingReportError(
+            f"{path}: field 'databaseId' must be a scalar identifier"
+        )
+    attempt = _require_attempt(payload["attempt"], path)
+    head_sha = _require_string(payload["headSha"], "headSha", path)
+    _require_string(payload["displayTitle"], "displayTitle", path)
+    status = _require_string(payload["status"], "status", path)
+    conclusion = _optional_status(payload["conclusion"], "conclusion", path)
+    jobs = payload["jobs"]
+    if not isinstance(jobs, list):
+        raise TimingReportError(f"{path}: field 'jobs' must be an array")
+    _parse_timestamp(payload["createdAt"], "createdAt", path)
+    started = _parse_timestamp(payload["startedAt"], "startedAt", path)
+    updated = _parse_timestamp(payload["updatedAt"], "updatedAt", path)
+    overall = _duration(started, updated, "run", path)
+    parsed_jobs = []
+    seen_job_ids = set()
+    for index, raw_job in enumerate(jobs):
+        job = _parse_job(raw_job, index, path)
+        if job is None:
+            continue
+        if job.database_id is not None and job.database_id in seen_job_ids:
+            continue
+        if job.database_id is not None:
+            seen_job_ids.add(job.database_id)
+        parsed_jobs.append(job)
+    metadata, metadata_error = _metadata(payload, path)
+    return TimingSample(
+        str(database_id),
+        attempt,
+        head_sha,
+        status,
+        conclusion,
+        overall,
+        tuple(parsed_jobs),
+        metadata,
+        metadata_error,
+    )
+
+
+def load_exports(paths: Iterable[Path]) -> Tuple[List[TimingSample], int]:
+    """Load exports, deduplicating samples by Actions run ID and attempt."""
+    samples: List[TimingSample] = []
+    seen = set()
+    duplicates = 0
+    for path in paths:
+        try:
+            with path.open(encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except OSError as exc:
+            raise TimingReportError(f"{path}: cannot read export: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise TimingReportError(f"{path}: invalid JSON: {exc.msg}") from exc
+        sample = parse_export(payload, path)
+        key = (sample.database_id, sample.attempt)
+        if key in seen:
+            duplicates += 1
+            continue
+        seen.add(key)
+        samples.append(sample)
+    return samples, duplicates
+
+
+def _seconds(value: Optional[float]) -> str:
+    return "—" if value is None else f"{value:.3f}s"
+
+
+def _summary(values: Sequence[float]) -> str:
+    return f"n={len(values)} median={statistics.median(values):.3f}s range={min(values):.3f}-{max(values):.3f}s"
+
+
+def _step_result(step: StepTiming) -> str:
+    return step.conclusion or step.status or "not-success"
+
+
+def _job_is_complete(job: JobTiming) -> bool:
+    if (
+        job.status != "completed"
+        or job.conclusion != "success"
+        or job.duration_seconds is None
+    ):
+        return False
+    return all(
+        _is_skipped(step)
+        or (
+            step.status == "completed"
+            and step.conclusion == "success"
+            and step.duration_seconds is not None
+        )
+        for step in job.steps
+    )
+
+
+def _job_signature(job: JobTiming) -> Dict[str, Any]:
+    return {
+        "name": job.name,
+        "status": job.status,
+        "conclusion": job.conclusion,
+        "steps": [
+            {
+                "name": step.name,
+                "status": step.status,
+                "conclusion": step.conclusion,
+            }
+            for step in job.steps
+        ],
+    }
+
+
+def _sample_lines(sample: TimingSample) -> List[str]:
+    base_sha = sample.metadata.get("baseSha")
+    base_label = base_sha if _meaningful_string(base_sha) else "unknown"
+    lines = [
+        f"Run {sample.database_id} attempt {sample.attempt}: head={sample.head_sha} "
+        f"base={base_label} status={sample.status} conclusion={sample.conclusion or 'none'}",
+        f"  overall run span: {_seconds(sample.overall_seconds)}; "
+        f"summed job time: {_seconds(sample.summed_job_seconds)}",
+    ]
+    if sample.metadata_error:
+        lines.append(f"  compatibility: unverified ({sample.metadata_error})")
+    else:
+        lines.append(f"  compatibility: supplied metadata; cache={sample.cache_label}")
+    if not sample.jobs:
+        lines.append("  jobs: none with steps (synthetic Checks API jobs ignored)")
+    for job in sample.jobs:
+        lines.append(
+            f"  job {job.name}: {_seconds(job.duration_seconds)} "
+            f"status={job.status or 'none'} conclusion={job.conclusion or 'none'}"
+        )
+        for step in job.steps:
+            lines.append(
+                f"    step {step.name}: "
+                f"{_seconds(step.duration_seconds) if not _is_skipped(step) else 'not-run/unknown'} "
+                f"[{_step_result(step)}]"
+            )
+    return lines
+
+
+def _summary_lines(samples: Sequence[TimingSample]) -> List[str]:
+    groups: Dict[str, List[TimingSample]] = {}
+    for sample in samples:
+        if sample.eligible_for_summary and sample.compatibility_key is not None:
+            groups.setdefault(sample.compatibility_key, []).append(sample)
+    if not groups:
+        return ["No compatible completed-success samples for median/range summaries."]
+    lines = [
+        "Compatible summaries (grouped by head/base revision, metadata, and workload):"
+    ]
+    for group in groups.values():
+        first = group[0]
+        base_sha = first.metadata["baseSha"]
+        lines.append(
+            f"  head={first.head_sha} base={base_sha} cache={first.cache_label}: "
+            f"{_summary([sample.overall_seconds for sample in group if sample.overall_seconds is not None])} overall run span"
+        )
+        lines.append(
+            "    summed job time: "
+            f"{_summary([sample.summed_job_seconds for sample in group if sample.summed_job_seconds is not None])}"
+        )
+        names = sorted({job.name for sample in group for job in sample.jobs})
+        for name in names:
+            values = [
+                job.duration_seconds
+                for sample in group
+                for job in sample.jobs
+                if job.name == name and job.duration_seconds is not None
+            ]
+            if values:
+                lines.append(f"    job {name}: {_summary(values)}")
+    return lines
+
+
+def render_report(samples: Sequence[TimingSample], duplicates: int) -> str:
+    """Render a report for tests and callers that do not use stdout."""
+    lines = ["Validation timing report"]
+    duplicate_note = f" ({duplicates} duplicates ignored)" if duplicates else ""
+    lines.append(f"Samples: {len(samples)} unique run attempts{duplicate_note}")
+    for sample in samples:
+        lines.extend(_sample_lines(sample))
+    lines.extend(_summary_lines(samples))
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report GitHub Actions validation job and step timings from saved JSON exports.",
+        epilog="Exports with incomplete timestamps or non-success conclusions are reported but excluded from summaries.",
+    )
+    parser.add_argument("exports", nargs="+", type=Path, metavar="EXPORT")
+    args = parser.parse_args(argv)
+    try:
+        samples, duplicates = load_exports(args.exports)
+        print(render_report(samples, duplicates))
+    except TimingReportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/analysis/validation_timing_report_test.py
+++ b/tools/tests/analysis/validation_timing_report_test.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from validation_timing_report import (
+    TimingReportError,
+    load_exports,
+    parse_export,
+    render_report,
+)
+
+_BASE_METADATA = {
+    "workload": "tools-tests",
+    "runner": "ubuntu-24.04",
+    "tool": "6bf489e",
+    "python": "3.14.0",
+    "dependencies": {"pytest": "9.1.0"},
+    "cache": "cold",
+    "worker_budget": 4,
+    "baseSha": "base-sha",
+}
+
+
+def _export(
+    run_id="1",
+    head="head-sha",
+    *,
+    attempt=1,
+    status="completed",
+    conclusion: str | None = "success",
+):
+    return {
+        "databaseId": int(run_id),
+        "attempt": attempt,
+        "headSha": head,
+        "displayTitle": "Tools tests",
+        "status": status,
+        "conclusion": conclusion,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "startedAt": "2026-01-01T00:00:10Z",
+        "updatedAt": "2026-01-01T00:00:50Z",
+        "metadata": dict(_BASE_METADATA),
+        "jobs": [
+            {
+                "databaseId": 10,
+                "name": "Linux",
+                "status": "completed",
+                "conclusion": "success",
+                "startedAt": "2026-01-01T00:00:10Z",
+                "completedAt": "2026-01-01T00:00:30Z",
+                "steps": [
+                    {
+                        "name": "worktree",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "startedAt": "2026-01-01T00:00:10Z",
+                        "completedAt": "2026-01-01T00:00:20Z",
+                    },
+                    {
+                        "name": "skipped",
+                        "status": "completed",
+                        "conclusion": "skipped",
+                        "startedAt": "2026-01-01T00:00:20Z",
+                        "completedAt": "2026-01-01T00:00:25Z",
+                    },
+                    {
+                        "name": "zero",
+                        "status": "completed",
+                        "conclusion": "success",
+                        "startedAt": "2026-01-01T00:00:25Z",
+                        "completedAt": "2026-01-01T00:00:25Z",
+                    },
+                ],
+            },
+            {"name": "Linux", "status": "completed", "conclusion": "success"},
+        ],
+    }
+
+
+def _write_export(path: Path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_report_lists_real_jobs_steps_and_distinguishes_spans():
+    sample = parse_export(_export(), Path("run.json"))
+
+    report = render_report([sample], 0)
+
+    assert "Run 1 attempt 1:" in report
+    assert "compatibility: supplied metadata; cache=cold" in report
+    assert "overall run span: 40.000s" in report
+    assert "summed job time: 20.000s" in report
+    assert "job Linux: 20.000s" in report
+    assert "step worktree: 10.000s [success]" in report
+    assert "step skipped: not-run/unknown [skipped]" in report
+    assert "step zero: 0.000s [success]" in report
+    assert (
+        report.splitlines().count(
+            "  job Linux: 20.000s status=completed conclusion=success"
+        )
+        == 1
+    )
+
+
+def test_duplicate_runs_do_not_inflate_summary_and_same_revision_is_summarized(
+    tmp_path,
+):
+    first = _export("1")
+    second = _export("1", attempt=2)
+    second["updatedAt"] = "2026-01-01T00:01:00Z"
+    duplicate = _export("1")
+    first_path = tmp_path / "one.json"
+    second_path = tmp_path / "two.json"
+    duplicate_path = tmp_path / "duplicate.json"
+    _write_export(first_path, first)
+    _write_export(second_path, second)
+    _write_export(duplicate_path, duplicate)
+
+    samples, duplicates = load_exports([first_path, second_path, duplicate_path])
+    report = render_report(samples, duplicates)
+
+    assert len(samples) == 2
+    assert duplicates == 1
+    assert "Samples: 2 unique run attempts (1 duplicates ignored)" in report
+    assert "head=head-sha base=base-sha cache=cold: n=2" in report
+    assert "median=45.000s range=40.000-50.000s" in report
+
+
+def test_reruns_with_distinct_attempts_are_retained():
+    first = parse_export(_export("8", attempt=1), Path("first.json"))
+    second = parse_export(_export("8", attempt=2), Path("second.json"))
+
+    assert first.database_id == second.database_id == "8"
+    assert [first.attempt, second.attempt] == [1, 2]
+
+
+def test_incomplete_cancelled_and_unverified_samples_have_no_summary():
+    incomplete = _export("3", status="in_progress", conclusion=None)
+    incomplete["startedAt"] = None
+    incomplete["updatedAt"] = None
+    cancelled = _export("4", status="completed", conclusion="cancelled")
+    unverified = _export("5")
+    del unverified["metadata"]
+
+    samples = [
+        parse_export(payload, Path(f"{index}.json"))
+        for index, payload in enumerate((incomplete, cancelled, unverified))
+    ]
+    report = render_report(samples, 0)
+
+    assert "conclusion=none" in report
+    assert "head=head-sha base=unknown" in report
+    assert "compatibility: unverified" in report
+    assert "No compatible completed-success samples" in report
+    assert "Compatible summaries" not in report
+
+
+def test_cross_revision_samples_are_not_aggregated():
+    first = parse_export(_export("6", head="head-a"), Path("a.json"))
+    second = parse_export(_export("7", head="head-b"), Path("b.json"))
+
+    report = render_report([first, second], 0)
+
+    assert "head=head-a base=base-sha cache=cold: n=1" in report
+    assert "head=head-b base=base-sha cache=cold: n=1" in report
+    assert "range=40.000-40.000s" in report
+
+
+def test_missing_executed_step_timestamps_have_no_summary():
+    payload = _export("9")
+    payload["jobs"][0]["steps"][0]["completedAt"] = None
+
+    sample = parse_export(payload, Path("incomplete-step.json"))
+
+    assert sample.eligible_for_summary is False
+    assert "No compatible completed-success samples" in render_report([sample], 0)
+    assert "step worktree: — [success]" in render_report([sample], 0)
+
+
+def test_skipped_and_executed_workloads_are_separate_groups():
+    first = _export("10")
+    second = _export("11")
+    second["jobs"][0]["steps"][1]["conclusion"] = "success"
+    second["jobs"][0]["steps"][1]["status"] = "completed"
+
+    samples = [
+        parse_export(first, Path("skipped.json")),
+        parse_export(second, Path("executed.json")),
+    ]
+    report = render_report(samples, 0)
+
+    assert report.count("cache=cold: n=1") == 2
+
+
+def test_duplicate_actual_jobs_do_not_inflate_job_summary():
+    payload = _export("12")
+    payload["jobs"].append(dict(payload["jobs"][0]))
+
+    sample = parse_export(payload, Path("duplicate-job.json"))
+    report = render_report([sample], 0)
+
+    assert len(sample.jobs) == 1
+    assert "job Linux: n=1" in report
+
+
+def test_job_response_order_does_not_change_compatibility_key():
+    first = _export("19")
+    windows = {
+        "databaseId": 11,
+        "name": "Windows",
+        "status": "completed",
+        "conclusion": "success",
+        "startedAt": "2026-01-01T00:00:10Z",
+        "completedAt": "2026-01-01T00:00:30Z",
+        "steps": [
+            {
+                "name": "worktree",
+                "status": "completed",
+                "conclusion": "success",
+                "startedAt": "2026-01-01T00:00:10Z",
+                "completedAt": "2026-01-01T00:00:20Z",
+            }
+        ],
+    }
+    first["jobs"].insert(1, windows)
+    second = _export("20")
+    second["jobs"] = [windows, second["jobs"][0], second["jobs"][1]]
+
+    first_sample = parse_export(first, Path("first-order.json"))
+    second_sample = parse_export(second, Path("reverse-order.json"))
+
+    assert first_sample.compatibility_key == second_sample.compatibility_key
+    assert "cache=cold: n=2" in render_report([first_sample, second_sample], 0)
+
+    second["jobs"][1]["steps"][1]["conclusion"] = "success"
+    second["jobs"][1]["steps"][1]["status"] = "completed"
+    changed_sample = parse_export(second, Path("changed-step-selection.json"))
+
+    assert changed_sample.compatibility_key != first_sample.compatibility_key
+    assert (
+        render_report([first_sample, changed_sample], 0).count("cache=cold: n=1") == 2
+    )
+
+
+@pytest.mark.parametrize("cache", [[], {}, False, None])
+def test_non_scalar_cache_metadata_is_unverified(cache):
+    payload = _export("21")
+    payload["metadata"]["cache"] = cache
+
+    sample = parse_export(payload, Path("bad-cache.json"))
+    report = render_report([sample], 0)
+
+    assert sample.metadata_error is not None
+    assert "compatibility: unverified" in report
+    assert "No compatible completed-success samples" in report
+
+
+def test_non_list_steps_are_a_clear_error():
+    payload = _export("13")
+    payload["jobs"][0]["steps"] = {}
+
+    with pytest.raises(TimingReportError, match=r"jobs\[0\]\.steps must be an array"):
+        parse_export(payload, Path("bad-steps.json"))
+
+
+def test_unusable_metadata_is_reported_without_a_summary():
+    payload = _export("14")
+    payload["metadata"].update(
+        {
+            "workload": {},
+            "runner": [],
+            "tool": False,
+            "python": 0,
+            "dependencies": [],
+            "cache": "anything",
+            "worker_budget": 0,
+            "baseSha": "unknown",
+        }
+    )
+
+    sample = parse_export(payload, Path("bad-metadata.json"))
+    report = render_report([sample], 0)
+
+    assert sample.metadata_error is not None
+    assert "compatibility: unverified" in report
+    assert "No compatible completed-success samples" in report
+
+
+def test_optional_metadata_does_not_split_compatible_groups():
+    first = _export("15")
+    second = _export("16")
+    first["metadata"]["memory_mb"] = 100
+    second["metadata"]["memory_mb"] = 200
+
+    samples = [
+        parse_export(first, Path("memory-a.json")),
+        parse_export(second, Path("memory-b.json")),
+    ]
+
+    assert "cache=cold: n=2" in render_report(samples, 0)
+
+
+@pytest.mark.parametrize("attempt", [0, -1, True, "1"])
+def test_attempt_must_be_positive_integer(attempt):
+    payload = _export("17", attempt=attempt)
+
+    with pytest.raises(TimingReportError, match="attempt.*positive integer"):
+        parse_export(payload, Path("bad-attempt.json"))
+
+
+def test_malformed_metadata_structure_has_explicit_error():
+    payload = _export("18")
+    payload["metadata"] = []
+
+    with pytest.raises(TimingReportError, match="metadata.*object"):
+        parse_export(payload, Path("bad-metadata-structure.json"))
+
+
+def test_malformed_export_has_explicit_error():
+    payload = _export()
+    del payload["jobs"]
+
+    with pytest.raises(TimingReportError, match="missing required field.*jobs"):
+        parse_export(payload, Path("bad.json"))

--- a/tools/tests/validation/disk_cache_test.py
+++ b/tools/tests/validation/disk_cache_test.py
@@ -5,6 +5,7 @@ import os
 
 import disk_cache
 import pytest
+import sprite_index
 
 
 @pytest.fixture(autouse=True)
@@ -13,33 +14,98 @@ def clear_env(monkeypatch):
     monkeypatch.delenv("MD_NO_CACHE", raising=False)
 
 
+def _counted_compute(calls, namespace):
+    def run():
+        calls[namespace] += 1
+        return calls[namespace]
+
+    return run
+
+
+def _patch_helper_change(monkeypatch, namespace, helper_name):
+    helper = next(
+        path
+        for path in disk_cache._fingerprint_paths(namespace)
+        if path.name == helper_name
+    )
+    original_read_bytes = type(helper).read_bytes
+
+    def changed_read_bytes(path):
+        if path == helper:
+            return original_read_bytes(path) + b"\\nhelper change"
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(type(helper), "read_bytes", changed_read_bytes)
+
+
 def test_code_fingerprints_are_scoped_to_owner_and_shared_code():
     events = disk_cache._fingerprint_paths("events.metadata")
     focus = disk_cache._fingerprint_paths("focus_tree.parse")
+    sprites = disk_cache._fingerprint_paths("sprite_index.names")
 
     assert any(path.name == "validate_events.py" for path in events)
     assert any(path.name == "shared_utils.py" for path in events)
     assert any(path.name == "validator_common.py" for path in events)
     assert not any(path.name == "validate_focus_tree.py" for path in events)
     assert any(path.name == "validate_focus_tree.py" for path in focus)
+    assert any(path.name == "validate_gfx_references.py" for path in sprites)
+    assert not any(path.name == "validate_focus_tree.py" for path in sprites)
+
+
+def test_sprite_index_cached_and_uncached_results_match(tmp_path, monkeypatch):
+    gfx = tmp_path / "sample.gfx"
+    gfx.write_text('spriteType = { name = "GFX_sample" }', encoding="utf-8")
+
+    cached = sprite_index._names_in_file(str(gfx), str(tmp_path))
+    monkeypatch.setenv("MD_NO_CACHE", "1")
+    uncached = sprite_index._names_in_file(str(gfx), str(tmp_path))
+
+    assert cached == uncached == ["GFX_sample"]
+
+
+def test_sprite_index_helper_change_invalidates_actual_cache(tmp_path, monkeypatch):
+    gfx = tmp_path / "sample.gfx"
+    gfx.write_text('spriteType = { name = "GFX_sample" }', encoding="utf-8")
+    disk_cache._FINGERPRINT_CACHE.clear()
+    sprite_index._names_in_file(str(gfx), str(tmp_path))
+
+    original_parse = sprite_index._parse_names
+    calls = []
+
+    def counted_parse(raw):
+        calls.append(raw)
+        return original_parse(raw)
+
+    _patch_helper_change(
+        monkeypatch, "sprite_index.names", "validate_gfx_references.py"
+    )
+    monkeypatch.setattr(sprite_index, "_parse_names", counted_parse)
+    disk_cache._FINGERPRINT_CACHE.clear()
+
+    assert sprite_index._names_in_file(str(gfx), str(tmp_path)) == ["GFX_sample"]
+    assert len(calls) == 1
 
 
 def test_namespace_mapping_covers_all_real_cache_prefixes():
     expected = {
         "agency",
+        "building_guards_scan_v3",
         "cosmetic",
         "decisions",
         "dlc_guards",
+        "dynamic_modifier_guards_scan_v1",
         "events",
         "focus_tree",
         "gfx_ref",
         "history_techs",
         "ideas",
         "loc",
+        "math_expr",
         "modifiers",
         "oob_units",
         "on_actions",
         "scripted_gui",
+        "sgui",
         "scripted_params",
         "set_variables",
         "simplifications",
@@ -93,30 +159,82 @@ def test_owner_source_change_invalidates_only_that_namespace(tmp_path, monkeypat
     disk_cache._FINGERPRINT_CACHE.clear()
     calls = {"owned": 0, "other": 0}
 
-    def compute(namespace):
-        def run():
-            calls[namespace] += 1
-            return calls[namespace]
-
-        return run
-
     first_owned = disk_cache.per_file_cached_by_content(
-        str(tmp_path), "owned.result", "source.txt", "body", compute("owned")
+        str(tmp_path),
+        "owned.result",
+        "source.txt",
+        "body",
+        _counted_compute(calls, "owned"),
     )
     first_other = disk_cache.per_file_cached_by_content(
-        str(tmp_path), "other.result", "source.txt", "body", compute("other")
+        str(tmp_path),
+        "other.result",
+        "source.txt",
+        "body",
+        _counted_compute(calls, "other"),
     )
     owner.write_text("changed owner", encoding="utf-8")
     second_owned = disk_cache.per_file_cached_by_content(
-        str(tmp_path), "owned.result", "source.txt", "body", compute("owned")
+        str(tmp_path),
+        "owned.result",
+        "source.txt",
+        "body",
+        _counted_compute(calls, "owned"),
     )
     second_other = disk_cache.per_file_cached_by_content(
-        str(tmp_path), "other.result", "source.txt", "body", compute("other")
+        str(tmp_path),
+        "other.result",
+        "source.txt",
+        "body",
+        _counted_compute(calls, "other"),
     )
 
     assert (first_owned, second_owned) == (1, 2)
     assert (first_other, second_other) == (1, 1)
     assert calls == {"owned": 2, "other": 1}
+
+
+def test_configured_helper_change_invalidates_affected_namespace_only(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "data.txt"
+    source.write_text("hello", encoding="utf-8")
+    disk_cache._FINGERPRINT_CACHE.clear()
+    calls = {"building": 0, "events": 0}
+
+    disk_cache.per_file_cached_by_content(
+        str(tmp_path),
+        "building_guards_scan_v3.result",
+        str(source),
+        "body",
+        _counted_compute(calls, "building"),
+    )
+    disk_cache.per_file_cached_by_content(
+        str(tmp_path),
+        "events.result",
+        str(source),
+        "body",
+        _counted_compute(calls, "events"),
+    )
+
+    _patch_helper_change(monkeypatch, "building_guards_scan_v3.result", "guard_scan.py")
+    disk_cache._FINGERPRINT_CACHE.clear()
+    disk_cache.per_file_cached_by_content(
+        str(tmp_path),
+        "building_guards_scan_v3.result",
+        str(source),
+        "body",
+        _counted_compute(calls, "building"),
+    )
+    disk_cache.per_file_cached_by_content(
+        str(tmp_path),
+        "events.result",
+        str(source),
+        "body",
+        _counted_compute(calls, "events"),
+    )
+
+    assert calls == {"building": 2, "events": 1}
 
 
 def test_per_file_cached_hits_on_unchanged_file(tmp_path):

--- a/tools/validation/disk_cache.py
+++ b/tools/validation/disk_cache.py
@@ -48,19 +48,23 @@ CACHE_VERSION = 8
 _VALIDATOR_NAMESPACES = {
     "agency": "validate_agency_upgrades.py",
     "agency_upgrades": "validate_agency_upgrades.py",
+    "building_guards_scan_v3": "validate_building_guards.py",
     "cosmetic": "validate_cosmetic_tags.py",
     "decisions": "validate_decisions.py",
     "dlc_guards": "validate_dlc_guards.py",
+    "dynamic_modifier_guards_scan_v1": "validate_dynamic_modifier_guards.py",
     "events": "validate_events.py",
     "focus_tree": "validate_focus_tree.py",
     "gfx_ref": "validate_gfx_references.py",
     "history_techs": "validate_history.py",
     "ideas": "validate_ideas.py",
     "loc": "validate_localisation.py",
+    "math_expr": "validate_math_expressions.py",
     "modifiers": "validate_modifiers.py",
     "oob_units": "validate_oob_units.py",
     "on_actions": "validate_on_actions.py",
     "scripted_gui": "validate_scripted_gui.py",
+    "sgui": "validate_scripted_gui.py",
     "scripted_params": "validate_scripted_params.py",
     "set_variables": "validate_set_variables.py",
     "simplifications": "validate_simplifications.py",
@@ -73,6 +77,16 @@ _VALIDATOR_NAMESPACES = {
 
 _FINGERPRINT_CACHE: Dict[str, Tuple[Tuple[Tuple[str, int, int], ...], str]] = {}
 
+# These helpers are called inside cached computations, so their source changes
+# must invalidate the owning namespace without making unrelated namespaces cold.
+_HELPER_DEPENDENCIES = {
+    "building_guards_scan_v3": ("guard_scan.py",),
+    "dynamic_modifier_guards_scan_v1": ("guard_scan.py",),
+    "math_expr": ("equipment_module_slots.py",),
+    "oob_units": ("equipment_module_slots.py",),
+    "sprite_index": ("validate_gfx_references.py",),
+}
+
 
 def _fingerprint_paths(namespace: str) -> list[Path]:
     paths = [
@@ -80,11 +94,14 @@ def _fingerprint_paths(namespace: str) -> list[Path]:
         Path(__file__).parent.parent / "shared_utils.py",
         Path(__file__).parent / "validator_common.py",
     ]
-    owner = _VALIDATOR_NAMESPACES.get(namespace.split(".", 1)[0])
+    prefix = namespace.split(".", 1)[0]
+    owner = _VALIDATOR_NAMESPACES.get(prefix)
     if owner:
         paths.append(Path(__file__).parent / owner)
     else:
         paths.extend(Path(__file__).parent.glob("*.py"))
+    for dependency in _HELPER_DEPENDENCIES.get(prefix, ()):
+        paths.append(Path(__file__).parent / dependency)
     return sorted(set(paths))
 
 


### PR DESCRIPTION
## Bottom line
Add an offline Actions timing reporter and fix namespace cache invalidation when imported parser helpers change.

Closes #3917. Supports #3916, which remains open until controlled repeated cold/warm CI samples are collected. No measured speedup is claimed.

## How
The reporter separates run span from summed job time, distinguishes rerun attempts, and groups only complete samples with matching revisions, supplied environment metadata, and executed workloads. The cache fix uses explicit helper dependencies and preserves unrelated warm namespaces.

Full pytest: 4,793 passed, 3 skipped. Staged hooks passed. Local duplication checking was blocked by command policy and remains pending CI.

Follow-up validation issues: #3922 (slot refill), #3919 (checkout scope), #3920 (Python support), #3918 (discovery), #3921 (CLI cleanup), and conditional #3925 (cache portability).

BLUF