### PR TITLE
Modify Ranger combat width, manpower, and equipment needs

### DIFF
--- a/common/units/MD_land_units.txt
+++ b/common/units/MD_land_units.txt
@@ -1470,13 +1470,13 @@ sub_units = {
 			category_rcon_ranger #new
 		}
 
-		combat_width = 2
+		combat_width = 5
 
 		#Size Definitions
 		max_strength = 15
 		max_organisation = 46
 		default_morale = 0.16
-		manpower = 200
+		manpower = 150
 		entrenchment = 0.1
 		suppression = 1
 
@@ -1487,10 +1487,10 @@ sub_units = {
 		transport = cnc_equipment_type
 
 		need = {
-			infantry_weapons_type = 300
-			L_AT_Equipment = 20
-			AA_Equipment = 10
-			cnc_equipment_type = 20
+			infantry_weapons_type = 225
+			L_AT_Equipment = 15
+			AA_Equipment = 8
+			cnc_equipment_type = 15
 		}
 		plains = { attack = -0.05 }
 		desert = { attack = 0.05 movement = 0.05 }


### PR DESCRIPTION
Updated combat width and manpower values, and adjusted equipment requirements based on suggestions by R3d Kn19h7

Reason: Combat width seen as too small for size and bonuses relative to other comparable units such as light infantry companies and special forces companies. 

Provisional suggestion are to reduce size by 75% and increase combat width by 3 to reflect more realistic sizing. 

Left terrain bonuses untouched, if a senior dev approves of this + bonus stacking changes I'd be happy to help.

### Changes
**Please describe the scope of the changes for this pull request.**

Closes #<issue number here>