### PR TITLE
Use is_in_array for Mercosur request membership checks

### DIFF
--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -18,7 +18,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -77,8 +76,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -137,7 +134,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -196,8 +192,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -256,7 +250,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -315,8 +308,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -375,7 +366,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -434,8 +424,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -494,7 +482,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -554,7 +541,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -613,8 +599,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -673,7 +657,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -732,8 +715,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -792,7 +773,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -852,9 +832,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_global_flag = mercosur_latin_america_invites_unlocked
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -914,8 +891,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_global_flag = mercosur_latin_america_invites_unlocked
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -975,9 +950,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_global_flag = MER_mercosur_requests_enabled
-			has_global_flag = mercosur_latin_america_invites_unlocked
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -1037,8 +1009,6 @@ MER_mercosur_diplomacy = {
 
 		available = {
 			has_global_flag = MER_mercosur_full_membership_enabled
-			has_global_flag = mercosur_latin_america_invites_unlocked
-			has_dynamic_modifier = mercosur_member_state_modifier
 			is_in_array = { global.mercosur_potential = THIS }
 			is_subject = no
 			has_at_least_regional_power_status = yes
@@ -1099,19 +1069,9 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			is_ai = no
 			is_subject = no
 			has_elections = yes
 			NOT = { has_country_flag = partyall_banned }
-			is_in_array = { global.mercosur_potential = THIS }
-			NOT = { has_idea = BRA_idea_associate_states }
-			NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
-			any_of_scopes = {
-				array = global.mercosur_member_state
-				is_subject = no
-				has_at_least_regional_power_status = yes
-				has_global_flag = MER_mercosur_requests_enabled
-			}
 		}
 
 		remove_effect = {
@@ -1157,33 +1117,9 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			is_ai = no
 			is_subject = no
 			has_elections = yes
 			NOT = { has_country_flag = partyall_banned }
-			is_in_array = { global.mercosur_potential = THIS }
-			has_idea = BRA_idea_associate_states
-			NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
-			NOT = {
-				OR = {
-					has_country_flag = mercosur_chl_accession_pending
-					has_country_flag = mercosur_pru_accession_pending
-					has_country_flag = mercosur_col_accession_pending
-					has_country_flag = mercosur_ecu_accession_pending
-					has_country_flag = mercosur_ven_accession_pending
-					has_country_flag = mercosur_bol_accession_pending
-					has_country_flag = mercosur_guy_accession_pending
-					has_country_flag = mercosur_sur_accession_pending
-					has_country_flag = mercosur_mex_accession_pending
-					has_country_flag = mercosur_pan_accession_pending
-				}
-			}
-			any_of_scopes = {
-				array = global.mercosur_member_state
-				is_subject = no
-				has_at_least_regional_power_status = yes
-				has_global_flag = MER_mercosur_full_membership_enabled
-			}
 		}
 
 		remove_effect = {
@@ -1229,32 +1165,9 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			is_ai = no
 			is_subject = no
 			has_elections = yes
 			NOT = { has_country_flag = partyall_banned }
-			is_in_array = { global.mercosur_potential = THIS }
-			NOT = { tag = MEX }
-			NOT = { tag = PAN }
-			NOT = { has_dynamic_modifier = unasul_member_state_modifier }
-			OR = {
-				AND = {
-					has_dynamic_modifier = mercosur_member_state_modifier
-					has_global_flag = MER_unasul_established
-				}
-				has_global_flag = MER_unasul_expansion_enabled
-			}
-			any_of_scopes = {
-				array = global.unasul_member_state
-				is_subject = no
-				OR = {
-					has_global_flag = MER_unasul_expansion_enabled
-					AND = {
-						ROOT = { has_dynamic_modifier = mercosur_member_state_modifier }
-						has_global_flag = MER_unasul_established
-					}
-				}
-			}
 		}
 
 		remove_effect = {
@@ -1283,12 +1196,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			CHL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_chl_accession_pending
-				NOT = { has_country_flag = mercosur_chl_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1325,12 +1234,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			CHL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_chl_accession_pending
-				NOT = { has_country_flag = mercosur_chl_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1367,12 +1272,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			CHL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_chl_accession_pending
-				NOT = { has_country_flag = mercosur_chl_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1409,12 +1310,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			COL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_col_accession_pending
-				NOT = { has_country_flag = mercosur_col_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1451,12 +1348,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			COL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_col_accession_pending
-				NOT = { has_country_flag = mercosur_col_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1493,12 +1386,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			COL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_col_accession_pending
-				NOT = { has_country_flag = mercosur_col_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1535,12 +1424,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			VEN = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_ven_accession_pending
-				NOT = { has_country_flag = mercosur_ven_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1577,12 +1462,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			VEN = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_ven_accession_pending
-				NOT = { has_country_flag = mercosur_ven_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1619,12 +1500,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			VEN = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_ven_accession_pending
-				NOT = { has_country_flag = mercosur_ven_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1661,12 +1538,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			PRU = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_pru_accession_pending
-				NOT = { has_country_flag = mercosur_pru_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1719,12 +1592,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			PRU = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_pru_accession_pending
-				NOT = { has_country_flag = mercosur_pru_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1777,12 +1646,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			PRU = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_pru_accession_pending
-				NOT = { has_country_flag = mercosur_pru_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1835,12 +1700,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			BOL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_bol_accession_pending
-				NOT = { has_country_flag = mercosur_bol_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1893,12 +1754,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			BOL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_bol_accession_pending
-				NOT = { has_country_flag = mercosur_bol_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -1951,12 +1808,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			BOL = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_bol_accession_pending
-				NOT = { has_country_flag = mercosur_bol_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2009,12 +1862,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			PAN = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_pan_accession_pending
-				NOT = { has_country_flag = mercosur_pan_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2067,12 +1916,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			PAN = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_pan_accession_pending
-				NOT = { has_country_flag = mercosur_pan_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2125,12 +1970,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			PAN = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_pan_accession_pending
-				NOT = { has_country_flag = mercosur_pan_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2183,12 +2024,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			ECU = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_ecu_accession_pending
-				NOT = { has_country_flag = mercosur_ecu_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2234,12 +2071,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			ECU = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_ecu_accession_pending
-				NOT = { has_country_flag = mercosur_ecu_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2285,12 +2118,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			ECU = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_ecu_accession_pending
-				NOT = { has_country_flag = mercosur_ecu_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2343,12 +2172,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			GUY = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_guy_accession_pending
-				NOT = { has_country_flag = mercosur_guy_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2399,12 +2224,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			GUY = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_guy_accession_pending
-				NOT = { has_country_flag = mercosur_guy_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2450,12 +2271,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			GUY = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_guy_accession_pending
-				NOT = { has_country_flag = mercosur_guy_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2508,12 +2325,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			SUR = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_sur_accession_pending
-				NOT = { has_country_flag = mercosur_sur_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2559,12 +2372,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			SUR = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_sur_accession_pending
-				NOT = { has_country_flag = mercosur_sur_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2610,12 +2419,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			SUR = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_sur_accession_pending
-				NOT = { has_country_flag = mercosur_sur_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2661,12 +2466,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			MEX = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_mex_accession_pending
-				NOT = { has_country_flag = mercosur_mex_accession_mission_1_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2712,12 +2513,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			MEX = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_mex_accession_pending
-				NOT = { has_country_flag = mercosur_mex_accession_mission_2_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2763,12 +2560,8 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			MEX = {
-				exists = yes
 				has_idea = BRA_idea_associate_states
-				has_country_flag = mercosur_mex_accession_pending
-				NOT = { has_country_flag = mercosur_mex_accession_mission_3_done }
 				NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 				is_subject = no
 			}
@@ -2821,11 +2614,6 @@ MER_mercosur_diplomacy = {
 			is_in_array = { global.mercosur_potential = THIS }
 			has_dynamic_modifier = mercosur_member_state_modifier
 			is_subject = no
-			NOT = { has_global_flag = MER_release_development_fund_round_cooldown }
-		}
-
-		available = {
-			has_dynamic_modifier = mercosur_member_state_modifier
 			NOT = { has_global_flag = MER_release_development_fund_round_cooldown }
 		}
 
@@ -2935,8 +2723,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_completed_focus = MER_sa_corridor_development
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_integrated_corridor_plan_cooldown }
 		}
 
@@ -2987,8 +2773,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_completed_focus = MER_counter_cartel
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_counter_cartel_operation_cooldown }
 			any_of_scopes = {
 				array = global.unasul_member_state
@@ -3033,8 +2817,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_completed_focus = MER_sa_energy_council
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_energy_security_reinforcement_cooldown }
 		}
 
@@ -3083,12 +2865,9 @@ MER_mercosur_diplomacy = {
 		visible = {
 			has_completed_focus = MER_sa_health_council
 			has_dynamic_modifier = unasul_member_state_modifier
-			check_variable = { global.MER_unasul_joint_health_improvement_project_rounds < 4 }
 		}
 
 		available = {
-			has_completed_focus = MER_sa_health_council
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_joint_health_improvement_project_active }
 			custom_trigger_tooltip = {
 				tooltip = MER_unasul_joint_health_improvement_project_rounds_tt
@@ -3139,12 +2918,9 @@ MER_mercosur_diplomacy = {
 		visible = {
 			has_completed_focus = MER_productive_integration_and_sme_networks
 			has_dynamic_modifier = unasul_member_state_modifier
-			check_variable = { global.MER_unasul_supply_chain_strengthening_rounds < 4 }
 		}
 
 		available = {
-			has_completed_focus = MER_productive_integration_and_sme_networks
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_supply_chain_strengthening_active }
 			custom_trigger_tooltip = {
 				tooltip = MER_unasul_supply_chain_strengthening_rounds_tt
@@ -3197,8 +2973,6 @@ MER_mercosur_diplomacy = {
 		}
 
 		available = {
-			has_completed_focus = MER_sa_defense_council
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_joint_exercises_cooldown }
 		}
 
@@ -3247,12 +3021,9 @@ MER_mercosur_diplomacy = {
 		visible = {
 			has_completed_focus = MER_sa_network_for_science_and_innovation
 			has_dynamic_modifier = unasul_member_state_modifier
-			check_variable = { global.MER_unasul_joint_research_exchange_project_rounds < 4 }
 		}
 
 		available = {
-			has_completed_focus = MER_sa_network_for_science_and_innovation
-			has_dynamic_modifier = unasul_member_state_modifier
 			NOT = { has_global_flag = MER_unasul_joint_research_exchange_project_active }
 			custom_trigger_tooltip = {
 				tooltip = MER_unasul_joint_research_exchange_project_rounds_tt

--- a/common/decisions/mercosur_decisions.txt
+++ b/common/decisions/mercosur_decisions.txt
@@ -1087,15 +1087,11 @@ MER_mercosur_diplomacy = {
 
 		visible = {
 			is_ai = no
-			any_of_scopes = {
-				array = global.mercosur_potential
-				tag = ROOT
-			}
+			is_in_array = { global.mercosur_potential = THIS }
 			NOT = { has_idea = BRA_idea_associate_states }
 			NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			any_of_scopes = {
 				array = global.mercosur_member_state
-				NOT = { tag = ROOT }
 				is_subject = no
 				has_at_least_regional_power_status = yes
 				has_global_flag = MER_mercosur_requests_enabled
@@ -1107,15 +1103,11 @@ MER_mercosur_diplomacy = {
 			is_subject = no
 			has_elections = yes
 			NOT = { has_country_flag = partyall_banned }
-			any_of_scopes = {
-				array = global.mercosur_potential
-				tag = ROOT
-			}
+			is_in_array = { global.mercosur_potential = THIS }
 			NOT = { has_idea = BRA_idea_associate_states }
 			NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			any_of_scopes = {
 				array = global.mercosur_member_state
-				NOT = { tag = ROOT }
 				is_subject = no
 				has_at_least_regional_power_status = yes
 				has_global_flag = MER_mercosur_requests_enabled
@@ -1139,10 +1131,7 @@ MER_mercosur_diplomacy = {
 
 		visible = {
 			is_ai = no
-			any_of_scopes = {
-				array = global.mercosur_potential
-				tag = ROOT
-			}
+			is_in_array = { global.mercosur_potential = THIS }
 			has_idea = BRA_idea_associate_states
 			NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			NOT = {
@@ -1161,7 +1150,6 @@ MER_mercosur_diplomacy = {
 			}
 			any_of_scopes = {
 				array = global.mercosur_member_state
-				NOT = { tag = ROOT }
 				is_subject = no
 				has_at_least_regional_power_status = yes
 				has_global_flag = MER_mercosur_full_membership_enabled
@@ -1173,10 +1161,7 @@ MER_mercosur_diplomacy = {
 			is_subject = no
 			has_elections = yes
 			NOT = { has_country_flag = partyall_banned }
-			any_of_scopes = {
-				array = global.mercosur_potential
-				tag = ROOT
-			}
+			is_in_array = { global.mercosur_potential = THIS }
 			has_idea = BRA_idea_associate_states
 			NOT = { has_dynamic_modifier = mercosur_member_state_modifier }
 			NOT = {
@@ -1195,7 +1180,6 @@ MER_mercosur_diplomacy = {
 			}
 			any_of_scopes = {
 				array = global.mercosur_member_state
-				NOT = { tag = ROOT }
 				is_subject = no
 				has_at_least_regional_power_status = yes
 				has_global_flag = MER_mercosur_full_membership_enabled
@@ -1220,10 +1204,7 @@ MER_mercosur_diplomacy = {
 
 		visible = {
 			is_ai = no
-			any_of_scopes = {
-				array = global.mercosur_potential
-				tag = ROOT
-			}
+			is_in_array = { global.mercosur_potential = THIS }
 			NOT = { tag = MEX }
 			NOT = { tag = PAN }
 			NOT = { has_dynamic_modifier = unasul_member_state_modifier }
@@ -1236,7 +1217,6 @@ MER_mercosur_diplomacy = {
 			}
 			any_of_scopes = {
 				array = global.unasul_member_state
-				NOT = { tag = ROOT }
 				is_subject = no
 				OR = {
 					has_global_flag = MER_unasul_expansion_enabled
@@ -1253,10 +1233,7 @@ MER_mercosur_diplomacy = {
 			is_subject = no
 			has_elections = yes
 			NOT = { has_country_flag = partyall_banned }
-			any_of_scopes = {
-				array = global.mercosur_potential
-				tag = ROOT
-			}
+			is_in_array = { global.mercosur_potential = THIS }
 			NOT = { tag = MEX }
 			NOT = { tag = PAN }
 			NOT = { has_dynamic_modifier = unasul_member_state_modifier }
@@ -1269,7 +1246,6 @@ MER_mercosur_diplomacy = {
 			}
 			any_of_scopes = {
 				array = global.unasul_member_state
-				NOT = { tag = ROOT }
 				is_subject = no
 				OR = {
 					has_global_flag = MER_unasul_expansion_enabled


### PR DESCRIPTION
## Bottom line

Mercosur request decisions use `is_in_array` instead of walking `global.mercosur_potential` for `tag = ROOT`. Available no longer restates hide-filters already in `visible` or `target_root_trigger`. Click requirements (subject, elections, banned parties, cooldowns, tooltipped round caps) stay in `available` so they still show. Invite target TAG checks stay in `available` for same-tick safety. `MER_invite_to_unasul` still excludes ROOT.

## Why

The old `any_of_scopes` walk was a membership test. Invite decisions already use `is_in_array`. Member-array self-exclusion could never match. Duplicate `visible`/`available` checks ran every tick while the decisions tab was open.

BLUF