### PR TITLE
Making Gun Ports Useful

### DIFF
--- a/common/units/equipment/modules/MD_tank_modules.txt
+++ b/common/units/equipment/modules/MD_tank_modules.txt
@@ -5670,7 +5670,7 @@ equipment_modules = {
 			build_cost_ic = 2.45
 			defense = 0
 			breakthrough = 0
-			armor_value = 1.5
+			armor_value = 2
 			maximum_speed = -1
 			reliability = -0.05
 		}
@@ -5695,7 +5695,7 @@ equipment_modules = {
 			build_cost_ic = 3.14
 			defense = 0.75
 			breakthrough = 1
-			armor_value = 3
+			armor_value = 3.5
 			maximum_speed = -1.25
 			reliability = -0.05
 		}
@@ -5720,7 +5720,7 @@ equipment_modules = {
 			build_cost_ic = 3.82
 			defense = 1
 			breakthrough = 2
-			armor_value = 4.5
+			armor_value = 5
 			maximum_speed = -1.5
 			reliability = -0.05
 		}
@@ -5745,7 +5745,7 @@ equipment_modules = {
 			build_cost_ic = 4.4
 			defense = 1.25
 			breakthrough = 3
-			armor_value = 6
+			armor_value = 6.5
 			maximum_speed = -1.75
 			reliability = -0.05
 		}
@@ -5773,7 +5773,7 @@ equipment_modules = {
 			build_cost_ic = 4.94
 			defense = 2.5
 			breakthrough = 4
-			armor_value = 7.5
+			armor_value = 8
 			maximum_speed = -2
 			reliability = -0.05
 		}
@@ -5801,7 +5801,7 @@ equipment_modules = {
 			build_cost_ic = 5.48
 			defense = 2.5
 			breakthrough = 4
-			armor_value = 9
+			armor_value = 9.5
 			maximum_speed = -2.25
 			reliability = -0.05
 		}
