### PR TITLE
Fix Algeria disaster contingency spirit cleanup

### DIFF
--- a/events/Algeria.txt
+++ b/events/Algeria.txt
@@ -4442,6 +4442,7 @@ country_event = {
 		modify_treasury_effect = yes
 		add_popularity = { ideology = democratic popularity = 0.03 }
 		add_ideas = ALG_government_led_disaster
+		remove_ideas = ALG_no_disasters_plan
 		custom_effect_tooltip = ALG_state_aid_fund_tt
 		set_temp_variable = { percent_change = 10 }
 		change_domestic_influence_percentage = yes
@@ -4461,6 +4462,7 @@ country_event = {
 		set_temp_variable = { treasury_change = 45.00 }
 		modify_treasury_effect = yes
 		add_ideas = ALG_charity_disasters
+		remove_ideas = ALG_no_disasters_plan
 		custom_effect_tooltip = ALG_foreign_aid_dependence_tt
 		set_temp_variable = { percent_change = -10 }
 		change_domestic_influence_percentage = yes


### PR DESCRIPTION
### Changes

Fixes the Algeria disaster contingency national spirit not being removed after the player selects a disaster response plan.

Both outcomes in `algeria_disaster.2` now remove `ALG_no_disasters_plan` when their replacement disaster-response spirit is added:

- State Aid Fund → `ALG_government_led_disaster`
- Foreign Assistance → `ALG_charity_disasters`

This prevents Algeria from keeping the "No Disaster Contingency Plan" penalty after establishing an actual disaster response framework.

### Validation

- Confirmed `ALG_no_disasters_plan` is added by `algeria_disaster.1`
- Confirmed both resolution paths add replacement disaster-response spirits
- `git diff --check` passes
- Only `events/Algeria.txt` is changed

Closes #3858