### PR TITLE
Update 05_france.txt

### DIFF
--- a/common/national_focus/05_france.txt
+++ b/common/national_focus/05_france.txt
@@ -15045,6 +15045,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_EXPENDITURE }
 
 		available = {
+				has_tech = high_speed_rail
 			OR = {
 				has_full_control_of_state = 55
 				has_full_control_of_state = 65


### PR DESCRIPTION
Bird and I discussed in comments:

Fix for #4028: Lock focus behind HSR unlock

Justification: All French States start with 3 Infra, max Infra slots at game start is 2. 

Need at least 1 free Infra slot unlocked for focuses to make sense.

Bird suggested HSR soft lock (see #4028 comments), code change reflects suggestion.

### Changes
**Please describe the scope of the changes for this pull request.**

Closes #4028 