@@ -6980,9 +6980,10 @@ equipment_modules = {
 		abbreviation = "agp"
 		category = tank_special_module
 		sfx = sfx_ui_sd_module_turret
-
+	
+		manpower = 2
 		add_stats = {
-			soft_attack = 1
+			soft_attack = 1.5
 			build_cost_ic = 0.3
 			reliability = -0.05
 			supply_consumption = 0.01
@@ -8172,7 +8173,7 @@ equipment_modules = {
 			hard_attack = 0.6 #add 1.8
 			air_attack = 0
 			ap_attack = 1 #add 3
-			build_cost_ic = 0.58 #add 1.36
+			build_cost_ic = 1.1
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8193,7 +8194,7 @@ equipment_modules = {
 			hard_attack = 1
 			air_attack = 0
 			ap_attack = 1.4
-			build_cost_ic = 1.77
+			build_cost_ic = 1.75
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8214,7 +8215,7 @@ equipment_modules = {
 			hard_attack = 1.4 #add 4.2
 			air_attack = 0.75
 			ap_attack = 1.8 #5.4
-			build_cost_ic = 3.10
+			build_cost_ic = 2.4
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8235,7 +8236,7 @@ equipment_modules = {
 			hard_attack = 1.8 #add 5.4
 			air_attack = 0.75
 			ap_attack = 2.4 #add 7.2
-			build_cost_ic = 5.42
+			build_cost_ic = 3.05
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8256,7 +8257,7 @@ equipment_modules = {
 			hard_attack = 2.2 #add 6.6
 			air_attack = 1
 			ap_attack = 3 #add 9
-			build_cost_ic = 9.49
+			build_cost_ic = 3.7
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8277,7 +8278,7 @@ equipment_modules = {
 			hard_attack = 5.2
 			air_attack = 2.5
 			ap_attack = 7.2
-			build_cost_ic = 12
+			build_cost_ic = 4.35
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8298,7 +8299,7 @@ equipment_modules = {
 			hard_attack = 6
 			air_attack = 3
 			ap_attack = 8.4
-			build_cost_ic = 14.5
+			build_cost_ic = 5
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8319,7 +8320,7 @@ equipment_modules = {
 			hard_attack = 6.8
 			air_attack = 3.5
 			ap_attack = 9.6
-			build_cost_ic = 17
+			build_cost_ic = 5.56
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8340,7 +8341,7 @@ equipment_modules = {
 			hard_attack = 8
 			air_attack = 4
 			ap_attack = 10.8
-			build_cost_ic = 19.5
+			build_cost_ic = 6.3
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8360,7 +8361,7 @@ equipment_modules = {
 			hard_attack = 1
 			air_attack = 0
 			ap_attack = 1
-			build_cost_ic = 0.58
+			build_cost_ic = 1.1
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8381,7 +8382,7 @@ equipment_modules = {
 			hard_attack = 2
 			air_attack = 0
 			ap_attack = 1.4
-			build_cost_ic = 1.77
+			build_cost_ic = 1.75
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8402,7 +8403,7 @@ equipment_modules = {
 			hard_attack = 3.2
 			air_attack = 0.75
 			ap_attack = 1.8
-			build_cost_ic = 3.10
+			build_cost_ic = 2.4
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8423,7 +8424,7 @@ equipment_modules = {
 			hard_attack = 4.2
 			air_attack = 0.75
 			ap_attack = 2.4
-			build_cost_ic = 5.42
+			build_cost_ic = 3.05
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8444,7 +8445,7 @@ equipment_modules = {
 			hard_attack = 4.8
 			air_attack = 1
 			ap_attack = 3
-			build_cost_ic = 9.49
+			build_cost_ic = 3.7
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8465,7 +8466,7 @@ equipment_modules = {
 			hard_attack = 10.8
 			air_attack = 2.5
 			ap_attack = 7.2
-			build_cost_ic = 10.95
+			build_cost_ic = 4.35
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8486,7 +8487,7 @@ equipment_modules = {
 			hard_attack = 12
 			air_attack = 3
 			ap_attack = 9.6
-			build_cost_ic = 12.77
+			build_cost_ic = 5
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8507,7 +8508,7 @@ equipment_modules = {
 			hard_attack = 13.2
 			air_attack = 3.5
 			ap_attack = 10.8
-			build_cost_ic = 14.59
+			build_cost_ic = 5.65
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8528,7 +8529,7 @@ equipment_modules = {
 			hard_attack = 14.4
 			air_attack = 4
 			ap_attack = 12
-			build_cost_ic = 16.41
+			build_cost_ic = 6.3
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8548,7 +8549,7 @@ equipment_modules = {
 			hard_attack = 0.2
 			air_attack = 0
 			ap_attack = 1
-			build_cost_ic = 0.58
+			build_cost_ic = 1.1
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8569,7 +8570,7 @@ equipment_modules = {
 			hard_attack = 0.6
 			air_attack = 0
 			ap_attack = 1.4
-			build_cost_ic = 1.77
+			build_cost_ic = 1.75
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8590,7 +8591,7 @@ equipment_modules = {
 			hard_attack = 1
 			air_attack = 0.75
 			ap_attack = 1.8
-			build_cost_ic = 3.10
+			build_cost_ic = 2.4
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8611,7 +8612,7 @@ equipment_modules = {
 			hard_attack = 1.2
 			air_attack = 0.75
 			ap_attack = 2.4
-			build_cost_ic = 5.42
+			build_cost_ic = 3.05
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8632,7 +8633,7 @@ equipment_modules = {
 			hard_attack = 1.8
 			air_attack = 1
 			ap_attack = 3
-			build_cost_ic = 9.49
+			build_cost_ic = 3.7
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8653,7 +8654,7 @@ equipment_modules = {
 			hard_attack = 4.8
 			air_attack = 2.5
 			ap_attack = 7.2
-			build_cost_ic = 10.95
+			build_cost_ic = 4.35
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8674,7 +8675,7 @@ equipment_modules = {
 			hard_attack = 6
 			air_attack = 3
 			ap_attack = 8.4
-			build_cost_ic = 12.77
+			build_cost_ic = 5
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8695,7 +8696,7 @@ equipment_modules = {
 			hard_attack = 7.2
 			air_attack = 3.5
 			ap_attack = 9.6
-			build_cost_ic = 14.59
+			build_cost_ic = 5.65
 			supply_consumption = 0.01
 		}
 		xp_cost = 3
@@ -8716,7 +8717,7 @@ equipment_modules = {
 			hard_attack = 8.4
 			air_attack = 4
 			ap_attack = 10.8
-			build_cost_ic = 16.41
+			build_cost_ic = 6.3
 			supply_consumption = 0.01
 		}
 		xp_cost = 3


### PR DESCRIPTION
Based on feedback of some of our esteemed players, you know who you are.

- Gun Ports had their soft attack increased from 1 to 1.5, they now need +2 manpower each. Great for your APC militia apcs.
- Autocannon ammo costs normalized with a more natural progression, similar to what you see in MGs but more expensive.
- Reactive armor value raised by 0.5 all around as spaced armor is still beating it in low armor vehicles.