### PR TITLE
Point Paradox formatter at CWTools MD edition with tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 !.opencode/agent/
 !.opencode/command/
 .vs/
-.vscode/
+.vscode/hoi4_millennium_dawn-personal.code-workspace
 vscode-userdata:/
 .pi-subagents/
 
@@ -56,9 +56,6 @@ specs/
 .validation_cache/
 .tmp-archive/
 repomix-*.xml
-
-# Game assets
-.vscode/hoi4_millennium_dawn-personal.code-workspace
 
 # Photoshop source files — not for distribution
 *.psd

--- a/.vscode/hoi4_millennium_dawn.code-workspace
+++ b/.vscode/hoi4_millennium_dawn.code-workspace
@@ -64,8 +64,12 @@
 			"editor.wordWrap": "off"
 		},
 		"[paradox]": {
-			"editor.defaultFormatter": "tboby.cwtools-vscode"
+			"editor.defaultFormatter": "milleniumdawnmodteam.cwtools-md-edition",
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
 		},
+		"cwtools.formatting.indentStyle": "tab",
+		"cwtools.formatting.indentSize": 4,
 		"hoi4ModUtilities.modFile": "/mnt/Linux/Millennium-Dawn/descriptor.mod",
 		"hoi4ModUtilities.installPath": "C:\\Games\\Hearts of Iron IV\\",
 		"search.exclude": {


### PR DESCRIPTION
## Bottom line

Paradox files in the team VS Code workspace now format with `milleniumdawnmodteam.cwtools-md-edition` using tabs of size 4. `.vscode/` is tracked. Only the personal workspace copy stays gitignored.

## Why

The recommended extension was already the MD edition, but `[paradox]` still pointed at `tboby.cwtools-vscode`. That edition also defaults Paradox files to 4 spaces, which overrode the workspace tab setting. Local overrides belong in `hoi4_millennium_dawn-personal.code-workspace`.

BLUF