### PR TITLE
Point USoE leaders at country portraits and traits

### DIFF
--- a/common/scripted_effects/CRO_political_leaders.txt
+++ b/common/scripted_effects/CRO_political_leaders.txt
@@ -23,7 +23,7 @@ set_leader_CRO = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Andrej Plenkovic"
+				name = "Andrej Plenković"
 				picture = "CRO_Andrej_Plenkovic.dds"
 				ideology = conservatism
 				traits = {

--- a/common/scripted_effects/DEN_political_leaders.txt
+++ b/common/scripted_effects/DEN_political_leaders.txt
@@ -41,7 +41,7 @@ set_leader_DEN = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Lars Loekke Rasmussen"
+				name = "Lars Løkke Rasmussen"
 				picture = "lars_loekke_rasmussen.dds"
 				ideology = liberalism
 				traits = {

--- a/common/scripted_effects/FRA_political_leaders.txt
+++ b/common/scripted_effects/FRA_political_leaders.txt
@@ -437,7 +437,7 @@ set_leader_FRA = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Francois Hollande"
+				name = "François Hollande"
 				picture = "Francois_Hollande.dds"
 				ideology = socialism
 				traits = {
@@ -445,7 +445,6 @@ set_leader_FRA = {
 					western_socialism
 					emotional
 					cautious
-
 				}
 			}
 
@@ -896,7 +895,7 @@ set_leader_FRA = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Jean-Luc Melenchon"
+				name = "Jean-Luc Mélenchon"
 				picture = "Jean-Luc_Melenchon.dds"
 				ideology = Neutral_social
 				traits = {

--- a/common/scripted_effects/HUN_political_leaders.txt
+++ b/common/scripted_effects/HUN_political_leaders.txt
@@ -75,7 +75,7 @@ set_leader_HUN = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Viktor Orban"
+				name = "Viktor Orbán"
 				picture = "Viktor_Orban.dds"
 				ideology = Neutral_conservatism
 				traits = {

--- a/common/scripted_effects/IRE_political_leaders.txt
+++ b/common/scripted_effects/IRE_political_leaders.txt
@@ -195,7 +195,7 @@ set_leader_IRE = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Micheal Martin"
+				name = "Micheál Martin"
 				picture = "micheal_martin.dds"
 				ideology = liberalism
 				traits = {

--- a/common/scripted_effects/SPR_political_leaders.txt
+++ b/common/scripted_effects/SPR_political_leaders.txt
@@ -380,7 +380,7 @@ set_leader_SPR = {
 			hidden_effect = { kill_country_leader = yes }
 
 			create_country_leader = {
-				name = "Pedro Sanchez"
+				name = "Pedro Sánchez"
 				picture = "pedro_sanchez.dds"
 				ideology = socialism
 				traits = {

--- a/common/scripted_effects/USoE_political_leaders.txt
+++ b/common/scripted_effects/USoE_political_leaders.txt
@@ -7,7 +7,7 @@ set_leader_USoE = {
 			#HoS
 			create_country_leader = {
 				name = "Jacques Chirac"
-				picture = "gfx/leaders/USoE/jacques_chirac.dds"
+				picture = "gfx/leaders/FRA/jacques_chirac.dds"
 				ideology = conservatism
 				traits = {
 					western_conservatism
@@ -26,15 +26,15 @@ set_leader_USoE = {
 			#HoG
 			create_country_leader = {
 				name = "Angela Merkel"
-				picture = "gfx/leaders/USoE/Angela_Merkel.dds"
+				picture = "gfx/leaders/GER/Angela_Merkel.dds"
 				ideology = conservatism
 				traits = {
-										scientist
-										western_conservatism
-										ruthless
-										honest
-										stubborn
-										political_dancer
+					scientist
+					western_conservatism
+					ruthless
+					honest
+					stubborn
+					political_dancer
 				}
 			}
 
@@ -42,24 +42,21 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2005.11.22 date > 2021.10.25 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoS
 			create_country_leader = {
 				name = "Nicolas Sarkozy"
-				picture = "gfx/leaders/USoE/Cons_Nicolas_Sarkozy.dds"
+				picture = "gfx/leaders/FRA/Cons_Nicolas_Sarkozy.dds"
 				ideology = conservatism
 				traits = {
-										lawyer
-										western_conservatism
-										rash
-										polished
-										deceitful
-					#
+					western_conservatism
+					lawyer
+					rash
+					polished
+					deceitful
+					pro_american
 				}
 			}
 
@@ -67,24 +64,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2007.5.16 date > 2012.5.15 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "David Cameron"
-				picture = "gfx/leaders/USoE/David_Cameron.dds"
+				picture = "gfx/leaders/ENG/David_Cameron.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
+					career_politician
 				}
 			}
 
@@ -92,24 +82,19 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2010.5.11 date > 2016.7.13 ENG = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "José María Aznar"
-				picture = "gfx/leaders/USoE/jose_maria_aznar.dds"
+				picture = "gfx/leaders/SPR/jose_maria_aznar.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
+					lawyer
+					career_politician
+					silent_workhorse
 				}
 			}
 
@@ -117,24 +102,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2004.4.16 SPR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 5 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Mariano Rajoy"
-				picture = "gfx/leaders/USoE/mariano_rajoy.dds"
+				picture = "gfx/leaders/SPR/mariano_rajoy.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -142,24 +119,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2011.12.21 date > 2018.6.1 SPR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 6 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Silvio Berlusconi"
-				picture = "gfx/leaders/USoE/silvio_berlusconi.dds"
+				picture = "gfx/leaders/ITA/silvio_berlusconi.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
+					businessman
 				}
 			}
 
@@ -167,24 +137,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2001.6.11 date > 2011.11.16 ITA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 7 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#President of the European Commission
 			create_country_leader = {
 				name = "José Manuel Barroso"
-				picture = "gfx/leaders/USoE/Jose_Manuel_Durao_Barroso.dds"
+				picture = "gfx/leaders/POR/Jose_Manuel_Durao_Barroso.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -192,24 +154,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.11.22 date > 2014.10.31 POR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 8 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#President of the European Commission
 			create_country_leader = {
 				name = "Jean-Claude Juncker"
-				picture = "gfx/leaders/USoE/Jean-Claude_Juncker.dds"
+				picture = "gfx/leaders/LUX/Jean-Claude_Juncker.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -217,24 +171,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.11.1 date > 2019.11.30 LUX = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 9 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#President of the European Commission
 			create_country_leader = {
 				name = "Ursula von der Leyen"
-				picture = "gfx/leaders/USoE/Ursula_von_der_Leyen.dds"
+				picture = "gfx/leaders/GER/Ursula_von_der_Leyen.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -242,24 +188,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.12.1 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 10 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#President of the EPP
 			create_country_leader = {
 				name = "Wilfried Martens"
-				picture = "gfx/leaders/USoE/Wilfried_Martens.dds"
+				picture = "gfx/leaders/BEL/Wilfried_Martens.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -267,24 +205,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2013.10.9 BEL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 11 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#President of the EPP/EPP group leader in EP
 			create_country_leader = {
 				name = "Joseph Daul"
-				picture = "gfx/leaders/USoE/Joseph_Daul.dds"
+				picture = "gfx/leaders/FRA/Joseph_Daul.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -292,24 +222,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2007.1.9 date > 2019.11.30 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 12 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#President of the EPP
 			create_country_leader = {
 				name = "Donald Tusk"
-				picture = "gfx/leaders/USoE/POL_Donald_Tusk.dds"
+				picture = "gfx/leaders/POL/donald_tusk.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -317,24 +239,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.12.1 POL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 13 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#EPP group leader in EP
 			create_country_leader = {
 				name = "Manfred Weber"
-				picture = "gfx/leaders/USoE/Manfred_Weber.dds"
+				picture = "gfx/leaders/GER/Manfred_Weber.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -342,24 +256,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.6.4 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 14 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Sebastian Kurz"
-				picture = "gfx/leaders/USoE/Sebastian_Kurz.dds"
+				picture = "gfx/leaders/AUS/Sebastian_Kurz.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -367,24 +273,19 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2017.12.18 AUS = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 15 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoS
 			create_country_leader = {
 				name = "Klaus Iohannis"
-				picture = "gfx/leaders/USoE/Klaus_Iohannis.dds"
+				picture = "gfx/leaders/ROM/Klaus_Iohannis.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
+					sly
+					greedy
+					backroom_backstabber
 				}
 			}
 
@@ -392,24 +293,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.12.21 ROM = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 16 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Boyko Borisov"
-				picture = "gfx/leaders/USoE/Boyko_Borissov.dds"
+				picture = "gfx/leaders/BUL/Boyko_Borissov.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -417,24 +310,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.11.7 BUL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 17 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Andrej Plenković"
-				picture = "gfx/leaders/USoE/CRO_Andrej_Plenkovic.dds"
+				picture = "gfx/leaders/CRO/CRO_Andrej_Plenkovic.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -442,24 +327,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2016.10.19 CRO = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 18 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoS
 			create_country_leader = {
 				name = "Nicos Anastasiades"
-				picture = "gfx/leaders/USoE/CYP_Nicos_Anastasiades.dds"
+				picture = "gfx/leaders/CYP/CYP_Nicos_Anastasiades.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -467,24 +344,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2013.2.28 CYP = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 19 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Antonis Samaras"
-				picture = "gfx/leaders/USoE/Antonis_Samaras.dds"
+				picture = "gfx/leaders/GRE/Antonis_Samaras.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -492,24 +361,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2012.6.20 date > 2015.1.26 GRE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 20 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Kyriakos Mitsotakis"
-				picture = "gfx/leaders/USoE/kyriakos_mitsotakis.dds"
+				picture = "gfx/leaders/GRE/kyriakos_mitsotakis.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -517,24 +378,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.7.8 GRE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 21 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Arturs Krišjānis Kariņš"
-				picture = "gfx/leaders/USoE/Arturs_Krisjanis_Karins.dds"
+				picture = "gfx/leaders/LAT/Arturs_Krisjanis_Karins.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -542,24 +395,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.1.23 LAT = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 22 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Igor Matovič"
-				picture = "gfx/leaders/USoE/igor_matovic.dds"
+				picture = "gfx/leaders/SLO/igor_matovic.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -567,24 +412,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.3.21 SLO = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { conservatism_leader = 23 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { conservatism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Janez Janša"
-				picture = "gfx/leaders/USoE/janez_jansa.dds"
+				picture = "gfx/leaders/SLV/janez_jansa.dds"
 				ideology = conservatism
 				traits = {
-										western_conservatism
-					#
-					#
-					#
-					#
-					#
+					western_conservatism
 				}
 			}
 
@@ -601,15 +438,13 @@ set_leader_USoE = {
 			#HoS
 			create_country_leader = {
 				name = "Emmanuel Macron"
-				picture = "gfx/leaders/USoE/Emmanuel_Macron.dds"
+				picture = "gfx/leaders/FRA/Emmanuel_Macron.dds"
 				ideology = liberalism
 				traits = {
-										businessman
-										western_liberalism
-										polished
-					#
-					#
-					#
+					western_liberalism
+					businessman
+					polished
+					stubborn
 				}
 			}
 
@@ -617,24 +452,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2017.5.14 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 1 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG/ALDE group leader in EP
 			create_country_leader = {
 				name = "Guy Verhofstadt"
-				picture = "gfx/leaders/USoE/Guy_Verhofstadt.dds"
+				picture = "gfx/leaders/BEL/Guy_Verhofstadt.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -642,24 +469,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 BEL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Mark Rutte"
-				picture = "gfx/leaders/USoE/Mark_Rutte.dds"
+				picture = "gfx/leaders/HOL/Mark_Rutte.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
+					teacher
+					HOL_consensus_politician
 				}
 			}
 
@@ -667,24 +488,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2010.10.14 HOL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG/President of the European Council
 			create_country_leader = {
 				name = "Charles Michel"
-				picture = "gfx/leaders/USoE/BEL_Charles_Michel.dds"
+				picture = "gfx/leaders/BEL/BEL_Charles_Michel.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -692,24 +505,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.10.11 BEL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Sophie Wilmès"
-				picture = "gfx/leaders/USoE/Sophie_Wilmes.dds"
+				picture = "gfx/leaders/BEL/Sophie_Wilmes.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -717,24 +522,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.10.27 BEL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 5 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Lars Løkke Rasmussen"
-				picture = "gfx/leaders/USoE/lars_loekke_rasmussen.dds"
+				picture = "gfx/leaders/DEN/lars_loekke_rasmussen.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -742,24 +539,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.6.28 date > 2019.6.27 DEN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 6 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Vice President of the European Commission
 			create_country_leader = {
 				name = "Margrethe Vestager"
-				picture = "gfx/leaders/USoE/Margrethe_Vestager.dds"
+				picture = "gfx/leaders/DEN/Margrethe_Vestager.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -767,9 +556,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.12.1 DEN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 7 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -779,12 +565,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Pat_Cox.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -792,9 +573,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2004.7.20 IRE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 8 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -804,12 +582,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Graham_Watson.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -817,9 +590,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2002.1.6 date > 2015.11.21 ENG = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 9 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -829,12 +599,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Hans_van_Baalen.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -842,9 +607,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.11.21 HOL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 10 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -854,12 +616,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Dacian_Ciolos.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -867,24 +624,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.11.17 ROM = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 11 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Andrej Babiš"
-				picture = "gfx/leaders/USoE/andrej_babis.dds"
+				picture = "gfx/leaders/CZE/andrej_babis.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
+					former_finance_minister
+					economist
 				}
 			}
 
@@ -892,24 +643,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2017.12.6 CZE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 12 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Xavier Bettel"
-				picture = "gfx/leaders/USoE/Xavier_Bettel.dds"
+				picture = "gfx/leaders/LUX/Xavier_Bettel.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -917,9 +660,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2013.12.4 LUX = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 13 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -929,12 +669,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/juri_ratas.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -942,24 +677,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2016.11.23 EST = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 14 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Micheál Martin"
-				picture = "gfx/leaders/USoE/micheal_martin.dds"
+				picture = "gfx/leaders/IRE/micheal_martin.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -967,24 +694,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.6.27 IRE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { liberalism_leader = 15 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { liberalism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#GER party leader
 			create_country_leader = {
 				name = "Christian Lindner"
-				picture = "gfx/leaders/USoE/lib_Christian_Lindner.dds"
+				picture = "gfx/leaders/GER/lib_Christian_Lindner.dds"
 				ideology = liberalism
 				traits = {
-										western_liberalism
-					#
-					#
-					#
-					#
-					#
+					western_liberalism
 				}
 			}
 
@@ -1014,21 +733,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2005.11.22 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 1 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Tony Blair"
-				picture = "gfx/leaders/USoE/tony_blair.dds"
+				picture = "gfx/leaders/ENG/tony_blair.dds"
 				ideology = socialism
 				traits = {
 					western_socialism
 					career_politician
-					judiciary
 				}
 			}
 
@@ -1036,24 +751,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2007.6.27 ENG = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Gordon Brown"
-				picture = "gfx/leaders/USoE/Gordon_Brown.dds"
+				picture = "gfx/leaders/ENG/Gordon_Brown.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
+					educator
 				}
 			}
 
@@ -1061,9 +769,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2007.6.27 date > 2010.5.11 ENG = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1073,12 +778,10 @@ set_leader_USoE = {
 				picture = "gfx/leaders/FRA/Francois_Hollande.dds"
 				ideology = socialism
 				traits = {
-										career_politician
-										western_socialism
-										emotional
-										cautious
-					#
-					#
+					career_politician
+					western_socialism
+					emotional
+					cautious
 				}
 			}
 
@@ -1086,9 +789,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2012.5.15 date > 2017.5.14 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1098,12 +798,8 @@ set_leader_USoE = {
 				picture = "gfx/leaders/ITA/romano_prodi.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
+					economist
 				}
 			}
 
@@ -1136,15 +832,10 @@ set_leader_USoE = {
 			#HoG
 			create_country_leader = {
 				name = "José Luis Rodríguez Zapatero"
-				picture = "gfx/leaders/USoE/Jose_Luis_Rodriguez_Zapatero.dds"
+				picture = "gfx/leaders/SPR/jose_zapatero.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
 				}
 			}
 
@@ -1152,24 +843,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.4.17 date > 2011.12.21 SPR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 7 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Pedro Sánchez"
-				picture = "gfx/leaders/USoE/pedro_sanchez.dds"
+				picture = "gfx/leaders/SPR/pedro_sanchez.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
 				}
 			}
 
@@ -1177,24 +860,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2018.6.2 SPR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 8 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Stefan Löfven"
-				picture = "gfx/leaders/USoE/Western-Socialdemocrat_Stefan_Lofven.dds"
+				picture = "gfx/leaders/SWE/Stefan_Lofven.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					career_politician
+					western_socialism
 				}
 			}
 
@@ -1202,24 +878,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.10.3 SWE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 9 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "António Costa"
-				picture = "gfx/leaders/USoE/Antonio_Costa.dds"
+				picture = "gfx/leaders/POR/Antonio_Costa.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
 				}
 			}
 
@@ -1227,24 +895,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.11.26 POR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 10 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Mette Frederiksen"
-				picture = "gfx/leaders/USoE/mette_frederiksen.dds"
+				picture = "gfx/leaders/DEN/mette_frederiksen.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
 				}
 			}
 
