### PR TITLE
Assault Cannon/Marines Tweaks

### DIFF
--- a/common/units/MD_land_units.txt
+++ b/common/units/MD_land_units.txt
@@ -876,9 +876,9 @@ sub_units = {
 		need = {
 			infantry_weapons_type = 240
 			L_AT_Equipment = 16
-			H_AT_Equipment = 10
+			H_AT_Equipment = 20
 			AA_Equipment = 8
-			cnc_equipment_type = 16
+			cnc_equipment_type = 20
 			medium_tank_amphibious_chassis = 20
 		}
 		amphibious = { attack = 0.10 }
@@ -938,9 +938,9 @@ sub_units = {
 		need = {
 			infantry_weapons_type = 180
 			L_AT_Equipment = 12
-			H_AT_Equipment = 10
+			H_AT_Equipment = 20
 			AA_Equipment = 6
-			cnc_equipment_type = 12
+			cnc_equipment_type = 20
 			medium_tank_flame_chassis = 20
 		}
 		amphibious = { attack = 0.10 }

--- a/common/units/equipment/modules/MD_tank_modules.txt
+++ b/common/units/equipment/modules/MD_tank_modules.txt
@@ -3135,18 +3135,17 @@ equipment_modules = {
 				main_gun_ammo
 			}
 			special_type_slot_1 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_2 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_3 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			secondary_armament_slot = {
 				tank_longer_gun_category
 				tank_atgm_module
-				afv_atgm_module
 				light_afv_coax_gun
 			}
 		}
@@ -3197,15 +3196,15 @@ equipment_modules = {
 				main_gun_ammo
 			}
 			special_type_slot_1 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_2 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_3 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
-			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module afv_atgm_module light_afv_coax_gun }
+			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module light_afv_coax_gun }
 		}
 
 		add_stats = {
@@ -3254,15 +3253,15 @@ equipment_modules = {
 				main_gun_ammo
 			}
 			special_type_slot_1 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_2 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_3 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
-			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module afv_atgm_module light_afv_coax_gun }
+			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module light_afv_coax_gun }
 		}
 
 		add_stats = {
@@ -3312,15 +3311,15 @@ equipment_modules = {
 				main_gun_ammo
 			}
 			special_type_slot_1 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_2 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_3 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
-			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module afv_atgm_module light_afv_coax_gun }
+			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module light_afv_coax_gun }
 		}
 
 		add_stats = {
@@ -3370,15 +3369,15 @@ equipment_modules = {
 				main_gun_ammo
 			}
 			special_type_slot_1 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_2 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_3 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
-			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module afv_atgm_module light_afv_coax_gun }
+			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module light_afv_coax_gun }
 		}
 
 		add_stats = {
@@ -3426,15 +3425,15 @@ equipment_modules = {
 				main_gun_ammo
 			}
 			special_type_slot_1 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_2 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
 			special_type_slot_3 = {
-				tank_atgm_module afv_atgm_module
+				tank_atgm_module
 			}
-			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module afv_atgm_module light_afv_coax_gun }
+			secondary_armament_slot = { tank_longer_gun_category tank_atgm_module light_afv_coax_gun }
 		}
 
 		add_stats = {


### PR DESCRIPTION
- All assault cannons can no longer use externally mounted ATGMS
- Mechanized and IFV marines now need a little more equipment per battalion (more C&C and more motorized ATGMs)

Closes #3625 