### PR TITLE
Let indebted AI combat foreign influence

### DIFF
--- a/common/decisions/Influence Decisions.txt
+++ b/common/decisions/Influence Decisions.txt
@@ -287,32 +287,46 @@ influence_decisions = {
 				check_variable = { domestic_influence_amount < 10 }
 			}
 			modifier = {
+				factor = 1.5
+				any_of_scopes = {
+					array = influence_array
+					OR = {
+						has_war_with = ROOT
+						ROOT = {
+							has_opinion = {
+								target = PREV
+								value < 0
+							}
+						}
+					}
+				}
+			}
+			modifier = {
+				factor = 1.5
+				any_of_scopes = {
+					array = influence_array
+					ROOT = {
+						has_opinion = {
+							target = PREV
+							value < -50
+						}
+					}
+				}
+			}
+			modifier = {
 				factor = 0.75
 				has_idea = NATO_member
-				OR = {
-					var:influence_array^0 = { has_idea = NATO_member }
-					var:influence_array^1 = { has_idea = NATO_member }
-					var:influence_array^2 = { has_idea = NATO_member }
+				any_of_scopes = {
+					array = influence_array
+					has_idea = NATO_member
 				}
 				NOT = {
-					OR = {
-						var:influence_array^0 = {
-							OR = {
-								original_tag = SOV
-								original_tag = CHI
-							}
-						}
-						var:influence_array^1 = {
-							OR = {
-								original_tag = SOV
-								original_tag = CHI
-							}
-						}
-						var:influence_array^2 = {
-							OR = {
-								original_tag = SOV
-								original_tag = CHI
-							}
+					any_of_scopes = {
+						array = influence_array
+						OR = {
+							original_tag = SOV
+							original_tag = CHI
+							has_war_with = ROOT
 						}
 					}
 				}
@@ -333,6 +347,7 @@ influence_decisions = {
 								NOT = { SOV = { has_idea = EU_member } }
 							}
 							original_tag = CHI
+							has_war_with = ROOT
 						}
 					}
 				}
@@ -366,7 +381,7 @@ influence_decisions = {
 			modifier = {
 				factor = 0
 				OR = {
-					check_variable = { interest_rate > 12 }
+					has_active_mission = bankruptcy_incoming_collapse
 					check_variable = { domestic_influence_amount > 69 }
 				}
 			}
@@ -540,7 +555,7 @@ influence_decisions = {
 			modifier = {
 				factor = 0
 				OR = {
-					check_variable = { interest_rate > 12 }
+					has_active_mission = bankruptcy_incoming_collapse
 					check_variable = { domestic_influence_amount > 69 }
 				}
 			}
@@ -715,7 +730,7 @@ influence_decisions = {
 			modifier = {
 				factor = 0
 				OR = {
-					check_variable = { interest_rate > 12 }
+					has_active_mission = bankruptcy_incoming_collapse
 					check_variable = { domestic_influence_amount > 69 }
 				}
 			}
@@ -889,7 +904,7 @@ influence_decisions = {
 			modifier = {
 				factor = 0
 				OR = {
-					check_variable = { interest_rate > 12 }
+					has_active_mission = bankruptcy_incoming_collapse
 					check_variable = { domestic_influence_amount > 69 }
 				}
 			}

--- a/common/scripted_effects/00_influence_scripted_effects.txt
+++ b/common/scripted_effects/00_influence_scripted_effects.txt
@@ -410,7 +410,7 @@ mp_economic_aid_transfer = {
 
 automation_combat_foreign_influence_execute = {
 	set_country_flag = { flag = automation_combat_foreign_influence_cooldown value = 1 days = 100 }
-	set_temp_variable = { percent_change = 2.5 }
+	set_temp_variable = { percent_change = 5 }
 	change_domestic_influence_percentage = yes
 }
 


### PR DESCRIPTION
## Bottom line
Indebted AI can take combat_foreign_influence again. The decision also hits harder and prefers hostile influencers.

Interest rate no longer zeros combat decisions (bankruptcy still does). Hostile or at-war influencers raise the weight. NATO now checks the full influence array. Combat adds 5% domestic instead of 2.5% so one use keeps up with a monthly spread pulse.

No in-game check.

Closes #3976

BLUF