@@ -1252,24 +912,20 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.6.27 DEN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 11 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoG
 			create_country_leader = {
 				name = "Sanna Marin"
-				picture = "gfx/leaders/USoE/Sanna_Marin.dds"
+				picture = "gfx/leaders/FIN/sanna_marin.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
+					career_politician
+					likeable
+					backroom_backstabber
+					educator
 				}
 			}
 
@@ -1277,9 +933,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.12.10 FIN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 12 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1289,12 +942,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Josep_Borrell.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
 				}
 			}
 
@@ -1302,24 +950,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.7.20 SPR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 13 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Vice President of the European Commission
 			create_country_leader = {
 				name = "Frans Timmermans"
-				picture = "gfx/leaders/USoE/Frans_Timmermans.dds"
+				picture = "gfx/leaders/HOL/hol_frans_timmermans.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
+					environmentalist
+					hater_opposition
 				}
 			}
 
@@ -1327,24 +969,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.11.1 HOL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 14 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#PES group leader in EP/President of the EP
 			create_country_leader = {
 				name = "Martin Schulz"
-				picture = "gfx/leaders/USoE/Martin_Schulz.dds"
+				picture = "gfx/leaders/GER/Martin_Schulz.dds"
 				ideology = socialism
 				traits = {
-										career_politician
-										western_socialism
-					#
-					#
-					#
-					#
+					career_politician
+					western_socialism
 				}
 			}
 
