### PR TITLE
Allowlist inflation_rate_lower_than_2 in unused-scripted validator

### DIFF
--- a/tools/validation/validate_unused_scripted.py
+++ b/tools/validation/validate_unused_scripted.py
@@ -68,6 +68,7 @@ FALSE_POSITIVE_NAMES = frozenset(
         "ai_has_acceptable_surplus",
         "ai_has_acceptable_deficit_factories",
         "interest_rate_lower_than_5_5",
+        "inflation_rate_lower_than_2",
         "debt_higher_than_30",
         "gdp_per_capita_greater_than_2",
         "gdp_per_capita_greater_than_7",


### PR DESCRIPTION
## Bottom line
- Adds `inflation_rate_lower_than_2` to `FALSE_POSITIVE_NAMES` so the unused-scripted validator stops flagging it.

## Why
- The trigger is a preset kept next to its `_lower_than_1` / `_higher_than_2` siblings for content authors; it has no caller by design.

## How
- One entry in `tools/validation/validate_unused_scripted.py` under the `00_economic_triggers.txt` group.
- No changelog entry.

BLUF