### PR TITLE
R3D regimental support balanace

### DIFF
--- a/common/units/MD_regimental_support.txt
+++ b/common/units/MD_regimental_support.txt
@@ -1692,7 +1692,7 @@ sub_units = {
 		ai_priority = 0
 		priority = 1
 		active = yes
-		affects_speed = no
+		affects_speed = yes
 		divisional = no
 		allowed_battalion_groups = { mobile armor airborne_infantry marine_infantry }
 

--- a/common/units/MD_regimental_support.txt
+++ b/common/units/MD_regimental_support.txt
@@ -716,10 +716,6 @@ sub_units = {
 			artillery_equipment = 6
 			cnc_equipment_type = 6
 		}
-		jungle = { attack = -0.03 movement = -0.03 }
-		forest = { attack = 0.03 }
-		marsh = { movement = -0.03 }
-		urban = { attack = -0.03 }
 
 		manpower = 40
 		training_time = 120
@@ -732,8 +728,8 @@ sub_units = {
 		# Support nerfs to combat abilities
 		defense = -0.5
 		breakthrough = -0.5
-		soft_attack = -0.5
-		hard_attack = -0.3
+		soft_attack = -0.4
+		hard_attack = -0.4
 		ap_attack = -0.3
 		suppression = 1
 
@@ -787,8 +783,8 @@ sub_units = {
 		# Support nerfs to combat abilities
 		defense = -0.5
 		breakthrough = -0.5
-		soft_attack = -0.5
-		hard_attack = -0.5
+		soft_attack = -0.4
+		hard_attack = -0.4
 		armor_value = -0.3
 		ap_attack = -0.3
 		suppression = 1
@@ -842,8 +838,8 @@ sub_units = {
 		# Support nerfs to combat abilities
 		defense = -0.5
 		breakthrough = -0.5
-		soft_attack = -0.5
-		hard_attack = -0.5
+		soft_attack = -0.4
+		hard_attack = -0.4
 		armor_value = -0.3
 		ap_attack = -0.3
 		suppression = 1
@@ -892,8 +888,8 @@ sub_units = {
 		# Support nerfs to combat abilities
 		defense = -0.5
 		breakthrough = -0.5
-		soft_attack = -0.5
-		hard_attack = -0.5
+		soft_attack = -0.4
+		hard_attack = -0.4
 		armor_value = -0.3
 		ap_attack = -0.3
 		suppression = 0.5
@@ -999,8 +995,8 @@ sub_units = {
 
 		defense = -0.5
 		breakthrough = -0.5
-		soft_attack = -0.5
-		hard_attack = -0.5
+		soft_attack = -0.4
+		hard_attack = -0.4
 		armor_value = -0.3
 		ap_attack = -0.3
 
@@ -1047,8 +1043,8 @@ sub_units = {
 
 		defense = -0.5
 		breakthrough = -0.5
-		soft_attack = -0.5
-		hard_attack = -0.5
+		soft_attack = -0.4
+		hard_attack = -0.4
 		armor_value = -0.3
 		ap_attack = -0.3
 		suppression = 1
@@ -1060,10 +1056,6 @@ sub_units = {
 			heavy_tank_chassis = 4
 			cnc_equipment_type = 4
 		}
-		plains = { attack = 0.03 }
-		jungle = { attack = -0.03 }
-		urban = { attack = -0.03 }
-
 	}
 
 	#Drone Elements
@@ -1559,9 +1551,9 @@ sub_units = {
 		combat_width = 0
 
 		need = {
-			infantry_weapons_type = 200
+			infantry_weapons_type = 150
 			L_AT_Equipment = 10
-			cnc_equipment_type = 20
+			cnc_equipment_type = 10
 		}
 
 		essential = {
@@ -1578,9 +1570,9 @@ sub_units = {
 
 		# Support nerfs to combat abilities
 		defense = 0.2
-		breakthrough = 0.2
-		soft_attack = 0.3
-		hard_attack = 0.2
+		breakthrough = -0.3
+		soft_attack = -0.2
+		hard_attack = -0.2
 		ap_attack = 1
 		suppression = 0.5
 
@@ -1612,16 +1604,18 @@ sub_units = {
 		combat_width = 0
 
 		need = {
-			infantry_weapons_type = 200
-			cnc_equipment_type = 20
+			infantry_weapons_type = 100
+			cnc_equipment_type = 10
+			util_vehicle_type = 10
 		}
 
 		essential = {
 			infantry_weapons_type
+			util_vehicle_type
 		}
 
 		manpower = 100
-		max_organisation = 30
+		max_organisation = 25
 		default_morale = 0.05
 		max_strength = 5
 		training_time = 120
@@ -1629,14 +1623,14 @@ sub_units = {
 		entrenchment = -0.3
 
 		# Support nerfs to combat abilities
-		breakthrough = 0.2
-		defense = 0.2
-		soft_attack = 3
-		hard_attack = 0.2
+		breakthrough = 0.3
+		defense = 0.0
+		soft_attack = -0.0
+		hard_attack = -0.0
 		ap_attack = 0.2
-		suppression = 0.5
+		suppression = 0.0
 
-		transport = cnc_equipment_type
+		transport = util_vehicle_type
 		can_be_parachuted = yes
 	}
 	AT_company = {
@@ -1682,12 +1676,12 @@ sub_units = {
 		entrenchment = -0.3
 
 		# Support nerfs to combat abilities
-		defense = -0.7
+		defense = -0.2
 		breakthrough = -0.7
-		soft_attack = -0.7
-		hard_attack = 2.5
+		soft_attack = -0.5
+		hard_attack = 0.5
 		ap_attack = 2
-		suppression = 0.5
+		suppression = 0.0
 
 		transport = cnc_equipment_type
 		can_be_parachuted = yes
@@ -1717,10 +1711,10 @@ sub_units = {
 		combat_width = 0
 
 		need = {
-			infantry_weapons_type = 160
-			H_AT_Equipment = 16
-			cnc_equipment_type = 16
-			util_vehicle_type = 16
+			infantry_weapons_type = 100
+			H_AT_Equipment = 20
+			cnc_equipment_type = 10
+			util_vehicle_type = 10
 		}
 
 		essential = {
@@ -1736,12 +1730,12 @@ sub_units = {
 		entrenchment = -0.3
 
 		# Support nerfs to combat abilities
-		defense = -0.8
-		breakthrough = -0.8
-		soft_attack = -0.8
-		hard_attack = 2.5
+		defense = -0.2
+		breakthrough = -0.7
+		soft_attack = -0.5
+		hard_attack = 1
 		ap_attack = 2
-		suppression = 0.5
+		suppression = 0.0
 
 		transport = util_vehicle_type
 		can_be_parachuted = yes
@@ -1772,7 +1766,7 @@ sub_units = {
 		need = {
 			infantry_weapons_type = 100
 			AA_Equipment = 20
-			cnc_equipment_type = 20
+			cnc_equipment_type = 10
 		}
 
 		essential = {
@@ -1788,13 +1782,13 @@ sub_units = {
 		entrenchment = -0.3
 
 		# Support nerfs to combat abilities
-		defense = -0.8
-		breakthrough = -0.8
-		soft_attack = -0.8
-		hard_attack = -0.8
-		ap_attack = -0.8
+		defense = -0.5
+		breakthrough = -0.5
+		soft_attack = -0.5
+		hard_attack = -0.0
+		ap_attack = -0.5
+		suppression = 0.0
 		air_attack = 3
-		suppression = 0.5
 
 		transport = cnc_equipment_type
 		can_be_parachuted = yes
@@ -1823,9 +1817,9 @@ sub_units = {
 		combat_width = 0
 
 		need = {
-			infantry_weapons_type = 150
-			L_AT_Equipment = 10
-			cnc_equipment_type = 20
+			infantry_weapons_type = 100
+			cnc_equipment_type = 10
+			util_vehicle_type = 10
 		}
 
 		essential = {
@@ -1840,19 +1834,21 @@ sub_units = {
 		weight = 0.5
 
 		# Support nerfs to combat abilities
-		defense = -0.2
-		breakthrough = -0.2
-		soft_attack = -0.5
-		hard_attack = -0.5
-		ap_attack = -0.5
-		suppression = 0.5
+		defense = -1
+		breakthrough = -1
+		soft_attack = -1
+		hard_attack = -1
+		ap_attack = -1
+		suppression = 0.0
 
-		forest = { attack = 0.03 defence = 0.03 }
-		mountain = { attack = 0.03 defence = 0.03 }
-		jungle = { attack = 0.03 defence = 0.03 }
-		urban = { attack = 0.03 defence = 0.03 }
+		forest = { attack = 0.02 defence = 0.02 }
+		jungle = { attack = 0.02 defence = 0.02 }
+		mountain = { attack = 0.02 defence = 0.02 }
+		marsh = { attack = 0.02 defence = 0.02 }
+		urban = { attack = 0.02 defence = 0.02 }
+		supercity = { attack = 0.02 defence = 0.02 }
 
-		transport = cnc_equipment_type
+		transport = util_vehicle_type
 		can_be_parachuted = yes
 	}
 	amphibious_landing_detachment = {


### PR DESCRIPTION
Fine comb pass to regimental support.

- All combat regiments were balanced to provide extra soft/hard attack and piercing as per their specialization, with Weapons Company being the middle of the road.
- Mortar Company and Combat Engineer Company are now motorized with their speed to match.
- Combat Engineers now have no combat stats of their own but add a stacking 2% bonus to attack and defence in difficult terrain, up to 10% a division has five of them.