@@ -1352,9 +987,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2012.1.17 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { socialism_leader = 15 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { socialism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1364,12 +996,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Robert_Abela.dds"
 				ideology = socialism
 				traits = {
-										western_socialism
-					#
-					#
-					#
-					#
-					#
+					western_socialism
 				}
 			}
 
@@ -1397,24 +1024,19 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.9.21 GRE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { anarchist_communism_leader = 1 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { anarchist_communism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#candidate  presidential election
 			create_country_leader = {
 				name = "Jean-Luc Mélenchon"
-				picture = "gfx/leaders/USoE/Jean-Luc_Melenchon.dds"
-				ideology = anarchist_communism
+				picture = "gfx/leaders/FRA/Jean-Luc_Melenchon.dds"
+				ideology = Neutral_social
 				traits = {
-										emerging_anarchist_communism
-					#
-					#
-					#
-					#
-					#
+					neutrality_neutral_Social
+					career_politician
+					ecological_economist
+					stubborn
 				}
 			}
 
@@ -1422,9 +1044,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2008.1.1 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { anarchist_communism_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { anarchist_communism_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1434,12 +1053,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Catarina_Martins.dds"
 				ideology = anarchist_communism
 				traits = {
-										emerging_anarchist_communism
-					#
-					#
-					#
-					#
-					#
+					emerging_anarchist_communism
 				}
 			}
 
@@ -1456,15 +1070,10 @@ set_leader_USoE = {
 			#HoG
 			create_country_leader = {
 				name = "Viktor Orbán"
-				picture = "gfx/leaders/USoE/Viktor_Orban.dds"
+				picture = "gfx/leaders/HUN/Viktor_Orban.dds"
 				ideology = Neutral_conservatism
 				traits = {
-										emerging_anarchist_communism
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_conservatism
 				}
 			}
 
@@ -1481,15 +1090,10 @@ set_leader_USoE = {
 			#Minister of Foreign Affairs
 			create_country_leader = {
 				name = "Joschka Fischer"
-				picture = "gfx/leaders/USoE/Joschka_Fischer.dds"
+				picture = "gfx/leaders/GER/Joschka_Fischer.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1497,24 +1101,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2005.11.22 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 1 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoS
 			create_country_leader = {
 				name = "Alexander Van der Bellen"
-				picture = "gfx/leaders/USoE/alexander_van_der_bellen.dds"
+				picture = "gfx/leaders/AUS/alexander_van_der_bellen.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1522,9 +1118,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2017.1.26 AUS = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1534,12 +1127,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Pekka_Haavisto.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1547,9 +1135,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.6.6 FIN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1559,12 +1144,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Winfried_Kretschmann.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1572,9 +1152,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2011.5.12 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1584,12 +1161,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Daniel_Cohn-Bendit.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1597,9 +1169,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.1.1 date > 2009.7.13 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 5 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1609,12 +1178,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Philippe_Lamberts.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1622,9 +1186,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2009.7.14 BEL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 6 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1634,12 +1195,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Rebecca_Harms.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1647,9 +1203,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.7.20 date > 2016.12.13 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 7 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1659,12 +1212,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ska_Keller.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1672,9 +1220,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2016.12.14 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 8 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1684,12 +1229,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Werner_Kogler.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1697,9 +1237,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.7.1 AUS = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 9 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1709,12 +1246,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Michaele_Schreyer.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1722,9 +1254,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2004.11.21 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 10 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1734,12 +1263,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Alice_Bah_Kuhnke.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1747,9 +1271,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.7.2 SWE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Neutral_green_leader = 11 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Neutral_green_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1759,12 +1280,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Greta_Thunberg.dds"
 				ideology = Neutral_green
 				traits = {
-										neutrality_Neutral_green
-					#
-					#
-					#
-					#
-					#
+					neutrality_Neutral_green
 				}
 			}
 
@@ -1781,15 +1297,12 @@ set_leader_USoE = {
 			#Chairman EUMC/Army
 			create_country_leader = {
 				name = "Gustav Hägglund"
-				picture = "gfx/leaders/USoE/Gustav_Haegglund.dds"
+				picture = "gfx/leaders/FIN/gustav_hagglund.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
+					military_career
+					nato_enjoyer
 				}
 			}
 
@@ -1797,24 +1310,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2001.6.3 date > 2004.4.9 FIN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 1 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chairman EUMC/Army
 			create_country_leader = {
 				name = "Rolando Mosca Moschini"
-				picture = "gfx/leaders/USoE/Rolando_Mosca_Moschini.dds"
+				picture = "gfx/leaders/ITA/Portrait_Rolando_Mosca_Moschini.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1822,24 +1327,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.4.9 date > 2006.11.6 ITA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chairman EUMC/Army
 			create_country_leader = {
 				name = "Henri Bentégeat"
-				picture = "gfx/leaders/USoE/Henri_Bentegeat.dds"
+				picture = "gfx/leaders/FRA/henri_bentengeat.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1847,9 +1344,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2006.11.6 date > 2009.11.6 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1859,12 +1353,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Hakan_Syren.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1872,9 +1361,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2009.11.6 date > 2012.11.6 SWE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1884,12 +1370,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Patrick_de_Rousiers.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1897,24 +1378,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2012.11.6 date > 2015.11.6 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 5 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chairman EUMC/Army
 			create_country_leader = {
 				name = "Michail Kostarakos"
-				picture = "gfx/leaders/USoE/Michail_Kostarakos.dds"
+				picture = "gfx/leaders/GRE/Michail_Kostarakos.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1922,24 +1395,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.11.6 date > 2018.11.6 GRE = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 6 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chairman EUMC/Army
 			create_country_leader = {
 				name = "Claudio Graziano"
-				picture = "gfx/leaders/USoE/gen_claudio_graziano.dds"
+				picture = "gfx/leaders/ITA/gen_claudio_graziano.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
+					military_career
 				}
 			}
 
@@ -1947,24 +1413,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2018.11.6 ITA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 7 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#DGEUMS/Army
 			create_country_leader = {
 				name = "Rainer Schuwirth"
-				picture = "gfx/leaders/USoE/Rainer_Schuwirth.dds"
+				picture = "gfx/leaders/GER/Rainer_Schuwirth.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1972,9 +1430,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2001.6.11 date > 2004.3.1 GER = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 8 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -1984,12 +1439,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Jean-Paul_Perruche.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -1997,9 +1447,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2004.3.1 date > 2007.2.28 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 9 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2009,12 +1456,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/David_Leakey.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2022,24 +1464,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2007.3.1 date > 2010.5.28 ENG = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 10 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#DGEUMS/Army
 			create_country_leader = {
 				name = "Ton van Osch"
-				picture = "gfx/leaders/USoE/Ton_van_Osch.dds"
+				picture = "gfx/leaders/HOL/Ton_van_Osch.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2047,9 +1481,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2010.5.28 date > 2013.5.28 HOL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 11 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2059,12 +1490,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Wolfgang_Wosolsobe.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2072,9 +1498,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2013.5.28 date > 2016.5.1 AUS = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 12 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2084,12 +1507,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Portrait_Esa_Pukkinen.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2097,9 +1515,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2016.5.1 date > 2020.6.30 FIN = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 13 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2109,12 +1524,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Herve_Blejean.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2122,9 +1532,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.6.30 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 14 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2134,12 +1541,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Bruce_Williams.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2147,9 +1549,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2011.1.1 date > 2015.1.1 ENG = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 15 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2159,12 +1558,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Waldemar_Gluszko.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2172,9 +1566,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.1.1 date > 2017.1.1 POL = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 16 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2184,12 +1575,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Giovanni_Manione.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2197,24 +1583,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2017.1.1 ITA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 17 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chief of AF
 			create_country_leader = {
 				name = "Denis Mercier"
-				picture = "gfx/leaders/USoE/Denis_Mercier.dds"
+				picture = "gfx/leaders/FRA/Denis_Mercier.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2222,24 +1600,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2012.9.17 date > 2018.9.11 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 18 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chief of AF
 			create_country_leader = {
 				name = "André Lanata"
-				picture = "gfx/leaders/USoE/Andre_Lanata.dds"
+				picture = "gfx/leaders/FRA/Andre_Lanata.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2247,9 +1617,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.9.21 FRA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 19 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2259,12 +1626,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Pasquale_Preziosa.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2272,24 +1634,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2013.2.1 date > 2016.2.1 ITA = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 20 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chief of AF
 			create_country_leader = {
 				name = "José Jiménez Ruiz"
-				picture = "gfx/leaders/USoE/Jose_Jimenez_Ruiz.dds"
+				picture = "gfx/leaders/SPR/air/Jose_Jimenez_Ruiz.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2297,24 +1651,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2008.7.18 date > 2012.7.31 SPR = { NOT = { has_country_flag = USoE_member } } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Nat_Autocracy_leader = 21 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Nat_Autocracy_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Chief of AF
 			create_country_leader = {
 				name = "Javier Salto"
-				picture = "gfx/leaders/USoE/Portrait_Javier_Salto.dds"
+				picture = "gfx/leaders/SPR/air/Javier_Salto_Martinez.dds"
 				ideology = Nat_Autocracy
 				traits = {
-										nationalist_Nat_Autocracy
-					#
-					#
-					#
-					#
-					#
+					nationalist_Nat_Autocracy
 				}
 			}
 
@@ -2331,15 +1677,10 @@ set_leader_USoE = {
 			#HoH/Vittorio Emanuele, Prince of Naples
 			create_country_leader = {
 				name = "Vittorio Emanuele"
-				picture = "gfx/leaders/USoE/vittorio_emanuele_iv.dds"
+				picture = "gfx/leaders/ITA/vittorio_emanuele_iv.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2347,9 +1688,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2006.7.7 ITA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_savoy } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 1 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2359,12 +1697,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Emanuele_Filiberto.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2372,9 +1705,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2006.7.7 ITA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_savoy } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 2 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2384,12 +1714,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Amedeo.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2397,24 +1722,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2006.7.7 ITA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_savoy } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 3 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Vittorio Emanuele, Prince of Naples
 			create_country_leader = {
 				name = "Vittorio Emanuele IV"
-				picture = "gfx/leaders/USoE/vittorio_emanuele_iv.dds"
+				picture = "gfx/leaders/ITA/vittorio_emanuele_iv.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					king
+					businessman
 				}
 			}
 
@@ -2422,9 +1741,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2006.7.7 ITA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_savoy } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 4 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2434,12 +1750,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Emanuele_Filiberto.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2447,9 +1758,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2006.7.7 ITA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_savoy } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 5 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2459,12 +1767,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Amedeo.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2472,9 +1775,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2006.7.7 ITA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_savoy } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 6 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2484,12 +1784,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Francis_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2497,9 +1792,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_wittelsbach } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 7 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2509,12 +1801,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Maximilian_III.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2522,9 +1809,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_wittelsbach } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 8 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2534,12 +1818,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Louis_IV.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2547,9 +1826,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_wittelsbach } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 9 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2559,12 +1835,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Francis_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2572,9 +1843,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_wittelsbach } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 10 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2584,12 +1852,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Maximilian_III.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2597,9 +1860,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_wittelsbach } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 11 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2609,12 +1869,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Louis_IV.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2622,24 +1877,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_wittelsbach } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 12 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH, King of Spain
 			create_country_leader = {
 				name = "Charles VIII"
-				picture = "gfx/leaders/USoE/juan_carlos_i.dds"
+				picture = "gfx/leaders/SPR/juan_carlos_i.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					king
+					military_career
 				}
 			}
 
@@ -2647,24 +1896,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2014.6.19 SPR = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_borbon_anjou } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 13 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH, King of Spain
 			create_country_leader = {
 				name = "Philip"
-				picture = "gfx/leaders/USoE/felipe_vi.dds"
+				picture = "gfx/leaders/SPR/felipe_vi.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					king
+					military_career
 				}
 			}
 
@@ -2672,9 +1915,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.6.19 SPR = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_borbon_anjou } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 14 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2684,12 +1924,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Leonor.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2697,24 +1932,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2023.10.31 SPR = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_borbon_anjou } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 15 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH, King of Spain
 			create_country_leader = {
 				name = "Juan Carlos I"
-				picture = "gfx/leaders/USoE/juan_carlos_i.dds"
+				picture = "gfx/leaders/SPR/juan_carlos_i.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					king
+					military_career
 				}
 			}
 
