### PR TITLE
Stop AI annexing locked autonomy subjects

### DIFF
--- a/common/autonomous_states/MD_AFG_autonomies.txt
+++ b/common/autonomous_states/MD_AFG_autonomies.txt
@@ -26,7 +26,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.0 }
-	ai_overlord_wants_lower = { factor = 0.3 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {

--- a/common/autonomous_states/MD_IRQ_autonomies.txt
+++ b/common/autonomous_states/MD_IRQ_autonomies.txt
@@ -27,7 +27,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.0 }
-	ai_overlord_wants_lower = { factor = 0.3 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {
@@ -70,7 +70,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.0 }
-	ai_overlord_wants_lower = { factor = 0.3 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {

--- a/common/autonomous_states/MD_danish_autonomies.txt
+++ b/common/autonomous_states/MD_danish_autonomies.txt
@@ -29,7 +29,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.5 }
-	ai_overlord_wants_lower = { factor = 0.2 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {

--- a/common/autonomous_states/MD_israeli_autonomies.txt
+++ b/common/autonomous_states/MD_israeli_autonomies.txt
@@ -27,11 +27,11 @@ autonomy_state = {
 	}
 
 	ai_subject_wants_higher = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_lower = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_garrison = {
@@ -135,7 +135,7 @@ autonomy_state = {
 	}
 
 	ai_subject_wants_higher = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_lower = {
@@ -190,11 +190,11 @@ autonomy_state = {
 	}
 
 	ai_subject_wants_higher = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_lower = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_garrison = {

--- a/common/autonomous_states/MD_tajik_autonomies.txt
+++ b/common/autonomous_states/MD_tajik_autonomies.txt
@@ -25,11 +25,11 @@ autonomy_state = {
 	}
 
 	ai_subject_wants_higher = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_lower = {
-		factor = 1.0
+		factor = 0.0
 	}
 
 	ai_overlord_wants_garrison = {
@@ -81,7 +81,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.0 }
-	ai_overlord_wants_lower = { factor = 0.3 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {

--- a/common/autonomous_states/MD_turkish_autonomies.txt
+++ b/common/autonomous_states/MD_turkish_autonomies.txt
@@ -26,7 +26,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.0 }
-	ai_overlord_wants_lower = { factor = 0.3 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {

--- a/common/autonomous_states/MD_union_state.txt
+++ b/common/autonomous_states/MD_union_state.txt
@@ -29,7 +29,7 @@ autonomy_state = {
 
 
 	ai_subject_wants_higher = { factor = 0.0 }
-	ai_overlord_wants_lower = { factor = 0.3 }
+	ai_overlord_wants_lower = { factor = 0.0 }
 	ai_overlord_wants_garrison = { always = yes }
 
 	allowed = {

--- a/common/continuous_focus/generic.txt
+++ b/common/continuous_focus/generic.txt
@@ -266,7 +266,9 @@ continuous_focus_palette = {
 			base = 0
 			modifier = {
 				add = 10
-				num_subjects > 0
+				any_subject_country = {
+					NOT = { is_autonomy_that_cannot_change_level = yes }
+				}
 			}
 			modifier = {
 				factor = 4
@@ -275,6 +277,7 @@ continuous_focus_palette = {
 			modifier = {
 				factor = 1.25
 				any_subject_country = {
+					NOT = { is_autonomy_that_cannot_change_level = yes }
 					check_variable = { office_park_total > 5 }
 				}
 			}

--- a/common/scripted_triggers/00_diplo_action_valid_triggers.txt
+++ b/common/scripted_triggers/00_diplo_action_valid_triggers.txt
@@ -42,7 +42,10 @@ is_autonomy_that_cannot_change_level = {
 		has_autonomy_state = autonomy_socialist_union
 		has_autonomy_state = autonomy_federal_state_iran
 		has_autonomy_state = autonomy_fifty_first_state_iraq
+		has_autonomy_state = autonomy_occupation_zone_IRQ
+		has_autonomy_state = autonomy_fifty_second_state_afghanistan
 		has_autonomy_state = autonomy_authority_of_palestine
+		has_autonomy_state = autonomy_authority_of_palestine_2
 		has_autonomy_state = autonomy_provisional_security_of_gaza
 		has_autonomy_state = autonomy_autonomous_province
 		has_autonomy_state = autonomy_autonomous_province1
@@ -53,6 +56,11 @@ is_autonomy_that_cannot_change_level = {
 		has_autonomy_state = autonomy_republic_ukr
 		has_autonomy_state = autonomy_novorossiya_ukr
 		has_autonomy_state = autonomy_union_state
+		has_autonomy_state = autonomy_french_overseas_department
+		has_autonomy_state = autonomy_korean_federation
+		has_autonomy_state = autonomy_ads_subject
+		has_autonomy_state = autonomy_constituent_country_very_low_devolution
+		has_autonomy_state = HOL_personal_union
 	}
 }
 


### PR DESCRIPTION
## Bottom line
AI no longer takes Restrict Freedom, or pushes autonomy laws, unless a subject can actually change level or be annexed.

## Why
Locked autonomies (`can_take_level` / `can_lose_level = { always = no }`) still counted as subjects, so Russia, China, Denmark, and similar majors wasted the continuous focus on subjects that cannot move.

## How
Restrict Freedom scores only when any subject is not `is_autonomy_that_cannot_change_level`. That trigger now includes the missing locked levels. Overlord/subject autonomy AI is zeroed on levels that cannot move or be annexed. Players can still pick the focus.

Closes #3979

BLUF