### PR TITLE
Module Interaction fixes

### DIFF
--- a/common/doctrines/grand_doctrines/land_equipment.txt
+++ b/common/doctrines/grand_doctrines/land_equipment.txt
@@ -540,11 +540,11 @@ fires_equipment = {
 		}
 		{
 			category_asg = {
-				max_organisation = 2
+				max_organisation = 3
 				hard_attack = 0.1
 			}
 			category_asg = {
-				combat_width = -0.75
+				combat_width = -0.5
 				supply_consumption = -0.01
 			}
 		}

--- a/common/doctrines/tracks/air.txt
+++ b/common/doctrines/tracks/air.txt
@@ -42,7 +42,7 @@ multirole_aircraft = {
 
 	mastery = {
 		multiplier = 5
-		equipment = { tactical_bomber fighter cas }
+		equipment = { tactical_bomber fighter cas suicide }
 	}
 }
 

--- a/common/units/equipment/modules/MD_plane_modules.txt
+++ b/common/units/equipment/modules/MD_plane_modules.txt
@@ -1590,7 +1590,6 @@ equipment_modules = {
 
 		forbid_equipment_type_exact_match_for_category = {
 			plane_intercept_weapons = suicide
-			plane_fighter_weapons = suicide
 			plane_nav_weapons = suicide
 			plane_multipurpose_gun = suicide
 		}

--- a/common/units/equipment/modules/MD_tank_modules.txt
+++ b/common/units/equipment/modules/MD_tank_modules.txt
@@ -13,6 +13,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -55,6 +56,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -97,6 +99,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -139,6 +142,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -181,6 +185,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -223,6 +228,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -265,6 +271,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -307,6 +314,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -349,6 +357,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -391,6 +400,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -434,6 +444,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -476,6 +487,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -518,6 +530,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -559,7 +572,8 @@ equipment_modules = {
 			special_type_slot_1 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
-			special_type_slot_4 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -602,6 +616,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -645,6 +660,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -691,6 +707,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -737,6 +754,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -783,6 +801,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1178,6 +1197,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1229,6 +1249,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1280,6 +1301,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1330,6 +1352,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1381,6 +1404,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1432,6 +1456,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1483,6 +1508,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1534,6 +1560,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1585,6 +1612,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1635,6 +1663,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1686,6 +1715,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1737,6 +1767,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -1788,6 +1819,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -4553,6 +4585,7 @@ equipment_modules = {
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -4580,8 +4613,8 @@ equipment_modules = {
 			special_type_slot_1 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
-			special_type_slot_4 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -4609,8 +4642,8 @@ equipment_modules = {
 			special_type_slot_1 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
-			special_type_slot_4 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {
@@ -4638,8 +4671,8 @@ equipment_modules = {
 			special_type_slot_1 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_2 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_3 = { tank_auxiliary_electric_engine_module }
-			special_type_slot_4 = { tank_auxiliary_electric_engine_module }
 			special_type_slot_5 = { tank_auxiliary_electric_engine_module }
+			special_type_slot_6 = { tank_auxiliary_electric_engine_module }
 		}
 
 		add_stats = {


### PR DESCRIPTION
- Fixed the weird interaction between engines and the electric aux engine
- Aux Elect Engine no longer appears under the Battlestation slot for all engines
- To compensate you can use the extra armor slot to install one of those if using a chemical powered engine
- Fixed some weird changes made to fire support bonus that I clearly did while sleep deprived
- Added drones XP track to the multirole track as they get MR modules after Gen 3 (Not sure if bonuses will apply to MR drones)