@@ -2722,24 +1951,18 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2014.6.19 SPR = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_borbon_anjou } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 16 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH, King of Spain
 			create_country_leader = {
 				name = "Felipe VI"
-				picture = "gfx/leaders/USoE/felipe_vi.dds"
+				picture = "gfx/leaders/SPR/felipe_vi.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					king
+					military_career
 				}
 			}
 
@@ -2747,9 +1970,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2014.6.19 SPR = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_borbon_anjou } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 17 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2759,12 +1979,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Leonor.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2772,24 +1987,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2023.10.31 SPR = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_borbon_anjou } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 18 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Louis Alphonse de Bourbon
 			create_country_leader = {
 				name = "Louis V"
-				picture = "gfx/leaders/USoE/Louis_XX_de_Bourbon.dds"
+				picture = "gfx/leaders/FRA/Louis_XX_de_Bourbon.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2797,9 +2004,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bourbon } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 19 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2809,12 +2013,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Henry_VII.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2822,24 +2021,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2019.1.21 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bourbon } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 20 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH of Orléans/Jean, Count of Paris
 			create_country_leader = {
 				name = "Jean"
-				picture = "gfx/leaders/USoE/Jean_IV.dds"
+				picture = "gfx/leaders/FRA/Jean_dOrleans.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2847,24 +2038,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.1.21 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bourbon } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 21 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Louis Alphonse de Bourbon
 			create_country_leader = {
 				name = "Louis XX"
-				picture = "gfx/leaders/USoE/Louis_XX_de_Bourbon.dds"
+				picture = "gfx/leaders/FRA/Louis_XX_de_Bourbon.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2872,9 +2055,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bourbon } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 22 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2884,12 +2064,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Henry_VII.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2897,24 +2072,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2019.1.21 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bourbon } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 23 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH of Orléans/Jean, Count of Paris
 			create_country_leader = {
 				name = "Jean IV"
-				picture = "gfx/leaders/USoE/Jean_IV.dds"
+				picture = "gfx/leaders/FRA/Jean_dOrleans.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2922,9 +2089,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2019.1.21 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bourbon } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 24 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2934,12 +2098,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ernest_Augustus_I.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2947,9 +2106,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2020.7.15 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hanover } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 25 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2959,12 +2115,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ernest_Augustus_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2972,9 +2123,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.7.15 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hanover } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 26 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -2984,12 +2132,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ernest_Augustus_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -2997,9 +2140,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.7.15 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hanover } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 27 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3009,12 +2149,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ernest_Augustus_I.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3022,9 +2157,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2020.7.15 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hanover } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 28 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3034,12 +2166,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ernest_Augustus_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3047,9 +2174,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.7.15 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hanover } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 29 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3059,12 +2183,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ernest_Augustus_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3072,24 +2191,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2020.7.15 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hanover } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 30 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#King of Greece
 			create_country_leader = {
 				name = "Constantine"
-				picture = "gfx/leaders/USoE/constantine_ii.dds"
+				picture = "gfx/leaders/GRE/constantine_ii.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3097,24 +2208,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GRE = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_glucksburg } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 31 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Queen of Denmark
 			create_country_leader = {
 				name = "Margrethe"
-				picture = "gfx/leaders/USoE/margrethe_ii.dds"
+				picture = "gfx/leaders/DEN/margrethe_ii.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					popular_figurehead
 				}
 			}
 
@@ -3122,24 +2226,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 DEN = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_glucksburg } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 32 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#King of Norway
 			create_country_leader = {
 				name = "Harald"
-				picture = "gfx/leaders/USoE/Harald_V.dds"
+				picture = "gfx/leaders/NRY/Harald_V.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					king
+					nationalist_Monarchist
 				}
 			}
 
@@ -3147,24 +2244,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 NRY = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_glucksburg } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 33 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#King of Greece
 			create_country_leader = {
 				name = "Constantine II"
-				picture = "gfx/leaders/USoE/constantine_ii.dds"
+				picture = "gfx/leaders/GRE/constantine_ii.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3172,24 +2261,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GRE = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_glucksburg } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 34 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Queen of Denmark
 			create_country_leader = {
 				name = "Margrethe II"
-				picture = "gfx/leaders/USoE/margrethe_ii.dds"
+				picture = "gfx/leaders/DEN/margrethe_ii.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					popular_figurehead
 				}
 			}
 
@@ -3197,24 +2279,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 DEN = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_glucksburg } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 35 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#King of Norway
 			create_country_leader = {
 				name = "Harald V"
-				picture = "gfx/leaders/USoE/Harald_V.dds"
+				picture = "gfx/leaders/NRY/Harald_V.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					king
+					nationalist_Monarchist
 				}
 			}
 
@@ -3222,24 +2297,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 NRY = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_glucksburg } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 36 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Queen of UK
 			create_country_leader = {
 				name = "Elizabeth"
-				picture = "gfx/leaders/USoE/Elizabeth_II.dds"
+				picture = "gfx/leaders/ENG/Elizabeth_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3247,24 +2314,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 ENG = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_windsor } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 37 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Heir apparent/Prince of Wales
 			create_country_leader = {
 				name = "Charles VIII"
-				picture = "gfx/leaders/USoE/Prince_Charles.dds"
+				picture = "gfx/leaders/ENG/Prince_Charles.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3272,9 +2331,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 ENG = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_windsor } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 38 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3284,12 +2340,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/William_V.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3297,24 +2348,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 ENG = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_windsor } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 39 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Queen of UK
 			create_country_leader = {
 				name = "Elizabeth II"
-				picture = "gfx/leaders/USoE/Elizabeth_II.dds"
+				picture = "gfx/leaders/ENG/Elizabeth_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3322,24 +2365,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 ENG = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_windsor } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 40 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Heir apparent/Prince of Wales
 			create_country_leader = {
 				name = "George VII"
-				picture = "gfx/leaders/USoE/Prince_Charles.dds"
+				picture = "gfx/leaders/ENG/Prince_Charles.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3347,9 +2382,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 ENG = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_windsor } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 41 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3359,12 +2391,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/William_V.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3372,24 +2399,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 ENG = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_windsor } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 42 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Queen of Netherlands
 			create_country_leader = {
 				name = "Beatrix"
-				picture = "gfx/leaders/USoE/beatrix.dds"
+				picture = "gfx/leaders/HOL/beatrix.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3397,24 +2416,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2013.4.30 HOL = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_orange_nassau } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 43 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#King of Netherlands
 			create_country_leader = {
 				name = "Willem-Alexander"
-				picture = "gfx/leaders/USoE/willem_alexander.dds"
+				picture = "gfx/leaders/HOL/willem_alexander.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					military_career
 				}
 			}
 
@@ -3422,9 +2434,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2013.4.30 HOL = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_orange_nassau } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 44 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3434,12 +2443,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Catharina-Amalia.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3447,24 +2451,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2021.12.7 HOL = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_orange_nassau } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 45 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#Queen of Netherlands
 			create_country_leader = {
 				name = "Beatrix"
-				picture = "gfx/leaders/USoE/beatrix.dds"
+				picture = "gfx/leaders/HOL/beatrix.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3472,24 +2468,17 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2013.4.30 HOL = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_orange_nassau } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 46 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#King of Netherlands
 			create_country_leader = {
 				name = "Willem-Alexander"
-				picture = "gfx/leaders/USoE/willem_alexander.dds"
+				picture = "gfx/leaders/HOL/willem_alexander.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
+					military_career
 				}
 			}
 
@@ -3497,9 +2486,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2013.4.30 HOL = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_orange_nassau } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 47 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3509,12 +2495,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Catharina-Amalia.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3522,24 +2503,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2021.12.7 HOL = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_orange_nassau } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 48 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Otto von Habsburg
 			create_country_leader = {
 				name = "Otto V"
-				picture = "gfx/leaders/USoE/otto_von_habsburg.dds"
+				picture = "gfx/leaders/AUS/otto_von_habsburg.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3547,24 +2520,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2007.1.1 AUS = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_habsburg_lorraine } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 49 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Karl von Habsburg
 			create_country_leader = {
 				name = "Charles VIII"
-				picture = "gfx/leaders/USoE/karl_von_habsburg.dds"
+				picture = "gfx/leaders/AUS/karl_von_habsburg.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3572,9 +2537,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2007.1.1 AUS = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_habsburg_lorraine } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 50 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3584,12 +2546,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ferdinand_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3597,24 +2554,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.6.21 AUS = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_habsburg_lorraine } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 51 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Otto von Habsburg
 			create_country_leader = {
 				name = "Otto I"
-				picture = "gfx/leaders/USoE/otto_von_habsburg.dds"
+				picture = "gfx/leaders/AUS/otto_von_habsburg.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3622,24 +2571,16 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 date > 2007.1.1 AUS = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_habsburg_lorraine } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 52 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Karl von Habsburg
 			create_country_leader = {
 				name = "Charles II"
-				picture = "gfx/leaders/USoE/karl_von_habsburg.dds"
+				picture = "gfx/leaders/AUS/karl_von_habsburg.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3647,9 +2588,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2007.1.1 AUS = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_habsburg_lorraine } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 53 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3659,12 +2597,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Ferdinand_II.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3672,9 +2605,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2015.6.21 AUS = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_habsburg_lorraine } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 54 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3684,12 +2614,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Napoleon_VII_Charles.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3697,16 +2622,13 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bonaparte } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 55 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Jean-Christophe, Prince Napoléon
 			create_country_leader = {
 				name = "Ferdinand IV Napoléon"
-				picture = "gfx/leaders/USoE/jean_christophe_bonaparte.dds"
+				picture = "gfx/leaders/FRA/jean_christophe_bonaparte.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -3720,9 +2642,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bonaparte } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 56 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3732,12 +2651,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Napoleon_VIII_Jerome.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3745,9 +2659,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bonaparte } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 57 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3757,12 +2668,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Napoleon_VII_Charles.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3770,16 +2676,13 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bonaparte } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 58 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Jean-Christophe, Prince Napoléon
 			create_country_leader = {
 				name = "Napoléon VII Jean-Christophe"
-				picture = "gfx/leaders/USoE/jean_christophe_bonaparte.dds"
+				picture = "gfx/leaders/FRA/jean_christophe_bonaparte.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -3793,9 +2696,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 FRA = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_bonaparte } NOT = { has_country_flag = USoE_new_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 59 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3805,12 +2705,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Napoleon_VIII_Jerome.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3824,7 +2719,7 @@ set_leader_USoE = {
 			#HoH/Georg Friedrich, Prince of Prussia
 			create_country_leader = {
 				name = "Frederick IV"
-				picture = "gfx/leaders/USoE/georg_friedrich.dds"
+				picture = "gfx/leaders/GER/georg_friedrich.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -3844,12 +2739,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Charles_Frederick.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3857,9 +2747,6 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 2031.1.20 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hohenzollern } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 62 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
@@ -3869,12 +2756,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Christian-Sigismund.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 
@@ -3882,16 +2764,13 @@ set_leader_USoE = {
 			if = { limit = { OR = { date < 1999.12.31 GER = { NOT = { has_country_flag = USoE_member } } NOT = { has_country_flag = USoE_house_of_hohenzollern } NOT = { has_country_flag = USoE_imperial_crown } } } set_temp_variable = { b = 0 } }
 			else = { set_temp_variable = { b = 1 } }
 		}
-		#
-		#
-
 		if = { limit = { check_variable = { Monarchist_leader = 63 } NOT = { check_variable = { b = 1 } } }
 			add_to_variable = { Monarchist_leader = 1 }
 			hidden_effect = { kill_country_leader = yes }
 			#HoH/Georg Friedrich, Prince of Prussia
 			create_country_leader = {
 				name = "George Frederick"
-				picture = "gfx/leaders/USoE/georg_friedrich.dds"
+				picture = "gfx/leaders/GER/georg_friedrich.dds"
 				ideology = Monarchist
 				traits = {
 					nationalist_Monarchist
@@ -3928,12 +2807,7 @@ set_leader_USoE = {
 				picture = "gfx/leaders/USoE/Christian-Sigismund.dds"
 				ideology = Monarchist
 				traits = {
-										nationalist_Monarchist
-					#
-					#
-					#
-					#
-					#
+					nationalist_Monarchist
 				}
 			}
 


### PR DESCRIPTION
## Bottom line

USoE country leaders now use the matching country-folder portraits and traits instead of missing `gfx/leaders/USoE` copies, and the empty `#` placeholder rows are gone.

## Why

Most USoE `picture` paths pointed at files that are not in `gfx/leaders/USoE`. Country tags already ship the art. A few country names also used the unaccented form (Hollande, Orbán, Martín, Sánchez, Plenković, Løkke).

## How

Where a country roster entry exists, USoE now points at `gfx/leaders/<TAG>/<country picture>` and copies that leader's traits, keeping the USoE ideology-category trait when the country ideology differs (Tusk stays conservative). Remaining EU-only or pretender portraits stay on USoE when no country file exists.

BLUF